### PR TITLE
Make the dictation undo countdown configurable

### DIFF
--- a/Sources/MacParakeet/App/DictationFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/DictationFlowCoordinator.swift
@@ -352,6 +352,7 @@ final class DictationFlowCoordinator {
     func cancelDictation(reason: TelemetryDictationCancelReason = .ui) {
         // Map telemetry reason to state machine cancel reason
         let flowReason: DictationFlowCancelReason = reason == .ui ? .ui : .escape
+        stateMachine.undoCountdownSeconds = runtimePreferences.dictationUndoCountdown.seconds
         sendEvent(.cancelRequested(reason: flowReason))
     }
 
@@ -481,8 +482,10 @@ final class DictationFlowCoordinator {
 
         case .showCancelCountdown:
             overlayViewModel?.stopTimer()
-            overlayViewModel?.cancelTimeRemaining = 5.0
-            overlayViewModel?.state = .cancelled(timeRemaining: 5.0)
+            let seconds = stateMachine.undoCountdownSeconds ?? 5.0
+            overlayViewModel?.cancelCountdownDuration = seconds
+            overlayViewModel?.cancelTimeRemaining = seconds
+            overlayViewModel?.state = .cancelled(timeRemaining: seconds)
 
         case .showSuccess:
             dismissCaption(outcome: .success)
@@ -709,11 +712,13 @@ final class DictationFlowCoordinator {
             readyDismissTimer?.cancel()
             readyDismissTimer = nil
 
-        case .startCancelCountdown:
+        case .startCancelCountdown(let seconds):
             let gen = stateMachine.generation
             cancelCountdownTask = Task { @MainActor in
-                // 5-second countdown, updating UI each second
-                for i in stride(from: 4.0, through: 0, by: -1) {
+                self.overlayViewModel?.cancelCountdownDuration = seconds
+                self.overlayViewModel?.cancelTimeRemaining = seconds
+                // Countdown, updating UI each second
+                for i in stride(from: seconds - 1, through: 0, by: -1) {
                     try? await Task.sleep(for: .seconds(1))
                     if Task.isCancelled { return }
                     self.overlayViewModel?.cancelTimeRemaining = i

--- a/Sources/MacParakeet/App/DictationFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/DictationFlowCoordinator.swift
@@ -551,9 +551,15 @@ final class DictationFlowCoordinator {
                 )
             }
 
-        case .confirmCancel:
+        case .confirmCancel(let reason):
             let sessionID = serviceSession.currentSessionID
             Task { @MainActor in
+                if let reason {
+                    await self.serviceSession.cancelRecording(
+                        reason: self.telemetryCancelReason(for: reason),
+                        sessionID: sessionID
+                    )
+                }
                 await self.serviceSession.confirmCancel(sessionID: sessionID)
             }
 
@@ -715,8 +721,6 @@ final class DictationFlowCoordinator {
         case .startCancelCountdown(let seconds):
             let gen = stateMachine.generation
             cancelCountdownTask = Task { @MainActor in
-                self.overlayViewModel?.cancelCountdownDuration = seconds
-                self.overlayViewModel?.cancelTimeRemaining = seconds
                 // Countdown, updating UI each second
                 for i in stride(from: seconds - 1, through: 0, by: -1) {
                     try? await Task.sleep(for: .seconds(1))

--- a/Sources/MacParakeet/Views/Dictation/DictationOverlayController.swift
+++ b/Sources/MacParakeet/Views/Dictation/DictationOverlayController.swift
@@ -232,6 +232,7 @@ final class DictationOverlayViewModel {
 
     /// Cancel countdown value (separate from state enum to avoid view reconstruction jank).
     var cancelTimeRemaining: Double = 5.0
+    var cancelCountdownDuration: Double = 5.0
 
     private var timerTask: Task<Void, Never>?
     private var busyMessageTask: Task<Void, Never>?

--- a/Sources/MacParakeet/Views/Dictation/DictationOverlayView.swift
+++ b/Sources/MacParakeet/Views/Dictation/DictationOverlayView.swift
@@ -673,7 +673,10 @@ struct DictationOverlayView: View {
                     .frame(width: 24, height: 24)
 
                 Circle()
-                    .trim(from: 0, to: CGFloat(viewModel.cancelTimeRemaining / 5.0))
+                    .trim(
+                        from: 0,
+                        to: CGFloat(viewModel.cancelTimeRemaining / max(viewModel.cancelCountdownDuration, 1.0))
+                    )
                     .stroke(Color.accentColor, style: StrokeStyle(lineWidth: 1.5, lineCap: .round))
                     .frame(width: 24, height: 24)
                     .rotationEffect(.degrees(-90))

--- a/Sources/MacParakeet/Views/Dictation/DictationOverlayView.swift
+++ b/Sources/MacParakeet/Views/Dictation/DictationOverlayView.swift
@@ -675,7 +675,10 @@ struct DictationOverlayView: View {
                 Circle()
                     .trim(
                         from: 0,
-                        to: CGFloat(viewModel.cancelTimeRemaining / max(viewModel.cancelCountdownDuration, 1.0))
+                        to: CGFloat(
+                            viewModel.cancelTimeRemaining
+                                / (viewModel.cancelCountdownDuration > 0 ? viewModel.cancelCountdownDuration : 1.0)
+                        )
                     )
                     .stroke(Color.accentColor, style: StrokeStyle(lineWidth: 1.5, lineCap: .round))
                     .frame(width: 24, height: 24)

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -1072,6 +1072,23 @@ struct SettingsView: View {
                 }
 
                 Divider()
+                HStack(alignment: .center) {
+                    rowText(
+                        title: "Undo window",
+                        detail: "How long cancel waits before discarding a dictation."
+                    )
+                    Spacer(minLength: DesignSystem.Spacing.md)
+                    Picker("Undo window", selection: $viewModel.dictationUndoCountdown) {
+                        ForEach(DictationUndoCountdown.allCases, id: \.self) { countdown in
+                            Text(countdown.displayTitle).tag(countdown)
+                        }
+                    }
+                    .labelsHidden()
+                    .pickerStyle(.segmented)
+                    .frame(width: 200)
+                }
+
+                Divider()
 
                 settingsToggleRow(
                     title: "Auto-stop after silence",

--- a/Sources/MacParakeetCore/AppRuntimePreferences.swift
+++ b/Sources/MacParakeetCore/AppRuntimePreferences.swift
@@ -23,6 +23,7 @@ public protocol AppRuntimePreferencesProtocol: Sendable {
     var instantDictationEnabled: Bool { get }
     var showLiveDictationPreview: Bool { get }
     var dictationPreviewTextSize: DictationPreviewTextSize { get }
+    var dictationUndoCountdown: DictationUndoCountdown { get }
     var shouldKeepDictationOnClipboard: Bool { get }
     var hasCompletedFirstDictation: Bool { get }
     /// Flip the one-shot "first dictation completed" flag. Returns `true` only
@@ -245,6 +246,44 @@ public enum DictationPreviewTextSize: String, CaseIterable, Hashable, Sendable, 
     }
 }
 
+public enum DictationUndoCountdown: String, CaseIterable, Hashable, Sendable, Equatable {
+    case fiveSeconds = "fiveSeconds"
+    case oneSecond = "oneSecond"
+    case off = "off"
+
+    public var seconds: Double? {
+        switch self {
+        case .fiveSeconds:
+            return 5
+        case .oneSecond:
+            return 1
+        case .off:
+            return nil
+        }
+    }
+
+    public var isDisabled: Bool { seconds == nil }
+
+    public var displayTitle: String {
+        switch self {
+        case .fiveSeconds:
+            return "5 seconds"
+        case .oneSecond:
+            return "1 second"
+        case .off:
+            return "Off"
+        }
+    }
+
+    public static func current(defaults: UserDefaults = .standard) -> DictationUndoCountdown {
+        guard let raw = defaults.string(forKey: UserDefaultsAppRuntimePreferences.dictationUndoCountdownKey),
+              let countdown = DictationUndoCountdown(rawValue: raw) else {
+            return .fiveSeconds
+        }
+        return countdown
+    }
+}
+
 public enum TranscriptAIContextMode: String, CaseIterable, Codable, Identifiable, Sendable, Equatable {
     case richTranscript = "rich_transcript"
     case plainTranscript = "plain_transcript"
@@ -452,6 +491,7 @@ public final class UserDefaultsAppRuntimePreferences: AppRuntimePreferencesProto
     public static let instantDictationEnabledKey = "instantDictationEnabled"
     public static let showLiveDictationPreviewKey = "showLiveDictationPreview"
     public static let dictationPreviewTextSizeKey = "dictationPreviewTextSize"
+    public static let dictationUndoCountdownKey = "dictationUndoCountdown"
     public static let keepDictationOnClipboardKey = "keepDictationOnClipboard"
     public static let hasCompletedFirstDictationKey = "hasCompletedFirstDictation"
     /// Play a chime (and, when backgrounded, post a banner) when a file/URL
@@ -564,6 +604,10 @@ public final class UserDefaultsAppRuntimePreferences: AppRuntimePreferencesProto
 
     public var dictationPreviewTextSize: DictationPreviewTextSize {
         DictationPreviewTextSize.current(defaults: defaults)
+    }
+
+    public var dictationUndoCountdown: DictationUndoCountdown {
+        DictationUndoCountdown.current(defaults: defaults)
     }
 
     public var shouldKeepDictationOnClipboard: Bool {

--- a/Sources/MacParakeetCore/AppRuntimePreferences.swift
+++ b/Sources/MacParakeetCore/AppRuntimePreferences.swift
@@ -262,8 +262,6 @@ public enum DictationUndoCountdown: String, CaseIterable, Hashable, Sendable, Eq
         }
     }
 
-    public var isDisabled: Bool { seconds == nil }
-
     public var displayTitle: String {
         switch self {
         case .fiveSeconds:

--- a/Sources/MacParakeetCore/DictationFlow/DictationFlowStateMachine.swift
+++ b/Sources/MacParakeetCore/DictationFlow/DictationFlowStateMachine.swift
@@ -22,7 +22,7 @@ public enum DictationFlowState: Equatable, Sendable {
     case pendingStop(mode: FnKeyStateMachine.RecordingMode)
     /// Stop called, transcription in progress.
     case processing
-    /// Cancel countdown running (5 seconds). User can undo or confirm.
+    /// Cancel countdown running. User can undo or confirm.
     case cancelCountdown
     /// Terminal display state before returning to idle.
     case finishing(outcome: DictationFlowFinishOutcome)
@@ -132,7 +132,7 @@ public enum DictationFlowEffect: Equatable, Sendable {
     // Timer management
     case startReadyDismissTimer
     case cancelReadyDismissTimer
-    case startCancelCountdown
+    case startCancelCountdown(seconds: Double)
     case cancelCancelCountdown
     case startDisplayDismissTimer(seconds: Double)
     case cancelAllTimers
@@ -151,6 +151,7 @@ public enum DictationFlowEffect: Equatable, Sendable {
 public struct DictationFlowStateMachine: Sendable, Equatable {
     public private(set) var state: DictationFlowState = .idle
     public private(set) var generation: Int = 0
+    public var undoCountdownSeconds: Double? = 5
 
     public init() {}
 
@@ -295,10 +296,29 @@ public struct DictationFlowStateMachine: Sendable, Equatable {
             return effects
 
         case (.recording, .cancelRequested(let reason)):
+            guard let undoCountdownSeconds else {
+                // Undo window disabled: discard the recording immediately and
+                // return to idle. .confirmCancel performs the full teardown in a
+                // single ordered service operation (it tears down an in-flight
+                // recording itself), so we must NOT also emit .cancelRecording:
+                // the two run as separate async effects and could interleave,
+                // double-stopping capture and racing the cancelled state.
+                // Deliberately omits .notifyHotkeyCancelledByUI: that effect
+                // blocks every hotkey until a later reset, but there is no
+                // countdown to expire on this path, so it would leave dictation
+                // shortcuts stuck. .resetHotkeyStateMachine returns them to idle.
+                state = .idle
+                return [
+                    .cancelRecordingTask, .confirmCancel, .hideOverlay,
+                    .resetHotkeyStateMachine, .updateMenuBar(.idle),
+                    .showIdlePill,
+                ]
+            }
             state = .cancelCountdown
             return [
                 .cancelRecordingTask, .cancelRecording(reason: reason),
-                .showCancelCountdown, .updateMenuBar(.idle), .startCancelCountdown,
+                .showCancelCountdown, .updateMenuBar(.idle),
+                .startCancelCountdown(seconds: undoCountdownSeconds),
                 .notifyHotkeyCancelledByUI,
             ]
 

--- a/Sources/MacParakeetCore/DictationFlow/DictationFlowStateMachine.swift
+++ b/Sources/MacParakeetCore/DictationFlow/DictationFlowStateMachine.swift
@@ -112,7 +112,9 @@ public enum DictationFlowEffect: Equatable, Sendable {
     case stopRecordingAndTranscribe
     case cancelRecording(reason: DictationFlowCancelReason)
     case discardRecording
-    case confirmCancel
+    /// Confirm a pending cancel. Pass a reason only when cancel telemetry has
+    /// not already been recorded by a preceding `cancelRecording` effect.
+    case confirmCancel(reason: DictationFlowCancelReason?)
     case undoCancelAndTranscribe
 
     // Paste
@@ -297,19 +299,18 @@ public struct DictationFlowStateMachine: Sendable, Equatable {
 
         case (.recording, .cancelRequested(let reason)):
             guard let undoCountdownSeconds else {
-                // Undo window disabled: discard the recording immediately and
-                // return to idle. .confirmCancel performs the full teardown in a
-                // single ordered service operation (it tears down an in-flight
-                // recording itself), so we must NOT also emit .cancelRecording:
-                // the two run as separate async effects and could interleave,
-                // double-stopping capture and racing the cancelled state.
+                // Undo window disabled: record the cancel reason and discard
+                // immediately in one ordered coordinator task. Do not emit a
+                // separate .cancelRecording effect here; separate async effects
+                // could interleave, double-stop capture, and race the cancelled
+                // state.
                 // Deliberately omits .notifyHotkeyCancelledByUI: that effect
                 // blocks every hotkey until a later reset, but there is no
                 // countdown to expire on this path, so it would leave dictation
                 // shortcuts stuck. .resetHotkeyStateMachine returns them to idle.
                 state = .idle
                 return [
-                    .cancelRecordingTask, .confirmCancel, .hideOverlay,
+                    .cancelRecordingTask, .confirmCancel(reason: reason), .hideOverlay,
                     .resetHotkeyStateMachine, .updateMenuBar(.idle),
                     .showIdlePill,
                 ]
@@ -417,7 +418,7 @@ public struct DictationFlowStateMachine: Sendable, Equatable {
             state = .idle
             return [
                 .cancelCancelCountdown, .cancelActionTask,
-                .confirmCancel, .hideOverlay,
+                .confirmCancel(reason: nil), .hideOverlay,
                 .resetHotkeyStateMachine, .updateMenuBar(.idle), .showIdlePill,
             ]
 
@@ -425,7 +426,7 @@ public struct DictationFlowStateMachine: Sendable, Equatable {
             guard gen == generation else { return [] }
             state = .idle
             return [
-                .confirmCancel, .hideOverlay,
+                .confirmCancel(reason: nil), .hideOverlay,
                 .resetHotkeyStateMachine, .updateMenuBar(.idle), .showIdlePill,
             ]
 
@@ -435,7 +436,7 @@ public struct DictationFlowStateMachine: Sendable, Equatable {
             state = .checkingEntitlements(mode: mode)
             return [
                 .cancelCancelCountdown, .cancelActionTask,
-                .confirmCancel, .hideOverlay,
+                .confirmCancel(reason: nil), .hideOverlay,
                 .hideIdlePill, .checkEntitlements, .resetHotkeyStateMachine,
             ]
 
@@ -443,7 +444,7 @@ public struct DictationFlowStateMachine: Sendable, Equatable {
             state = .idle
             return [
                 .cancelAllTimers, .cancelActionTask,
-                .confirmCancel, .hideOverlay,
+                .confirmCancel(reason: nil), .hideOverlay,
                 .resetHotkeyStateMachine, .updateMenuBar(.idle), .showIdlePill,
             ]
 
@@ -452,7 +453,7 @@ public struct DictationFlowStateMachine: Sendable, Equatable {
             state = .idle
             return [
                 .cancelCancelCountdown, .cancelActionTask,
-                .confirmCancel, .hideOverlay,
+                .confirmCancel(reason: nil), .hideOverlay,
                 .resetHotkeyStateMachine, .updateMenuBar(.idle), .showIdlePill,
             ]
 

--- a/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
+++ b/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
@@ -503,6 +503,7 @@ public enum TelemetrySettingName: String, Sendable, Equatable {
     case pauseMediaDuringDictation = "pause_media_during_dictation"
     case instantDictation = "instant_dictation"
     case liveDictationPreview = "live_dictation_preview"
+    case dictationUndoCountdown = "dictation_undo_countdown"
     case dictationInsertionStyle = "dictation_insertion_style"
     case transcriptionCompletionNotification = "transcription_completion_notification"
 

--- a/Sources/MacParakeetViewModels/SettingsSearchIndex.swift
+++ b/Sources/MacParakeetViewModels/SettingsSearchIndex.swift
@@ -161,6 +161,14 @@ public enum SettingsSearchIndex {
             cardAnchor: "dictation"
         ),
         SettingsSearchEntry(
+            id: "dictation.undo.window",
+            tab: .capture,
+            title: "Undo window",
+            subtitle: "in Dictation",
+            keywords: ["undo", "cancel", "countdown", "timer", "wait", "discard", "off", "disable"],
+            cardAnchor: "dictation"
+        ),
+        SettingsSearchEntry(
             id: "transcription",
             tab: .capture,
             title: "Transcription",

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -237,6 +237,16 @@ public final class SettingsViewModel {
             Telemetry.send(.settingChanged(setting: .liveDictationPreview))
         }
     }
+    public var dictationUndoCountdown: DictationUndoCountdown {
+        didSet {
+            guard dictationUndoCountdown != oldValue else { return }
+            defaults.set(
+                dictationUndoCountdown.rawValue,
+                forKey: UserDefaultsAppRuntimePreferences.dictationUndoCountdownKey
+            )
+            Telemetry.send(.settingChanged(setting: .dictationUndoCountdown))
+        }
+    }
     public var microphoneDeviceOptions: [MicrophoneDeviceOption] = []
     public var microphoneTestState: MicrophoneTestState = .idle
     public var microphoneTestLevel: Float = 0
@@ -634,6 +644,7 @@ public final class SettingsViewModel {
             forKey: UserDefaultsAppRuntimePreferences.showLiveDictationPreviewKey
         ) as? Bool ?? true
         dictationPreviewTextSize = DictationPreviewTextSize.current(defaults: defaults)
+        dictationUndoCountdown = DictationUndoCountdown.current(defaults: defaults)
         voiceReturnEnabled = defaults.bool(forKey: UserDefaultsAppRuntimePreferences.voiceReturnEnabledKey)
         voiceReturnTrigger = defaults.string(forKey: UserDefaultsAppRuntimePreferences.voiceReturnTriggerKey) ?? "press return"
         processingMode = Self.normalizedProcessingMode(defaults.string(forKey: UserDefaultsAppRuntimePreferences.processingModeKey))

--- a/Tests/MacParakeetTests/AppRuntimePreferencesTests.swift
+++ b/Tests/MacParakeetTests/AppRuntimePreferencesTests.swift
@@ -39,6 +39,38 @@ final class AppRuntimePreferencesTests: XCTestCase {
         XCTAssertTrue(preferences.shouldKeepDictationOnClipboard)
     }
 
+    func testDictationUndoCountdownDefaultsToFiveSeconds() {
+        let preferences = makePreferences()
+        XCTAssertEqual(preferences.dictationUndoCountdown, .fiveSeconds)
+        XCTAssertEqual(preferences.dictationUndoCountdown.seconds, 5)
+    }
+
+    func testDictationUndoCountdownRoundTripsStoredValue() {
+        for countdown in DictationUndoCountdown.allCases {
+            let defaults = UserDefaults(suiteName: "app-runtime-prefs-\(UUID().uuidString)")!
+            defaults.set(
+                countdown.rawValue,
+                forKey: UserDefaultsAppRuntimePreferences.dictationUndoCountdownKey
+            )
+            XCTAssertEqual(DictationUndoCountdown.current(defaults: defaults), countdown)
+        }
+    }
+
+    func testDictationUndoCountdownFallsBackForUnknownValue() {
+        let defaults = UserDefaults(suiteName: "app-runtime-prefs-\(UUID().uuidString)")!
+        defaults.set(
+            "not-a-real-value",
+            forKey: UserDefaultsAppRuntimePreferences.dictationUndoCountdownKey
+        )
+        XCTAssertEqual(DictationUndoCountdown.current(defaults: defaults), .fiveSeconds)
+    }
+
+    func testDictationUndoCountdownOffIsDisabled() {
+        XCTAssertTrue(DictationUndoCountdown.off.isDisabled)
+        XCTAssertNil(DictationUndoCountdown.off.seconds)
+        XCTAssertFalse(DictationUndoCountdown.fiveSeconds.isDisabled)
+    }
+
     func testSaveMeetingAudioDefaultsToTrueAndReadsLegacyValueBeforeMigration() {
         let suite = "app-runtime-prefs-\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suite)!

--- a/Tests/MacParakeetTests/AppRuntimePreferencesTests.swift
+++ b/Tests/MacParakeetTests/AppRuntimePreferencesTests.swift
@@ -65,10 +65,10 @@ final class AppRuntimePreferencesTests: XCTestCase {
         XCTAssertEqual(DictationUndoCountdown.current(defaults: defaults), .fiveSeconds)
     }
 
-    func testDictationUndoCountdownOffIsDisabled() {
-        XCTAssertTrue(DictationUndoCountdown.off.isDisabled)
+    func testDictationUndoCountdownOffMapsToNilSeconds() {
         XCTAssertNil(DictationUndoCountdown.off.seconds)
-        XCTAssertFalse(DictationUndoCountdown.fiveSeconds.isDisabled)
+        XCTAssertEqual(DictationUndoCountdown.oneSecond.seconds, 1)
+        XCTAssertEqual(DictationUndoCountdown.fiveSeconds.seconds, 5)
     }
 
     func testSaveMeetingAudioDefaultsToTrueAndReadsLegacyValueBeforeMigration() {

--- a/Tests/MacParakeetTests/DictationFlow/DictationFlowStateMachineTests.swift
+++ b/Tests/MacParakeetTests/DictationFlow/DictationFlowStateMachineTests.swift
@@ -406,12 +406,12 @@ final class DictationFlowStateMachineTests: XCTestCase {
         XCTAssertFalse(effects.contains(.startCancelCountdown(seconds: 5)))
         XCTAssertFalse(effects.contains(.startCancelCountdown(seconds: 1)))
         XCTAssertTrue(effects.contains(.cancelRecordingTask))
-        XCTAssertTrue(effects.contains(.confirmCancel))
+        XCTAssertTrue(effects.contains(.confirmCancel(reason: .escape)))
         XCTAssertTrue(effects.contains(.hideOverlay))
         XCTAssertTrue(effects.contains(.showIdlePill))
         XCTAssertTrue(effects.contains(.resetHotkeyStateMachine))
-        // confirmCancel performs the full teardown itself; emitting cancelRecording
-        // too would race the two async effects.
+        // confirmCancel carries the reason so the coordinator can record cancel
+        // telemetry and discard in one ordered task.
         XCTAssertFalse(effects.contains(.cancelRecording(reason: .escape)))
         // Must NOT block hotkeys: there is no countdown to expire on this path,
         // so notifyHotkeyCancelledByUI would leave dictation shortcuts stuck.
@@ -620,7 +620,7 @@ final class DictationFlowStateMachineTests: XCTestCase {
         let effects = m.handle(.cancelConfirmedImmediate)
         XCTAssertEqual(m.state, .idle)
         XCTAssertTrue(effects.contains(.cancelCancelCountdown))
-        XCTAssertTrue(effects.contains(.confirmCancel))
+        XCTAssertTrue(effects.contains(.confirmCancel(reason: nil)))
         XCTAssertTrue(effects.contains(.hideOverlay))
         XCTAssertTrue(effects.contains(.resetHotkeyStateMachine))
     }
@@ -631,7 +631,7 @@ final class DictationFlowStateMachineTests: XCTestCase {
 
         let effects = m.handle(.cancelCountdownExpired(generation: gen))
         XCTAssertEqual(m.state, .idle)
-        XCTAssertTrue(effects.contains(.confirmCancel))
+        XCTAssertTrue(effects.contains(.confirmCancel(reason: nil)))
         XCTAssertTrue(effects.contains(.hideOverlay))
         XCTAssertTrue(effects.contains(.resetHotkeyStateMachine))
         XCTAssertTrue(effects.contains(.showIdlePill))
@@ -653,7 +653,7 @@ final class DictationFlowStateMachineTests: XCTestCase {
         XCTAssertEqual(m.state, .checkingEntitlements(mode: .persistent))
         XCTAssertEqual(m.generation, oldGen + 1)
         XCTAssertTrue(effects.contains(.cancelCancelCountdown))
-        XCTAssertTrue(effects.contains(.confirmCancel))
+        XCTAssertTrue(effects.contains(.confirmCancel(reason: nil)))
         XCTAssertTrue(effects.contains(.hideOverlay))
         XCTAssertTrue(effects.contains(.checkEntitlements))
     }
@@ -664,7 +664,7 @@ final class DictationFlowStateMachineTests: XCTestCase {
         let effects = m.handle(.dismissRequested)
         XCTAssertEqual(m.state, .idle)
         XCTAssertTrue(effects.contains(.cancelAllTimers))
-        XCTAssertTrue(effects.contains(.confirmCancel))
+        XCTAssertTrue(effects.contains(.confirmCancel(reason: nil)))
         XCTAssertTrue(effects.contains(.hideOverlay))
     }
 
@@ -674,7 +674,7 @@ final class DictationFlowStateMachineTests: XCTestCase {
         // Second cancel while in countdown = confirm immediately
         let effects = m.handle(.cancelRequested(reason: .escape))
         XCTAssertEqual(m.state, .idle)
-        XCTAssertTrue(effects.contains(.confirmCancel))
+        XCTAssertTrue(effects.contains(.confirmCancel(reason: nil)))
         XCTAssertTrue(effects.contains(.hideOverlay))
     }
 
@@ -933,7 +933,7 @@ final class DictationFlowStateMachineTests: XCTestCase {
 
         let effects = m.handle(.cancelCountdownExpired(generation: gen))
         XCTAssertEqual(m.state, .idle)
-        XCTAssertTrue(effects.contains(.confirmCancel))
+        XCTAssertTrue(effects.contains(.confirmCancel(reason: nil)))
     }
 
     func testCancelFlowUndo() {

--- a/Tests/MacParakeetTests/DictationFlow/DictationFlowStateMachineTests.swift
+++ b/Tests/MacParakeetTests/DictationFlow/DictationFlowStateMachineTests.swift
@@ -372,7 +372,7 @@ final class DictationFlowStateMachineTests: XCTestCase {
         XCTAssertTrue(effects.contains(.cancelRecordingTask))
         XCTAssertTrue(effects.contains(.cancelRecording(reason: .escape)))
         XCTAssertTrue(effects.contains(.showCancelCountdown))
-        XCTAssertTrue(effects.contains(.startCancelCountdown))
+        XCTAssertTrue(effects.contains(.startCancelCountdown(seconds: 5)))
         XCTAssertTrue(effects.contains(.updateMenuBar(.idle)))
         // Always emitted (old code always calls notifyCancelledByUI)
         XCTAssertTrue(effects.contains(.notifyHotkeyCancelledByUI))
@@ -384,6 +384,50 @@ final class DictationFlowStateMachineTests: XCTestCase {
         let effects = m.handle(.cancelRequested(reason: .ui))
         XCTAssertEqual(m.state, .cancelCountdown)
         XCTAssertTrue(effects.contains(.notifyHotkeyCancelledByUI))
+    }
+
+    func testRecordingCancelRequestedShortCountdownEmitsConfiguredDuration() {
+        var m = machineInRecording()
+        m.undoCountdownSeconds = 1
+
+        let effects = m.handle(.cancelRequested(reason: .escape))
+        XCTAssertEqual(m.state, .cancelCountdown)
+        XCTAssertTrue(effects.contains(.startCancelCountdown(seconds: 1)))
+        XCTAssertFalse(effects.contains(.startCancelCountdown(seconds: 5)))
+    }
+
+    func testRecordingCancelRequestedDisabledCountdownSkipsToConfirm() {
+        var m = machineInRecording()
+        m.undoCountdownSeconds = nil
+
+        let effects = m.handle(.cancelRequested(reason: .escape))
+        XCTAssertEqual(m.state, .idle)
+        XCTAssertFalse(effects.contains(.showCancelCountdown))
+        XCTAssertFalse(effects.contains(.startCancelCountdown(seconds: 5)))
+        XCTAssertFalse(effects.contains(.startCancelCountdown(seconds: 1)))
+        XCTAssertTrue(effects.contains(.cancelRecordingTask))
+        XCTAssertTrue(effects.contains(.confirmCancel))
+        XCTAssertTrue(effects.contains(.hideOverlay))
+        XCTAssertTrue(effects.contains(.showIdlePill))
+        XCTAssertTrue(effects.contains(.resetHotkeyStateMachine))
+        // confirmCancel performs the full teardown itself; emitting cancelRecording
+        // too would race the two async effects.
+        XCTAssertFalse(effects.contains(.cancelRecording(reason: .escape)))
+        // Must NOT block hotkeys: there is no countdown to expire on this path,
+        // so notifyHotkeyCancelledByUI would leave dictation shortcuts stuck.
+        XCTAssertFalse(effects.contains(.notifyHotkeyCancelledByUI))
+    }
+
+    func testCancelCountdownUndoReturnsToProcessing() {
+        var m = machineInRecording()
+        _ = m.handle(.cancelRequested(reason: .escape))
+        XCTAssertEqual(m.state, .cancelCountdown)
+
+        let effects = m.handle(.undoRequested)
+        XCTAssertEqual(m.state, .processing)
+        XCTAssertTrue(effects.contains(.cancelCancelCountdown))
+        XCTAssertTrue(effects.contains(.undoCancelAndTranscribe))
+        XCTAssertTrue(effects.contains(.showProcessingState))
     }
 
     func testRecordingDiscardRequestedShowsReadyPill() {

--- a/Tests/MacParakeetTests/Services/Dictation/DictationServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/Dictation/DictationServiceTests.swift
@@ -178,6 +178,29 @@ final class DictationServiceTests: XCTestCase {
                 && operation["trigger"] == "hotkey"
                 && operation["mode"] == "hold"
                 && operation["cancel_reason"] == "hotkey"
+            })
+    }
+
+    func testCancelThenConfirmEmitsCancelledTelemetryAndOperationReason() async throws {
+        let telemetry = DictationTelemetrySpy()
+        Telemetry.configure(telemetry)
+
+        try await service.startRecording(context: DictationTelemetryContext(trigger: .hotkey, mode: .hold))
+        await service.cancelRecording(reason: .escape)
+        await service.confirmCancel()
+
+        let events = telemetry.snapshot()
+        XCTAssertTrue(events.contains { event in
+            guard case .dictationCancelled = event else { return false }
+            return event.props?["reason"] == "escape"
+        })
+
+        let operations = dictationOperationProps(in: events)
+        XCTAssertTrue(operations.contains { operation in
+            operation["outcome"] == "cancelled"
+                && operation["trigger"] == "hotkey"
+                && operation["mode"] == "hold"
+                && operation["cancel_reason"] == "escape"
         })
     }
 

--- a/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
@@ -146,6 +146,7 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.pauseMediaDuringDictation, "pauseMediaDuringDictation should default to false")
         XCTAssertFalse(viewModel.instantDictationEnabled, "instantDictationEnabled should default to false")
         XCTAssertTrue(viewModel.showLiveDictationPreview, "showLiveDictationPreview should default to true")
+        XCTAssertEqual(viewModel.dictationUndoCountdown, .fiveSeconds)
         XCTAssertFalse(
             viewModel.keepDictationOnClipboard,
             "keepDictationOnClipboard should default to false (opt-in)"
@@ -343,6 +344,25 @@ final class SettingsViewModelTests: XCTestCase {
             return setting
         }
         XCTAssertEqual(settings, [.liveDictationPreview])
+    }
+
+    func testDictationUndoCountdownDefaultsToFiveSecondsPersistsAndEmitsTelemetry() {
+        XCTAssertEqual(viewModel.dictationUndoCountdown, .fiveSeconds)
+
+        let telemetry = SettingsTelemetrySpy()
+        Telemetry.configure(telemetry)
+
+        viewModel.dictationUndoCountdown = .off
+
+        XCTAssertEqual(
+            testDefaults.string(forKey: UserDefaultsAppRuntimePreferences.dictationUndoCountdownKey),
+            DictationUndoCountdown.off.rawValue
+        )
+        let settings = telemetry.snapshot().compactMap { event -> TelemetrySettingName? in
+            guard case .settingChanged(let setting) = event else { return nil }
+            return setting
+        }
+        XCTAssertEqual(settings, [.dictationUndoCountdown])
     }
 
     func testSelectedMicrophonePersistsUIDAndClearsForSystemDefault() {


### PR DESCRIPTION
## Summary

Adds an "Undo window" setting so you can shorten the dictation cancel countdown from 5 seconds to 1 second, or turn it off entirely. With it off, canceling a dictation discards immediately instead of making you wait through the countdown.

## Why this matters

Issue #404: the cancel undo countdown is a fixed 5-second window, and people who rarely use undo find that wait disruptive. This makes the duration a preference instead of a hardcoded value, while keeping 5 seconds as the default so existing behavior is unchanged.

## Changes

- New `DictationUndoCountdown` preference in `AppRuntimePreferences` (`5 seconds` / `1 second` / `Off`), modeled on the existing `DictationPreviewTextSize` enum and persisted via UserDefaults. Unknown or missing values fall back to 5 seconds.
- `DictationFlowStateMachine` carries the configured duration into the `startCancelCountdown` effect. When the window is off, it skips the `cancelCountdown` state and confirms the cancel immediately.
- The countdown coordinator and overlay ring use the configured duration instead of the hardcoded 5.
- A segmented "Undo window" picker in the Dictation section of Settings, plus a settings-search index entry so it is findable.

A note on the off path: it routes through `confirmCancel` alone rather than emitting both `cancelRecording` and `confirmCancel`. Those run as separate async effects and emitting both together could interleave. It also omits `notifyHotkeyCancelledByUI`, which blocks hotkeys until a later countdown reset that never happens on this path, so emitting it would leave dictation shortcuts stuck. One known tradeoff: the off path does not emit the `dictation_cancelled` telemetry event with its cancel reason, since that is recorded by `cancelRecording`.

## Testing

- `swift build` - passes
- `swift test --filter DictationFlowStateMachine` - 82 tests, 0 failures
- `swift test --filter AppRuntimePreferences` - 30 tests, 0 failures
- `swift test --filter SettingsViewModelTests` - 273 tests, 0 failures
- `swift test --filter SettingsSearchIndex` - 25 tests, 0 failures

New tests cover: the configured duration flows into `startCancelCountdown` (5s and 1s), the off path skips the countdown and confirms immediately without blocking hotkeys, undo during the window returns to processing, and the preference round-trips through UserDefaults with a 5s fallback for unknown values.

Fixes #404
