### PR TITLE
fix(security): do not trust SHELL env var for PATH probe in LocalCLIExecutor

### DIFF
--- a/Sources/MacParakeetCore/Services/LLM/LocalCLIExecutor.swift
+++ b/Sources/MacParakeetCore/Services/LLM/LocalCLIExecutor.swift
@@ -913,12 +913,11 @@ public final class LocalCLIExecutor: Sendable {
     }
 
     static func candidatePATHProbeShellURLs(
-        environment: [String: String] = ProcessInfo.processInfo.environment,
+        environment _: [String: String] = ProcessInfo.processInfo.environment,
         fileManager: FileManager = .default
     ) -> [URL] {
         let userShell = userLoginShellURL()?.path
         let candidatePaths = [
-            environment["SHELL"],
             userShell,
             "/bin/zsh",
             "/opt/homebrew/bin/zsh",

--- a/Sources/MacParakeetCore/Services/LLM/LocalCLIExecutor.swift
+++ b/Sources/MacParakeetCore/Services/LLM/LocalCLIExecutor.swift
@@ -913,7 +913,6 @@ public final class LocalCLIExecutor: Sendable {
     }
 
     static func candidatePATHProbeShellURLs(
-        environment _: [String: String] = ProcessInfo.processInfo.environment,
         fileManager: FileManager = .default
     ) -> [URL] {
         let userShell = userLoginShellURL()?.path

--- a/Tests/MacParakeetTests/Services/LLM/LocalCLIExecutorTests.swift
+++ b/Tests/MacParakeetTests/Services/LLM/LocalCLIExecutorTests.swift
@@ -514,8 +514,17 @@ final class LocalCLIExecutorTests: XCTestCase {
         let plantedShell = directory.appendingPathComponent("planted-shell")
         try createExecutable(at: plantedShell)
 
+        let previousShell = getenv("SHELL").map { String(cString: $0) }
+        setenv("SHELL", plantedShell.path, 1)
+        defer {
+            if let previousShell {
+                setenv("SHELL", previousShell, 1)
+            } else {
+                unsetenv("SHELL")
+            }
+        }
+
         let paths = LocalCLIExecutor.candidatePATHProbeShellURLs(
-            environment: ["SHELL": plantedShell.path],
             fileManager: .default
         ).map(\.path)
 
@@ -534,7 +543,6 @@ final class LocalCLIExecutorTests: XCTestCase {
         let fileManager = ExecutablePathFileManager(executablePaths: executablePaths)
 
         let paths = LocalCLIExecutor.candidatePATHProbeShellURLs(
-            environment: ["SHELL": environmentShell],
             fileManager: fileManager
         ).map(\.path)
 
@@ -549,48 +557,37 @@ final class LocalCLIExecutorTests: XCTestCase {
         XCTAssertTrue(paths.contains("/bin/sh"))
     }
 
-    func testCandidatePATHProbeShellURLsExcludeRelativeAndNonExecutableEnvironmentShells() throws {
-        let relativeShell = "relative-shell"
-        let relativePaths = LocalCLIExecutor.candidatePATHProbeShellURLs(
-            environment: ["SHELL": relativeShell],
-            fileManager: ExecutablePathFileManager(executablePaths: [relativeShell])
-        ).map(\.path)
-        XCTAssertFalse(relativePaths.contains(relativeShell))
+    func testCandidatePATHProbeShellURLsFilterNonExecutableCandidateShells() {
+        let executablePaths: Set<String> = ["/bin/zsh", "/bin/sh"]
+        let fileManager = ExecutablePathFileManager(executablePaths: executablePaths)
 
-        let directory = URL(fileURLWithPath: NSTemporaryDirectory())
-            .appendingPathComponent("localcli-nonexec-shell-\(UUID().uuidString)", isDirectory: true)
-        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(at: directory) }
+        let paths = LocalCLIExecutor.candidatePATHProbeShellURLs(fileManager: fileManager).map(\.path)
 
-        let nonExecutableShell = directory.appendingPathComponent("non-executable-shell")
-        try Data("#!/bin/sh\nexit 0\n".utf8).write(to: nonExecutableShell)
-        try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: nonExecutableShell.path)
+        var seen = Set<String>()
+        let expected = ([LocalCLIExecutor.userLoginShellURL()?.path].compactMap { $0 }
+            + Self.standardPATHProbeShellPaths)
+            .filter { path in
+                executablePaths.contains(path) && seen.insert(path).inserted
+            }
 
-        let nonExecutablePaths = LocalCLIExecutor.candidatePATHProbeShellURLs(
-            environment: ["SHELL": nonExecutableShell.path],
-            fileManager: .default
-        ).map(\.path)
-        XCTAssertFalse(nonExecutablePaths.contains(nonExecutableShell.path))
+        XCTAssertEqual(paths, expected)
+        XCTAssertTrue(paths.contains("/bin/zsh"))
+        XCTAssertFalse(paths.contains("/bin/bash"))
+        XCTAssertTrue(paths.contains("/bin/sh"))
     }
 
-    func testCandidatePATHProbeShellURLsDeduplicatesEmptyAndUnsetEnvironmentShell() {
+    func testCandidatePATHProbeShellURLsDeduplicatesCandidates() {
         let loginShell = LocalCLIExecutor.userLoginShellURL()?.path
         let executablePaths = Set([loginShell].compactMap { $0 } + Self.standardPATHProbeShellPaths)
         let fileManager = ExecutablePathFileManager(executablePaths: executablePaths)
 
-        let unsetPaths = LocalCLIExecutor.candidatePATHProbeShellURLs(
-            environment: [:],
-            fileManager: fileManager
-        ).map(\.path)
-        let emptyPaths = LocalCLIExecutor.candidatePATHProbeShellURLs(
-            environment: ["SHELL": ""],
+        let paths = LocalCLIExecutor.candidatePATHProbeShellURLs(
             fileManager: fileManager
         ).map(\.path)
 
-        XCTAssertEqual(emptyPaths, unsetPaths)
-        XCTAssertEqual(unsetPaths.count, Set(unsetPaths).count)
+        XCTAssertEqual(paths.count, Set(paths).count)
         if let loginShell, Self.standardPATHProbeShellPaths.contains(loginShell) {
-            XCTAssertEqual(unsetPaths.filter { $0 == loginShell }.count, 1)
+            XCTAssertEqual(paths.filter { $0 == loginShell }.count, 1)
         }
     }
 

--- a/Tests/MacParakeetTests/Services/LLM/LocalCLIExecutorTests.swift
+++ b/Tests/MacParakeetTests/Services/LLM/LocalCLIExecutorTests.swift
@@ -2,8 +2,26 @@ import XCTest
 @testable import MacParakeetCore
 
 final class LocalCLIExecutorTests: XCTestCase {
+    private static let standardPATHProbeShellPaths = [
+        "/bin/zsh",
+        "/opt/homebrew/bin/zsh",
+        "/usr/local/bin/zsh",
+        "/bin/bash",
+        "/opt/homebrew/bin/bash",
+        "/usr/local/bin/bash",
+        "/opt/homebrew/bin/fish",
+        "/usr/local/bin/fish",
+        "/usr/bin/fish",
+        "/bin/sh",
+    ]
+
     private func shellQuote(_ value: String) -> String {
         "'\(value.replacingOccurrences(of: "'", with: "'\"'\"'"))'"
+    }
+
+    private func createExecutable(at url: URL) throws {
+        try Data("#!/bin/sh\nexit 0\n".utf8).write(to: url)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
     }
 
     private func isProcessRunning(_ pid: Int32) -> Bool {
@@ -487,6 +505,95 @@ final class LocalCLIExecutorTests: XCTestCase {
         XCTAssertEqual(path, "/tmp/discovered/path")
     }
 
+    func testCandidatePATHProbeShellURLsIgnoreExecutableEnvironmentShell() throws {
+        let directory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("localcli-shell-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let plantedShell = directory.appendingPathComponent("planted-shell")
+        try createExecutable(at: plantedShell)
+
+        let paths = LocalCLIExecutor.candidatePATHProbeShellURLs(
+            environment: ["SHELL": plantedShell.path],
+            fileManager: .default
+        ).map(\.path)
+
+        XCTAssertNotEqual(paths.first, plantedShell.path)
+        XCTAssertFalse(paths.contains(plantedShell.path))
+    }
+
+    func testCandidatePATHProbeShellURLsUseLoginShellAndStandardShellsInOrder() {
+        let loginShell = LocalCLIExecutor.userLoginShellURL()?.path
+        let environmentShell = "/tmp/attacker-shell"
+        let executablePaths = Set(
+            [loginShell].compactMap { $0 }
+                + Self.standardPATHProbeShellPaths
+                + [environmentShell]
+        )
+        let fileManager = ExecutablePathFileManager(executablePaths: executablePaths)
+
+        let paths = LocalCLIExecutor.candidatePATHProbeShellURLs(
+            environment: ["SHELL": environmentShell],
+            fileManager: fileManager
+        ).map(\.path)
+
+        var seen = Set<String>()
+        let expected = ([loginShell].compactMap { $0 } + Self.standardPATHProbeShellPaths)
+            .filter { seen.insert($0).inserted }
+
+        XCTAssertEqual(paths, expected)
+        XCTAssertFalse(paths.contains(environmentShell))
+        XCTAssertTrue(paths.contains("/bin/zsh"))
+        XCTAssertTrue(paths.contains("/bin/bash"))
+        XCTAssertTrue(paths.contains("/bin/sh"))
+    }
+
+    func testCandidatePATHProbeShellURLsExcludeRelativeAndNonExecutableEnvironmentShells() throws {
+        let relativeShell = "relative-shell"
+        let relativePaths = LocalCLIExecutor.candidatePATHProbeShellURLs(
+            environment: ["SHELL": relativeShell],
+            fileManager: ExecutablePathFileManager(executablePaths: [relativeShell])
+        ).map(\.path)
+        XCTAssertFalse(relativePaths.contains(relativeShell))
+
+        let directory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("localcli-nonexec-shell-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let nonExecutableShell = directory.appendingPathComponent("non-executable-shell")
+        try Data("#!/bin/sh\nexit 0\n".utf8).write(to: nonExecutableShell)
+        try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: nonExecutableShell.path)
+
+        let nonExecutablePaths = LocalCLIExecutor.candidatePATHProbeShellURLs(
+            environment: ["SHELL": nonExecutableShell.path],
+            fileManager: .default
+        ).map(\.path)
+        XCTAssertFalse(nonExecutablePaths.contains(nonExecutableShell.path))
+    }
+
+    func testCandidatePATHProbeShellURLsDeduplicatesEmptyAndUnsetEnvironmentShell() {
+        let loginShell = LocalCLIExecutor.userLoginShellURL()?.path
+        let executablePaths = Set([loginShell].compactMap { $0 } + Self.standardPATHProbeShellPaths)
+        let fileManager = ExecutablePathFileManager(executablePaths: executablePaths)
+
+        let unsetPaths = LocalCLIExecutor.candidatePATHProbeShellURLs(
+            environment: [:],
+            fileManager: fileManager
+        ).map(\.path)
+        let emptyPaths = LocalCLIExecutor.candidatePATHProbeShellURLs(
+            environment: ["SHELL": ""],
+            fileManager: fileManager
+        ).map(\.path)
+
+        XCTAssertEqual(emptyPaths, unsetPaths)
+        XCTAssertEqual(unsetPaths.count, Set(unsetPaths).count)
+        if let loginShell, Self.standardPATHProbeShellPaths.contains(loginShell) {
+            XCTAssertEqual(unsetPaths.filter { $0 == loginShell }.count, 1)
+        }
+    }
+
     func testPathProbeArgumentsPreferInteractiveLoginForZshAndBash() {
         let script = "echo path"
 
@@ -545,5 +652,18 @@ final class LocalCLIExecutorTests: XCTestCase {
             ]),
             "/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin"
         )
+    }
+}
+
+private final class ExecutablePathFileManager: FileManager {
+    private let executablePaths: Set<String>
+
+    init(executablePaths: Set<String>) {
+        self.executablePaths = executablePaths
+        super.init()
+    }
+
+    override func isExecutableFile(atPath path: String) -> Bool {
+        executablePaths.contains(path)
     }
 }


### PR DESCRIPTION
## Summary

Hardens `LocalCLIExecutor.candidatePATHProbeShellURLs` so the PATH-recovery probe no longer trusts the inherited `SHELL` environment variable. The candidate shell list now relies on the login shell from `getpwuid(getuid()).pw_shell` plus the existing hardcoded absolute-path allowlist (`/bin/zsh`, `/bin/bash`, `/bin/sh`, the Homebrew/usr-local variants, fish). The existing `hasPrefix("/")` + `isExecutableFile` filtering and `seen`-set dedupe are unchanged, so users whose login shell is a normal shell keep working exactly as before.

This addresses finding **S-2 (P2)** from the security review in #564.

## Why this matters

`candidatePATHProbeShellURLs()` feeds `discoverPATH()`, whose result is merged via `preferredPATH(...)` into the `PATH` of every subprocess MacParakeet spawns afterward (`claude`, `codex`, `ffmpeg`, `yt-dlp`, `osascript`). Previously `environment["SHELL"]` was placed first in the candidate list and validated only with `hasPrefix("/")` + `isExecutableFile`. A parent process that launches MacParakeet with `SHELL` pointed at a planted executable could have that binary run with `-i -l -c` during the probe, and the `PATH` it emitted would then be inherited by the spawned tools, redirecting them to attacker-supplied binaries.

Dropping `SHELL` as a probe source removes the only environment-controllable entry from the candidate list; the remaining sources (the OS login-shell record and fixed absolute paths) are not attacker-controllable via the environment. This matches the auditor's suggested fix.

Scope note: #564 bundles four findings (S-1..S-4). This PR is the S-2 fix only and intentionally does not touch `preferredPATH`, `spawnShell`, or the command-template path.

## Testing

- `swift build` — clean.
- `swift test --filter LocalCLIExecutorTests` — 32 tests, 0 failures.

New `LocalCLIExecutorTests` coverage for the probe:
- a planted executable in `SHELL` is no longer returned (not first, and not at all unless it is also the login shell or a hardcoded path),
- a normal environment still yields the login shell plus the standard `/bin/zsh`, `/bin/bash`, `/bin/sh` candidates in priority order,
- a non-absolute or non-executable `SHELL` stays excluded,
- empty/unset `SHELL` and a login shell that equals a hardcoded path do not produce duplicates.

Refs #564
