### PR TITLE
[codex] Fix reused meeting pill refresh

### DIFF
--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingRecordingPillController.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingRecordingPillController.swift
@@ -85,6 +85,9 @@ final class MeetingRecordingPillController {
     func show() {
         if let panel {
             panel.orderFront(nil)
+            // Back-to-back recordings can reuse the saved-completion pill; push
+            // the fresh state now instead of waiting for the 1 s view tick.
+            pillView?.refresh()
             return
         }
 


### PR DESCRIPTION
## What

Fixes one post-merge back-to-back interruption gap from PR #587: when the saved-completion pill window is still alive and a new meeting starts, `show()` now refreshes the existing AppKit pill view immediately after bringing it forward.

## Why

The coordinator moves the shared pill view model back to `.recording` immediately, but the AppKit pill view pulls state on `refresh()` / its 1-second tick. Without this refresh, a reused saved-completion pill could briefly keep rendering the Metatron/checkmark face before the next tick caught up.

## Validation

- `git diff --check`
- `swift test --filter MeetingRecordingFlowCoordinatorTests`
- `swift test --filter MeetingRecordingFlowStateMachineTests`
- Hosted CI `swift-test` passed on both push and pull_request runs

