### PR TITLE
Improve retranscribe engine choices

### DIFF
--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
@@ -617,29 +617,36 @@ struct TranscriptResultView: View {
         for option: TranscriptionViewModel.RetranscriptionEngineOption
     ) -> some View {
         VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
-            Text("Retranscribe with")
-                .font(DesignSystem.Typography.body.weight(.semibold))
-                .foregroundStyle(DesignSystem.Colors.textPrimary)
+            HStack(spacing: DesignSystem.Spacing.sm) {
+                Label("Retranscribe with", systemImage: "arrow.trianglehead.2.clockwise")
+                    .font(DesignSystem.Typography.body.weight(.semibold))
+                    .foregroundStyle(DesignSystem.Colors.textPrimary)
+
+                Spacer(minLength: 8)
+
+                Button {
+                    showingRetranscribeOptions = false
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(.tertiary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Close retranscribe options")
+            }
 
             VStack(spacing: DesignSystem.Spacing.sm) {
-                EngineOptionCard(
-                    selection: option.primaryEngine,
-                    nemotronVariant: option.nemotronVariant,
-                    isPrimary: true,
-                    isAvailable: true,
-                    unavailableReason: nil
-                ) {
-                    selectRetranscribeEngine(option.primaryEngine, in: option)
-                }
-
-                EngineOptionCard(
-                    selection: option.alternativeEngine,
-                    nemotronVariant: option.nemotronVariant,
-                    isPrimary: false,
-                    isAvailable: option.isAlternativeAvailable,
-                    unavailableReason: option.unavailableReason
-                ) {
-                    selectRetranscribeEngine(option.alternativeEngine, in: option)
+                ForEach(option.choices) { choice in
+                    EngineOptionCard(
+                        selection: choice.selection,
+                        nemotronVariant: option.nemotronVariant,
+                        isPrimary: choice.isPrimary,
+                        isAvailable: choice.isAvailable,
+                        unavailableReason: choice.unavailableReason,
+                        advisory: choice.advisory
+                    ) {
+                        selectRetranscribeEngine(choice)
+                    }
                 }
             }
 
@@ -649,14 +656,13 @@ struct TranscriptResultView: View {
                 .fixedSize(horizontal: false, vertical: true)
         }
         .padding(DesignSystem.Spacing.md)
-        .frame(width: 360)
+        .frame(width: 390)
     }
 
     private func selectRetranscribeEngine(
-        _ selection: SpeechEngineSelection,
-        in option: TranscriptionViewModel.RetranscriptionEngineOption
+        _ choice: TranscriptionViewModel.RetranscriptionEngineOption.Choice
     ) {
-        let override: SpeechEngineSelection? = (selection == option.primaryEngine) ? nil : selection
+        let override: SpeechEngineSelection? = choice.isPrimary ? nil : choice.selection
         pendingRetranscribePick = RetranscribePick(transcriptionID: transcription.id, override: override)
         showingRetranscribeOptions = false
         // Confirmation alert is presented from the .onChange handler that
@@ -2970,6 +2976,7 @@ private struct EngineOptionCard: View {
     let isPrimary: Bool
     let isAvailable: Bool
     let unavailableReason: String?
+    let advisory: String?
     let onSelect: () -> Void
 
     @State private var hovering = false
@@ -3021,10 +3028,12 @@ private struct EngineOptionCard: View {
                             .foregroundStyle(titleColor)
                         if isPrimary {
                             EngineBadge(text: "Current", tint: DesignSystem.Colors.accent)
-                        } else if !isAvailable {
+                        }
+                        if !isAvailable {
                             EngineBadge(text: "Unavailable", tint: DesignSystem.Colors.warningAmber)
                         }
                     }
+                    .lineLimit(1)
 
                     Text(subtitle)
                         .font(DesignSystem.Typography.caption)
@@ -3036,6 +3045,14 @@ private struct EngineOptionCard: View {
                         Text(languageDetail)
                             .font(DesignSystem.Typography.caption)
                             .foregroundStyle(DesignSystem.Colors.textTertiary)
+                    }
+
+                    if let advisory, isAvailable {
+                        Text(advisory)
+                            .font(DesignSystem.Typography.caption)
+                            .foregroundStyle(DesignSystem.Colors.textTertiary)
+                            .multilineTextAlignment(.leading)
+                            .fixedSize(horizontal: false, vertical: true)
                     }
 
                     if let unavailableReason, !isAvailable {
@@ -3080,6 +3097,9 @@ private struct EngineOptionCard: View {
         if !isAvailable {
             return unavailableReason ?? "Unavailable for this rerun."
         }
+        if let advisory {
+            return "\(advisory) Rerun with \(selection.engine.displayName)."
+        }
         return "Rerun with \(selection.engine.displayName)."
     }
 
@@ -3116,6 +3136,9 @@ private struct EngineOptionCard: View {
     private var accessibilityHint: String {
         if !isAvailable {
             return unavailableReason ?? "Unavailable for this rerun."
+        }
+        if let advisory {
+            return "\(advisory) Reruns this transcription with \(selection.engine.displayName)."
         }
         return "Reruns this transcription with \(selection.engine.displayName)."
     }

--- a/Sources/MacParakeetCore/STT/NemotronEngine.swift
+++ b/Sources/MacParakeetCore/STT/NemotronEngine.swift
@@ -67,13 +67,13 @@ public actor NemotronEngine: STTTranscribing, NativeLiveDictating {
             try Task.checkCancellation()
             _ = try await manager.process(samples: samples)
             onProgress?(90, 100)
-            let text = try await manager.finish()
+            let final = try await manager.finishWithTokenTimings()
             let detectedLanguage = await manager.detectedLanguage()
             onProgress?(100, 100)
 
             return STTResult(
-                text: text,
-                words: [],
+                text: final.text,
+                words: STTWordTimingBuilder.words(from: final.timings),
                 language: detectedLanguage ?? requestedLanguage,
                 engine: .nemotron,
                 engineVariant: modelVariant.rawValue
@@ -137,11 +137,11 @@ public actor NemotronEngine: STTTranscribing, NativeLiveDictating {
 
         do {
             await manager.setPartialCallback { _ in }
-            let text = try await manager.finish()
+            let final = try await manager.finishWithTokenTimings()
             let detectedLanguage = await manager.detectedLanguage()
             return STTResult(
-                text: text,
-                words: [],
+                text: final.text,
+                words: STTWordTimingBuilder.words(from: final.timings),
                 language: detectedLanguage ?? requestedLanguage,
                 engine: .nemotron,
                 engineVariant: modelVariant.rawValue

--- a/Sources/MacParakeetCore/STT/NemotronEnglishEngine.swift
+++ b/Sources/MacParakeetCore/STT/NemotronEnglishEngine.swift
@@ -83,16 +83,14 @@ public actor NemotronEnglishEngine: STTTranscribing, NativeLiveDictating {
                 let fraction = Double(offset) / Double(samples.count)
                 onProgress?(25 + Int(fraction * 65), 100)
             }
-            let text = try await manager.finish()
+            let final = try await manager.finishWithTokenTimings()
             onProgress?(100, 100)
 
             // `language` reflects the build's fixed configuration (the model is
-            // English-only), mirroring the Parakeet attribution posture. No
-            // word timings: the streaming RNN-T path exposes none (same
-            // posture as the multilingual Nemotron build).
+            // English-only), mirroring the Parakeet attribution posture.
             return STTResult(
-                text: text,
-                words: [],
+                text: final.text,
+                words: STTWordTimingBuilder.words(from: final.timings),
                 language: "en",
                 engine: .nemotron,
                 engineVariant: Self.modelVariant.rawValue
@@ -163,10 +161,10 @@ public actor NemotronEnglishEngine: STTTranscribing, NativeLiveDictating {
 
         do {
             await manager.setPartialCallback { _ in }
-            let text = try await manager.finish()
+            let final = try await manager.finishWithTokenTimings()
             return STTResult(
-                text: text,
-                words: [],
+                text: final.text,
+                words: STTWordTimingBuilder.words(from: final.timings),
                 language: "en",
                 engine: .nemotron,
                 engineVariant: Self.modelVariant.rawValue

--- a/Sources/MacParakeetCore/STT/README.md
+++ b/Sources/MacParakeetCore/STT/README.md
@@ -50,12 +50,15 @@ to one `STTRuntime`; callers do not own model lifecycles directly.
 - `NemotronEngine.swift` — FluidAudio Nemotron 3.5 wrapper for the
   Beta local multilingual engine. Uses separate interactive/background
   managers backed by shared model weights so it fits the scheduler lanes.
+  Preserves FluidAudio token timings as MacParakeet word timestamps when
+  available.
 - `NemotronEnglishEngine.swift` — FluidAudio Nemotron Speech Streaming
   EN 0.6B wrapper (English-only Beta build, `english-1120ms`). Same
   two-lane shape; no language hints, no shared-weights API (both lanes
   load the same compiled artifacts). File/meeting jobs feed batch-at-stop
   through the streaming manager in bounded slices; live dictation drives
-  the same manager incrementally and emits partials (see below).
+  the same manager incrementally and emits partials (see below). Preserves
+  FluidAudio token timings as MacParakeet word timestamps when available.
 - `NativeLiveDictating.swift` — internal protocol the native streaming engines
   conform to so `STTRuntime` can route a live dictation session to the active
   Nemotron or Parakeet Unified build without knowing the concrete engine type.

--- a/Sources/MacParakeetCore/STT/STTRuntime.swift
+++ b/Sources/MacParakeetCore/STT/STTRuntime.swift
@@ -428,7 +428,7 @@ public actor STTRuntime: STTRuntimeProtocol {
             var decoderState = TdtDecoderState.make(decoderLayers: decoderLayers)
             try Task.checkCancellation()
             let result = try await manager.transcribe(audioURL, decoderState: &decoderState)
-            let words = Self.mergeTokenTimingsIntoWords(result.tokenTimings)
+            let words = STTWordTimingBuilder.words(from: result.tokenTimings)
             onProgress?(100, 100)
             // Telemetry `language` is attributed "en": MacParakeet positions
             // Parakeet as English-first (v2 is English-only; v3 multilingual is
@@ -478,7 +478,7 @@ public actor STTRuntime: STTRuntimeProtocol {
             let result = try await manager.transcribe(samples, decoderState: &decoderState)
             return STTResult(
                 text: result.text,
-                words: Self.mergeTokenTimingsIntoWords(result.tokenTimings),
+                words: STTWordTimingBuilder.words(from: result.tokenTimings),
                 // Mirrors batch Parakeet attribution: the build variant carries v2/v3.
                 language: "en",
                 engine: .parakeet,
@@ -1691,60 +1691,6 @@ public actor STTRuntime: STTRuntimeProtocol {
         case .compiling:
             return "Compiling speech model..."
         }
-    }
-
-    private nonisolated static func mergeTokenTimingsIntoWords(_ tokenTimings: [TokenTiming]?) -> [TimestampedWord] {
-        guard let tokenTimings, !tokenTimings.isEmpty else { return [] }
-
-        var words: [TimestampedWord] = []
-        var currentWord = ""
-        var currentStartTime: TimeInterval?
-        var currentEndTime: TimeInterval = 0
-        var currentConfidences: [Float] = []
-
-        func flushCurrentWord() {
-            guard !currentWord.isEmpty, let startTime = currentStartTime else { return }
-            let averageConfidence = currentConfidences.isEmpty
-                ? 0.0
-                : (currentConfidences.reduce(0, +) / Float(currentConfidences.count))
-
-            words.append(
-                TimestampedWord(
-                    word: currentWord,
-                    startMs: Int((startTime * 1_000).rounded()),
-                    endMs: Int((currentEndTime * 1_000).rounded()),
-                    confidence: Double(averageConfidence)
-                ))
-
-            currentWord = ""
-            currentStartTime = nil
-            currentEndTime = 0
-            currentConfidences.removeAll(keepingCapacity: true)
-        }
-
-        for timing in tokenTimings {
-            let normalizedToken = timing.token.replacingOccurrences(of: "▁", with: " ")
-            let trimmedToken = normalizedToken.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !trimmedToken.isEmpty else { continue }
-
-            if normalizedToken.hasPrefix(" ") || normalizedToken.hasPrefix("\n") || normalizedToken.hasPrefix("\t") {
-                flushCurrentWord()
-                currentWord = trimmedToken
-                currentStartTime = timing.startTime
-                currentEndTime = timing.endTime
-                currentConfidences = [timing.confidence]
-            } else {
-                if currentStartTime == nil {
-                    currentStartTime = timing.startTime
-                }
-                currentWord += trimmedToken
-                currentEndTime = timing.endTime
-                currentConfidences.append(timing.confidence)
-            }
-        }
-
-        flushCurrentWord()
-        return words
     }
 }
 

--- a/Sources/MacParakeetCore/STT/STTWordTimingBuilder.swift
+++ b/Sources/MacParakeetCore/STT/STTWordTimingBuilder.swift
@@ -1,0 +1,60 @@
+import FluidAudio
+import Foundation
+
+enum STTWordTimingBuilder {
+    static func words(from tokenTimings: [TokenTiming]?) -> [TimestampedWord] {
+        guard let tokenTimings, !tokenTimings.isEmpty else { return [] }
+
+        var words: [TimestampedWord] = []
+        var currentWord = ""
+        var currentStartTime: TimeInterval?
+        var currentEndTime: TimeInterval = 0
+        var currentConfidences: [Float] = []
+
+        func flushCurrentWord() {
+            guard !currentWord.isEmpty, let startTime = currentStartTime else { return }
+            let averageConfidence =
+                currentConfidences.isEmpty
+                ? 0.0
+                : (currentConfidences.reduce(0, +) / Float(currentConfidences.count))
+
+            words.append(
+                TimestampedWord(
+                    word: currentWord,
+                    startMs: Int((startTime * 1_000).rounded()),
+                    endMs: Int((currentEndTime * 1_000).rounded()),
+                    confidence: Double(averageConfidence)
+                )
+            )
+
+            currentWord = ""
+            currentStartTime = nil
+            currentEndTime = 0
+            currentConfidences.removeAll(keepingCapacity: true)
+        }
+
+        for timing in tokenTimings {
+            let normalizedToken = timing.token.replacingOccurrences(of: "▁", with: " ")
+            let trimmedToken = normalizedToken.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmedToken.isEmpty else { continue }
+
+            if normalizedToken.first?.isWhitespace == true {
+                flushCurrentWord()
+                currentWord = trimmedToken
+                currentStartTime = timing.startTime
+                currentEndTime = timing.endTime
+                currentConfidences = [timing.confidence]
+            } else {
+                if currentStartTime == nil {
+                    currentStartTime = timing.startTime
+                }
+                currentWord += trimmedToken
+                currentEndTime = timing.endTime
+                currentConfidences.append(timing.confidence)
+            }
+        }
+
+        flushCurrentWord()
+        return words
+    }
+}

--- a/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
@@ -7,16 +7,26 @@ import SwiftUI
 @Observable
 public final class TranscriptionViewModel {
     public struct RetranscriptionEngineOption: Equatable, Sendable {
+        public struct Choice: Identifiable, Equatable, Sendable {
+            public let selection: SpeechEngineSelection
+            public let isPrimary: Bool
+            public let isAvailable: Bool
+            public let unavailableReason: String?
+            public let advisory: String?
+
+            public var id: String {
+                "\(selection.engine.rawValue)-\(selection.language ?? "none")"
+            }
+        }
+
         public let primaryEngine: SpeechEngineSelection
-        public let alternativeEngine: SpeechEngineSelection
-        public let isAlternativeAvailable: Bool
-        public let unavailableReason: String?
+        public let choices: [Choice]
         /// Persisted Nemotron build a Nemotron rerun would load (STTRuntime
         /// resolves the persisted variant at run start).
         public let nemotronVariant: NemotronModelVariant
 
         public var title: String {
-            "Try with \(alternativeEngine.engine.displayName)"
+            "Retranscribe with speech engine"
         }
     }
 
@@ -428,33 +438,58 @@ public final class TranscriptionViewModel {
             primaryEngine = SpeechEngineSelection.current(defaults: defaults)
         }
 
-        let alternativePreference = retranscriptionAlternativePreference(for: primaryEngine.engine)
-        let alternativeEngine = SpeechEngineSelection(
-            engine: alternativePreference,
-            language: Self.retranscriptionLanguage(for: alternativePreference, defaults: defaults)
-        )
-        let unavailableReason: String?
-        if alternativePreference == .nemotron && !isNemotronModelDownloaded() {
-            unavailableReason = "Download the Nemotron model in Settings before trying Nemotron."
-        } else if alternativePreference == .whisper && !isWhisperModelDownloaded() {
-            unavailableReason = "Download the Whisper model in Settings before trying Whisper."
-        } else {
-            unavailableReason = nil
+        let choices = retranscriptionEngineOrder(primary: primaryEngine.engine).map { engine in
+            let selection = SpeechEngineSelection(
+                engine: engine,
+                language: Self.retranscriptionLanguage(for: engine, defaults: defaults)
+            )
+            let unavailableReason = retranscriptionUnavailableReason(for: engine)
+            return RetranscriptionEngineOption.Choice(
+                selection: engine == primaryEngine.engine ? primaryEngine : selection,
+                isPrimary: engine == primaryEngine.engine,
+                isAvailable: unavailableReason == nil,
+                unavailableReason: unavailableReason,
+                advisory: retranscriptionAdvisory(for: engine, unavailableReason: unavailableReason)
+            )
         }
 
         return RetranscriptionEngineOption(
             primaryEngine: primaryEngine,
-            alternativeEngine: alternativeEngine,
-            isAlternativeAvailable: unavailableReason == nil,
-            unavailableReason: unavailableReason,
+            choices: choices,
             nemotronVariant: SpeechEnginePreference.nemotronModelVariant(defaults: defaults)
         )
     }
 
-    private func retranscriptionAlternativePreference(
-        for primaryEngine: SpeechEnginePreference
-    ) -> SpeechEnginePreference {
-        return primaryEngine.alternative
+    private func retranscriptionEngineOrder(primary: SpeechEnginePreference) -> [SpeechEnginePreference] {
+        let defaultOrder: [SpeechEnginePreference] = [.parakeet, .nemotron, .whisper]
+        return [primary] + defaultOrder.filter { $0 != primary }
+    }
+
+    private func retranscriptionUnavailableReason(for engine: SpeechEnginePreference) -> String? {
+        switch engine {
+        case .parakeet:
+            return nil
+        case .nemotron:
+            return isNemotronModelDownloaded()
+                ? nil
+                : "Download the Nemotron model in Settings before trying Nemotron."
+        case .whisper:
+            return isWhisperModelDownloaded()
+                ? nil
+                : "Download the Whisper model in Settings before trying Whisper."
+        }
+    }
+
+    private func retranscriptionAdvisory(
+        for engine: SpeechEnginePreference,
+        unavailableReason: String?
+    ) -> String? {
+        guard engine == .whisper,
+              unavailableReason == nil,
+              SpeechEnginePreference.isColdSwitch(to: .whisper, defaults: defaults) else {
+            return nil
+        }
+        return "First run may spend a few minutes preparing this Whisper model."
     }
 
     private static func retranscriptionLanguage(

--- a/Tests/MacParakeetTests/STT/STTWordTimingBuilderTests.swift
+++ b/Tests/MacParakeetTests/STT/STTWordTimingBuilderTests.swift
@@ -1,0 +1,74 @@
+import FluidAudio
+@testable import MacParakeetCore
+import XCTest
+
+final class STTWordTimingBuilderTests: XCTestCase {
+    func testWordsGroupSentencePieceTokens() {
+        let words = STTWordTimingBuilder.words(from: [
+            TokenTiming(token: "▁hello", tokenId: 1, startTime: 0.10, endTime: 0.18, confidence: 0.8),
+            TokenTiming(token: "world", tokenId: 2, startTime: 0.18, endTime: 0.36, confidence: 1.0),
+            TokenTiming(token: "▁again", tokenId: 3, startTime: 0.50, endTime: 0.72, confidence: 0.9),
+        ])
+
+        XCTAssertEqual(words.count, 2)
+        XCTAssertEqual(words[0].word, "helloworld")
+        XCTAssertEqual(words[0].startMs, 100)
+        XCTAssertEqual(words[0].endMs, 360)
+        XCTAssertEqual(words[0].confidence, 0.9, accuracy: 0.0001)
+        XCTAssertEqual(words[1].word, "again")
+        XCTAssertEqual(words[1].startMs, 500)
+        XCTAssertEqual(words[1].endMs, 720)
+        XCTAssertEqual(words[1].confidence, 0.9, accuracy: 0.0001)
+    }
+
+    func testWordsIgnoreBlankTokens() {
+        let words = STTWordTimingBuilder.words(from: [
+            TokenTiming(token: "▁", tokenId: 1, startTime: 0, endTime: 0.08, confidence: 0.5),
+            TokenTiming(token: "▁done", tokenId: 2, startTime: 0.16, endTime: 0.32, confidence: 0.95),
+        ])
+
+        XCTAssertEqual(words.count, 1)
+        XCTAssertEqual(words[0].word, "done")
+        XCTAssertEqual(words[0].startMs, 160)
+        XCTAssertEqual(words[0].endMs, 320)
+    }
+
+    func testWordsStartPlainFirstTokenAsWord() {
+        let words = STTWordTimingBuilder.words(from: [
+            TokenTiming(token: "hello", tokenId: 1, startTime: 0.04, endTime: 0.20, confidence: 0.7),
+            TokenTiming(token: "▁world", tokenId: 2, startTime: 0.32, endTime: 0.48, confidence: 0.9),
+        ])
+
+        XCTAssertEqual(words.count, 2)
+        XCTAssertEqual(words[0].word, "hello")
+        XCTAssertEqual(words[0].startMs, 40)
+        XCTAssertEqual(words[0].endMs, 200)
+        XCTAssertEqual(words[1].word, "world")
+        XCTAssertEqual(words[1].startMs, 320)
+        XCTAssertEqual(words[1].endMs, 480)
+    }
+
+    func testWordsReturnEmptyForAllBlankTokens() {
+        let words = STTWordTimingBuilder.words(from: [
+            TokenTiming(token: "▁", tokenId: 1, startTime: 0.00, endTime: 0.04, confidence: 0.2),
+            TokenTiming(token: " ", tokenId: 2, startTime: 0.04, endTime: 0.08, confidence: 0.3),
+            TokenTiming(token: "\n", tokenId: 3, startTime: 0.08, endTime: 0.12, confidence: 0.4),
+        ])
+
+        XCTAssertTrue(words.isEmpty)
+    }
+
+    func testWordsAverageConfidenceAcrossMultipleTokens() {
+        let words = STTWordTimingBuilder.words(from: [
+            TokenTiming(token: "▁pro", tokenId: 1, startTime: 0.10, endTime: 0.18, confidence: 0.2),
+            TokenTiming(token: "duc", tokenId: 2, startTime: 0.18, endTime: 0.26, confidence: 0.5),
+            TokenTiming(token: "tion", tokenId: 3, startTime: 0.26, endTime: 0.40, confidence: 0.8),
+        ])
+
+        XCTAssertEqual(words.count, 1)
+        XCTAssertEqual(words[0].word, "production")
+        XCTAssertEqual(words[0].startMs, 100)
+        XCTAssertEqual(words[0].endMs, 400)
+        XCTAssertEqual(words[0].confidence, 0.5, accuracy: 0.0001)
+    }
+}

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
@@ -1707,13 +1707,30 @@ final class TranscriptionViewModelTests: XCTestCase {
         try await waitUntil { !self.viewModel.isTranscribing }
     }
 
+    private func retranscriptionChoice(
+        _ engine: SpeechEnginePreference,
+        in option: TranscriptionViewModel.RetranscriptionEngineOption,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws -> TranscriptionViewModel.RetranscriptionEngineOption.Choice {
+        try XCTUnwrap(
+            option.choices.first { $0.selection.engine == engine },
+            "Missing retranscription choice for \(engine.rawValue)",
+            file: file,
+            line: line
+        )
+    }
+
     func testRetranscriptionEngineOptionUsesCapturedMeetingEngine() throws {
         let archivedMeeting = try makeArchivedMeetingRecording(
             speechEngine: SpeechEngineSelection(engine: .whisper, language: "KO")
         )
         defer { try? FileManager.default.removeItem(at: archivedMeeting.folderURL) }
 
-        viewModel = TranscriptionViewModel(isWhisperModelDownloaded: { true })
+        viewModel = TranscriptionViewModel(
+            isWhisperModelDownloaded: { true },
+            isNemotronModelDownloaded: { true }
+        )
         let original = Transcription(
             id: UUID(),
             fileName: "Korean Meeting",
@@ -1727,10 +1744,11 @@ final class TranscriptionViewModelTests: XCTestCase {
         let option = try XCTUnwrap(viewModel.retranscriptionEngineOption(for: original))
 
         XCTAssertEqual(option.primaryEngine, SpeechEngineSelection(engine: .whisper, language: "ko"))
-        XCTAssertEqual(option.alternativeEngine, SpeechEngineSelection(engine: .parakeet))
-        XCTAssertTrue(option.isAlternativeAvailable)
-        XCTAssertNil(option.unavailableReason)
-        XCTAssertEqual(option.title, "Try with Parakeet")
+        XCTAssertEqual(option.choices.map(\.selection.engine), [.whisper, .parakeet, .nemotron])
+        XCTAssertTrue(try retranscriptionChoice(.whisper, in: option).isPrimary)
+        XCTAssertTrue(try retranscriptionChoice(.parakeet, in: option).isAvailable)
+        XCTAssertTrue(try retranscriptionChoice(.nemotron, in: option).isAvailable)
+        XCTAssertEqual(option.title, "Retranscribe with speech engine")
     }
 
     func testRetranscriptionEngineOptionUsesCurrentSettingsForLegacyMeetingMetadata() throws {
@@ -1740,7 +1758,11 @@ final class TranscriptionViewModelTests: XCTestCase {
         SpeechEnginePreference.whisper.save(to: defaults)
         SpeechEnginePreference.saveWhisperDefaultLanguage("ja", defaults: defaults)
         SpeechEnginePreference.saveNemotronModelVariant(.english1120, defaults: defaults)
-        viewModel = TranscriptionViewModel(defaults: defaults, isWhisperModelDownloaded: { true })
+        viewModel = TranscriptionViewModel(
+            defaults: defaults,
+            isWhisperModelDownloaded: { true },
+            isNemotronModelDownloaded: { true }
+        )
 
         let archivedMeeting = try makeArchivedMeetingRecording(speechEngine: nil)
         defer { try? FileManager.default.removeItem(at: archivedMeeting.folderURL) }
@@ -1758,11 +1780,15 @@ final class TranscriptionViewModelTests: XCTestCase {
         let option = try XCTUnwrap(viewModel.retranscriptionEngineOption(for: original))
 
         XCTAssertEqual(option.primaryEngine, SpeechEngineSelection(engine: .whisper, language: "ja"))
-        XCTAssertEqual(option.alternativeEngine, SpeechEngineSelection(engine: .parakeet))
+        XCTAssertEqual(option.choices.map(\.selection.engine), [.whisper, .parakeet, .nemotron])
+        XCTAssertEqual(
+            try retranscriptionChoice(.parakeet, in: option).selection,
+            SpeechEngineSelection(engine: .parakeet)
+        )
         XCTAssertEqual(option.nemotronVariant, .english1120)
     }
 
-    func testRetranscriptionEngineOptionKeepsWhisperForParakeetWhenNemotronIsMissing() throws {
+    func testRetranscriptionEngineOptionIncludesNemotronButDisablesItWhenMissing() throws {
         let archivedMeeting = try makeArchivedMeetingRecording(
             speechEngine: SpeechEngineSelection(engine: .parakeet)
         )
@@ -1784,12 +1810,18 @@ final class TranscriptionViewModelTests: XCTestCase {
 
         let option = try XCTUnwrap(viewModel.retranscriptionEngineOption(for: original))
 
-        XCTAssertEqual(option.alternativeEngine, SpeechEngineSelection(engine: .whisper))
-        XCTAssertTrue(option.isAlternativeAvailable)
-        XCTAssertNil(option.unavailableReason)
+        XCTAssertEqual(option.choices.map(\.selection.engine), [.parakeet, .nemotron, .whisper])
+        XCTAssertTrue(try retranscriptionChoice(.parakeet, in: option).isPrimary)
+        XCTAssertTrue(try retranscriptionChoice(.whisper, in: option).isAvailable)
+        let nemotron = try retranscriptionChoice(.nemotron, in: option)
+        XCTAssertFalse(nemotron.isAvailable)
+        XCTAssertEqual(
+            nemotron.unavailableReason,
+            "Download the Nemotron model in Settings before trying Nemotron."
+        )
     }
 
-    func testRetranscriptionEngineOptionKeepsWhisperForParakeetWhenNemotronIsDownloaded() throws {
+    func testRetranscriptionEngineOptionIncludesNemotronWhenDownloaded() throws {
         let archivedMeeting = try makeArchivedMeetingRecording(
             speechEngine: SpeechEngineSelection(engine: .parakeet)
         )
@@ -1811,9 +1843,51 @@ final class TranscriptionViewModelTests: XCTestCase {
 
         let option = try XCTUnwrap(viewModel.retranscriptionEngineOption(for: original))
 
-        XCTAssertEqual(option.alternativeEngine, SpeechEngineSelection(engine: .whisper))
-        XCTAssertTrue(option.isAlternativeAvailable)
-        XCTAssertNil(option.unavailableReason)
+        XCTAssertEqual(option.choices.map(\.selection.engine), [.parakeet, .nemotron, .whisper])
+        XCTAssertTrue(try retranscriptionChoice(.nemotron, in: option).isAvailable)
+        XCTAssertNil(try retranscriptionChoice(.nemotron, in: option).unavailableReason)
+        XCTAssertTrue(try retranscriptionChoice(.whisper, in: option).isAvailable)
+    }
+
+    func testRetranscriptionEngineOptionAdvisesColdWhisperSwitch() throws {
+        let suiteName = "TranscriptionViewModelTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        SpeechEnginePreference.parakeet.save(to: defaults)
+        SpeechEnginePreference.saveWhisperModelVariant(
+            SpeechEnginePreference.defaultWhisperModelVariant,
+            defaults: defaults
+        )
+        viewModel = TranscriptionViewModel(
+            defaults: defaults,
+            isWhisperModelDownloaded: { true },
+            isNemotronModelDownloaded: { true }
+        )
+
+        let tmpFile = FileManager.default.temporaryDirectory
+            .appendingPathComponent("retranscribe-engine-cold-whisper-\(UUID().uuidString).mp3")
+        FileManager.default.createFile(atPath: tmpFile.path, contents: Data([0]))
+        defer { try? FileManager.default.removeItem(at: tmpFile) }
+
+        let original = Transcription(
+            id: UUID(),
+            fileName: "Audio File",
+            filePath: tmpFile.path,
+            durationMs: 2_000,
+            rawTranscript: "Old transcript",
+            status: .completed,
+            sourceType: .file
+        )
+
+        let option = try XCTUnwrap(viewModel.retranscriptionEngineOption(for: original))
+        let whisper = try retranscriptionChoice(.whisper, in: option)
+
+        XCTAssertTrue(whisper.isAvailable)
+        XCTAssertNil(whisper.unavailableReason)
+        XCTAssertEqual(
+            whisper.advisory,
+            "First run may spend a few minutes preparing this Whisper model."
+        )
     }
 
     func testRetranscriptionEngineOptionDisablesMissingWhisperModel() throws {
@@ -1838,9 +1912,16 @@ final class TranscriptionViewModelTests: XCTestCase {
 
         let option = try XCTUnwrap(viewModel.retranscriptionEngineOption(for: original))
 
-        XCTAssertEqual(option.alternativeEngine, SpeechEngineSelection(engine: .whisper))
-        XCTAssertFalse(option.isAlternativeAvailable)
-        XCTAssertEqual(option.unavailableReason, "Download the Whisper model in Settings before trying Whisper.")
+        XCTAssertEqual(option.choices.map(\.selection.engine), [.nemotron, .parakeet, .whisper])
+        XCTAssertTrue(try retranscriptionChoice(.nemotron, in: option).isPrimary)
+        let whisper = try retranscriptionChoice(.whisper, in: option)
+        XCTAssertFalse(whisper.isAvailable)
+        XCTAssertEqual(
+            whisper.unavailableReason,
+            "Download the Whisper model in Settings before trying Whisper."
+        )
+        XCTAssertNil(whisper.advisory)
+        XCTAssertTrue(try retranscriptionChoice(.parakeet, in: option).isAvailable)
     }
 
     func testRetranscriptionEngineOptionAvailableForYouTubeSource() throws {
@@ -1873,9 +1954,13 @@ final class TranscriptionViewModelTests: XCTestCase {
         let option = try XCTUnwrap(viewModel.retranscriptionEngineOption(for: original))
 
         XCTAssertEqual(option.primaryEngine, SpeechEngineSelection(engine: .parakeet))
-        XCTAssertEqual(option.alternativeEngine, SpeechEngineSelection(engine: .whisper))
-        XCTAssertTrue(option.isAlternativeAvailable)
-        XCTAssertNil(option.unavailableReason)
+        XCTAssertEqual(option.choices.map(\.selection.engine), [.parakeet, .nemotron, .whisper])
+        XCTAssertEqual(
+            try retranscriptionChoice(.nemotron, in: option).selection,
+            SpeechEngineSelection(engine: .nemotron, language: "en-US")
+        )
+        XCTAssertTrue(try retranscriptionChoice(.nemotron, in: option).isAvailable)
+        XCTAssertTrue(try retranscriptionChoice(.whisper, in: option).isAvailable)
     }
 
     func testRetranscriptionEngineOptionAvailableForFileSource() throws {
@@ -1884,7 +1969,11 @@ final class TranscriptionViewModelTests: XCTestCase {
         defer { defaults.removePersistentDomain(forName: suiteName) }
         SpeechEnginePreference.whisper.save(to: defaults)
         SpeechEnginePreference.saveWhisperDefaultLanguage("ko", defaults: defaults)
-        viewModel = TranscriptionViewModel(defaults: defaults, isWhisperModelDownloaded: { true })
+        viewModel = TranscriptionViewModel(
+            defaults: defaults,
+            isWhisperModelDownloaded: { true },
+            isNemotronModelDownloaded: { true }
+        )
 
         let tmpFile = FileManager.default.temporaryDirectory
             .appendingPathComponent("retranscribe-engine-file-\(UUID().uuidString).mp3")
@@ -1904,8 +1993,12 @@ final class TranscriptionViewModelTests: XCTestCase {
         let option = try XCTUnwrap(viewModel.retranscriptionEngineOption(for: original))
 
         XCTAssertEqual(option.primaryEngine, SpeechEngineSelection(engine: .whisper, language: "ko"))
-        XCTAssertEqual(option.alternativeEngine, SpeechEngineSelection(engine: .parakeet))
-        XCTAssertTrue(option.isAlternativeAvailable)
+        XCTAssertEqual(option.choices.map(\.selection.engine), [.whisper, .parakeet, .nemotron])
+        XCTAssertEqual(
+            try retranscriptionChoice(.parakeet, in: option).selection,
+            SpeechEngineSelection(engine: .parakeet)
+        )
+        XCTAssertTrue(try retranscriptionChoice(.nemotron, in: option).isAvailable)
     }
 
     func testRetranscriptionEngineOptionNilWhenFileMissing() {

--- a/docs/planning/2026-06-per-capture-speech-engine-routing.md
+++ b/docs/planning/2026-06-per-capture-speech-engine-routing.md
@@ -91,7 +91,9 @@ Nemotron is a promising meeting candidate because it is local and fast in the
 smoke benchmark, but it should stay Beta until tested on real meeting audio.
 Known caution areas:
 
-- Nemotron does not currently surface word timestamps through MacParakeet.
+- Nemotron now maps FluidAudio token timings into MacParakeet word timestamps
+  when the upstream runtime reports them, but coverage still needs real meeting
+  audio validation before treating it as a default-quality path.
 - VAD-guided live chunking is currently Parakeet-only; Nemotron meetings use the
   fixed live chunk cadence.
 - Synthetic smoke data showed good speed but not enough quality proof to make
@@ -131,7 +133,7 @@ Do not:
 - Should the first setting be `App Default` or `Parakeet` by default?
 - Should CLI expose `config set meeting-speech-engine` immediately, or wait until
   the GUI proves the setting is useful?
-- Should Nemotron be allowed for meeting live preview before word timestamps are
-  available, or should it initially apply only to final transcription?
+- What real-world meeting coverage should gate broader Nemotron live-preview
+  promotion now that token-derived word timestamps are preserved when available?
 - What minimum real-world corpus result would promote Nemotron from Beta for
   meetings?

--- a/docs/research/2026-06-14-ai-formatting-architecture-findings.md
+++ b/docs/research/2026-06-14-ai-formatting-architecture-findings.md
@@ -152,9 +152,10 @@ substantive gap behind "should meetings get special treatment" — it's
 structural (the LLM rewrite breaks word-timestamp alignment that attribution
 depends on), not a prompt-wording issue.
 
-**Engine nuance:** Nemotron surfaces **no word-level timestamps**, so a Nemotron
-meeting has no `wordTimestamps` → no `.timed` mode and effectively **no speaker
-turns at all**. Parakeet (default) and Whisper do produce word timestamps.
+**Engine nuance, historical:** at the time of this note, Nemotron did not
+surface word-level timestamps, so Nemotron meetings had no `.timed` mode or
+speaker turns. Issue #497 follow-up changed the wrappers to preserve
+FluidAudio token timings as `wordTimestamps` when available.
 
 **Already speaker-aware:** the *LLM-context* path
 (`TranscriptAIContextFormatter` rich mode) builds speaker+timestamp-labeled
@@ -191,8 +192,8 @@ speaker-attributed input. It's the *cleanup formatter* and the *default display
 - Remove dead `rawTranscriptText` accessor.
 - Transcript revert is one-way vs dictation's reversible toggle — unify via the
   planned viewer.
-- Nemotron meetings get no speaker turns (word-timestamp limitation) — document
-  or warn?
+- Nemotron meeting speaker turns depended on surfacing upstream token timings;
+  issue #497 follow-up changed the wrappers to preserve them when available.
 
 ## 10. File map (where each concern lives)
 

--- a/spec/03-architecture.md
+++ b/spec/03-architecture.md
@@ -719,7 +719,7 @@ Speech recognition runs in the app process. Parakeet via FluidAudio CoreML on th
 | Model | Nemotron 3.5 ASR Streaming 0.6B (`nemotron-multilingual-1120ms`, default) / Nemotron Speech Streaming EN 0.6B (`nemotron-english-1120ms`, English-only) |
 | Runtime | FluidAudio CoreML streaming path |
 | Sizes | ~1.5 GB (multilingual) / ~600 MB (English) |
-| Output | Text + detected/specified language; no word-level timestamps surfaced |
+| Output | Text + token-derived word-level timestamps when FluidAudio reports token timings + detected/specified language |
 | Model cache | FluidAudio cache (`nemotron-multilingual/` and `nemotron-streaming/<tier>ms`) |
 | Selection | Settings speech-engine + Nemotron Model picker, or CLI `--engine nemotron --nemotron-model <id>` |
 

--- a/spec/06-stt-engine.md
+++ b/spec/06-stt-engine.md
@@ -46,7 +46,7 @@ Unified build, all exposed to the user as selectable Parakeet models:
 | Model | Nemotron 3.5 ASR Streaming 0.6B (`multilingual-1120ms`, default) / Nemotron Speech Streaming EN 0.6B (`english-1120ms`, English-only, ~600 MB) |
 | Runtime | FluidAudio streaming Nemotron CoreML path |
 | Model cache | FluidAudio model cache under `~/Library/Application Support/FluidAudio/Models/` |
-| Output | Text and detected/specified language when reported; word timestamps are not currently surfaced through MacParakeet |
+| Output | Text, token-derived word timestamps when FluidAudio reports token timings, and detected/specified language when reported |
 | Languages | Multilingual build: 40 language-locales upstream; English build: English only (ignores the `nemotron-language` hint); both exposed as opt-in Beta while MacParakeet benchmarks quality on real product audio |
 | Selection | Explicit in Settings or CLI (`--engine nemotron --language <code>`); build via the Settings *Nemotron Model* card, `config set nemotron-model`, or `transcribe --nemotron-model`; no automatic fallback |
 | Download | ~1.5 GB (multilingual) / ~600 MB (English), explicit Settings/CLI download before selecting as the shared default |

--- a/spec/adr/001-parakeet-stt.md
+++ b/spec/adr/001-parakeet-stt.md
@@ -128,6 +128,12 @@ Parakeet remains the default engine for dictation, file transcription, and meeti
 
 Nemotron is labeled Beta because the first MacParakeet smoke benchmark showed strong warm-path speed but weaker English-heavy transcript quality than Parakeet on the synthetic corpus. It should not replace Parakeet as the default without a larger real-world dictation/meeting benchmark.
 
+> Amendment (2026-06-20): MacParakeet now preserves FluidAudio's Nemotron token
+> timings through `finishWithTokenTimings()` and maps them into `STTResult.words`
+> for both Nemotron builds. Timed transcript views, subtitle exports, and
+> meeting speaker-turn assembly can therefore use Nemotron timestamps when the
+> upstream manager reports them; the engine remains Beta for quality reasons.
+
 ## Addendum: Nemotron English Beta Build (June 2026)
 
 > Date: 2026-06-11
@@ -149,9 +155,9 @@ Nemotron model preference (Settings build picker, `config set nemotron-model`,
   `research/stt-models-voice-personalization` branch pending merge).
 
 Scope notes: file and meeting jobs run batch-at-stop through the streaming
-manager; the EN build exposes no word-level timestamps or confidence scores
-(the established Nemotron posture), and only the 1120 ms tier is surfaced.
-Build swaps follow the same scheduler guards as
+manager; MacParakeet maps FluidAudio token timings into word-level timestamps
+when the EN build reports them, and only the 1120 ms tier is surfaced. Build
+swaps follow the same scheduler guards as
 Parakeet v2/v3 swaps (ADR-016). License posture: FluidAudio and its CoreML
 conversion are Apache-2.0, but upstream NVIDIA model terms are not publicly
 verifiable, so the model stays a user-triggered download — never bundled.


### PR DESCRIPTION
## Summary

Fixes #497 by making retranscribe choices explicit across all local STT engines:

- Shows Parakeet, Nemotron, and Whisper in the retranscribe popover, with the current/original engine first.
- Keeps reruns one-off: choosing another engine passes an override for that retranscription only and does not change the global Settings selection.
- Disables unavailable optional engines with direct Settings download guidance, and surfaces the cold Whisper preparation advisory when relevant.
- Adds a close affordance, clearer badges, hover/help text, and accessibility labels/hints for the popover cards.
- Preserves FluidAudio Nemotron token timings as `STTResult.words` when the upstream runtime reports them, so timed transcript views, subtitles, and speaker-turn assembly can use Nemotron timestamps.
- Aligns STT docs/specs/ADR notes with the new Nemotron timestamp behavior. README intentionally untouched.

## Review Feedback

- Addressed Gemini comments by making retranscribe choices `Identifiable`, using `ForEach(option.choices)`, and replacing explicit whitespace-prefix checks with `first?.isWhitespace`.
- Addressed Greptile P2 comments by adding coverage for the cold Whisper advisory path and extra `STTWordTimingBuilder` edge cases.

## Validation

- `swift test --filter 'TranscriptionViewModelTests|STTWordTimingBuilderTests'`
  - 103 tests, 0 failures
- `swift test`
  - 3,971 tests, 10 skipped, 0 failures
  - Swift Testing suites: 16 tests, 0 failures
- `git diff --check`
- `scripts/check-readme-references.sh`
- GitHub CI `swift-test` on `74908c0ad`: 2/2 successful

## Screenshot

Not attached. A `MacParakeet-Dev.app` from latest `main` was already running locally, and replacing it just for this PR screenshot would have interrupted the current dev session. I avoided using a mock screenshot.
