### PR TITLE
Fix Remove Audio dialog counting non-meetings as skipped meetings

### DIFF
--- a/Sources/MacParakeetViewModels/TranscriptionLibraryViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionLibraryViewModel.swift
@@ -282,14 +282,19 @@ public final class TranscriptionLibraryViewModel {
 
     public func requestDeleteSelectedMeetingAudio() {
         guard !isBulkOperationInProgress else { return }
-        let selected = selectedLoadedTranscriptions
-        let targets = selected.filter(Self.hasAvailableMeetingAudio)
+        // Scope to meetings: "Remove Audio" only applies to meeting rows, so the
+        // skipped count must be meetings-without-saved-audio, not every selected
+        // non-meeting item. Counting all non-targets here mislabels videos/
+        // podcasts/local files as "meetings already with no saved audio" in the
+        // confirmation copy (which is meeting-only by design).
+        let meetings = selectedLoadedTranscriptions.filter { $0.sourceType == .meeting }
+        let targets = meetings.filter(Self.hasAvailableMeetingAudio)
         guard !targets.isEmpty else {
             return
         }
         pendingBulkOperation = .deleteAudioOnly(
             targets: targets,
-            skipped: selected.count - targets.count
+            skipped: meetings.count - targets.count
         )
     }
 

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionLibraryViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionLibraryViewModelTests.swift
@@ -553,7 +553,9 @@ final class TranscriptionLibraryViewModelTests: XCTestCase {
         vm.requestDeleteSelectedMeetingAudio()
         let result = await vm.confirmPendingBulkOperation()
 
-        XCTAssertEqual(result, BulkOperationResult(succeeded: 1, failed: 0, skipped: 2))
+        // skipped counts only the audio-less meeting; the non-meeting `local`
+        // file is ineligible for meeting-audio removal and must not inflate it.
+        XCTAssertEqual(result, BulkOperationResult(succeeded: 1, failed: 0, skipped: 1))
         XCTAssertFalse(vm.isBulkOperationInProgress)
         XCTAssertFalse(vm.isBulkSelectionModeEnabled)
         XCTAssertTrue(vm.selectedTranscriptionIDs.isEmpty)
@@ -570,6 +572,54 @@ final class TranscriptionLibraryViewModelTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: audioURL.path))
         XCTAssertFalse(FileManager.default.fileExists(atPath: systemURL.path))
         XCTAssertTrue(FileManager.default.fileExists(atPath: manifestURL.path))
+    }
+
+    func testRequestDeleteAudioOnlySkipCountExcludesNonMeetings() async throws {
+        // Mixed Library selection: meetings and non-meetings together. The
+        // "Remove Audio" skipped count must reflect meetings-without-saved-audio
+        // only, so the confirmation copy never mislabels videos/podcasts/local
+        // files as "selected meetings already with no saved audio."
+        try AppPaths.ensureDirectories()
+        let folder = URL(fileURLWithPath: AppPaths.meetingRecordingsDir, isDirectory: true)
+            .appendingPathComponent("library-mixed-skip-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+        let audioURL = folder.appendingPathComponent("meeting.m4a")
+        XCTAssertTrue(FileManager.default.createFile(atPath: audioURL.path, contents: Data("audio".utf8)))
+        defer { try? FileManager.default.removeItem(at: folder) }
+
+        let meetingWithAudio = Transcription(
+            fileName: "Meeting",
+            filePath: audioURL.path,
+            status: .completed,
+            sourceType: .meeting
+        )
+        let meetingWithoutAudio = Transcription(fileName: "No Audio", status: .completed, sourceType: .meeting)
+        let youtube = Transcription(
+            fileName: "video",
+            status: .completed,
+            sourceURL: "https://youtube.com/watch?v=abc",
+            sourceType: .youtube
+        )
+        let podcast = Transcription(fileName: "episode", status: .completed, sourceType: .podcast)
+        let local = Transcription(fileName: "local.mp3", status: .completed, sourceType: .file)
+        for transcription in [meetingWithAudio, meetingWithoutAudio, youtube, podcast, local] {
+            try repo.save(transcription)
+        }
+        await load()
+
+        vm.beginBulkSelection(startingWith: meetingWithAudio)
+        for transcription in [meetingWithoutAudio, youtube, podcast, local] {
+            vm.toggleSelection(for: transcription)
+        }
+
+        XCTAssertEqual(vm.selectedTranscriptionCount, 5)
+        vm.requestDeleteSelectedMeetingAudio()
+        let operation = try XCTUnwrap(vm.pendingBulkOperation)
+        XCTAssertTrue(operation.isDeleteAudioOnly)
+        XCTAssertEqual(operation.targetCount, 1)
+        // Only the audio-less meeting is skipped — the three non-meeting items
+        // are not counted (the old behavior reported 4).
+        XCTAssertEqual(operation.skippedCount, 1)
     }
 }
 

