### PR TITLE
CLI: direct srt/vtt output from `transcribe` + signpost the saved record

### DIFF
--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -91,6 +91,17 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
 
 ### Added
 
+- `transcribe --format` now accepts `srt` and `vtt` in addition to `text`,
+  `transcript`, and `json`. Both emit timed subtitles through the same renderer
+  as `export --format srt|vtt`, so output is byte-identical between the two
+  paths. This lets `transcribe clip.mp3 --format vtt --output-dir .` write
+  `clip.vtt` in a single step instead of `transcribe` then `export <id>`. A
+  single input without `--output-dir` prints the subtitle to stdout (redirect
+  with `> clip.vtt`); multiple inputs or `--output-dir` write one file each.
+- `transcribe` now prints a one-line stderr hint after a saved single-input
+  run (text/transcript output), naming the new library record id and showing
+  how to write a file or `export` it. Suppressed for `--no-history`,
+  `--format json|srt|vtt`, and batch runs. stdout is unchanged.
 - `config get|set|list` now includes `auto-meeting-titles`, the shared
   on/off preference for LLM-generated meeting recording titles.
 - `config get|set|list` now includes `meeting-audio-retention`:

--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -98,9 +98,9 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
   `clip.vtt` in a single step instead of `transcribe` then `export <id>`. A
   single input without `--output-dir` prints the subtitle to stdout (redirect
   with `> clip.vtt`); multiple inputs or `--output-dir` write one file each.
-- `transcribe` now prints a one-line stderr hint after a saved single-input
-  run (text/transcript output), naming the new library record id and showing
-  how to write a file or `export` it. Suppressed for `--no-history`,
+- `transcribe` now prints a short stderr hint after a saved single-input run
+  (text/transcript output), naming the new library record id and the `export`
+  command to turn it into a file. Suppressed for `--no-history`,
   `--format json|srt|vtt`, and batch runs. stdout is unchanged.
 - `config get|set|list` now includes `auto-meeting-titles`, the shared
   on/off preference for LLM-generated meeting recording titles.

--- a/Sources/CLI/Commands/TranscribeCommand.swift
+++ b/Sources/CLI/Commands/TranscribeCommand.swift
@@ -916,8 +916,8 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
         guard !noHistory, format == .text || format == .transcript else { return }
         printErr("")
         printErr("Saved to your library (id \(t.id.uuidString)).")
-        printErr("Write a file: re-run with --format vtt (or srt/json) and --output-dir . , "
-            + "or export this one: macparakeet-cli export \(t.id.uuidString) --format vtt")
+        printErr("Turn it into a file: macparakeet-cli export \(t.id.uuidString) --format vtt"
+            + "   (or srt, txt, markdown, json)")
     }
 
     private func printText(_ t: Transcription) {

--- a/Sources/CLI/Commands/TranscribeCommand.swift
+++ b/Sources/CLI/Commands/TranscribeCommand.swift
@@ -25,6 +25,8 @@ enum TranscribeOutputFormat: String, ExpressibleByArgument, CaseIterable, Sendab
     case text
     case transcript
     case json
+    case srt
+    case vtt
 }
 
 enum TranscribeSpeechEngine: String, ExpressibleByArgument, CaseIterable, Sendable {
@@ -83,7 +85,7 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
     @Option(name: .long, help: "Directory to write one transcript per input. Implies batch mode; created if missing. When omitted with multiple inputs, the current directory is used.")
     var outputDir: String?
 
-    @Option(name: .shortAndLong, help: "Output format: text, transcript, json.")
+    @Option(name: .shortAndLong, help: "Output format: text, transcript, json, srt, vtt. srt/vtt emit timed subtitles (same renderer as `export`); pair with --output-dir to write one file per input.")
     var format: TranscribeOutputFormat = .text
 
     @Option(help: "Processing mode: raw, clean, app-default.")
@@ -534,14 +536,17 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
                 )
                 if let outputDir {
                     let dir = try Self.prepareOutputDir(outputDir)
-                    let url = try Self.writeOutput(result, to: dir, format: format)
+                    let url = try await Self.writeOutput(result, to: dir, format: format)
                     printErr("  \u{2192} \(url.path)")
                 } else {
                     switch format {
                     case .json: try printJSON(result)
                     case .transcript: printTranscript(result)
                     case .text: printText(result)
+                    case .srt, .vtt:
+                        print(await Self.subtitleString(for: result, format: format) ?? "", terminator: "")
                     }
+                    printSaveHintIfSaved(result, format: format)
                 }
             } else if writeToFiles {
                 try await runBatch(
@@ -562,7 +567,10 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
                     printTranscript(result)
                 case .text:
                     printText(result)
+                case .srt, .vtt:
+                    print(await Self.subtitleString(for: result, format: format) ?? "", terminator: "")
                 }
+                printSaveHintIfSaved(result, format: format)
             }
             runResult = .success(())
         } catch {
@@ -600,7 +608,7 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
                     service: service,
                     speechEngine: speechEngine
                 )
