### PR TITLE
Polish Library selection controls

### DIFF
--- a/Sources/MacParakeet/Views/Transcription/BulkTranscriptionSelectionBar.swift
+++ b/Sources/MacParakeet/Views/Transcription/BulkTranscriptionSelectionBar.swift
@@ -33,96 +33,253 @@ struct BulkTranscriptionSelectionBar: View {
             wrappedBar
         }
         .padding(.horizontal, DesignSystem.Spacing.lg)
-        .padding(.vertical, DesignSystem.Spacing.sm)
-        .background(DesignSystem.Colors.surfaceElevated)
-        .overlay(alignment: .bottom) { Divider() }
+        .padding(.vertical, 10)
+        .background(DesignSystem.Colors.background)
+        .overlay(alignment: .top) {
+            Divider()
+                .opacity(0.35)
+        }
+        .overlay(alignment: .bottom) {
+            Divider()
+                .opacity(0.55)
+        }
         .accessibilityElement(children: .contain)
         .accessibilityLabel(isPerformingOperation ? "Deleting selected items" : "\(selectedCount) selected")
     }
 
     private var horizontalBar: some View {
-        HStack(spacing: DesignSystem.Spacing.sm) {
+        HStack(spacing: DesignSystem.Spacing.md) {
             selectionSummary
 
             Spacer(minLength: DesignSystem.Spacing.md)
 
-            utilityActions
-            destructiveActions
+            actionCluster
         }
+        .frame(minHeight: 34)
     }
 
     private var wrappedBar: some View {
         VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
             selectionSummary
-            HStack(spacing: DesignSystem.Spacing.sm) {
+            actionCluster
+        }
+    }
+
+    private var selectionSummary: some View {
+        HStack(spacing: 8) {
+            if isPerformingOperation {
+                ProgressView()
+                    .controlSize(.small)
+            } else {
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(DesignSystem.Colors.accent)
+            }
+
+            Text(isPerformingOperation ? "Deleting..." : "\(selectedCount) selected")
+                .font(DesignSystem.Typography.bodySmall.weight(.semibold))
+                .foregroundStyle(DesignSystem.Colors.textPrimary)
+        }
+        .padding(.horizontal, 10)
+        .frame(height: 30)
+        .background(
+            Capsule()
+                .fill(DesignSystem.Colors.accentLight)
+        )
+        .accessibilityHidden(true)
+    }
+
+    private var actionCluster: some View {
+        ViewThatFits(in: .horizontal) {
+            HStack(spacing: 6) {
+                utilityActions
+                destructiveActions
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
                 utilityActions
                 destructiveActions
             }
         }
     }
 
-    private var selectionSummary: some View {
-        HStack(spacing: 7) {
-            if isPerformingOperation {
-                ProgressView()
-                    .controlSize(.small)
-            } else {
-                Image(systemName: "checkmark.circle.fill")
-                    .font(.system(size: 13, weight: .semibold))
-                    .foregroundStyle(DesignSystem.Colors.accent)
-            }
-
-            Text(isPerformingOperation ? "Deleting..." : "\(selectedCount) selected")
-                .font(DesignSystem.Typography.bodySmall.weight(.medium))
-                .foregroundStyle(DesignSystem.Colors.textPrimary)
-        }
-        .accessibilityHidden(true)
-    }
-
     private var utilityActions: some View {
-        HStack(spacing: DesignSystem.Spacing.sm) {
-            Button("Cancel", action: onCancel)
-                .parakeetAction(.subtle)
-                .keyboardShortcut(.escape, modifiers: [])
-                .disabled(isPerformingOperation)
+        HStack(spacing: 6) {
+            SelectionBarActionButton(
+                title: "Cancel",
+                systemImage: "xmark",
+                tone: .subtle,
+                isDisabled: isPerformingOperation,
+                usesEscapeShortcut: true,
+                action: onCancel
+            )
 
-            Button {
-                onSelectLoaded()
-            } label: {
-                Label("Select All", systemImage: "checkmark.circle")
-            }
-            .disabled(areAllLoadedSelected || isPerformingOperation)
-            .parakeetAction(.secondary)
+            SelectionBarActionButton(
+                title: "Select Loaded",
+                systemImage: "checkmark.circle",
+                tone: .utility,
+                isDisabled: areAllLoadedSelected || isPerformingOperation,
+                action: onSelectLoaded
+            )
 
-            Button {
-                onClear()
-            } label: {
-                Label("Clear", systemImage: "xmark.circle")
-            }
-            .disabled(selectedCount == 0 || isPerformingOperation)
-            .parakeetAction(.secondary)
+            SelectionBarActionButton(
+                title: "Clear",
+                systemImage: "xmark.circle",
+                tone: .utility,
+                isDisabled: selectedCount == 0 || isPerformingOperation,
+                action: onClear
+            )
         }
     }
 
     private var destructiveActions: some View {
-        HStack(spacing: DesignSystem.Spacing.sm) {
+        HStack(spacing: 6) {
             if showsAudioAction {
-                Button(role: .destructive) {
-                    onDeleteAudioOnly()
-                } label: {
-                    Label(deleteAudioTitle, systemImage: "waveform.slash")
-                }
-                .disabled(selectedMeetingAudioCount == 0 || isPerformingOperation)
-                .parakeetAction(.destructive)
+                SelectionBarActionButton(
+                    title: deleteAudioTitle,
+                    systemImage: "waveform.slash",
+                    tone: .destructive,
+                    isDisabled: selectedMeetingAudioCount == 0 || isPerformingOperation,
+                    role: .destructive,
+                    action: onDeleteAudioOnly
+                )
             }
 
-            Button(role: .destructive) {
-                onDeleteItems()
-            } label: {
-                Label(deleteItemsTitle, systemImage: "trash")
+            SelectionBarActionButton(
+                title: deleteItemsTitle,
+                systemImage: "trash",
+                tone: .destructive,
+                isDisabled: selectedCount == 0 || isPerformingOperation,
+                role: .destructive,
+                action: onDeleteItems
+            )
+        }
+    }
+}
+
+private enum SelectionBarActionTone {
+    case utility
+    case destructive
+    case subtle
+
+    func foreground(isHovered: Bool, isDisabled: Bool) -> Color {
+        if isDisabled { return DesignSystem.Colors.textTertiary }
+        switch self {
+        case .utility:
+            return isHovered ? DesignSystem.Colors.textPrimary : DesignSystem.Colors.textSecondary
+        case .destructive:
+            return DesignSystem.Colors.errorRed
+        case .subtle:
+            return isHovered ? DesignSystem.Colors.textPrimary : DesignSystem.Colors.textSecondary
+        }
+    }
+
+    func fill(isHovered: Bool) -> Color {
+        switch self {
+        case .utility:
+            return isHovered
+                ? DesignSystem.Colors.textPrimary.opacity(0.08)
+                : DesignSystem.Colors.surface.opacity(0.72)
+        case .destructive:
+            return DesignSystem.Colors.errorRed.opacity(isHovered ? 0.16 : 0.09)
+        case .subtle:
+            return isHovered ? DesignSystem.Colors.textPrimary.opacity(0.06) : .clear
+        }
+    }
+
+    var stroke: Color {
+        switch self {
+        case .utility:
+            return DesignSystem.Colors.border.opacity(0.7)
+        case .destructive:
+            return DesignSystem.Colors.errorRed.opacity(0.24)
+        case .subtle:
+            return .clear
+        }
+    }
+}
+
+private struct SelectionBarActionButton: View {
+    let title: String
+    let systemImage: String
+    let tone: SelectionBarActionTone
+    var isDisabled: Bool = false
+    var usesEscapeShortcut: Bool = false
+    var role: ButtonRole?
+    let action: () -> Void
+
+    @State private var isHovered = false
+    @State private var didPushCursor = false
+
+    var body: some View {
+        Group {
+            if usesEscapeShortcut {
+                baseButton
+                    .keyboardShortcut(.escape, modifiers: [])
+            } else {
+                baseButton
             }
-            .disabled(selectedCount == 0 || isPerformingOperation)
-            .parakeetAction(.destructive)
+        }
+    }
+
+    private var baseButton: some View {
+        Button(role: role, action: action) {
+            HStack(spacing: 6) {
+                Image(systemName: systemImage)
+                    .font(.system(size: 12, weight: .semibold))
+                Text(title)
+                    .lineLimit(1)
+            }
+            .font(DesignSystem.Typography.bodySmall.weight(.semibold))
+            .foregroundStyle(tone.foreground(isHovered: isHovered, isDisabled: isDisabled))
+            .padding(.horizontal, tone == .subtle ? 8 : 11)
+            .frame(height: 30)
+            .background(
+                Capsule()
+                    .fill(tone.fill(isHovered: isHovered))
+            )
+            .overlay {
+                Capsule()
+                    .strokeBorder(tone.stroke, lineWidth: tone == .subtle ? 0 : 0.6)
+            }
+            .contentShape(Capsule())
+        }
+        .buttonStyle(.plain)
+        .disabled(isDisabled)
+        .opacity(isDisabled ? 0.48 : 1)
+        .onHover { hovering in
+            isHovered = hovering && !isDisabled
+            updateCursor(isHovering: hovering)
+        }
+        .onChange(of: isDisabled) { _, _ in
+            if isDisabled {
+                isHovered = false
+            }
+            updateCursor(isHovering: isHovered)
+        }
+        .onDisappear {
+            releaseCursorIfNeeded()
+        }
+        .animation(DesignSystem.Animation.hoverTransition, value: isHovered)
+        .animation(DesignSystem.Animation.hoverTransition, value: isDisabled)
+    }
+
+    private func updateCursor(isHovering: Bool) {
+        let shouldShowPointer = isHovering && !isDisabled
+        if shouldShowPointer, !didPushCursor {
+            NSCursor.pointingHand.push()
+            didPushCursor = true
+            return
+        }
+        if !shouldShowPointer, didPushCursor {
+            releaseCursorIfNeeded()
+        }
+    }
+
+    private func releaseCursorIfNeeded() {
+        if didPushCursor {
+            NSCursor.pop()
+            didPushCursor = false
         }
     }
 }

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
@@ -213,6 +213,7 @@ struct TranscriptionLibraryView: View {
                 loadMoreFooter
             }
             .padding(.horizontal, DesignSystem.Spacing.lg)
+            .padding(.top, DesignSystem.Spacing.md)
             .padding(.bottom, DesignSystem.Spacing.lg)
         }
     }

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionThumbnailCard.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionThumbnailCard.swift
@@ -99,8 +99,8 @@ struct TranscriptionThumbnailCard<MenuContent: View>: View {
     private var selectionBadge: some View {
         ZStack {
             Circle()
-                .fill(isSelected ? DesignSystem.Colors.accent : DesignSystem.Colors.surface.opacity(0.92))
-                .frame(width: 22, height: 22)
+                .fill(isSelected ? DesignSystem.Colors.accent : DesignSystem.Colors.surface.opacity(0.94))
+                .frame(width: 24, height: 24)
                 .overlay {
                     Circle()
                         .strokeBorder(
@@ -109,9 +109,11 @@ struct TranscriptionThumbnailCard<MenuContent: View>: View {
                         )
                 }
 
-            Image(systemName: isSelected ? "checkmark" : "circle")
-                .font(.system(size: isSelected ? 10 : 8, weight: .bold))
-                .foregroundStyle(isSelected ? DesignSystem.Colors.onAccent : DesignSystem.Colors.accent.opacity(0.75))
+            if isSelected {
+                Image(systemName: "checkmark")
+                    .font(.system(size: 11, weight: .bold))
+                    .foregroundStyle(DesignSystem.Colors.onAccent)
+            }
         }
         .accessibilityHidden(true)
     }

--- a/Sources/MacParakeetCore/Services/Dictation/DictationService.swift
+++ b/Sources/MacParakeetCore/Services/Dictation/DictationService.swift
@@ -1114,7 +1114,7 @@ public actor DictationService: DictationServiceProtocol {
 
     private func processCapturedAudio(
         audioURL: URL,
-        formatterContext: AppPromptContext?,
+        formatterContext: AppPromptContext?
     ) async throws -> DictationResult {
         // Track whether the audio file is consumed (moved or explicitly deleted).
         // If an error occurs before that point, clean up the temp file.


### PR DESCRIPTION
## Summary
Library bulk selection now reads as a calmer native utility surface instead of a heavy gray strip. The selected count gets its own coral chip, action buttons use compact hoverable pills that wrap cleanly on narrower widths, and the bulk selector now says `Select Loaded` so paginated Library scope is explicit.

The first grid row also gets breathing room below the contextual bar, and thumbnail selection badges no longer show a double-ring artifact on unselected cards.

Also removes one existing trailing comma in `DictationService.swift` that is accepted locally but breaks the CI release build on Xcode 16.1.

## Verification
- `git diff --check`
- `swift build`
- `swift build -c release`
- `swift test --filter TranscriptionLibraryViewModelTests`
- `swift test --skip-build`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
