### PR TITLE
fix: stabilize dictation note expansion

### DIFF
--- a/Sources/MacParakeet/Views/History/DictationHistoryView.swift
+++ b/Sources/MacParakeet/Views/History/DictationHistoryView.swift
@@ -351,6 +351,7 @@ enum DictationTranscriptPresentation {
     static let expansionCharacterThreshold = 220
     static let expansionLineBreakThreshold = 3
     static let expandedBoxMaxHeight: CGFloat = 280
+    static let remeasuringExpandedContentHeight = expandedBoxMaxHeight + 1
 
     static func isExpandable(_ text: String, canToggleExpansion: Bool = true) -> Bool {
         guard canToggleExpansion else { return false }
@@ -378,12 +379,12 @@ enum DictationTranscriptPresentation {
         return collapsedLineLimit
     }
 
-    static func expandedHeight(forMeasuredContentHeight measuredContentHeight: CGFloat) -> CGFloat {
-        guard measuredContentHeight > 0 else {
-            return expandedBoxMaxHeight
-        }
+    static func expandedViewportHeight(forMeasuredContentHeight measuredContentHeight: CGFloat) -> CGFloat? {
+        measuredContentHeight > expandedBoxMaxHeight ? expandedBoxMaxHeight : nil
+    }
 
-        return min(measuredContentHeight, expandedBoxMaxHeight)
+    static func resetMeasuredExpandedContentHeight(isCurrentlyExpanded: Bool) -> CGFloat {
+        isCurrentlyExpanded ? remeasuringExpandedContentHeight : 0
     }
 }
 
@@ -540,6 +541,11 @@ struct DictationCardRow: View {
             }
 
             transcriptContent
+                .background(alignment: .topLeading) {
+                    if transcriptIsExpandable && !isExpanded {
+                        expandedTranscriptMeasurementProbe
+                    }
+                }
         }
         .padding(DesignSystem.Spacing.md)
         .scaleEffect(isPlayingThis ? 1.005 : 1.0)
@@ -565,7 +571,11 @@ struct DictationCardRow: View {
         .animation(DesignSystem.Animation.selectionChange, value: isSelected)
         .animation(DesignSystem.Animation.contentSwap, value: isExpanded)
         .onChange(of: transcriptPlainText) { _, _ in
-            expandedTranscriptContentHeight = 0
+            expandedTranscriptContentHeight = DictationTranscriptPresentation
+                .resetMeasuredExpandedContentHeight(isCurrentlyExpanded: isExpanded)
+        }
+        .onPreferenceChange(ExpandedTranscriptHeightKey.self) { height in
+            updateExpandedTranscriptContentHeight(height)
         }
     }
 
@@ -593,31 +603,7 @@ struct DictationCardRow: View {
     private var transcriptContent: some View {
         let isExpandable = transcriptIsExpandable
         if isExpanded && isExpandable {
-            ScrollView {
-                transcriptText(lineLimit: nil)
-                    .padding(DesignSystem.Spacing.sm)
-                    .background {
-                        GeometryReader { proxy in
-                            Color.clear
-                                .onAppear {
-                                    expandedTranscriptContentHeight = proxy.size.height
-                                }
-                                .onChange(of: proxy.size.height) { _, height in
-                                    expandedTranscriptContentHeight = height
-                                }
-                        }
-                    }
-            }
-            .frame(height: expandedTranscriptHeight)
-            .background(
-                RoundedRectangle(cornerRadius: 8)
-                    .fill(DesignSystem.Colors.surfaceElevated.opacity(0.55))
-            )
-            .overlay {
-                RoundedRectangle(cornerRadius: 8)
-                    .strokeBorder(DesignSystem.Colors.border.opacity(0.6), lineWidth: 0.5)
-            }
-            .contentTransition(.opacity)
+            expandedTranscriptContent
         } else {
             let lineLimit = isExpandable
                 ? DictationTranscriptPresentation.lineLimit(
@@ -640,10 +626,63 @@ struct DictationCardRow: View {
         }
     }
 
-    private var expandedTranscriptHeight: CGFloat {
-        DictationTranscriptPresentation.expandedHeight(
+    private var expandedTranscriptContent: some View {
+        expandedTranscriptViewport
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(DesignSystem.Colors.surfaceElevated.opacity(0.55))
+            )
+            .overlay {
+                RoundedRectangle(cornerRadius: 8)
+                    .strokeBorder(DesignSystem.Colors.border.opacity(0.6), lineWidth: 0.5)
+            }
+            .contentTransition(.opacity)
+    }
+
+    @ViewBuilder
+    private var expandedTranscriptViewport: some View {
+        if let viewportHeight = DictationTranscriptPresentation.expandedViewportHeight(
             forMeasuredContentHeight: expandedTranscriptContentHeight
-        )
+        ) {
+            ScrollView {
+                expandedTranscriptText
+            }
+            .frame(height: viewportHeight)
+        } else {
+            expandedTranscriptText
+        }
+    }
+
+    private var expandedTranscriptText: some View {
+        transcriptText(lineLimit: nil)
+            .padding(DesignSystem.Spacing.sm)
+            .fixedSize(horizontal: false, vertical: true)
+            .background {
+                GeometryReader { proxy in
+                    Color.clear.preference(
+                        key: ExpandedTranscriptHeightKey.self,
+                        value: proxy.size.height
+                    )
+                }
+            }
+    }
+
+    private var expandedTranscriptMeasurementProbe: some View {
+        expandedTranscriptText
+            .opacity(0)
+            .accessibilityHidden(true)
+            .allowsHitTesting(false)
+    }
+
+    private func updateExpandedTranscriptContentHeight(_ height: CGFloat) {
+        guard height > 0,
+              abs(height - expandedTranscriptContentHeight) > 0.5 else {
+            return
+        }
+
+        withAnimation(nil) {
+            expandedTranscriptContentHeight = height
+        }
     }
 
     private func transcriptText(lineLimit: Int?) -> some View {
@@ -751,6 +790,14 @@ struct DictationCardRow: View {
         case .global, nil:
             return ""
         }
+    }
+}
+
+private struct ExpandedTranscriptHeightKey: PreferenceKey {
+    static let defaultValue: CGFloat = 0
+
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = nextValue()
     }
 }
 

--- a/Sources/MacParakeetCore/Services/Dictation/DictationService.swift
+++ b/Sources/MacParakeetCore/Services/Dictation/DictationService.swift
@@ -1114,7 +1114,7 @@ public actor DictationService: DictationServiceProtocol {
 
     private func processCapturedAudio(
         audioURL: URL,
-        formatterContext: AppPromptContext?,
+        formatterContext: AppPromptContext?
     ) async throws -> DictationResult {
         // Track whether the audio file is consumed (moved or explicitly deleted).
         // If an error occurs before that point, clean up the temp file.

--- a/Tests/MacParakeetTests/Views/DictationHistoryViewTests.swift
+++ b/Tests/MacParakeetTests/Views/DictationHistoryViewTests.swift
@@ -64,23 +64,38 @@ final class DictationHistoryViewTests: XCTestCase {
         XCTAssertNil(DictationTranscriptPresentation.lineLimit(for: text, isExpanded: false))
     }
 
-    func testExpandedHeightUsesCapBeforeContentIsMeasured() {
+    func testExpandedViewportDoesNotForceCapBeforeContentIsMeasured() {
+        XCTAssertNil(
+            DictationTranscriptPresentation.expandedViewportHeight(forMeasuredContentHeight: 0)
+        )
+    }
+
+    func testExpandedViewportIsUnfixedWhenMeasuredContentFits() {
+        XCTAssertNil(
+            DictationTranscriptPresentation.expandedViewportHeight(forMeasuredContentHeight: 120)
+        )
+    }
+
+    func testExpandedViewportCapsMeasuredContentWhenTallerThanCap() {
         XCTAssertEqual(
-            DictationTranscriptPresentation.expandedHeight(forMeasuredContentHeight: 0),
+            DictationTranscriptPresentation.expandedViewportHeight(forMeasuredContentHeight: 640),
             DictationTranscriptPresentation.expandedBoxMaxHeight
         )
     }
 
-    func testExpandedHeightShrinksToMeasuredContentWhenShorterThanCap() {
+    func testCollapsedTextChangesResetMeasurementToUnknownNaturalHeight() {
         XCTAssertEqual(
-            DictationTranscriptPresentation.expandedHeight(forMeasuredContentHeight: 120),
-            120
+            DictationTranscriptPresentation.resetMeasuredExpandedContentHeight(isCurrentlyExpanded: false),
+            0
         )
     }
 
-    func testExpandedHeightCapsMeasuredContentWhenTallerThanCap() {
+    func testExpandedTextChangesStayCappedWhileRemeasuring() {
+        let pendingHeight = DictationTranscriptPresentation
+            .resetMeasuredExpandedContentHeight(isCurrentlyExpanded: true)
+
         XCTAssertEqual(
-            DictationTranscriptPresentation.expandedHeight(forMeasuredContentHeight: 640),
+            DictationTranscriptPresentation.expandedViewportHeight(forMeasuredContentHeight: pendingHeight),
             DictationTranscriptPresentation.expandedBoxMaxHeight
         )
     }


### PR DESCRIPTION
## Summary
Dictation note expansion no longer flashes through an oversized expanded box the first time a row is opened. Visible rows now pre-measure their full note height while collapsed, and expanded rows only use the capped internal scroll viewport when the measured content actually exceeds the cap.

This keeps short and medium notes at their natural expanded height immediately, while long notes still get the existing scrollable containment. A fresh-eye review found one related edge case for already-expanded notes whose text changes; the final commit keeps those capped while remeasurement is pending.

This PR also removes one existing trailing comma in `DictationService.processCapturedAudio(...)` that caused GitHub's release-build CI step to fail on `origin/main`.

## Testing
- `git diff --check`
- `swift build -c release`
- `MACPARAKEET_SKIP_WHISPERKIT=1 swift build --build-path .build-swift6-no-whisper -Xswiftc -swift-version -Xswiftc 6`
- `swift test --filter DictationHistoryViewTests`
- `swift test` (3,993 XCTest tests + 16 Swift Testing tests; 0 failures)

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
