### PR TITLE
Fix meeting pill rosette reentry

### DIFF
--- a/Sources/MacParakeet/Views/MeetingRecording/MerkabaPillIcon.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MerkabaPillIcon.swift
@@ -108,8 +108,20 @@ final class MerkabaPillIconView: NSView {
         }.sorted()
     }
 
+    private var hasRecordingRotationAnimation: Bool {
+        flowerLayer.animation(forKey: "recordingRotation") != nil
+    }
+
     var testHook_rosetteCompletionAnimationKeys: [String] {
         rosetteCompletionAnimationKeys
+    }
+
+    var testHook_hasRecordingRotationAnimation: Bool {
+        hasRecordingRotationAnimation
+    }
+
+    func testHook_removeRecordingRotationAnimation() {
+        flowerLayer.removeAnimation(forKey: "recordingRotation")
     }
 
     private var didBuildLayers = false
@@ -170,7 +182,8 @@ final class MerkabaPillIconView: NSView {
             resetRosetteAfterCompletion()
         }
 
-        if currentAnimating != isAnimating {
+        let shouldRestartRecordingAnimation = isAnimating && currentAnimating && !hasRecordingRotationAnimation
+        if currentAnimating != isAnimating || shouldRestartRecordingAnimation {
             currentAnimating = isAnimating
             isAnimating ? startAnimations() : stopAnimations()
         }
@@ -911,7 +924,7 @@ final class MerkabaPillIconView: NSView {
     }
 
     private func startAnimations() {
-        guard flowerLayer.animation(forKey: "recordingRotation") == nil else { return }
+        guard !hasRecordingRotationAnimation else { return }
         // Clear any held collapse transforms from a prior cycle (defensive;
         // views are normally fresh per session).
         flowerLayer.removeAnimation(forKey: "completionSpin")

--- a/Sources/MacParakeet/Views/MeetingRecording/MerkabaPillIcon.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MerkabaPillIcon.swift
@@ -91,6 +91,27 @@ final class MerkabaPillIconView: NSView {
         ]
     }
 
+    private var rosetteCompletionAnimationKeys: [String] {
+        let layers: [(String, CALayer)] = [
+            ("glow", glowLayer),
+            ("flower", flowerLayer),
+            ("stem", stemLayer),
+            ("leftLeafFill", leftLeafFillLayer),
+            ("leftLeafStroke", leftLeafStrokeLayer),
+            ("rightLeafFill", rightLeafFillLayer),
+            ("rightLeafStroke", rightLeafStrokeLayer),
+        ]
+        return layers.flatMap { name, layer in
+            (layer.animationKeys() ?? [])
+                .filter { $0.hasPrefix("completion") }
+                .map { "\(name).\($0)" }
+        }.sorted()
+    }
+
+    var testHook_rosetteCompletionAnimationKeys: [String] {
+        rosetteCompletionAnimationKeys
+    }
+
     private var didBuildLayers = false
     private var currentShowStem = true
     private var currentAnimating = false
@@ -143,7 +164,11 @@ final class MerkabaPillIconView: NSView {
 
     func update(isAnimating: Bool, audioLevel: Float) {
         buildLayersIfNeeded()
+        let shouldResetRosette = currentFace != .rosette || !rosetteCompletionAnimationKeys.isEmpty
         setFace(.rosette)
+        if shouldResetRosette {
+            resetRosetteAfterCompletion()
+        }
 
         if currentAnimating != isAnimating {
             currentAnimating = isAnimating
@@ -848,6 +873,42 @@ final class MerkabaPillIconView: NSView {
     }
 
     // MARK: - Recording rosette animations
+
+    private func resetRosetteAfterCompletion() {
+        completionDelayTask?.cancel()
+        completionDelayTask = nil
+
+        flowerLayer.removeAnimation(forKey: "completionSpin")
+        flowerLayer.removeAnimation(forKey: "completionScale")
+        flowerLayer.removeAnimation(forKey: "completionHeadFade")
+        glowLayer.removeAnimation(forKey: "completionWarm")
+        glowLayer.removeAnimation(forKey: "completionGlowFade")
+        stemLayer.removeAnimation(forKey: "completionRetract")
+        stemLayer.removeAnimation(forKey: "completionStemFade")
+        for layer in rosetteLayers {
+            layer.removeAnimation(forKey: "completionFade")
+        }
+        for layer in [leftLeafFillLayer, leftLeafStrokeLayer, rightLeafFillLayer, rightLeafStrokeLayer] {
+            layer.removeAnimation(forKey: "completionDrift")
+        }
+
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        flowerLayer.opacity = 1
+        flowerLayer.transform = CATransform3DIdentity
+        stemLayer.opacity = 1
+        stemLayer.strokeEnd = 1
+        stemLayer.transform = CATransform3DIdentity
+        for layer in [leftLeafFillLayer, leftLeafStrokeLayer, rightLeafFillLayer, rightLeafStrokeLayer] {
+            layer.opacity = 1
+            layer.transform = CATransform3DIdentity
+        }
+        applyRosetteColors()
+        CATransaction.commit()
+
+        currentAudioLevel = -1
+        smoothedGlow = -1
+    }
 
     private func startAnimations() {
         guard flowerLayer.animation(forKey: "recordingRotation") == nil else { return }

--- a/Sources/MacParakeet/Views/MeetingRecording/MerkabaPillIcon.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MerkabaPillIcon.swift
@@ -909,6 +909,7 @@ final class MerkabaPillIconView: NSView {
         CATransaction.setDisableActions(true)
         flowerLayer.opacity = 1
         flowerLayer.transform = CATransform3DIdentity
+        glowLayer.opacity = glowBase
         stemLayer.opacity = 1
         stemLayer.strokeEnd = 1
         stemLayer.transform = CATransform3DIdentity

--- a/Sources/MacParakeet/Views/MeetingRecording/MerkabaPillIcon.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MerkabaPillIcon.swift
@@ -926,10 +926,6 @@ final class MerkabaPillIconView: NSView {
 
     private func startAnimations() {
         guard !hasRecordingRotationAnimation else { return }
-        // Clear any held collapse transforms from a prior cycle (defensive;
-        // views are normally fresh per session).
-        flowerLayer.removeAnimation(forKey: "completionSpin")
-        flowerLayer.removeAnimation(forKey: "completionScale")
 
         let rotation = spinAnimation(to: CGFloat.pi * 2, duration: 12)
         flowerLayer.add(rotation, forKey: "recordingRotation")

--- a/Tests/MacParakeetTests/Views/MerkabaPillIconViewTests.swift
+++ b/Tests/MacParakeetTests/Views/MerkabaPillIconViewTests.swift
@@ -17,6 +17,19 @@ final class MerkabaPillIconViewTests: XCTestCase {
         XCTAssertTrue(view.testHook_hasRecordingRotationAnimation)
     }
 
+    func testRecordingReentryClearsHeldCompletionAnimationsBeforeMetatron() {
+        let view = MerkabaPillIconView(frame: NSRect(x: 0, y: 0, width: 30, height: 74))
+        view.layoutSubtreeIfNeeded()
+
+        view.playCompletion(reduceMotion: false) {}
+        XCTAssertFalse(view.testHook_rosetteCompletionAnimationKeys.isEmpty)
+
+        view.update(isAnimating: true, audioLevel: 0)
+
+        XCTAssertEqual(view.testHook_rosetteCompletionAnimationKeys, [])
+        XCTAssertTrue(view.testHook_hasRecordingRotationAnimation)
+    }
+
     func testRecordingUpdateRestartsMissingRotationAnimation() {
         let view = MerkabaPillIconView(frame: NSRect(x: 0, y: 0, width: 30, height: 74))
         view.layoutSubtreeIfNeeded()

--- a/Tests/MacParakeetTests/Views/MerkabaPillIconViewTests.swift
+++ b/Tests/MacParakeetTests/Views/MerkabaPillIconViewTests.swift
@@ -1,0 +1,18 @@
+import XCTest
+@testable import MacParakeet
+
+@MainActor
+final class MerkabaPillIconViewTests: XCTestCase {
+    func testRecordingReentryClearsHeldCompletionAnimations() {
+        let view = MerkabaPillIconView(frame: NSRect(x: 0, y: 0, width: 30, height: 74))
+        view.layoutSubtreeIfNeeded()
+
+        view.playCompletion(reduceMotion: false) {}
+        view.showMetatron(animated: true)
+        XCTAssertFalse(view.testHook_rosetteCompletionAnimationKeys.isEmpty)
+
+        view.update(isAnimating: true, audioLevel: 0)
+
+        XCTAssertEqual(view.testHook_rosetteCompletionAnimationKeys, [])
+    }
+}

--- a/Tests/MacParakeetTests/Views/MerkabaPillIconViewTests.swift
+++ b/Tests/MacParakeetTests/Views/MerkabaPillIconViewTests.swift
@@ -14,5 +14,21 @@ final class MerkabaPillIconViewTests: XCTestCase {
         view.update(isAnimating: true, audioLevel: 0)
 
         XCTAssertEqual(view.testHook_rosetteCompletionAnimationKeys, [])
+        XCTAssertTrue(view.testHook_hasRecordingRotationAnimation)
+    }
+
+    func testRecordingUpdateRestartsMissingRotationAnimation() {
+        let view = MerkabaPillIconView(frame: NSRect(x: 0, y: 0, width: 30, height: 74))
+        view.layoutSubtreeIfNeeded()
+
+        view.update(isAnimating: true, audioLevel: 0)
+        XCTAssertTrue(view.testHook_hasRecordingRotationAnimation)
+
+        view.testHook_removeRecordingRotationAnimation()
+        XCTAssertFalse(view.testHook_hasRecordingRotationAnimation)
+
+        view.update(isAnimating: true, audioLevel: 0)
+
+        XCTAssertTrue(view.testHook_hasRecordingRotationAnimation)
     }
 }


### PR DESCRIPTION
## Summary

Back-to-back meeting recordings now reset the floating pill's rosette before recording animation restarts, even when the next recording starts during the saved-completion Metatron/check transition window.

The reused `MerkabaPillIconView` could still have fill-forwards completion animations attached to the flower/stem/leaf layers, leaving the timer visible while the mark stayed visually collapsed. The fix clears those held completion animations and restores the rosette model state when the view re-enters recording.

## Testing

- `swift test --filter MerkabaPillIconViewTests`
- `swift test --filter MeetingRecordingFlowCoordinatorTests`
- `swift test --filter MeetingRecordingFlowStateMachineTests`
- `git diff --check`
- `swift test`