-                let url = try Self.writeOutput(result, to: dir, format: format)
+                let url = try await Self.writeOutput(result, to: dir, format: format)
                 printErr("  \u{2192} \(url.path)")
                 ok += 1
             } catch {
@@ -745,11 +753,35 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
         return String(trimmed[..<queryOrFragmentIndex])
     }
 
+    /// File extension for a written transcript, keyed by output format.
+    static func fileExtension(for format: TranscribeOutputFormat) -> String {
+        switch format {
+        case .json: return "json"
+        case .srt: return "srt"
+        case .vtt: return "vtt"
+        case .text, .transcript: return "txt"
+        }
+    }
+
+    /// Render the timed-subtitle body for `srt`/`vtt` using the same
+    /// `ExportService` renderer the `export` command and the GUI use, so a file
+    /// produced by `transcribe --format vtt` is byte-identical to one produced
+    /// by `export <id> --format vtt`. Returns nil for non-subtitle formats.
+    @MainActor
+    static func subtitleString(for t: Transcription, format: TranscribeOutputFormat) -> String? {
+        let exporter = ExportService()
+        switch format {
+        case .srt: return exporter.formatSRT(transcription: t)
+        case .vtt: return exporter.formatVTT(transcription: t)
+        case .text, .transcript, .json: return nil
+        }
+    }
+
     /// Write one transcript file for `t` into `dir`, named after the source and
-    /// suffixed by format (`.json` for json, `.txt` otherwise). Never
+    /// suffixed by format (`.json`/`.srt`/`.vtt`, else `.txt`). Never
     /// overwrites — collisions get a `-2`, `-3`, … suffix.
-    static func writeOutput(_ t: Transcription, to dir: URL, format: TranscribeOutputFormat) throws -> URL {
-        let ext = format == .json ? "json" : "txt"
+    static func writeOutput(_ t: Transcription, to dir: URL, format: TranscribeOutputFormat) async throws -> URL {
+        let ext = fileExtension(for: format)
         let base = sanitizedBasename(t.fileName)
         let url = uniqueURL(dir.appendingPathComponent(base).appendingPathExtension(ext))
         let contents: String
@@ -763,6 +795,8 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
             contents = transcriptOutput(for: t)
         case .text:
             contents = plainTextOutput(for: t)
+        case .srt, .vtt:
+            contents = await subtitleString(for: t, format: format) ?? ""
         }
         try Data(contents.utf8).write(to: url)
         return url
@@ -868,6 +902,22 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
         let serviceName = Bundle.main.bundleIdentifier ?? "com.macparakeet"
         let store = KeychainKeyValueStore(service: serviceName)
         return EntitlementsService(config: config, store: store, api: LemonSqueezyLicenseAPI())
+    }
+
+    /// After a single transcription has been printed to stdout, point the user
+    /// at the saved library record and how to turn it into a file. This closes
+    /// the gap behind discussion #596: `transcribe` saves to history by default,
+    /// but nothing previously signposted the record or the `export` step.
+    /// Written to stderr so it never pollutes stdout (text, or a piped `> out`).
+    /// Skipped for `--no-history` (nothing was saved) and for `json`/`srt`/`vtt`,
+    /// where the user already requested machine/file output and the hint would
+    /// be noise.
+    private func printSaveHintIfSaved(_ t: Transcription, format: TranscribeOutputFormat) {
+        guard !noHistory, format == .text || format == .transcript else { return }
+        printErr("")
+        printErr("Saved to your library (id \(t.id.uuidString)).")
+        printErr("Write a file: re-run with --format vtt (or srt/json) and --output-dir . , "
+            + "or export this one: macparakeet-cli export \(t.id.uuidString) --format vtt")
     }
 
     private func printText(_ t: Transcription) {

--- a/Sources/CLI/Commands/TranscribeCommand.swift
+++ b/Sources/CLI/Commands/TranscribeCommand.swift
@@ -544,7 +544,7 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
                     case .transcript: printTranscript(result)
                     case .text: printText(result)
                     case .srt, .vtt:
-                        print(await Self.subtitleString(for: result, format: format) ?? "", terminator: "")
+                        print(await Self.subtitleString(for: result, format: format), terminator: "")
                     }
                     printSaveHintIfSaved(result, format: format)
                 }
