### PR TITLE
Heal stranded meeting filePath on partial audio removal

### DIFF
--- a/Sources/MacParakeetCore/Utilities/TranscriptionAssetCleanup.swift
+++ b/Sources/MacParakeetCore/Utilities/TranscriptionAssetCleanup.swift
@@ -101,7 +101,28 @@ public enum TranscriptionAssetCleanup {
             id: transcription.id,
             folderPath: removalPlan.folderURL.path
         )
-        try removeMeetingAudioFiles(removalPlan, fileManager: fileManager)
+        do {
+            try removeMeetingAudioFiles(removalPlan, fileManager: fileManager)
+        } catch let removalError {
+            // The candidate set is unordered, so a mid-loop failure can leave the
+            // canonical mixed file (the one `filePath` points at) already deleted
+            // while a sibling (microphone.m4a/system.m4a) removal throws. Keep the
+            // DB pointer consistent with disk: if the mixed file is gone, clear
+            // `filePath` so the row stops advertising playable audio and the
+            // retention sweeper stops re-selecting and re-failing on it forever.
+            // Re-throw so callers still learn the removal was incomplete.
+            if let mixedAudioURL = removalPlan.mixedAudioURL,
+               !fileManager.fileExists(atPath: mixedAudioURL.path) {
+                do {
+                    try repository.updateFilePath(id: transcription.id, filePath: nil)
+                } catch {
+                    logger.warning(
+                        "Failed to clear stranded meeting audio path after partial removal: \(String(describing: error), privacy: .private)"
+                    )
+                }
+            }
+            throw removalError
+        }
         try repository.updateFilePath(id: transcription.id, filePath: nil)
         return MeetingAudioDetachResult(removedOwnedAudio: true, hadAudioPath: true)
     }
@@ -135,7 +156,8 @@ public enum TranscriptionAssetCleanup {
 
         return MeetingAudioRemovalPlan(
             folderURL: folderURL,
-            candidates: meetingAudioFileCandidates(mixedAudioURL: mixedAudioURL, folderURL: folderURL)
+            candidates: meetingAudioFileCandidates(mixedAudioURL: mixedAudioURL, folderURL: folderURL),
+            mixedAudioURL: mixedAudioURL
         )
     }
 
@@ -309,4 +331,7 @@ private struct MeetingArtifactManifestProbe: Decodable {
 private struct MeetingAudioRemovalPlan {
     let folderURL: URL
     let candidates: Set<URL>
+    /// The audio file `transcription.filePath` points at (the canonical mixed
+    /// recording). `nil` for bulk folder cleanup, which has no single owning row.
+    var mixedAudioURL: URL?
 }

--- a/Sources/MacParakeetCore/Utilities/TranscriptionAssetCleanup.swift
+++ b/Sources/MacParakeetCore/Utilities/TranscriptionAssetCleanup.swift
@@ -216,7 +216,8 @@ public enum TranscriptionAssetCleanup {
             )
             let plan = MeetingAudioRemovalPlan(
                 folderURL: folderURL,
-                candidates: try managedMeetingAudioFiles(in: folderURL, fileManager: fileManager)
+                candidates: try managedMeetingAudioFiles(in: folderURL, fileManager: fileManager),
+                mixedAudioURL: nil
             )
             try removeMeetingAudioFiles(plan, fileManager: fileManager)
         }
@@ -333,5 +334,5 @@ private struct MeetingAudioRemovalPlan {
     let candidates: Set<URL>
     /// The audio file `transcription.filePath` points at (the canonical mixed
     /// recording). `nil` for bulk folder cleanup, which has no single owning row.
-    var mixedAudioURL: URL?
+    let mixedAudioURL: URL?
 }

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionDeletionCleanupTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionDeletionCleanupTests.swift
@@ -250,6 +250,45 @@ final class TranscriptionDeletionCleanupTests: XCTestCase {
         XCTAssertEqual(repo.transcriptions.first?.meetingArtifactFolderPath, folderURL.standardizedFileURL.path)
     }
 
