### PR TITLE
Fix Library/Meetings bulk-delete confirm doing nothing

### DIFF
--- a/Sources/MacParakeet/Views/Meetings/MeetingsView.swift
+++ b/Sources/MacParakeet/Views/Meetings/MeetingsView.swift
@@ -137,8 +137,15 @@ struct MeetingsView: View {
                 viewModel.recentMeetingsViewModel.cancelPendingBulkOperation()
             }
             Button(recentMeetingsBulkOperationConfirmTitle, role: .destructive) {
+                // Capture the operation synchronously. Tapping this button also
+                // dismisses the alert, whose isPresented setter runs
+                // cancelPendingBulkOperation() and nils pendingBulkOperation —
+                // and that dismissal fires before the deferred Task body. Reading
+                // the VM state inside the Task would therefore see nil and
+                // silently no-op (the "delete does nothing" bug). Snapshot here.
+                guard let operation = viewModel.recentMeetingsViewModel.pendingBulkOperation else { return }
                 Task {
-                    await viewModel.recentMeetingsViewModel.confirmPendingBulkOperation()
+                    await viewModel.recentMeetingsViewModel.confirmBulkOperation(operation)
                 }
             }
         } message: {

--- a/Sources/MacParakeet/Views/Transcription/BulkTranscriptionSelectionBar.swift
+++ b/Sources/MacParakeet/Views/Transcription/BulkTranscriptionSelectionBar.swift
@@ -46,6 +46,13 @@ struct BulkTranscriptionSelectionBar: View {
         }
         .accessibilityElement(children: .contain)
         .accessibilityLabel(isPerformingOperation ? "Deleting selected items" : "\(selectedCount) selected")
+        // Resolve the bar's internal layout as one unit so the enclosing
+        // selection-mode animation moves it as a cohesive block. Without this,
+        // the container animation interpolates the inner `Spacer` from
+        // collapsed to full width, sweeping the trailing action cluster (Cancel
+        // first) from center to edge — a visible "Cancel flashes mid-bar"
+        // artifact — and re-runs the nested ViewThatFits/FlowLayout every frame.
+        .geometryGroup()
     }
 
     private var horizontalBar: some View {

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
@@ -161,8 +161,15 @@ struct TranscriptionLibraryView: View {
                 viewModel.cancelPendingBulkOperation()
             }
             Button(bulkOperationConfirmTitle, role: .destructive) {
+                // Capture the operation synchronously. Tapping this button also
+                // dismisses the alert, whose isPresented setter runs
+                // cancelPendingBulkOperation() and nils pendingBulkOperation —
+                // and that dismissal fires before the deferred Task body. Reading
+                // the VM state inside the Task would therefore see nil and
+                // silently no-op (the "delete does nothing" bug). Snapshot here.
+                guard let operation = viewModel.pendingBulkOperation else { return }
                 Task {
-                    await viewModel.confirmPendingBulkOperation()
+                    await viewModel.confirmBulkOperation(operation)
                 }
             }
         } message: {

--- a/Sources/MacParakeetViewModels/TranscriptionLibraryViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionLibraryViewModel.swift
@@ -298,10 +298,30 @@ public final class TranscriptionLibraryViewModel {
         )
     }
 
+    /// Snapshot the current pending operation and run it. Convenience for
+    /// callers (and tests) that have just populated `pendingBulkOperation`.
     @discardableResult
     public func confirmPendingBulkOperation() async -> BulkOperationResult {
         guard let operation = pendingBulkOperation else {
             return BulkOperationResult(succeeded: 0, failed: 0)
+        }
+        return await confirmBulkOperation(operation)
+    }
+
+    /// Run a previously captured bulk operation.
+    ///
+    /// The confirm button in the bulk-delete alert MUST capture the operation
+    /// synchronously and call this, rather than re-reading `pendingBulkOperation`
+    /// from inside its deferred `Task`. Tapping that button also dismisses the
+    /// alert, and the alert's `isPresented` setter runs
+    /// `cancelPendingBulkOperation()`, which nils `pendingBulkOperation`. The
+    /// dismissal fires before the Task body, so a re-read would see `nil` and
+    /// silently no-op (the "delete does nothing" bug). Taking the operation by
+    /// value sidesteps the race.
+    @discardableResult
+    public func confirmBulkOperation(_ operation: BulkTranscriptionOperation) async -> BulkOperationResult {
+        guard !isBulkOperationInProgress else {
+            return BulkOperationResult(succeeded: 0, failed: 0, skipped: operation.skippedCount)
         }
         pendingBulkOperation = nil
         guard let repo = transcriptionRepo else {

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionLibraryViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionLibraryViewModelTests.swift
@@ -411,6 +411,41 @@ final class TranscriptionLibraryViewModelTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: notesURL.path))
     }
 