@@ -568,7 +568,7 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
                 case .text:
                     printText(result)
                 case .srt, .vtt:
-                    print(await Self.subtitleString(for: result, format: format) ?? "", terminator: "")
+                    print(await Self.subtitleString(for: result, format: format), terminator: "")
                 }
                 printSaveHintIfSaved(result, format: format)
             }
@@ -766,14 +766,16 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
     /// Render the timed-subtitle body for `srt`/`vtt` using the same
     /// `ExportService` renderer the `export` command and the GUI use, so a file
     /// produced by `transcribe --format vtt` is byte-identical to one produced
-    /// by `export <id> --format vtt`. Returns nil for non-subtitle formats.
+    /// by `export <id> --format vtt`. Only the `.srt`/`.vtt` output paths call
+    /// this; the other formats render through their own text/JSON writers, so
+    /// they return an empty body here.
     @MainActor
-    static func subtitleString(for t: Transcription, format: TranscribeOutputFormat) -> String? {
+    static func subtitleString(for t: Transcription, format: TranscribeOutputFormat) -> String {
         let exporter = ExportService()
         switch format {
         case .srt: return exporter.formatSRT(transcription: t)
         case .vtt: return exporter.formatVTT(transcription: t)
-        case .text, .transcript, .json: return nil
+        case .text, .transcript, .json: return ""
         }
     }
 
@@ -796,7 +798,7 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
         case .text:
             contents = plainTextOutput(for: t)
         case .srt, .vtt:
-            contents = await subtitleString(for: t, format: format) ?? ""
+            contents = await subtitleString(for: t, format: format)
         }
         try Data(contents.utf8).write(to: url)
         return url

--- a/Tests/CLITests/TranscribeCommandTests.swift
+++ b/Tests/CLITests/TranscribeCommandTests.swift
@@ -628,7 +628,7 @@ final class TranscribeCommandTests: XCTestCase {
         XCTAssertEqual(TranscribeCommand.sanitizedBasename("Q3 2026 review.final"), "Q3 2026 review.final")
     }
 