+    func testDetachMeetingAudioClearsFilePathWhenMixedFileGoneButSiblingRemovalFails() throws {
+        // Regression: the canonical mixed recording (meeting.m4a, the file
+        // `filePath` points at) is already gone -- e.g. removed by an earlier
+        // partial detach -- while a sibling (microphone.m4a) remains and fails to
+        // delete. The detach must still heal the DB pointer: clear `filePath` so a
+        // row never advertises playable audio that no longer exists (and the
+        // retention sweeper stops re-selecting and re-failing it every sweep), yet
+        // still surface the partial-failure error to the caller.
+        let folderURL = URL(fileURLWithPath: AppPaths.meetingRecordingsDir, isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: folderURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: folderURL) }
+
+        // filePath points at meeting.m4a, but that file is intentionally absent.
+        let mixedURL = folderURL.appendingPathComponent("meeting.m4a")
+        let siblingURL = folderURL.appendingPathComponent("microphone.m4a")
+        XCTAssertTrue(FileManager.default.createFile(atPath: siblingURL.path, contents: Data("mic".utf8)))
+
+        let transcription = Transcription(
+            fileName: "Meeting",
+            filePath: mixedURL.path,
+            status: .completed,
+            sourceType: .meeting
+        )
+        let repo = MockTranscriptionRepository()
+        repo.transcriptions = [transcription]
+
+        XCTAssertThrowsError(try TranscriptionAssetCleanup.detachOwnedMeetingAudio(
+            for: transcription,
+            repository: repo,
+            fileManager: ThrowingRemoveFileManager(failingURLs: [siblingURL])
+        ))
+        XCTAssertNil(repo.transcriptions.first?.filePath)
+        XCTAssertEqual(repo.transcriptions.first?.meetingArtifactFolderPath, folderURL.standardizedFileURL.path)
+        // The undeletable sibling is left on disk (the partial-failure residue);
+        // the folder stays visible so the meeting remains recoverable.
+        XCTAssertTrue(FileManager.default.fileExists(atPath: siblingURL.path))
+    }
+
     func testMeetingDeletionOutsideAppSupportIsIgnored() throws {
         let folderURL = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)


### PR DESCRIPTION
## What

`detachOwnedMeetingAudio` (the shared "Delete Audio Only" implementation) could leave a meeting row's `filePath` pointing at a file that no longer exists, when audio deletion fails partway through.

`removeMeetingAudioFiles` walks an unordered `Set<URL>` of candidates (`meeting.m4a`, `microphone.m4a`, `system.m4a`). If a sibling removal throws mid-loop (permission/IO error) **after** the canonical mixed file the row points at was already deleted, the throw propagated and the final `updateFilePath(nil)` never ran.

## Why it matters

- `MeetingAudioRetentionSweeper` selects candidates by `filePath` being non-empty (not by on-disk existence), so it re-selected and re-failed the same stranded row on **every sweep**, never converging.
- The row keeps advertising playable audio that is gone.

No user data is lost: the durable artifact folder path is recorded *before* the deletion loop, so transcript / notes / prompt results are untouched and the meeting stays recoverable.

## Fix

On a `removeMeetingAudioFiles` throw, check whether the mixed audio file (now exposed on `MeetingAudioRemovalPlan.mixedAudioURL`) still exists. If it's gone, clear `filePath` so the DB reflects disk, then **re-throw the original removal error** so callers (UI / CLI / sweeper) still learn the deletion was incomplete. A secondary repo error during the corrective clear is logged, not swallowed into the primary signal.

Unchanged:
- Happy path (full clean delete → `filePath` nil).
- The "mixed file itself failed to delete → keep `filePath`" path (the file is still there, so the pointer is still valid).
- Deletion gating (`isKnownMeetingFolder` + `assertMeetingFolderUnlocked`).

The undeletable sibling is left on disk as a minor residue; the folder stays visible.

## Tests

- New `testDetachMeetingAudioClearsFilePathWhenMixedFileGoneButSiblingRemovalFails`: sibling removal throws while the mixed file is gone → call throws AND `filePath` ends nil AND `meetingArtifactFolderPath` preserved.
- Existing `testDetachMeetingAudioKeepsFilePathWhenFileRemovalFails` still pins the keep-`filePath` behavior when the mixed file is the one that fails.
- Full suite: `swift test` → 4014 tests, 0 failures (was 4013; +1 new).

No CLI contract change; no CHANGELOG entry needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where "Delete Audio Only" could leave a stale meeting `filePath` after a partial audio deletion failure. This prevents the retention sweeper from reprocessing the same meeting and removes phantom playable audio.

- **Bug Fixes**
  - If `removeMeetingAudioFiles` throws and the mixed recording is already gone, clear `filePath` to match disk, then rethrow the original error.
  - Added `mixedAudioURL` to `MeetingAudioRemovalPlan` to detect this condition.
  - Preserves artifact folder path; happy path unchanged. If the mixed file fails to delete, `filePath` is kept.
  - Added a regression test for the sibling-failure-after-mixed-file-removed case.

- **Refactors**
  - Made `MeetingAudioRemovalPlan.mixedAudioURL` immutable (`let`); bulk cleanup now passes `mixedAudioURL: nil` explicitly. No behavior change.

<sup>Written for commit 26c1a90d86e3edda1220cc7a99b5929806eb01c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/592?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

