### PR TITLE
Fix Library bulk-selection hit target, focus ring, and Select All label

### DIFF
--- a/Sources/MacParakeet/Views/Meetings/MeetingsView.swift
+++ b/Sources/MacParakeet/Views/Meetings/MeetingsView.swift
@@ -48,7 +48,7 @@ struct MeetingsView: View {
         .focused($recentMeetingsSelectionFocused)
         // Keep keyboard focus (for ⌘A / Delete) but suppress the system focus
         // ring so entering selection mode doesn't flash a blue focus line.
-        .focusEffectDisabled()
+        .focusEffectDisabled(viewModel.recentMeetingsViewModel.isBulkSelectionModeEnabled)
         .onChange(of: viewModel.recentMeetingsViewModel.isBulkSelectionModeEnabled) { _, enabled in
             if enabled {
                 recentMeetingsSelectionFocused = true

--- a/Sources/MacParakeet/Views/Meetings/MeetingsView.swift
+++ b/Sources/MacParakeet/Views/Meetings/MeetingsView.swift
@@ -46,6 +46,9 @@ struct MeetingsView: View {
         }
         .focusable(viewModel.recentMeetingsViewModel.isBulkSelectionModeEnabled)
         .focused($recentMeetingsSelectionFocused)
+        // Keep keyboard focus (for ⌘A / Delete) but suppress the system focus
+        // ring so entering selection mode doesn't flash a blue focus line.
+        .focusEffectDisabled()
         .onChange(of: viewModel.recentMeetingsViewModel.isBulkSelectionModeEnabled) { _, enabled in
             if enabled {
                 recentMeetingsSelectionFocused = true
@@ -623,7 +626,6 @@ struct MeetingsView: View {
             selectedCount: viewModel.recentMeetingsViewModel.selectedTranscriptionCount,
             selectedMeetingAudioCount: viewModel.recentMeetingsViewModel.selectedMeetingAudioCount,
             isMeetingContext: true,
-            selectVisibleTitle: viewModel.recentMeetingsViewModel.hasMore ? "Select Visible" : "Select All",
             areAllVisibleSelected: viewModel.recentMeetingsViewModel.areAllLoadedVisibleTranscriptionsSelected,
             isPerformingOperation: viewModel.recentMeetingsViewModel.isBulkOperationInProgress,
             onSelectVisible: { viewModel.recentMeetingsViewModel.selectLoadedVisibleTranscriptions() },

--- a/Sources/MacParakeet/Views/Transcription/BulkTranscriptionSelectionBar.swift
+++ b/Sources/MacParakeet/Views/Transcription/BulkTranscriptionSelectionBar.swift
@@ -4,7 +4,6 @@ struct BulkTranscriptionSelectionBar: View {
     let selectedCount: Int
     let selectedMeetingAudioCount: Int
     let isMeetingContext: Bool
-    let selectVisibleTitle: String
     let areAllVisibleSelected: Bool
     let isPerformingOperation: Bool
     let onSelectVisible: () -> Void
@@ -146,9 +145,13 @@ struct BulkTranscriptionSelectionBar: View {
         )
     }
 
+    // Labeled "Select All" but scoped to the loaded rows by design: selection
+    // (and therefore deletion) never reaches rows that aren't loaded yet. The
+    // selected-count chip and the delete confirmation always state the exact
+    // number, so the scope is explicit at the moment of action.
     private var selectVisibleAction: some View {
         SelectionBarActionButton(
-            title: selectVisibleTitle,
+            title: "Select All",
             systemImage: "checkmark.circle",
             tone: .utility,
             isDisabled: areAllVisibleSelected || isPerformingOperation,

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
@@ -93,6 +93,11 @@ struct TranscriptionLibraryView: View {
         .searchable(text: $viewModel.searchText, prompt: "Search transcriptions")
         .focusable(viewModel.isBulkSelectionModeEnabled)
         .focused($selectionKeyboardFocused)
+        // Keep keyboard focus (for ⌘A / Delete) but suppress the system focus
+        // ring. The ring is drawn in the system accent (blue), reads as a
+        // full-width line across the content's top edge on entering selection
+        // mode, and its first-responder draw is the hitch felt as "jank".
+        .focusEffectDisabled()
         .onChange(of: viewModel.isBulkSelectionModeEnabled) { _, enabled in
             if enabled {
                 selectionKeyboardFocused = true
@@ -355,7 +360,6 @@ struct TranscriptionLibraryView: View {
             selectedCount: viewModel.selectedTranscriptionCount,
             selectedMeetingAudioCount: viewModel.selectedMeetingAudioCount,
             isMeetingContext: isMeetingListMode,
-            selectVisibleTitle: viewModel.hasMore ? "Select Visible" : "Select All",
             areAllVisibleSelected: viewModel.areAllLoadedVisibleTranscriptionsSelected,
             isPerformingOperation: viewModel.isBulkOperationInProgress,
             onSelectVisible: { viewModel.selectLoadedVisibleTranscriptions() },

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
@@ -97,7 +97,7 @@ struct TranscriptionLibraryView: View {
         // ring. The ring is drawn in the system accent (blue), reads as a
         // full-width line across the content's top edge on entering selection
         // mode, and its first-responder draw is the hitch felt as "jank".
-        .focusEffectDisabled()
+        .focusEffectDisabled(viewModel.isBulkSelectionModeEnabled)
         .onChange(of: viewModel.isBulkSelectionModeEnabled) { _, enabled in
             if enabled {
                 selectionKeyboardFocused = true

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionThumbnailCard.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionThumbnailCard.swift
@@ -42,6 +42,10 @@ struct TranscriptionThumbnailCard<MenuContent: View>: View {
             if showsSelectionControls {
                 selectionBadge
                     .padding(8)
+                    // Decorative state indicator only — the whole card is the
+                    // tap target. Without this, the filled circle intercepts
+                    // clicks that land directly on it and swallows the toggle.
+                    .allowsHitTesting(false)
             }
         }
         .overlay(alignment: .topTrailing) {

--- a/Sources/MacParakeetViewModels/TranscriptionLibraryViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionLibraryViewModel.swift
@@ -153,7 +153,7 @@ public final class TranscriptionLibraryViewModel {
 
     public var areAllLoadedVisibleTranscriptionsSelected: Bool {
         let ids = loadedVisibleTranscriptionIDs
-        return !ids.isEmpty && ids.isSubset(of: selectedTranscriptionIDs)
+        return ids.isEmpty || ids.isSubset(of: selectedTranscriptionIDs)
     }
 
     public var selectedMeetingAudioCount: Int {

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionLibraryViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionLibraryViewModelTests.swift
@@ -315,6 +315,21 @@ final class TranscriptionLibraryViewModelTests: XCTestCase {
         XCTAssertEqual(vm.selectedTranscriptionIDs, [matching.id])
     }
 
+    func testAllLoadedVisibleTranscriptionsSelectedWhenSearchHasNoMatches() async throws {
+        let matching = Transcription(fileName: "Swift Tutorial", status: .completed)
+        try repo.save(matching)
+
+        await load()
+
+        vm.beginBulkSelection(startingWith: matching)
+        vm.searchText = "no matches"
+        await load()
+
+        XCTAssertTrue(vm.filteredTranscriptions.isEmpty)
+        XCTAssertTrue(vm.selectedTranscriptionIDs.isEmpty)
+        XCTAssertTrue(vm.areAllLoadedVisibleTranscriptionsSelected)
+    }
+
     // MARK: - Delete
 
     func testDeleteTranscription() async throws {

--- a/spec/02-features.md
+++ b/spec/02-features.md
@@ -601,7 +601,7 @@ The app lives primarily in the menu bar. Click the icon for quick actions, or op
 - Context menu: Play/Pause, Copy, Download Audio, Delete
 - Keyboard shortcut: Cmd+Backspace to delete
 - Text selection enabled on transcript text
-- Multi-select cleanup is an explicit bulk-selection mode: hidden during ordinary browsing, entered via the row three-dot menu's `Select Many...` (which preselects that row), surfacing per-row selection circles and a bulk action bar (Cancel, Select All, Clear, Delete). If additional rows are not yet loaded, the bulk action reads `Select Visible` so deletion never silently targets unloaded records. The mode exits on confirmed bulk delete, Cancel, switching to the Stats sub-tab, or leaving the Dictations section.
+- Multi-select cleanup is an explicit bulk-selection mode: hidden during ordinary browsing, entered via the row three-dot menu's `Select Many...` (which preselects that row), surfacing per-row selection circles and a bulk action bar (Cancel, Select All, Clear, Delete). `Select All` targets the loaded rows only, so deletion never silently reaches unloaded records. The mode exits on confirmed bulk delete, Cancel, switching to the Stats sub-tab, or leaving the Dictations section.
 - Delete confirmation dialog before permanent removal
 
 **Database schema:**
@@ -1557,7 +1557,7 @@ Embedded video/audio playback, split-pane detail view, synced transcript highlig
 - [x] Filter bar: All / YouTube / Local / Favorites
 - [x] Search across transcription titles and content
 - [x] Sort by date (newest/oldest)
-- [x] Multi-select cleanup with `Select Many...`, `Select All` / `Select Visible`, clear/cancel, and contextual destructive confirmations
+- [x] Multi-select cleanup with `Select Many...`, `Select All`, clear/cancel, and contextual destructive confirmations
 - [x] Meeting cleanup supports both full deletion and `Remove Audio Only...`; optional notes, AI results, and chats are removed only by full meeting deletion
 
 ### F27: Home Page Redesign

--- a/spec/04-ui-patterns.md
+++ b/spec/04-ui-patterns.md
@@ -125,7 +125,7 @@ When `Library.filter == .meeting`, the view renders a date-grouped list (`Today`
 
 ### Library Multi-Select Cleanup
 
-Library offers a `Select Many...` secondary action when there are visible rows. Selection mode keeps actions in a contextual bar above the content: `Cancel`, `Select All` when all matching rows are loaded or `Select Visible` while more rows can still be loaded, `Clear`, `Remove Audio Only...` for selected meetings with stored audio, and `Delete Items...` / `Delete Meetings...` for full deletion.
+Library offers a `Select Many...` secondary action when there are visible rows. Selection mode keeps actions in a contextual bar above the content: `Cancel`, `Select All` (which targets the loaded rows only, so deletion never reaches unloaded records), `Clear`, `Remove Audio Only...` for selected meetings with stored audio, and `Delete Items...` / `Delete Meetings...` for full deletion.
 
 Selected cards and meeting rows use the app accent/coral selected state. Destructive red is reserved for confirmation actions and destructive menu items, not for the selected state itself. Meeting full deletion removes the meeting row, transcript, stored audio, notes, AI results, and chats when those optional artifacts exist. `Remove Audio Only...` removes only stored meeting audio and leaves the transcript plus optional notes, AI results, and chats. Confirmation copy must state that playback and retranscription become unavailable unless the user saved a copy of the audio.
 


### PR DESCRIPTION
## What & why

Three fixes to the Library/Meetings **Select Many** bulk-selection UI, reported from real use, plus a label cleanup.

### 1. Clicking the selection circle did nothing
On a Library thumbnail card, clicking the rest of the card toggled selection but clicking **directly on the circle** did nothing. The circle (`selectionBadge`) is an `.overlay` layered *on top of* the card `Button` and was hit-testable, so taps landing on it were swallowed instead of reaching the Button's toggle.
**Fix:** `.allowsHitTesting(false)` on the decorative badge so the whole card surface — circle included — routes to the Button. (`MeetingRowCard` puts its badge *inside* the Button, which is exactly why only the thumbnail grid had the bug.)

### 2. Blue line + jank entering selection mode
Entering selection mode flashed a blue line across the top of the content (only the first time) and felt janky. The content is `.focusable(isBulkSelectionModeEnabled)` and gets programmatically focused to capture ⌘A / Delete; macOS draws the **system focus ring** (system-accent *blue*, not the app's coral) on first-responder acquisition — that's the line, and its first-frame draw is the felt hitch.
**Fix:** `.focusEffectDisabled()` on `TranscriptionLibraryView` and `MeetingsView` — keeps focus + key handling, removes the ring and its draw cost. (macOS 14+, matches our deployment target.)

### 3. "Select Visible" → "Select All"
The bulk action was conditionally labeled `Select Visible` (paginated) / `Select All` (fully loaded). Renamed to an unconditional **Select All**, matching the Dictation surface and Finder-style "select what's loaded" semantics. It still targets only loaded rows *by design*, so deletion never reaches unloaded records; the selected-count chip and delete confirmation always state exact counts. Drops the now-constant `selectVisibleTitle` parameter. Specs updated.

## Known follow-up (intentionally not in this PR)
The broad container `.animation(_:value:)` still reflows the lazy grid and inserts every card's badge in one pass on mode entry — a separate, *measurable* smoothness improvement. Left out to avoid a speculative layout change; the focus-ring removal was the high-impact, low-risk half.

## Verification
- `swift build` clean; full `swift test` green.
- Two independent fresh-eye reviews (Swift/SwiftUI reviewer + a second-opinion model) converged on **ship**, confirming both modifiers are correct and side-effect-free on macOS 14 (focus/⌘A/Delete and VoiceOver preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Library/Meetings Select Many UX: the selection circle now toggles as expected, the blue focus-ring flash is gone, and the action is standardized to “Select All” (still scoped to loaded rows) and disabled when no rows are visible.

- **Bug Fixes**
  - Make the thumbnail selection badge non-hit-testable so clicks on the circle toggle selection.
  - Suppress the macOS focus ring on selection mode entry while keeping ⌘A/Delete handling.
  - Always show “Select All”; remove `selectVisibleTitle`, keep scope to loaded rows, and update specs.
  - Treat zero visible rows as “all selected” to disable Select All; add a test for empty-search results.

<sup>Written for commit f295ff82090d1c50506ff1f777b00cfccaa79581. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