+    func testConfirmBulkOperationRunsAfterPendingClearedByAlertDismissal() async throws {
+        // Reproduces the alert race: tapping the destructive confirm button
+        // dismisses the alert, whose isPresented setter nils pendingBulkOperation
+        // (via cancelPendingBulkOperation) BEFORE the deferred Task body runs.
+        // The view captures the operation synchronously and calls
+        // confirmBulkOperation(_:), which must still delete even though
+        // pendingBulkOperation is already nil. Re-reading the pending state here
+        // (the old behavior) would no-op and nothing would delete.
+        let first = Transcription(fileName: "first.mp3", status: .completed)
+        let second = Transcription(fileName: "second.mp3", status: .completed)
+        try repo.save(first)
+        try repo.save(second)
+        await load()
+
+        vm.beginBulkSelection(startingWith: first)
+        vm.toggleSelection(for: second)
+        vm.requestDeleteSelectedItems()
+
+        // Snapshot as the view's button action does, then simulate the alert's
+        // dismissal clearing the pending state out from under the deferred Task.
+        let operation = try XCTUnwrap(vm.pendingBulkOperation)
+        vm.cancelPendingBulkOperation()
+        XCTAssertNil(vm.pendingBulkOperation)
+
+        let result = await vm.confirmBulkOperation(operation)
+
+        XCTAssertEqual(result, BulkOperationResult(succeeded: 2, failed: 0))
+        XCTAssertNil(try repo.fetch(id: first.id))
+        XCTAssertNil(try repo.fetch(id: second.id))
+        XCTAssertTrue(vm.transcriptions.isEmpty)
+        XCTAssertFalse(vm.isBulkOperationInProgress)
+        XCTAssertFalse(vm.isBulkSelectionModeEnabled)
+        XCTAssertTrue(vm.selectedTranscriptionIDs.isEmpty)
+    }
+
     func testBulkDeleteSelectedItemsRemovesRowsAndExitsMode() async throws {
         let first = Transcription(fileName: "first.mp3", status: .completed)
         let second = Transcription(fileName: "second.mp3", status: .completed)


### PR DESCRIPTION
## Problem

In bulk-selection mode, the confirmation buttons for **Delete Items**, **Delete Meetings**, and **Remove Audio Only** silently did nothing — the alert dismissed, but no rows were deleted and no error surfaced. Single-item delete worked fine.

## Root cause

An alert-dismissal race. The destructive button's action ran:

```swift
Task { await viewModel.confirmPendingBulkOperation() }
```

`confirmPendingBulkOperation()` re-reads `pendingBulkOperation` inside the deferred `Task`. But tapping the button also dismisses the alert, and the alert's `isPresented` setter runs `cancelPendingBulkOperation()`, which nils `pendingBulkOperation`. That dismissal fires **before** the Task body, so the deferred read saw `nil` and the method bailed at its `guard let` without deleting.

Single-item delete was unaffected because it reads its `@State` target synchronously in the button action (no `Task`).

## Fix

- Capture the operation **synchronously** in the button action and pass it by value to a new `confirmBulkOperation(_:)` that no longer depends on `pendingBulkOperation` still being set.
- `confirmPendingBulkOperation()` stays as a thin snapshot-and-delegate wrapper for existing tests/callers.
- Group the selection bar's layout with `.geometryGroup()` so the selection-mode animation moves it as one block instead of sweeping the trailing action cluster from center to edge (the "Cancel flashes mid-bar" artifact).

## Tests

- New regression test `testConfirmBulkOperationRunsAfterPendingClearedByAlertDismissal` clears `pendingBulkOperation` before running the captured operation — the exact sequence the alert produces. Unit tests that call the view model directly previously skipped this race.
- `swift build` clean; `swift test` green (4018 tests, 10 skipped, 0 failures).

## Notes

Branched fresh from `origin/main`. The earlier local branch had overlap with already-merged work (#597's meeting-scoped skip count); this PR contains only the genuinely-new alert-race fix plus the one remaining selection-bar polish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes bulk-delete confirm in Library and Meetings where the alert closed but nothing was deleted. We now capture the operation synchronously to avoid the alert-dismissal race so deletes run reliably.

- **Bug Fixes**
  - Capture the pending operation in the button handler and run it via `confirmBulkOperation(_:)`; keep `confirmPendingBulkOperation()` as a thin wrapper.
  - Update Library and Meetings views to pass the captured operation; add a regression test reproducing the alert-dismissal sequence.
  - Apply `.geometryGroup()` to the selection bar to keep the selection-mode animation cohesive (prevents the mid-bar “Cancel” flash).

<sup>Written for commit 05ab3c6c17fa901fd9c9da561ccc04f20399a16d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/599?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