--- a/Tests/MacParakeetTests/Views/MeetingDeletionCopyTests.swift
+++ b/Tests/MacParakeetTests/Views/MeetingDeletionCopyTests.swift
@@ -63,4 +63,21 @@ final class MeetingDeletionCopyTests: XCTestCase {
         XCTAssertTrue(message.contains("1 selected meeting already has no saved audio"))
         XCTAssertTrue(message.contains("it will be skipped"))
     }
+
+    // Mixed Library selection (the surface where the miscount bug appeared):
+    // the skipped count is meeting-scoped, so the rendered copy only ever talks
+    // about meetings and stays consistent with the Delete dialog's meeting count
+    // — e.g. 7 meetings selected, 2 with saved audio, 5 already removed.
+    func testBulkAudioOnlyCopyForLibrarySurfaceOnlyCountsMeetings() {
+        let message = MeetingDeletionCopy.bulkAudioOnlyMessage(
+            count: 2,
+            skippedCount: 5,
+            surface: .library
+        )
+
+        XCTAssertTrue(message.contains("7 selected meetings"))
+        XCTAssertTrue(message.contains("removes saved audio from 2 meetings"))
+        XCTAssertTrue(message.contains("meetings stay in Library"))
+        XCTAssertTrue(message.contains("5 selected meetings already have no saved audio"))
+    }
 }


### PR DESCRIPTION
## Problem

In a mixed Library selection, the bulk **Remove Audio** confirmation reported every non-target item as a skipped *meeting*. With 7 meetings (2 with saved audio) and 7 non-meeting items (videos/podcasts/local) selected, the dialog read:

> 14 selected meetings. This removes saved audio from 2 meetings… 12 selected meetings already have no saved audio, so they will be skipped.

That labels videos/podcasts/local files as "meetings" and directly contradicts the **Delete Items** dialog, which correctly says *"14 items, including 7 meetings."* The action button (`Remove Audio for 2 Meetings…`) was already correct; only the confirmation copy was wrong.

## Root cause

`requestDeleteSelectedMeetingAudio()` computed `skipped = selected.count - targets.count` over the **whole** selection, so ineligible non-meeting rows inflated the skip count. `bulkAudioOnlyMessage` was written for the meeting-only Meetings tab (where `selected == meetings`) and faithfully renders whatever counts it is handed — so the bad input surfaced as bad copy on the mixed Library surface.

## Fix

Scope the skipped count to meetings, so it reflects *meetings-without-saved-audio* only. `targets` are unchanged (the audio filter already excludes non-meetings); only the reported skip count changes — now consistent with the Delete dialog (e.g. *"7 selected meetings… 5 already have no saved audio"*).

## Tests

- New mixed-selection view-model test (`testRequestDeleteAudioOnlySkipCountExcludesNonMeetings`) pinning the meeting-scoped skip count.
- Updated the existing audio-only test: the non-meeting file is no longer counted (`skipped 2 → 1`).
- Full suite green: 4016 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Remove Audio dialog mislabeling non-meeting items as skipped meetings in mixed Library selections. Skip count now only reflects meetings without saved audio, and the Library confirmation message is now pinned by tests.

- **Bug Fixes**
  - Scope skipped count to meetings only; non-meetings no longer inflate it.
  - Tests: added mixed-selection view-model test, updated audio-only test (skipped 2 → 1), and added a Library-surface copy test to assert the final string.

<sup>Written for commit 71ea774806f1cd3c4ce49fa85eb38b5ae7631c15. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