-    func testWriteOutputWritesTranscriptAndAvoidsOverwrite() throws {
+    func testWriteOutputWritesTranscriptAndAvoidsOverwrite() async throws {
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("cli-write-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
@@ -640,16 +640,16 @@ final class TranscribeCommandTests: XCTestCase {
             status: .completed
         )
 
-        let first = try TranscribeCommand.writeOutput(transcription, to: dir, format: .transcript)
+        let first = try await TranscribeCommand.writeOutput(transcription, to: dir, format: .transcript)
         XCTAssertEqual(first.lastPathComponent, "lecture01.txt")
         XCTAssertEqual(try String(contentsOf: first, encoding: .utf8), "hello world")
 
         // A second write of the same name must not clobber the first.
-        let second = try TranscribeCommand.writeOutput(transcription, to: dir, format: .transcript)
+        let second = try await TranscribeCommand.writeOutput(transcription, to: dir, format: .transcript)
         XCTAssertEqual(second.lastPathComponent, "lecture01-2.txt")
     }
 
-    func testWriteOutputJSONIsParseable() throws {
+    func testWriteOutputJSONIsParseable() async throws {
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("cli-write-json-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
@@ -660,10 +660,76 @@ final class TranscribeCommandTests: XCTestCase {
             rawTranscript: "hi",
             status: .completed
         )
-        let url = try TranscribeCommand.writeOutput(transcription, to: dir, format: .json)
+        let url = try await TranscribeCommand.writeOutput(transcription, to: dir, format: .json)
         XCTAssertEqual(url.pathExtension, "json")
         let object = try JSONSerialization.jsonObject(with: Data(contentsOf: url)) as? [String: Any]
         XCTAssertNotNil(object)
+    }
+
+    func testFileExtensionMapsEachFormat() {
+        XCTAssertEqual(TranscribeCommand.fileExtension(for: .text), "txt")
+        XCTAssertEqual(TranscribeCommand.fileExtension(for: .transcript), "txt")
+        XCTAssertEqual(TranscribeCommand.fileExtension(for: .json), "json")
+        XCTAssertEqual(TranscribeCommand.fileExtension(for: .srt), "srt")
+        XCTAssertEqual(TranscribeCommand.fileExtension(for: .vtt), "vtt")
+    }
+
+    func testParsesSubtitleFormats() throws {
+        XCTAssertEqual(try TranscribeCommand.parse(["clip.mp3", "--format", "vtt"]).format, .vtt)
+        XCTAssertEqual(try TranscribeCommand.parse(["clip.mp3", "--format", "srt"]).format, .srt)
+    }
+
+    /// `transcribe --format vtt`/`srt` must produce the same timed-subtitle body
+    /// as `export <id> --format vtt`/`srt` — both go through `ExportService`.
+    @MainActor
+    func testSubtitleStringMatchesExportServiceRenderer() {
+        let words = [
+            WordTimestamp(word: "hello", startMs: 0, endMs: 400, confidence: 0.9, speakerId: "S1"),
+            WordTimestamp(word: "world", startMs: 400, endMs: 900, confidence: 0.95, speakerId: "S1"),
+        ]
+        let transcription = Transcription(
+            fileName: "clip.mp3",
+            durationMs: 900,
+            rawTranscript: "hello world",
+            wordTimestamps: words,
+            speakers: [SpeakerInfo(id: "S1", label: "Speaker 1")],
+            status: .completed
+        )
+        let exporter = ExportService()
+
+        let vtt = TranscribeCommand.subtitleString(for: transcription, format: .vtt)
+        XCTAssertEqual(vtt, exporter.formatVTT(transcription: transcription))
+        XCTAssertEqual(vtt?.hasPrefix("WEBVTT"), true)
+
+        let srt = TranscribeCommand.subtitleString(for: transcription, format: .srt)
+        XCTAssertEqual(srt, exporter.formatSRT(transcription: transcription))
+
+        // Non-subtitle formats render through the text/json paths, not here.
+        XCTAssertNil(TranscribeCommand.subtitleString(for: transcription, format: .text))
+        XCTAssertNil(TranscribeCommand.subtitleString(for: transcription, format: .json))
+    }
+
+    func testWriteOutputWritesVTTFile() async throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cli-write-vtt-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let transcription = Transcription(
+            fileName: "clip.mp3",
+            durationMs: 900,
+            rawTranscript: "hello world",
+            wordTimestamps: [
+                WordTimestamp(word: "hello", startMs: 0, endMs: 400, confidence: 0.9, speakerId: nil),
+                WordTimestamp(word: "world", startMs: 400, endMs: 900, confidence: 0.95, speakerId: nil),
+            ],
+            status: .completed
+        )
+        let url = try await TranscribeCommand.writeOutput(transcription, to: dir, format: .vtt)
+        XCTAssertEqual(url.lastPathComponent, "clip.vtt")
+        let contents = try String(contentsOf: url, encoding: .utf8)
+        XCTAssertTrue(contents.hasPrefix("WEBVTT"), "VTT file should start with the WEBVTT header")
+        XCTAssertTrue(contents.contains("hello"))
     }
 
     func testPlainTextOutputToleratesDuplicateSpeakerIDs() {

--- a/Tests/CLITests/TranscribeCommandTests.swift
+++ b/Tests/CLITests/TranscribeCommandTests.swift
@@ -699,14 +699,15 @@ final class TranscribeCommandTests: XCTestCase {
 
         let vtt = TranscribeCommand.subtitleString(for: transcription, format: .vtt)
         XCTAssertEqual(vtt, exporter.formatVTT(transcription: transcription))
-        XCTAssertEqual(vtt?.hasPrefix("WEBVTT"), true)
+        XCTAssertTrue(vtt.hasPrefix("WEBVTT"))
 
         let srt = TranscribeCommand.subtitleString(for: transcription, format: .srt)
         XCTAssertEqual(srt, exporter.formatSRT(transcription: transcription))
 
-        // Non-subtitle formats render through the text/json paths, not here.
-        XCTAssertNil(TranscribeCommand.subtitleString(for: transcription, format: .text))
-        XCTAssertNil(TranscribeCommand.subtitleString(for: transcription, format: .json))
+        // Non-subtitle formats render through the text/json paths, so the
+        // subtitle renderer returns an empty body for them.
+        XCTAssertEqual(TranscribeCommand.subtitleString(for: transcription, format: .text), "")
+        XCTAssertEqual(TranscribeCommand.subtitleString(for: transcription, format: .json), "")
     }
 
     func testWriteOutputWritesVTTFile() async throws {

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -159,6 +159,23 @@ macparakeet-cli transcribe /path/to/audio.mp3 --format transcript
 macparakeet-cli transcribe /path/to/audio.mp3 --format transcript --no-history | pbcopy
 ```
 
+To write a subtitle file directly, transcribe with `--format srt|vtt` and an
+`--output-dir` (one command, no separate `export` step):
+
+```bash
+macparakeet-cli transcribe /path/to/audio.mp3 --format vtt --output-dir .
+# -> ./audio.vtt   (same renderer as `export --format vtt`)
+```
+
+A single input without `--output-dir` prints the subtitle to stdout, so you can
+also redirect it: `macparakeet-cli transcribe audio.mp3 --format vtt > audio.vtt`.
+To re-export something already in your library, list it and export by id:
+
+```bash
+macparakeet-cli history transcriptions          # note the subcommand; lists ids
+macparakeet-cli export <id> --format vtt
+```
+
 `--no-history` avoids retaining the completed transcription in the shared
 MacParakeet history. For media URL and podcast inputs, downloaded audio is
 temporary when `--no-history` is set.


### PR DESCRIPTION
## What this fixes

Discussion [#596](https://github.com/moona3k/macparakeet/discussions/596) hit a
real seam in the CLI. After `transcribe file.mp3` you get the text on stdout,
but two things were unclear: the result was *also* saved to your library, and
there was no obvious way to turn it into a subtitle file. `transcribe` only
spoke `text` / `transcript` / `json`, while `export` spoke `srt` / `vtt` — so
getting a `.vtt` meant a two-step `transcribe` then `export <id>` dance, and you
had to already know the id.

## What changed

**1. `transcribe --format` now accepts `srt` and `vtt`.**

Both render through the same `ExportService` that `export` and the GUI use, so
the output is byte-identical no matter which path you take. One step instead of
two:

```bash
macparakeet-cli transcribe clip.mp3 --format vtt --output-dir .
# -> ./clip.vtt
```

A single input without `--output-dir` prints to stdout, so you can redirect:

```bash
macparakeet-cli transcribe clip.mp3 --format vtt > clip.vtt
```

**2. A short stderr hint after a saved run** names the new library record and
the one command to turn it into a file:

```
Saved to your library (id 7f3a…).
Turn it into a file: macparakeet-cli export 7f3a… --format vtt   (or srt, txt, markdown, json)
```

It is written to stderr, so it never pollutes stdout or a redirected file.
Suppressed for `--no-history` (nothing was saved), for `json` / `srt` / `vtt`
(you already asked for file/machine output), and for batch runs.

## Notes

- Additive and backward-compatible: existing `text` / `transcript` / `json`
  behavior is unchanged. Bumped as a CLI semver MINOR.
- Updates `Sources/CLI/CHANGELOG.md` and `integrations/README.md`.
- Tests cover format parsing, the file-extension map, the `.vtt` file write, and
  byte-for-byte parity between `transcribe --format vtt` and `export`'s renderer.
- Does **not** cover [#595](https://github.com/moona3k/macparakeet/issues/595)
  (a GUI "Install Command Line Tool" menu item) — that is a separate request.

Refs #596

🤖 Generated with [Claude Code](https://claude.com/claude-code)
