### PR TITLE
Fix Unified meeting live preview

### DIFF
--- a/Sources/MacParakeetCore/Services/Dictation/DictationService.swift
+++ b/Sources/MacParakeetCore/Services/Dictation/DictationService.swift
@@ -1114,7 +1114,7 @@ public actor DictationService: DictationServiceProtocol {
 
     private func processCapturedAudio(
         audioURL: URL,
-        formatterContext: AppPromptContext?,
+        formatterContext: AppPromptContext?
     ) async throws -> DictationResult {
         // Track whether the audio file is consumed (moved or explicitly deleted).
         // If an error occurs before that point, clean up the temp file.

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingTranscriptAssembler.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingTranscriptAssembler.swift
@@ -55,15 +55,7 @@ struct MeetingTranscriptAssembler {
         chunk: AudioChunker.AudioChunk,
         source: AudioSource
     ) -> MeetingTranscriptUpdate {
-        let offsetWords = result.words.map {
-            WordTimestamp(
-                word: $0.word,
-                startMs: $0.startMs + chunk.startMs,
-                endMs: $0.endMs + chunk.startMs,
-                confidence: $0.confidence,
-                speakerId: source.rawValue
-            )
-        }
+        let offsetWords = Self.offsetWords(from: result, chunk: chunk, source: source)
 
         let cutoff = lastCommittedEndMs[source] ?? Int.min
         let deduplicated = offsetWords.filter { $0.endMs > cutoff }
@@ -74,6 +66,48 @@ struct MeetingTranscriptAssembler {
         }
 
         return currentUpdate
+    }
+
+    private static func offsetWords(
+        from result: STTResult,
+        chunk: AudioChunker.AudioChunk,
+        source: AudioSource
+    ) -> [WordTimestamp] {
+        if !result.words.isEmpty {
+            return result.words.map {
+                WordTimestamp(
+                    word: $0.word,
+                    startMs: $0.startMs + chunk.startMs,
+                    endMs: $0.endMs + chunk.startMs,
+                    confidence: $0.confidence,
+                    speakerId: source.rawValue
+                )
+            }
+        }
+
+        return synthesizeWords(from: result.text, chunk: chunk, source: source)
+    }
+
+    private static func synthesizeWords(
+        from text: String,
+        chunk: AudioChunker.AudioChunk,
+        source: AudioSource
+    ) -> [WordTimestamp] {
+        let tokens = text.split { $0.isWhitespace }.map(String.init)
+        guard !tokens.isEmpty else { return [] }
+
+        let durationMs = max(chunk.endMs - chunk.startMs, tokens.count)
+        return tokens.enumerated().map { index, token in
+            let startMs = chunk.startMs + (durationMs * index / tokens.count)
+            let endMs = chunk.startMs + max(durationMs * (index + 1) / tokens.count, index + 1)
+            return WordTimestamp(
+                word: token,
+                startMs: startMs,
+                endMs: endMs,
+                confidence: 0,
+                speakerId: source.rawValue
+            )
+        }
     }
 
     var currentUpdate: MeetingTranscriptUpdate {

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingTranscriptAssembler.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingTranscriptAssembler.swift
@@ -113,7 +113,10 @@ struct MeetingTranscriptAssembler {
         committedThroughMs: Int?
     ) -> [WordTimestamp] {
         let rawTokens = text.split { $0.isWhitespace }.map(String.init)
-        let tokens = trimOverlappingPrefix(rawTokens, committedWords: committedWords)
+        let hasTemporalOverlap = committedThroughMs.map { $0 > chunk.startMs } ?? false
+        let tokens = hasTemporalOverlap
+            ? trimOverlappingPrefix(rawTokens, committedWords: committedWords)
+            : rawTokens
         guard !tokens.isEmpty else { return [] }
 
         let startBoundary = committedThroughMs

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingTranscriptAssembler.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingTranscriptAssembler.swift
@@ -41,6 +41,7 @@ public struct MeetingRealtimeTranscript: Sendable, Equatable {
 
 struct MeetingTranscriptAssembler {
     private static let orderedSources: [AudioSource] = [.microphone, .system]
+    private static let syntheticOverlapAnchorLength = 6
 
     private var wordsBySource: [AudioSource: [WordTimestamp]] = [:]
     private var lastCommittedEndMs: [AudioSource: Int] = [:]
@@ -55,10 +56,18 @@ struct MeetingTranscriptAssembler {
         chunk: AudioChunker.AudioChunk,
         source: AudioSource
     ) -> MeetingTranscriptUpdate {
-        let offsetWords = Self.offsetWords(from: result, chunk: chunk, source: source)
-
-        let cutoff = lastCommittedEndMs[source] ?? Int.min
-        let deduplicated = offsetWords.filter { $0.endMs > cutoff }
+        let cutoff = lastCommittedEndMs[source]
+        let offsetWords = Self.offsetWords(
+            from: result,
+            chunk: chunk,
+            source: source,
+            committedWords: wordsBySource[source] ?? [],
+            committedThroughMs: cutoff
+        )
+        let deduplicated = offsetWords.filter { word in
+            guard let cutoff else { return true }
+            return word.endMs > cutoff
+        }
 
         if !deduplicated.isEmpty {
             wordsBySource[source, default: []].append(contentsOf: deduplicated)
@@ -71,7 +80,9 @@ struct MeetingTranscriptAssembler {
     private static func offsetWords(
         from result: STTResult,
         chunk: AudioChunker.AudioChunk,
-        source: AudioSource
+        source: AudioSource,
+        committedWords: [WordTimestamp],
+        committedThroughMs: Int?
     ) -> [WordTimestamp] {
         if !result.words.isEmpty {
             return result.words.map {
@@ -85,21 +96,35 @@ struct MeetingTranscriptAssembler {
             }
         }
 
-        return synthesizeWords(from: result.text, chunk: chunk, source: source)
+        return synthesizeWords(
+            from: result.text,
+            chunk: chunk,
+            source: source,
+            committedWords: committedWords,
+            committedThroughMs: committedThroughMs
+        )
     }
 
     private static func synthesizeWords(
         from text: String,
         chunk: AudioChunker.AudioChunk,
-        source: AudioSource
+        source: AudioSource,
+        committedWords: [WordTimestamp],
+        committedThroughMs: Int?
     ) -> [WordTimestamp] {
-        let tokens = text.split { $0.isWhitespace }.map(String.init)
+        let rawTokens = text.split { $0.isWhitespace }.map(String.init)
+        let tokens = trimOverlappingPrefix(rawTokens, committedWords: committedWords)
         guard !tokens.isEmpty else { return [] }
 
-        let durationMs = max(chunk.endMs - chunk.startMs, tokens.count)
+        let startBoundary = committedThroughMs
+            .map { max(chunk.startMs, min($0, chunk.endMs)) }
+            ?? chunk.startMs
+        guard startBoundary < chunk.endMs else { return [] }
+
+        let durationMs = max(chunk.endMs - startBoundary, tokens.count)
         return tokens.enumerated().map { index, token in
-            let startMs = chunk.startMs + (durationMs * index / tokens.count)
-            let endMs = chunk.startMs + max(durationMs * (index + 1) / tokens.count, index + 1)
+            let startMs = startBoundary + (durationMs * index / tokens.count)
+            let endMs = startBoundary + (durationMs * (index + 1) / tokens.count)
             return WordTimestamp(
                 word: token,
                 startMs: startMs,
@@ -109,6 +134,36 @@ struct MeetingTranscriptAssembler {
             )
         }
     }
+
+    private static func trimOverlappingPrefix(
+        _ tokens: [String],
+        committedWords: [WordTimestamp]
+    ) -> [String] {
+        guard !tokens.isEmpty, !committedWords.isEmpty else { return tokens }
+
+        let normalizedTokens = tokens.map(normalizeOverlapToken)
+        let normalizedCommitted = committedWords
+            .suffix(syntheticOverlapAnchorLength)
+            .map { normalizeOverlapToken($0.word) }
+        var overlap = min(normalizedTokens.count, normalizedCommitted.count)
+
+        while overlap > 0 {
+            if normalizedCommitted.suffix(overlap).elementsEqual(normalizedTokens.prefix(overlap)) {
+                return Array(tokens.dropFirst(overlap))
+            }
+            overlap -= 1
+        }
+
+        return tokens
+    }
+
+    private static func normalizeOverlapToken(_ token: String) -> String {
+        let trimmed = token.trimmingCharacters(in: overlapTrimSet)
+        return trimmed.isEmpty ? token.lowercased() : trimmed.lowercased()
+    }
+
+    private static let overlapTrimSet = CharacterSet.punctuationCharacters
+        .union(.symbols)
 
     var currentUpdate: MeetingTranscriptUpdate {
         let words = normalizedWords()

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingServiceTests.swift
@@ -816,6 +816,44 @@ final class MeetingRecordingServiceTests: XCTestCase {
         XCTAssertNotNil(output.sourceAlignment.microphone)
     }
 
+    func testLivePreviewEmitsTextOnlyChunkResults() async throws {
+        let captureService = MockMeetingAudioCaptureService()
+        let audioConverter = MockMeetingAudioFileConverter()
+        let sttClient = PrefixScriptedMeetingSTTClient(
+            microphoneSteps: [
+                .result(STTResult(text: "hello unified preview", words: [])),
+            ]
+        )
+        let service = MeetingRecordingService(
+            audioCaptureService: captureService,
+            audioConverter: audioConverter,
+            sttTranscriber: sttClient
+        )
+
+        let updates = await service.transcriptUpdates
+        let nextUpdate = Task {
+            var iterator = updates.makeAsyncIterator()
+            return await iterator.next()
+        }
+
+        try await service.startRecording()
+
+        let microphoneBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 80_000, sampleValue: 0.25))
+        await captureService.yield(.microphoneBuffer(
+            microphoneBuffer,
+            AVAudioTime(hostTime: AVAudioTime.hostTime(forSeconds: 100.0))
+        ))
+
+        let maybeUpdate = await nextUpdate.value
+        let update = try XCTUnwrap(maybeUpdate)
+        XCTAssertEqual(update.words.map(\.word), ["hello", "unified", "preview"])
+        XCTAssertEqual(update.speakers, [SpeakerInfo(id: "microphone", label: "Me")])
+
+        let output = try await service.stopRecording()
+        defer { try? FileManager.default.removeItem(at: output.folderURL) }
+        XCTAssertNotNil(output.sourceAlignment.microphone)
+    }
+
     func testStaleChunkFailureFromPreviousSessionDoesNotPoisonNextSession() async throws {
         let captureService = MockMeetingAudioCaptureService()
         let audioConverter = MockMeetingAudioFileConverter()

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingTranscriptAssemblerTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingTranscriptAssemblerTests.swift
@@ -23,6 +23,33 @@ final class MeetingTranscriptAssemblerTests: XCTestCase {
         XCTAssertEqual(update.words.map(\.speakerId), ["microphone", "microphone", "microphone"])
     }
 
+    func testApplySynthesizesLivePreviewWordsForTextOnlyResult() {
+        var assembler = MeetingTranscriptAssembler()
+
+        let chunk = AudioChunker.AudioChunk(samples: [0], startMs: 4_000, endMs: 9_000)
+        let result = STTResult(text: "Hello unified world.", words: [])
+        let update = assembler.apply(result: result, chunk: chunk, source: .microphone)
+
+        XCTAssertEqual(update.words.map(\.word), ["Hello", "unified", "world."])
+        XCTAssertEqual(update.words.map(\.speakerId), ["microphone", "microphone", "microphone"])
+        XCTAssertEqual(update.words.first?.startMs, 0)
+        XCTAssertEqual(update.words.last?.endMs, 5_000)
+        XCTAssertEqual(update.speakers, [SpeakerInfo(id: "microphone", label: "Me")])
+    }
+
+    func testApplyIgnoresTextOnlyResultWithoutWords() {
+        var assembler = MeetingTranscriptAssembler()
+
+        let update = assembler.apply(
+            result: STTResult(text: " \n\t ", words: []),
+            chunk: AudioChunker.AudioChunk(samples: [0], startMs: 0, endMs: 5_000),
+            source: .microphone
+        )
+
+        XCTAssertTrue(update.words.isEmpty)
+        XCTAssertTrue(update.speakers.isEmpty)
+    }
+
     func testFinalizedTranscriptBuildsSpeakerMetadataAcrossSources() {
         var assembler = MeetingTranscriptAssembler()
 

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingTranscriptAssemblerTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingTranscriptAssemblerTests.swift
@@ -57,6 +57,26 @@ final class MeetingTranscriptAssemblerTests: XCTestCase {
         XCTAssertEqual(update.words.last?.endMs, 9_000)
     }
 
+    func testApplyPreservesRepeatedPrefixForContiguousTextOnlyChunks() {
+        var assembler = MeetingTranscriptAssembler()
+
+        _ = assembler.apply(
+            result: STTResult(text: "yes", words: []),
+            chunk: AudioChunker.AudioChunk(samples: [0], startMs: 0, endMs: 1_000),
+            source: .microphone
+        )
+
+        let update = assembler.apply(
+            result: STTResult(text: "yes please", words: []),
+            chunk: AudioChunker.AudioChunk(samples: [0], startMs: 1_000, endMs: 3_000),
+            source: .microphone
+        )
+
+        XCTAssertEqual(update.words.map(\.word), ["yes", "yes", "please"])
+        XCTAssertEqual(update.words[1].startMs, 1_000)
+        XCTAssertEqual(update.words.last?.endMs, 3_000)
+    }
+
     func testApplyIgnoresTextOnlyResultWithoutWords() {
         var assembler = MeetingTranscriptAssembler()
 

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingTranscriptAssemblerTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingTranscriptAssemblerTests.swift
@@ -37,6 +37,26 @@ final class MeetingTranscriptAssemblerTests: XCTestCase {
         XCTAssertEqual(update.speakers, [SpeakerInfo(id: "microphone", label: "Me")])
     }
 
+    func testApplyTrimsTextOnlyOverlapPrefix() {
+        var assembler = MeetingTranscriptAssembler()
+
+        _ = assembler.apply(
+            result: STTResult(text: "Hello team", words: []),
+            chunk: AudioChunker.AudioChunk(samples: [0], startMs: 0, endMs: 5_000),
+            source: .microphone
+        )
+
+        let update = assembler.apply(
+            result: STTResult(text: "Team, again", words: []),
+            chunk: AudioChunker.AudioChunk(samples: [0], startMs: 4_000, endMs: 9_000),
+            source: .microphone
+        )
+
+        XCTAssertEqual(update.words.map(\.word), ["Hello", "team", "again"])
+        XCTAssertEqual(update.words.last?.startMs, 5_000)
+        XCTAssertEqual(update.words.last?.endMs, 9_000)
+    }
+
     func testApplyIgnoresTextOnlyResultWithoutWords() {
         var assembler = MeetingTranscriptAssembler()
 


### PR DESCRIPTION
## Summary

Unified meeting recordings now show live transcript text while recording instead of staying on `Listening...` until stop-time transcription completes.

The bug was an API-shape mismatch, not a capture failure: Parakeet v2/v3 live chunk results include word timings, while the Parakeet Unified offline chunk path returns transcript text with an empty `words` array. The live meeting renderer is driven by `WordTimestamp` values, so text-only Unified chunks were valid STT results that the assembler could not display.

## Fix

The live transcript assembler now keeps the existing timed-word path unchanged and only falls back for text-only chunk results. For those results, it tokenizes the chunk text and synthesizes coarse word timings across the chunk window so the existing transcript update, speaker labeling, dedupe, and rendering path can keep working.

Fresh review found one real overlap issue in that fallback: fixed/vad live chunks can include an already-committed tail. The fallback now trims a matching committed suffix/new prefix before synthesizing text-only timestamps, then places the remaining tokens in the uncommitted portion of the chunk. That preserves the existing overlap-dedup invariant without changing timed-word engines.

This deliberately stays at the adapter boundary. It does not change capture, scheduler behavior, final meeting transcription, dictation, or the Parakeet Unified engine API.

This branch also removes a behavior-free trailing comma in `DictationService.processCapturedAudio` that current CI's release compiler rejects. That was already on `main`; it is included here because the PR exposed the release-build failure.

## QA Notes

During local QA before the fix, microphone meeting capture and final transcription were healthy: recent meetings saved completed transcripts after stop, but the live Transcript tab stayed blank during recording. That matches the code path: final transcription can persist text directly, while live preview needed word timestamps.

Manual QA for this PR should focus on:

| Case | Expected result |
| --- | --- |
| Parakeet Unified, microphone-only meeting | Live transcript text appears during recording after the first chunk, not only after stop |
| Parakeet Unified, microphone + system | Mic text appears when mic is not suppressed by dominant system audio; final transcript still completes after stop |
| Overlapping live chunks | Repeated overlap words are not duplicated at chunk boundaries |
| Parakeet v3/v2 meeting | Existing timed-word live preview behavior is unchanged |
| Stop-time meeting transcription | Completed Library transcript still contains the full meeting |

## Verification

- `swift test --filter MeetingTranscriptAssemblerTests`
- `swift test --filter MeetingRecordingServiceTests`
- `swift build -c release` from a clean `/tmp/macparakeet-pr584-verify` worktree
- `swift test` from the clean verification worktree before the fresh-review follow-up: 3,994 XCTest tests plus 16 Swift Testing tests passed
- `git diff --check`
- GitHub Actions `swift-test` checks passed for both push and pull_request runs on `4fd1a9a99`
- All review threads are resolved

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)