### PR TITLE
Add Cohere Transcribe as an on-device speech engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,6 @@ Assets/local-videos/
 
 # Data recovery
 recup_dir*/
+
+# Phase-0 Cohere latency spike (throwaway)
+spike/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,8 @@ MacParakeet is a fast, private, local-first voice app for Apple Silicon Macs.
 It ships three primary capture modes -- system-wide dictation, file/media URL
 transcription, and meeting recording -- plus Transforms for selected-text
 rewrites. Speech recognition runs locally by default through Parakeet via
-FluidAudio CoreML/ANE, with optional Nemotron and WhisperKit engines.
+FluidAudio CoreML/ANE, with optional Nemotron, WhisperKit, and Cohere Transcribe
+engines.
 
 The repo contains two products:
 

--- a/README.md
+++ b/README.md
@@ -90,14 +90,15 @@ Meeting calendar support is live in the stable DMG. MacParakeet reads upcoming m
 - Optional English-only Parakeet Unified model with punctuation/capitalization and strong offline accuracy
 - ~66 MB working memory per active Parakeet inference slot
 - 25 European languages with Parakeet auto-detection
-- Optional local Nemotron Beta engine for fast multilingual ASR (a smaller English-only build is also available), plus WhisperKit for Korean, Japanese, Chinese, and many other languages
+- Optional local Nemotron Beta engine for fast multilingual ASR (a smaller English-only build is also available), WhisperKit for broad language coverage, and Cohere Transcribe for opt-in batch accuracy work
 
 ### Limitations
 
 - Apple Silicon only (M1/M2/M3/M4)
 - Parakeet is best for English and supported European languages
 - Nemotron is Beta while real-world quality is benchmarked
-- Nemotron and WhisperKit multilingual support require separate local model downloads before first use
+- Nemotron, WhisperKit, and Cohere Transcribe require separate local model downloads before first use
+- Cohere is batch-only: it can be used for dictation after recording stops, file transcription, and meeting finalization, but it does not show live dictation preview or meeting live-preview chunks and does not provide word timestamps/speaker labels
 
 ## Get it
 
@@ -147,11 +148,13 @@ macparakeet-cli transcribe /path/to/audio.mp3
 macparakeet-cli transcribe /path/to/audio.mp3 --format transcript --no-history
 macparakeet-cli transcribe lecture1.m4a lecture2.m4a --output-dir Transcripts --format transcript
 macparakeet-cli models download nemotron-multilingual-1120ms
+macparakeet-cli models download cohere-transcribe
 macparakeet-cli models download whisper-large-v3-v20240930-turbo-632MB
 macparakeet-cli models list
 macparakeet-cli models select parakeet-v3
 macparakeet-cli config set parakeet-model v2
 macparakeet-cli transcribe /path/to/meeting.m4a --engine nemotron --language auto --format json
+macparakeet-cli transcribe /path/to/japanese.m4a --engine cohere --language ja --format json
 macparakeet-cli transcribe /path/to/korean.mp3 --engine whisper --language ko --format json
 macparakeet-cli models status
 macparakeet-cli history
@@ -163,16 +166,16 @@ row to MacParakeet history. Multiple inputs or `--output-dir` write one transcri
 file per input. `models list` and `models select` inspect or update the shared
 speech default used by the app and `--engine app-default`; Parakeet rows are
 `parakeet-v3` and `parakeet-v2`, Nemotron rows are `nemotron-multilingual-1120ms`
-and `nemotron-english-1120ms`, and Whisper rows use the configured
-`whisper-*` model id. The Nemotron and Whisper CLI commands above require their
-local models to be downloaded first. When developing from source, prefix the
-same commands with `swift run`.
+and `nemotron-english-1120ms`, Cohere is `cohere-transcribe`, and Whisper rows
+use the configured `whisper-*` model id. The Nemotron, Cohere, and Whisper CLI
+commands above require their local models to be downloaded first. When
+developing from source, prefix the same commands with `swift run`.
 
 ## Tech stack
 
 | Layer | Choice |
 |-------|--------|
-| STT | Parakeet via [FluidAudio](https://github.com/FluidInference/FluidAudio) CoreML (`v3` multilingual default, `v2` English-only opt-in, `unified` English-only punctuated opt-in) + optional local Nemotron Beta and WhisperKit engines |
+| STT | Parakeet via [FluidAudio](https://github.com/FluidInference/FluidAudio) CoreML (`v3` multilingual default, `v2` English-only opt-in, `unified` English-only punctuated opt-in) + optional local Nemotron Beta, Cohere Transcribe, and WhisperKit engines |
 | STT orchestration | Shared runtime + explicit scheduler with a reserved dictation slot and a shared meeting/file slot; speech-engine routing and meeting-session pinning |
 | Language | Swift 6 language mode (package tools-version 5.9) + SwiftUI |
 | Database | SQLite via GRDB |
@@ -224,7 +227,7 @@ AI features are entirely **opt-in** and separate from speech recognition — tra
 
 ## Privacy
 
-All speech recognition runs locally. Parakeet uses the Neural Engine; optional Nemotron Beta and WhisperKit engines also run on-device. Your audio never leaves your Mac.
+All speech recognition runs locally. Parakeet uses the Neural Engine; optional Nemotron Beta, Cohere Transcribe, and WhisperKit engines also run on-device. Your audio never leaves your Mac.
 
 - **No cloud STT.** The model runs on-device. No audio is transmitted.
 - **No accounts.** No login, no email, no registration.

--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -127,6 +127,9 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
   the native 2080ms streaming path used by app live dictation preview.
   `transcribe --parakeet-model unified` is unchanged and still uses the offline
   build for best stop-time quality.
+- `models delete cohere-transcribe` now removes an incomplete Cohere cache
+  directory as well as a fully downloaded model, so cancelled or failed
+  downloads can be cleaned up from the CLI.
 - `history clear-meeting-audio` now refuses to run while **any** meeting
   recording lock file is present, including dead-owner sessions still
   `.awaitingTranscription` in the background queue or pending crash recovery.

--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -99,6 +99,8 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
   `--language` is omitted.
 - `models list`/`select`/`download`/`delete`/`status` include Cohere Transcribe
   model availability alongside Parakeet, Nemotron, and Whisper.
+- Cohere transcription now fails fast when the local Cohere model is missing;
+  use `models download cohere-transcribe` for the explicit ~2.1 GB download.
 - `transcribe --format` now accepts `srt` and `vtt` in addition to `text`,
   `transcript`, and `json`. Both emit timed subtitles through the same renderer
   as `export --format srt|vtt`, so output is byte-identical between the two

--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -91,6 +91,14 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
 
 ### Added
 
+- `transcribe --engine` now accepts `cohere` as an explicit on-device Cohere
+  Transcribe selection. `--language` is used as Cohere's required language hint
+  when provided; otherwise the saved Cohere language preference is used.
+- `config get|set|list` now includes `cohere-language`, the saved language used
+  by explicit `--engine cohere` and app-default Cohere transcription when
+  `--language` is omitted.
+- `models list`/`select`/`download`/`delete`/`status` include Cohere Transcribe
+  model availability alongside Parakeet, Nemotron, and Whisper.
 - `transcribe --format` now accepts `srt` and `vtt` in addition to `text`,
   `transcript`, and `json`. Both emit timed subtitles through the same renderer
   as `export --format srt|vtt`, so output is byte-identical between the two

--- a/Sources/CLI/Commands/ConfigCommand.swift
+++ b/Sources/CLI/Commands/ConfigCommand.swift
@@ -446,8 +446,7 @@ struct ConfigCommand: ParsableCommand {
 
     static func parseCohereLanguage(_ value: String) throws -> String {
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard let language = SpeechEnginePreference.normalizeCohereLanguage(trimmed),
-              CohereTranscribeEngine.supportedLanguages.contains(where: { $0.code == language }) else {
+        guard let language = SpeechEnginePreference.normalizeCohereLanguage(trimmed) else {
             let supported = CohereTranscribeEngine.supportedLanguages.map(\.code).joined(separator: ", ")
             throw ValidationError("Invalid value for cohere-language: '\(value)'. Use one of: \(supported).")
         }

--- a/Sources/CLI/Commands/ConfigCommand.swift
+++ b/Sources/CLI/Commands/ConfigCommand.swift
@@ -23,7 +23,7 @@ struct ConfigCommand: ParsableCommand {
         Supported keys:
           telemetry                 on|off                         default: on
           processing-mode           raw|clean                       default: raw
-          speech-engine             parakeet|nemotron|whisper       default: parakeet
+          speech-engine             parakeet|nemotron|whisper|cohere default: parakeet
           parakeet-model            v3|v2|unified                   default: v3
                                     (v3=multilingual, v2=English,
                                     unified=English punctuated)
@@ -32,6 +32,7 @@ struct ConfigCommand: ParsableCommand {
           nemotron-language         auto|<Nemotron language code>   default: auto
                                     (multilingual build only)
           whisper-language          auto|<Whisper language code>    default: auto
+          cohere-language           <Cohere language code>          default: en
           speaker-detection         on|off                          default: off
           auto-meeting-titles       on|off                          default: on
           save-transcription-audio  on|off                          default: on
@@ -70,6 +71,7 @@ struct ConfigCommand: ParsableCommand {
         "nemotron-model",
         "nemotron-language",
         "whisper-language",
+        "cohere-language",
         "speaker-detection",
         "auto-meeting-titles",
         "save-transcription-audio",
@@ -197,6 +199,8 @@ struct ConfigCommand: ParsableCommand {
             return SpeechEnginePreference.nemotronDefaultLanguage(defaults: store) ?? "auto"
         case "whisper-language":
             return SpeechEnginePreference.whisperDefaultLanguage(defaults: store) ?? WhisperLanguageCatalog.autoCode
+        case "cohere-language":
+            return SpeechEnginePreference.cohereDefaultLanguage(defaults: store) ?? "en"
         case "speaker-detection":
             let on = store.object(forKey: UserDefaultsAppRuntimePreferences.speakerDiarizationKey) as? Bool ?? false
             return on ? "on" : "off"
@@ -273,6 +277,10 @@ struct ConfigCommand: ParsableCommand {
             let language = try parseWhisperLanguage(value)
             SpeechEnginePreference.saveWhisperDefaultLanguage(language, defaults: store)
             return language ?? WhisperLanguageCatalog.autoCode
+        case "cohere-language":
+            let language = try parseCohereLanguage(value)
+            SpeechEnginePreference.saveCohereDefaultLanguage(language, defaults: store)
+            return language
         case "speaker-detection":
             let parsed = try parseBool(value, key: key)
             store.set(parsed, forKey: UserDefaultsAppRuntimePreferences.speakerDiarizationKey)
@@ -373,7 +381,7 @@ struct ConfigCommand: ParsableCommand {
     static func parseSpeechEngine(_ value: String) throws -> SpeechEnginePreference {
         let raw = value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         guard let engine = SpeechEnginePreference(rawValue: raw) else {
-            throw ValidationError("Invalid value for speech-engine: '\(value)'. Use parakeet, nemotron, or whisper.")
+            throw ValidationError("Invalid value for speech-engine: '\(value)'. Use parakeet, nemotron, whisper, or cohere.")
         }
         return engine
     }
@@ -432,6 +440,16 @@ struct ConfigCommand: ParsableCommand {
         }
         guard let language = SpeechEnginePreference.normalizeNemotronLanguage(trimmed) else {
             throw ValidationError("Invalid value for nemotron-language: '\(value)'. Use auto or a language code such as en-US, ko, or zh-CN.")
+        }
+        return language
+    }
+
+    static func parseCohereLanguage(_ value: String) throws -> String {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let language = SpeechEnginePreference.normalizeCohereLanguage(trimmed),
+              CohereTranscribeEngine.supportedLanguages.contains(where: { $0.code == language }) else {
+            let supported = CohereTranscribeEngine.supportedLanguages.map(\.code).joined(separator: ", ")
+            throw ValidationError("Invalid value for cohere-language: '\(value)'. Use one of: \(supported).")
         }
         return language
     }

--- a/Sources/CLI/Commands/ModelsCommand.swift
+++ b/Sources/CLI/Commands/ModelsCommand.swift
@@ -437,7 +437,7 @@ func resolveWhisperDownloadModel(_ variant: String) throws -> String {
         throw ValidationError("Model variant cannot be empty.")
     }
     guard normalizedInput.hasPrefix("whisper-") else {
-        throw ValidationError("Unsupported model identifier '\(variant)'. Use a parakeet-v2, parakeet-v3, nemotron-multilingual-1120ms, nemotron-english-1120ms, cohere-transcribe, or whisper-* id from `models list`.")
+        throw ValidationError("Unsupported model identifier '\(variant)'. Use a parakeet-v2, parakeet-v3, parakeet-unified, nemotron-multilingual-1120ms, nemotron-english-1120ms, cohere-transcribe, or whisper-* id from `models list`.")
     }
     return WhisperEngine.normalizeModelVariant(normalizedInput)
 }

--- a/Sources/CLI/Commands/ModelsCommand.swift
+++ b/Sources/CLI/Commands/ModelsCommand.swift
@@ -334,7 +334,7 @@ extension ModelsCommand {
                 let freed = whisperModelSizeLabel(for: variant).map { " · freed \($0)" } ?? ""
                 print("Deleted \(target.displayName)\(freed).")
             case .cohere:
-                guard CohereTranscribeEngine.isModelCached() else {
+                guard CohereTranscribeEngine.hasModelCacheDirectory() else {
                     print("Cohere Transcribe is not downloaded — nothing to delete.")
                     return
                 }

--- a/Sources/CLI/Commands/ModelsCommand.swift
+++ b/Sources/CLI/Commands/ModelsCommand.swift
@@ -524,6 +524,8 @@ func loadSpeechStackStatus(
         nemotronDownloaded
     case .whisper:
         whisperDownloaded
+    case .cohere:
+        CohereTranscribeEngine.isModelCached()
     }
 
     async let speechRuntimeReady = sttClient.isReady()

--- a/Sources/CLI/Commands/ModelsCommand.swift
+++ b/Sources/CLI/Commands/ModelsCommand.swift
@@ -133,7 +133,7 @@ extension ModelsCommand {
             abstract: "Download a local speech model without starting a transcription."
         )
 
-        @Argument(help: "Model identifier from `models list`, e.g. parakeet-v2, parakeet-v3, parakeet-unified, nemotron-multilingual-1120ms, nemotron-english-1120ms, or whisper-large-v3-v20240930-turbo-632MB.")
+        @Argument(help: "Model identifier from `models list`, e.g. parakeet-v2, parakeet-v3, parakeet-unified, nemotron-multilingual-1120ms, nemotron-english-1120ms, cohere-transcribe, or whisper-large-v3-v20240930-turbo-632MB.")
         var variant: String
 
         func run() async throws {
@@ -166,6 +166,21 @@ extension ModelsCommand {
                     if shouldPrint { print("Nemotron: \(message)") }
                 }
                 print("Nemotron: ready (\(nemotronVariant.modelName))")
+                return
+            }
+
+            if isCohereModelID(lowered) {
+                print("Cohere: downloading Cohere Transcribe...")
+                let lastMessage = OSAllocatedUnfairLock(initialState: "")
+                _ = try await CohereTranscribeEngine.downloadModel { message in
+                    let shouldPrint = lastMessage.withLock { last in
+                        guard last != message else { return false }
+                        last = message
+                        return true
+                    }
+                    if shouldPrint { print("Cohere: \(message)") }
+                }
+                print("Cohere: ready (Cohere Transcribe)")
                 return
             }
 
@@ -257,7 +272,7 @@ extension ModelsCommand {
             commandName: "delete",
             abstract: "Delete one downloaded speech model, freeing its disk space.",
             discussion: """
-                Removes a single model (one Parakeet build, one Nemotron build, or the Whisper variant) \
+                Removes a single model (one Parakeet build, one Nemotron build, the Cohere model, or the Whisper variant) \
                 while leaving every other model in place — unlike `models clear`, \
                 which wipes the whole local stack.
 
@@ -267,7 +282,7 @@ extension ModelsCommand {
                 """
         )
 
-        @Argument(help: "Model identifier from `models list`, e.g. parakeet-v2, parakeet-v3, parakeet-unified, nemotron-multilingual-1120ms, nemotron-english-1120ms, or whisper-large-v3-v20240930-turbo-632MB.")
+        @Argument(help: "Model identifier from `models list`, e.g. parakeet-v2, parakeet-v3, parakeet-unified, nemotron-multilingual-1120ms, nemotron-english-1120ms, cohere-transcribe, or whisper-large-v3-v20240930-turbo-632MB.")
         var id: String
 
         @Flag(name: .long, help: "Delete even the model currently in use (it will re-download on next use).")
@@ -318,6 +333,16 @@ extension ModelsCommand {
                 }
                 let freed = whisperModelSizeLabel(for: variant).map { " · freed \($0)" } ?? ""
                 print("Deleted \(target.displayName)\(freed).")
+            case .cohere:
+                guard CohereTranscribeEngine.isModelCached() else {
+                    print("Cohere Transcribe is not downloaded — nothing to delete.")
+                    return
+                }
+                let removed = CohereTranscribeEngine.deleteModel()
+                guard removed else {
+                    throw ModelDeletionError.deleteFailed("Could not delete Cohere Transcribe. It may be missing or in use by another process.")
+                }
+                print("Deleted \(target.displayName) · freed ~2.1 GB.")
             }
         }
     }
@@ -395,13 +420,24 @@ func nemotronDownloadVariant(
     return parseNemotronSelectionVariant(lowered)
 }
 
+private let cohereModelID = "cohere-transcribe"
+private let cohereModelName = "Cohere Transcribe"
+private let cohereModelSize = "~2.1 GB"
+
+func isCohereModelID(_ lowered: String) -> Bool {
+    lowered == SpeechEnginePreference.cohere.rawValue
+        || lowered == cohereModelID
+        || lowered == "cohere-transcribe-03-2026"
+        || lowered == "cohere:transcribe"
+}
+
 func resolveWhisperDownloadModel(_ variant: String) throws -> String {
     let normalizedInput = variant.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !normalizedInput.isEmpty else {
         throw ValidationError("Model variant cannot be empty.")
     }
     guard normalizedInput.hasPrefix("whisper-") else {
-        throw ValidationError("Unsupported model identifier '\(variant)'. Use a parakeet-v2, parakeet-v3, nemotron-multilingual-1120ms, nemotron-english-1120ms, or whisper-* id from `models list`.")
+        throw ValidationError("Unsupported model identifier '\(variant)'. Use a parakeet-v2, parakeet-v3, nemotron-multilingual-1120ms, nemotron-english-1120ms, cohere-transcribe, or whisper-* id from `models list`.")
     }
     return WhisperEngine.normalizeModelVariant(normalizedInput)
 }
@@ -418,6 +454,7 @@ struct SpeechStackPayload: Encodable {
     let nemotronModelDownloaded: Bool
     let whisperModelVariant: String
     let whisperModelDownloaded: Bool
+    let cohereModelDownloaded: Bool
     let summary: String
 
     init(status: SpeechStackStatus) {
@@ -432,6 +469,7 @@ struct SpeechStackPayload: Encodable {
         self.nemotronModelDownloaded = status.nemotronModelDownloaded
         self.whisperModelVariant = status.whisperModelVariant
         self.whisperModelDownloaded = status.whisperModelDownloaded
+        self.cohereModelDownloaded = status.cohereModelDownloaded
         self.summary = status.summary
     }
 }
@@ -448,6 +486,7 @@ struct SpeechStackStatus: Sendable, Equatable {
     let nemotronModelDownloaded: Bool
     let whisperModelVariant: String
     let whisperModelDownloaded: Bool
+    let cohereModelDownloaded: Bool
 
     var summary: String {
         if speechRuntimeReady && speakerModelsPrepared {
@@ -501,7 +540,8 @@ func loadSpeechStackStatus(
     nemotronModelVariant: NemotronModelVariant? = nil,
     isNemotronModelDownloaded: (@Sendable (NemotronModelVariant) -> Bool)? = nil,
     whisperModelVariant: String? = nil,
-    isWhisperModelDownloaded: (@Sendable (String) -> Bool)? = nil
+    isWhisperModelDownloaded: (@Sendable (String) -> Bool)? = nil,
+    isCohereModelDownloaded: (@Sendable () -> Bool)? = nil
 ) async -> SpeechStackStatus {
     let speechEngine = SpeechEnginePreference.current(defaults: defaults)
     let parakeetModelVariant = SpeechEnginePreference.parakeetModelVariant(defaults: defaults)
@@ -517,6 +557,9 @@ func loadSpeechStackStatus(
     let whisperDownloaded = (isWhisperModelDownloaded ?? { variant in
         WhisperEngine.isModelDownloaded(model: variant)
     })(whisperModelVariant)
+    let cohereDownloaded = (isCohereModelDownloaded ?? {
+        CohereTranscribeEngine.isModelCached()
+    })()
     let activeSpeechModelCached = switch speechEngine {
     case .parakeet:
         parakeetDownloaded
@@ -525,7 +568,7 @@ func loadSpeechStackStatus(
     case .whisper:
         whisperDownloaded
     case .cohere:
-        CohereTranscribeEngine.isModelCached()
+        cohereDownloaded
     }
 
     async let speechRuntimeReady = sttClient.isReady()
@@ -543,7 +586,8 @@ func loadSpeechStackStatus(
         nemotronModelVariant: nemotronModelVariant,
         nemotronModelDownloaded: nemotronDownloaded,
         whisperModelVariant: whisperModelVariant,
-        whisperModelDownloaded: whisperDownloaded
+        whisperModelDownloaded: whisperDownloaded,
+        cohereModelDownloaded: cohereDownloaded
     )
 }
 
@@ -562,6 +606,7 @@ func printSpeechStackStatus(_ status: SpeechStackStatus, includeHeader: Bool = t
     print("  Nemotron model downloaded: \(status.nemotronModelDownloaded ? "Yes" : "No")")
     print("  Whisper model variant: \(status.whisperModelVariant)")
     print("  Whisper model downloaded: \(status.whisperModelDownloaded ? "Yes" : "No")")
+    print("  Cohere model downloaded: \(status.cohereModelDownloaded ? "Yes" : "No")")
     print("  Status: \(status.summary)")
 }
 
@@ -589,7 +634,8 @@ func loadSelectableSpeechModels(
     defaults: UserDefaults = macParakeetAppDefaults(),
     isParakeetModelCached: ((ParakeetModelVariant) -> Bool)? = nil,
     isNemotronModelDownloaded: ((NemotronModelVariant) -> Bool)? = nil,
-    isWhisperModelDownloaded: ((String) -> Bool)? = nil
+    isWhisperModelDownloaded: ((String) -> Bool)? = nil,
+    isCohereModelDownloaded: (() -> Bool)? = nil
 ) -> [SelectableSpeechModel] {
     let checkParakeetModelCached = isParakeetModelCached ?? {
         isParakeetVariantCached($0)
@@ -601,8 +647,10 @@ func loadSelectableSpeechModels(
         STTClient.isNemotronModelCached(modelVariant: $0, language: nemotronLanguage)
     }
     let checkWhisperModelDownloaded = isWhisperModelDownloaded ?? { WhisperEngine.isModelDownloaded(model: $0) }
+    let checkCohereModelDownloaded = isCohereModelDownloaded ?? { CohereTranscribeEngine.isModelCached() }
     let whisperVariant = SpeechEnginePreference.whisperModelVariant(defaults: defaults)
     let whisperLanguage = SpeechEnginePreference.whisperDefaultLanguage(defaults: defaults)
+    let cohereLanguage = SpeechEnginePreference.cohereDefaultLanguage(defaults: defaults) ?? "en"
 
     let parakeetModels = ParakeetModelVariant.allCases.map { variant in
         SelectableSpeechModel(
@@ -632,6 +680,16 @@ func loadSelectableSpeechModels(
     }
 
     return parakeetModels + nemotronModels + [
+        SelectableSpeechModel(
+            id: cohereModelID,
+            name: cohereModelName,
+            engine: SpeechEnginePreference.cohere.rawValue,
+            variant: nil,
+            size: cohereModelSize,
+            installed: checkCohereModelDownloaded(),
+            selected: currentEngine == .cohere,
+            language: cohereLanguage
+        ),
         SelectableSpeechModel(
             id: whisperModelID(for: whisperVariant),
             name: "Whisper \(SpeechEnginePreference.friendlyVariantName(whisperVariant))",
@@ -697,6 +755,10 @@ func resolveSelectableSpeechModel(
         )
     }
 
+    if isCohereModelID(lowered) {
+        return SelectableSpeechModelSelection(engine: .cohere, whisperVariant: nil)
+    }
+
     let variantInput: String?
     if lowered.hasPrefix("whisper:") {
         variantInput = String(trimmed.dropFirst("whisper:".count))
@@ -721,7 +783,8 @@ func validateSelectableSpeechModelDownload(
     _ selection: SelectableSpeechModelSelection,
     defaults: UserDefaults = macParakeetAppDefaults(),
     isNemotronModelDownloaded: ((NemotronModelVariant, String?) -> Bool)? = nil,
-    isWhisperModelDownloaded: ((String) -> Bool)? = nil
+    isWhisperModelDownloaded: ((String) -> Bool)? = nil,
+    isCohereModelDownloaded: (() -> Bool)? = nil
 ) throws {
     if let nemotronVariant = selection.nemotronVariant {
         let language = SpeechEnginePreference.nemotronDefaultLanguage(defaults: defaults)
@@ -743,6 +806,15 @@ func validateSelectableSpeechModelDownload(
             )
         }
     }
+
+    if selection.engine == .cohere {
+        let downloaded = (isCohereModelDownloaded ?? { CohereTranscribeEngine.isModelCached() })()
+        guard downloaded else {
+            throw ValidationError(
+                "Cohere Transcribe is not downloaded. Run `macparakeet-cli models download \(cohereModelID)` first."
+            )
+        }
+    }
 }
 
 /// One concrete model that `models delete` can target, resolved from a
@@ -753,6 +825,7 @@ struct ModelDeletionTarget: Equatable {
         case nemotron(NemotronModelVariant)
         /// Normalized Whisper variant id (matches the stored preference).
         case whisper(String)
+        case cohere
     }
 
     let kind: Kind
@@ -797,6 +870,9 @@ func resolveModelDeletionTarget(
             displayName: "Whisper \(SpeechEnginePreference.friendlyVariantName(whisperVariant))"
         )
     }
+    if selection.engine == .cohere {
+        return ModelDeletionTarget(kind: .cohere, displayName: cohereModelName)
+    }
     throw ValidationError("Unknown model ID: '\(id)'. Run `macparakeet-cli models list` for valid IDs.")
 }
 
@@ -818,6 +894,8 @@ func isModelInUse(
     case .whisper(let variant):
         return currentEngine == .whisper
             && SpeechEnginePreference.whisperModelVariant(defaults: defaults) == variant
+    case .cohere:
+        return currentEngine == .cohere
     }
 }
 

--- a/Sources/CLI/Commands/ModelsCommand.swift
+++ b/Sources/CLI/Commands/ModelsCommand.swift
@@ -342,7 +342,7 @@ extension ModelsCommand {
                 guard removed else {
                     throw ModelDeletionError.deleteFailed("Could not delete Cohere Transcribe. It may be missing or in use by another process.")
                 }
-                print("Deleted \(target.displayName) · freed ~2.1 GB.")
+                print("Deleted \(target.displayName) · freed \(cohereModelSize).")
             }
         }
     }

--- a/Sources/CLI/Commands/SpecCommand.swift
+++ b/Sources/CLI/Commands/SpecCommand.swift
@@ -179,10 +179,10 @@ private extension CLISpecCommand {
             options: [
                 CLISpecParameter.option("--podcast", valueName: "QUERY", summary: "Search Apple Podcasts by show/episode text and transcribe the selected episode."),
                 CLISpecParameter.option("--output-dir", valueName: "DIR", summary: "Write one transcript file per input to this directory; implies batch mode."),
-                CLISpecParameter.option("--format", valueName: "text|transcript|json", summary: "Output format for stdout or written transcript files."),
+                CLISpecParameter.option("--format", valueName: "text|transcript|json|srt|vtt", summary: "Output format for stdout or written transcript files."),
                 CLISpecParameter.option("--mode", valueName: "raw|clean|app-default", summary: "Text processing mode for this run."),
-                CLISpecParameter.option("--engine", valueName: "parakeet|nemotron|whisper|app-default", summary: "Speech engine for this run."),
-                CLISpecParameter.option("--language", valueName: "CODE", summary: "Language hint for Nemotron or Whisper; the English-only Nemotron build ignores it."),
+                CLISpecParameter.option("--engine", valueName: "parakeet|nemotron|whisper|cohere|app-default", summary: "Speech engine for this run."),
+                CLISpecParameter.option("--language", valueName: "CODE", summary: "Language hint for Nemotron, Whisper, or Cohere; the English-only Nemotron build ignores it."),
                 CLISpecParameter.option("--parakeet-model", valueName: "app-default|v3|v2|unified", summary: "Parakeet build for this run; ignored for Nemotron and Whisper."),
                 CLISpecParameter.option("--nemotron-model", valueName: "app-default|multilingual-1120ms|english-1120ms", summary: "Nemotron build for this run; ignored for Parakeet and Whisper."),
                 CLISpecParameter.option("--downloaded-audio", valueName: "app-default|keep|delete", summary: "Downloaded media retention policy."),
@@ -204,7 +204,7 @@ private extension CLISpecCommand {
         CLISpecCommand(
             ["config", "get"],
             summary: "Read one shared app/CLI configuration value.",
-            arguments: [.argument("key", summary: "Configuration key, such as speech-engine, parakeet-model, nemotron-model, nemotron-language, whisper-language, auto-meeting-titles, meeting-artifacts-folder, meeting-hook-enabled, meeting-hook-path, or meeting-hook-timeout.")],
+            arguments: [.argument("key", summary: "Configuration key, such as speech-engine, parakeet-model, nemotron-model, nemotron-language, whisper-language, cohere-language, auto-meeting-titles, meeting-artifacts-folder, meeting-hook-enabled, meeting-hook-path, or meeting-hook-timeout.")],
             output: "Configuration value."
         ),
         CLISpecCommand(

--- a/Sources/CLI/Commands/TranscribeCommand.swift
+++ b/Sources/CLI/Commands/TranscribeCommand.swift
@@ -208,6 +208,7 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
         storedEngine: String?,
         storedLanguage: String?,
         storedNemotronLanguage: String? = nil,
+        storedCohereLanguage: String? = nil,
         explicitLanguage: String?
     ) -> SpeechEngineSelection {
         let preference: SpeechEnginePreference
@@ -223,7 +224,7 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
             case .whisper:
                 explicitLanguage ?? storedLanguage
             case .cohere:
-                explicitLanguage
+                explicitLanguage ?? storedCohereLanguage
             }
         case .parakeet:
             preference = .parakeet
@@ -436,6 +437,7 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
                 storedEngine: defaults.string(forKey: SpeechEnginePreference.defaultsKey),
                 storedLanguage: SpeechEnginePreference.whisperDefaultLanguage(defaults: defaults),
                 storedNemotronLanguage: SpeechEnginePreference.nemotronDefaultLanguage(defaults: defaults),
+                storedCohereLanguage: SpeechEnginePreference.cohereDefaultLanguage(defaults: defaults),
                 explicitLanguage: self.language
             )
             let resolvedSpeakerDetection = Self.resolveSpeakerDetection(

--- a/Sources/CLI/Commands/TranscribeCommand.swift
+++ b/Sources/CLI/Commands/TranscribeCommand.swift
@@ -243,6 +243,20 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
         return SpeechEngineSelection(engine: preference, language: language)
     }
 
+    static func validateCohereLanguageOverride(
+        _ explicitLanguage: String?,
+        speechEngine: SpeechEngineSelection
+    ) throws {
+        guard speechEngine.engine == .cohere, let explicitLanguage else { return }
+        guard SpeechEnginePreference.normalizeCohereLanguage(explicitLanguage) != nil else {
+            let supported = CohereTranscribeEngine.supportedLanguages.map(\.code).joined(separator: ", ")
+            throw ValidationError(
+                "Invalid value for --language with Cohere: '\(explicitLanguage)'. "
+                    + "Cohere has no auto-detect; use one of: \(supported)."
+            )
+        }
+    }
+
     static func resolveParakeetModelVariant(
         _ option: TranscribeParakeetModel,
         storedVariant: ParakeetModelVariant
@@ -444,6 +458,7 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
                 storedCohereLanguage: SpeechEnginePreference.cohereDefaultLanguage(defaults: defaults),
                 explicitLanguage: self.language
             )
+            try Self.validateCohereLanguageOverride(self.language, speechEngine: speechEngine)
             let resolvedSpeakerDetection = Self.resolveSpeakerDetection(
                 self.speakerDetection,
                 storedEnabled: defaults.object(forKey: UserDefaultsAppRuntimePreferences.speakerDiarizationKey) as? Bool,

--- a/Sources/CLI/Commands/TranscribeCommand.swift
+++ b/Sources/CLI/Commands/TranscribeCommand.swift
@@ -222,6 +222,8 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
                 explicitLanguage ?? storedNemotronLanguage
             case .whisper:
                 explicitLanguage ?? storedLanguage
+            case .cohere:
+                explicitLanguage
             }
         case .parakeet:
             preference = .parakeet
@@ -416,6 +418,7 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
         var nemotronEngine: NemotronEngine?
         var nemotronEnglishEngine: NemotronEnglishEngine?
         var whisperEngine: WhisperEngine?
+        var cohereEngine: CohereTranscribeEngine?
         let runResult: Result<Void, Error>
         do {
             guard podcastQuery != nil || !resolvedInputs.isEmpty else {
@@ -494,6 +497,12 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
                 let createdWhisperEngine = WhisperEngine(language: speechEngine.language)
                 whisperEngine = createdWhisperEngine
                 sttTranscriber = createdWhisperEngine
+            case .cohere:
+                let createdCohereEngine = CohereTranscribeEngine(
+                    computePolicy: CohereTranscribeEngine.ComputePolicy.current(defaults: defaults)
+                )
+                cohereEngine = createdCohereEngine
+                sttTranscriber = createdCohereEngine
             }
             let audioProcessor = AudioProcessor()
             let youtubeDownloader = YouTubeDownloader(audioQuality: {
@@ -581,6 +590,7 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
         await nemotronEngine?.unload()
         await nemotronEnglishEngine?.unload()
         await whisperEngine?.unload()
+        await cohereEngine?.unload()
         try emitJSONOrRethrow(json: format == .json) {
             try runResult.get()
         }

--- a/Sources/CLI/Commands/TranscribeCommand.swift
+++ b/Sources/CLI/Commands/TranscribeCommand.swift
@@ -500,8 +500,11 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
                 whisperEngine = createdWhisperEngine
                 sttTranscriber = createdWhisperEngine
             case .cohere:
+                // Thread the resolved language into the engine — the no-`language:`
+                // transcribe path the CLI uses otherwise falls back to English.
                 let createdCohereEngine = CohereTranscribeEngine(
-                    computePolicy: CohereTranscribeEngine.ComputePolicy.current(defaults: defaults)
+                    computePolicy: CohereTranscribeEngine.ComputePolicy.current(defaults: defaults),
+                    defaultLanguageCode: speechEngine.language
                 )
                 cohereEngine = createdCohereEngine
                 sttTranscriber = createdCohereEngine

--- a/Sources/CLI/Commands/TranscribeCommand.swift
+++ b/Sources/CLI/Commands/TranscribeCommand.swift
@@ -34,6 +34,7 @@ enum TranscribeSpeechEngine: String, ExpressibleByArgument, CaseIterable, Sendab
     case parakeet
     case nemotron
     case whisper
+    case cohere
 }
 
 enum TranscribeParakeetModel: String, ExpressibleByArgument, CaseIterable, Sendable {
@@ -91,10 +92,10 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
     @Option(help: "Processing mode: raw, clean, app-default.")
     var mode: TranscribeMode = .appDefault
 
-    @Option(help: "Speech engine: app-default, parakeet, nemotron, whisper. Default: parakeet; app-default follows the saved GUI preference.")
+    @Option(help: "Speech engine: app-default, parakeet, nemotron, whisper, cohere. Default: parakeet; app-default follows the saved GUI preference.")
     var engine: TranscribeSpeechEngine = .parakeet
 
-    @Option(help: "Language hint for Whisper or Nemotron, such as ko, en, or en-US. Parakeet and the English-only Nemotron build ignore this flag.")
+    @Option(help: "Language hint for Whisper, Nemotron, or Cohere, such as ko, en, or en-US. Parakeet and the English-only Nemotron build ignore this flag.")
     var language: String?
 
     @Option(name: .long, help: "Parakeet build: app-default, v3 (multilingual), v2 (English-only), unified (English-only with punctuation/capitalization). app-default follows the saved preference; ignored for Nemotron and Whisper.")
@@ -235,6 +236,9 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
         case .whisper:
             preference = .whisper
             language = explicitLanguage
+        case .cohere:
+            preference = .cohere
+            language = explicitLanguage ?? storedCohereLanguage
         }
         return SpeechEngineSelection(engine: preference, language: language)
     }

--- a/Sources/MacParakeet/App/AppEnvironment.swift
+++ b/Sources/MacParakeet/App/AppEnvironment.swift
@@ -288,6 +288,9 @@ final class AppEnvironment {
                     return SpeechEnginePreference.parakeetModelVariant().usesUnifiedEngine
                 case .whisper:
                     return false
+                case .cohere:
+                    // Batch engine — record-then-transcribe, no live partials.
+                    return false
                 }
             },
             shouldShowDictationPreview: { [runtimePreferences] in
@@ -304,6 +307,9 @@ final class AppEnvironment {
                 case .nemotron:
                     return nil
                 case .whisper:
+                    return nil
+                case .cohere:
+                    // No display-preview path; Cohere finalizes on stop.
                     return nil
                 }
             },

--- a/Sources/MacParakeet/App/AppEnvironment.swift
+++ b/Sources/MacParakeet/App/AppEnvironment.swift
@@ -278,40 +278,13 @@ final class AppEnvironment {
             shouldUseAIFormatter: dictationAIFormatterEnabledClosure,
             aiFormatterPromptResolver: aiFormatterPromptResolver,
             shouldAttemptLiveDictationTranscription: {
-                guard AppFeatures.liveDictationStreamingEnabled else { return false }
-                switch SpeechEnginePreference.current() {
-                case .nemotron:
-                    // Both Nemotron builds stream live dictation partials from
-                    // their FluidAudio streaming managers.
-                    return true
-                case .parakeet:
-                    return SpeechEnginePreference.parakeetModelVariant().usesUnifiedEngine
-                case .whisper:
-                    return false
-                case .cohere:
-                    // Batch engine — record-then-transcribe, no live partials.
-                    return false
-                }
+                Self.shouldAttemptLiveDictationTranscription()
             },
             shouldShowDictationPreview: { [runtimePreferences] in
                 runtimePreferences.showLiveDictationPreview
             },
             dictationPreviewSpeechEngine: {
-                guard AppFeatures.liveDictationStreamingEnabled else { return nil }
-                switch SpeechEnginePreference.current() {
-                case .parakeet:
-                    guard !SpeechEnginePreference.parakeetModelVariant().usesUnifiedEngine else {
-                        return nil
-                    }
-                    return SpeechEngineSelection(engine: .parakeet)
-                case .nemotron:
-                    return nil
-                case .whisper:
-                    return nil
-                case .cohere:
-                    // No display-preview path; Cohere finalizes on stop.
-                    return nil
-                }
+                Self.dictationPreviewSpeechEngine()
             },
             markFirstDictationCompleted: { [runtimePreferences] in
                 // Fire the activation milestone exactly once, the first time a
@@ -366,6 +339,49 @@ final class AppEnvironment {
 
         derivedFieldsBackfill = DerivedFieldsBackfillService(dbQueue: databaseManager.dbQueue)
         derivedFieldsBackfill.runInBackground()
+    }
+
+    nonisolated static func shouldAttemptLiveDictationTranscription(
+        speechEngine: SpeechEnginePreference = SpeechEnginePreference.current(),
+        parakeetModelVariant: ParakeetModelVariant = SpeechEnginePreference.parakeetModelVariant(),
+        liveDictationStreamingEnabled: Bool = AppFeatures.liveDictationStreamingEnabled
+    ) -> Bool {
+        guard liveDictationStreamingEnabled else { return false }
+        switch speechEngine {
+        case .nemotron:
+            // Both Nemotron builds stream live dictation partials from
+            // their FluidAudio streaming managers.
+            return true
+        case .parakeet:
+            return parakeetModelVariant.usesUnifiedEngine
+        case .whisper:
+            return false
+        case .cohere:
+            // Batch engine: record-then-transcribe, no live partials.
+            return false
+        }
+    }
+
+    nonisolated static func dictationPreviewSpeechEngine(
+        speechEngine: SpeechEnginePreference = SpeechEnginePreference.current(),
+        parakeetModelVariant: ParakeetModelVariant = SpeechEnginePreference.parakeetModelVariant(),
+        liveDictationStreamingEnabled: Bool = AppFeatures.liveDictationStreamingEnabled
+    ) -> SpeechEngineSelection? {
+        guard liveDictationStreamingEnabled else { return nil }
+        switch speechEngine {
+        case .parakeet:
+            guard !parakeetModelVariant.usesUnifiedEngine else {
+                return nil
+            }
+            return SpeechEngineSelection(engine: .parakeet)
+        case .nemotron:
+            return nil
+        case .whisper:
+            return nil
+        case .cohere:
+            // No display-preview path; Cohere finalizes on stop.
+            return nil
+        }
     }
 
     nonisolated static func syncAIFormatterAvailabilityWithLLMConfiguration(

--- a/Sources/MacParakeet/App/DictationFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/DictationFlowCoordinator.swift
@@ -584,6 +584,11 @@ final class DictationFlowCoordinator {
             overlayController?.resignKeyWindow()
 
         case .pasteTranscript:
+            // Transcription succeeded — clear the engine-warmup caption with a
+            // success outcome here (there is no longer a `.showSuccess` checkmark
+            // effect to carry it). Idempotent: a later `.hideOverlay` dismiss is a
+            // no-op once this has recorded the duration.
+            dismissCaption(outcome: .success)
             let gen = stateMachine.generation
             guard let dictation = currentDictation else {
                 sendEvent(.pasteFailed(generation: gen, message: "No transcription available."))
@@ -592,8 +597,8 @@ final class DictationFlowCoordinator {
             let transcript = dictation.cleanTranscript ?? dictation.rawTranscript
             let insertionStyle = currentDictationInsertionStyle
             actionTask = Task { @MainActor in
-                // Brief pause so user sees the checkmark before paste
-                try? await Task.sleep(for: .milliseconds(200))
+                // Paste immediately — there's no success checkmark to wait for;
+                // the pasted text is the confirmation.
                 guard !Task.isCancelled else { return }
 
                 let action = self.pendingPostPasteAction

--- a/Sources/MacParakeet/App/DictationFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/DictationFlowCoordinator.swift
@@ -147,6 +147,10 @@ final class DictationFlowCoordinator {
     private let permissionService: PermissionServiceProtocol
     private let focusedAppContextService: any FocusedAppContextProviding
     private let captionTiming: DictationProcessingLoadCaptionTiming
+    /// The engine the next dictation will use. Drives the Cohere-specific
+    /// "Optimizing…" warm-up caption. Defaults to the persisted selection, the
+    /// same source the menu bar reads.
+    private let activeSpeechEngine: @MainActor () -> SpeechEnginePreference
     private let mediaPauseCoordinator: any DictationMediaPauseCoordinating
     private let overlayControllerFactory: @MainActor (DictationOverlayViewModel) -> any DictationOverlayControlling
     private let shouldSuppressIdlePill: () -> Bool
@@ -210,6 +214,7 @@ final class DictationFlowCoordinator {
         permissionService: PermissionServiceProtocol = PermissionService(),
         focusedAppContextService: any FocusedAppContextProviding = FocusedAppContextService(),
         captionTiming: DictationProcessingLoadCaptionTiming = .production,
+        activeSpeechEngine: @escaping @MainActor () -> SpeechEnginePreference = { SpeechEnginePreference.current() },
         mediaPauseCoordinator: (any DictationMediaPauseCoordinating)? = nil,
         overlayControllerFactory: @escaping @MainActor (DictationOverlayViewModel) -> any DictationOverlayControlling = {
             DictationOverlayController(viewModel: $0)
@@ -230,6 +235,7 @@ final class DictationFlowCoordinator {
         self.permissionService = permissionService
         self.focusedAppContextService = focusedAppContextService
         self.captionTiming = captionTiming
+        self.activeSpeechEngine = activeSpeechEngine
         self.mediaPauseCoordinator = mediaPauseCoordinator ?? NoOpDictationMediaPauseCoordinator()
         self.overlayControllerFactory = overlayControllerFactory
         self.shouldSuppressIdlePill = shouldSuppressIdlePill
@@ -816,16 +822,25 @@ final class DictationFlowCoordinator {
         guard let state = overlayViewModel?.state, case .processing = state else { return }
 
         let firstInstall = !runtimePreferences.hasCompletedFirstDictation
-        overlayViewModel?.processingLoadCaption = .preparing
+        // Cohere pays a one-time, per-launch Core ML graph specialization (~2 min
+        // on the GPU path). That warm-up recurs every launch, not just on first
+        // install, so we show a Cohere-specific caption and always escalate to the
+        // time-estimate copy — not only on the very first dictation.
+        let isCohere = activeSpeechEngine() == .cohere
+        let baseCaption: DictationOverlayViewModel.ProcessingLoadCaption = isCohere ? .optimizing : .preparing
+        let extendedCaption: DictationOverlayViewModel.ProcessingLoadCaption =
+            isCohere ? .optimizingExtended : .preparingExtended
+
+        overlayViewModel?.processingLoadCaption = baseCaption
         captionShownAt = Date()
         Telemetry.send(.dictationFirstLoadCaptionShown(firstInstall: firstInstall))
 
-        guard firstInstall else { return }
+        guard isCohere || firstInstall else { return }
         let escalation = DispatchWorkItem { [weak self] in
             Task { @MainActor in
                 guard self?.captionGeneration == generation else { return }
-                guard self?.overlayViewModel?.processingLoadCaption == .preparing else { return }
-                self?.overlayViewModel?.processingLoadCaption = .preparingExtended
+                guard self?.overlayViewModel?.processingLoadCaption == baseCaption else { return }
+                self?.overlayViewModel?.processingLoadCaption = extendedCaption
             }
         }
         captionEscalationTimer = escalation
@@ -862,7 +877,7 @@ final class DictationFlowCoordinator {
         captionEscalationTimer = nil
 
         switch overlayViewModel?.processingLoadCaption {
-        case .preparing, .preparingExtended:
+        case .preparing, .preparingExtended, .optimizing, .optimizingExtended:
             overlayViewModel?.processingLoadCaption = .failed
             captionFailureDismissTask?.cancel()
             captionFailureDismissTask = Task { @MainActor [weak self] in

--- a/Sources/MacParakeet/App/DictationFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/DictationFlowCoordinator.swift
@@ -584,13 +584,9 @@ final class DictationFlowCoordinator {
             overlayController?.resignKeyWindow()
 
         case .pasteTranscript:
-            // Transcription succeeded — clear the engine-warmup caption with a
-            // success outcome here (there is no longer a `.showSuccess` checkmark
-            // effect to carry it). Idempotent: a later `.hideOverlay` dismiss is a
-            // no-op once this has recorded the duration.
-            dismissCaption(outcome: .success)
             let gen = stateMachine.generation
             guard let dictation = currentDictation else {
+                dismissCaption(outcome: .failure)
                 sendEvent(.pasteFailed(generation: gen, message: "No transcription available."))
                 return
             }
@@ -615,6 +611,7 @@ final class DictationFlowCoordinator {
                 do {
                     if action == nil && !transcriptHasText {
                         self.dictationLog.notice("dictation_paste_skipped gen=\(gen) reason=empty_transcript")
+                        self.dismissCaption(outcome: .success)
                         self.sendEvent(.pasteSucceeded(generation: gen))
                         return
                     }
@@ -656,11 +653,13 @@ final class DictationFlowCoordinator {
                     let app = self.currentDictation?.pastedToApp ?? "none"
                     self.dictationLog.notice("dictation_completed gen=\(gen) outcome=success rawChars=\(rawChars) cleanChars=\(cleanChars) autoPasted=true pastedToApp=\(app, privacy: .public)")
 
+                    self.dismissCaption(outcome: .success)
                     self.sendEvent(.pasteSucceeded(generation: gen))
                 } catch {
                     guard !Task.isCancelled else { return }
                     let bucket = Self.commandFailureBucket(for: error)
                     self.dictationLog.error("dictation_paste_failed gen=\(gen) bucket=\(bucket, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
+                    self.dismissCaption(outcome: .failure)
                     if !transcriptHasText {
                         // Pure action-only dictation (e.g., "press return") — nothing to paste
                         self.sendEvent(.pasteFailed(generation: gen, message: "Keystroke failed. Check Accessibility permissions."))

--- a/Sources/MacParakeet/App/DictationFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/DictationFlowCoordinator.swift
@@ -827,10 +827,10 @@ final class DictationFlowCoordinator {
         guard let state = overlayViewModel?.state, case .processing = state else { return }
 
         let firstInstall = !runtimePreferences.hasCompletedFirstDictation
-        // Cohere pays a one-time, per-launch Core ML graph specialization (~2 min
-        // on the GPU path). That warm-up recurs every launch, not just on first
-        // install, so we show a Cohere-specific caption and always escalate to the
-        // time-estimate copy — not only on the very first dictation.
+        // Cohere has its own model download / Core ML preparation path, and a
+        // user may switch to it after already completing dictation with another
+        // engine. Keep its load caption specific even when this is not the
+        // app's first completed dictation.
         let isCohere = activeSpeechEngine() == .cohere
         let baseCaption: DictationOverlayViewModel.ProcessingLoadCaption = isCohere ? .optimizing : .preparing
         let extendedCaption: DictationOverlayViewModel.ProcessingLoadCaption =

--- a/Sources/MacParakeet/App/MenuBarCoordinator.swift
+++ b/Sources/MacParakeet/App/MenuBarCoordinator.swift
@@ -38,6 +38,9 @@ final class MenuBarCoordinator: NSObject, NSMenuDelegate {
     private var transcribeFileMenuItems: [NSMenuItem] = []
     private var transcribeYouTubeMenuItems: [NSMenuItem] = []
     private var hotkeyMenuItem: NSMenuItem?
+    /// "Cohere Language ▸" submenu — only shown while Cohere is the active engine
+    /// (Cohere has no auto-detect, so the language must be chosen).
+    private var cohereLanguageMenuItem: NSMenuItem?
 
     init(
         updaterController: SPUStandardUpdaterController,
@@ -413,6 +416,23 @@ final class MenuBarCoordinator: NSObject, NSMenuDelegate {
 
         menu.addItem(NSMenuItem.separator())
 
+        let cohereLanguageItem = NSMenuItem(title: "Cohere Language", action: nil, keyEquivalent: "")
+        let cohereLanguageSubmenu = NSMenu()
+        for language in CohereTranscribeEngine.supportedLanguages {
+            let languageItem = NSMenuItem(
+                title: language.name,
+                action: #selector(selectCohereLanguage(_:)),
+                keyEquivalent: ""
+            )
+            languageItem.target = self
+            languageItem.representedObject = language.code
+            cohereLanguageSubmenu.addItem(languageItem)
+        }
+        cohereLanguageItem.submenu = cohereLanguageSubmenu
+        cohereLanguageItem.isHidden = true
+        menu.addItem(cohereLanguageItem)
+        cohereLanguageMenuItem = cohereLanguageItem
+
         let hotkeyItem = NSMenuItem(
             title: hotkeyMenuTitleProvider(),
             action: nil,
@@ -453,6 +473,26 @@ final class MenuBarCoordinator: NSObject, NSMenuDelegate {
 
     func refreshHotkeyTitle() {
         hotkeyMenuItem?.title = hotkeyMenuTitleProvider()
+    }
+
+    /// Show the Cohere-language submenu only while Cohere is the active engine,
+    /// and check the chosen language. Cohere has no auto-detect, so this is how
+    /// the user picks among its 14 languages without opening the app.
+    private func updateCohereLanguageMenu() {
+        guard let item = cohereLanguageMenuItem else { return }
+        let isCohere = SpeechEnginePreference.current() == .cohere
+        item.isHidden = !isCohere
+        guard isCohere, let submenu = item.submenu else { return }
+        let selected = SpeechEnginePreference.cohereDefaultLanguage() ?? "en"
+        for languageItem in submenu.items {
+            languageItem.state = (languageItem.representedObject as? String) == selected ? .on : .off
+        }
+    }
+
+    @objc private func selectCohereLanguage(_ sender: NSMenuItem) {
+        guard let code = sender.representedObject as? String else { return }
+        SpeechEnginePreference.saveCohereDefaultLanguage(code)
+        updateCohereLanguageMenu()
     }
 
     func refreshMeetingHotkeyShortcut() {
@@ -644,6 +684,8 @@ final class MenuBarCoordinator: NSObject, NSMenuDelegate {
                 ? "Stop Recording"
                 : "Start Recording"
         }
+
+        updateCohereLanguageMenu()
 
         guard let env = environmentProvider() else {
             pasteLastMenuItem?.isEnabled = false

--- a/Sources/MacParakeet/Hotkey/HotkeyManager.swift
+++ b/Sources/MacParakeet/Hotkey/HotkeyManager.swift
@@ -818,6 +818,24 @@ public final class HotkeyManager {
             return []
 
         case nil:
+            // A tap-disable + recovery can land in the brief window after a fresh
+            // trigger press but before its startup timer has fired, when no
+            // recording is active yet. Hard-resetting here cancels the armed
+            // startup timer and gesture state, dropping the start the user is
+            // mid-gesture on — and because the key is still physically held, no
+            // new edge arrives to re-arm it, so "nothing happens" until they
+            // release and press again. (The Instant-Dictation warm-mic restart
+            // right after a paste is what disables the tap in the first place.)
+            // If a press is still pending and the trigger is still held, preserve
+            // the gesture across the recovery instead of resetting it.
+            if triggerPressed, gestureController.hasPendingTriggerPress {
+                syncRecoveredTriggerState(
+                    flags: flags,
+                    triggerKeyPressed: triggerKeyPressed,
+                    triggerPressed: triggerPressed
+                )
+                return []
+            }
             resetGestureState(flags: flags, triggerKeyPressed: triggerKeyPressed)
             return []
         }

--- a/Sources/MacParakeet/Views/Dictation/DictationOverlayController.swift
+++ b/Sources/MacParakeet/Views/Dictation/DictationOverlayController.swift
@@ -207,6 +207,11 @@ final class DictationOverlayViewModel {
     enum ProcessingLoadCaption: Equatable {
         case preparing
         case preparingExtended
+        /// Cohere's one-time, per-launch Core ML graph specialization (~2 min on
+        /// the GPU path). Shown when a dictation is triggered before the launch
+        /// warm-up has finished, so the wait reads as setup, not a hang.
+        case optimizing
+        case optimizingExtended
         case failed
     }
 

--- a/Sources/MacParakeet/Views/Dictation/LoadingCaptionView.swift
+++ b/Sources/MacParakeet/Views/Dictation/LoadingCaptionView.swift
@@ -49,7 +49,7 @@ struct LoadingCaptionView: View {
         case .preparingExtended:
             "First-time setup — may take a few minutes"
         case .optimizingExtended:
-            "About two minutes — one-time per launch"
+            "Model setup — may take a few minutes"
         case .preparing, .optimizing, .failed:
             nil
         }

--- a/Sources/MacParakeet/Views/Dictation/LoadingCaptionView.swift
+++ b/Sources/MacParakeet/Views/Dictation/LoadingCaptionView.swift
@@ -37,6 +37,8 @@ struct LoadingCaptionView: View {
         switch caption {
         case .preparing, .preparingExtended:
             "Preparing speech engine…"
+        case .optimizing, .optimizingExtended:
+            "Optimizing Cohere…"
         case .failed:
             "Couldn't load speech engine."
         }
@@ -46,14 +48,16 @@ struct LoadingCaptionView: View {
         switch caption {
         case .preparingExtended:
             "First-time setup — may take a few minutes"
-        case .preparing, .failed:
+        case .optimizingExtended:
+            "About two minutes — one-time per launch"
+        case .preparing, .optimizing, .failed:
             nil
         }
     }
 
     private var titleColor: Color {
         switch caption {
-        case .preparing, .preparingExtended:
+        case .preparing, .preparingExtended, .optimizing, .optimizingExtended:
             .white.opacity(0.85)
         case .failed:
             DesignSystem.Colors.recordingRed
@@ -72,6 +76,8 @@ struct LoadingCaptionView: View {
     VStack(spacing: 10) {
         LoadingCaptionView(caption: .preparing)
         LoadingCaptionView(caption: .preparingExtended)
+        LoadingCaptionView(caption: .optimizing)
+        LoadingCaptionView(caption: .optimizingExtended)
         LoadingCaptionView(caption: .failed)
     }
     .padding(24)

--- a/Sources/MacParakeet/Views/Settings/SettingsStatusRules.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsStatusRules.swift
@@ -24,9 +24,11 @@ enum SettingsStatusRules {
         nemotron: SettingsViewModel.LocalModelStatus,
         whisper: SettingsViewModel.LocalModelStatus,
         cohere: SettingsViewModel.LocalModelStatus,
+        cohereEnabled: Bool = true,
         activeEngine: SpeechEnginePreference
     ) -> SettingsCardStatus? {
-        if parakeet == .failed || nemotron == .failed || whisper == .failed || cohere == .failed {
+        let cohereStatus = cohereEnabled || activeEngine == .cohere ? cohere : .notDownloaded
+        if parakeet == .failed || nemotron == .failed || whisper == .failed || cohereStatus == .failed {
             return SettingsCardStatus(.required, label: "Action needed")
         }
 
@@ -35,7 +37,7 @@ enum SettingsStatusRules {
         case .parakeet: activeStatus = parakeet
         case .nemotron: activeStatus = nemotron
         case .whisper: activeStatus = whisper
-        case .cohere: activeStatus = cohere
+        case .cohere: activeStatus = cohereStatus
         }
 
         if activeStatus == .notDownloaded {
@@ -49,7 +51,7 @@ enum SettingsStatusRules {
         let optionalNemotronReady = nemotron == .notDownloaded || isAvailable(nemotron)
         // Cohere is an optional, large-download engine like Nemotron: its absence
         // must not block the "Ready" state when it isn't the active engine.
-        let optionalCohereReady = cohere == .notDownloaded || isAvailable(cohere)
+        let optionalCohereReady = cohereStatus == .notDownloaded || isAvailable(cohereStatus)
         if isAvailable(parakeet), isAvailable(whisper), optionalNemotronReady, optionalCohereReady {
             return SettingsCardStatus(.ok, label: "Ready")
         }

--- a/Sources/MacParakeet/Views/Settings/SettingsStatusRules.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsStatusRules.swift
@@ -23,9 +23,10 @@ enum SettingsStatusRules {
         parakeet: SettingsViewModel.LocalModelStatus,
         nemotron: SettingsViewModel.LocalModelStatus,
         whisper: SettingsViewModel.LocalModelStatus,
+        cohere: SettingsViewModel.LocalModelStatus,
         activeEngine: SpeechEnginePreference
     ) -> SettingsCardStatus? {
-        if parakeet == .failed || nemotron == .failed || whisper == .failed {
+        if parakeet == .failed || nemotron == .failed || whisper == .failed || cohere == .failed {
             return SettingsCardStatus(.required, label: "Action needed")
         }
 
@@ -34,6 +35,7 @@ enum SettingsStatusRules {
         case .parakeet: activeStatus = parakeet
         case .nemotron: activeStatus = nemotron
         case .whisper: activeStatus = whisper
+        case .cohere: activeStatus = cohere
         }
 
         if activeStatus == .notDownloaded {
@@ -45,7 +47,10 @@ enum SettingsStatusRules {
         }
 
         let optionalNemotronReady = nemotron == .notDownloaded || isAvailable(nemotron)
-        if isAvailable(parakeet), isAvailable(whisper), optionalNemotronReady {
+        // Cohere is an optional, large-download engine like Nemotron: its absence
+        // must not block the "Ready" state when it isn't the active engine.
+        let optionalCohereReady = cohere == .notDownloaded || isAvailable(cohere)
+        if isAvailable(parakeet), isAvailable(whisper), optionalNemotronReady, optionalCohereReady {
             return SettingsCardStatus(.ok, label: "Ready")
         }
 

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -2596,7 +2596,7 @@ struct SettingsView: View {
                     overflowActions: displayedWhisperModelStatus == .preparing ? [] : whisperOverflowActions
                 )
 
-                if AppFeatures.cohereEngineEnabled {
+                if shouldShowCohereModelRow {
                     Divider()
 
                     modelStatusRow(
@@ -2661,8 +2661,13 @@ struct SettingsView: View {
             nemotron: displayedNemotronModelStatus,
             whisper: displayedWhisperModelStatus,
             cohere: displayedCohereModelStatus,
+            cohereEnabled: shouldShowCohereModelRow,
             activeEngine: viewModel.engine.speechEnginePreference
         )
+    }
+
+    private var shouldShowCohereModelRow: Bool {
+        AppFeatures.cohereEngineEnabled || viewModel.engine.speechEnginePreference == .cohere
     }
 
     private var currentSpeechEngineSwitchTarget: SpeechEnginePreference {
@@ -3082,29 +3087,33 @@ struct SettingsView: View {
     }
 
     private var cohereOverflowActions: [ModelRowAction] {
+        var actions: [ModelRowAction] = []
         switch viewModel.engine.cohereModelStatus {
         case .ready, .notLoaded:
-            var actions = [ModelRowAction(
+            actions.append(ModelRowAction(
                 label: "Repair…",
                 isProminent: false,
                 help: "Re-check Cohere Transcribe files and re-download any missing model assets."
             ) {
                 viewModel.engine.downloadCohereModel()
-            }]
-            if viewModel.engine.speechEnginePreference != .cohere {
-                actions.append(ModelRowAction(
-                    label: "Delete download…",
-                    isProminent: false,
-                    isDestructive: true,
-                    help: "Remove the Cohere Transcribe download from this Mac."
-                ) {
-                    pendingModelDeletion = .cohere
-                })
-            }
-            return actions
+            })
+        case .failed, .notDownloaded:
+            break
         default:
             return []
         }
+        if viewModel.engine.canDeleteCohereModel,
+           viewModel.engine.speechEnginePreference != .cohere {
+            actions.append(ModelRowAction(
+                label: "Delete download…",
+                isProminent: false,
+                isDestructive: true,
+                help: "Remove the Cohere Transcribe download from this Mac."
+            ) {
+                pendingModelDeletion = .cohere
+            })
+        }
+        return actions
     }
 
     fileprivate struct ModelRowAction: Identifiable {

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -502,12 +502,14 @@ struct SettingsView: View {
         case parakeet(ParakeetModelVariant)
         case nemotron(NemotronModelVariant)
         case whisper
+        case cohere
 
         var id: String {
             switch self {
             case .parakeet(let variant): "parakeet-\(variant.rawValue)"
             case .nemotron(let variant): "nemotron-\(variant.rawValue)"
             case .whisper: "whisper"
+            case .cohere: "cohere"
             }
         }
     }
@@ -525,6 +527,7 @@ struct SettingsView: View {
         case .parakeet(let variant): "Delete \(variant.modelName)?"
         case .nemotron(let variant): "Delete \(variant.modelName)?"
         case .whisper: "Delete the Whisper model?"
+        case .cohere: "Delete Cohere Transcribe?"
         case nil: "Delete this model?"
         }
     }
@@ -537,6 +540,8 @@ struct SettingsView: View {
             return "This frees \(variant.approximateDownloadSize). You can download \(variant.modelName) again at any time."
         case .whisper:
             return "This removes the configured Whisper model download from this Mac. You can download it again at any time."
+        case .cohere:
+            return "This frees about 2.1 GB. You can download Cohere Transcribe again at any time."
         }
     }
 
@@ -548,6 +553,8 @@ struct SettingsView: View {
             viewModel.engine.deleteNemotronVariant(variant)
         case .whisper:
             viewModel.engine.deleteWhisperModel()
+        case .cohere:
+            viewModel.engine.deleteCohereModel()
         }
         pendingModelDeletion = nil
     }
@@ -2253,7 +2260,7 @@ struct SettingsView: View {
                             isSelected: viewModel.engine.speechEnginePreference == .cohere,
                             isBusy: viewModel.engine.speechEngineSwitching,
                             unavailableReason: engineSwitchUnavailableReason(for: .cohere),
-                            onSelect: { selectEngine(.cohere) }
+                            onSelect: { handleCohereTileTap() }
                         )
                     }
                 }
@@ -2275,6 +2282,15 @@ struct SettingsView: View {
                         subtitle: banner.subtitle,
                         mode: banner.mode,
                         action: { viewModel.engine.downloadWhisperModel() }
+                    )
+                }
+
+                if let banner = cohereDownloadBannerState {
+                    EngineDownloadBanner(
+                        title: "Cohere Transcribe",
+                        subtitle: banner.subtitle,
+                        mode: banner.mode,
+                        action: { viewModel.engine.downloadCohereModel() }
                     )
                 }
 
@@ -2534,7 +2550,7 @@ struct SettingsView: View {
         }
     }
 
-    /// Status chip rolls up the worst severity across both engines via
+    /// Status chip rolls up the worst severity across engines via
     /// `SettingsStatusRules.localModelsCardStatus`. Inline action button
     /// only renders for actionable states; Repair / Re-download for healthy
     /// models tucks into a `…` menu so calm rows stay calm.
@@ -2579,6 +2595,20 @@ struct SettingsView: View {
                     primaryAction: displayedWhisperModelStatus == .preparing ? nil : whisperPrimaryAction,
                     overflowActions: displayedWhisperModelStatus == .preparing ? [] : whisperOverflowActions
                 )
+
+                if AppFeatures.cohereEngineEnabled {
+                    Divider()
+
+                    modelStatusRow(
+                        title: "Cohere",
+                        detail: displayedCohereModelStatusDetail,
+                        status: displayedCohereModelStatus,
+                        isWorking: viewModel.engine.cohereDownloading,
+                        actionsDisabled: viewModel.engine.speechEngineSwitching,
+                        primaryAction: displayedCohereModelStatus == .preparing ? nil : coherePrimaryAction,
+                        overflowActions: displayedCohereModelStatus == .preparing ? [] : cohereOverflowActions
+                    )
+                }
             }
         }
     }
@@ -2692,6 +2722,14 @@ struct SettingsView: View {
         return .preparing
     }
 
+    private var displayedCohereModelStatusDetail: String {
+        guard viewModel.engine.speechEngineSwitching,
+              currentSpeechEngineSwitchTarget == .cohere else {
+            return viewModel.engine.cohereModelStatusDetail
+        }
+        return viewModel.engine.speechEngineSwitchDetail ?? "Loading Cohere with Core ML..."
+    }
+
     private var displayedNemotronModelStatusDetail: String {
         guard viewModel.engine.speechEngineSwitching,
               currentSpeechEngineSwitchTarget == .nemotron else {
@@ -2795,6 +2833,26 @@ struct SettingsView: View {
         }
     }
 
+    private var cohereDownloadBannerState: (mode: EngineDownloadBanner.Mode, subtitle: String)? {
+        guard AppFeatures.cohereEngineEnabled,
+              viewModel.engine.speechEnginePreference == .cohere else {
+            return nil
+        }
+        if viewModel.engine.cohereDownloading {
+            return (.downloading, viewModel.engine.cohereModelStatusDetail)
+        }
+        switch viewModel.engine.cohereModelStatus {
+        case .notDownloaded:
+            return (.download, "About 2.1 GB · downloads once, runs locally afterwards")
+        case .repairing:
+            return (.downloading, viewModel.engine.cohereModelStatusDetail)
+        case .failed:
+            return (.retry, viewModel.engine.cohereModelStatusDetail)
+        case .ready, .notLoaded, .preparing, .checking, .unknown:
+            return nil
+        }
+    }
+
     /// Pre-empts every "Whisper isn't ready" state so the user never sees
     /// a briefly-selected-then-reverted tile. Mirrors the VM's
     /// `isWhisperModelAvailable` (`ready` or `notLoaded`); for everything
@@ -2833,6 +2891,23 @@ struct SettingsView: View {
             viewModel.engine.speechEngineError = "Nemotron model failed to load — retry below."
         case .checking, .unknown:
             selectEngine(.nemotron)
+        }
+    }
+
+    private func handleCohereTileTap() {
+        switch viewModel.engine.cohereModelStatus {
+        case .ready, .notLoaded:
+            selectEngine(.cohere)
+        case .notDownloaded:
+            viewModel.engine.speechEngineError = "Download Cohere Transcribe from Local Models below before switching engines."
+        case .repairing:
+            viewModel.engine.speechEngineError = "Cohere Transcribe is downloading — switch engines once it finishes."
+        case .preparing:
+            viewModel.engine.speechEngineError = "Cohere is preparing for this Mac — switch engines once it finishes."
+        case .failed:
+            viewModel.engine.speechEngineError = "Cohere Transcribe failed to load — retry below."
+        case .checking, .unknown:
+            selectEngine(.cohere)
         }
     }
 
@@ -2924,6 +2999,29 @@ struct SettingsView: View {
         }
     }
 
+    private var coherePrimaryAction: ModelRowAction? {
+        switch viewModel.engine.cohereModelStatus {
+        case .notDownloaded:
+            return ModelRowAction(
+                label: "Download",
+                isProminent: true,
+                help: "Download Cohere Transcribe for local speech recognition."
+            ) {
+                viewModel.engine.downloadCohereModel()
+            }
+        case .failed:
+            return ModelRowAction(
+                label: "Retry",
+                isProminent: true,
+                help: "Try downloading Cohere Transcribe again."
+            ) {
+                viewModel.engine.downloadCohereModel()
+            }
+        default:
+            return nil
+        }
+    }
+
     private var nemotronOverflowActions: [ModelRowAction] {
         switch viewModel.engine.nemotronModelStatus {
         case .ready, .notLoaded:
@@ -2975,6 +3073,32 @@ struct SettingsView: View {
                     help: "Remove the configured Whisper model download from this Mac."
                 ) {
                     pendingModelDeletion = .whisper
+                })
+            }
+            return actions
+        default:
+            return []
+        }
+    }
+
+    private var cohereOverflowActions: [ModelRowAction] {
+        switch viewModel.engine.cohereModelStatus {
+        case .ready, .notLoaded:
+            var actions = [ModelRowAction(
+                label: "Repair…",
+                isProminent: false,
+                help: "Re-check Cohere Transcribe files and re-download any missing model assets."
+            ) {
+                viewModel.engine.downloadCohereModel()
+            }]
+            if viewModel.engine.speechEnginePreference != .cohere {
+                actions.append(ModelRowAction(
+                    label: "Delete download…",
+                    isProminent: false,
+                    isDestructive: true,
+                    help: "Remove the Cohere Transcribe download from this Mac."
+                ) {
+                    pendingModelDeletion = .cohere
                 })
             }
             return actions

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -2690,7 +2690,10 @@ struct SettingsView: View {
     private var displayedCohereModelStatus: SettingsViewModel.LocalModelStatus {
         guard viewModel.engine.speechEngineSwitching,
               currentSpeechEngineSwitchTarget == .cohere else {
-            return CohereTranscribeEngine.isModelCached() ? .ready : .notDownloaded
+            guard CohereTranscribeEngine.isModelCached() else { return .notDownloaded }
+            // Mirror the other engines: `.ready` only when Cohere is the active
+            // (loaded) engine; on disk but inactive is `.notLoaded`.
+            return viewModel.engine.speechEnginePreference == .cohere ? .ready : .notLoaded
         }
         return .preparing
     }

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -2839,7 +2839,7 @@ struct SettingsView: View {
     }
 
     private var cohereDownloadBannerState: (mode: EngineDownloadBanner.Mode, subtitle: String)? {
-        guard AppFeatures.cohereEngineEnabled,
+        guard shouldShowCohereModelRow,
               viewModel.engine.speechEnginePreference == .cohere else {
             return nil
         }

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -2684,16 +2684,10 @@ struct SettingsView: View {
         return .preparing
     }
 
-    /// Phase-1 lightweight Cohere status: there is no reactive download-state
-    /// pipeline yet, so derive presence directly from disk. Reflects "preparing"
-    /// while switching to Cohere, otherwise downloaded-or-not.
     private var displayedCohereModelStatus: SettingsViewModel.LocalModelStatus {
         guard viewModel.engine.speechEngineSwitching,
               currentSpeechEngineSwitchTarget == .cohere else {
-            guard CohereTranscribeEngine.isModelCached() else { return .notDownloaded }
-            // Mirror the other engines: `.ready` only when Cohere is the active
-            // (loaded) engine; on disk but inactive is `.notLoaded`.
-            return viewModel.engine.speechEnginePreference == .cohere ? .ready : .notLoaded
+            return viewModel.engine.cohereModelStatus
         }
         return .preparing
     }

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -2839,8 +2839,7 @@ struct SettingsView: View {
     }
 
     private var cohereDownloadBannerState: (mode: EngineDownloadBanner.Mode, subtitle: String)? {
-        guard shouldShowCohereModelRow,
-              viewModel.engine.speechEnginePreference == .cohere else {
+        guard viewModel.engine.speechEnginePreference == .cohere else {
             return nil
         }
         if viewModel.engine.cohereDownloading {

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -570,6 +570,8 @@ struct SettingsView: View {
             return "Preparing Whisper can take several minutes the first time while Core ML optimizes it for this Mac. Dictation, file transcription, and meetings pause until the switch finishes."
         case .parakeet:
             return "Switching back to Parakeet reloads the speech engine. Dictation, file transcription, and meetings pause until the switch finishes."
+        case .cohere:
+            return "Cohere is a high-accuracy dictation engine (~2.1 GB on-device model). The first transcription after each launch may take a moment while Core ML prepares the model; after that, dictation is fast. Dictation, file transcription, and meetings pause until the switch finishes."
         }
     }
 
@@ -2235,6 +2237,25 @@ struct SettingsView: View {
                             && !viewModel.engine.whisperHasBeenOptimized,
                         onSelect: { handleWhisperTileTap() }
                     )
+
+                    if AppFeatures.cohereEngineEnabled {
+                        EngineOptionTile(
+                            icon: "waveform",
+                            name: "Cohere",
+                            tagline: "Highest-accuracy engine",
+                            strengths: [
+                                "State-of-the-art accuracy (Cohere Transcribe)",
+                                "Fully on-device Core ML — audio never leaves your Mac",
+                                "Powers dictation, files, and meetings (English)"
+                            ],
+                            helpText: "Cohere Transcribe (03-2026) running fully on-device via Core ML — the highest accuracy of the available engines, at the cost of a ~2.1 GB model download and a brief one-time prepare after each launch. Powers dictation, file transcription, and meetings. Note: Cohere produces no word timestamps, so meetings transcribed with it are plain text without live preview or speaker labels — switch to Parakeet for speaker-labeled, timestamped meetings.",
+                            modelStatus: displayedCohereModelStatus,
+                            isSelected: viewModel.engine.speechEnginePreference == .cohere,
+                            isBusy: viewModel.engine.speechEngineSwitching,
+                            unavailableReason: engineSwitchUnavailableReason(for: .cohere),
+                            onSelect: { selectEngine(.cohere) }
+                        )
+                    }
                 }
 
                 if let banner = nemotronDownloadBannerState {
@@ -2599,6 +2620,8 @@ struct SettingsView: View {
             return "Preparing Nemotron"
         case .whisper:
             return "Preparing Whisper"
+        case .cohere:
+            return "Preparing Cohere"
         }
     }
 
@@ -2607,6 +2630,7 @@ struct SettingsView: View {
             parakeet: displayedParakeetModelStatus,
             nemotron: displayedNemotronModelStatus,
             whisper: displayedWhisperModelStatus,
+            cohere: displayedCohereModelStatus,
             activeEngine: viewModel.engine.speechEnginePreference
         )
     }
@@ -2656,6 +2680,17 @@ struct SettingsView: View {
         guard viewModel.engine.speechEngineSwitching,
               currentSpeechEngineSwitchTarget == .nemotron else {
             return viewModel.engine.nemotronModelStatus
+        }
+        return .preparing
+    }
+
+    /// Phase-1 lightweight Cohere status: there is no reactive download-state
+    /// pipeline yet, so derive presence directly from disk. Reflects "preparing"
+    /// while switching to Cohere, otherwise downloaded-or-not.
+    private var displayedCohereModelStatus: SettingsViewModel.LocalModelStatus {
+        guard viewModel.engine.speechEngineSwitching,
+              currentSpeechEngineSwitchTarget == .cohere else {
+            return CohereTranscribeEngine.isModelCached() ? .ready : .notDownloaded
         }
         return .preparing
     }

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -2246,7 +2246,7 @@ struct SettingsView: View {
                             strengths: [
                                 "State-of-the-art accuracy (Cohere Transcribe)",
                                 "Fully on-device Core ML — audio never leaves your Mac",
-                                "Powers dictation, files, and meetings (English)"
+                                "Powers dictation, files, and meetings (14 languages)"
                             ],
                             helpText: "Cohere Transcribe (03-2026) running fully on-device via Core ML — the highest accuracy of the available engines, at the cost of a ~2.1 GB model download and a brief one-time prepare after each launch. Powers dictation, file transcription, and meetings. Note: Cohere produces no word timestamps, so meetings transcribed with it are plain text without live preview or speaker labels — switch to Parakeet for speaker-labeled, timestamped meetings.",
                             modelStatus: displayedCohereModelStatus,

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -571,7 +571,7 @@ struct SettingsView: View {
         case .parakeet:
             return "Switching back to Parakeet reloads the speech engine. Dictation, file transcription, and meetings pause until the switch finishes."
         case .cohere:
-            return "Cohere is a high-accuracy dictation engine (~2.1 GB on-device model). The first transcription after each launch may take a moment while Core ML prepares the model; after that, dictation is fast. Dictation, file transcription, and meetings pause until the switch finishes."
+            return "Cohere is a high-accuracy engine (~2.1 GB on-device model). Dictation records first and transcribes after you stop; live preview stays off because Cohere is batch-only. The first transcription may take a moment while Core ML prepares the model. Dictation, file transcription, and meetings pause until the switch finishes."
         }
     }
 
@@ -2248,7 +2248,7 @@ struct SettingsView: View {
                                 "Fully on-device Core ML — audio never leaves your Mac",
                                 "Powers dictation, files, and meetings (14 languages)"
                             ],
-                            helpText: "Cohere Transcribe (03-2026) running fully on-device via Core ML — the highest accuracy of the available engines, at the cost of a ~2.1 GB model download and a brief one-time prepare after each launch. Powers dictation, file transcription, and meetings. Note: Cohere produces no word timestamps, so meetings transcribed with it are plain text without live preview or speaker labels — switch to Parakeet for speaker-labeled, timestamped meetings.",
+                            helpText: "Cohere Transcribe (03-2026) running fully on-device via Core ML — the highest accuracy of the available engines, at the cost of a ~2.1 GB model download and higher memory use than the default engines. Powers record-then-transcribe dictation, file transcription, and final meeting transcription. Note: Cohere produces no word timestamps, so meetings transcribed with it are plain text without live preview or speaker labels — switch to Parakeet for speaker-labeled, timestamped meetings.",
                             modelStatus: displayedCohereModelStatus,
                             isSelected: viewModel.engine.speechEnginePreference == .cohere,
                             isBusy: viewModel.engine.speechEngineSwitching,

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -957,6 +957,14 @@ struct SettingsView: View {
 
     // MARK: - Dictation
 
+    private var liveDictationPreviewDetail: String {
+        if viewModel.engine.speechEnginePreference == .cohere {
+            return "Cohere transcribes after you stop recording, so live preview is unavailable with this engine."
+        }
+
+        return "Shows a running transcript above the dictation pill as you speak. Works with Parakeet and Nemotron; not yet available with Whisper."
+    }
+
     private var dictationCard: some View {
         settingsCard(
             title: "Dictation",
@@ -1053,7 +1061,7 @@ struct SettingsView: View {
 
                 settingsToggleRow(
                     title: "Live transcript preview",
-                    detail: "Shows a running transcript above the dictation pill as you speak. Works with Parakeet and Nemotron; not yet available with Whisper.",
+                    detail: liveDictationPreviewDetail,
                     isBeta: true,
                     // Animate via the binding so only this toggle's state change
                     // animates the sub-row reveal/reflow — not a blanket
@@ -2253,7 +2261,8 @@ struct SettingsView: View {
                             strengths: [
                                 "State-of-the-art accuracy (Cohere Transcribe)",
                                 "Fully on-device Core ML — audio never leaves your Mac",
-                                "Powers dictation, files, and meetings (14 languages)"
+                                "Record-then-transcribe dictation, files, and final meeting transcripts",
+                                "No live preview, word timestamps, or speaker labels"
                             ],
                             helpText: "Cohere Transcribe (03-2026) running fully on-device via Core ML — the highest accuracy of the available engines, at the cost of a ~2.1 GB model download and higher memory use than the default engines. Powers record-then-transcribe dictation, file transcription, and final meeting transcription. Note: Cohere produces no word timestamps, so meetings transcribed with it are plain text without live preview or speaker labels — switch to Parakeet for speaker-labeled, timestamped meetings.",
                             modelStatus: displayedCohereModelStatus,

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
@@ -3003,7 +3003,7 @@ private struct EngineOptionCard: View {
         case .whisper:
             "Broader languages • Korean, Chinese, Japanese, and more"
         case .cohere:
-            "High accuracy • Cohere Transcribe, on-device (English)"
+            "High accuracy • On-device, 14 languages"
         }
     }
 

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
@@ -739,6 +739,8 @@ struct TranscriptResultView: View {
                 return "Whisper"
             }
             return "Whisper \(SpeechEnginePreference.friendlyVariantName(variant))"
+        case .cohere:
+            return "Cohere Transcribe"
         }
     }
 
@@ -2986,6 +2988,7 @@ private struct EngineOptionCard: View {
         case .parakeet: "bolt.fill"
         case .nemotron: "sparkles"
         case .whisper: "globe"
+        case .cohere: "waveform"
         }
     }
 
@@ -2999,6 +3002,8 @@ private struct EngineOptionCard: View {
                 : "Beta • Nemotron 3.5 multilingual streaming"
         case .whisper:
             "Broader languages • Korean, Chinese, Japanese, and more"
+        case .cohere:
+            "High accuracy • Cohere Transcribe, on-device (English)"
         }
     }
 

--- a/Sources/MacParakeetCore/AppFeatures.swift
+++ b/Sources/MacParakeetCore/AppFeatures.swift
@@ -61,6 +61,15 @@ public enum AppFeatures {
     /// `transform_executed` / `transform_failed` (ADR-022 §9).
     public static let transformsEnabled: Bool = true
 
+    /// Cohere Transcribe dictation engine. When `true`, Settings offers Cohere
+    /// as a selectable speech engine (on-device Core ML via FluidAudio's
+    /// `CoherePipeline`). When `false`, the engine type, runtime routing, and
+    /// model plumbing remain compiled and intact — only the Settings surface
+    /// that lets a user select it is hidden, so flipping the flag is a no-data
+    /// operation. Gated separately because the model is a ~2.1 GB download and
+    /// the engine is dictation-only (batch, no live partials/word timestamps).
+    public static let cohereEngineEnabled: Bool = true
+
     /// VAD-guided meeting live chunking
     /// (`plans/completed/2026-05-meeting-vad-guided-live-chunking.md`). When
     /// `false`, meeting live-preview chunks use the fixed 5s / 1s-overlap

--- a/Sources/MacParakeetCore/AppFeatures.swift
+++ b/Sources/MacParakeetCore/AppFeatures.swift
@@ -67,7 +67,7 @@ public enum AppFeatures {
     /// model plumbing remain compiled and intact — only the Settings surface
     /// that lets a user select it is hidden, so flipping the flag is a no-data
     /// operation. Gated separately because the model is a ~2.1 GB download and
-    /// the engine is dictation-only (batch, no live partials/word timestamps).
+    /// the engine is batch-only (no live partials/word timestamps).
     public static let cohereEngineEnabled: Bool = true
 
     /// VAD-guided meeting live chunking

--- a/Sources/MacParakeetCore/DictationFlow/DictationFlowStateMachine.swift
+++ b/Sources/MacParakeetCore/DictationFlow/DictationFlowStateMachine.swift
@@ -383,8 +383,12 @@ public struct DictationFlowStateMachine: Sendable, Equatable {
 
         case (.processing, .transcriptionCompleted(let gen)):
             guard gen == generation else { return [] }
+            // No success checkmark — the pasted text is the confirmation. Keep
+            // the processing pill up through the paste, then drop straight to
+            // idle on pasteSucceeded (below) so the next dictation can start the
+            // instant the text lands.
             state = .finishing(outcome: .success)
-            return [.showSuccess, .updateMenuBar(.idle), .resignKeyWindow, .pasteTranscript]
+            return [.updateMenuBar(.idle), .resignKeyWindow, .pasteTranscript]
 
         case (.processing, .transcriptionFailedNoSpeech(let gen)):
             guard gen == generation else { return [] }
@@ -461,8 +465,11 @@ public struct DictationFlowStateMachine: Sendable, Equatable {
 
         case (.finishing(.success), .pasteSucceeded(let gen)):
             guard gen == generation else { return [] }
-            // Stay in finishing(.success), start dismiss timer
-            return [.startDisplayDismissTimer(seconds: 0.8)]
+            // Text is in — no checkmark dwell. Return to idle and re-arm the
+            // hotkey immediately so a press right after drop-in starts a new
+            // dictation instead of waiting out a success animation.
+            state = .idle
+            return [.hideOverlay, .reloadHistory, .resetHotkeyStateMachine, .updateMenuBar(.idle), .showIdlePill]
 
         case (.finishing(.success), .pasteFailed(let gen, let message)):
             guard gen == generation else { return [] }

--- a/Sources/MacParakeetCore/STT/CohereTranscribeEngine.swift
+++ b/Sources/MacParakeetCore/STT/CohereTranscribeEngine.swift
@@ -416,7 +416,8 @@ public actor CohereTranscribeEngine: STTTranscribing {
                  0x30A0...0x30FF, // Katakana
                  0x3400...0x4DBF, // CJK Unified Ideographs Extension A
                  0x4E00...0x9FFF, // CJK Unified Ideographs
-                 0xF900...0xFAFF: // CJK Compatibility Ideographs
+                 0xF900...0xFAFF, // CJK Compatibility Ideographs
+                 0x20000...0x323AF: // CJK Unified Ideographs Extensions B-H and supplement
                 return true
             default:
                 return false

--- a/Sources/MacParakeetCore/STT/CohereTranscribeEngine.swift
+++ b/Sources/MacParakeetCore/STT/CohereTranscribeEngine.swift
@@ -113,6 +113,7 @@ public actor CohereTranscribeEngine: STTTranscribing {
     private let transcriptionPermit = AsyncPermit()
     private var models: CoherePipeline.LoadedModels?
     private var initializationTask: Task<Void, Error>?
+    private var activeLoadID: UUID?
 
     public init(
         computePolicy: ComputePolicy = .ane,
@@ -506,7 +507,9 @@ public actor CohereTranscribeEngine: STTTranscribing {
         // finishes. This task is shared by concurrent prepare() callers, so an
         // individual awaiter cancellation must not cancel shared work for other
         // waiters. Explicit lifecycle paths such as unload() still cancel it.
-        let task = Task { try await loadModels(onProgress: onProgress) }
+        let loadID = UUID()
+        activeLoadID = loadID
+        let task = Task { [loadID] in try await loadModels(loadID: loadID, onProgress: onProgress) }
         initializationTask = task
 
         do {
@@ -531,22 +534,29 @@ public actor CohereTranscribeEngine: STTTranscribing {
     }
 
     public func unload() async {
-        initializationTask?.cancel()
-        _ = try? await initializationTask?.value
+        let task = initializationTask
         initializationTask = nil
+        activeLoadID = nil
         // Dropping `LoadedModels` releases the encoder/decoder `MLModel`s.
         models = nil
+        task?.cancel()
+        _ = try? await task?.value
     }
 
     public func isReady() -> Bool {
         models != nil
     }
 
-    private func loadModels(onProgress: (@Sendable (String) -> Void)?) async throws {
+    private func loadModels(loadID: UUID, onProgress: (@Sendable (String) -> Void)?) async throws {
         // Clear the shared handle when this work finishes (success or failure),
         // from inside the task — not from a possibly-cancelled awaiting caller —
         // so concurrent prepare() calls coalesce onto this one task.
-        defer { initializationTask = nil }
+        defer {
+            if activeLoadID == loadID {
+                initializationTask = nil
+                activeLoadID = nil
+            }
+        }
         try Task.checkCancellation()
         let dir = Self.defaultCacheRoot()
         try Self.requireModelCached(cacheRoot: dir)
@@ -581,6 +591,7 @@ public actor CohereTranscribeEngine: STTTranscribing {
             logger.error("cohere_warmup_failed error=\(error.localizedDescription, privacy: .public)")
         }
         try Task.checkCancellation()
+        guard activeLoadID == loadID else { throw CancellationError() }
         self.models = loaded
         logger.notice("cohere_model_prepare_complete compute=\(self.computePolicy.rawValue, privacy: .public)")
         AudioCaptureDiagnostics.append("cohere_model_prepare_complete compute=\(self.computePolicy.rawValue)")

--- a/Sources/MacParakeetCore/STT/CohereTranscribeEngine.swift
+++ b/Sources/MacParakeetCore/STT/CohereTranscribeEngine.swift
@@ -451,18 +451,14 @@ public actor CohereTranscribeEngine: STTTranscribing {
         }
 
         // `loadModels` clears `initializationTask` itself (via defer) when it
-        // finishes. Cancellation should stop the heavy load/warm-up task, but the
-        // handle is still owned by that task so concurrent prepare() calls either
-        // coalesce onto the same work or observe a clean retry after cancellation.
+        // finishes. This task is shared by concurrent prepare() callers, so an
+        // individual awaiter cancellation must not cancel shared work for other
+        // waiters. Explicit lifecycle paths such as unload() still cancel it.
         let task = Task { try await loadModels(onProgress: onProgress) }
         initializationTask = task
 
         do {
-            try await withTaskCancellationHandler {
-                try await task.value
-            } onCancel: {
-                task.cancel()
-            }
+            try await task.value
         } catch {
             throw try Self.mapWarmUpError(error)
         }

--- a/Sources/MacParakeetCore/STT/CohereTranscribeEngine.swift
+++ b/Sources/MacParakeetCore/STT/CohereTranscribeEngine.swift
@@ -450,16 +450,18 @@ public actor CohereTranscribeEngine: STTTranscribing {
         }
 
         // `loadModels` clears `initializationTask` itself (via defer) when it
-        // finishes. If we cleared it here in a cancelled `catch`, a caller whose
-        // await was cancelled mid-warm-up (e.g. dictation Escape during the
-        // launch optimize) would null the handle while the unstructured task
-        // keeps running — letting the next prepare() spawn a duplicate ~115 s
-        // download/warm-up.
+        // finishes. Cancellation should stop the heavy load/warm-up task, but the
+        // handle is still owned by that task so concurrent prepare() calls either
+        // coalesce onto the same work or observe a clean retry after cancellation.
         let task = Task { try await loadModels(onProgress: onProgress) }
         initializationTask = task
 
         do {
-            try await task.value
+            try await withTaskCancellationHandler {
+                try await task.value
+            } onCancel: {
+                task.cancel()
+            }
         } catch {
             throw try Self.mapWarmUpError(error)
         }
@@ -500,9 +502,11 @@ public actor CohereTranscribeEngine: STTTranscribing {
         // now (at load / launch warm-up) instead of on the user's first
         // dictation. On the GPU path this is the heavy ~115s specialization; on
         // ANE it's ~2s. Runs on 1s of silence; the transcript is discarded.
-        // After this returns, every real utterance is warm (~0.4s short / ~1.3s
-        // long on GPU). `models` is published only once fully warm, so
-        // `isReady()` reflecting true readiness gates the live engine swap UI.
+        // After this returns successfully, every real utterance is warm (~0.4s
+        // short / ~1.3s long on GPU). Non-cancellation warm-up failures are
+        // logged and treated as non-fatal because the loaded models can still run
+        // the first real transcription; cancellation still prevents readiness
+        // from being published.
         onProgress?("Optimizing Cohere for this Mac...")
         try Task.checkCancellation()
         let warmUpSamples = [Float](repeating: 0, count: CohereAsrConfig.sampleRate)

--- a/Sources/MacParakeetCore/STT/CohereTranscribeEngine.swift
+++ b/Sources/MacParakeetCore/STT/CohereTranscribeEngine.swift
@@ -544,6 +544,10 @@ public actor CohereTranscribeEngine: STTTranscribing {
         isModelCached(cacheRoot: defaultCacheRoot())
     }
 
+    public nonisolated static func hasModelCacheDirectory() -> Bool {
+        hasModelCacheDirectory(cacheRoot: defaultCacheRoot())
+    }
+
     /// Cached only when the encoder bundle, the v2 decoder bundle, and the vocab
     /// are all present — the exact inputs `CoherePipeline.loadModels` reads.
     nonisolated static func isModelCached(cacheRoot: URL) -> Bool {
@@ -554,6 +558,12 @@ public actor CohereTranscribeEngine: STTTranscribing {
         return fileManager.fileExists(atPath: encoder.path)
             && fileManager.fileExists(atPath: decoder.path)
             && fileManager.fileExists(atPath: vocab.path)
+    }
+
+    nonisolated static func hasModelCacheDirectory(cacheRoot: URL) -> Bool {
+        var isDirectory: ObjCBool = false
+        return FileManager.default.fileExists(atPath: cacheRoot.path, isDirectory: &isDirectory)
+            && isDirectory.boolValue
     }
 
     /// Pre-fetches the model to its cache without loading it. A cached model is

--- a/Sources/MacParakeetCore/STT/CohereTranscribeEngine.swift
+++ b/Sources/MacParakeetCore/STT/CohereTranscribeEngine.swift
@@ -213,14 +213,37 @@ public actor CohereTranscribeEngine: STTTranscribing {
         models: CoherePipeline.LoadedModels,
         language: CohereAsrConfig.Language
     ) async throws -> String {
+        let outputCap = CohereAsrConfig.maxSeqLen - language.promptSequence.count
         let sr = CohereAsrConfig.sampleRate
         let overlap = 4 * sr
         let maxWindow = 20 * sr
+        let minWindow = 4 * sr
         // Audio that fit the encoder window but truncated is dense — shrink the
         // window so it still produces at least two chunks.
         let window = samples.count <= CohereAsrConfig.maxSamples
             ? min(maxWindow, max(8 * sr, samples.count * 3 / 5))
             : maxWindow
+        return try await chunkAndStitch(
+            samples: samples,
+            models: models,
+            language: language,
+            outputCap: outputCap,
+            window: window,
+            overlap: overlap,
+            minWindow: minWindow
+        )
+    }
+
+    private func chunkAndStitch(
+        samples: [Float],
+        models: CoherePipeline.LoadedModels,
+        language: CohereAsrConfig.Language,
+        outputCap: Int,
+        window: Int,
+        overlap: Int,
+        minWindow: Int
+    ) async throws -> String {
+        let sr = CohereAsrConfig.sampleRate
         let hop = max(sr, window - overlap)
 
         var merged = ""
@@ -235,7 +258,31 @@ public actor CohereTranscribeEngine: STTTranscribing {
             let chunk = Array(samples[start..<end])
             let result = try await pipeline.transcribe(
                 audio: chunk, models: models, language: language)
-            merged = merged.isEmpty ? result.text : Self.mergeOnOverlap(merged, result.text)
+            let text: String
+            if result.tokenIds.count < outputCap - 1 {
+                text = result.text
+            } else if window > minWindow {
+                let nextWindow = max(minWindow, window * 3 / 5)
+                let nextOverlap = min(overlap, max(sr, nextWindow / 5))
+                logger.notice(
+                    "cohere_chunk_truncation_guard tokens=\(result.tokenIds.count, privacy: .public) cap=\(outputCap, privacy: .public) window=\(window, privacy: .public) action=rechunk next_window=\(nextWindow, privacy: .public)"
+                )
+                text = try await chunkAndStitch(
+                    samples: chunk,
+                    models: models,
+                    language: language,
+                    outputCap: outputCap,
+                    window: nextWindow,
+                    overlap: nextOverlap,
+                    minWindow: minWindow
+                )
+            } else {
+                logger.warning(
+                    "cohere_chunk_truncation_guard tokens=\(result.tokenIds.count, privacy: .public) cap=\(outputCap, privacy: .public) window=\(window, privacy: .public) action=return_capped"
+                )
+                text = result.text
+            }
+            merged = merged.isEmpty ? text : Self.mergeOnOverlap(merged, text)
             if end >= samples.count { break }
             start += hop
         }
@@ -389,7 +436,11 @@ public actor CohereTranscribeEngine: STTTranscribing {
         if models != nil { return }
 
         if let initializationTask {
-            try await initializationTask.value
+            do {
+                try await initializationTask.value
+            } catch {
+                throw try Self.mapWarmUpError(error)
+            }
             return
         }
 

--- a/Sources/MacParakeetCore/STT/CohereTranscribeEngine.swift
+++ b/Sources/MacParakeetCore/STT/CohereTranscribeEngine.swift
@@ -169,8 +169,7 @@ public actor CohereTranscribeEngine: STTTranscribing {
 
         do {
             // Lazy path (CLI, or first dictation before background warm-up
-            // finished): a first-time ~2.1 GB model download would otherwise be
-            // silent and read as a hang, so log prepare progress to the console.
+            // finished): log model-load progress to the console.
             try await prepare(onProgress: { [logger] message in
                 logger.notice("cohere_prepare \(message, privacy: .public)")
             })
@@ -262,7 +261,8 @@ public actor CohereTranscribeEngine: STTTranscribing {
         let minWindow = 4 * sr
         // Audio that fit the encoder window but truncated is dense — shrink the
         // window so it still produces at least two chunks.
-        let window = samples.count <= CohereAsrConfig.maxSamples
+        let window =
+            samples.count <= CohereAsrConfig.maxSamples
             ? min(maxWindow, max(8 * sr, samples.count * 3 / 5))
             : maxWindow
         return try await chunkAndStitch(
@@ -343,12 +343,14 @@ public actor CohereTranscribeEngine: STTTranscribing {
         // whole transcript on every merge.
         let safeSuffixLength = max(maxOverlap * 40, 1000)
         if let splitIndex = a.index(a.endIndex, offsetBy: -safeSuffixLength, limitedBy: a.startIndex),
-           splitIndex > a.startIndex {
-            return String(a[..<splitIndex]) + mergeOnOverlap(
-                String(a[splitIndex...]),
-                b,
-                maxOverlap: maxOverlap
-            )
+            splitIndex > a.startIndex
+        {
+            return String(a[..<splitIndex])
+                + mergeOnOverlap(
+                    String(a[splitIndex...]),
+                    b,
+                    maxOverlap: maxOverlap
+                )
         }
 
         if shouldUseCharacterOverlap(a, b) {
@@ -390,8 +392,9 @@ public actor CohereTranscribeEngine: STTTranscribing {
 
         var mergedA = a
         if bestK > 0,
-           let lastA = mergedA.last,
-           isTrailingPartial(unit: lastA, completedBy: b[bestK - 1]) {
+            let lastA = mergedA.last,
+            isTrailingPartial(unit: lastA, completedBy: b[bestK - 1])
+        {
             mergedA[mergedA.count - 1] = b[bestK - 1]
         }
         return (mergedA + b.dropFirst(bestK)).joined(separator: separator)
@@ -426,7 +429,7 @@ public actor CohereTranscribeEngine: STTTranscribing {
     private static func isLeadingPartial(unit: String, completedBy fullUnit: String) -> Bool {
         let minimumPartialLength = 2
         guard let unit = normalizedOverlapUnit(unit),
-              let fullUnit = normalizedOverlapUnit(fullUnit)
+            let fullUnit = normalizedOverlapUnit(fullUnit)
         else { return false }
         return unit.count >= minimumPartialLength
             && fullUnit.count > unit.count
@@ -436,7 +439,7 @@ public actor CohereTranscribeEngine: STTTranscribing {
     private static func isTrailingPartial(unit: String, completedBy fullUnit: String) -> Bool {
         let minimumPartialLength = 2
         guard let unit = normalizedOverlapUnit(unit),
-              let fullUnit = normalizedOverlapUnit(fullUnit)
+            let fullUnit = normalizedOverlapUnit(fullUnit)
         else { return false }
         return unit.count >= minimumPartialLength
             && fullUnit.count > unit.count
@@ -462,12 +465,12 @@ public actor CohereTranscribeEngine: STTTranscribing {
     private static func containsCJK(_ string: String) -> Bool {
         string.unicodeScalars.contains { scalar in
             switch scalar.value {
-            case 0x3040...0x309F, // Hiragana
-                 0x30A0...0x30FF, // Katakana
-                 0x3400...0x4DBF, // CJK Unified Ideographs Extension A
-                 0x4E00...0x9FFF, // CJK Unified Ideographs
-                 0xF900...0xFAFF, // CJK Compatibility Ideographs
-                 0x20000...0x323AF: // CJK Unified Ideographs Extensions B-H and supplement
+            case 0x3040...0x309F,  // Hiragana
+                0x30A0...0x30FF,  // Katakana
+                0x3400...0x4DBF,  // CJK Unified Ideographs Extension A
+                0x4E00...0x9FFF,  // CJK Unified Ideographs
+                0xF900...0xFAFF,  // CJK Compatibility Ideographs
+                0x20000...0x323AF:  // CJK Unified Ideographs Extensions B-H and supplement
                 return true
             default:
                 return false
@@ -478,7 +481,7 @@ public actor CohereTranscribeEngine: STTTranscribing {
     private static func containsHangul(_ string: String) -> Bool {
         string.unicodeScalars.contains { scalar in
             switch scalar.value {
-            case 0xAC00...0xD7AF: // Hangul syllables
+            case 0xAC00...0xD7AF:  // Hangul syllables
                 return true
             default:
                 return false
@@ -546,10 +549,10 @@ public actor CohereTranscribeEngine: STTTranscribing {
         // so concurrent prepare() calls coalesce onto this one task.
         defer { initializationTask = nil }
         try Task.checkCancellation()
-        try await Self.downloadModel(onProgress: onProgress)
+        let dir = Self.defaultCacheRoot()
+        try Self.requireModelCached(cacheRoot: dir)
         try Task.checkCancellation()
         onProgress?("Loading Cohere model with Core ML...")
-        let dir = Self.defaultCacheRoot()
         try Task.checkCancellation()
         let loaded = try await CoherePipeline.loadModels(
             encoderDir: dir,
@@ -637,6 +640,18 @@ public actor CohereTranscribeEngine: STTTranscribing {
         var isDirectory: ObjCBool = false
         return FileManager.default.fileExists(atPath: cacheRoot.path, isDirectory: &isDirectory)
             && isDirectory.boolValue
+    }
+
+    nonisolated static func requireModelCached(cacheRoot: URL = defaultCacheRoot()) throws {
+        guard isModelCached(cacheRoot: cacheRoot) else {
+            throw missingModelError()
+        }
+    }
+
+    private nonisolated static func missingModelError() -> STTError {
+        .engineStartFailed(
+            "Cohere Transcribe is not downloaded. Run `macparakeet-cli models download cohere-transcribe` first."
+        )
     }
 
     /// Pre-fetches the model to its cache without loading it. A cached model is

--- a/Sources/MacParakeetCore/STT/CohereTranscribeEngine.swift
+++ b/Sources/MacParakeetCore/STT/CohereTranscribeEngine.swift
@@ -377,6 +377,8 @@ public actor CohereTranscribeEngine: STTTranscribing {
 
     private static func isLeadingPartial(unit: String, completedBy fullUnit: String) -> Bool {
         let minimumPartialLength = 2
+        let unit = normalizedOverlapUnit(unit)
+        let fullUnit = normalizedOverlapUnit(fullUnit)
         return unit.count >= minimumPartialLength
             && fullUnit.count > unit.count
             && fullUnit.hasSuffix(unit)
@@ -384,6 +386,8 @@ public actor CohereTranscribeEngine: STTTranscribing {
 
     private static func isTrailingPartial(unit: String, completedBy fullUnit: String) -> Bool {
         let minimumPartialLength = 2
+        let unit = normalizedOverlapUnit(unit)
+        let fullUnit = normalizedOverlapUnit(fullUnit)
         return unit.count >= minimumPartialLength
             && fullUnit.count > unit.count
             && fullUnit.hasPrefix(unit)

--- a/Sources/MacParakeetCore/STT/CohereTranscribeEngine.swift
+++ b/Sources/MacParakeetCore/STT/CohereTranscribeEngine.swift
@@ -58,10 +58,10 @@ private final class CancellationResponsiveTaskAwaiter: @unchecked Sendable {
 ///   graph on the **first transcribe of every launch (~115 s, not cached)**, so
 ///   we pay it in the background via a launch warm-up; for a resident app that
 ///   is once per session, then every dictation is fast.
-    /// - **`.ane`** (`cpuAndNeuralEngine`, default): warm ~1.3–1.6 s after Core
-    ///   ML preparation. Fresh app processes can still pay a cold preparation
-    ///   cost, but this avoids the GPU path's uncached per-launch specialization
-    ///   and leaves the GPU free for the LLM formatter.
+/// - **`.ane`** (`cpuAndNeuralEngine`, default): warm ~1.3–1.6 s after Core
+///   ML preparation. Fresh app processes can still pay a cold preparation
+///   cost, but this avoids the GPU path's uncached per-launch specialization
+///   and leaves the GPU free for the LLM formatter.
 /// NOTE: most apparent slowness in development is the unoptimized **Debug**
 /// build — the per-step decoder + mel hot path runs ~9× slower than release.
 /// Always judge latency from a release build.

--- a/Sources/MacParakeetCore/STT/CohereTranscribeEngine.swift
+++ b/Sources/MacParakeetCore/STT/CohereTranscribeEngine.swift
@@ -252,7 +252,7 @@ public actor CohereTranscribeEngine: STTTranscribing {
         // Only the tail of the accumulated transcript can overlap the next
         // chunk. Keep long-file stitching bounded instead of re-tokenizing the
         // whole transcript on every merge.
-        let safeSuffixLength = max(maxOverlap * 15, maxOverlap + 1)
+        let safeSuffixLength = max(maxOverlap * 40, 1000)
         if let splitIndex = a.index(a.endIndex, offsetBy: -safeSuffixLength, limitedBy: a.startIndex),
            splitIndex > a.startIndex {
             return String(a[..<splitIndex]) + mergeOnOverlap(
@@ -535,12 +535,13 @@ public actor CohereTranscribeEngine: STTTranscribing {
     }
 
     private nonisolated static func removeIfEmpty(_ directory: URL, fileManager: FileManager) {
-        guard let children = try? fileManager.contentsOfDirectory(atPath: directory.path),
-            children.isEmpty
-        else {
-            return
-        }
+        guard let children = try? fileManager.contentsOfDirectory(atPath: directory.path) else { return }
+        guard children.allSatisfy(isFinderMetadataFile) else { return }
         try? fileManager.removeItem(at: directory)
+    }
+
+    private nonisolated static func isFinderMetadataFile(_ name: String) -> Bool {
+        name == ".DS_Store" || name == ".localized" || name == "Icon\r"
     }
 
     // MARK: - Helpers

--- a/Sources/MacParakeetCore/STT/CohereTranscribeEngine.swift
+++ b/Sources/MacParakeetCore/STT/CohereTranscribeEngine.swift
@@ -292,15 +292,54 @@ public actor CohereTranscribeEngine: STTTranscribing {
         var bestK = 0
         var k = limit
         while k >= 1 {
-            if zip(a.suffix(k), b.prefix(k)).allSatisfy({
-                normalizedOverlapUnit($0) == normalizedOverlapUnit($1)
-            }) {
+            if overlapMatches(a: Array(a.suffix(k)), b: Array(b.prefix(k))) {
                 bestK = k
                 break
             }
             k -= 1
         }
-        return (a + b.dropFirst(bestK)).joined(separator: separator)
+
+        var mergedA = a
+        if bestK > 0,
+           let lastA = mergedA.last,
+           isTrailingPartial(unit: lastA, completedBy: b[bestK - 1]) {
+            mergedA[mergedA.count - 1] = b[bestK - 1]
+        }
+        return (mergedA + b.dropFirst(bestK)).joined(separator: separator)
+    }
+
+    private static func overlapMatches(a: [String], b: [String]) -> Bool {
+        guard a.count == b.count else { return false }
+        let strongOverlap = a.count >= 2
+
+        for index in a.indices {
+            let aUnit = normalizedOverlapUnit(a[index])
+            let bUnit = normalizedOverlapUnit(b[index])
+            if aUnit == bUnit { continue }
+
+            if strongOverlap, index == a.startIndex, isLeadingPartial(unit: bUnit, completedBy: aUnit) {
+                continue
+            }
+            if strongOverlap, index == a.index(before: a.endIndex), isTrailingPartial(unit: aUnit, completedBy: bUnit) {
+                continue
+            }
+            return false
+        }
+        return true
+    }
+
+    private static func isLeadingPartial(unit: String, completedBy fullUnit: String) -> Bool {
+        let minimumPartialLength = 2
+        return unit.count >= minimumPartialLength
+            && fullUnit.count > unit.count
+            && fullUnit.hasSuffix(unit)
+    }
+
+    private static func isTrailingPartial(unit: String, completedBy fullUnit: String) -> Bool {
+        let minimumPartialLength = 2
+        return unit.count >= minimumPartialLength
+            && fullUnit.count > unit.count
+            && fullUnit.hasPrefix(unit)
     }
 
     private static func normalizedOverlapUnit(_ unit: String) -> String {

--- a/Sources/MacParakeetCore/STT/CohereTranscribeEngine.swift
+++ b/Sources/MacParakeetCore/STT/CohereTranscribeEngine.swift
@@ -206,16 +206,17 @@ public actor CohereTranscribeEngine: STTTranscribing {
 
         var merged = ""
         var start = 0
-        var chunkCount = 0
-        let chunkLimit = 64  // safety bound against pathological inputs
-        while start < samples.count, chunkCount < chunkLimit {
+        // `hop` is at least `sr` (>= 1 s) and `samples` is a finite in-memory
+        // buffer, so this loop always terminates — no chunk cap is needed. A
+        // hard 64-chunk bound here previously truncated audio past ~17 min
+        // (64 * 16 s hop), silently dropping the tail of long file transcripts.
+        while start < samples.count {
             try Task.checkCancellation()
             let end = min(start + window, samples.count)
             let chunk = Array(samples[start..<end])
             let result = try await pipeline.transcribe(
                 audio: chunk, models: models, language: language)
             merged = merged.isEmpty ? result.text : Self.mergeOnOverlap(merged, result.text)
-            chunkCount += 1
             if end >= samples.count { break }
             start += hop
         }

--- a/Sources/MacParakeetCore/STT/CohereTranscribeEngine.swift
+++ b/Sources/MacParakeetCore/STT/CohereTranscribeEngine.swift
@@ -58,10 +58,10 @@ private final class CancellationResponsiveTaskAwaiter: @unchecked Sendable {
 ///   graph on the **first transcribe of every launch (~115 s, not cached)**, so
 ///   we pay it in the background via a launch warm-up; for a resident app that
 ///   is once per session, then every dictation is fast.
-/// - **`.ane`** (`cpuAndNeuralEngine`, default): warm ~1.3–1.6 s, but its
-///   one-time specialization is **cached across launches**
-///   (`com.apple.e5rt.e5bundlecache`) so there is no per-launch stall, and it
-///   leaves the GPU free for the LLM formatter.
+    /// - **`.ane`** (`cpuAndNeuralEngine`, default): warm ~1.3–1.6 s after Core
+    ///   ML preparation. Fresh app processes can still pay a cold preparation
+    ///   cost, but this avoids the GPU path's uncached per-launch specialization
+    ///   and leaves the GPU free for the LLM formatter.
 /// NOTE: most apparent slowness in development is the unoptimized **Debug**
 /// build — the per-step decoder + mel hot path runs ~9× slower than release.
 /// Always judge latency from a release build.
@@ -70,9 +70,8 @@ public actor CohereTranscribeEngine: STTTranscribing {
     /// Core ML compute-unit policy for the Cohere models. See the type doc for
     /// the latency/cold-start tradeoff measured in the Phase-0 spike.
     public enum ComputePolicy: String, CaseIterable, Sendable {
-        /// `cpuAndNeuralEngine` — default. Warm ~1.3–1.6 s, one-time
-        /// specialization cached across launches (e5bundlecache); no
-        /// per-launch stall.
+        /// `cpuAndNeuralEngine` — default. Warm ~1.3–1.6 s after Core ML
+        /// preparation; avoids the GPU path's recurring per-launch specialization.
         case ane
         /// `.all` — warm ~0.4–0.6 s; ~115 s graph specialization on the
         /// first transcribe of every launch (not cached), hidden by launch warm-up.

--- a/Sources/MacParakeetCore/STT/CohereTranscribeEngine.swift
+++ b/Sources/MacParakeetCore/STT/CohereTranscribeEngine.swift
@@ -496,8 +496,12 @@ public actor CohereTranscribeEngine: STTTranscribing {
         // `isReady()` reflecting true readiness gates the live engine swap UI.
         onProgress?("Optimizing Cohere for this Mac...")
         let warmUpSamples = [Float](repeating: 0, count: CohereAsrConfig.sampleRate)
-        _ = try? await pipeline.transcribe(
-            audio: warmUpSamples, models: loaded, language: defaultLanguage)
+        do {
+            _ = try await pipeline.transcribe(
+                audio: warmUpSamples, models: loaded, language: defaultLanguage)
+        } catch {
+            logger.error("cohere_warmup_failed error=\(error.localizedDescription, privacy: .public)")
+        }
         self.models = loaded
         logger.notice("cohere_model_prepare_complete compute=\(self.computePolicy.rawValue, privacy: .public)")
         AudioCaptureDiagnostics.append("cohere_model_prepare_complete compute=\(self.computePolicy.rawValue)")

--- a/Sources/MacParakeetCore/STT/CohereTranscribeEngine.swift
+++ b/Sources/MacParakeetCore/STT/CohereTranscribeEngine.swift
@@ -415,7 +415,8 @@ public actor CohereTranscribeEngine: STTTranscribing {
             case 0x3040...0x309F, // Hiragana
                  0x30A0...0x30FF, // Katakana
                  0x3400...0x4DBF, // CJK Unified Ideographs Extension A
-                 0x4E00...0x9FFF: // CJK Unified Ideographs
+                 0x4E00...0x9FFF, // CJK Unified Ideographs
+                 0xF900...0xFAFF: // CJK Compatibility Ideographs
                 return true
             default:
                 return false

--- a/Sources/MacParakeetCore/STT/CohereTranscribeEngine.swift
+++ b/Sources/MacParakeetCore/STT/CohereTranscribeEngine.swift
@@ -1,0 +1,496 @@
+import AVFoundation
+import CoreML
+import FluidAudio
+import Foundation
+import os
+
+/// Wraps FluidAudio's `CoherePipeline` (Cohere Transcribe 03-2026, a 2B
+/// Conformer encoder + lightweight Transformer decoder converted to Core ML by
+/// Fluid Inference). Cohere is a **batch, record-then-transcribe** engine: it
+/// has no streaming/partial path and emits no word timestamps, so it does not
+/// conform to ``NativeLiveDictating`` and `STTResult.words` is always empty.
+///
+/// ## Compute policy
+/// The big INT8 encoder behaves very differently per Core ML backend. Defaults
+/// to **`.gpu`** — the fast path that makes the engine feel instant:
+/// - **`.gpu`** (`.all`, default): warm ~0.4–0.6 s. Core ML specializes the
+///   graph on the **first transcribe of every launch (~115 s, not cached)**, so
+///   we pay it in the background via a launch warm-up; for a resident app that
+///   is once per session, then every dictation is fast.
+/// - **`.ane`** (`cpuAndNeuralEngine`): warm ~1.3–1.6 s, but its one-time
+///   specialization is **cached across launches** (`com.apple.e5rt.e5bundlecache`)
+///   so there is no per-launch stall, and it leaves the GPU free for the LLM
+///   formatter. The escape hatch for users who relaunch often.
+/// NOTE: most apparent slowness in development is the unoptimized **Debug**
+/// build — the per-step decoder + mel hot path runs ~9× slower than release.
+/// Always judge latency from a release build.
+public actor CohereTranscribeEngine: STTTranscribing {
+
+    /// Core ML compute-unit policy for the Cohere models. See the type doc for
+    /// the latency/cold-start tradeoff measured in the Phase-0 spike.
+    public enum ComputePolicy: String, CaseIterable, Sendable {
+        /// `cpuAndNeuralEngine` — warm ~1.3–1.6 s, one-time specialization cached
+        /// across launches (e5bundlecache); no per-launch stall. Escape hatch.
+        case ane
+        /// `.all` — default. Warm ~0.4–0.6 s; ~115 s graph specialization on the
+        /// first transcribe of every launch (not cached), hidden by launch warm-up.
+        case gpu
+
+        public static let defaultsKey = "cohereComputePolicy"
+
+        public static func current(defaults: UserDefaults = .standard) -> ComputePolicy {
+            guard let raw = defaults.string(forKey: defaultsKey),
+                let policy = ComputePolicy(rawValue: raw)
+            else {
+                return .gpu
+            }
+            return policy
+        }
+
+        var computeUnits: MLComputeUnits {
+            switch self {
+            case .ane: return .cpuAndNeuralEngine
+            case .gpu: return .all
+            }
+        }
+    }
+
+    private let logger = Logger(subsystem: "com.macparakeet.core", category: "CohereTranscribeEngine")
+
+    private let computePolicy: ComputePolicy
+    /// Default transcription language. Cohere requires the language up front
+    /// (no auto-detect); English is the Phase-1 default. A per-call override is
+    /// threaded through ``transcribe(audioURL:job:language:onProgress:)``.
+    private let defaultLanguage: CohereAsrConfig.Language
+
+    /// `CoherePipeline` is itself an actor and holds no per-call mutable state
+    /// (it takes `LoadedModels` as an argument), so a single instance serializes
+    /// dictation and any other batch job safely. When Cohere is the selected
+    /// engine it serves every job kind (dictation, file, meeting); the actor
+    /// queues overlapping jobs rather than running them concurrently.
+    private let pipeline = CoherePipeline()
+    private var models: CoherePipeline.LoadedModels?
+    private var initializationTask: Task<Void, Error>?
+    private var isTranscribing = false
+
+    public init(
+        computePolicy: ComputePolicy = .gpu,
+        defaultLanguage: CohereAsrConfig.Language = .english
+    ) {
+        self.computePolicy = computePolicy
+        self.defaultLanguage = defaultLanguage
+    }
+
+    // MARK: - Languages
+
+    /// The languages Cohere Transcribe supports, as `(code, displayName)` pairs
+    /// (e.g. `("en", "English")`). Source of truth is FluidAudio's
+    /// `CohereAsrConfig.Language`; exposed here so UI layers can offer a picker
+    /// without importing FluidAudio. Cohere has no auto-detect — one must be set.
+    public static var supportedLanguages: [(code: String, name: String)] {
+        CohereAsrConfig.Language.allCases.map { ($0.rawValue, $0.englishName) }
+    }
+
+    // MARK: - Transcription
+
+    public func transcribe(
+        audioPath: String,
+        job: STTJobKind,
+        onProgress: (@Sendable (Int, Int) -> Void)? = nil
+    ) async throws -> STTResult {
+        try await transcribe(
+            audioURL: URL(fileURLWithPath: audioPath),
+            job: job,
+            language: nil,
+            onProgress: onProgress
+        )
+    }
+
+    public func transcribe(
+        audioURL: URL,
+        job: STTJobKind,
+        language: String?,
+        onProgress: (@Sendable (Int, Int) -> Void)? = nil
+    ) async throws -> STTResult {
+        guard !isTranscribing else { throw STTError.engineBusy }
+        isTranscribing = true
+        defer { isTranscribing = false }
+
+        do {
+            try await prepare(onProgress: nil)
+            guard let models else { throw STTError.modelNotLoaded }
+
+            onProgress?(0, 100)
+            try Task.checkCancellation()
+            let samples = try await Task.detached(priority: .userInitiated) {
+                try AudioConverter().resampleAudioFile(audioURL)
+            }.value
+            onProgress?(40, 100)
+            try Task.checkCancellation()
+
+            let resolvedLanguage = Self.cohereLanguage(language) ?? defaultLanguage
+            let text = try await transcribeGuardingTruncation(
+                samples: samples, models: models, language: resolvedLanguage)
+            onProgress?(100, 100)
+
+            // Cohere ASR exposes no word timestamps or per-word confidence, so
+            // `words` is intentionally empty. Meeting speaker-diarization,
+            // word-level timing, and the live preview are all word-driven, so a
+            // meeting transcribed by Cohere degrades to a plain-text transcript
+            // (same graceful path Nemotron already uses); Parakeet remains the
+            // choice when speaker-labeled, timestamped meetings are wanted.
+            return STTResult(
+                text: text,
+                words: [],
+                language: resolvedLanguage.rawValue,
+                engine: .cohere,
+                engineVariant: computePolicy.rawValue
+            )
+        } catch {
+            throw try Self.mapTranscriptionError(error)
+        }
+    }
+
+    // MARK: - Truncation guard (chunk + stitch)
+
+    /// Cohere's decoder KV cache is baked at `maxSeqLen` (108) positions, so a
+    /// single pass can only emit ~98 output tokens — a dense utterance is
+    /// silently cut mid-sentence, and the encoder itself can't see past 35 s.
+    /// Fast path: one pass; if it neither overran the 35 s window nor hit the
+    /// token cap (the overwhelmingly common case) it is returned untouched, with
+    /// no added latency. Only when the audio is long OR the pass actually
+    /// truncated do we fall back to safe-window chunk-and-stitch (Spokenly takes
+    /// the same chunking approach for long input).
+    private func transcribeGuardingTruncation(
+        samples: [Float],
+        models: CoherePipeline.LoadedModels,
+        language: CohereAsrConfig.Language
+    ) async throws -> String {
+        // ~98: the decode-loop ceiling minus the fixed language prompt prefix.
+        let outputCap = CohereAsrConfig.maxSeqLen - language.promptSequence.count
+
+        if samples.count <= CohereAsrConfig.maxSamples {
+            let result = try await pipeline.transcribe(
+                audio: samples, models: models, language: language)
+            // Stopped on EOS before the ceiling → complete; return as-is.
+            if result.tokenIds.count < outputCap - 1 {
+                return result.text
+            }
+            logger.notice(
+                "cohere_truncation_guard tokens=\(result.tokenIds.count, privacy: .public) cap=\(outputCap, privacy: .public) action=chunk"
+            )
+        }
+
+        return try await chunkAndStitch(samples: samples, models: models, language: language)
+    }
+
+    /// Splits audio into overlapping windows short enough to stay under the
+    /// ~98-token decode cap, transcribes each, and stitches on the duplicated
+    /// overlap. Windows are ≤20 s (well under the cap for normal/fast speech);
+    /// for a dense utterance that fit inside 35 s we shrink the window so it
+    /// still splits into ≥2 chunks.
+    private func chunkAndStitch(
+        samples: [Float],
+        models: CoherePipeline.LoadedModels,
+        language: CohereAsrConfig.Language
+    ) async throws -> String {
+        let sr = CohereAsrConfig.sampleRate
+        let overlap = 4 * sr
+        let maxWindow = 20 * sr
+        // Audio that fit the encoder window but truncated is dense — shrink the
+        // window so it still produces at least two chunks.
+        let window = samples.count <= CohereAsrConfig.maxSamples
+            ? min(maxWindow, max(8 * sr, samples.count * 3 / 5))
+            : maxWindow
+        let hop = max(sr, window - overlap)
+
+        var merged = ""
+        var start = 0
+        var chunkCount = 0
+        let chunkLimit = 64  // safety bound against pathological inputs
+        while start < samples.count, chunkCount < chunkLimit {
+            try Task.checkCancellation()
+            let end = min(start + window, samples.count)
+            let chunk = Array(samples[start..<end])
+            let result = try await pipeline.transcribe(
+                audio: chunk, models: models, language: language)
+            merged = merged.isEmpty ? result.text : Self.mergeOnOverlap(merged, result.text)
+            chunkCount += 1
+            if end >= samples.count { break }
+            start += hop
+        }
+        return merged
+    }
+
+    /// Joins two transcript fragments produced from overlapping audio windows by
+    /// dropping the duplicated words at the seam: compares up to `maxOverlap`
+    /// trailing words of `a` against the leading words of `b`
+    /// (case/punctuation-insensitive) and removes the longest match from `b`.
+    static func mergeOnOverlap(_ a: String, _ b: String, maxOverlap: Int = 30) -> String {
+        let aWords = a.split(separator: " ").map(String.init)
+        let bWords = b.split(separator: " ").map(String.init)
+        guard !aWords.isEmpty else { return b }
+        guard !bWords.isEmpty else { return a }
+
+        func norm(_ word: String) -> String {
+            word.lowercased().trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+        }
+        let limit = min(maxOverlap, aWords.count, bWords.count)
+        var bestK = 0
+        var k = limit
+        while k >= 1 {
+            if zip(aWords.suffix(k), bWords.prefix(k)).allSatisfy({ norm($0) == norm($1) }) {
+                bestK = k
+                break
+            }
+            k -= 1
+        }
+        return (aWords + bWords.dropFirst(bestK)).joined(separator: " ")
+    }
+
+    // MARK: - Lifecycle
+
+    public func prepare(onProgress: (@Sendable (String) -> Void)? = nil) async throws {
+        if models != nil { return }
+
+        if let initializationTask {
+            try await initializationTask.value
+            return
+        }
+
+        let task = Task { try await loadModels(onProgress: onProgress) }
+        initializationTask = task
+
+        do {
+            try await task.value
+            initializationTask = nil
+        } catch {
+            initializationTask = nil
+            throw try Self.mapWarmUpError(error)
+        }
+    }
+
+    public func unload() async {
+        initializationTask?.cancel()
+        _ = try? await initializationTask?.value
+        initializationTask = nil
+        // Dropping `LoadedModels` releases the encoder/decoder `MLModel`s.
+        models = nil
+    }
+
+    public func isReady() -> Bool {
+        models != nil
+    }
+
+    private func loadModels(onProgress: (@Sendable (String) -> Void)?) async throws {
+        try await Self.downloadModel(onProgress: onProgress)
+        onProgress?("Loading Cohere model with Core ML...")
+        let dir = Self.defaultCacheRoot()
+        let loaded = try await CoherePipeline.loadModels(
+            encoderDir: dir,
+            decoderDir: dir,
+            vocabDir: dir,
+            decoderVariant: .v2,
+            computeUnits: computePolicy.computeUnits
+        )
+        // Warm-up inference: pay CoreML's one-time graph/weight specialization
+        // now (at load / launch warm-up) instead of on the user's first
+        // dictation. On the GPU path this is the heavy ~115s specialization; on
+        // ANE it's ~2s. Runs on 1s of silence; the transcript is discarded.
+        // After this returns, every real utterance is warm (~0.4s short / ~1.3s
+        // long on GPU). `models` is published only once fully warm, so
+        // `isReady()` reflecting true readiness gates the live engine swap UI.
+        onProgress?("Optimizing Cohere for this Mac...")
+        let warmUpSamples = [Float](repeating: 0, count: CohereAsrConfig.sampleRate)
+        _ = try? await pipeline.transcribe(
+            audio: warmUpSamples, models: loaded, language: defaultLanguage)
+        self.models = loaded
+        logger.notice("cohere_model_prepare_complete compute=\(self.computePolicy.rawValue, privacy: .public)")
+        AudioCaptureDiagnostics.append("cohere_model_prepare_complete compute=\(self.computePolicy.rawValue)")
+        onProgress?("Ready")
+    }
+
+    // MARK: - Model files
+
+    /// `<Application Support>/FluidAudio/Models` — the base FluidAudio's
+    /// download/load resolves against, shared with the Parakeet/Nemotron engines.
+    nonisolated static func modelsBaseDirectory() -> URL {
+        let appSupport =
+            FileManager.default.urls(
+                for: .applicationSupportDirectory,
+                in: .userDomainMask
+            ).first
+            ?? FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library", isDirectory: true)
+            .appendingPathComponent("Application Support", isDirectory: true)
+        return
+            appSupport
+            .appendingPathComponent("FluidAudio", isDirectory: true)
+            .appendingPathComponent("Models", isDirectory: true)
+    }
+
+    /// `…/Models/cohere-transcribe/q8` — `DownloadUtils.downloadRepo` strips the
+    /// repo's `q8` subPath prefix but `Repo.cohereTranscribeCoreml.folderName`
+    /// re-adds it, so the encoder, v2 decoder and `vocab.json` all land in this
+    /// single directory (which is what `CoherePipeline.loadModels` expects).
+    public nonisolated static func defaultCacheRoot() -> URL {
+        modelsBaseDirectory()
+            .appendingPathComponent(Repo.cohereTranscribeCoreml.folderName, isDirectory: true)
+    }
+
+    public nonisolated static func isModelCached() -> Bool {
+        isModelCached(cacheRoot: defaultCacheRoot())
+    }
+
+    /// Cached only when the encoder bundle, the v2 decoder bundle, and the vocab
+    /// are all present — the exact inputs `CoherePipeline.loadModels` reads.
+    nonisolated static func isModelCached(cacheRoot: URL) -> Bool {
+        let fileManager = FileManager.default
+        let encoder = cacheRoot.appendingPathComponent(ModelNames.CohereTranscribe.encoderCompiledFile)
+        let decoder = cacheRoot.appendingPathComponent(ModelNames.CohereTranscribe.decoderCacheExternalV2CompiledFile)
+        let vocab = cacheRoot.appendingPathComponent(ModelNames.CohereTranscribe.vocab)
+        return fileManager.fileExists(atPath: encoder.path)
+            && fileManager.fileExists(atPath: decoder.path)
+            && fileManager.fileExists(atPath: vocab.path)
+    }
+
+    /// Pre-fetches the model to its cache without loading it. A cached model is
+    /// a cheap no-op, mirroring `NemotronEnglishEngine.downloadModel`.
+    @discardableResult
+    public nonisolated static func downloadModel(
+        onProgress: (@Sendable (String) -> Void)? = nil
+    ) async throws -> URL {
+        let cacheRoot = defaultCacheRoot()
+        guard !isModelCached(cacheRoot: cacheRoot) else { return cacheRoot }
+        onProgress?("Preparing Cohere model download...")
+        let progressHandler = makeDownloadProgressHandler(onProgress)
+        try await DownloadUtils.downloadRepo(
+            .cohereTranscribeCoreml,
+            to: modelsBaseDirectory(),
+            progressHandler: progressHandler
+        )
+        return cacheRoot
+    }
+
+    @discardableResult
+    public nonisolated static func deleteModel() -> Bool {
+        deleteModel(cacheRoot: defaultCacheRoot())
+    }
+
+    @discardableResult
+    nonisolated static func deleteModel(cacheRoot: URL) -> Bool {
+        let fileManager = FileManager.default
+        guard fileManager.fileExists(atPath: cacheRoot.path) else { return false }
+        do {
+            try fileManager.removeItem(at: cacheRoot)
+        } catch {
+            return false
+        }
+        // Prune the now-empty `cohere-transcribe` parent if nothing else uses it.
+        removeIfEmpty(cacheRoot.deletingLastPathComponent(), fileManager: fileManager)
+        return !fileManager.fileExists(atPath: cacheRoot.path)
+    }
+
+    private nonisolated static func removeIfEmpty(_ directory: URL, fileManager: FileManager) {
+        guard let children = try? fileManager.contentsOfDirectory(atPath: directory.path),
+            children.isEmpty
+        else {
+            return
+        }
+        try? fileManager.removeItem(at: directory)
+    }
+
+    // MARK: - Helpers
+
+    /// Maps a BCP-47-ish language hint to a Cohere-supported language, falling
+    /// back to `nil` (caller substitutes its default) for unknown/empty input.
+    static func cohereLanguage(_ code: String?) -> CohereAsrConfig.Language? {
+        guard let code else { return nil }
+        let primary =
+            code.lowercased()
+            .replacingOccurrences(of: "_", with: "-")
+            .split(separator: "-")
+            .first
+            .map(String.init) ?? code.lowercased()
+        return CohereAsrConfig.Language(rawValue: primary)
+    }
+
+    private nonisolated static func makeDownloadProgressHandler(
+        _ onProgress: (@Sendable (String) -> Void)?
+    ) -> DownloadUtils.ProgressHandler? {
+        guard let onProgress else { return nil }
+        let clock = ContinuousClock()
+        let lastProgressUpdate = OSAllocatedUnfairLock(initialState: clock.now - .seconds(1))
+        let lastProgressMessage = OSAllocatedUnfairLock(initialState: "")
+        return { progress in
+            guard let message = Self.progressMessage(from: progress) else { return }
+            let now = clock.now
+            let shouldEmit = lastProgressUpdate.withLock { lastUpdate in
+                guard lastUpdate.duration(to: now) >= .milliseconds(250) else { return false }
+                lastUpdate = now
+                return true
+            }
+            guard shouldEmit else { return }
+
+            let isNewMessage = lastProgressMessage.withLock { lastMessage in
+                guard lastMessage != message else { return false }
+                lastMessage = message
+                return true
+            }
+            guard isNewMessage else { return }
+
+            onProgress(message)
+        }
+    }
+
+    private nonisolated static func progressMessage(from progress: DownloadUtils.DownloadProgress) -> String? {
+        switch progress.phase {
+        case .listing:
+            return "Preparing Cohere model download..."
+        case .downloading(let completedFiles, let totalFiles):
+            guard totalFiles > 0 else { return nil }
+            let percent = max(0, min(100, Int(progress.fractionCompleted * 100.0)))
+            return "Downloading Cohere model... \(percent)% (\(completedFiles)/\(totalFiles))"
+        case .compiling:
+            return "Compiling Cohere model..."
+        }
+    }
+
+    private nonisolated static func mapWarmUpError(_ error: Error) throws -> STTError {
+        if error is CancellationError { throw error }
+        if let mapped = mapCommonError(error) { return mapped }
+        return .engineStartFailed(error.localizedDescription)
+    }
+
+    private nonisolated static func mapTranscriptionError(_ error: Error) throws -> STTError {
+        if error is CancellationError { throw error }
+        if let mapped = mapCommonError(error) { return mapped }
+        return .transcriptionFailed(error.localizedDescription)
+    }
+
+    private nonisolated static func mapCommonError(_ error: Error) -> STTError? {
+        if let sttError = error as? STTError {
+            return sttError
+        }
+        if let cohereError = error as? CohereAsrError {
+            switch cohereError {
+            case .modelNotFound:
+                return .modelNotLoaded
+            case .invalidInput(let message):
+                return .transcriptionFailed(message)
+            case .encodingFailed(let message), .decodingFailed(let message), .generationFailed(let message):
+                return .transcriptionFailed(message)
+            }
+        }
+        if let urlError = error as? URLError {
+            switch urlError.code {
+            case .notConnectedToInternet, .networkConnectionLost, .timedOut,
+                .cannotFindHost, .cannotConnectToHost, .dnsLookupFailed:
+                return .modelDownloadFailed
+            default:
+                return .engineStartFailed(urlError.localizedDescription)
+            }
+        }
+        return nil
+    }
+}

--- a/Sources/MacParakeetCore/STT/CohereTranscribeEngine.swift
+++ b/Sources/MacParakeetCore/STT/CohereTranscribeEngine.swift
@@ -249,6 +249,19 @@ public actor CohereTranscribeEngine: STTTranscribing {
     /// ASCII space. Whitespace-free Hangul uses the character path too; Korean
     /// with spaces stays on the word path.
     static func mergeOnOverlap(_ a: String, _ b: String, maxOverlap: Int = 30) -> String {
+        // Only the tail of the accumulated transcript can overlap the next
+        // chunk. Keep long-file stitching bounded instead of re-tokenizing the
+        // whole transcript on every merge.
+        let safeSuffixLength = max(maxOverlap * 15, maxOverlap + 1)
+        if let splitIndex = a.index(a.endIndex, offsetBy: -safeSuffixLength, limitedBy: a.startIndex),
+           splitIndex > a.startIndex {
+            return String(a[..<splitIndex]) + mergeOnOverlap(
+                String(a[splitIndex...]),
+                b,
+                maxOverlap: maxOverlap
+            )
+        }
+
         if shouldUseCharacterOverlap(a, b) {
             return mergeUnits(
                 a: a.map(String.init),
@@ -291,7 +304,8 @@ public actor CohereTranscribeEngine: STTTranscribing {
     }
 
     private static func normalizedOverlapUnit(_ unit: String) -> String {
-        unit.lowercased().trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+        let normalized = unit.lowercased().trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+        return normalized.isEmpty ? unit : normalized
     }
 
     private static func shouldUseCharacterOverlap(_ a: String, _ b: String) -> Bool {

--- a/Sources/MacParakeetCore/STT/CohereTranscribeEngine.swift
+++ b/Sources/MacParakeetCore/STT/CohereTranscribeEngine.swift
@@ -136,9 +136,14 @@ public actor CohereTranscribeEngine: STTTranscribing {
 
             onProgress?(0, 100)
             try Task.checkCancellation()
-            let samples = try await Task.detached(priority: .userInitiated) {
+            let resamplingTask = Task.detached(priority: .userInitiated) {
                 try AudioConverter().resampleAudioFile(audioURL)
-            }.value
+            }
+            let samples = try await withTaskCancellationHandler {
+                try await resamplingTask.value
+            } onCancel: {
+                resamplingTask.cancel()
+            }
             onProgress?(40, 100)
             try Task.checkCancellation()
 
@@ -239,15 +244,16 @@ public actor CohereTranscribeEngine: STTTranscribing {
 
     /// Joins two transcript fragments produced from overlapping audio windows by
     /// dropping duplicated text at the seam. Space-delimited languages use the
-    /// word path; whitespace-free CJK/Hangul fragments use a character path so
-    /// Japanese/Chinese chunks do not duplicate the whole seam with an inserted
-    /// ASCII space.
+    /// word path; CJK fragments use a character path even when mixed with spaces
+    /// so Japanese/Chinese chunks do not duplicate the seam with an inserted
+    /// ASCII space. Whitespace-free Hangul uses the character path too; Korean
+    /// with spaces stays on the word path.
     static func mergeOnOverlap(_ a: String, _ b: String, maxOverlap: Int = 30) -> String {
         if shouldUseCharacterOverlap(a, b) {
             return mergeUnits(
                 a: a.map(String.init),
                 b: b.map(String.init),
-                maxOverlap: maxOverlap,
+                maxOverlap: maxOverlap * 3,
                 separator: ""
             )
         }
@@ -289,21 +295,34 @@ public actor CohereTranscribeEngine: STTTranscribing {
     }
 
     private static func shouldUseCharacterOverlap(_ a: String, _ b: String) -> Bool {
-        !containsWhitespace(a) && !containsWhitespace(b) && (containsCJKOrHangul(a) || containsCJKOrHangul(b))
+        if containsCJK(a) || containsCJK(b) {
+            return true
+        }
+        return !containsWhitespace(a) && !containsWhitespace(b) && (containsHangul(a) || containsHangul(b))
     }
 
     private static func containsWhitespace(_ string: String) -> Bool {
         string.unicodeScalars.contains { CharacterSet.whitespacesAndNewlines.contains($0) }
     }
 
-    private static func containsCJKOrHangul(_ string: String) -> Bool {
+    private static func containsCJK(_ string: String) -> Bool {
         string.unicodeScalars.contains { scalar in
             switch scalar.value {
             case 0x3040...0x309F, // Hiragana
                  0x30A0...0x30FF, // Katakana
                  0x3400...0x4DBF, // CJK Unified Ideographs Extension A
-                 0x4E00...0x9FFF, // CJK Unified Ideographs
-                 0xAC00...0xD7AF: // Hangul syllables
+                 0x4E00...0x9FFF: // CJK Unified Ideographs
+                return true
+            default:
+                return false
+            }
+        }
+    }
+
+    private static func containsHangul(_ string: String) -> Bool {
+        string.unicodeScalars.contains { scalar in
+            switch scalar.value {
+            case 0xAC00...0xD7AF: // Hangul syllables
                 return true
             default:
                 return false

--- a/Sources/MacParakeetCore/STT/CohereTranscribeEngine.swift
+++ b/Sources/MacParakeetCore/STT/CohereTranscribeEngine.swift
@@ -11,16 +11,15 @@ import os
 /// conform to ``NativeLiveDictating`` and `STTResult.words` is always empty.
 ///
 /// ## Compute policy
-/// The big INT8 encoder behaves very differently per Core ML backend. Defaults
-/// to **`.gpu`** — the fast path that makes the engine feel instant:
-/// - **`.gpu`** (`.all`, default): warm ~0.4–0.6 s. Core ML specializes the
+/// The big INT8 encoder behaves very differently per Core ML backend:
+/// - **`.gpu`** (`.all`): warm ~0.4–0.6 s. Core ML specializes the
 ///   graph on the **first transcribe of every launch (~115 s, not cached)**, so
 ///   we pay it in the background via a launch warm-up; for a resident app that
 ///   is once per session, then every dictation is fast.
-/// - **`.ane`** (`cpuAndNeuralEngine`): warm ~1.3–1.6 s, but its one-time
-///   specialization is **cached across launches** (`com.apple.e5rt.e5bundlecache`)
-///   so there is no per-launch stall, and it leaves the GPU free for the LLM
-///   formatter. The escape hatch for users who relaunch often.
+/// - **`.ane`** (`cpuAndNeuralEngine`, default): warm ~1.3–1.6 s, but its
+///   one-time specialization is **cached across launches**
+///   (`com.apple.e5rt.e5bundlecache`) so there is no per-launch stall, and it
+///   leaves the GPU free for the LLM formatter.
 /// NOTE: most apparent slowness in development is the unoptimized **Debug**
 /// build — the per-step decoder + mel hot path runs ~9× slower than release.
 /// Always judge latency from a release build.
@@ -29,10 +28,11 @@ public actor CohereTranscribeEngine: STTTranscribing {
     /// Core ML compute-unit policy for the Cohere models. See the type doc for
     /// the latency/cold-start tradeoff measured in the Phase-0 spike.
     public enum ComputePolicy: String, CaseIterable, Sendable {
-        /// `cpuAndNeuralEngine` — warm ~1.3–1.6 s, one-time specialization cached
-        /// across launches (e5bundlecache); no per-launch stall. Escape hatch.
+        /// `cpuAndNeuralEngine` — default. Warm ~1.3–1.6 s, one-time
+        /// specialization cached across launches (e5bundlecache); no
+        /// per-launch stall.
         case ane
-        /// `.all` — default. Warm ~0.4–0.6 s; ~115 s graph specialization on the
+        /// `.all` — warm ~0.4–0.6 s; ~115 s graph specialization on the
         /// first transcribe of every launch (not cached), hidden by launch warm-up.
         case gpu
 
@@ -42,7 +42,7 @@ public actor CohereTranscribeEngine: STTTranscribing {
             guard let raw = defaults.string(forKey: defaultsKey),
                 let policy = ComputePolicy(rawValue: raw)
             else {
-                return .gpu
+                return .ane
             }
             return policy
         }
@@ -65,16 +65,16 @@ public actor CohereTranscribeEngine: STTTranscribing {
 
     /// `CoherePipeline` is itself an actor and holds no per-call mutable state
     /// (it takes `LoadedModels` as an argument), so a single instance serves
-    /// every job kind (dictation, file, meeting) safely. Cohere is batch-only:
-    /// a second job that arrives while one is already in flight is rejected with
-    /// `STTError.engineBusy` rather than run concurrently or queued.
+    /// every job kind (dictation, file, meeting) safely. Cohere is batch-only,
+    /// so transcriptions are serialized by ``transcriptionPermit`` rather than
+    /// racing multiple `CoherePipeline` calls through the same loaded models.
     private let pipeline = CoherePipeline()
+    private let transcriptionPermit = AsyncPermit()
     private var models: CoherePipeline.LoadedModels?
     private var initializationTask: Task<Void, Error>?
-    private var isTranscribing = false
 
     public init(
-        computePolicy: ComputePolicy = .gpu,
+        computePolicy: ComputePolicy = .ane,
         defaultLanguage: CohereAsrConfig.Language = .english
     ) {
         self.computePolicy = computePolicy
@@ -86,7 +86,7 @@ public actor CohereTranscribeEngine: STTTranscribing {
     /// `CohereAsrConfig.Language`). Unknown or empty codes fall back to English,
     /// matching the no-auto-detect Phase-1 default. The code becomes the engine's
     /// default language for the no-`language:` `transcribe(audioPath:job:)` path.
-    public init(computePolicy: ComputePolicy = .gpu, defaultLanguageCode: String?) {
+    public init(computePolicy: ComputePolicy = .ane, defaultLanguageCode: String?) {
         self.computePolicy = computePolicy
         self.defaultLanguage = Self.cohereLanguage(defaultLanguageCode) ?? .english
     }
@@ -122,9 +122,8 @@ public actor CohereTranscribeEngine: STTTranscribing {
         language: String?,
         onProgress: (@Sendable (Int, Int) -> Void)? = nil
     ) async throws -> STTResult {
-        guard !isTranscribing else { throw STTError.engineBusy }
-        isTranscribing = true
-        defer { isTranscribing = false }
+        try await transcriptionPermit.wait()
+        defer { transcriptionPermit.signal() }
 
         do {
             // Lazy path (CLI, or first dictation before background warm-up
@@ -239,29 +238,77 @@ public actor CohereTranscribeEngine: STTTranscribing {
     }
 
     /// Joins two transcript fragments produced from overlapping audio windows by
-    /// dropping the duplicated words at the seam: compares up to `maxOverlap`
-    /// trailing words of `a` against the leading words of `b`
-    /// (case/punctuation-insensitive) and removes the longest match from `b`.
+    /// dropping duplicated text at the seam. Space-delimited languages use the
+    /// word path; whitespace-free CJK/Hangul fragments use a character path so
+    /// Japanese/Chinese chunks do not duplicate the whole seam with an inserted
+    /// ASCII space.
     static func mergeOnOverlap(_ a: String, _ b: String, maxOverlap: Int = 30) -> String {
-        let aWords = a.split(whereSeparator: { $0.isWhitespace }).map(String.init)
-        let bWords = b.split(whereSeparator: { $0.isWhitespace }).map(String.init)
-        guard !aWords.isEmpty else { return b }
-        guard !bWords.isEmpty else { return a }
-
-        func norm(_ word: String) -> String {
-            word.lowercased().trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+        if shouldUseCharacterOverlap(a, b) {
+            return mergeUnits(
+                a: a.map(String.init),
+                b: b.map(String.init),
+                maxOverlap: maxOverlap,
+                separator: ""
+            )
         }
-        let limit = min(maxOverlap, aWords.count, bWords.count)
+
+        return mergeUnits(
+            a: a.split(whereSeparator: { $0.isWhitespace }).map(String.init),
+            b: b.split(whereSeparator: { $0.isWhitespace }).map(String.init),
+            maxOverlap: maxOverlap,
+            separator: " "
+        )
+    }
+
+    private static func mergeUnits(
+        a: [String],
+        b: [String],
+        maxOverlap: Int,
+        separator: String
+    ) -> String {
+        guard !a.isEmpty else { return b.joined(separator: separator) }
+        guard !b.isEmpty else { return a.joined(separator: separator) }
+
+        let limit = min(maxOverlap, a.count, b.count)
         var bestK = 0
         var k = limit
         while k >= 1 {
-            if zip(aWords.suffix(k), bWords.prefix(k)).allSatisfy({ norm($0) == norm($1) }) {
+            if zip(a.suffix(k), b.prefix(k)).allSatisfy({
+                normalizedOverlapUnit($0) == normalizedOverlapUnit($1)
+            }) {
                 bestK = k
                 break
             }
             k -= 1
         }
-        return (aWords + bWords.dropFirst(bestK)).joined(separator: " ")
+        return (a + b.dropFirst(bestK)).joined(separator: separator)
+    }
+
+    private static func normalizedOverlapUnit(_ unit: String) -> String {
+        unit.lowercased().trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+    }
+
+    private static func shouldUseCharacterOverlap(_ a: String, _ b: String) -> Bool {
+        !containsWhitespace(a) && !containsWhitespace(b) && (containsCJKOrHangul(a) || containsCJKOrHangul(b))
+    }
+
+    private static func containsWhitespace(_ string: String) -> Bool {
+        string.unicodeScalars.contains { CharacterSet.whitespacesAndNewlines.contains($0) }
+    }
+
+    private static func containsCJKOrHangul(_ string: String) -> Bool {
+        string.unicodeScalars.contains { scalar in
+            switch scalar.value {
+            case 0x3040...0x309F, // Hiragana
+                 0x30A0...0x30FF, // Katakana
+                 0x3400...0x4DBF, // CJK Unified Ideographs Extension A
+                 0x4E00...0x9FFF, // CJK Unified Ideographs
+                 0xAC00...0xD7AF: // Hangul syllables
+                return true
+            default:
+                return false
+            }
+        }
     }
 
     // MARK: - Lifecycle

--- a/Sources/MacParakeetCore/STT/CohereTranscribeEngine.swift
+++ b/Sources/MacParakeetCore/STT/CohereTranscribeEngine.swift
@@ -243,8 +243,8 @@ public actor CohereTranscribeEngine: STTTranscribing {
     /// trailing words of `a` against the leading words of `b`
     /// (case/punctuation-insensitive) and removes the longest match from `b`.
     static func mergeOnOverlap(_ a: String, _ b: String, maxOverlap: Int = 30) -> String {
-        let aWords = a.split(separator: " ").map(String.init)
-        let bWords = b.split(separator: " ").map(String.init)
+        let aWords = a.split(whereSeparator: { $0.isWhitespace }).map(String.init)
+        let bWords = b.split(whereSeparator: { $0.isWhitespace }).map(String.init)
         guard !aWords.isEmpty else { return b }
         guard !bWords.isEmpty else { return a }
 
@@ -274,14 +274,18 @@ public actor CohereTranscribeEngine: STTTranscribing {
             return
         }
 
+        // `loadModels` clears `initializationTask` itself (via defer) when it
+        // finishes. If we cleared it here in a cancelled `catch`, a caller whose
+        // await was cancelled mid-warm-up (e.g. dictation Escape during the
+        // launch optimize) would null the handle while the unstructured task
+        // keeps running — letting the next prepare() spawn a duplicate ~115 s
+        // download/warm-up.
         let task = Task { try await loadModels(onProgress: onProgress) }
         initializationTask = task
 
         do {
             try await task.value
-            initializationTask = nil
         } catch {
-            initializationTask = nil
             throw try Self.mapWarmUpError(error)
         }
     }
@@ -299,6 +303,10 @@ public actor CohereTranscribeEngine: STTTranscribing {
     }
 
     private func loadModels(onProgress: (@Sendable (String) -> Void)?) async throws {
+        // Clear the shared handle when this work finishes (success or failure),
+        // from inside the task — not from a possibly-cancelled awaiting caller —
+        // so concurrent prepare() calls coalesce onto this one task.
+        defer { initializationTask = nil }
         try await Self.downloadModel(onProgress: onProgress)
         onProgress?("Loading Cohere model with Core ML...")
         let dir = Self.defaultCacheRoot()
@@ -421,14 +429,10 @@ public actor CohereTranscribeEngine: STTTranscribing {
     /// Maps a BCP-47-ish language hint to a Cohere-supported language, falling
     /// back to `nil` (caller substitutes its default) for unknown/empty input.
     static func cohereLanguage(_ code: String?) -> CohereAsrConfig.Language? {
-        guard let code else { return nil }
-        let primary =
-            code.lowercased()
-            .replacingOccurrences(of: "_", with: "-")
-            .split(separator: "-")
-            .first
-            .map(String.init) ?? code.lowercased()
-        return CohereAsrConfig.Language(rawValue: primary)
+        // Reuse the canonical normalizer (folds to a lowercased primary subtag,
+        // rejects "auto"/empty/non-letter) so language handling stays consistent.
+        guard let normalized = SpeechEnginePreference.normalizeCohereLanguage(code) else { return nil }
+        return CohereAsrConfig.Language(rawValue: normalized)
     }
 
     private nonisolated static func makeDownloadProgressHandler(

--- a/Sources/MacParakeetCore/STT/CohereTranscribeEngine.swift
+++ b/Sources/MacParakeetCore/STT/CohereTranscribeEngine.swift
@@ -64,10 +64,10 @@ public actor CohereTranscribeEngine: STTTranscribing {
     private let defaultLanguage: CohereAsrConfig.Language
 
     /// `CoherePipeline` is itself an actor and holds no per-call mutable state
-    /// (it takes `LoadedModels` as an argument), so a single instance serializes
-    /// dictation and any other batch job safely. When Cohere is the selected
-    /// engine it serves every job kind (dictation, file, meeting); the actor
-    /// queues overlapping jobs rather than running them concurrently.
+    /// (it takes `LoadedModels` as an argument), so a single instance serves
+    /// every job kind (dictation, file, meeting) safely. Cohere is batch-only:
+    /// a second job that arrives while one is already in flight is rejected with
+    /// `STTError.engineBusy` rather than run concurrently or queued.
     private let pipeline = CoherePipeline()
     private var models: CoherePipeline.LoadedModels?
     private var initializationTask: Task<Void, Error>?
@@ -79,6 +79,16 @@ public actor CohereTranscribeEngine: STTTranscribing {
     ) {
         self.computePolicy = computePolicy
         self.defaultLanguage = defaultLanguage
+    }
+
+    /// Convenience initializer for callers that resolve a language as a string
+    /// code (e.g. the CLI, which must not import FluidAudio to name
+    /// `CohereAsrConfig.Language`). Unknown or empty codes fall back to English,
+    /// matching the no-auto-detect Phase-1 default. The code becomes the engine's
+    /// default language for the no-`language:` `transcribe(audioPath:job:)` path.
+    public init(computePolicy: ComputePolicy = .gpu, defaultLanguageCode: String?) {
+        self.computePolicy = computePolicy
+        self.defaultLanguage = Self.cohereLanguage(defaultLanguageCode) ?? .english
     }
 
     // MARK: - Languages
@@ -117,7 +127,12 @@ public actor CohereTranscribeEngine: STTTranscribing {
         defer { isTranscribing = false }
 
         do {
-            try await prepare(onProgress: nil)
+            // Lazy path (CLI, or first dictation before background warm-up
+            // finished): a first-time ~2.1 GB model download would otherwise be
+            // silent and read as a hang, so log prepare progress to the console.
+            try await prepare(onProgress: { [logger] message in
+                logger.notice("cohere_prepare \(message, privacy: .public)")
+            })
             guard let models else { throw STTError.modelNotLoaded }
 
             onProgress?(0, 100)

--- a/Sources/MacParakeetCore/STT/CohereTranscribeEngine.swift
+++ b/Sources/MacParakeetCore/STT/CohereTranscribeEngine.swift
@@ -481,9 +481,12 @@ public actor CohereTranscribeEngine: STTTranscribing {
         // from inside the task — not from a possibly-cancelled awaiting caller —
         // so concurrent prepare() calls coalesce onto this one task.
         defer { initializationTask = nil }
+        try Task.checkCancellation()
         try await Self.downloadModel(onProgress: onProgress)
+        try Task.checkCancellation()
         onProgress?("Loading Cohere model with Core ML...")
         let dir = Self.defaultCacheRoot()
+        try Task.checkCancellation()
         let loaded = try await CoherePipeline.loadModels(
             encoderDir: dir,
             decoderDir: dir,
@@ -491,6 +494,7 @@ public actor CohereTranscribeEngine: STTTranscribing {
             decoderVariant: .v2,
             computeUnits: computePolicy.computeUnits
         )
+        try Task.checkCancellation()
         // Warm-up inference: pay CoreML's one-time graph/weight specialization
         // now (at load / launch warm-up) instead of on the user's first
         // dictation. On the GPU path this is the heavy ~115s specialization; on
@@ -499,13 +503,16 @@ public actor CohereTranscribeEngine: STTTranscribing {
         // long on GPU). `models` is published only once fully warm, so
         // `isReady()` reflecting true readiness gates the live engine swap UI.
         onProgress?("Optimizing Cohere for this Mac...")
+        try Task.checkCancellation()
         let warmUpSamples = [Float](repeating: 0, count: CohereAsrConfig.sampleRate)
         do {
             _ = try await pipeline.transcribe(
                 audio: warmUpSamples, models: loaded, language: defaultLanguage)
         } catch {
+            if error is CancellationError { throw error }
             logger.error("cohere_warmup_failed error=\(error.localizedDescription, privacy: .public)")
         }
+        try Task.checkCancellation()
         self.models = loaded
         logger.notice("cohere_model_prepare_complete compute=\(self.computePolicy.rawValue, privacy: .public)")
         AudioCaptureDiagnostics.append("cohere_model_prepare_complete compute=\(self.computePolicy.rawValue)")

--- a/Sources/MacParakeetCore/STT/CohereTranscribeEngine.swift
+++ b/Sources/MacParakeetCore/STT/CohereTranscribeEngine.swift
@@ -4,6 +4,48 @@ import FluidAudio
 import Foundation
 import os
 
+private final class CancellationResponsiveTaskAwaiter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<Void, Error>?
+    private var result: Result<Void, Error>?
+
+    func wait() async throws {
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                let pendingResult: Result<Void, Error>?
+                lock.lock()
+                if let result {
+                    pendingResult = result
+                } else {
+                    self.continuation = continuation
+                    pendingResult = nil
+                }
+                lock.unlock()
+
+                if let pendingResult {
+                    continuation.resume(with: pendingResult)
+                }
+            }
+        } onCancel: {
+            resume(with: .failure(CancellationError()))
+        }
+    }
+
+    func resume(with result: Result<Void, Error>) {
+        lock.lock()
+        guard self.result == nil else {
+            lock.unlock()
+            return
+        }
+        self.result = result
+        let continuation = self.continuation
+        self.continuation = nil
+        lock.unlock()
+
+        continuation?.resume(with: result)
+    }
+}
+
 /// Wraps FluidAudio's `CoherePipeline` (Cohere Transcribe 03-2026, a 2B
 /// Conformer encoder + lightweight Transformer decoder converted to Core ML by
 /// Fluid Inference). Cohere is a **batch, record-then-transcribe** engine: it
@@ -358,10 +400,16 @@ public actor CohereTranscribeEngine: STTTranscribing {
     private static func overlapMatches(a: [String], b: [String]) -> Bool {
         guard a.count == b.count else { return false }
         let strongOverlap = a.count >= 2
+        var matchedLexicalUnit = false
 
         for index in a.indices {
             let aUnit = normalizedOverlapUnit(a[index])
             let bUnit = normalizedOverlapUnit(b[index])
+            if aUnit == nil && bUnit == nil {
+                continue
+            }
+            guard let aUnit, let bUnit else { return false }
+            matchedLexicalUnit = true
             if aUnit == bUnit { continue }
 
             if strongOverlap, index == a.startIndex, isLeadingPartial(unit: bUnit, completedBy: aUnit) {
@@ -372,13 +420,14 @@ public actor CohereTranscribeEngine: STTTranscribing {
             }
             return false
         }
-        return true
+        return matchedLexicalUnit
     }
 
     private static func isLeadingPartial(unit: String, completedBy fullUnit: String) -> Bool {
         let minimumPartialLength = 2
-        let unit = normalizedOverlapUnit(unit)
-        let fullUnit = normalizedOverlapUnit(fullUnit)
+        guard let unit = normalizedOverlapUnit(unit),
+              let fullUnit = normalizedOverlapUnit(fullUnit)
+        else { return false }
         return unit.count >= minimumPartialLength
             && fullUnit.count > unit.count
             && fullUnit.hasSuffix(unit)
@@ -386,16 +435,17 @@ public actor CohereTranscribeEngine: STTTranscribing {
 
     private static func isTrailingPartial(unit: String, completedBy fullUnit: String) -> Bool {
         let minimumPartialLength = 2
-        let unit = normalizedOverlapUnit(unit)
-        let fullUnit = normalizedOverlapUnit(fullUnit)
+        guard let unit = normalizedOverlapUnit(unit),
+              let fullUnit = normalizedOverlapUnit(fullUnit)
+        else { return false }
         return unit.count >= minimumPartialLength
             && fullUnit.count > unit.count
             && fullUnit.hasPrefix(unit)
     }
 
-    private static func normalizedOverlapUnit(_ unit: String) -> String {
+    private static func normalizedOverlapUnit(_ unit: String) -> String? {
         let normalized = unit.lowercased().trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
-        return normalized.isEmpty ? unit : normalized
+        return normalized.isEmpty ? nil : normalized
     }
 
     private static func shouldUseCharacterOverlap(_ a: String, _ b: String) -> Bool {
@@ -443,7 +493,7 @@ public actor CohereTranscribeEngine: STTTranscribing {
 
         if let initializationTask {
             do {
-                try await initializationTask.value
+                try await Self.awaitSharedInitializationTask(initializationTask)
             } catch {
                 throw try Self.mapWarmUpError(error)
             }
@@ -458,10 +508,24 @@ public actor CohereTranscribeEngine: STTTranscribing {
         initializationTask = task
 
         do {
-            try await task.value
+            try await Self.awaitSharedInitializationTask(task)
         } catch {
             throw try Self.mapWarmUpError(error)
         }
+    }
+
+    nonisolated static func awaitSharedInitializationTask(_ task: Task<Void, Error>) async throws {
+        let awaiter = CancellationResponsiveTaskAwaiter()
+        let waiter = Task {
+            do {
+                try await task.value
+                awaiter.resume(with: .success(()))
+            } catch {
+                awaiter.resume(with: .failure(error))
+            }
+        }
+        defer { waiter.cancel() }
+        try await awaiter.wait()
     }
 
     public func unload() async {

--- a/Sources/MacParakeetCore/STT/CohereTranscribeEngine.swift
+++ b/Sources/MacParakeetCore/STT/CohereTranscribeEngine.swift
@@ -446,8 +446,10 @@ public actor CohereTranscribeEngine: STTTranscribing {
             && fullUnit.hasPrefix(unit)
     }
 
+    private static let nonAlphanumerics = CharacterSet.alphanumerics.inverted
+
     private static func normalizedOverlapUnit(_ unit: String) -> String? {
-        let normalized = unit.lowercased().trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+        let normalized = unit.lowercased().trimmingCharacters(in: Self.nonAlphanumerics)
         return normalized.isEmpty ? nil : normalized
     }
 

--- a/Sources/MacParakeetCore/STT/HotkeyGestureController.swift
+++ b/Sources/MacParakeetCore/STT/HotkeyGestureController.swift
@@ -45,6 +45,21 @@ public final class HotkeyGestureController {
     private let stateMachine: FnKeyStateMachine
     private var holdOnlyState: HoldOnlyState = .idle
     private var singleTapState: SingleTapState = .idle
+
+    /// True while a trigger press is still being evaluated (pressed once, not yet
+    /// resolved into a tap, hold, or double-tap) — i.e. a recording start may be
+    /// armed but has not fired. Used to avoid dropping that pending start when a
+    /// CGEvent-tap recovery happens mid-gesture while the trigger is still held.
+    public var hasPendingTriggerPress: Bool {
+        switch mode {
+        case .holdOnly:
+            return holdOnlyState == .pressed
+        case .doubleTapAndHold, .doubleTapOnly:
+            return stateMachine.state == .waitingForSecondTap
+        case .singleTapToggle:
+            return false
+        }
+    }
     private var suppressedUntilReset = false
 
     public init(

--- a/Sources/MacParakeetCore/STT/README.md
+++ b/Sources/MacParakeetCore/STT/README.md
@@ -7,8 +7,8 @@
 > as opt-in Parakeet variants; Nemotron is an opt-in Beta
 > engine with two builds — multilingual (Nemotron 3.5, default) and an
 > English-only streaming build (Nemotron Speech Streaming EN 0.6B);
-> WhisperKit is optional for languages outside Parakeet/Nemotron
-> coverage; Cohere Transcribe is an opt-in batch-only accuracy engine.
+> WhisperKit is optional for broad language coverage; Cohere Transcribe is an
+> opt-in batch-only accuracy engine.
 
 ## Entry point
 
@@ -167,10 +167,11 @@ unhealthy-runtime watchdog before unloading or clearing model state.
 build is `v3` unless the user opts into `v2` through Settings or the CLI
 (`config set parakeet-model`, `models select parakeet-v2`, or
 `transcribe --parakeet-model v2`). A subscriber can request Nemotron or
-WhisperKit globally (Settings / `models select`) or per call (CLI
-`--engine nemotron --language ko`, `--engine whisper --language ko`). When set
-globally, dictation also routes there; when set per-job, only that job uses the
-requested engine.
+WhisperKit or Cohere globally (Settings / `models select`) or per call (CLI
+`--engine nemotron --language ko`, `--engine cohere --language ja`,
+`--engine whisper --language ko`). When set globally, dictation also routes
+there; when set per-job, only that job uses the requested engine. Cohere
+dictation remains record-then-transcribe and does not enter live-preview paths.
 
 **Active meetings hold an engine lease.** Once a meeting recording
 starts, its engine selection is captured for the session's duration.

--- a/Sources/MacParakeetCore/STT/README.md
+++ b/Sources/MacParakeetCore/STT/README.md
@@ -22,7 +22,8 @@ to one `STTRuntime`; callers do not own model lifecycles directly.
 
 **Speech control plane**
 - `STTScheduler.swift` — public broker. Job admission, slot scheduling,
-  engine routing, session leases for active meetings.
+  engine routing, session leases for active meetings, and Cohere's
+  scheduler-level single-flight admission.
 - `STTRuntime.swift` — sole owner of the Parakeet TDT `AsrManager`s, the
   optional `ParakeetUnifiedEngine` (routed when the persisted
   `ParakeetModelVariant` is `.unified`), the optional Beta
@@ -64,7 +65,8 @@ to one `STTRuntime`; callers do not own model lifecycles directly.
   Batch-only: dictation records first and transcribes after stop, file and
   meeting-finalize jobs run offline, live dictation preview stays off, and
   meeting live preview chunks are not routed to Cohere. No word timings;
-  meetings degrade to plain text.
+  meetings degrade to plain text. Loads only an explicitly downloaded model
+  cache; it does not download from normal transcription/warm-up paths.
 - `NativeLiveDictating.swift` — internal protocol the native streaming engines
   conform to so `STTRuntime` can route a live dictation session to the active
   Nemotron or Parakeet Unified build without knowing the concrete engine type.

--- a/Sources/MacParakeetCore/STT/README.md
+++ b/Sources/MacParakeetCore/STT/README.md
@@ -8,7 +8,7 @@
 > engine with two builds — multilingual (Nemotron 3.5, default) and an
 > English-only streaming build (Nemotron Speech Streaming EN 0.6B);
 > WhisperKit is optional for languages outside Parakeet/Nemotron
-> coverage.
+> coverage; Cohere Transcribe is an opt-in batch-only accuracy engine.
 
 ## Entry point
 
@@ -27,8 +27,9 @@ to one `STTRuntime`; callers do not own model lifecycles directly.
   optional `ParakeetUnifiedEngine` (routed when the persisted
   `ParakeetModelVariant` is `.unified`), the optional Beta
   `NemotronEngine`/`NemotronEnglishEngine` pair (routed by the persisted
-  `NemotronModelVariant`), and the optional `WhisperEngine`. Handles warm-up,
-  model init, cache clearing, shutdown, and Parakeet/Nemotron build swaps.
+  `NemotronModelVariant`), the optional `WhisperEngine`, and the optional
+  `CohereTranscribeEngine`. Handles warm-up, model init, cache clearing,
+  shutdown, and Parakeet/Nemotron build swaps.
 - `STTClient.swift` + `STTClientProtocol.swift` — **CLI / test
   facade only**. Each `STTClient` instantiates its own runtime and
   scheduler, bypassing the process singleton. App code must use the
@@ -59,6 +60,11 @@ to one `STTRuntime`; callers do not own model lifecycles directly.
   through the streaming manager in bounded slices; live dictation drives
   the same manager incrementally and emits partials (see below). Preserves
   FluidAudio token timings as MacParakeet word timestamps when available.
+- `CohereTranscribeEngine.swift` — FluidAudio Cohere Transcribe wrapper.
+  Batch-only: dictation records first and transcribes after stop, file and
+  meeting-finalize jobs run offline, live dictation preview stays off, and
+  meeting live preview chunks are not routed to Cohere. No word timings;
+  meetings degrade to plain text.
 - `NativeLiveDictating.swift` — internal protocol the native streaming engines
   conform to so `STTRuntime` can route a live dictation session to the active
   Nemotron or Parakeet Unified build without knowing the concrete engine type.
@@ -92,6 +98,8 @@ minor historical wart, not a design statement.
   is the implementation.
 - ADR-021 — WhisperKit as optional multilingual engine; engine
   routing and meeting engine leases live in `STTScheduler`.
+- ADR-001 amendment / benchmark notes — Cohere Transcribe as an opt-in local
+  accuracy engine.
 - ADR-009 — custom hotkey support (relevant to the hotkey files
   above).
 - `spec/06-stt-engine.md` — narrative spec.
@@ -147,7 +155,7 @@ Dictation can request a single-flight tail-window preview via
 does not replace the recorded-file final transcript; it is only for the
 floating overlay text while capture is active. Parakeet v2/v3 use this
 tail-window batch preview; Parakeet Unified and Nemotron use native streaming
-partials instead, and Whisper remains default-off. Engine switches, variant
+partials instead, and Whisper and Cohere remain default-off. Engine switches, variant
 switches, and dictation stop/cancel paths cancel the preview with bounded drain.
 If a cancelled preview still has runtime work in flight, engine/variant switches
 fail fast with `engineBusy` rather than reloading under active inference; the

--- a/Sources/MacParakeetCore/STT/STTRuntime.swift
+++ b/Sources/MacParakeetCore/STT/STTRuntime.swift
@@ -761,8 +761,8 @@ public actor STTRuntime: STTRuntimeProtocol {
         )
         // Cohere caches under `…/Models/cohere-transcribe/q8`; remove the family
         // root so a full clear can't strand the precision subdirectory.
-        _ = Self.removeNemotronModelFiles(
-            at: CohereTranscribeEngine.defaultCacheRoot().deletingLastPathComponent()
+        _ = CohereTranscribeEngine.deleteModel(
+            cacheRoot: CohereTranscribeEngine.defaultCacheRoot().deletingLastPathComponent()
         )
         setBackgroundWarmUpState(.idle)
         Telemetry.send(.modelOperation(

--- a/Sources/MacParakeetCore/STT/STTRuntime.swift
+++ b/Sources/MacParakeetCore/STT/STTRuntime.swift
@@ -404,15 +404,13 @@ public actor STTRuntime: STTRuntimeProtocol {
         return engine
     }
 
-    /// Mirrors `ensureNemotronEnglishEngine` for the Cohere engine. The compute
-    /// policy is read once at construction; language is supplied per-call, so an
-    /// existing engine is always reusable.
+    /// Owns the single Cohere engine instance. The compute policy is read once
+    /// at construction; language is supplied per-call, so an existing engine is
+    /// always reusable. Cohere job serialization lives in `STTScheduler`, so
+    /// construction only needs this actor's normal single-threaded mutation.
     private func ensureCohereEngine() throws -> CohereTranscribeEngine {
         if let cohereEngine {
             return cohereEngine
-        }
-        guard activeTranscriptionCount <= 1 else {
-            throw STTError.engineBusy
         }
         let engine = CohereTranscribeEngine(
             computePolicy: CohereTranscribeEngine.ComputePolicy.current(defaults: defaults)

--- a/Sources/MacParakeetCore/STT/STTRuntime.swift
+++ b/Sources/MacParakeetCore/STT/STTRuntime.swift
@@ -107,8 +107,8 @@ public actor STTRuntime: STTRuntimeProtocol {
     private var whisperEngine: WhisperEngine?
     private let whisperModelVariant: String
     /// Owns the Cohere Transcribe runtime (FluidAudio `CoherePipeline`). Lazily
-    /// created on first use; sibling of the Parakeet/Nemotron/Whisper engines.
-    /// Batch-only (no live dictation / preview path).
+    /// created on first use; sibling of the other speech engines. Batch-only
+    /// (no live dictation / preview path).
     private var cohereEngine: CohereTranscribeEngine?
     private let defaults: UserDefaults
     private var activeTranscriptionCount = 0

--- a/Sources/MacParakeetCore/STT/STTRuntime.swift
+++ b/Sources/MacParakeetCore/STT/STTRuntime.swift
@@ -106,6 +106,10 @@ public actor STTRuntime: STTRuntimeProtocol {
     private var nemotronModelVariant: NemotronModelVariant
     private var whisperEngine: WhisperEngine?
     private let whisperModelVariant: String
+    /// Owns the Cohere Transcribe runtime (FluidAudio `CoherePipeline`). Lazily
+    /// created on first use; sibling of the Parakeet/Nemotron/Whisper engines.
+    /// Batch-only (no live dictation / preview path).
+    private var cohereEngine: CohereTranscribeEngine?
     private let defaults: UserDefaults
     private var activeTranscriptionCount = 0
     private var liveDictationSession: LiveDictationSessionState? {
@@ -184,6 +188,13 @@ public actor STTRuntime: STTRuntimeProtocol {
             )
         case .whisper:
             return try await transcribeWithWhisper(audioPath: audioPath, language: selection.language, onProgress: onProgress)
+        case .cohere:
+            return try await transcribeWithCohere(
+                audioPath: audioPath,
+                job: job,
+                language: selection.language,
+                onProgress: onProgress
+            )
         }
     }
 
@@ -205,6 +216,8 @@ public actor STTRuntime: STTRuntimeProtocol {
             return try await transcribeWhisperPreview(samples: samples, language: selection.language)
         case .nemotron:
             throw STTError.transcriptionFailed("Nemotron uses native live dictation partials and does not support display-preview transcription.")
+        case .cohere:
+            throw STTError.transcriptionFailed("Cohere uses record-then-transcribe dictation and does not support display-preview transcription.")
         }
     }
 
@@ -246,6 +259,9 @@ public actor STTRuntime: STTRuntimeProtocol {
             }
         case .whisper:
             throw STTLiveDictationTranscriptionError.unsupportedEngine(.whisper)
+        case .cohere:
+            // Batch engine — no native live-partial path.
+            throw STTLiveDictationTranscriptionError.unsupportedEngine(.cohere)
         }
         guard await engine.isReady() else {
             throw STTLiveDictationTranscriptionError.modelNotReady
@@ -340,6 +356,21 @@ public actor STTRuntime: STTRuntimeProtocol {
         )
     }
 
+    private func transcribeWithCohere(
+        audioPath: String,
+        job: STTJobKind,
+        language: String?,
+        onProgress: (@Sendable (Int, Int) -> Void)?
+    ) async throws -> STTResult {
+        let engine = try ensureCohereEngine()
+        return try await engine.transcribe(
+            audioURL: URL(fileURLWithPath: audioPath),
+            job: job,
+            language: language,
+            onProgress: onProgress
+        )
+    }
+
     private func transcribeWhisperPreview(samples: [Float], language: String?) async throws -> STTResult {
         let engine = try ensureWhisperEngine()
         return try await engine.transcribe(samples: samples, language: language)
@@ -370,6 +401,23 @@ public actor STTRuntime: STTRuntimeProtocol {
         }
         let engine = WhisperEngine(model: whisperModelVariant)
         whisperEngine = engine
+        return engine
+    }
+
+    /// Mirrors `ensureNemotronEnglishEngine` for the Cohere engine. The compute
+    /// policy is read once at construction; language is supplied per-call, so an
+    /// existing engine is always reusable.
+    private func ensureCohereEngine() throws -> CohereTranscribeEngine {
+        if let cohereEngine {
+            return cohereEngine
+        }
+        guard activeTranscriptionCount <= 1 else {
+            throw STTError.engineBusy
+        }
+        let engine = CohereTranscribeEngine(
+            computePolicy: CohereTranscribeEngine.ComputePolicy.current(defaults: defaults)
+        )
+        cohereEngine = engine
         return engine
     }
 
@@ -523,6 +571,9 @@ public actor STTRuntime: STTRuntimeProtocol {
                 let engine = whisperEngine ?? WhisperEngine(model: whisperModelVariant)
                 whisperEngine = engine
                 try await engine.prepare(onProgress: onProgress)
+            case .cohere:
+                let engine = try ensureCohereEngine()
+                try await engine.prepare(onProgress: onProgress)
             }
             let elapsed = start.duration(to: .now)
             let seconds = Double(elapsed.components.seconds) + Double(elapsed.components.attoseconds) / 1e18
@@ -649,6 +700,9 @@ public actor STTRuntime: STTRuntimeProtocol {
         if speechEngine == .whisper {
             return await whisperEngine?.isReady() ?? false
         }
+        if speechEngine == .cohere {
+            return await cohereEngine?.isReady() ?? false
+        }
 
         // Parakeet engine: Unified reports through its own engine actor.
         if currentParakeetVariant.usesUnifiedEngine {
@@ -667,6 +721,7 @@ public actor STTRuntime: STTRuntimeProtocol {
         await unloadWhisper()
         await unloadNemotron()
         await unloadParakeet()
+        await unloadCohere()
         warmUpProgressHandler = nil
         setBackgroundWarmUpState(.idle)
     }
@@ -703,6 +758,11 @@ public actor STTRuntime: STTRuntimeProtocol {
         // full clear can't strand a tier directory.
         _ = Self.removeNemotronModelFiles(
             at: NemotronEnglishEngine.defaultCacheRoot().deletingLastPathComponent()
+        )
+        // Cohere caches under `…/Models/cohere-transcribe/q8`; remove the family
+        // root so a full clear can't strand the precision subdirectory.
+        _ = Self.removeNemotronModelFiles(
+            at: CohereTranscribeEngine.defaultCacheRoot().deletingLastPathComponent()
         )
         setBackgroundWarmUpState(.idle)
         Telemetry.send(.modelOperation(
@@ -776,6 +836,7 @@ public actor STTRuntime: STTRuntimeProtocol {
         var preparedWhisper: WhisperEngine?
         var preparedNemotron: NemotronEngine?
         var preparedNemotronEnglish: NemotronEnglishEngine?
+        var preparedCohere: CohereTranscribeEngine?
 
         switch preference {
         case .parakeet:
@@ -798,6 +859,10 @@ public actor STTRuntime: STTRuntimeProtocol {
             )
             try await engine.prepare(onProgress: onProgress)
             preparedWhisper = engine
+        case .cohere:
+            let engine = try ensureCohereEngine()
+            try await engine.prepare(onProgress: onProgress)
+            preparedCohere = engine
         }
 
         if let preparedWhisper {
@@ -808,6 +873,9 @@ public actor STTRuntime: STTRuntimeProtocol {
         }
         if let preparedNemotronEnglish {
             nemotronEnglishEngine = preparedNemotronEnglish
+        }
+        if let preparedCohere {
+            cohereEngine = preparedCohere
         }
         speechEngine = preference
         preference.save(to: defaults)
@@ -822,6 +890,9 @@ public actor STTRuntime: STTRuntimeProtocol {
         case .whisper where preference != .whisper:
             onProgress?("Releasing Whisper model...")
             await unloadWhisper()
+        case .cohere where preference != .cohere:
+            onProgress?("Releasing Cohere model...")
+            await unloadCohere()
         default:
             break
         }
@@ -1309,6 +1380,12 @@ public actor STTRuntime: STTRuntimeProtocol {
         await engine?.unload()
     }
 
+    private func unloadCohere() async {
+        let engine = cohereEngine
+        cohereEngine = nil
+        await engine?.unload()
+    }
+
     private func unloadNemotron() async {
         let engine = nemotronEngine
         let englishEngine = nemotronEnglishEngine
@@ -1555,6 +1632,8 @@ public actor STTRuntime: STTRuntimeProtocol {
             .nemotronSTT
         case .whisper:
             .whisperSTT
+        case .cohere:
+            .cohereSTT
         }
     }
 
@@ -1571,6 +1650,10 @@ public actor STTRuntime: STTRuntimeProtocol {
             nemotronModelVariant.rawValue
         case .whisper:
             whisperModelVariant
+        case .cohere:
+            // Surface the active compute policy (ane/gpu) so model-load
+            // telemetry can compare the two backends' load/latency posture.
+            CohereTranscribeEngine.ComputePolicy.current(defaults: defaults).rawValue
         }
     }
 
@@ -1582,6 +1665,8 @@ public actor STTRuntime: STTRuntimeProtocol {
             SpeechEnginePreference.nemotronDefaultLanguage(defaults: defaults)
         case .whisper:
             SpeechEnginePreference.whisperDefaultLanguage(defaults: defaults)
+        case .cohere:
+            SpeechEnginePreference.cohereDefaultLanguage(defaults: defaults)
         }
     }
 

--- a/Sources/MacParakeetCore/STT/STTScheduler.swift
+++ b/Sources/MacParakeetCore/STT/STTScheduler.swift
@@ -21,17 +21,24 @@ public enum STTSchedulerError: Error, LocalizedError, Equatable {
 ///
 /// Jobs execute independently per slot so dictation can remain responsive while
 /// meeting and file work share an explicitly prioritized background path.
-public actor STTScheduler: STTManaging, STTDictationPreviewTranscribing, SpeechEngineRoutedTranscribing, STTLiveDictationTranscribing, SpeechEngineSwitching, SpeechEngineSwitchAvailabilityProviding, SpeechEngineSessionManaging {
+public actor STTScheduler: STTManaging, STTDictationPreviewTranscribing, SpeechEngineRoutedTranscribing,
+    STTLiveDictationTranscribing, SpeechEngineSwitching, SpeechEngineSwitchAvailabilityProviding,
+    SpeechEngineSessionManaging
+{
     private struct ScheduledJob: Sendable {
         let id: UUID
         let audioPath: String
         let job: STTJobKind
-        let speechEngine: SpeechEngineSelection?
+        let speechEngine: SpeechEngineSelection
         let enqueueOrder: UInt64
         let onProgress: (@Sendable (Int, Int) -> Void)?
 
         var slot: SchedulerSlot {
             SchedulerSlot(job: job)
+        }
+
+        var serialResource: SchedulerSerialResource? {
+            speechEngine.engine == .cohere ? .cohere : nil
         }
     }
 
@@ -73,6 +80,7 @@ public actor STTScheduler: STTManaging, STTDictationPreviewTranscribing, SpeechE
     )
     private var cancelledJobIDs: Set<UUID> = []
     private var acceptsNewJobs = true
+    private var pendingJobAdmissionCount = 0
     private var activeSpeechEngineSessionIDs: Set<UUID> = []
     private var speechEngineSwitchTask: Task<Void, Error>?
     private var dictationPreviewExecution: DictationPreviewExecution?
@@ -125,16 +133,27 @@ public actor STTScheduler: STTManaging, STTDictationPreviewTranscribing, SpeechE
         job: STTJobKind,
         onProgress: (@Sendable (Int, Int) -> Void)? = nil
     ) async throws -> STTResult {
+        try Task.checkCancellation()
         let id = UUID()
+        pendingJobAdmissionCount += 1
+        var admissionOpen = true
+        defer {
+            if admissionOpen {
+                pendingJobAdmissionCount -= 1
+            }
+        }
+        let selection = await runtime.currentSpeechEngineSelection()
         try Task.checkCancellation()
         return try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { continuation in
+                admissionOpen = false
+                pendingJobAdmissionCount -= 1
                 enqueue(
                     ScheduledJob(
                         id: id,
                         audioPath: audioPath,
                         job: job,
-                        speechEngine: nil,
+                        speechEngine: selection,
                         enqueueOrder: nextEnqueueOrder(),
                         onProgress: onProgress
                     ),
@@ -191,7 +210,8 @@ public actor STTScheduler: STTManaging, STTDictationPreviewTranscribing, SpeechE
         }
         let interactiveState = slotState(for: .interactive)
         guard interactiveState.currentJob == nil,
-              interactiveState.pendingJobs.isEmpty else {
+            interactiveState.pendingJobs.isEmpty
+        else {
             throw STTError.engineBusy
         }
 
@@ -340,9 +360,10 @@ public actor STTScheduler: STTManaging, STTDictationPreviewTranscribing, SpeechE
             throw STTError.engineBusy
         }
         guard acceptsNewJobs,
-              activeSpeechEngineSessionIDs.isEmpty,
-              !hasQueuedOrRunningJobs,
-              speechEngineSwitchTask == nil else {
+            activeSpeechEngineSessionIDs.isEmpty,
+            !hasQueuedOrRunningJobs,
+            speechEngineSwitchTask == nil
+        else {
             throw STTError.engineBusy
         }
 
@@ -374,9 +395,10 @@ public actor STTScheduler: STTManaging, STTDictationPreviewTranscribing, SpeechE
         // Shares the engine-switch guard + task slot: a variant swap reloads the
         // model and must not race transcription, meetings, or an engine switch.
         guard acceptsNewJobs,
-              activeSpeechEngineSessionIDs.isEmpty,
-              !hasQueuedOrRunningJobs,
-              speechEngineSwitchTask == nil else {
+            activeSpeechEngineSessionIDs.isEmpty,
+            !hasQueuedOrRunningJobs,
+            speechEngineSwitchTask == nil
+        else {
             throw STTError.engineBusy
         }
 
@@ -408,9 +430,10 @@ public actor STTScheduler: STTManaging, STTDictationPreviewTranscribing, SpeechE
         // Shares the engine-switch guard + task slot: a variant swap reloads the
         // model and must not race transcription, meetings, or an engine switch.
         guard acceptsNewJobs,
-              activeSpeechEngineSessionIDs.isEmpty,
-              !hasQueuedOrRunningJobs,
-              speechEngineSwitchTask == nil else {
+            activeSpeechEngineSessionIDs.isEmpty,
+            !hasQueuedOrRunningJobs,
+            speechEngineSwitchTask == nil
+        else {
             throw STTError.engineBusy
         }
 
@@ -464,7 +487,9 @@ public actor STTScheduler: STTManaging, STTDictationPreviewTranscribing, SpeechE
         if let speechEngineSwitchTask {
             let result = await speechEngineSwitchTask.result
             if case .failure(let error) = result {
-                logger.warning("Proceeding with speech engine session after failed engine switch: \(error.localizedDescription, privacy: .public)")
+                logger.warning(
+                    "Proceeding with speech engine session after failed engine switch: \(error.localizedDescription, privacy: .public)"
+                )
             }
         }
         return SpeechEngineLease(id: sessionID, selection: await runtime.currentSpeechEngineSelection())
@@ -497,8 +522,9 @@ public actor STTScheduler: STTManaging, STTDictationPreviewTranscribing, SpeechE
         var currentSlotState = slotState(for: job.slot)
 
         if job.job == .meetingLiveChunk,
-           pendingMeetingLiveJobCount(in: currentSlotState) >= meetingLiveChunkBacklogLimit,
-           let droppedJob = dropOldestPendingMeetingLiveJob(in: &currentSlotState) {
+            pendingMeetingLiveJobCount(in: currentSlotState) >= meetingLiveChunkBacklogLimit,
+            let droppedJob = dropOldestPendingMeetingLiveJob(in: &currentSlotState)
+        {
             logger.notice(
                 "stt_backpressure drop_pending_meeting_live_chunk id=\(droppedJob.id.uuidString, privacy: .public)"
             )
@@ -509,7 +535,7 @@ public actor STTScheduler: STTManaging, STTDictationPreviewTranscribing, SpeechE
 
         currentSlotState.pendingJobs.append(job)
         setSlotState(currentSlotState, for: job.slot)
-        startNextJobIfNeeded(in: job.slot)
+        startNextJobsIfNeeded()
     }
 
     private func nextEnqueueOrder() -> UInt64 {
@@ -526,9 +552,10 @@ public actor STTScheduler: STTManaging, STTDictationPreviewTranscribing, SpeechE
     }
 
     private var hasQueuedOrRunningJobs: Bool {
-        liveDictationSession != nil || slotStates.values.contains { state in
-            state.currentJob != nil || !state.pendingJobs.isEmpty
-        }
+        pendingJobAdmissionCount > 0 || liveDictationSession != nil
+            || slotStates.values.contains { state in
+                state.currentJob != nil || !state.pendingJobs.isEmpty
+            }
     }
 
     private func pendingMeetingLiveJobCount(in slotState: SlotState) -> Int {
@@ -540,10 +567,12 @@ public actor STTScheduler: STTManaging, STTDictationPreviewTranscribing, SpeechE
     }
 
     private func dropOldestPendingMeetingLiveJob(in slotState: inout SlotState) -> ScheduledJob? {
-        guard let index = slotState.pendingJobs.enumerated()
-            .filter({ $0.element.job == .meetingLiveChunk })
-            .min(by: { $0.element.enqueueOrder < $1.element.enqueueOrder })?
-            .offset else {
+        guard
+            let index = slotState.pendingJobs.enumerated()
+                .filter({ $0.element.job == .meetingLiveChunk })
+                .min(by: { $0.element.enqueueOrder < $1.element.enqueueOrder })?
+                .offset
+        else {
             return nil
         }
         return slotState.pendingJobs.remove(at: index)
@@ -559,16 +588,12 @@ public actor STTScheduler: STTManaging, STTDictationPreviewTranscribing, SpeechE
 
         currentSlotState.currentJob = next
         currentSlotState.currentExecutionTask = Task {
-            if let speechEngine = next.speechEngine {
-                try await runtime.transcribe(
-                    audioPath: next.audioPath,
-                    job: next.job,
-                    speechEngine: speechEngine,
-                    onProgress: next.onProgress
-                )
-            } else {
-                try await runtime.transcribe(audioPath: next.audioPath, job: next.job, onProgress: next.onProgress)
-            }
+            try await runtime.transcribe(
+                audioPath: next.audioPath,
+                job: next.job,
+                speechEngine: next.speechEngine,
+                onProgress: next.onProgress
+            )
         }
         currentSlotState.currentWaitTask = Task { [weak self] in
             await self?.awaitCurrentJobCompletion(jobID: next.id, in: slot)
@@ -576,18 +601,35 @@ public actor STTScheduler: STTManaging, STTDictationPreviewTranscribing, SpeechE
         setSlotState(currentSlotState, for: slot)
     }
 
+    private func startNextJobsIfNeeded() {
+        for slot in SchedulerSlot.allCases {
+            startNextJobIfNeeded(in: slot)
+        }
+    }
+
     private func dequeueNextJob(in slotState: inout SlotState) -> ScheduledJob? {
-        guard let index = slotState.pendingJobs.indices.min(by: { lhs, rhs in
-            let left = slotState.pendingJobs[lhs]
-            let right = slotState.pendingJobs[rhs]
-            if left.job.priorityRank != right.job.priorityRank {
-                return left.job.priorityRank < right.job.priorityRank
-            }
-            return left.enqueueOrder < right.enqueueOrder
-        }) else {
+        guard
+            let index = slotState.pendingJobs.indices
+                .filter({ !isSerialResourceBusy(for: slotState.pendingJobs[$0]) })
+                .min(by: { lhs, rhs in
+                    let left = slotState.pendingJobs[lhs]
+                    let right = slotState.pendingJobs[rhs]
+                    if left.job.priorityRank != right.job.priorityRank {
+                        return left.job.priorityRank < right.job.priorityRank
+                    }
+                    return left.enqueueOrder < right.enqueueOrder
+                })
+        else {
             return nil
         }
         return slotState.pendingJobs.remove(at: index)
+    }
+
+    private func isSerialResourceBusy(for job: ScheduledJob) -> Bool {
+        guard let resource = job.serialResource else { return false }
+        return slotStates.values.contains { state in
+            state.currentJob?.serialResource == resource
+        }
     }
 
     private func awaitCurrentJobCompletion(jobID: UUID, in slot: SchedulerSlot) async {
@@ -622,7 +664,7 @@ public actor STTScheduler: STTManaging, STTDictationPreviewTranscribing, SpeechE
             continuation?.resume(throwing: error)
         }
 
-        startNextJobIfNeeded(in: slot)
+        startNextJobsIfNeeded()
     }
 
     private func cancel(jobID: UUID) {
@@ -802,6 +844,10 @@ private enum SchedulerSlot: CaseIterable, Sendable {
             self = .background
         }
     }
+}
+
+private enum SchedulerSerialResource: Sendable {
+    case cohere
 }
 
 private extension STTJobKind {

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
@@ -1016,7 +1016,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
             }
         }
 
-        guard currentSession?.supportsLiveChunkTranscription != false else { return }
+        guard let session = currentSession, session.supportsLiveChunkTranscription else { return }
 
         for chunk in output.chunks {
             switch chunk.source {

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
@@ -118,6 +118,10 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         let systemAudioURL: URL
         let mixedAudioURL: URL
         let speechEngine: SpeechEngineSelection
+
+        var supportsLiveChunkTranscription: Bool {
+            speechEngine.engine != .cohere
+        }
     }
 
     private struct HostTimeRange: Sendable {
@@ -1011,6 +1015,8 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
                 updateProcessedMicrophoneRms(with: processedMicRms)
             }
         }
+
+        guard currentSession?.supportsLiveChunkTranscription != false else { return }
 
         for chunk in output.chunks {
             switch chunk.source {

--- a/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
+++ b/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
@@ -211,6 +211,7 @@ public enum TelemetryModelKind: String, Sendable, Equatable {
     case parakeetSTT = "parakeet_stt"
     case nemotronSTT = "nemotron_stt"
     case whisperSTT = "whisper_stt"
+    case cohereSTT = "cohere_stt"
     case speakerDiarization = "speaker_diarization"
     case localSpeechStack = "local_speech_stack"
 }

--- a/Sources/MacParakeetCore/SpeechEnginePreference.swift
+++ b/Sources/MacParakeetCore/SpeechEnginePreference.swift
@@ -99,16 +99,20 @@ public enum SpeechEnginePreference: String, CaseIterable, Codable, Sendable {
         defaults.set(normalized, forKey: cohereDefaultLanguageKey)
     }
 
-    /// Cohere language codes are simple primary subtags ("en", "zh"). Fold any
-    /// BCP-47-ish input down to its lowercased primary subtag; the engine maps
-    /// unknown codes to English.
+    /// Cohere language codes are simple supported primary subtags ("en", "zh").
+    /// Fold any BCP-47-ish input down to its lowercased primary subtag and drop
+    /// unsupported values so manual defaults edits cannot leak stale picker
+    /// state into the runtime.
     public static func normalizeCohereLanguage(_ language: String?) -> String? {
         guard let language else { return nil }
         let trimmed = language.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         guard !trimmed.isEmpty, trimmed != "auto" else { return nil }
         let primary = trimmed.replacingOccurrences(of: "_", with: "-")
             .split(separator: "-").first.map(String.init) ?? trimmed
-        guard (2...3).contains(primary.count), primary.allSatisfy(\.isLetter) else { return nil }
+        guard primary.count == 2, primary.allSatisfy(\.isLetter) else { return nil }
+        guard CohereTranscribeEngine.supportedLanguages.contains(where: { $0.code == primary }) else {
+            return nil
+        }
         return primary
     }
 

--- a/Sources/MacParakeetCore/SpeechEnginePreference.swift
+++ b/Sources/MacParakeetCore/SpeechEnginePreference.swift
@@ -4,6 +4,10 @@ public enum SpeechEnginePreference: String, CaseIterable, Codable, Sendable {
     case parakeet
     case nemotron
     case whisper
+    /// Cohere Transcribe (03-2026) via FluidAudio's `CoherePipeline`, on-device
+    /// Core ML. A batch, dictation-oriented engine (no live partials, no word
+    /// timestamps); see ``CohereTranscribeEngine``.
+    case cohere
 
     public static let defaultsKey = "speechRecognitionEngine"
     public static let parakeetModelVariantKey = "parakeetModelVariant"
@@ -11,6 +15,10 @@ public enum SpeechEnginePreference: String, CaseIterable, Codable, Sendable {
     public static let nemotronDefaultLanguageKey = "nemotronDefaultLanguage"
     public static let whisperDefaultLanguageKey = "whisperDefaultLanguage"
     public static let whisperModelVariantKey = "whisperModelVariant"
+    /// Cohere has no auto language detection — the user picks one of its 14
+    /// supported languages (default English). Stored as a primary subtag ("en",
+    /// "fr", …); the engine maps it to `CohereAsrConfig.Language`.
+    public static let cohereDefaultLanguageKey = "cohereDefaultLanguage"
 
     /// New users stay on the multilingual `v3` build — it "works for everyone".
     /// `v2` (English-only) is surfaced as a clearly-labeled opt-in.
@@ -35,6 +43,8 @@ public enum SpeechEnginePreference: String, CaseIterable, Codable, Sendable {
             "Nemotron"
         case .whisper:
             "Whisper"
+        case .cohere:
+            "Cohere"
         }
     }
 
@@ -45,6 +55,8 @@ public enum SpeechEnginePreference: String, CaseIterable, Codable, Sendable {
         case .nemotron:
             .whisper
         case .whisper:
+            .parakeet
+        case .cohere:
             .parakeet
         }
     }
@@ -71,6 +83,33 @@ public enum SpeechEnginePreference: String, CaseIterable, Codable, Sendable {
             return
         }
         defaults.set(normalized, forKey: whisperDefaultLanguageKey)
+    }
+
+    /// The persisted Cohere dictation language, as a primary subtag ("en",
+    /// "fr", …). `nil` means none chosen yet → the engine defaults to English.
+    public static func cohereDefaultLanguage(defaults: UserDefaults = .standard) -> String? {
+        normalizeCohereLanguage(defaults.string(forKey: cohereDefaultLanguageKey))
+    }
+
+    public static func saveCohereDefaultLanguage(_ language: String?, defaults: UserDefaults = .standard) {
+        guard let normalized = normalizeCohereLanguage(language) else {
+            defaults.removeObject(forKey: cohereDefaultLanguageKey)
+            return
+        }
+        defaults.set(normalized, forKey: cohereDefaultLanguageKey)
+    }
+
+    /// Cohere language codes are simple primary subtags ("en", "zh"). Fold any
+    /// BCP-47-ish input down to its lowercased primary subtag; the engine maps
+    /// unknown codes to English.
+    public static func normalizeCohereLanguage(_ language: String?) -> String? {
+        guard let language else { return nil }
+        let trimmed = language.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !trimmed.isEmpty, trimmed != "auto" else { return nil }
+        let primary = trimmed.replacingOccurrences(of: "_", with: "-")
+            .split(separator: "-").first.map(String.init) ?? trimmed
+        guard (2...3).contains(primary.count), primary.allSatisfy(\.isLetter) else { return nil }
+        return primary
     }
 
     public static func nemotronDefaultLanguage(defaults: UserDefaults = .standard) -> String? {
@@ -449,6 +488,10 @@ public struct SpeechEngineSelection: Codable, Equatable, Sendable {
             SpeechEnginePreference.normalizeNemotronLanguage(language)
         case .whisper:
             SpeechEnginePreference.normalizeLanguage(language)
+        case .cohere:
+            // Cohere uses simple language subtags ("en", "fr", …); the engine
+            // maps the primary subtag to a supported language (English default).
+            SpeechEnginePreference.normalizeCohereLanguage(language)
         }
     }
 
@@ -461,6 +504,8 @@ public struct SpeechEngineSelection: Codable, Equatable, Sendable {
             SpeechEnginePreference.nemotronDefaultLanguage(defaults: defaults)
         case .whisper:
             SpeechEnginePreference.whisperDefaultLanguage(defaults: defaults)
+        case .cohere:
+            SpeechEnginePreference.cohereDefaultLanguage(defaults: defaults)
         }
         return SpeechEngineSelection(engine: engine, language: language)
     }

--- a/Sources/MacParakeetViewModels/EngineSettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/EngineSettingsViewModel.swift
@@ -75,6 +75,7 @@ public final class EngineSettingsViewModel {
     public var cohereModelStatus: LocalModelStatus = .unknown
     public var cohereModelStatusDetail: String = "Not checked yet."
     public var cohereDownloading = false
+    public var cohereCacheDirectoryExists = false
     public var isNemotronModelAvailable: Bool {
         nemotronModelStatus == .ready || nemotronModelStatus == .notLoaded
     }
@@ -83,6 +84,9 @@ public final class EngineSettingsViewModel {
     }
     public var isCohereModelDownloaded: Bool {
         cohereModelStatus == .ready || cohereModelStatus == .notLoaded
+    }
+    public var canDeleteCohereModel: Bool {
+        isCohereModelDownloaded || cohereModelStatus == .failed || cohereCacheDirectoryExists
     }
     /// True once the active Whisper variant has paid its one-time on-device
     /// optimize, so the next load is fast. Drives cold ("Setup needed",
@@ -114,6 +118,7 @@ public final class EngineSettingsViewModel {
     private let parakeetModelVariantCached: @Sendable (ParakeetModelVariant) -> Bool
     private let nemotronModelVariantCached: @Sendable (NemotronModelVariant, String?) -> Bool
     private let cohereModelCached: @Sendable () -> Bool
+    private let cohereModelCacheDirectoryExistsOnDisk: @Sendable () -> Bool
     private let deleteParakeetModelOnDisk: @Sendable (ParakeetModelVariant) -> Bool
     private let deleteNemotronModelOnDisk: @Sendable (NemotronModelVariant, String?) -> Bool
     private let deleteWhisperModelOnDisk: @Sendable (String) -> Bool
@@ -136,6 +141,9 @@ public final class EngineSettingsViewModel {
         cohereModelCached: @escaping @Sendable () -> Bool = {
             CohereTranscribeEngine.isModelCached()
         },
+        cohereModelCacheDirectoryExists: @escaping @Sendable () -> Bool = {
+            CohereTranscribeEngine.hasModelCacheDirectory()
+        },
         deleteParakeetModelOnDisk: @escaping @Sendable (ParakeetModelVariant) -> Bool = {
             if $0.usesUnifiedEngine { return ParakeetUnifiedEngine.deleteModel() }
             guard let version = $0.asrModelVersion else { return false }
@@ -155,6 +163,7 @@ public final class EngineSettingsViewModel {
         self.parakeetModelVariantCached = parakeetModelVariantCached
         self.nemotronModelVariantCached = nemotronModelVariantCached
         self.cohereModelCached = cohereModelCached
+        self.cohereModelCacheDirectoryExistsOnDisk = cohereModelCacheDirectoryExists
         self.deleteParakeetModelOnDisk = deleteParakeetModelOnDisk
         self.deleteNemotronModelOnDisk = deleteNemotronModelOnDisk
         self.deleteWhisperModelOnDisk = deleteWhisperModelOnDisk
@@ -250,6 +259,7 @@ public final class EngineSettingsViewModel {
         let parakeetModelVariantCached = self.parakeetModelVariantCached
         let nemotronModelVariantCached = self.nemotronModelVariantCached
         let cohereModelCached = self.cohereModelCached
+        let cohereModelCacheDirectoryExistsOnDisk = self.cohereModelCacheDirectoryExistsOnDisk
 
         guard let sttClient else {
             parakeetStatus = .unknown
@@ -268,7 +278,8 @@ public final class EngineSettingsViewModel {
                             nemotronModelVariantCached($0, nemotronLanguage)
                         }),
                         whisperDownloaded: WhisperEngine.isModelDownloaded(model: whisperModelVariant),
-                        cohereDownloaded: cohereModelCached()
+                        cohereDownloaded: cohereModelCached(),
+                        cohereCacheDirectoryExists: cohereModelCacheDirectoryExistsOnDisk()
                     )
                 }.value
                 guard let self,
@@ -280,6 +291,7 @@ public final class EngineSettingsViewModel {
                 }
                 self.downloadedParakeetVariants = disk.parakeetDownloaded
                 self.downloadedNemotronVariants = disk.nemotronDownloaded
+                self.cohereCacheDirectoryExists = disk.cohereCacheDirectoryExists
                 self.applyNemotronDownloadedStatus(disk.nemotronDownloaded.contains(activeNemotronVariant))
                 self.applyWhisperDownloadedStatus(disk.whisperDownloaded)
                 self.applyCohereDownloadedStatus(disk.cohereDownloaded)
@@ -315,7 +327,8 @@ public final class EngineSettingsViewModel {
                         nemotronModelVariantCached($0, nemotronLanguage)
                     }),
                     whisperDownloaded: WhisperEngine.isModelDownloaded(model: whisperModelVariant),
-                    cohereDownloaded: cohereModelCached()
+                    cohereDownloaded: cohereModelCached(),
+                    cohereCacheDirectoryExists: cohereModelCacheDirectoryExistsOnDisk()
                 )
             }.value
 
@@ -329,6 +342,7 @@ public final class EngineSettingsViewModel {
 
             self.downloadedParakeetVariants = modelDiskState.parakeetDownloaded
             self.downloadedNemotronVariants = modelDiskState.nemotronDownloaded
+            self.cohereCacheDirectoryExists = modelDiskState.cohereCacheDirectoryExists
             let parakeetName = activeVariant.modelName
             if activeEngine == .parakeet, activeEngineIsLoaded {
                 self.parakeetStatus = .ready
@@ -1163,9 +1177,10 @@ public final class EngineSettingsViewModel {
         // Protect the in-use engine's model; deleting it would force a silent
         // re-download the next time the active runtime prepares.
         guard speechEnginePreference != .cohere else { return }
-        guard isCohereModelDownloaded else { return }
+        guard canDeleteCohereModel else { return }
 
         modelStatusRefreshGeneration += 1
+        cohereCacheDirectoryExists = false
         applyCohereDownloadedStatus(false)
         let deleter = deleteCohereModelOnDisk
         Task { @MainActor [weak self] in

--- a/Sources/MacParakeetViewModels/EngineSettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/EngineSettingsViewModel.swift
@@ -117,6 +117,7 @@ public final class EngineSettingsViewModel {
     private let deleteParakeetModelOnDisk: @Sendable (ParakeetModelVariant) -> Bool
     private let deleteNemotronModelOnDisk: @Sendable (NemotronModelVariant, String?) -> Bool
     private let deleteWhisperModelOnDisk: @Sendable (String) -> Bool
+    private let deleteCohereModelOnDisk: @Sendable () -> Bool
     private var isApplyingSpeechEngineState = false
     private var isApplyingParakeetVariantState = false
     private var isApplyingNemotronVariantState = false
@@ -145,6 +146,9 @@ public final class EngineSettingsViewModel {
         },
         deleteWhisperModelOnDisk: @escaping @Sendable (String) -> Bool = {
             STTRuntime.deleteWhisperModel(variant: $0)
+        },
+        deleteCohereModelOnDisk: @escaping @Sendable () -> Bool = {
+            CohereTranscribeEngine.deleteModel()
         }
     ) {
         self.defaults = defaults
@@ -154,6 +158,7 @@ public final class EngineSettingsViewModel {
         self.deleteParakeetModelOnDisk = deleteParakeetModelOnDisk
         self.deleteNemotronModelOnDisk = deleteNemotronModelOnDisk
         self.deleteWhisperModelOnDisk = deleteWhisperModelOnDisk
+        self.deleteCohereModelOnDisk = deleteCohereModelOnDisk
         speechEnginePreference = SpeechEnginePreference.current(defaults: defaults)
         parakeetModelVariant = SpeechEnginePreference.parakeetModelVariant(defaults: defaults)
         nemotronModelVariant = SpeechEnginePreference.nemotronModelVariant(defaults: defaults)
@@ -1162,9 +1167,10 @@ public final class EngineSettingsViewModel {
 
         modelStatusRefreshGeneration += 1
         applyCohereDownloadedStatus(false)
+        let deleter = deleteCohereModelOnDisk
         Task { @MainActor [weak self] in
             await Task.detached(priority: .userInitiated) {
-                _ = CohereTranscribeEngine.deleteModel()
+                _ = deleter()
             }.value
             guard let self else { return }
             self.refreshModelStatus()

--- a/Sources/MacParakeetViewModels/EngineSettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/EngineSettingsViewModel.swift
@@ -87,8 +87,10 @@ public final class EngineSettingsViewModel {
     }
     private var shouldBlockCohereSwitchForModelStatus: Bool {
         switch cohereModelStatus {
-        case .ready, .notLoaded, .checking:
+        case .ready, .notLoaded:
             return false
+        case .checking:
+            return !cohereModelCached()
         case .unknown, .notDownloaded, .preparing, .repairing, .failed:
             return true
         }

--- a/Sources/MacParakeetViewModels/EngineSettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/EngineSettingsViewModel.swift
@@ -279,8 +279,10 @@ public final class EngineSettingsViewModel {
             nemotronModelStatusDetail = "Checking model state..."
             whisperModelStatus = .checking
             whisperModelStatusDetail = "Checking model state..."
-            cohereModelStatus = .checking
-            cohereModelStatusDetail = "Checking model state..."
+            if !cohereDownloading, !cohereDeleting {
+                cohereModelStatus = .checking
+                cohereModelStatusDetail = "Checking model state..."
+            }
             Task { @MainActor [weak self] in
                 let disk = await Task.detached(priority: .userInitiated) {
                     (
@@ -302,10 +304,14 @@ public final class EngineSettingsViewModel {
                 }
                 self.downloadedParakeetVariants = disk.parakeetDownloaded
                 self.downloadedNemotronVariants = disk.nemotronDownloaded
-                self.cohereCacheDirectoryExists = disk.cohereCacheDirectoryExists
+                if !self.cohereDownloading, !self.cohereDeleting {
+                    self.cohereCacheDirectoryExists = disk.cohereCacheDirectoryExists
+                }
                 self.applyNemotronDownloadedStatus(disk.nemotronDownloaded.contains(activeNemotronVariant))
                 self.applyWhisperDownloadedStatus(disk.whisperDownloaded)
-                self.applyCohereDownloadedStatus(disk.cohereDownloaded)
+                if !self.cohereDownloading, !self.cohereDeleting {
+                    self.applyCohereDownloadedStatus(disk.cohereDownloaded)
+                }
             }
             return
         }
@@ -316,8 +322,10 @@ public final class EngineSettingsViewModel {
         nemotronModelStatusDetail = "Checking model state..."
         whisperModelStatus = .checking
         whisperModelStatusDetail = "Checking model state..."
-        cohereModelStatus = .checking
-        cohereModelStatusDetail = "Checking model state..."
+        if !cohereDownloading, !cohereDeleting {
+            cohereModelStatus = .checking
+            cohereModelStatusDetail = "Checking model state..."
+        }
 
         Task { @MainActor [weak self] in
             guard let self else { return }
@@ -353,7 +361,9 @@ public final class EngineSettingsViewModel {
 
             self.downloadedParakeetVariants = modelDiskState.parakeetDownloaded
             self.downloadedNemotronVariants = modelDiskState.nemotronDownloaded
-            self.cohereCacheDirectoryExists = modelDiskState.cohereCacheDirectoryExists
+            if !self.cohereDownloading, !self.cohereDeleting {
+                self.cohereCacheDirectoryExists = modelDiskState.cohereCacheDirectoryExists
+            }
             let parakeetName = activeVariant.modelName
             if activeEngine == .parakeet, activeEngineIsLoaded {
                 self.parakeetStatus = .ready
@@ -383,7 +393,7 @@ public final class EngineSettingsViewModel {
             if activeEngine == .cohere, activeEngineIsLoaded {
                 self.cohereModelStatus = .ready
                 self.cohereModelStatusDetail = "Cohere Transcribe · Loaded in memory."
-            } else {
+            } else if !self.cohereDownloading, !self.cohereDeleting {
                 self.applyCohereDownloadedStatus(modelDiskState.cohereDownloaded)
             }
         }

--- a/Sources/MacParakeetViewModels/EngineSettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/EngineSettingsViewModel.swift
@@ -74,6 +74,7 @@ public final class EngineSettingsViewModel {
     public var nemotronDownloading = false
     public var cohereModelStatus: LocalModelStatus = .unknown
     public var cohereModelStatusDetail: String = "Not checked yet."
+    public var cohereDownloading = false
     public var isNemotronModelAvailable: Bool {
         nemotronModelStatus == .ready || nemotronModelStatus == .notLoaded
     }
@@ -610,6 +611,94 @@ public final class EngineSettingsViewModel {
         }
     }
 
+    public func downloadCohereModel() {
+        guard !speechEngineSwitching else { return }
+        guard !cohereDownloading else { return }
+        speechEngineError = nil
+        cohereDownloading = true
+        cohereModelStatus = .repairing
+        cohereModelStatusDetail = "Downloading Cohere Transcribe..."
+        let operationContext = Observability.childOperationContext()
+        let engineVariant = CohereTranscribeEngine.ComputePolicy.current(defaults: defaults).rawValue
+        Telemetry.send(.modelDownloadStarted(
+            modelKind: .cohereSTT,
+            speechEngine: .cohere,
+            engineVariant: engineVariant
+        ))
+
+        Task {
+            do {
+                _ = try await CohereTranscribeEngine.downloadModel { message in
+                    Task { @MainActor [weak self] in
+                        self?.cohereModelStatusDetail = message
+                    }
+                }
+                let durationSeconds = Observability.durationSeconds(since: operationContext.startedAt)
+                Telemetry.send(.modelDownloadCompleted(
+                    durationSeconds: durationSeconds,
+                    modelKind: .cohereSTT,
+                    speechEngine: .cohere,
+                    engineVariant: engineVariant
+                ))
+                Telemetry.send(.modelOperation(
+                    operationID: operationContext.operationID,
+                    operationContext: operationContext,
+                    action: .download,
+                    outcome: .success,
+                    stage: .download,
+                    modelKind: .cohereSTT,
+                    speechEngine: .cohere,
+                    engineVariant: engineVariant,
+                    durationSeconds: durationSeconds,
+                    errorType: nil
+                ))
+                self.cohereDownloading = false
+                self.refreshModelStatus()
+            } catch is CancellationError {
+                let durationSeconds = Observability.durationSeconds(since: operationContext.startedAt)
+                Telemetry.send(.modelOperation(
+                    operationID: operationContext.operationID,
+                    operationContext: operationContext,
+                    action: .download,
+                    outcome: .cancelled,
+                    stage: .download,
+                    modelKind: .cohereSTT,
+                    speechEngine: .cohere,
+                    engineVariant: engineVariant,
+                    durationSeconds: durationSeconds,
+                    errorType: "CancellationError"
+                ))
+                self.cohereDownloading = false
+                self.refreshModelStatus()
+            } catch {
+                let durationSeconds = Observability.durationSeconds(since: operationContext.startedAt)
+                let errorType = TelemetryErrorClassifier.classify(error)
+                Telemetry.send(.modelDownloadFailed(
+                    errorType: errorType,
+                    errorDetail: TelemetryErrorClassifier.errorDetail(error),
+                    modelKind: .cohereSTT,
+                    speechEngine: .cohere,
+                    engineVariant: engineVariant
+                ))
+                Telemetry.send(.modelOperation(
+                    operationID: operationContext.operationID,
+                    operationContext: operationContext,
+                    action: .download,
+                    outcome: .failure,
+                    stage: .download,
+                    modelKind: .cohereSTT,
+                    speechEngine: .cohere,
+                    engineVariant: engineVariant,
+                    durationSeconds: durationSeconds,
+                    errorType: errorType
+                ))
+                self.cohereDownloading = false
+                self.cohereModelStatus = .failed
+                self.cohereModelStatusDetail = error.localizedDescription
+            }
+        }
+    }
+
     private func applySpeechEngineChange(_ preference: SpeechEnginePreference) {
         speechEngineError = nil
         let previousPreference = SpeechEnginePreference.current(defaults: defaults)
@@ -637,6 +726,25 @@ public final class EngineSettingsViewModel {
 
         if preference == .whisper && !isWhisperModelDownloaded {
             speechEngineError = "Download the Whisper model before switching engines."
+            Telemetry.send(.speechEngineSwitchOperation(
+                operationID: operationContext.operationID,
+                operationContext: operationContext,
+                fromEngine: previousPreference,
+                toEngine: preference,
+                outcome: .unavailable,
+                durationSeconds: Observability.durationSeconds(since: operationContext.startedAt),
+                blockedReason: .modelNotDownloaded,
+                errorType: "model_not_downloaded",
+                wasCold: switchWasCold
+            ))
+            isApplyingSpeechEngineState = true
+            speechEnginePreference = previousPreference
+            isApplyingSpeechEngineState = false
+            return
+        }
+
+        if preference == .cohere && !isCohereModelDownloaded {
+            speechEngineError = "Download Cohere Transcribe before switching engines."
             Telemetry.send(.speechEngineSwitchOperation(
                 operationID: operationContext.operationID,
                 operationContext: operationContext,
@@ -1039,6 +1147,24 @@ public final class EngineSettingsViewModel {
         Task { @MainActor [weak self] in
             await Task.detached(priority: .userInitiated) {
                 _ = deleter(variant)
+            }.value
+            guard let self else { return }
+            self.refreshModelStatus()
+        }
+    }
+
+    public func deleteCohereModel() {
+        guard !speechEngineSwitching, !cohereDownloading else { return }
+        // Protect the in-use engine's model; deleting it would force a silent
+        // re-download the next time the active runtime prepares.
+        guard speechEnginePreference != .cohere else { return }
+        guard isCohereModelDownloaded else { return }
+
+        modelStatusRefreshGeneration += 1
+        applyCohereDownloadedStatus(false)
+        Task { @MainActor [weak self] in
+            await Task.detached(priority: .userInitiated) {
+                _ = CohereTranscribeEngine.deleteModel()
             }.value
             guard let self else { return }
             self.refreshModelStatus()

--- a/Sources/MacParakeetViewModels/EngineSettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/EngineSettingsViewModel.swift
@@ -647,7 +647,7 @@ public final class EngineSettingsViewModel {
 
         Task {
             do {
-                _ = try await CohereTranscribeEngine.downloadModel { message in
+                _ = try await CohereTranscribeEngine.downloadModel { [weak self] message in
                     Task { @MainActor [weak self] in
                         self?.cohereModelStatusDetail = message
                     }

--- a/Sources/MacParakeetViewModels/EngineSettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/EngineSettingsViewModel.swift
@@ -72,11 +72,16 @@ public final class EngineSettingsViewModel {
     public var nemotronModelStatus: LocalModelStatus = .unknown
     public var nemotronModelStatusDetail: String = "Not checked yet."
     public var nemotronDownloading = false
+    public var cohereModelStatus: LocalModelStatus = .unknown
+    public var cohereModelStatusDetail: String = "Not checked yet."
     public var isNemotronModelAvailable: Bool {
         nemotronModelStatus == .ready || nemotronModelStatus == .notLoaded
     }
     public var isWhisperModelDownloaded: Bool {
         whisperModelStatus == .ready || whisperModelStatus == .notLoaded
+    }
+    public var isCohereModelDownloaded: Bool {
+        cohereModelStatus == .ready || cohereModelStatus == .notLoaded
     }
     /// True once the active Whisper variant has paid its one-time on-device
     /// optimize, so the next load is fast. Drives cold ("Setup needed",
@@ -107,6 +112,7 @@ public final class EngineSettingsViewModel {
     private let defaults: UserDefaults
     private let parakeetModelVariantCached: @Sendable (ParakeetModelVariant) -> Bool
     private let nemotronModelVariantCached: @Sendable (NemotronModelVariant, String?) -> Bool
+    private let cohereModelCached: @Sendable () -> Bool
     private let deleteParakeetModelOnDisk: @Sendable (ParakeetModelVariant) -> Bool
     private let deleteNemotronModelOnDisk: @Sendable (NemotronModelVariant, String?) -> Bool
     private let deleteWhisperModelOnDisk: @Sendable (String) -> Bool
@@ -125,6 +131,9 @@ public final class EngineSettingsViewModel {
         nemotronModelVariantCached: @escaping @Sendable (NemotronModelVariant, String?) -> Bool = {
             STTRuntime.isNemotronModelCached(modelVariant: $0, language: $1)
         },
+        cohereModelCached: @escaping @Sendable () -> Bool = {
+            CohereTranscribeEngine.isModelCached()
+        },
         deleteParakeetModelOnDisk: @escaping @Sendable (ParakeetModelVariant) -> Bool = {
             if $0.usesUnifiedEngine { return ParakeetUnifiedEngine.deleteModel() }
             guard let version = $0.asrModelVersion else { return false }
@@ -140,6 +149,7 @@ public final class EngineSettingsViewModel {
         self.defaults = defaults
         self.parakeetModelVariantCached = parakeetModelVariantCached
         self.nemotronModelVariantCached = nemotronModelVariantCached
+        self.cohereModelCached = cohereModelCached
         self.deleteParakeetModelOnDisk = deleteParakeetModelOnDisk
         self.deleteNemotronModelOnDisk = deleteNemotronModelOnDisk
         self.deleteWhisperModelOnDisk = deleteWhisperModelOnDisk
@@ -233,6 +243,7 @@ public final class EngineSettingsViewModel {
 
         let parakeetModelVariantCached = self.parakeetModelVariantCached
         let nemotronModelVariantCached = self.nemotronModelVariantCached
+        let cohereModelCached = self.cohereModelCached
 
         guard let sttClient else {
             parakeetStatus = .unknown
@@ -241,6 +252,8 @@ public final class EngineSettingsViewModel {
             nemotronModelStatusDetail = "Checking model state..."
             whisperModelStatus = .checking
             whisperModelStatusDetail = "Checking model state..."
+            cohereModelStatus = .checking
+            cohereModelStatusDetail = "Checking model state..."
             Task { @MainActor [weak self] in
                 let disk = await Task.detached(priority: .userInitiated) {
                     (
@@ -248,7 +261,8 @@ public final class EngineSettingsViewModel {
                         nemotronDownloaded: Set(NemotronModelVariant.allCases.filter {
                             nemotronModelVariantCached($0, nemotronLanguage)
                         }),
-                        whisperDownloaded: WhisperEngine.isModelDownloaded(model: whisperModelVariant)
+                        whisperDownloaded: WhisperEngine.isModelDownloaded(model: whisperModelVariant),
+                        cohereDownloaded: cohereModelCached()
                     )
                 }.value
                 guard let self,
@@ -262,6 +276,7 @@ public final class EngineSettingsViewModel {
                 self.downloadedNemotronVariants = disk.nemotronDownloaded
                 self.applyNemotronDownloadedStatus(disk.nemotronDownloaded.contains(activeNemotronVariant))
                 self.applyWhisperDownloadedStatus(disk.whisperDownloaded)
+                self.applyCohereDownloadedStatus(disk.cohereDownloaded)
             }
             return
         }
@@ -272,6 +287,8 @@ public final class EngineSettingsViewModel {
         nemotronModelStatusDetail = "Checking model state..."
         whisperModelStatus = .checking
         whisperModelStatusDetail = "Checking model state..."
+        cohereModelStatus = .checking
+        cohereModelStatusDetail = "Checking model state..."
 
         Task { @MainActor [weak self] in
             guard let self else { return }
@@ -291,7 +308,8 @@ public final class EngineSettingsViewModel {
                     nemotronDownloaded: Set(NemotronModelVariant.allCases.filter {
                         nemotronModelVariantCached($0, nemotronLanguage)
                     }),
-                    whisperDownloaded: WhisperEngine.isModelDownloaded(model: whisperModelVariant)
+                    whisperDownloaded: WhisperEngine.isModelDownloaded(model: whisperModelVariant),
+                    cohereDownloaded: cohereModelCached()
                 )
             }.value
 
@@ -329,6 +347,13 @@ public final class EngineSettingsViewModel {
                 self.whisperModelStatusDetail = "\(self.whisperVariantFriendlyName) · Loaded in memory."
             } else {
                 self.applyWhisperDownloadedStatus(modelDiskState.whisperDownloaded)
+            }
+
+            if activeEngine == .cohere, activeEngineIsLoaded {
+                self.cohereModelStatus = .ready
+                self.cohereModelStatusDetail = "Cohere Transcribe · Loaded in memory."
+            } else {
+                self.applyCohereDownloadedStatus(modelDiskState.cohereDownloaded)
             }
         }
     }
@@ -375,6 +400,16 @@ public final class EngineSettingsViewModel {
         } else {
             whisperModelStatus = .notDownloaded
             whisperModelStatusDetail = "\(friendly) · Needs download before use."
+        }
+    }
+
+    private func applyCohereDownloadedStatus(_ isDownloaded: Bool) {
+        if isDownloaded {
+            cohereModelStatus = .notLoaded
+            cohereModelStatusDetail = "Cohere Transcribe · Installed locally, loads when selected."
+        } else {
+            cohereModelStatus = .notDownloaded
+            cohereModelStatusDetail = "Cohere Transcribe · Needs download before use."
         }
     }
 

--- a/Sources/MacParakeetViewModels/EngineSettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/EngineSettingsViewModel.swift
@@ -1059,6 +1059,8 @@ public final class EngineSettingsViewModel {
                 : "Loading Nemotron 3.5 Beta with Core ML..."
         case .whisper:
             "Optimizing Whisper for this Mac..."
+        case .cohere:
+            "Loading Cohere with Core ML..."
         }
     }
 

--- a/Sources/MacParakeetViewModels/EngineSettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/EngineSettingsViewModel.swift
@@ -75,6 +75,7 @@ public final class EngineSettingsViewModel {
     public var cohereModelStatus: LocalModelStatus = .unknown
     public var cohereModelStatusDetail: String = "Not checked yet."
     public var cohereDownloading = false
+    public var cohereDeleting = false
     public var cohereCacheDirectoryExists = false
     public var isNemotronModelAvailable: Bool {
         nemotronModelStatus == .ready || nemotronModelStatus == .notLoaded
@@ -642,7 +643,7 @@ public final class EngineSettingsViewModel {
 
     public func downloadCohereModel() {
         guard !speechEngineSwitching else { return }
-        guard !cohereDownloading else { return }
+        guard !cohereDownloading, !cohereDeleting else { return }
         speechEngineError = nil
         cohereDownloading = true
         cohereModelStatus = .repairing
@@ -1186,12 +1187,13 @@ public final class EngineSettingsViewModel {
     }
 
     public func deleteCohereModel() {
-        guard !speechEngineSwitching, !cohereDownloading else { return }
+        guard !speechEngineSwitching, !cohereDownloading, !cohereDeleting else { return }
         // Protect the in-use engine's model; deleting it would force a silent
         // re-download the next time the active runtime prepares.
         guard speechEnginePreference != .cohere else { return }
         guard canDeleteCohereModel else { return }
 
+        cohereDeleting = true
         modelStatusRefreshGeneration += 1
         cohereCacheDirectoryExists = false
         applyCohereDownloadedStatus(false)
@@ -1201,6 +1203,7 @@ public final class EngineSettingsViewModel {
                 _ = deleter()
             }.value
             guard let self else { return }
+            self.cohereDeleting = false
             self.refreshModelStatus()
         }
     }

--- a/Sources/MacParakeetViewModels/EngineSettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/EngineSettingsViewModel.swift
@@ -85,6 +85,14 @@ public final class EngineSettingsViewModel {
     public var isCohereModelDownloaded: Bool {
         cohereModelStatus == .ready || cohereModelStatus == .notLoaded
     }
+    private var shouldBlockCohereSwitchForModelStatus: Bool {
+        switch cohereModelStatus {
+        case .ready, .notLoaded, .checking:
+            return false
+        case .unknown, .notDownloaded, .preparing, .repairing, .failed:
+            return true
+        }
+    }
     public var canDeleteCohereModel: Bool {
         isCohereModelDownloaded || cohereModelStatus == .failed || cohereCacheDirectoryExists
     }
@@ -645,7 +653,7 @@ public final class EngineSettingsViewModel {
             engineVariant: engineVariant
         ))
 
-        Task {
+        Task { @MainActor [weak self] in
             do {
                 _ = try await CohereTranscribeEngine.downloadModel { [weak self] message in
                     Task { @MainActor [weak self] in
@@ -671,6 +679,7 @@ public final class EngineSettingsViewModel {
                     durationSeconds: durationSeconds,
                     errorType: nil
                 ))
+                guard let self else { return }
                 self.cohereDownloading = false
                 self.refreshModelStatus()
             } catch is CancellationError {
@@ -687,6 +696,7 @@ public final class EngineSettingsViewModel {
                     durationSeconds: durationSeconds,
                     errorType: "CancellationError"
                 ))
+                guard let self else { return }
                 self.cohereDownloading = false
                 self.refreshModelStatus()
             } catch {
@@ -711,6 +721,7 @@ public final class EngineSettingsViewModel {
                     durationSeconds: durationSeconds,
                     errorType: errorType
                 ))
+                guard let self else { return }
                 self.cohereDownloading = false
                 self.cohereModelStatus = .failed
                 self.cohereModelStatusDetail = error.localizedDescription
@@ -762,7 +773,7 @@ public final class EngineSettingsViewModel {
             return
         }
 
-        if preference == .cohere && !isCohereModelDownloaded {
+        if preference == .cohere && shouldBlockCohereSwitchForModelStatus {
             speechEngineError = "Download Cohere Transcribe before switching engines."
             Telemetry.send(.speechEngineSwitchOperation(
                 operationID: operationContext.operationID,

--- a/Sources/MacParakeetViewModels/EngineSettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/EngineSettingsViewModel.swift
@@ -87,6 +87,7 @@ public final class EngineSettingsViewModel {
         cohereModelStatus == .ready || cohereModelStatus == .notLoaded
     }
     private var shouldBlockCohereSwitchForModelStatus: Bool {
+        if cohereDeleting { return true }
         switch cohereModelStatus {
         case .ready, .notLoaded:
             return false
@@ -787,7 +788,9 @@ public final class EngineSettingsViewModel {
         }
 
         if preference == .cohere && shouldBlockCohereSwitchForModelStatus {
-            speechEngineError = "Download Cohere Transcribe before switching engines."
+            speechEngineError = cohereDeleting
+                ? "Finish deleting Cohere Transcribe before switching engines."
+                : "Download Cohere Transcribe before switching engines."
             Telemetry.send(.speechEngineSwitchOperation(
                 operationID: operationContext.operationID,
                 operationContext: operationContext,

--- a/Sources/MacParakeetViewModels/EngineSettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/EngineSettingsViewModel.swift
@@ -267,6 +267,7 @@ public final class EngineSettingsViewModel {
         let whisperModelVariant = SpeechEnginePreference.whisperModelVariant(defaults: defaults)
         let activeNemotronVariant = nemotronModelVariant
         let nemotronLanguage = SpeechEnginePreference.nemotronDefaultLanguage(defaults: defaults)
+        let cohereOperationActiveAtRefreshStart = cohereDownloading || cohereDeleting
 
         let parakeetModelVariantCached = self.parakeetModelVariantCached
         let nemotronModelVariantCached = self.nemotronModelVariantCached
@@ -280,7 +281,7 @@ public final class EngineSettingsViewModel {
             nemotronModelStatusDetail = "Checking model state..."
             whisperModelStatus = .checking
             whisperModelStatusDetail = "Checking model state..."
-            if !cohereDownloading, !cohereDeleting {
+            if !cohereOperationActiveAtRefreshStart {
                 cohereModelStatus = .checking
                 cohereModelStatusDetail = "Checking model state..."
             }
@@ -305,12 +306,15 @@ public final class EngineSettingsViewModel {
                 }
                 self.downloadedParakeetVariants = disk.parakeetDownloaded
                 self.downloadedNemotronVariants = disk.nemotronDownloaded
-                if !self.cohereDownloading, !self.cohereDeleting {
+                let canApplyCohereStatus = !cohereOperationActiveAtRefreshStart &&
+                    !self.cohereDownloading &&
+                    !self.cohereDeleting
+                if canApplyCohereStatus {
                     self.cohereCacheDirectoryExists = disk.cohereCacheDirectoryExists
                 }
                 self.applyNemotronDownloadedStatus(disk.nemotronDownloaded.contains(activeNemotronVariant))
                 self.applyWhisperDownloadedStatus(disk.whisperDownloaded)
-                if !self.cohereDownloading, !self.cohereDeleting {
+                if canApplyCohereStatus {
                     self.applyCohereDownloadedStatus(disk.cohereDownloaded)
                 }
             }
@@ -323,7 +327,7 @@ public final class EngineSettingsViewModel {
         nemotronModelStatusDetail = "Checking model state..."
         whisperModelStatus = .checking
         whisperModelStatusDetail = "Checking model state..."
-        if !cohereDownloading, !cohereDeleting {
+        if !cohereOperationActiveAtRefreshStart {
             cohereModelStatus = .checking
             cohereModelStatusDetail = "Checking model state..."
         }
@@ -362,7 +366,10 @@ public final class EngineSettingsViewModel {
 
             self.downloadedParakeetVariants = modelDiskState.parakeetDownloaded
             self.downloadedNemotronVariants = modelDiskState.nemotronDownloaded
-            if !self.cohereDownloading, !self.cohereDeleting {
+            let canApplyCohereStatus = !cohereOperationActiveAtRefreshStart &&
+                !self.cohereDownloading &&
+                !self.cohereDeleting
+            if canApplyCohereStatus {
                 self.cohereCacheDirectoryExists = modelDiskState.cohereCacheDirectoryExists
             }
             let parakeetName = activeVariant.modelName
@@ -391,10 +398,10 @@ public final class EngineSettingsViewModel {
                 self.applyWhisperDownloadedStatus(modelDiskState.whisperDownloaded)
             }
 
-            if activeEngine == .cohere, activeEngineIsLoaded {
+            if activeEngine == .cohere, activeEngineIsLoaded, canApplyCohereStatus {
                 self.cohereModelStatus = .ready
                 self.cohereModelStatusDetail = "Cohere Transcribe · Loaded in memory."
-            } else if !self.cohereDownloading, !self.cohereDeleting {
+            } else if canApplyCohereStatus {
                 self.applyCohereDownloadedStatus(modelDiskState.cohereDownloaded)
             }
         }

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -561,6 +561,9 @@ public final class SettingsViewModel {
         nemotronModelVariantCached: @escaping @Sendable (NemotronModelVariant, String?) -> Bool = {
             STTRuntime.isNemotronModelCached(modelVariant: $0, language: $1)
         },
+        cohereModelCached: @escaping @Sendable () -> Bool = {
+            CohereTranscribeEngine.isModelCached()
+        },
         deleteParakeetModelOnDisk: @escaping @Sendable (ParakeetModelVariant) -> Bool = {
             if $0.usesUnifiedEngine { return ParakeetUnifiedEngine.deleteModel() }
             guard let version = $0.asrModelVersion else { return false }
@@ -591,6 +594,7 @@ public final class SettingsViewModel {
             defaults: defaults,
             parakeetModelVariantCached: parakeetModelVariantCached,
             nemotronModelVariantCached: nemotronModelVariantCached,
+            cohereModelCached: cohereModelCached,
             deleteParakeetModelOnDisk: deleteParakeetModelOnDisk,
             deleteNemotronModelOnDisk: deleteNemotronModelOnDisk,
             deleteWhisperModelOnDisk: deleteWhisperModelOnDisk

--- a/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
@@ -184,12 +184,14 @@ public final class TranscriptionViewModel {
     private let defaults: UserDefaults
     private let isWhisperModelDownloaded: () -> Bool
     private let isNemotronModelDownloaded: () -> Bool
+    private let isCohereModelDownloaded: () -> Bool
     public var promptResultsViewModel: PromptResultsViewModel?
 
     public init(
         defaults: UserDefaults = .standard,
         isWhisperModelDownloaded: (() -> Bool)? = nil,
-        isNemotronModelDownloaded: (() -> Bool)? = nil
+        isNemotronModelDownloaded: (() -> Bool)? = nil,
+        isCohereModelDownloaded: (() -> Bool)? = nil
     ) {
         self.defaults = defaults
         self.isWhisperModelDownloaded = isWhisperModelDownloaded ?? {
@@ -202,6 +204,9 @@ public final class TranscriptionViewModel {
                 modelVariant: SpeechEnginePreference.nemotronModelVariant(defaults: defaults),
                 language: SpeechEnginePreference.nemotronDefaultLanguage(defaults: defaults)
             )
+        }
+        self.isCohereModelDownloaded = isCohereModelDownloaded ?? {
+            CohereTranscribeEngine.isModelCached()
         }
     }
 
@@ -483,7 +488,7 @@ public final class TranscriptionViewModel {
                 ? nil
                 : "Download the Whisper model in Settings before trying Whisper."
         case .cohere:
-            return CohereTranscribeEngine.isModelCached()
+            return isCohereModelDownloaded()
                 ? nil
                 : "Download the Cohere model in Settings before trying Cohere."
         }

--- a/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
@@ -461,7 +461,12 @@ public final class TranscriptionViewModel {
     }
 
     private func retranscriptionEngineOrder(primary: SpeechEnginePreference) -> [SpeechEnginePreference] {
-        let defaultOrder: [SpeechEnginePreference] = [.parakeet, .nemotron, .whisper, .cohere]
+        // Gate Cohere on its feature flag, consistent with the settings engine
+        // picker — when the flag is off, Cohere must not leak in as a
+        // retranscription choice.
+        let defaultOrder: [SpeechEnginePreference] = AppFeatures.cohereEngineEnabled
+            ? [.parakeet, .nemotron, .whisper, .cohere]
+            : [.parakeet, .nemotron, .whisper]
         return [primary] + defaultOrder.filter { $0 != primary }
     }
 

--- a/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
@@ -508,7 +508,10 @@ public final class TranscriptionViewModel {
         case .whisper:
             return SpeechEnginePreference.whisperDefaultLanguage(defaults: defaults)
         case .cohere:
-            return nil
+            // Cohere has no auto-detect and its engine defaults to English, so a
+            // retranscription must carry the user's chosen language explicitly,
+            // exactly as Nemotron/Whisper do above.
+            return SpeechEnginePreference.cohereDefaultLanguage(defaults: defaults)
         }
     }
 

--- a/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
@@ -490,7 +490,7 @@ public final class TranscriptionViewModel {
         case .cohere:
             return isCohereModelDownloaded()
                 ? nil
-                : "Download the Cohere model in Settings before trying Cohere."
+                : "Download Cohere Transcribe in Settings before trying Cohere."
         }
     }
 

--- a/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
@@ -461,7 +461,7 @@ public final class TranscriptionViewModel {
     }
 
     private func retranscriptionEngineOrder(primary: SpeechEnginePreference) -> [SpeechEnginePreference] {
-        let defaultOrder: [SpeechEnginePreference] = [.parakeet, .nemotron, .whisper]
+        let defaultOrder: [SpeechEnginePreference] = [.parakeet, .nemotron, .whisper, .cohere]
         return [primary] + defaultOrder.filter { $0 != primary }
     }
 
@@ -477,6 +477,10 @@ public final class TranscriptionViewModel {
             return isWhisperModelDownloaded()
                 ? nil
                 : "Download the Whisper model in Settings before trying Whisper."
+        case .cohere:
+            return CohereTranscribeEngine.isModelCached()
+                ? nil
+                : "Download the Cohere model in Settings before trying Cohere."
         }
     }
 
@@ -503,6 +507,8 @@ public final class TranscriptionViewModel {
             return SpeechEnginePreference.nemotronDefaultLanguage(defaults: defaults)
         case .whisper:
             return SpeechEnginePreference.whisperDefaultLanguage(defaults: defaults)
+        case .cohere:
+            return nil
         }
     }
 
@@ -1088,6 +1094,8 @@ public final class TranscriptionViewModel {
             case .whisper:
                 let friendly = SpeechEnginePreference.friendlyVariantName(whisperVariant)
                 return "Whisper \(friendly) \u{00B7} Local Core ML"
+            case .cohere:
+                return "Cohere Transcribe \u{00B7} Local Core ML"
             }
         case .identifyingSpeakers:
             return "May take several minutes per hour of audio. Speaker labels are approximate \u{2014} click to rename."

--- a/Tests/CLITests/ConfigCommandTests.swift
+++ b/Tests/CLITests/ConfigCommandTests.swift
@@ -34,6 +34,7 @@ final class ConfigCommandTests: XCTestCase {
             "nemotron-model",
             "nemotron-language",
             "whisper-language",
+            "cohere-language",
             "speaker-detection",
             "auto-meeting-titles",
             "save-transcription-audio",
@@ -71,6 +72,7 @@ final class ConfigCommandTests: XCTestCase {
         XCTAssertEqual(try ConfigCommand.read(key: "nemotron-model", defaults: defaults), "multilingual-1120ms")
         XCTAssertEqual(try ConfigCommand.read(key: "nemotron-language", defaults: defaults), "auto")
         XCTAssertEqual(try ConfigCommand.read(key: "whisper-language", defaults: defaults), "auto")
+        XCTAssertEqual(try ConfigCommand.read(key: "cohere-language", defaults: defaults), "en")
         XCTAssertEqual(try ConfigCommand.read(key: "speaker-detection", defaults: defaults), "off")
         XCTAssertEqual(try ConfigCommand.read(key: "auto-meeting-titles", defaults: defaults), "on")
         XCTAssertEqual(try ConfigCommand.read(key: "save-transcription-audio", defaults: defaults), "on")
@@ -135,11 +137,17 @@ final class ConfigCommandTests: XCTestCase {
         XCTAssertEqual(try ConfigCommand.write(key: "speech-engine", value: "nemotron", defaults: defaults), "nemotron")
         XCTAssertEqual(defaults.string(forKey: SpeechEnginePreference.defaultsKey), SpeechEnginePreference.nemotron.rawValue)
 
+        XCTAssertEqual(try ConfigCommand.write(key: "speech-engine", value: "cohere", defaults: defaults), "cohere")
+        XCTAssertEqual(defaults.string(forKey: SpeechEnginePreference.defaultsKey), SpeechEnginePreference.cohere.rawValue)
+
         XCTAssertEqual(try ConfigCommand.write(key: "nemotron-language", value: "en_US", defaults: defaults), "en-US")
         XCTAssertEqual(defaults.string(forKey: SpeechEnginePreference.nemotronDefaultLanguageKey), "en-US")
 
         XCTAssertEqual(try ConfigCommand.write(key: "whisper-language", value: "ko", defaults: defaults), "ko")
         XCTAssertEqual(defaults.string(forKey: SpeechEnginePreference.whisperDefaultLanguageKey), "ko")
+
+        XCTAssertEqual(try ConfigCommand.write(key: "cohere-language", value: "JA", defaults: defaults), "ja")
+        XCTAssertEqual(defaults.string(forKey: SpeechEnginePreference.cohereDefaultLanguageKey), "ja")
 
         XCTAssertEqual(try ConfigCommand.write(key: "speaker-detection", value: "on", defaults: defaults), "on")
         XCTAssertEqual(defaults.object(forKey: UserDefaultsAppRuntimePreferences.speakerDiarizationKey) as? Bool, true)
@@ -434,6 +442,15 @@ final class ConfigCommandTests: XCTestCase {
             XCTAssertTrue(error is ValidationError)
         }
         XCTAssertNil(defaults.string(forKey: SpeechEnginePreference.nemotronDefaultLanguageKey))
+    }
+
+    func testWriteCohereLanguageRejectsUnsupportedCode() {
+        XCTAssertThrowsError(
+            try ConfigCommand.write(key: "cohere-language", value: "zz", defaults: defaults)
+        ) { error in
+            XCTAssertTrue(error is ValidationError)
+        }
+        XCTAssertNil(defaults.string(forKey: SpeechEnginePreference.cohereDefaultLanguageKey))
     }
 
     func testWriteAcceptsAllBoolSynonyms() throws {

--- a/Tests/CLITests/ModelLifecycleCommandTests.swift
+++ b/Tests/CLITests/ModelLifecycleCommandTests.swift
@@ -31,6 +31,8 @@ final class ModelLifecycleCommandTests: XCTestCase {
 
         XCTAssertThrowsError(try resolveWhisperDownloadModel("parakeet-v3")) { error in
             XCTAssertTrue(error is ValidationError)
+            XCTAssertTrue(String(describing: error).contains("parakeet-unified"))
+            XCTAssertTrue(String(describing: error).contains("cohere-transcribe"))
         }
     }
 

--- a/Tests/CLITests/ModelLifecycleCommandTests.swift
+++ b/Tests/CLITests/ModelLifecycleCommandTests.swift
@@ -51,10 +51,11 @@ final class ModelLifecycleCommandTests: XCTestCase {
             defaults: defaults,
             isParakeetModelCached: { $0 == .v3 },
             isNemotronModelDownloaded: { $0 == .multilingual1120 },
-            isWhisperModelDownloaded: { $0 == "large-v3-v20240930_turbo_632MB" }
+            isWhisperModelDownloaded: { $0 == "large-v3-v20240930_turbo_632MB" },
+            isCohereModelDownloaded: { false }
         )
 
-        XCTAssertEqual(models.count, 6)
+        XCTAssertEqual(models.count, 7)
         XCTAssertEqual(models[0], SelectableSpeechModel(
             id: "parakeet-v3",
             name: "Parakeet TDT 0.6B v3 (Multilingual)",
@@ -106,6 +107,16 @@ final class ModelLifecycleCommandTests: XCTestCase {
             language: "en"
         ))
         XCTAssertEqual(models[5], SelectableSpeechModel(
+            id: "cohere-transcribe",
+            name: "Cohere Transcribe",
+            engine: "cohere",
+            variant: nil,
+            size: "~2.1 GB",
+            installed: false,
+            selected: false,
+            language: "en"
+        ))
+        XCTAssertEqual(models[6], SelectableSpeechModel(
             id: "whisper-large-v3-v20240930-turbo-632MB",
             name: "Whisper Large v3 Turbo",
             engine: "whisper",
@@ -130,7 +141,8 @@ final class ModelLifecycleCommandTests: XCTestCase {
             defaults: defaults,
             isParakeetModelCached: { _ in true },
             isNemotronModelDownloaded: { _ in false },
-            isWhisperModelDownloaded: { _ in false }
+            isWhisperModelDownloaded: { _ in false },
+            isCohereModelDownloaded: { false }
         )
 
         let v3 = try XCTUnwrap(models.first { $0.id == "parakeet-v3" })
@@ -152,7 +164,8 @@ final class ModelLifecycleCommandTests: XCTestCase {
             defaults: defaults,
             isParakeetModelCached: { _ in false },
             isNemotronModelDownloaded: { _ in true },
-            isWhisperModelDownloaded: { _ in false }
+            isWhisperModelDownloaded: { _ in false },
+            isCohereModelDownloaded: { false }
         )
 
         let multilingual = try XCTUnwrap(models.first { $0.id == "nemotron-multilingual-1120ms" })
@@ -256,6 +269,18 @@ final class ModelLifecycleCommandTests: XCTestCase {
                 whisperVariant: "large-v3-v20240930_turbo_632MB"
             )
         )
+        XCTAssertEqual(
+            try resolveSelectableSpeechModel("cohere", defaults: defaults),
+            SelectableSpeechModelSelection(engine: .cohere, whisperVariant: nil)
+        )
+        XCTAssertEqual(
+            try resolveSelectableSpeechModel("cohere-transcribe", defaults: defaults),
+            SelectableSpeechModelSelection(engine: .cohere, whisperVariant: nil)
+        )
+        XCTAssertEqual(
+            try resolveSelectableSpeechModel("cohere-transcribe-03-2026", defaults: defaults),
+            SelectableSpeechModelSelection(engine: .cohere, whisperVariant: nil)
+        )
         // Bare "nemotron" follows the persisted variant; `models select` then
         // re-persists both the engine and that variant.
         SpeechEnginePreference.saveNemotronModelVariant(.english1120, defaults: defaults)
@@ -315,6 +340,26 @@ final class ModelLifecycleCommandTests: XCTestCase {
         // Non-Nemotron ids fall through (nil) so Whisper parsing runs.
         XCTAssertNil(nemotronDownloadVariant(from: "parakeet-v3", defaults: defaults))
         XCTAssertNil(nemotronDownloadVariant(from: "whisper-large-v3", defaults: defaults))
+    }
+
+    func testCohereModelLifecycleSubcommandsParseCanonicalModelID() throws {
+        let modelID = "cohere-transcribe"
+
+        let download = try ModelsCommand.Download.parse([modelID])
+        XCTAssertEqual(download.variant, modelID)
+        XCTAssertTrue(isCohereModelID(download.variant))
+
+        let select = try ModelsCommand.Select.parse([modelID])
+        XCTAssertEqual(select.id, modelID)
+        XCTAssertEqual(
+            try resolveSelectableSpeechModel(select.id),
+            SelectableSpeechModelSelection(engine: .cohere, whisperVariant: nil)
+        )
+
+        let delete = try ModelsCommand.Delete.parse([modelID, "--force"])
+        XCTAssertEqual(delete.id, modelID)
+        XCTAssertTrue(delete.force)
+        XCTAssertEqual(try resolveModelDeletionTarget(delete.id).kind, .cohere)
     }
 
     func testNemotronModelLifecycleSubcommandsParseCanonicalModelID() throws {
@@ -404,7 +449,8 @@ final class ModelLifecycleCommandTests: XCTestCase {
                     checkedLanguage = language
                     return false
                 },
-                isWhisperModelDownloaded: { _ in true }
+                isWhisperModelDownloaded: { _ in true },
+                isCohereModelDownloaded: { true }
             )
         ) { error in
             XCTAssertTrue(error is ValidationError)
@@ -436,7 +482,47 @@ final class ModelLifecycleCommandTests: XCTestCase {
                     XCTAssertNil(language)
                     return true
                 },
-                isWhisperModelDownloaded: { _ in false }
+                isWhisperModelDownloaded: { _ in false },
+                isCohereModelDownloaded: { false }
+            )
+        )
+    }
+
+    func testValidateSelectableSpeechModelDownloadRejectsMissingCohere() throws {
+        let suiteName = "com.macparakeet.tests.cli.model-select-cohere-missing.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let selection = SelectableSpeechModelSelection(engine: .cohere, whisperVariant: nil)
+
+        XCTAssertThrowsError(
+            try validateSelectableSpeechModelDownload(
+                selection,
+                defaults: defaults,
+                isNemotronModelDownloaded: { _, _ in true },
+                isWhisperModelDownloaded: { _ in true },
+                isCohereModelDownloaded: { false }
+            )
+        ) { error in
+            XCTAssertTrue(error is ValidationError)
+            XCTAssertTrue(String(describing: error).contains("models download cohere-transcribe"))
+        }
+    }
+
+    func testValidateSelectableSpeechModelDownloadAllowsDownloadedCohere() throws {
+        let suiteName = "com.macparakeet.tests.cli.model-select-cohere-downloaded.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        XCTAssertNoThrow(
+            try validateSelectableSpeechModelDownload(
+                SelectableSpeechModelSelection(engine: .cohere, whisperVariant: nil),
+                defaults: defaults,
+                isNemotronModelDownloaded: { _, _ in false },
+                isWhisperModelDownloaded: { _ in false },
+                isCohereModelDownloaded: { true }
             )
         )
     }
@@ -474,6 +560,10 @@ final class ModelLifecycleCommandTests: XCTestCase {
             try resolveModelDeletionTarget("whisper-large-v3-v20240930-turbo-632MB", defaults: defaults).kind,
             .whisper("large-v3-v20240930_turbo_632MB")
         )
+        XCTAssertEqual(
+            try resolveModelDeletionTarget("cohere-transcribe", defaults: defaults).kind,
+            .cohere
+        )
     }
 
     func testResolveModelDeletionTargetRejectsUnknownID() throws {
@@ -502,6 +592,7 @@ final class ModelLifecycleCommandTests: XCTestCase {
             )
         )
         XCTAssertFalse(isModelInUse(.init(kind: .nemotron(.multilingual1120), displayName: "nemotron"), defaults: defaults))
+        XCTAssertFalse(isModelInUse(.init(kind: .cohere, displayName: "cohere"), defaults: defaults))
     }
 
     func testIsModelInUseProtectsWhisperAndConfiguredParakeetWhenWhisperActive() throws {
@@ -529,6 +620,26 @@ final class ModelLifecycleCommandTests: XCTestCase {
         // No persisted variant: multilingual is the default Nemotron build.
         XCTAssertTrue(isModelInUse(.init(kind: .nemotron(.multilingual1120), displayName: "nemotron"), defaults: defaults))
         XCTAssertFalse(isModelInUse(.init(kind: .nemotron(.english1120), displayName: "nemotron-en"), defaults: defaults))
+        XCTAssertFalse(
+            isModelInUse(
+                .init(kind: .whisper(SpeechEnginePreference.defaultWhisperModelVariant), displayName: "whisper"),
+                defaults: defaults
+            )
+        )
+        XCTAssertFalse(isModelInUse(.init(kind: .cohere, displayName: "cohere"), defaults: defaults))
+    }
+
+    func testIsModelInUseProtectsCohereWhenCohereActive() throws {
+        let (defaults, suite) = try makeDeleteDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        SpeechEnginePreference.cohere.save(to: defaults)
+
+        XCTAssertTrue(isModelInUse(.init(kind: .cohere, displayName: "cohere"), defaults: defaults))
+        // The configured Parakeet build is also protected: it is what Parakeet
+        // would load if the user switches back from Cohere.
+        XCTAssertTrue(isModelInUse(.init(kind: .parakeet(.v3), displayName: "v3"), defaults: defaults))
+        XCTAssertFalse(isModelInUse(.init(kind: .nemotron(.multilingual1120), displayName: "nemotron"), defaults: defaults))
         XCTAssertFalse(
             isModelInUse(
                 .init(kind: .whisper(SpeechEnginePreference.defaultWhisperModelVariant), displayName: "whisper"),
@@ -611,7 +722,8 @@ final class ModelLifecycleCommandTests: XCTestCase {
             nemotronModelVariant: .multilingual1120,
             isNemotronModelDownloaded: { $0 == .multilingual1120 },
             whisperModelVariant: "large-v3-v20240930_turbo_632MB",
-            isWhisperModelDownloaded: { $0 == "large-v3-v20240930_turbo_632MB" }
+            isWhisperModelDownloaded: { $0 == "large-v3-v20240930_turbo_632MB" },
+            isCohereModelDownloaded: { false }
         )
 
         XCTAssertEqual(
@@ -627,7 +739,8 @@ final class ModelLifecycleCommandTests: XCTestCase {
                 nemotronModelVariant: .multilingual1120,
                 nemotronModelDownloaded: true,
                 whisperModelVariant: "large-v3-v20240930_turbo_632MB",
-                whisperModelDownloaded: true
+                whisperModelDownloaded: true,
+                cohereModelDownloaded: false
             )
         )
         XCTAssertEqual(status.summary, "Speech model present, speaker models missing")

--- a/Tests/CLITests/SpecCommandTests.swift
+++ b/Tests/CLITests/SpecCommandTests.swift
@@ -149,13 +149,15 @@ final class SpecCommandTests: XCTestCase {
         XCTAssertTrue(optionNames.contains("--database"))
 
         let engine = try XCTUnwrap(options.first { ($0["name"] as? String) == "--engine" })
-        XCTAssertEqual(engine["valueName"] as? String, "parakeet|nemotron|whisper|app-default")
+        XCTAssertEqual(engine["valueName"] as? String, "parakeet|nemotron|whisper|cohere|app-default")
+        let format = try XCTUnwrap(options.first { ($0["name"] as? String) == "--format" })
+        XCTAssertEqual(format["valueName"] as? String, "text|transcript|json|srt|vtt")
         let nemotronModel = try XCTUnwrap(options.first { ($0["name"] as? String) == "--nemotron-model" })
         XCTAssertEqual(nemotronModel["valueName"] as? String, "app-default|multilingual-1120ms|english-1120ms")
         let language = try XCTUnwrap(options.first { ($0["name"] as? String) == "--language" })
         XCTAssertEqual(
             language["summary"] as? String,
-            "Language hint for Nemotron or Whisper; the English-only Nemotron build ignores it."
+            "Language hint for Nemotron, Whisper, or Cohere; the English-only Nemotron build ignores it."
         )
     }
 

--- a/Tests/CLITests/TranscribeCommandTests.swift
+++ b/Tests/CLITests/TranscribeCommandTests.swift
@@ -175,6 +175,36 @@ final class TranscribeCommandTests: XCTestCase {
         XCTAssertEqual(selection.language, "en-US")
     }
 
+    func testResolveSpeechEngineUsesStoredCohereLanguageForAppDefault() {
+        // Cohere has no auto-detect and its engine defaults to English, so an
+        // app-default run with no explicit --language must carry the stored
+        // Cohere picker language, not silently fall back to English.
+        let selection = TranscribeCommand.resolveSpeechEngine(
+            .appDefault,
+            storedEngine: SpeechEnginePreference.cohere.rawValue,
+            storedLanguage: "ko",
+            storedNemotronLanguage: "en_US",
+            storedCohereLanguage: "fr",
+            explicitLanguage: nil
+        )
+
+        XCTAssertEqual(selection.engine, .cohere)
+        XCTAssertEqual(selection.language, "fr")
+    }
+
+    func testResolveSpeechEngineExplicitLanguageOverridesStoredCohereLanguage() {
+        let selection = TranscribeCommand.resolveSpeechEngine(
+            .appDefault,
+            storedEngine: SpeechEnginePreference.cohere.rawValue,
+            storedLanguage: "ko",
+            storedCohereLanguage: "fr",
+            explicitLanguage: "ja"
+        )
+
+        XCTAssertEqual(selection.engine, .cohere)
+        XCTAssertEqual(selection.language, "ja")
+    }
+
     func testResolveSpeechEngineExplicitNemotronUsesExplicitLanguage() {
         let selection = TranscribeCommand.resolveSpeechEngine(
             .nemotron,

--- a/Tests/CLITests/TranscribeCommandTests.swift
+++ b/Tests/CLITests/TranscribeCommandTests.swift
@@ -227,6 +227,34 @@ final class TranscribeCommandTests: XCTestCase {
         XCTAssertEqual(explicitSelection.language, "ja")
     }
 
+    func testValidateCohereLanguageOverrideRejectsExplicitAuto() {
+        let selection = TranscribeCommand.resolveSpeechEngine(
+            .cohere,
+            storedEngine: SpeechEnginePreference.parakeet.rawValue,
+            storedLanguage: nil,
+            storedCohereLanguage: "fr",
+            explicitLanguage: "auto"
+        )
+
+        XCTAssertThrowsError(try TranscribeCommand.validateCohereLanguageOverride("auto", speechEngine: selection)) { error in
+            let message = String(describing: error)
+            XCTAssertTrue(message.contains("Cohere has no auto-detect"), message)
+        }
+    }
+
+    func testValidateCohereLanguageOverrideAllowsSupportedExplicitCode() throws {
+        let selection = TranscribeCommand.resolveSpeechEngine(
+            .cohere,
+            storedEngine: SpeechEnginePreference.parakeet.rawValue,
+            storedLanguage: nil,
+            storedCohereLanguage: "fr",
+            explicitLanguage: "zh_CN"
+        )
+
+        try TranscribeCommand.validateCohereLanguageOverride("zh_CN", speechEngine: selection)
+        XCTAssertEqual(selection.language, "zh")
+    }
+
     func testResolveSpeechEngineExplicitNemotronUsesExplicitLanguage() {
         let selection = TranscribeCommand.resolveSpeechEngine(
             .nemotron,

--- a/Tests/CLITests/TranscribeCommandTests.swift
+++ b/Tests/CLITests/TranscribeCommandTests.swift
@@ -205,6 +205,28 @@ final class TranscribeCommandTests: XCTestCase {
         XCTAssertEqual(selection.language, "ja")
     }
 
+    func testResolveSpeechEngineExplicitCohereUsesExplicitOrStoredCohereLanguage() {
+        let storedSelection = TranscribeCommand.resolveSpeechEngine(
+            .cohere,
+            storedEngine: SpeechEnginePreference.whisper.rawValue,
+            storedLanguage: "ko",
+            storedCohereLanguage: "zh",
+            explicitLanguage: nil
+        )
+        XCTAssertEqual(storedSelection.engine, .cohere)
+        XCTAssertEqual(storedSelection.language, "zh")
+
+        let explicitSelection = TranscribeCommand.resolveSpeechEngine(
+            .cohere,
+            storedEngine: SpeechEnginePreference.whisper.rawValue,
+            storedLanguage: "ko",
+            storedCohereLanguage: "zh",
+            explicitLanguage: "ja"
+        )
+        XCTAssertEqual(explicitSelection.engine, .cohere)
+        XCTAssertEqual(explicitSelection.language, "ja")
+    }
+
     func testResolveSpeechEngineExplicitNemotronUsesExplicitLanguage() {
         let selection = TranscribeCommand.resolveSpeechEngine(
             .nemotron,
@@ -316,6 +338,17 @@ final class TranscribeCommandTests: XCTestCase {
 
         XCTAssertEqual(command.engine, .nemotron)
         XCTAssertEqual(command.language, "en-US")
+    }
+
+    func testParsesCohereEngineAndLanguage() throws {
+        let command = try TranscribeCommand.parse([
+            "sample.wav",
+            "--engine", "cohere",
+            "--language", "ja",
+        ])
+
+        XCTAssertEqual(command.engine, .cohere)
+        XCTAssertEqual(command.language, "ja")
     }
 
     func testParsesAppDefaultEngineAndSpeakerDetection() throws {

--- a/Tests/MacParakeetTests/App/AppEnvironmentTests.swift
+++ b/Tests/MacParakeetTests/App/AppEnvironmentTests.swift
@@ -3,6 +3,17 @@ import MacParakeetCore
 import XCTest
 
 final class AppEnvironmentTests: XCTestCase {
+    func testCohereDictationRoutingDisablesLiveAndDisplayPreview() {
+        XCTAssertFalse(AppEnvironment.shouldAttemptLiveDictationTranscription(
+            speechEngine: .cohere,
+            liveDictationStreamingEnabled: true
+        ))
+        XCTAssertNil(AppEnvironment.dictationPreviewSpeechEngine(
+            speechEngine: .cohere,
+            liveDictationStreamingEnabled: true
+        ))
+    }
+
     func testSyncAIFormatterAvailabilityWritesTrueWhenProviderExists() {
         let (suiteName, defaults) = makeDefaults()
         defer { defaults.removePersistentDomain(forName: suiteName) }

--- a/Tests/MacParakeetTests/DictationFlow/DictationFlowCoordinatorLoadCaptionTests.swift
+++ b/Tests/MacParakeetTests/DictationFlow/DictationFlowCoordinatorLoadCaptionTests.swift
@@ -257,17 +257,16 @@ final class DictationFlowCoordinatorLoadCaptionTests: XCTestCase {
             dictationInsertionStyle: .inline
         )
 
+        // The paste uses the insertion style captured when the transcript was
+        // produced. With the success checkmark removed, paste is immediate, so a
+        // later preference change can no longer race ahead of it — the captured
+        // (inline) style is applied. (When the finalize queue lands, the deferred
+        // paste will snapshot the style into the job, re-establishing this
+        // guarantee against a mid-flight preference change.)
         harness.coordinator.startDictation(mode: .persistent, trigger: .hotkey)
         let started = await waitUntil { harness.coordinator.overlayStateForTesting?.isRecordingForTest == true }
         XCTAssertTrue(started)
         harness.coordinator.stopDictation()
-        let completed = await waitUntil { harness.coordinator.overlayStateForTesting?.isSuccessForTest == true }
-        XCTAssertTrue(completed)
-
-        harness.preferencesDefaults.set(
-            DictationInsertionStyle.sentence.rawValue,
-            forKey: UserDefaultsAppRuntimePreferences.dictationInsertionStyleKey
-        )
 
         let pasted = await waitUntilAsync {
             await harness.clipboard.snapshot().lastPastedText != nil

--- a/Tests/MacParakeetTests/DictationFlow/DictationFlowCoordinatorLoadCaptionTests.swift
+++ b/Tests/MacParakeetTests/DictationFlow/DictationFlowCoordinatorLoadCaptionTests.swift
@@ -104,12 +104,10 @@ final class DictationFlowCoordinatorLoadCaptionTests: XCTestCase {
         XCTAssertTrue(harness.telemetry.snapshot().containsCaptionShown(firstInstall: false))
     }
 
-    func testCohereShowsOptimizingCaptionAndEscalatesEveryLaunch() async throws {
-        // Cohere's Core ML graph specialization recurs on every launch, so a
-        // warmed user (first dictation already completed) must still get the
-        // Cohere-specific "Optimizing…" caption and its time-estimate
-        // escalation — unlike the generic path, which only escalates on first
-        // install.
+    func testCohereShowsOptimizingCaptionAndEscalatesAfterFirstDictation() async throws {
+        // A user can complete first dictation on another engine before selecting
+        // Cohere, so the Cohere-specific model setup caption still escalates
+        // after the generic first-install milestone has passed.
         let harness = try makeHarness(
             isReady: false,
             transcribeDelayMs: 140,

--- a/Tests/MacParakeetTests/DictationFlow/DictationFlowCoordinatorLoadCaptionTests.swift
+++ b/Tests/MacParakeetTests/DictationFlow/DictationFlowCoordinatorLoadCaptionTests.swift
@@ -104,6 +104,27 @@ final class DictationFlowCoordinatorLoadCaptionTests: XCTestCase {
         XCTAssertTrue(harness.telemetry.snapshot().containsCaptionShown(firstInstall: false))
     }
 
+    func testCohereShowsOptimizingCaptionAndEscalatesEveryLaunch() async throws {
+        // Cohere's Core ML graph specialization recurs on every launch, so a
+        // warmed user (first dictation already completed) must still get the
+        // Cohere-specific "Optimizing…" caption and its time-estimate
+        // escalation — unlike the generic path, which only escalates on first
+        // install.
+        let harness = try makeHarness(
+            isReady: false,
+            transcribeDelayMs: 140,
+            hasCompletedFirstDictation: true,
+            engine: .cohere
+        )
+
+        try await harness.startAndStop()
+
+        let shown = await waitUntil { harness.coordinator.processingLoadCaptionForTesting == .optimizing }
+        XCTAssertTrue(shown)
+        let escalated = await waitUntil { harness.coordinator.processingLoadCaptionForTesting == .optimizingExtended }
+        XCTAssertTrue(escalated)
+    }
+
     func testFailureShowsFailureCaptionBeforeErrorCard() async throws {
         let harness = try makeHarness(
             isReady: false,
@@ -287,6 +308,7 @@ final class DictationFlowCoordinatorLoadCaptionTests: XCTestCase {
         keepDictationOnClipboard: Bool = false,
         processingMode: Dictation.ProcessingMode = .raw,
         dictationInsertionStyle: DictationInsertionStyle = .sentence,
+        engine: SpeechEnginePreference = .parakeet,
         timing: DictationProcessingLoadCaptionTiming? = nil
     ) throws -> Harness {
         let telemetry = LoadCaptionTelemetrySpy()
@@ -343,6 +365,7 @@ final class DictationFlowCoordinatorLoadCaptionTests: XCTestCase {
             sttRuntime: stt,
             runtimePreferences: preferences,
             captionTiming: timing ?? self.timing,
+            activeSpeechEngine: { engine },
             overlayControllerFactory: { SpyDictationOverlayController(viewModel: $0) },
             onMenuBarIconUpdate: { _ in },
             onHistoryReload: {},

--- a/Tests/MacParakeetTests/DictationFlow/DictationFlowCoordinatorLoadCaptionTests.swift
+++ b/Tests/MacParakeetTests/DictationFlow/DictationFlowCoordinatorLoadCaptionTests.swift
@@ -166,6 +166,21 @@ final class DictationFlowCoordinatorLoadCaptionTests: XCTestCase {
         XCTAssertTrue(harness.telemetry.snapshot().containsCaptionDuration(outcome: "no_speech"))
     }
 
+    func testPasteFailureDismissesCaptionWithFailureOutcome() async throws {
+        let harness = try makeHarness(isReady: false, transcribeDelayMs: 90)
+        await harness.clipboard.setPasteError(ClipboardServiceError.eventSourceUnavailable)
+
+        try await harness.startAndStop()
+        let shown = await waitUntil { self.isPreparingCaption(harness.coordinator.processingLoadCaptionForTesting) }
+        XCTAssertTrue(shown)
+        let recordedFailure = await waitUntil {
+            harness.telemetry.snapshot().containsCaptionDuration(outcome: "failure")
+        }
+
+        XCTAssertTrue(recordedFailure)
+        XCTAssertFalse(harness.telemetry.snapshot().containsCaptionDuration(outcome: "success"))
+    }
+
     func testCancelDuringVisibleCaptionClearsCaption() async throws {
         let harness = try makeHarness(isReady: false, transcribeDelayMs: 2_000)
 

--- a/Tests/MacParakeetTests/DictationFlow/DictationFlowStateMachineTests.swift
+++ b/Tests/MacParakeetTests/DictationFlow/DictationFlowStateMachineTests.swift
@@ -545,7 +545,8 @@ final class DictationFlowStateMachineTests: XCTestCase {
 
         let effects = m.handle(.transcriptionCompleted(generation: gen))
         XCTAssertEqual(m.state, .finishing(outcome: .success))
-        XCTAssertTrue(effects.contains(.showSuccess))
+        // No success checkmark — the pasted text is the confirmation.
+        XCTAssertFalse(effects.contains(.showSuccess))
         XCTAssertTrue(effects.contains(.updateMenuBar(.idle)))
         XCTAssertTrue(effects.contains(.resignKeyWindow))
         XCTAssertTrue(effects.contains(.pasteTranscript))
@@ -686,8 +687,14 @@ final class DictationFlowStateMachineTests: XCTestCase {
         _ = m.handle(.transcriptionCompleted(generation: gen))
 
         let effects = m.handle(.pasteSucceeded(generation: gen))
-        XCTAssertEqual(m.state, .finishing(outcome: .success))
-        XCTAssertTrue(effects.contains(.startDisplayDismissTimer(seconds: 0.8)))
+        // No checkmark dwell — paste lands and we return to idle + re-arm the
+        // hotkey immediately so the next dictation can start right after.
+        XCTAssertEqual(m.state, .idle)
+        XCTAssertTrue(effects.contains(.hideOverlay))
+        XCTAssertTrue(effects.contains(.reloadHistory))
+        XCTAssertTrue(effects.contains(.resetHotkeyStateMachine))
+        XCTAssertTrue(effects.contains(.showIdlePill))
+        XCTAssertFalse(effects.contains(.startDisplayDismissTimer(seconds: 0.8)))
     }
 
     func testFinishingPasteFailed() {
@@ -702,10 +709,12 @@ final class DictationFlowStateMachineTests: XCTestCase {
     }
 
     func testFinishingDisplayDismissExpired() {
+        // Success no longer uses a dismiss timer (it returns to idle on paste),
+        // so the dismiss-timer path is exercised via the no-speech leaf, which
+        // still dwells before clearing.
         var m = machineInProcessing()
         let gen = m.generation
-        _ = m.handle(.transcriptionCompleted(generation: gen))
-        _ = m.handle(.pasteSucceeded(generation: gen))
+        _ = m.handle(.transcriptionFailedNoSpeech(generation: gen))
 
         let effects = m.handle(.displayDismissExpired(generation: gen))
         XCTAssertEqual(m.state, .idle)
@@ -767,12 +776,11 @@ final class DictationFlowStateMachineTests: XCTestCase {
     func testFinishingStaleDisplayDismiss() {
         var m = machineInProcessing()
         let gen = m.generation
-        _ = m.handle(.transcriptionCompleted(generation: gen))
-        _ = m.handle(.pasteSucceeded(generation: gen))
+        _ = m.handle(.transcriptionFailedNoSpeech(generation: gen))
 
         let effects = m.handle(.displayDismissExpired(generation: gen - 1))
         XCTAssertTrue(effects.isEmpty)
-        XCTAssertEqual(m.state, .finishing(outcome: .success))
+        XCTAssertEqual(m.state, .finishing(outcome: .noSpeech))
     }
 
     func testFinishingReadyPillRequested() {
@@ -899,14 +907,11 @@ final class DictationFlowStateMachineTests: XCTestCase {
         _ = m.handle(.transcriptionCompleted(generation: gen))
         XCTAssertEqual(m.state, .finishing(outcome: .success))
 
-        // → paste succeeded
-        _ = m.handle(.pasteSucceeded(generation: gen))
-        XCTAssertEqual(m.state, .finishing(outcome: .success))
-
-        // → idle
-        let effects = m.handle(.displayDismissExpired(generation: gen))
+        // → paste succeeded returns straight to idle (no checkmark dwell)
+        let effects = m.handle(.pasteSucceeded(generation: gen))
         XCTAssertEqual(m.state, .idle)
         XCTAssertTrue(effects.contains(.reloadHistory))
+        XCTAssertTrue(effects.contains(.resetHotkeyStateMachine))
     }
 
     func testHappyPathHoldToTalk() {

--- a/Tests/MacParakeetTests/Hotkey/HotkeyManagerTests.swift
+++ b/Tests/MacParakeetTests/Hotkey/HotkeyManagerTests.swift
@@ -47,6 +47,59 @@ final class HotkeyManagerTests: XCTestCase {
         )
     }
 
+    func testRecoverFromDisabledTapPreservesArmedHoldStartWhileTriggerHeld() {
+        // Regression: holding Fn to start a new dictation in the ~1s window right
+        // after a previous one pastes did nothing. The Instant-Dictation warm-mic
+        // restart disables the CGEvent tap; on recovery (no active recording yet)
+        // the manager hard-reset the gesture and cancelled the armed start, and
+        // since Fn was still held no new edge re-armed it.
+        let manager = HotkeyManager(trigger: .fn, gestureMode: .holdOnly)
+
+        // Fresh Fn press arms the startup debounce; the start has not fired yet.
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskSecondaryFn],
+                timestampMs: 1_000
+            ),
+            [.scheduleStartupDebounce(milliseconds: FnKeyStateMachine.defaultStartupDebounceMs)]
+        )
+
+        // Tap disabled + recovered while Fn is still physically held.
+        manager.recoverFromDisabledTapForTesting(
+            flags: [.maskSecondaryFn],
+            triggerKeyPressed: true,
+            timestampMs: 1_050
+        )
+
+        // The pending start must survive the recovery and still fire.
+        XCTAssertEqual(
+            manager.startupDebounceElapsedForTesting(),
+            [.startRecording(mode: .holdToTalk)]
+        )
+    }
+
+    func testRecoverFromDisabledTapStillResetsPendingStartWhenTriggerReleased() {
+        // The preserve path is gated on the trigger still being held — if it was
+        // released, recovery must still clear the stale pending start (no phantom).
+        let manager = HotkeyManager(trigger: .fn, gestureMode: .holdOnly)
+
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskSecondaryFn],
+                timestampMs: 1_000
+            ),
+            [.scheduleStartupDebounce(milliseconds: FnKeyStateMachine.defaultStartupDebounceMs)]
+        )
+
+        manager.recoverFromDisabledTapForTesting(
+            flags: [],
+            triggerKeyPressed: false,
+            timestampMs: 1_050
+        )
+
+        XCTAssertEqual(manager.startupDebounceElapsedForTesting(), [])
+    }
+
     func testHoldOnlyGestureModeStartsAndStopsHoldRecording() {
         let manager = HotkeyManager(trigger: .fn, gestureMode: .holdOnly)
 
@@ -490,7 +543,14 @@ final class HotkeyManagerTests: XCTestCase {
         )
     }
 
-    func testTapRecoveryResyncsStillHeldModifierWithoutReleaseOutput() {
+    func testTapRecoveryPreservesPendingStartWhileModifierHeld() {
+        // Counterpart to testTapRecoveryResetsPendingModifierGesture (which
+        // recovers with the trigger released and resets). Here Fn is STILL held
+        // through the recovery. Previously the manager reset and cancelled the
+        // armed start even while held, so holding Fn right after a paste (when the
+        // Instant-Dictation warm-mic restart disables the tap) did nothing until
+        // the user released and re-pressed. Now the pending start is preserved and
+        // still fires on the debounce.
         let manager = HotkeyManager(trigger: .fn)
 
         _ = manager.modifierFlagsChangedOutputsForTesting(
@@ -498,24 +558,12 @@ final class HotkeyManagerTests: XCTestCase {
             timestampMs: 1_000
         )
 
+        // Tap disabled + recovered while Fn is still physically held.
         manager.recoverFromDisabledTapForTesting(flags: [.maskSecondaryFn])
 
         XCTAssertEqual(
-            manager.modifierFlagsChangedOutputsForTesting(
-                flags: [],
-                timestampMs: 1_050
-            ),
-            []
-        )
-        XCTAssertEqual(
-            manager.modifierFlagsChangedOutputsForTesting(
-                flags: [.maskSecondaryFn],
-                timestampMs: 1_100
-            ),
-            [
-                .scheduleStartupDebounce(milliseconds: FnKeyStateMachine.defaultStartupDebounceMs),
-                .scheduleHoldWindow(milliseconds: FnKeyStateMachine.defaultTapThresholdMs),
-            ]
+            manager.startupDebounceElapsedForTesting(),
+            [.startRecording(mode: .holdToTalk)]
         )
     }
 

--- a/Tests/MacParakeetTests/STT/CohereTranscribeEngineTests.swift
+++ b/Tests/MacParakeetTests/STT/CohereTranscribeEngineTests.swift
@@ -16,6 +16,30 @@ final class CohereTranscribeEngineTests: XCTestCase {
         XCTAssertEqual(merged, "the quick brown fox jumps over the lazy dog")
     }
 
+    func testMergeCompletesPartialTrailingWordWhenOverlapIsStrong() {
+        let merged = CohereTranscribeEngine.mergeOnOverlap(
+            "the quick brown fo",
+            "quick brown fox jumps over the lazy dog"
+        )
+        XCTAssertEqual(merged, "the quick brown fox jumps over the lazy dog")
+    }
+
+    func testMergeDropsPartialLeadingWordWhenOverlapIsStrong() {
+        let merged = CohereTranscribeEngine.mergeOnOverlap(
+            "the quick brown fox",
+            "own fox jumps over the lazy dog"
+        )
+        XCTAssertEqual(merged, "the quick brown fox jumps over the lazy dog")
+    }
+
+    func testMergeDoesNotUsePartialBoundaryWithoutStrongOverlap() {
+        let merged = CohereTranscribeEngine.mergeOnOverlap(
+            "alpha fo",
+            "fox beta"
+        )
+        XCTAssertEqual(merged, "alpha fo fox beta")
+    }
+
     func testMergeIsCaseAndPunctuationInsensitiveAtTheSeam() {
         let merged = CohereTranscribeEngine.mergeOnOverlap(
             "send me your feedback before the end of the day.",

--- a/Tests/MacParakeetTests/STT/CohereTranscribeEngineTests.swift
+++ b/Tests/MacParakeetTests/STT/CohereTranscribeEngineTests.swift
@@ -274,6 +274,8 @@ final class CohereTranscribeEngineTests: XCTestCase {
         XCTAssertNil(SpeechEnginePreference.normalizeCohereLanguage(""))
         XCTAssertNil(SpeechEnginePreference.normalizeCohereLanguage(nil))
         XCTAssertNil(SpeechEnginePreference.normalizeCohereLanguage("12"))
+        XCTAssertNil(SpeechEnginePreference.normalizeCohereLanguage("eng"))
+        XCTAssertNil(SpeechEnginePreference.normalizeCohereLanguage("xx"))
     }
 
     func testCohereDefaultLanguageRoundTrips() throws {
@@ -281,6 +283,8 @@ final class CohereTranscribeEngineTests: XCTestCase {
         XCTAssertNil(SpeechEnginePreference.cohereDefaultLanguage(defaults: defaults))
         SpeechEnginePreference.saveCohereDefaultLanguage("ja", defaults: defaults)
         XCTAssertEqual(SpeechEnginePreference.cohereDefaultLanguage(defaults: defaults), "ja")
+        defaults.set("eng", forKey: SpeechEnginePreference.cohereDefaultLanguageKey)
+        XCTAssertNil(SpeechEnginePreference.cohereDefaultLanguage(defaults: defaults))
         SpeechEnginePreference.saveCohereDefaultLanguage(nil, defaults: defaults)
         XCTAssertNil(SpeechEnginePreference.cohereDefaultLanguage(defaults: defaults))
     }

--- a/Tests/MacParakeetTests/STT/CohereTranscribeEngineTests.swift
+++ b/Tests/MacParakeetTests/STT/CohereTranscribeEngineTests.swift
@@ -131,6 +131,19 @@ final class CohereTranscribeEngineTests: XCTestCase {
         XCTAssertFalse(merged.contains(" "))
     }
 
+    func testMergeDropsSupplementaryCJKOverlapWithoutInsertingSpace() throws {
+        let first = try XCTUnwrap(UnicodeScalar(0x20000).map(String.init))
+        let second = try XCTUnwrap(UnicodeScalar(0x20001).map(String.init))
+
+        let merged = CohereTranscribeEngine.mergeOnOverlap(
+            first + first + first + second,
+            first + second + second
+        )
+
+        XCTAssertEqual(merged, first + first + first + second + second)
+        XCTAssertFalse(merged.contains(" "))
+    }
+
     func testMergeDoesNotTreatDifferentPunctuationAsOverlap() {
         let merged = CohereTranscribeEngine.mergeOnOverlap(
             "hello 。",

--- a/Tests/MacParakeetTests/STT/CohereTranscribeEngineTests.swift
+++ b/Tests/MacParakeetTests/STT/CohereTranscribeEngineTests.swift
@@ -119,6 +119,22 @@ final class CohereTranscribeEngineTests: XCTestCase {
         XCTAssertEqual(merged, prefix + " alpha beta gamma")
     }
 
+    func testMergeTailBoundKeepsLongWordOverlapIntact() {
+        let prefix = (0..<200).map { "word\($0)" }.joined(separator: " ")
+        let overlap = (0..<30)
+            .map { "overlapsegment\($0)abc" }
+            .joined(separator: " ")
+        XCTAssertGreaterThan(overlap.count, 450)
+        XCTAssertLessThan(overlap.count, 1000)
+
+        let merged = CohereTranscribeEngine.mergeOnOverlap(
+            prefix + " " + overlap,
+            overlap + " tail"
+        )
+
+        XCTAssertEqual(merged, prefix + " " + overlap + " tail")
+    }
+
     func testMergeHandlesEmptyFragments() {
         XCTAssertEqual(CohereTranscribeEngine.mergeOnOverlap("", "only b"), "only b")
         XCTAssertEqual(CohereTranscribeEngine.mergeOnOverlap("only a", ""), "only a")

--- a/Tests/MacParakeetTests/STT/CohereTranscribeEngineTests.swift
+++ b/Tests/MacParakeetTests/STT/CohereTranscribeEngineTests.swift
@@ -324,7 +324,7 @@ final class CohereTranscribeEngineTests: XCTestCase {
         XCTAssertNil(SpeechEnginePreference.cohereDefaultLanguage(defaults: defaults))
     }
 
-    /// Guards the mapper the string-code initializer (used by the CLI to thread a
+    /// Guards the mapper that the string-code initializer (used by the CLI to thread a
     /// resolved language into the engine) relies on: known BCP-47-ish codes map,
     /// unknown/empty/nil fall through to the caller's default.
     func testCohereLanguageMapsCodes() {

--- a/Tests/MacParakeetTests/STT/CohereTranscribeEngineTests.swift
+++ b/Tests/MacParakeetTests/STT/CohereTranscribeEngineTests.swift
@@ -210,6 +210,41 @@ final class CohereTranscribeEngineTests: XCTestCase {
         XCTAssertEqual(CohereTranscribeEngine.ComputePolicy.current(defaults: defaults), .gpu)
     }
 
+    func testRequireModelCachedFailsFastWhenCohereCacheIsMissing() throws {
+        let cacheRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cohere-cache-\(UUID().uuidString)", isDirectory: true)
+
+        XCTAssertThrowsError(try CohereTranscribeEngine.requireModelCached(cacheRoot: cacheRoot)) { error in
+            guard case STTError.engineStartFailed(let reason) = error else {
+                return XCTFail("Expected engineStartFailed, got \(error)")
+            }
+            XCTAssertTrue(reason.contains("Cohere Transcribe is not downloaded"))
+            XCTAssertTrue(reason.contains("models download cohere-transcribe"))
+        }
+    }
+
+    func testRequireModelCachedAcceptsCompleteCohereCache() throws {
+        let cacheRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cohere-cache-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: cacheRoot) }
+
+        try FileManager.default.createDirectory(
+            at: cacheRoot.appendingPathComponent("cohere_encoder.mlmodelc", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: cacheRoot.appendingPathComponent("cohere_decoder_cache_external_v2.mlmodelc", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        try "{}".write(
+            to: cacheRoot.appendingPathComponent("vocab.json"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        XCTAssertNoThrow(try CohereTranscribeEngine.requireModelCached(cacheRoot: cacheRoot))
+    }
+
     func testSharedInitializationAwaiterCancellationDoesNotCancelSharedTask() async throws {
         let shared = Task<Void, Error> {
             try await Task.sleep(for: .milliseconds(500))

--- a/Tests/MacParakeetTests/STT/CohereTranscribeEngineTests.swift
+++ b/Tests/MacParakeetTests/STT/CohereTranscribeEngineTests.swift
@@ -24,12 +24,28 @@ final class CohereTranscribeEngineTests: XCTestCase {
         XCTAssertEqual(merged, "the quick brown fox jumps over the lazy dog")
     }
 
+    func testMergeCompletesPartialTrailingWordWithCaseAndPunctuationDrift() {
+        let merged = CohereTranscribeEngine.mergeOnOverlap(
+            "the quick brown fo,",
+            "quick brown Fox jumps over the lazy dog"
+        )
+        XCTAssertEqual(merged, "the quick brown Fox jumps over the lazy dog")
+    }
+
     func testMergeDropsPartialLeadingWordWhenOverlapIsStrong() {
         let merged = CohereTranscribeEngine.mergeOnOverlap(
             "the quick brown fox",
             "own fox jumps over the lazy dog"
         )
         XCTAssertEqual(merged, "the quick brown fox jumps over the lazy dog")
+    }
+
+    func testMergeDropsPartialLeadingWordWithCaseAndPunctuationDrift() {
+        let merged = CohereTranscribeEngine.mergeOnOverlap(
+            "the quick Brown fox",
+            "own, Fox jumps over the lazy dog"
+        )
+        XCTAssertEqual(merged, "the quick Brown fox jumps over the lazy dog")
     }
 
     func testMergeDoesNotUsePartialBoundaryWithoutStrongOverlap() {

--- a/Tests/MacParakeetTests/STT/CohereTranscribeEngineTests.swift
+++ b/Tests/MacParakeetTests/STT/CohereTranscribeEngineTests.swift
@@ -1,0 +1,97 @@
+import XCTest
+
+@testable import MacParakeetCore
+
+/// Unit tests for `CohereTranscribeEngine`'s overlap-stitch used by the
+/// truncation guard (long/dense utterances are chunked into overlapping windows
+/// and re-joined). The transcription path itself needs the CoreML model and is
+/// exercised manually; this covers the pure stitching logic.
+final class CohereTranscribeEngineTests: XCTestCase {
+
+    func testMergeDropsDuplicatedOverlapWords() {
+        let merged = CohereTranscribeEngine.mergeOnOverlap(
+            "the quick brown fox",
+            "brown fox jumps over the lazy dog"
+        )
+        XCTAssertEqual(merged, "the quick brown fox jumps over the lazy dog")
+    }
+
+    func testMergeIsCaseAndPunctuationInsensitiveAtTheSeam() {
+        let merged = CohereTranscribeEngine.mergeOnOverlap(
+            "send me your feedback before the end of the day.",
+            "Day, we should also review the draft"
+        )
+        // "the day." / "Day," overlap by one word and must not duplicate.
+        XCTAssertEqual(
+            merged,
+            "send me your feedback before the end of the day. we should also review the draft"
+        )
+    }
+
+    func testMergeConcatenatesWhenNoOverlap() {
+        let merged = CohereTranscribeEngine.mergeOnOverlap("hello world", "foo bar")
+        XCTAssertEqual(merged, "hello world foo bar")
+    }
+
+    func testMergeHandlesFullPrefixOverlap() {
+        let merged = CohereTranscribeEngine.mergeOnOverlap("one two three", "two three")
+        XCTAssertEqual(merged, "one two three")
+    }
+
+    func testMergeHandlesEmptyFragments() {
+        XCTAssertEqual(CohereTranscribeEngine.mergeOnOverlap("", "only b"), "only b")
+        XCTAssertEqual(CohereTranscribeEngine.mergeOnOverlap("only a", ""), "only a")
+    }
+
+    /// On-device end-to-end guard: a long/dense (>98-token) utterance must come
+    /// back complete, not silently cut at the decode cap. Skipped unless
+    /// `COHERE_E2E_CLIP` points at a suitable wav and the model is downloaded,
+    /// so normal/CI runs are unaffected. Loads the real CoreML model.
+    func testLongDictationIsNotTruncated() async throws {
+        guard let clipPath = ProcessInfo.processInfo.environment["COHERE_E2E_CLIP"],
+            FileManager.default.fileExists(atPath: clipPath)
+        else {
+            throw XCTSkip("Set COHERE_E2E_CLIP to a long (>98-token) .wav to run this on-device check.")
+        }
+        guard CohereTranscribeEngine.isModelCached() else {
+            throw XCTSkip("Cohere model not downloaded.")
+        }
+        let expectedMinWords = Int(ProcessInfo.processInfo.environment["COHERE_E2E_MIN_WORDS"] ?? "90") ?? 90
+
+        let engine = CohereTranscribeEngine(computePolicy: .ane)
+        let result = try await engine.transcribe(audioPath: clipPath, job: .fileTranscription)
+        let wordCount = result.text.split(whereSeparator: { $0 == " " }).count
+        XCTAssertGreaterThanOrEqual(
+            wordCount, expectedMinWords,
+            "Transcript looks truncated (\(wordCount) words). Got: \(result.text)")
+    }
+
+    // MARK: - Language picker
+
+    func testSupportedLanguagesAreFourteenWithEnglish() {
+        let languages = CohereTranscribeEngine.supportedLanguages
+        XCTAssertEqual(languages.count, 14)
+        XCTAssertTrue(languages.contains { $0.code == "en" && $0.name == "English" })
+        XCTAssertTrue(languages.allSatisfy { $0.code.count == 2 && $0.code == $0.code.lowercased() })
+    }
+
+    func testNormalizeCohereLanguageFoldsToPrimarySubtag() {
+        XCTAssertEqual(SpeechEnginePreference.normalizeCohereLanguage("en"), "en")
+        XCTAssertEqual(SpeechEnginePreference.normalizeCohereLanguage("EN"), "en")
+        XCTAssertEqual(SpeechEnginePreference.normalizeCohereLanguage("en-US"), "en")
+        XCTAssertEqual(SpeechEnginePreference.normalizeCohereLanguage("fr_FR"), "fr")
+        XCTAssertNil(SpeechEnginePreference.normalizeCohereLanguage("auto"))
+        XCTAssertNil(SpeechEnginePreference.normalizeCohereLanguage(""))
+        XCTAssertNil(SpeechEnginePreference.normalizeCohereLanguage(nil))
+        XCTAssertNil(SpeechEnginePreference.normalizeCohereLanguage("12"))
+    }
+
+    func testCohereDefaultLanguageRoundTrips() throws {
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: "cohere-lang-test-\(UUID().uuidString)"))
+        XCTAssertNil(SpeechEnginePreference.cohereDefaultLanguage(defaults: defaults))
+        SpeechEnginePreference.saveCohereDefaultLanguage("ja", defaults: defaults)
+        XCTAssertEqual(SpeechEnginePreference.cohereDefaultLanguage(defaults: defaults), "ja")
+        SpeechEnginePreference.saveCohereDefaultLanguage(nil, defaults: defaults)
+        XCTAssertNil(SpeechEnginePreference.cohereDefaultLanguage(defaults: defaults))
+    }
+}

--- a/Tests/MacParakeetTests/STT/CohereTranscribeEngineTests.swift
+++ b/Tests/MacParakeetTests/STT/CohereTranscribeEngineTests.swift
@@ -58,6 +58,26 @@ final class CohereTranscribeEngineTests: XCTestCase {
         XCTAssertEqual(merged.components(separatedBy: "买东西").count - 1, 1)
     }
 
+    func testMergeDropsMixedSpaceChineseOverlap() {
+        let merged = CohereTranscribeEngine.mergeOnOverlap(
+            "今天 buy coffee 然后回家",
+            "coffee 然后回家休息"
+        )
+        XCTAssertEqual(merged, "今天 buy coffee 然后回家休息")
+        XCTAssertEqual(merged.components(separatedBy: "coffee 然后回家").count - 1, 1)
+    }
+
+    func testMergeDropsLongChineseCharacterOverlap() {
+        let overlap = "这是一个很长的中文重叠片段用于模拟四秒钟的快速讲话内容并且继续包含更多文字"
+        XCTAssertGreaterThan(overlap.count, 30)
+
+        let merged = CohereTranscribeEngine.mergeOnOverlap(
+            "开头内容" + overlap,
+            overlap + "结尾内容"
+        )
+        XCTAssertEqual(merged, "开头内容" + overlap + "结尾内容")
+    }
+
     func testMergeHandlesEmptyFragments() {
         XCTAssertEqual(CohereTranscribeEngine.mergeOnOverlap("", "only b"), "only b")
         XCTAssertEqual(CohereTranscribeEngine.mergeOnOverlap("only a", ""), "only a")

--- a/Tests/MacParakeetTests/STT/CohereTranscribeEngineTests.swift
+++ b/Tests/MacParakeetTests/STT/CohereTranscribeEngineTests.swift
@@ -118,6 +118,19 @@ final class CohereTranscribeEngineTests: XCTestCase {
         XCTAssertEqual(merged, "开头内容" + overlap + "结尾内容")
     }
 
+    func testMergeDropsCJKCompatibilityIdeographOverlapWithoutInsertingSpace() throws {
+        let first = try XCTUnwrap(UnicodeScalar(0xF900).map(String.init))
+        let second = try XCTUnwrap(UnicodeScalar(0xF901).map(String.init))
+
+        let merged = CohereTranscribeEngine.mergeOnOverlap(
+            first + first + first + second,
+            first + second + second
+        )
+
+        XCTAssertEqual(merged, first + first + first + second + second)
+        XCTAssertFalse(merged.contains(" "))
+    }
+
     func testMergeDoesNotTreatDifferentPunctuationAsOverlap() {
         let merged = CohereTranscribeEngine.mergeOnOverlap(
             "hello 。",

--- a/Tests/MacParakeetTests/STT/CohereTranscribeEngineTests.swift
+++ b/Tests/MacParakeetTests/STT/CohereTranscribeEngineTests.swift
@@ -78,6 +78,23 @@ final class CohereTranscribeEngineTests: XCTestCase {
         XCTAssertEqual(merged, "开头内容" + overlap + "结尾内容")
     }
 
+    func testMergeDoesNotTreatDifferentPunctuationAsOverlap() {
+        let merged = CohereTranscribeEngine.mergeOnOverlap(
+            "hello 。",
+            "、 world"
+        )
+        XCTAssertEqual(merged, "hello 。 、 world")
+    }
+
+    func testMergeUsesTailOfLongAccumulatedTranscript() {
+        let prefix = (0..<200).map { "word\($0)" }.joined(separator: " ")
+        let merged = CohereTranscribeEngine.mergeOnOverlap(
+            prefix + " alpha beta",
+            "alpha beta gamma"
+        )
+        XCTAssertEqual(merged, prefix + " alpha beta gamma")
+    }
+
     func testMergeHandlesEmptyFragments() {
         XCTAssertEqual(CohereTranscribeEngine.mergeOnOverlap("", "only b"), "only b")
         XCTAssertEqual(CohereTranscribeEngine.mergeOnOverlap("only a", ""), "only a")

--- a/Tests/MacParakeetTests/STT/CohereTranscribeEngineTests.swift
+++ b/Tests/MacParakeetTests/STT/CohereTranscribeEngineTests.swift
@@ -152,6 +152,22 @@ final class CohereTranscribeEngineTests: XCTestCase {
         XCTAssertEqual(merged, "hello 。 、 world")
     }
 
+    func testMergeDoesNotTreatMatchingPunctuationOnlyAsOverlap() {
+        let merged = CohereTranscribeEngine.mergeOnOverlap(
+            "hello 。",
+            "。 world"
+        )
+        XCTAssertEqual(merged, "hello 。 。 world")
+    }
+
+    func testMergeAllowsPunctuationInsideLexicalOverlap() {
+        let merged = CohereTranscribeEngine.mergeOnOverlap(
+            "你好。",
+            "好。明天见"
+        )
+        XCTAssertEqual(merged, "你好。明天见")
+    }
+
     func testMergeUsesTailOfLongAccumulatedTranscript() {
         let prefix = (0..<200).map { "word\($0)" }.joined(separator: " ")
         let merged = CohereTranscribeEngine.mergeOnOverlap(
@@ -192,6 +208,29 @@ final class CohereTranscribeEngineTests: XCTestCase {
 
         defaults.set("gpu", forKey: CohereTranscribeEngine.ComputePolicy.defaultsKey)
         XCTAssertEqual(CohereTranscribeEngine.ComputePolicy.current(defaults: defaults), .gpu)
+    }
+
+    func testSharedInitializationAwaiterCancellationDoesNotCancelSharedTask() async throws {
+        let shared = Task<Void, Error> {
+            try await Task.sleep(for: .milliseconds(500))
+        }
+        let waiter = Task<Void, Error> {
+            try await CohereTranscribeEngine.awaitSharedInitializationTask(shared)
+        }
+
+        let clock = ContinuousClock()
+        let started = clock.now
+        waiter.cancel()
+
+        do {
+            try await waiter.value
+            XCTFail("Cancelled waiter should throw CancellationError")
+        } catch is CancellationError {
+            let elapsed = started.duration(to: clock.now)
+            XCTAssertLessThan(elapsed, .milliseconds(200))
+        }
+
+        try await shared.value
     }
 
     /// On-device end-to-end guard: a long/dense (>98-token) utterance must come

--- a/Tests/MacParakeetTests/STT/CohereTranscribeEngineTests.swift
+++ b/Tests/MacParakeetTests/STT/CohereTranscribeEngineTests.swift
@@ -94,4 +94,16 @@ final class CohereTranscribeEngineTests: XCTestCase {
         SpeechEnginePreference.saveCohereDefaultLanguage(nil, defaults: defaults)
         XCTAssertNil(SpeechEnginePreference.cohereDefaultLanguage(defaults: defaults))
     }
+
+    /// Guards the mapper the string-code initializer (used by the CLI to thread a
+    /// resolved language into the engine) relies on: known BCP-47-ish codes map,
+    /// unknown/empty/nil fall through to the caller's default.
+    func testCohereLanguageMapsCodes() {
+        XCTAssertNotNil(CohereTranscribeEngine.cohereLanguage("fr"))
+        XCTAssertNotNil(CohereTranscribeEngine.cohereLanguage("fr-FR"))
+        XCTAssertNotNil(CohereTranscribeEngine.cohereLanguage("EN"))
+        XCTAssertNil(CohereTranscribeEngine.cohereLanguage("zz"))
+        XCTAssertNil(CohereTranscribeEngine.cohereLanguage(""))
+        XCTAssertNil(CohereTranscribeEngine.cohereLanguage(nil))
+    }
 }

--- a/Tests/MacParakeetTests/STT/CohereTranscribeEngineTests.swift
+++ b/Tests/MacParakeetTests/STT/CohereTranscribeEngineTests.swift
@@ -38,9 +38,41 @@ final class CohereTranscribeEngineTests: XCTestCase {
         XCTAssertEqual(merged, "one two three")
     }
 
+    func testMergeDropsJapaneseOverlapWithoutInsertingSpace() {
+        let merged = CohereTranscribeEngine.mergeOnOverlap(
+            "今日はいい天気ですね明日も",
+            "明日も晴れるでしょう"
+        )
+        XCTAssertEqual(merged, "今日はいい天気ですね明日も晴れるでしょう")
+        XCTAssertFalse(merged.contains(" "))
+        XCTAssertEqual(merged.components(separatedBy: "明日も").count - 1, 1)
+    }
+
+    func testMergeDropsChineseOverlapWithoutInsertingSpace() {
+        let merged = CohereTranscribeEngine.mergeOnOverlap(
+            "我今天去了商店买东西",
+            "买东西然后回家了"
+        )
+        XCTAssertEqual(merged, "我今天去了商店买东西然后回家了")
+        XCTAssertFalse(merged.contains(" "))
+        XCTAssertEqual(merged.components(separatedBy: "买东西").count - 1, 1)
+    }
+
     func testMergeHandlesEmptyFragments() {
         XCTAssertEqual(CohereTranscribeEngine.mergeOnOverlap("", "only b"), "only b")
         XCTAssertEqual(CohereTranscribeEngine.mergeOnOverlap("only a", ""), "only a")
+    }
+
+    func testComputePolicyDefaultsToANEWhenUnset() throws {
+        let suiteName = "cohere-compute-policy-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        XCTAssertEqual(CohereTranscribeEngine.ComputePolicy.current(defaults: defaults), .ane)
+
+        defaults.set("gpu", forKey: CohereTranscribeEngine.ComputePolicy.defaultsKey)
+        XCTAssertEqual(CohereTranscribeEngine.ComputePolicy.current(defaults: defaults), .gpu)
     }
 
     /// On-device end-to-end guard: a long/dense (>98-token) utterance must come

--- a/Tests/MacParakeetTests/STT/ModelDeletionTests.swift
+++ b/Tests/MacParakeetTests/STT/ModelDeletionTests.swift
@@ -299,6 +299,48 @@ final class ModelDeletionTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: multilingualVariant.path))
     }
 
+    // MARK: - Cohere cache file removal
+
+    func testCohereDeleteModelPrunesParentWithOnlyFinderDotfiles() throws {
+        let familyRoot = tempRoot.appendingPathComponent("cohere-transcribe", isDirectory: true)
+        let tierDir = familyRoot.appendingPathComponent("q8", isDirectory: true)
+        try FileManager.default.createDirectory(at: tierDir, withIntermediateDirectories: true)
+        try "weights".write(to: tierDir.appendingPathComponent("model.bin"), atomically: true, encoding: .utf8)
+        try "finder".write(to: familyRoot.appendingPathComponent(".DS_Store"), atomically: true, encoding: .utf8)
+
+        XCTAssertTrue(CohereTranscribeEngine.deleteModel(cacheRoot: tierDir))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: tierDir.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: familyRoot.path))
+    }
+
+    func testCohereDeleteModelKeepsParentWithVisibleSibling() throws {
+        let familyRoot = tempRoot.appendingPathComponent("cohere-transcribe", isDirectory: true)
+        let tierDir = familyRoot.appendingPathComponent("q8", isDirectory: true)
+        let visibleSibling = familyRoot.appendingPathComponent("other-tier", isDirectory: true)
+        for dir in [tierDir, visibleSibling] {
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            try "weights".write(to: dir.appendingPathComponent("model.bin"), atomically: true, encoding: .utf8)
+        }
+
+        XCTAssertTrue(CohereTranscribeEngine.deleteModel(cacheRoot: tierDir))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: tierDir.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: familyRoot.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: visibleSibling.path))
+    }
+
+    func testCohereDeleteModelKeepsParentWithNonFinderHiddenSibling() throws {
+        let familyRoot = tempRoot.appendingPathComponent("cohere-transcribe", isDirectory: true)
+        let tierDir = familyRoot.appendingPathComponent("q8", isDirectory: true)
+        try FileManager.default.createDirectory(at: tierDir, withIntermediateDirectories: true)
+        try "weights".write(to: tierDir.appendingPathComponent("model.bin"), atomically: true, encoding: .utf8)
+        try "state".write(to: familyRoot.appendingPathComponent(".download-state"), atomically: true, encoding: .utf8)
+
+        XCTAssertTrue(CohereTranscribeEngine.deleteModel(cacheRoot: tierDir))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: tierDir.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: familyRoot.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: familyRoot.appendingPathComponent(".download-state").path))
+    }
+
     func testDownloadNemotronEnglishModelEmitsRuntimeTelemetryOnSuccess() async throws {
         let telemetry = ModelDeletionTelemetrySpy()
         Telemetry.configure(telemetry)

--- a/Tests/MacParakeetTests/STT/ModelDeletionTests.swift
+++ b/Tests/MacParakeetTests/STT/ModelDeletionTests.swift
@@ -301,6 +301,17 @@ final class ModelDeletionTests: XCTestCase {
 
     // MARK: - Cohere cache file removal
 
+    func testCohereCacheDirectoryExistsForPartialDownloadDirectory() throws {
+        let tierDir = tempRoot
+            .appendingPathComponent("cohere-transcribe", isDirectory: true)
+            .appendingPathComponent("q8", isDirectory: true)
+        try FileManager.default.createDirectory(at: tierDir, withIntermediateDirectories: true)
+        try "partial".write(to: tierDir.appendingPathComponent("encoder.mlmodelc"), atomically: true, encoding: .utf8)
+
+        XCTAssertTrue(CohereTranscribeEngine.hasModelCacheDirectory(cacheRoot: tierDir))
+        XCTAssertFalse(CohereTranscribeEngine.isModelCached(cacheRoot: tierDir))
+    }
+
     func testCohereDeleteModelPrunesParentWithOnlyFinderDotfiles() throws {
         let familyRoot = tempRoot.appendingPathComponent("cohere-transcribe", isDirectory: true)
         let tierDir = familyRoot.appendingPathComponent("q8", isDirectory: true)

--- a/Tests/MacParakeetTests/STT/STTSchedulerTests.swift
+++ b/Tests/MacParakeetTests/STT/STTSchedulerTests.swift
@@ -43,7 +43,8 @@ final class STTSchedulerTests: XCTestCase {
             _ = try await scheduler.transcribe(audioPath: "dictation", job: .dictation)
             XCTFail("Expected live dictation to occupy the interactive slot")
         } catch let error as STTError {
-            if case .engineBusy = error {} else {
+            if case .engineBusy = error {
+            } else {
                 XCTFail("Expected engineBusy, got \(error)")
             }
         } catch {
@@ -515,6 +516,31 @@ final class STTSchedulerTests: XCTestCase {
         try await scheduler.setSpeechEngine(.whisper)
     }
 
+    func testSetSpeechEngineFailsWhileDefaultTranscribeAdmissionIsInFlight() async throws {
+        let runtime = MockSTTRuntime()
+        await runtime.blockNextSelectionRead()
+        let scheduler = STTScheduler(runtimeProvider: runtime)
+
+        let transcribeTask = Task {
+            try await scheduler.transcribe(audioPath: "dictation", job: .dictation)
+        }
+        try await waitForHeldSelectionRead(runtime: runtime, count: 1)
+
+        do {
+            try await scheduler.setSpeechEngine(.whisper)
+            XCTFail("Expected engine switch to fail while transcribe admission is in flight")
+        } catch let error as STTError {
+            XCTAssertEqual(error.localizedDescription, STTError.engineBusy.localizedDescription)
+        }
+
+        await runtime.releaseSelectionRead()
+        _ = try await transcribeTask.value
+        let switches = await runtime.setSpeechEngineCallCount
+        XCTAssertEqual(switches, 0, "No switch may reach the runtime mid-admission")
+
+        try await scheduler.setSpeechEngine(.whisper)
+    }
+
     /// Same AUDIT-071 window, via the Parakeet variant-swap path that shares
     /// the engine-switch guard.
     func testSetParakeetModelVariantFailsWhileSessionBeginIsInFlight() async throws {
@@ -818,6 +844,44 @@ final class STTSchedulerTests: XCTestCase {
 
         let routedSelection = await runtime.routedSelection(for: "meeting-final")
         XCTAssertEqual(routedSelection, SpeechEngineSelection(engine: .whisper, language: "ko"))
+    }
+
+    func testDefaultTranscribePinsCurrentSpeechEngineSelection() async throws {
+        let runtime = MockSTTRuntime()
+        await runtime.setCurrentSelection(SpeechEngineSelection(engine: .cohere, language: "JA"))
+        let scheduler = STTScheduler(runtimeProvider: runtime)
+
+        _ = try await scheduler.transcribe(audioPath: "dictation", job: .dictation)
+
+        let routedSelection = await runtime.routedSelection(for: "dictation")
+        XCTAssertEqual(routedSelection, SpeechEngineSelection(engine: .cohere, language: "ja"))
+    }
+
+    func testCohereJobsAreSingleFlightAcrossSchedulerSlots() async throws {
+        let runtime = MockSTTRuntime()
+        await runtime.setCurrentSelection(SpeechEngineSelection(engine: .cohere))
+        await runtime.block(path: "file")
+        let scheduler = STTScheduler(runtimeProvider: runtime, meetingLiveChunkBacklogLimit: 8)
+
+        let fileTask = Task {
+            try await scheduler.transcribe(audioPath: "file", job: .fileTranscription)
+        }
+        try await waitForStartedPaths(runtime: runtime, count: 1)
+
+        let dictationTask = Task {
+            try await scheduler.transcribe(audioPath: "dictation", job: .dictation)
+        }
+        try await Task.sleep(for: .milliseconds(100))
+
+        let startedWhileFileBlocked = await runtime.startedPaths()
+        XCTAssertEqual(startedWhileFileBlocked, ["file"])
+
+        await runtime.release(path: "file")
+        _ = try await fileTask.value
+        _ = try await dictationTask.value
+
+        let finalStartedPaths = await runtime.startedPaths()
+        XCTAssertEqual(finalStartedPaths, ["file", "dictation"])
     }
 
     func testProgressIsScopedPerJobAcrossSlots() async throws {

--- a/Tests/MacParakeetTests/Services/Dictation/DictationServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/Dictation/DictationServiceTests.swift
@@ -657,6 +657,48 @@ final class DictationServiceTests: XCTestCase {
         XCTAssertEqual(liveBeginCallCount, 0)
     }
 
+    func testCohereStyleDictationSkipsLivePathsAndUsesRecordedFileFinal() async throws {
+        service = DictationService(
+            audioProcessor: mockAudio,
+            sttTranscriber: mockSTT,
+            dictationRepo: dictationRepo,
+            shouldAttemptLiveDictationTranscription: { false },
+            shouldShowDictationPreview: { true },
+            dictationPreviewSpeechEngine: { nil },
+            dictationPreviewInterval: .zero
+        )
+        await mockSTT.configure(result: STTResult(text: "cohere final", words: [], engine: .cohere))
+
+        try await service.startRecording()
+        await mockAudio.emitLiveSamples([0.1, 0.2, 0.3])
+        try await Task.sleep(for: .milliseconds(50))
+
+        let liveTranscript = await service.liveTranscript
+        XCTAssertEqual(liveTranscript, "")
+
+        let result = try await service.stopRecording()
+
+        let transcribeCallCount = await mockSTT.transcribeCallCount
+        let lastJob = await mockSTT.lastJob
+        let liveBeginCallCount = await mockSTT.liveBeginCallCount
+        let liveAppendCallCount = await mockSTT.liveAppendCallCount
+        let liveFinishCallCount = await mockSTT.liveFinishCallCount
+        let liveCancelCallCount = await mockSTT.liveCancelCallCount
+        let previewCallCount = await mockSTT.previewCallCount
+        let previewCancelCallCount = await mockSTT.previewCancelCallCount
+        XCTAssertEqual(result.dictation.rawTranscript, "cohere final")
+        XCTAssertEqual(result.dictation.engine, SpeechEnginePreference.cohere.rawValue)
+        XCTAssertEqual(result.dictation.wordCount, 2)
+        XCTAssertEqual(transcribeCallCount, 1)
+        XCTAssertEqual(lastJob, .dictation)
+        XCTAssertEqual(liveBeginCallCount, 0)
+        XCTAssertEqual(liveAppendCallCount, 0)
+        XCTAssertEqual(liveFinishCallCount, 0)
+        XCTAssertEqual(liveCancelCallCount, 0)
+        XCTAssertEqual(previewCallCount, 0)
+        XCTAssertEqual(previewCancelCallCount, 0)
+    }
+
     func testDisplayPreviewDisabledSkipsPreviewTranscription() async throws {
         service = DictationService(
             audioProcessor: mockAudio,

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingServiceTests.swift
@@ -854,6 +854,35 @@ final class MeetingRecordingServiceTests: XCTestCase {
         XCTAssertNotNil(output.sourceAlignment.microphone)
     }
 
+    func testCohereMeetingDoesNotRouteLivePreviewChunks() async throws {
+        let captureService = MockMeetingAudioCaptureService()
+        let audioConverter = MockMeetingAudioFileConverter()
+        let sttClient = LeasingMeetingSTTClient(
+            selection: SpeechEngineSelection(engine: .cohere, language: "ja")
+        )
+        let service = MeetingRecordingService(
+            audioCaptureService: captureService,
+            audioConverter: audioConverter,
+            sttTranscriber: sttClient
+        )
+
+        try await service.startRecording()
+
+        let microphoneBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 80_000, sampleValue: 0.25))
+        await captureService.yield(.microphoneBuffer(
+            microphoneBuffer,
+            AVAudioTime(hostTime: AVAudioTime.hostTime(forSeconds: 100.0))
+        ))
+        try await Task.sleep(for: .milliseconds(100))
+
+        let routedSelections = await sttClient.routedSelections
+        XCTAssertEqual(routedSelections, [])
+
+        let output = try await service.stopRecording()
+        defer { try? FileManager.default.removeItem(at: output.folderURL) }
+        XCTAssertEqual(output.speechEngine, SpeechEngineSelection(engine: .cohere, language: "ja"))
+    }
+
     func testStaleChunkFailureFromPreviousSessionDoesNotPoisonNextSession() async throws {
         let captureService = MockMeetingAudioCaptureService()
         let audioConverter = MockMeetingAudioFileConverter()

--- a/Tests/MacParakeetTests/Services/System/MockClipboardService.swift
+++ b/Tests/MacParakeetTests/Services/System/MockClipboardService.swift
@@ -15,6 +15,7 @@ public actor MockClipboardService: ClipboardServiceProtocol {
     public var lastPostPasteAction: KeyAction?
     public var lastRestoresClipboard: Bool?
     public var pasteCallCount = 0
+    private var pasteError: Error?
 
     public init() {}
 
@@ -33,9 +34,12 @@ public actor MockClipboardService: ClipboardServiceProtocol {
     }
 
     public func pasteText(_ text: String, restoresClipboard: Bool) async throws {
+        pasteCallCount += 1
+        if let pasteError {
+            throw pasteError
+        }
         lastPastedText = text
         lastRestoresClipboard = restoresClipboard
-        pasteCallCount += 1
     }
 
     public func pasteTextWithAction(_ text: String, postPasteAction: KeyAction?) async throws -> Bool {
@@ -51,5 +55,9 @@ public actor MockClipboardService: ClipboardServiceProtocol {
     public func copyToClipboard(_ text: String) async -> Bool {
         lastCopiedText = text
         return true
+    }
+
+    public func setPasteError(_ error: Error?) {
+        pasteError = error
     }
 }

--- a/Tests/MacParakeetTests/ViewModels/EngineSettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/EngineSettingsViewModelTests.swift
@@ -26,7 +26,8 @@ final class EngineSettingsViewModelTests: XCTestCase {
         cohereCached: @escaping @Sendable () -> Bool = { false },
         deleteParakeet: @escaping @Sendable (ParakeetModelVariant) -> Bool = { _ in false },
         deleteNemotron: @escaping @Sendable (NemotronModelVariant, String?) -> Bool = { _, _ in false },
-        deleteWhisper: @escaping @Sendable (String) -> Bool = { _ in false }
+        deleteWhisper: @escaping @Sendable (String) -> Bool = { _ in false },
+        deleteCohere: @escaping @Sendable () -> Bool = { false }
     ) -> EngineSettingsViewModel {
         EngineSettingsViewModel(
             defaults: defaults,
@@ -35,7 +36,8 @@ final class EngineSettingsViewModelTests: XCTestCase {
             cohereModelCached: cohereCached,
             deleteParakeetModelOnDisk: deleteParakeet,
             deleteNemotronModelOnDisk: deleteNemotron,
-            deleteWhisperModelOnDisk: deleteWhisper
+            deleteWhisperModelOnDisk: deleteWhisper,
+            deleteCohereModelOnDisk: deleteCohere
         )
     }
 
@@ -330,6 +332,24 @@ final class EngineSettingsViewModelTests: XCTestCase {
         XCTAssertEqual(vm.cohereModelStatusDetail, "Cohere Transcribe · Loaded in memory.")
     }
 
+    func testDeleteCohereModelUsesInjectedDeleterAndRefreshesStatus() async throws {
+        let recorder = CohereDeleteRecorder()
+        let vm = makeViewModel(
+            cohereCached: { recorder.isCached },
+            deleteCohere: {
+                recorder.delete()
+                return true
+            }
+        )
+        vm.cohereModelStatus = .notLoaded
+
+        vm.deleteCohereModel()
+
+        try await waitUntil { recorder.deleteCount == 1 && vm.cohereModelStatus == .notDownloaded }
+        XCTAssertFalse(vm.isCohereModelDownloaded)
+        XCTAssertEqual(vm.cohereModelStatusDetail, "Cohere Transcribe · Needs download before use.")
+    }
+
     func testRefreshModelStatusPassesStoredNemotronLanguageToCachedStub() async throws {
         SpeechEnginePreference.saveNemotronDefaultLanguage("en_US", defaults: defaults)
         let recorder = NemotronCacheCheckRecorder()
@@ -387,5 +407,30 @@ private final class NemotronCacheCheckRecorder: @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
         return recordedCalls
+    }
+}
+
+private final class CohereDeleteRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var cached = true
+    private var deletes = 0
+
+    var isCached: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return cached
+    }
+
+    var deleteCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return deletes
+    }
+
+    func delete() {
+        lock.lock()
+        deletes += 1
+        cached = false
+        lock.unlock()
     }
 }

--- a/Tests/MacParakeetTests/ViewModels/EngineSettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/EngineSettingsViewModelTests.swift
@@ -24,6 +24,7 @@ final class EngineSettingsViewModelTests: XCTestCase {
         parakeetCached: @escaping @Sendable (ParakeetModelVariant) -> Bool = { _ in false },
         nemotronCached: @escaping @Sendable (NemotronModelVariant, String?) -> Bool = { _, _ in false },
         cohereCached: @escaping @Sendable () -> Bool = { false },
+        cohereCacheDirectoryExists: @escaping @Sendable () -> Bool = { false },
         deleteParakeet: @escaping @Sendable (ParakeetModelVariant) -> Bool = { _ in false },
         deleteNemotron: @escaping @Sendable (NemotronModelVariant, String?) -> Bool = { _, _ in false },
         deleteWhisper: @escaping @Sendable (String) -> Bool = { _ in false },
@@ -34,6 +35,7 @@ final class EngineSettingsViewModelTests: XCTestCase {
             parakeetModelVariantCached: parakeetCached,
             nemotronModelVariantCached: nemotronCached,
             cohereModelCached: cohereCached,
+            cohereModelCacheDirectoryExists: cohereCacheDirectoryExists,
             deleteParakeetModelOnDisk: deleteParakeet,
             deleteNemotronModelOnDisk: deleteNemotron,
             deleteWhisperModelOnDisk: deleteWhisper,
@@ -319,6 +321,21 @@ final class EngineSettingsViewModelTests: XCTestCase {
         )
     }
 
+    func testCoherePartialCacheRemainsNotDownloadedButCanBeDeleted() async throws {
+        let vm = makeViewModel(
+            cohereCached: { false },
+            cohereCacheDirectoryExists: { true }
+        )
+
+        vm.refreshModelStatus()
+
+        try await waitForModelStatusRefreshToFinish(vm)
+        XCTAssertFalse(vm.isCohereModelDownloaded)
+        XCTAssertEqual(vm.cohereModelStatus, .notDownloaded)
+        XCTAssertTrue(vm.cohereCacheDirectoryExists)
+        XCTAssertTrue(vm.canDeleteCohereModel)
+    }
+
     func testActiveReadyCohereReportsLoadedInMemory() async throws {
         SpeechEnginePreference.cohere.save(to: defaults)
         let vm = makeViewModel(cohereCached: { true })
@@ -347,6 +364,26 @@ final class EngineSettingsViewModelTests: XCTestCase {
 
         try await waitUntil { recorder.deleteCount == 1 && vm.cohereModelStatus == .notDownloaded }
         XCTAssertFalse(vm.isCohereModelDownloaded)
+        XCTAssertEqual(vm.cohereModelStatusDetail, "Cohere Transcribe · Needs download before use.")
+    }
+
+    func testDeleteCohereModelAllowsFailedPartialDownloadCleanup() async throws {
+        let recorder = CohereDeleteRecorder()
+        let vm = makeViewModel(
+            cohereCached: { false },
+            cohereCacheDirectoryExists: { recorder.isCached },
+            deleteCohere: {
+                recorder.delete()
+                return true
+            }
+        )
+        vm.cohereModelStatus = .failed
+        vm.cohereCacheDirectoryExists = true
+
+        vm.deleteCohereModel()
+
+        try await waitUntil { recorder.deleteCount == 1 && vm.cohereModelStatus == .notDownloaded }
+        XCTAssertFalse(vm.canDeleteCohereModel)
         XCTAssertEqual(vm.cohereModelStatusDetail, "Cohere Transcribe · Needs download before use.")
     }
 

--- a/Tests/MacParakeetTests/ViewModels/EngineSettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/EngineSettingsViewModelTests.swift
@@ -177,6 +177,35 @@ final class EngineSettingsViewModelTests: XCTestCase {
         XCTAssertNil(vm.speechEngineSwitchTarget)
     }
 
+    func testConfirmPendingSwitchClearsPendingAndPersistsWhenCohereIsMarkedDownloaded() {
+        let vm = makeViewModel()
+        vm.cohereModelStatus = .notLoaded
+        vm.requestSpeechEngineSwitchConfirmation(to: .cohere)
+
+        vm.confirmPendingSpeechEngineSwitch()
+
+        XCTAssertNil(vm.pendingSpeechEngineSwitchConfirmation)
+        XCTAssertEqual(vm.speechEnginePreference, .cohere)
+        XCTAssertEqual(SpeechEnginePreference.current(defaults: defaults), .cohere)
+        XCTAssertNil(vm.speechEngineError)
+        XCTAssertFalse(vm.speechEngineSwitching)
+        XCTAssertNil(vm.speechEngineSwitchTarget)
+    }
+
+    func testConfirmPendingSwitchClearsPendingAndRestoresCurrentEngineWhenCohereModelIsMissing() {
+        let vm = makeViewModel()
+        vm.requestSpeechEngineSwitchConfirmation(to: .cohere)
+
+        vm.confirmPendingSpeechEngineSwitch()
+
+        XCTAssertNil(vm.pendingSpeechEngineSwitchConfirmation)
+        XCTAssertEqual(vm.speechEnginePreference, .parakeet)
+        XCTAssertEqual(SpeechEnginePreference.current(defaults: defaults), .parakeet)
+        XCTAssertEqual(vm.speechEngineError, "Download Cohere Transcribe before switching engines.")
+        XCTAssertFalse(vm.speechEngineSwitching)
+        XCTAssertNil(vm.speechEngineSwitchTarget)
+    }
+
     func testSwitchUnavailableMessageReturnsNilWhenAvailable() {
         XCTAssertNil(EngineSettingsViewModel.speechEngineSwitchUnavailableMessage(for: .available))
     }
@@ -328,6 +357,19 @@ final class EngineSettingsViewModelTests: XCTestCase {
 
         vm.whisperModelStatus = .ready
         XCTAssertTrue(vm.isWhisperModelDownloaded)
+    }
+
+    func testIsCohereModelDownloadedReflectsPublicStatus() {
+        let vm = makeViewModel()
+
+        vm.cohereModelStatus = .notDownloaded
+        XCTAssertFalse(vm.isCohereModelDownloaded)
+
+        vm.cohereModelStatus = .notLoaded
+        XCTAssertTrue(vm.isCohereModelDownloaded)
+
+        vm.cohereModelStatus = .ready
+        XCTAssertTrue(vm.isCohereModelDownloaded)
     }
 }
 

--- a/Tests/MacParakeetTests/ViewModels/EngineSettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/EngineSettingsViewModelTests.swift
@@ -363,6 +363,48 @@ final class EngineSettingsViewModelTests: XCTestCase {
         XCTAssertTrue(vm.canDeleteCohereModel)
     }
 
+    func testRefreshModelStatusPreservesCohereDownloadState() async throws {
+        let recorder = CohereDiskStateRecorder(cached: false, cacheDirectoryExists: true)
+        let vm = makeViewModel(
+            cohereCached: { recorder.isCached() },
+            cohereCacheDirectoryExists: { recorder.cacheDirectoryExists() }
+        )
+        vm.configure(sttClient: MockSTTClient())
+        vm.cohereDownloading = true
+        vm.cohereModelStatus = .repairing
+        vm.cohereModelStatusDetail = "Downloading Cohere Transcribe..."
+        vm.cohereCacheDirectoryExists = false
+
+        vm.refreshModelStatus()
+
+        try await waitForModelStatusRefreshToFinish(vm)
+        XCTAssertTrue(recorder.didCheckCohere)
+        XCTAssertEqual(vm.cohereModelStatus, .repairing)
+        XCTAssertEqual(vm.cohereModelStatusDetail, "Downloading Cohere Transcribe...")
+        XCTAssertFalse(vm.cohereCacheDirectoryExists)
+    }
+
+    func testRefreshModelStatusPreservesCohereDeleteState() async throws {
+        let recorder = CohereDiskStateRecorder(cached: true, cacheDirectoryExists: true)
+        let vm = makeViewModel(
+            cohereCached: { recorder.isCached() },
+            cohereCacheDirectoryExists: { recorder.cacheDirectoryExists() }
+        )
+        vm.configure(sttClient: MockSTTClient())
+        vm.cohereDeleting = true
+        vm.cohereModelStatus = .notDownloaded
+        vm.cohereModelStatusDetail = "Deleting Cohere Transcribe..."
+        vm.cohereCacheDirectoryExists = false
+
+        vm.refreshModelStatus()
+
+        try await waitForModelStatusRefreshToFinish(vm)
+        XCTAssertTrue(recorder.didCheckCohere)
+        XCTAssertEqual(vm.cohereModelStatus, .notDownloaded)
+        XCTAssertEqual(vm.cohereModelStatusDetail, "Deleting Cohere Transcribe...")
+        XCTAssertFalse(vm.cohereCacheDirectoryExists)
+    }
+
     func testActiveReadyCohereReportsLoadedInMemory() async throws {
         SpeechEnginePreference.cohere.save(to: defaults)
         let vm = makeViewModel(cohereCached: { true })
@@ -523,6 +565,41 @@ private final class CohereDeleteRecorder: @unchecked Sendable {
         deletes += 1
         cached = false
         lock.unlock()
+    }
+}
+
+private final class CohereDiskStateRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private let cached: Bool
+    private let directoryExists: Bool
+    private var cacheCheckCount = 0
+    private var directoryCheckCount = 0
+
+    init(cached: Bool, cacheDirectoryExists: Bool) {
+        self.cached = cached
+        self.directoryExists = cacheDirectoryExists
+    }
+
+    var didCheckCohere: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return cacheCheckCount > 0 && directoryCheckCount > 0
+    }
+
+    func isCached() -> Bool {
+        lock.lock()
+        cacheCheckCount += 1
+        let value = cached
+        lock.unlock()
+        return value
+    }
+
+    func cacheDirectoryExists() -> Bool {
+        lock.lock()
+        directoryCheckCount += 1
+        let value = directoryExists
+        lock.unlock()
+        return value
     }
 }
 

--- a/Tests/MacParakeetTests/ViewModels/EngineSettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/EngineSettingsViewModelTests.swift
@@ -197,7 +197,7 @@ final class EngineSettingsViewModelTests: XCTestCase {
     }
 
     func testConfirmPendingSwitchAllowsCohereWhileModelStatusCheckIsInFlight() {
-        let vm = makeViewModel()
+        let vm = makeViewModel(cohereCached: { true })
         vm.cohereModelStatus = .checking
         vm.requestSpeechEngineSwitchConfirmation(to: .cohere)
 
@@ -207,6 +207,19 @@ final class EngineSettingsViewModelTests: XCTestCase {
         XCTAssertEqual(vm.speechEnginePreference, .cohere)
         XCTAssertEqual(SpeechEnginePreference.current(defaults: defaults), .cohere)
         XCTAssertNil(vm.speechEngineError)
+    }
+
+    func testConfirmPendingSwitchBlocksCohereWhileModelStatusCheckIsInFlightAndCacheMissing() {
+        let vm = makeViewModel(cohereCached: { false })
+        vm.cohereModelStatus = .checking
+        vm.requestSpeechEngineSwitchConfirmation(to: .cohere)
+
+        vm.confirmPendingSpeechEngineSwitch()
+
+        XCTAssertNil(vm.pendingSpeechEngineSwitchConfirmation)
+        XCTAssertEqual(vm.speechEnginePreference, .parakeet)
+        XCTAssertEqual(SpeechEnginePreference.current(defaults: defaults), .parakeet)
+        XCTAssertEqual(vm.speechEngineError, "Download Cohere Transcribe before switching engines.")
     }
 
     func testConfirmPendingSwitchClearsPendingAndRestoresCurrentEngineWhenCohereModelIsMissing() {

--- a/Tests/MacParakeetTests/ViewModels/EngineSettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/EngineSettingsViewModelTests.swift
@@ -209,6 +209,20 @@ final class EngineSettingsViewModelTests: XCTestCase {
         XCTAssertNil(vm.speechEngineError)
     }
 
+    func testConfirmPendingSwitchBlocksCohereWhileModelDeleteIsInFlight() {
+        let vm = makeViewModel(cohereCached: { true })
+        vm.cohereModelStatus = .notLoaded
+        vm.cohereDeleting = true
+        vm.requestSpeechEngineSwitchConfirmation(to: .cohere)
+
+        vm.confirmPendingSpeechEngineSwitch()
+
+        XCTAssertNil(vm.pendingSpeechEngineSwitchConfirmation)
+        XCTAssertEqual(vm.speechEnginePreference, .parakeet)
+        XCTAssertEqual(SpeechEnginePreference.current(defaults: defaults), .parakeet)
+        XCTAssertEqual(vm.speechEngineError, "Finish deleting Cohere Transcribe before switching engines.")
+    }
+
     func testConfirmPendingSwitchBlocksCohereWhileModelStatusCheckIsInFlightAndCacheMissing() {
         let vm = makeViewModel(cohereCached: { false })
         vm.cohereModelStatus = .checking

--- a/Tests/MacParakeetTests/ViewModels/EngineSettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/EngineSettingsViewModelTests.swift
@@ -398,6 +398,33 @@ final class EngineSettingsViewModelTests: XCTestCase {
         XCTAssertFalse(vm.cohereCacheDirectoryExists)
     }
 
+    func testRefreshStartedDuringCohereDownloadDoesNotOverwriteFailureAfterDownloadEnds() async throws {
+        let recorder = BlockingCohereDiskStateRecorder(cached: true, cacheDirectoryExists: true)
+        let vm = makeViewModel(
+            cohereCached: { recorder.isCached() },
+            cohereCacheDirectoryExists: { recorder.cacheDirectoryExists() }
+        )
+        vm.configure(sttClient: MockSTTClient())
+        vm.cohereDownloading = true
+        vm.cohereModelStatus = .repairing
+        vm.cohereModelStatusDetail = "Downloading Cohere Transcribe..."
+        vm.cohereCacheDirectoryExists = false
+
+        vm.refreshModelStatus()
+        try await waitUntil { recorder.cacheCheckStarted }
+
+        vm.cohereDownloading = false
+        vm.cohereModelStatus = .failed
+        vm.cohereModelStatusDetail = "Download failed"
+
+        recorder.release()
+
+        try await waitUntil { recorder.didCheckCohere && vm.parakeetStatus != .checking }
+        XCTAssertEqual(vm.cohereModelStatus, .failed)
+        XCTAssertEqual(vm.cohereModelStatusDetail, "Download failed")
+        XCTAssertFalse(vm.cohereCacheDirectoryExists)
+    }
+
     func testRefreshModelStatusPreservesCohereDeleteState() async throws {
         let recorder = CohereDiskStateRecorder(cached: true, cacheDirectoryExists: true)
         let vm = makeViewModel(
@@ -614,6 +641,51 @@ private final class CohereDiskStateRecorder: @unchecked Sendable {
         let value = directoryExists
         lock.unlock()
         return value
+    }
+}
+
+private final class BlockingCohereDiskStateRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private let releaseSemaphore = DispatchSemaphore(value: 0)
+    private let cached: Bool
+    private let directoryExists: Bool
+    private var cacheCheckCount = 0
+    private var directoryCheckCount = 0
+
+    init(cached: Bool, cacheDirectoryExists: Bool) {
+        self.cached = cached
+        self.directoryExists = cacheDirectoryExists
+    }
+
+    var cacheCheckStarted: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return cacheCheckCount > 0
+    }
+
+    var didCheckCohere: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return cacheCheckCount > 0 && directoryCheckCount > 0
+    }
+
+    func release() {
+        releaseSemaphore.signal()
+    }
+
+    func isCached() -> Bool {
+        lock.lock()
+        cacheCheckCount += 1
+        lock.unlock()
+        _ = releaseSemaphore.wait(timeout: .now() + 1)
+        return cached
+    }
+
+    func cacheDirectoryExists() -> Bool {
+        lock.lock()
+        directoryCheckCount += 1
+        lock.unlock()
+        return directoryExists
     }
 }
 

--- a/Tests/MacParakeetTests/ViewModels/EngineSettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/EngineSettingsViewModelTests.swift
@@ -196,8 +196,22 @@ final class EngineSettingsViewModelTests: XCTestCase {
         XCTAssertNil(vm.speechEngineSwitchTarget)
     }
 
+    func testConfirmPendingSwitchAllowsCohereWhileModelStatusCheckIsInFlight() {
+        let vm = makeViewModel()
+        vm.cohereModelStatus = .checking
+        vm.requestSpeechEngineSwitchConfirmation(to: .cohere)
+
+        vm.confirmPendingSpeechEngineSwitch()
+
+        XCTAssertNil(vm.pendingSpeechEngineSwitchConfirmation)
+        XCTAssertEqual(vm.speechEnginePreference, .cohere)
+        XCTAssertEqual(SpeechEnginePreference.current(defaults: defaults), .cohere)
+        XCTAssertNil(vm.speechEngineError)
+    }
+
     func testConfirmPendingSwitchClearsPendingAndRestoresCurrentEngineWhenCohereModelIsMissing() {
         let vm = makeViewModel()
+        vm.cohereModelStatus = .notDownloaded
         vm.requestSpeechEngineSwitchConfirmation(to: .cohere)
 
         vm.confirmPendingSpeechEngineSwitch()

--- a/Tests/MacParakeetTests/ViewModels/EngineSettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/EngineSettingsViewModelTests.swift
@@ -23,6 +23,7 @@ final class EngineSettingsViewModelTests: XCTestCase {
     private func makeViewModel(
         parakeetCached: @escaping @Sendable (ParakeetModelVariant) -> Bool = { _ in false },
         nemotronCached: @escaping @Sendable (NemotronModelVariant, String?) -> Bool = { _, _ in false },
+        cohereCached: @escaping @Sendable () -> Bool = { false },
         deleteParakeet: @escaping @Sendable (ParakeetModelVariant) -> Bool = { _ in false },
         deleteNemotron: @escaping @Sendable (NemotronModelVariant, String?) -> Bool = { _, _ in false },
         deleteWhisper: @escaping @Sendable (String) -> Bool = { _ in false }
@@ -31,6 +32,7 @@ final class EngineSettingsViewModelTests: XCTestCase {
             defaults: defaults,
             parakeetModelVariantCached: parakeetCached,
             nemotronModelVariantCached: nemotronCached,
+            cohereModelCached: cohereCached,
             deleteParakeetModelOnDisk: deleteParakeet,
             deleteNemotronModelOnDisk: deleteNemotron,
             deleteWhisperModelOnDisk: deleteWhisper
@@ -62,7 +64,8 @@ final class EngineSettingsViewModelTests: XCTestCase {
     ) async throws {
         try await waitUntil(file: file, line: line) {
             vm.nemotronModelStatus != .checking &&
-                vm.whisperModelStatus != .checking
+                vm.whisperModelStatus != .checking &&
+                vm.cohereModelStatus != .checking
         }
     }
 
@@ -255,6 +258,47 @@ final class EngineSettingsViewModelTests: XCTestCase {
             vm.nemotronModelStatusDetail,
             "Nemotron 3.5 ASR Streaming 0.6B · Needs download before use."
         )
+    }
+
+    func testCohereCacheStatusMarksDownloadedModelInstalledWhenInactive() async throws {
+        let vm = makeViewModel(cohereCached: { true })
+
+        vm.refreshModelStatus()
+
+        try await waitForModelStatusRefreshToFinish(vm)
+        XCTAssertTrue(vm.isCohereModelDownloaded)
+        XCTAssertEqual(vm.cohereModelStatus, .notLoaded)
+        XCTAssertEqual(
+            vm.cohereModelStatusDetail,
+            "Cohere Transcribe · Installed locally, loads when selected."
+        )
+    }
+
+    func testCohereCacheStatusMarksMissingModelNotDownloaded() async throws {
+        let vm = makeViewModel(cohereCached: { false })
+
+        vm.refreshModelStatus()
+
+        try await waitForModelStatusRefreshToFinish(vm)
+        XCTAssertFalse(vm.isCohereModelDownloaded)
+        XCTAssertEqual(vm.cohereModelStatus, .notDownloaded)
+        XCTAssertEqual(
+            vm.cohereModelStatusDetail,
+            "Cohere Transcribe · Needs download before use."
+        )
+    }
+
+    func testActiveReadyCohereReportsLoadedInMemory() async throws {
+        SpeechEnginePreference.cohere.save(to: defaults)
+        let vm = makeViewModel(cohereCached: { true })
+        let stt = MockSTTClient()
+        await stt.setReady(true)
+        vm.configure(sttClient: stt)
+
+        vm.refreshModelStatus()
+
+        try await waitUntil { vm.cohereModelStatus == .ready }
+        XCTAssertEqual(vm.cohereModelStatusDetail, "Cohere Transcribe · Loaded in memory.")
     }
 
     func testRefreshModelStatusPassesStoredNemotronLanguageToCachedStub() async throws {

--- a/Tests/MacParakeetTests/ViewModels/EngineSettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/EngineSettingsViewModelTests.swift
@@ -414,6 +414,33 @@ final class EngineSettingsViewModelTests: XCTestCase {
         XCTAssertEqual(vm.cohereModelStatusDetail, "Cohere Transcribe · Needs download before use.")
     }
 
+    func testDeleteCohereModelBlocksConcurrentDeleteAndDownloadUntilDiskWorkFinishes() async throws {
+        let recorder = BlockingCohereDeleteRecorder()
+        let vm = makeViewModel(
+            cohereCached: { recorder.isCached },
+            deleteCohere: {
+                recorder.delete()
+                return true
+            }
+        )
+        vm.cohereModelStatus = .notLoaded
+
+        vm.deleteCohereModel()
+        try await waitUntil { recorder.deleteStarted && vm.cohereDeleting }
+
+        vm.deleteCohereModel()
+        vm.downloadCohereModel()
+
+        XCTAssertEqual(recorder.deleteCount, 1)
+        XCTAssertTrue(vm.cohereDeleting)
+        XCTAssertFalse(vm.cohereDownloading)
+        XCTAssertEqual(vm.cohereModelStatus, .notDownloaded)
+
+        recorder.finishDelete()
+        try await waitUntil { !vm.cohereDeleting && vm.cohereModelStatus == .notDownloaded }
+        XCTAssertFalse(vm.canDeleteCohereModel)
+    }
+
     func testRefreshModelStatusPassesStoredNemotronLanguageToCachedStub() async throws {
         SpeechEnginePreference.saveNemotronDefaultLanguage("en_US", defaults: defaults)
         let recorder = NemotronCacheCheckRecorder()
@@ -496,5 +523,46 @@ private final class CohereDeleteRecorder: @unchecked Sendable {
         deletes += 1
         cached = false
         lock.unlock()
+    }
+}
+
+private final class BlockingCohereDeleteRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private let releaseSemaphore = DispatchSemaphore(value: 0)
+    private var cached = true
+    private var deletes = 0
+    private var started = false
+
+    var isCached: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return cached
+    }
+
+    var deleteStarted: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return started
+    }
+
+    var deleteCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return deletes
+    }
+
+    func delete() {
+        lock.lock()
+        started = true
+        deletes += 1
+        lock.unlock()
+        releaseSemaphore.wait()
+        lock.lock()
+        cached = false
+        lock.unlock()
+    }
+
+    func finishDelete() {
+        releaseSemaphore.signal()
     }
 }

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
@@ -1761,7 +1761,8 @@ final class TranscriptionViewModelTests: XCTestCase {
         viewModel = TranscriptionViewModel(
             defaults: defaults,
             isWhisperModelDownloaded: { true },
-            isNemotronModelDownloaded: { true }
+            isNemotronModelDownloaded: { true },
+            isCohereModelDownloaded: { true }
         )
 
         let archivedMeeting = try makeArchivedMeetingRecording(speechEngine: nil)
@@ -2035,6 +2036,42 @@ final class TranscriptionViewModelTests: XCTestCase {
         XCTAssertEqual(
             try retranscriptionChoice(.cohere, in: option).selection,
             SpeechEngineSelection(engine: .cohere, language: "fr")
+        )
+    }
+
+    func testRetranscriptionEngineOptionDisablesMissingCohereModel() throws {
+        let suiteName = "TranscriptionViewModelTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        SpeechEnginePreference.parakeet.save(to: defaults)
+        viewModel = TranscriptionViewModel(
+            defaults: defaults,
+            isWhisperModelDownloaded: { true },
+            isNemotronModelDownloaded: { true },
+            isCohereModelDownloaded: { false }
+        )
+
+        let tmpFile = FileManager.default.temporaryDirectory
+            .appendingPathComponent("retranscribe-engine-cohere-missing-\(UUID().uuidString).mp3")
+        FileManager.default.createFile(atPath: tmpFile.path, contents: Data([0]))
+        defer { try? FileManager.default.removeItem(at: tmpFile) }
+
+        let original = Transcription(
+            id: UUID(),
+            fileName: "Audio File",
+            filePath: tmpFile.path,
+            durationMs: 2_000,
+            rawTranscript: "Old transcript",
+            status: .completed,
+            sourceType: .file
+        )
+
+        let option = try XCTUnwrap(viewModel.retranscriptionEngineOption(for: original))
+        let cohere = try retranscriptionChoice(.cohere, in: option)
+        XCTAssertFalse(cohere.isAvailable)
+        XCTAssertEqual(
+            cohere.unavailableReason,
+            "Download the Cohere model in Settings before trying Cohere."
         )
     }
 

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
@@ -2001,6 +2001,43 @@ final class TranscriptionViewModelTests: XCTestCase {
         XCTAssertTrue(try retranscriptionChoice(.nemotron, in: option).isAvailable)
     }
 
+    func testRetranscriptionCohereChoiceCarriesStoredLanguage() throws {
+        // Cohere has no auto-detect and the engine defaults to English, so the
+        // retranscription choice must carry the persisted picker language —
+        // otherwise a non-English Cohere user gets silently English output.
+        let suiteName = "TranscriptionViewModelTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        SpeechEnginePreference.parakeet.save(to: defaults)
+        SpeechEnginePreference.saveCohereDefaultLanguage("fr", defaults: defaults)
+        viewModel = TranscriptionViewModel(
+            defaults: defaults,
+            isWhisperModelDownloaded: { true },
+            isNemotronModelDownloaded: { true }
+        )
+
+        let tmpFile = FileManager.default.temporaryDirectory
+            .appendingPathComponent("retranscribe-engine-cohere-lang-\(UUID().uuidString).mp3")
+        FileManager.default.createFile(atPath: tmpFile.path, contents: Data([0]))
+        defer { try? FileManager.default.removeItem(at: tmpFile) }
+
+        let original = Transcription(
+            id: UUID(),
+            fileName: "Audio File",
+            filePath: tmpFile.path,
+            durationMs: 2_000,
+            rawTranscript: "Old transcript",
+            status: .completed,
+            sourceType: .file
+        )
+
+        let option = try XCTUnwrap(viewModel.retranscriptionEngineOption(for: original))
+        XCTAssertEqual(
+            try retranscriptionChoice(.cohere, in: option).selection,
+            SpeechEngineSelection(engine: .cohere, language: "fr")
+        )
+    }
+
     func testRetranscriptionEngineOptionNilWhenFileMissing() {
         viewModel = TranscriptionViewModel(isWhisperModelDownloaded: { true })
         let original = Transcription(

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
@@ -1744,7 +1744,7 @@ final class TranscriptionViewModelTests: XCTestCase {
         let option = try XCTUnwrap(viewModel.retranscriptionEngineOption(for: original))
 
         XCTAssertEqual(option.primaryEngine, SpeechEngineSelection(engine: .whisper, language: "ko"))
-        XCTAssertEqual(option.choices.map(\.selection.engine), [.whisper, .parakeet, .nemotron])
+        XCTAssertEqual(option.choices.map(\.selection.engine), [.whisper, .parakeet, .nemotron, .cohere])
         XCTAssertTrue(try retranscriptionChoice(.whisper, in: option).isPrimary)
         XCTAssertTrue(try retranscriptionChoice(.parakeet, in: option).isAvailable)
         XCTAssertTrue(try retranscriptionChoice(.nemotron, in: option).isAvailable)
@@ -1780,7 +1780,7 @@ final class TranscriptionViewModelTests: XCTestCase {
         let option = try XCTUnwrap(viewModel.retranscriptionEngineOption(for: original))
 
         XCTAssertEqual(option.primaryEngine, SpeechEngineSelection(engine: .whisper, language: "ja"))
-        XCTAssertEqual(option.choices.map(\.selection.engine), [.whisper, .parakeet, .nemotron])
+        XCTAssertEqual(option.choices.map(\.selection.engine), [.whisper, .parakeet, .nemotron, .cohere])
         XCTAssertEqual(
             try retranscriptionChoice(.parakeet, in: option).selection,
             SpeechEngineSelection(engine: .parakeet)
@@ -1810,7 +1810,7 @@ final class TranscriptionViewModelTests: XCTestCase {
 
         let option = try XCTUnwrap(viewModel.retranscriptionEngineOption(for: original))
 
-        XCTAssertEqual(option.choices.map(\.selection.engine), [.parakeet, .nemotron, .whisper])
+        XCTAssertEqual(option.choices.map(\.selection.engine), [.parakeet, .nemotron, .whisper, .cohere])
         XCTAssertTrue(try retranscriptionChoice(.parakeet, in: option).isPrimary)
         XCTAssertTrue(try retranscriptionChoice(.whisper, in: option).isAvailable)
         let nemotron = try retranscriptionChoice(.nemotron, in: option)
@@ -1843,7 +1843,7 @@ final class TranscriptionViewModelTests: XCTestCase {
 
         let option = try XCTUnwrap(viewModel.retranscriptionEngineOption(for: original))
 
-        XCTAssertEqual(option.choices.map(\.selection.engine), [.parakeet, .nemotron, .whisper])
+        XCTAssertEqual(option.choices.map(\.selection.engine), [.parakeet, .nemotron, .whisper, .cohere])
         XCTAssertTrue(try retranscriptionChoice(.nemotron, in: option).isAvailable)
         XCTAssertNil(try retranscriptionChoice(.nemotron, in: option).unavailableReason)
         XCTAssertTrue(try retranscriptionChoice(.whisper, in: option).isAvailable)
@@ -1912,7 +1912,7 @@ final class TranscriptionViewModelTests: XCTestCase {
 
         let option = try XCTUnwrap(viewModel.retranscriptionEngineOption(for: original))
 
-        XCTAssertEqual(option.choices.map(\.selection.engine), [.nemotron, .parakeet, .whisper])
+        XCTAssertEqual(option.choices.map(\.selection.engine), [.nemotron, .parakeet, .whisper, .cohere])
         XCTAssertTrue(try retranscriptionChoice(.nemotron, in: option).isPrimary)
         let whisper = try retranscriptionChoice(.whisper, in: option)
         XCTAssertFalse(whisper.isAvailable)
@@ -1954,7 +1954,7 @@ final class TranscriptionViewModelTests: XCTestCase {
         let option = try XCTUnwrap(viewModel.retranscriptionEngineOption(for: original))
 
         XCTAssertEqual(option.primaryEngine, SpeechEngineSelection(engine: .parakeet))
-        XCTAssertEqual(option.choices.map(\.selection.engine), [.parakeet, .nemotron, .whisper])
+        XCTAssertEqual(option.choices.map(\.selection.engine), [.parakeet, .nemotron, .whisper, .cohere])
         XCTAssertEqual(
             try retranscriptionChoice(.nemotron, in: option).selection,
             SpeechEngineSelection(engine: .nemotron, language: "en-US")
@@ -1993,7 +1993,7 @@ final class TranscriptionViewModelTests: XCTestCase {
         let option = try XCTUnwrap(viewModel.retranscriptionEngineOption(for: original))
 
         XCTAssertEqual(option.primaryEngine, SpeechEngineSelection(engine: .whisper, language: "ko"))
-        XCTAssertEqual(option.choices.map(\.selection.engine), [.whisper, .parakeet, .nemotron])
+        XCTAssertEqual(option.choices.map(\.selection.engine), [.whisper, .parakeet, .nemotron, .cohere])
         XCTAssertEqual(
             try retranscriptionChoice(.parakeet, in: option).selection,
             SpeechEngineSelection(engine: .parakeet)

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
@@ -2071,7 +2071,7 @@ final class TranscriptionViewModelTests: XCTestCase {
         XCTAssertFalse(cohere.isAvailable)
         XCTAssertEqual(
             cohere.unavailableReason,
-            "Download the Cohere model in Settings before trying Cohere."
+            "Download Cohere Transcribe in Settings before trying Cohere."
         )
     }
 

--- a/Tests/MacParakeetTests/Views/Settings/SettingsStatusRulesTests.swift
+++ b/Tests/MacParakeetTests/Views/Settings/SettingsStatusRulesTests.swift
@@ -124,6 +124,32 @@ final class SettingsStatusRulesTests: XCTestCase {
         XCTAssertEqual(status, SettingsCardStatus(.recommended, label: "Preparing"))
     }
 
+    func testLocalModelsIgnoresInactiveCohereFailureWhenCohereIsHidden() {
+        let status = SettingsStatusRules.localModelsCardStatus(
+            parakeet: .notLoaded,
+            nemotron: .notLoaded,
+            whisper: .notLoaded,
+            cohere: .failed,
+            cohereEnabled: false,
+            activeEngine: .parakeet
+        )
+
+        XCTAssertEqual(status, SettingsCardStatus(.ok, label: "Ready"))
+    }
+
+    func testLocalModelsStillRequiresActionForActiveCohereFailureWhenCohereIsHidden() {
+        let status = SettingsStatusRules.localModelsCardStatus(
+            parakeet: .notLoaded,
+            nemotron: .notLoaded,
+            whisper: .notLoaded,
+            cohere: .failed,
+            cohereEnabled: false,
+            activeEngine: .cohere
+        )
+
+        XCTAssertEqual(status, SettingsCardStatus(.required, label: "Action needed"))
+    }
+
     func testMeetingRecordingRequiresScreenRecordingPermissionForSystemAudioModes() {
         let status = SettingsStatusRules.meetingRecordingCardStatus(
             meetingRecordingEnabled: true,

--- a/Tests/MacParakeetTests/Views/Settings/SettingsStatusRulesTests.swift
+++ b/Tests/MacParakeetTests/Views/Settings/SettingsStatusRulesTests.swift
@@ -9,6 +9,7 @@ final class SettingsStatusRulesTests: XCTestCase {
             parakeet: .ready,
             nemotron: .notLoaded,
             whisper: .notDownloaded,
+            cohere: .ready,
             activeEngine: .parakeet
         )
 
@@ -20,6 +21,7 @@ final class SettingsStatusRulesTests: XCTestCase {
             parakeet: .notLoaded,
             nemotron: .notLoaded,
             whisper: .notLoaded,
+            cohere: .ready,
             activeEngine: .parakeet
         )
 
@@ -31,6 +33,7 @@ final class SettingsStatusRulesTests: XCTestCase {
             parakeet: .notLoaded,
             nemotron: .notDownloaded,
             whisper: .notLoaded,
+            cohere: .ready,
             activeEngine: .parakeet
         )
 
@@ -42,6 +45,7 @@ final class SettingsStatusRulesTests: XCTestCase {
             parakeet: .notLoaded,
             nemotron: .notLoaded,
             whisper: .notDownloaded,
+            cohere: .ready,
             activeEngine: .whisper
         )
 
@@ -53,6 +57,7 @@ final class SettingsStatusRulesTests: XCTestCase {
             parakeet: .notLoaded,
             nemotron: .notLoaded,
             whisper: .preparing,
+            cohere: .ready,
             activeEngine: .whisper
         )
 
@@ -64,6 +69,7 @@ final class SettingsStatusRulesTests: XCTestCase {
             parakeet: .ready,
             nemotron: .notLoaded,
             whisper: .failed,
+            cohere: .ready,
             activeEngine: .parakeet
         )
 
@@ -75,10 +81,47 @@ final class SettingsStatusRulesTests: XCTestCase {
             parakeet: .notLoaded,
             nemotron: .notDownloaded,
             whisper: .notLoaded,
+            cohere: .ready,
             activeEngine: .nemotron
         )
 
         XCTAssertEqual(status, SettingsCardStatus(.recommended, label: "Download recommended"))
+    }
+
+    func testLocalModelsRecommendsDownloadWhenActiveCohereIsMissing() {
+        let status = SettingsStatusRules.localModelsCardStatus(
+            parakeet: .notLoaded,
+            nemotron: .notLoaded,
+            whisper: .notLoaded,
+            cohere: .notDownloaded,
+            activeEngine: .cohere
+        )
+
+        XCTAssertEqual(status, SettingsCardStatus(.recommended, label: "Download recommended"))
+    }
+
+    func testLocalModelsShowsReadyWhenOptionalCohereIsMissing() {
+        let status = SettingsStatusRules.localModelsCardStatus(
+            parakeet: .notLoaded,
+            nemotron: .notLoaded,
+            whisper: .notLoaded,
+            cohere: .notDownloaded,
+            activeEngine: .parakeet
+        )
+
+        XCTAssertEqual(status, SettingsCardStatus(.ok, label: "Ready"))
+    }
+
+    func testLocalModelsShowsPreparingWhenActiveCohereIsPreparing() {
+        let status = SettingsStatusRules.localModelsCardStatus(
+            parakeet: .notLoaded,
+            nemotron: .notLoaded,
+            whisper: .notLoaded,
+            cohere: .preparing,
+            activeEngine: .cohere
+        )
+
+        XCTAssertEqual(status, SettingsCardStatus(.recommended, label: "Preparing"))
     }
 
     func testMeetingRecordingRequiresScreenRecordingPermissionForSystemAudioModes() {

--- a/docs/cli-testing.md
+++ b/docs/cli-testing.md
@@ -194,7 +194,7 @@ English-only TDT opt-in, and Unified is the English-only punctuation/capitalizat
 opt-in. Use `--parakeet-model app-default|v3|v2|unified` for a single run, or
 `config set parakeet-model unified` / `models select parakeet-unified` to persist it.
 Use `--engine app-default` when you want the CLI to follow the GUI's saved
-speech engine, Parakeet model, and Nemotron/Whisper language defaults.
+speech engine, Parakeet model, and Nemotron/Cohere/Whisper language defaults.
 Nemotron is an opt-in Beta engine with two builds: the multilingual default
 and an English-only streaming build. Use `--nemotron-model
 app-default|multilingual-1120ms|english-1120ms` for a single run, or
@@ -220,6 +220,18 @@ swift run macparakeet-cli models download whisper-large-v3-v20240930-turbo-632MB
 swift run macparakeet-cli transcribe "<FILE_OR_MEDIA_URL>" \
   --engine whisper \
   --language ko
+```
+
+Use Cohere explicitly for batch-only accuracy-focused runs after downloading
+the local Cohere model. Cohere requires a language hint or saved
+`cohere-language` default and does not support live preview:
+
+```bash
+swift run macparakeet-cli models download cohere-transcribe
+
+swift run macparakeet-cli transcribe "<FILE_OR_MEDIA_URL>" \
+  --engine cohere \
+  --language ja
 ```
 
 `--language auto` or omitting `--language` lets Nemotron or Whisper detect the
@@ -490,8 +502,8 @@ swift run macparakeet-cli models clear
 ```
 
 `models warm-up` and `models repair` prepare the selected speech engine plus
-the diarization speech stack. Nemotron and Whisper are downloaded explicitly
-with `models download`. `models delete <id>` removes a single model - one
+the diarization speech stack. Nemotron, Cohere, and Whisper are downloaded
+explicitly with `models download`. `models delete <id>` removes a single model - one
 Parakeet build, the Nemotron Beta model, Cohere Transcribe, or the Whisper
 variant - and protects the active model plus Parakeet's configured build unless `--force` is passed;
 `models clear` still wipes everything.

--- a/docs/cli-testing.md
+++ b/docs/cli-testing.md
@@ -223,11 +223,14 @@ swift run macparakeet-cli transcribe "<FILE_OR_MEDIA_URL>" \
 ```
 
 Use Cohere explicitly for batch-only accuracy-focused runs after downloading
-the local Cohere model. Cohere requires a language hint or saved
-`cohere-language` default and does not support live preview:
+the local Cohere model. Cohere requires a supported language hint or saved
+`cohere-language` default, which you can set or inspect with `config`, and does
+not support live preview:
 
 ```bash
 swift run macparakeet-cli models download cohere-transcribe
+swift run macparakeet-cli config set cohere-language ja
+swift run macparakeet-cli config get cohere-language
 
 swift run macparakeet-cli transcribe "<FILE_OR_MEDIA_URL>" \
   --engine cohere \

--- a/docs/cli-testing.md
+++ b/docs/cli-testing.md
@@ -26,8 +26,8 @@ This script builds the latest debug binary, stops stale `/Applications`/`dist` a
 macparakeet-cli
 ├── transcribe <input...> [--podcast QUERY] [options]
 │                                         Transcribe files, folders, podcasts, or media URLs
-│   ├── --format text|transcript|json [--no-history] [--database PATH]
-│   └── --engine app-default|parakeet|nemotron|whisper [--language <code>]
+│   ├── --format text|transcript|json|srt|vtt [--no-history] [--database PATH]
+│   └── --engine app-default|parakeet|nemotron|whisper|cohere [--language <code>]
 │       --parakeet-model app-default|v3|v2|unified [--output-dir DIR]
 │       --mode raw|clean|app-default --downloaded-audio app-default|keep|delete
 │       --speaker-detection app-default|on|off
@@ -223,11 +223,10 @@ swift run macparakeet-cli transcribe "<FILE_OR_MEDIA_URL>" \
 ```
 
 `--language auto` or omitting `--language` lets Nemotron or Whisper detect the
-language. When `--engine app-default` resolves to Nemotron or Whisper, an
-explicit `--language` overrides the saved language for that invocation. When
-`--engine nemotron` or `--engine whisper` is explicit, pass `--language`
-explicitly if you do not want auto-detect; saved Nemotron/Whisper languages are
-only used by `--engine app-default`.
+language. Cohere has no auto-detect; `--engine cohere` uses the saved
+`cohere-language` default unless `--language` is passed. When `--engine
+app-default` resolves to Nemotron, Whisper, or Cohere, an explicit `--language`
+overrides the saved language for that invocation.
 
 ### Speaker Diarization
 
@@ -328,14 +327,17 @@ swift run macparakeet-cli models download nemotron-multilingual-1120ms
 swift run macparakeet-cli models select nemotron-multilingual-1120ms
 swift run macparakeet-cli models download nemotron-english-1120ms
 swift run macparakeet-cli models select nemotron-english-1120ms
+swift run macparakeet-cli models download cohere-transcribe
+swift run macparakeet-cli models select cohere-transcribe
 swift run macparakeet-cli models select whisper-large-v3-v20240930-turbo-632MB
 ```
 
 `models list` reports the selectable speech engines MacParakeet exposes today:
 Parakeet v3, Parakeet v2, the two Nemotron Beta builds (multilingual and
-English-only), and the configured WhisperKit variant. `models select` writes
+English-only), Cohere Transcribe, and the configured WhisperKit variant.
+`models select` writes
 the same shared default used by the GUI and `transcribe --engine app-default`;
-Nemotron and Whisper selection require the local model to be downloaded first.
+Nemotron, Cohere, and Whisper selection require the local model to be downloaded first.
 
 ## Retained Entitlements Parity
 
@@ -462,10 +464,11 @@ swift run macparakeet-cli calendar upcoming --days 7 --filter all --json
 # Non-invasive status (does not force downloads)
 swift run macparakeet-cli models status
 
-# Explicit Parakeet / Nemotron / Whisper downloads
+# Explicit Parakeet / Nemotron / Cohere / Whisper downloads
 swift run macparakeet-cli models download parakeet-v3
 swift run macparakeet-cli models download parakeet-v2
 swift run macparakeet-cli models download nemotron-multilingual-1120ms
+swift run macparakeet-cli models download cohere-transcribe
 swift run macparakeet-cli models download whisper-large-v3-v20240930-turbo-632MB
 
 # Warm-up (single attempt by default)
@@ -478,6 +481,7 @@ swift run macparakeet-cli models repair --attempts 5
 # Delete one downloaded model (frees its disk space; leaves the rest)
 swift run macparakeet-cli models delete parakeet-v2
 swift run macparakeet-cli models delete nemotron-multilingual-1120ms
+swift run macparakeet-cli models delete cohere-transcribe
 swift run macparakeet-cli models delete whisper-large-v3-v20240930-turbo-632MB
 swift run macparakeet-cli models delete parakeet-v3 --force   # override the in-use guard
 
@@ -488,8 +492,8 @@ swift run macparakeet-cli models clear
 `models warm-up` and `models repair` prepare the selected speech engine plus
 the diarization speech stack. Nemotron and Whisper are downloaded explicitly
 with `models download`. `models delete <id>` removes a single model - one
-Parakeet build, the Nemotron Beta model, or the Whisper variant - and protects
-the active model plus Parakeet's configured build unless `--force` is passed;
+Parakeet build, the Nemotron Beta model, Cohere Transcribe, or the Whisper
+variant - and protects the active model plus Parakeet's configured build unless `--force` is passed;
 `models clear` still wipes everything.
 
 ## Text Pipeline

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -16,7 +16,7 @@ testing.
 
 - **Local transcription** -- audio/video files, folders, public media URLs,
   Apple Podcasts links/searches, and YouTube to text, with engine selection
-  (Parakeet / Nemotron / Whisper) and per-invocation language hints.
+  (Parakeet / Nemotron / Cohere / Whisper) and per-invocation language hints.
 - **Scriptable shared defaults** -- `config get|set|list` over the same
   preference suite the GUI reads (`com.macparakeet.MacParakeet`). CLI-only
   installs work; a later GUI install picks up the same values.
@@ -24,8 +24,8 @@ testing.
   schemas pinned to the major CLI version. Failure envelopes carry a stable
   `errorType` so agents can branch deterministically.
 - **Model and binary health** -- `health --json` probes Parakeet / Nemotron /
-  Whisper model readiness, database accessibility, FFmpeg, and yt-dlp without
-  mutating state. Repair flags explicitly warm/download local caches.
+  Cohere / Whisper model readiness, database accessibility, FFmpeg, and yt-dlp
+  without mutating state. Repair flags explicitly warm/download local caches.
 - **Persisted history** -- list, search, and inspect prior dictations and
   transcriptions via the shared SQLite database.
 - **Prompt and meeting inspection** -- list and run prompt library entries
@@ -92,8 +92,9 @@ macparakeet-cli health --json
 
 This installs the standalone CLI plus its Homebrew-managed `ffmpeg` and
 `yt-dlp` runtime dependencies. It does not require `MacParakeet.app`.
-Parakeet's CoreML cache is managed by FluidAudio. WhisperKit model downloads
-live under `~/Library/Application Support/MacParakeet/models/stt/whisper/`.
+Parakeet, Nemotron, and Cohere CoreML caches are managed by FluidAudio.
+WhisperKit model downloads live under
+`~/Library/Application Support/MacParakeet/models/stt/whisper/`.
 
 **Bundled app alternative:** after installing
 [MacParakeet](https://macparakeet.com), the same CLI surface is available at:
@@ -182,8 +183,8 @@ temporary when `--no-history` is set.
 
 Parakeet is the default engine for compatibility with existing scripts. Use
 `--parakeet-model v2` or `config set parakeet-model v2` for the English-only
-Parakeet build. Use Nemotron Beta or Whisper per invocation for multilingual
-coverage outside the default Parakeet lane:
+Parakeet build. Use Nemotron Beta, Cohere, or Whisper per invocation for
+multilingual or accuracy-focused coverage outside the default Parakeet lane:
 
 Nemotron, Cohere, and Whisper require local model downloads before first use:
 
@@ -206,6 +207,7 @@ macparakeet-cli models select whisper-large-v3-v20240930-turbo-632MB --json
 
 ```bash
 macparakeet-cli transcribe /path/to/spanish.mp3 --engine nemotron --language auto --format json
+macparakeet-cli transcribe /path/to/japanese.m4a --engine cohere --language ja --format json
 macparakeet-cli transcribe /path/to/korean.mp3 --engine whisper --language ko --format json
 ```
 

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -185,10 +185,11 @@ Parakeet is the default engine for compatibility with existing scripts. Use
 Parakeet build. Use Nemotron Beta or Whisper per invocation for multilingual
 coverage outside the default Parakeet lane:
 
-Nemotron and Whisper require local model downloads before first use:
+Nemotron, Cohere, and Whisper require local model downloads before first use:
 
 ```bash
 macparakeet-cli models download nemotron-multilingual-1120ms
+macparakeet-cli models download cohere-transcribe
 macparakeet-cli models download whisper-large-v3-v20240930-turbo-632MB
 ```
 
@@ -199,6 +200,7 @@ macparakeet-cli models list --json
 macparakeet-cli models select parakeet-v3 --json
 macparakeet-cli models select parakeet-v2 --json
 macparakeet-cli models select nemotron-multilingual-1120ms --json
+macparakeet-cli models select cohere-transcribe --json
 macparakeet-cli models select whisper-large-v3-v20240930-turbo-632MB --json
 ```
 
@@ -246,6 +248,7 @@ macparakeet-cli config set speech-engine whisper
 macparakeet-cli config set parakeet-model v3
 macparakeet-cli config set nemotron-language auto
 macparakeet-cli config set whisper-language ko
+macparakeet-cli config set cohere-language ja
 macparakeet-cli config set processing-mode raw
 macparakeet-cli config set speaker-detection off
 macparakeet-cli config set save-transcription-audio off
@@ -253,8 +256,9 @@ macparakeet-cli config set youtube-audio-quality m4a
 ```
 
 `--engine whisper` uses Whisper with auto-detected language unless `--language`
-is passed. The saved Whisper language is used when `--engine app-default`
-resolves to Whisper.
+is passed. `--engine cohere` uses the saved Cohere language unless `--language`
+is passed, because Cohere has no auto-detect. Saved engine-specific languages
+are used when `--engine app-default` resolves to that engine.
 
 ### Transcribe a media URL
 
@@ -472,10 +476,12 @@ macparakeet-cli spec --json
 macparakeet-cli transcribe "<path-or-media-url>" --format json
 macparakeet-cli transcribe "<path-or-media-url>" --format transcript --no-history
 macparakeet-cli models download whisper-large-v3-v20240930-turbo-632MB
+macparakeet-cli models download cohere-transcribe
 macparakeet-cli models list --json
 macparakeet-cli models select parakeet-v3 --json
 macparakeet-cli config set parakeet-model v3 --json
 macparakeet-cli transcribe "<path-or-media-url>" --engine whisper --language ko --format json
+macparakeet-cli transcribe "<path-or-media-url>" --engine cohere --language ja --format json
 macparakeet-cli transcribe "<path-or-media-url>" \
   --engine app-default \
   --parakeet-model app-default \

--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -26,8 +26,8 @@ macparakeet-cli health --json
 
 If MacParakeet.app is already installed, the bundled CLI is also available at
 `/Applications/MacParakeet.app/Contents/MacOS/macparakeet-cli`.
-Parakeet and Nemotron CoreML caches are managed by FluidAudio. WhisperKit model
-downloads live under
+Parakeet, Nemotron, and Cohere CoreML caches are managed by FluidAudio.
+WhisperKit model downloads live under
 `~/Library/Application Support/MacParakeet/models/stt/whisper/`.
 
 ## Suggested skill bindings (sketch)
@@ -36,8 +36,8 @@ downloads live under
 # Illustrative -- adapt to your Hermes skill manifest format.
 name: macparakeet
 description: Local speech-to-text, transcription, and prompt automation
-             on Apple Silicon. Powered by local Parakeet/Nemotron/Whisper
-             speech engines.
+             on Apple Silicon. Powered by local Parakeet/Nemotron/Cohere/
+             Whisper speech engines.
 when_to_use:
   - User wants to transcribe a local audio/video file.
   - User wants to transcribe a media URL.
@@ -61,7 +61,7 @@ commands:
       --format json
   list_models: macparakeet-cli models list --json
   set_parakeet_model: macparakeet-cli config set parakeet-model "{v3_or_v2}" --json
-  set_speech_engine: macparakeet-cli config set speech-engine "{parakeet_nemotron_or_whisper}" --json
+  set_speech_engine: macparakeet-cli config set speech-engine "{parakeet_nemotron_cohere_or_whisper}" --json
   set_speaker_detection: macparakeet-cli config set speaker-detection "{value}" --json
   list_transcriptions: macparakeet-cli history transcriptions --json
   search_transcriptions: macparakeet-cli history search-transcriptions "{query}" --json

--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -23,7 +23,8 @@ Silicon. Wraps `macparakeet-cli` so an OpenClaw skill can:
 - Inspect meeting recordings and store external meeting results.
 - Run a prompt against a transcription (action items, summary, etc.).
 
-Speech-to-text execution is local on the Apple Neural Engine. No cloud STT.
+Speech-to-text execution is local on Apple Silicon. Parakeet, Nemotron, and
+Cohere use FluidAudio/CoreML; Whisper uses WhisperKit. No cloud STT.
 
 ## Install
 
@@ -35,7 +36,7 @@ macparakeet-cli health --json
 
 Requires macOS 14.2+ on Apple Silicon. The Homebrew formula installs FFmpeg
 and yt-dlp as runtime dependencies. Parakeet's CoreML cache is managed by
-FluidAudio, Nemotron uses FluidAudio's CoreML cache, and WhisperKit model
+FluidAudio, Nemotron and Cohere use FluidAudio's CoreML cache, and WhisperKit model
 downloads live under
 `~/Library/Application Support/MacParakeet/models/stt/whisper/`.
 
@@ -52,8 +53,9 @@ If MacParakeet.app is already installed, the bundled CLI is also available at
 | Transcribe a media URL | `macparakeet-cli transcribe <url> --format json` |
 | Transcribe a podcast | `macparakeet-cli transcribe --podcast "Lex Fridman episode 400" --format json` |
 | Use GUI/default preferences | `macparakeet-cli transcribe <path> --engine app-default --parakeet-model app-default --speaker-detection app-default --mode app-default --downloaded-audio app-default --media-audio-quality app-default --format json` |
-| Inspect/select speech models | `macparakeet-cli models list --json` / `macparakeet-cli models select parakeet-v3 --json` / `macparakeet-cli models select parakeet-v2 --json` / `macparakeet-cli models select nemotron-multilingual-1120ms --json` |
-| Configure shared defaults | `macparakeet-cli config set speaker-detection off --json`; `macparakeet-cli config set parakeet-model v3 --json`; `macparakeet-cli config set speech-engine nemotron --json` |
+| Inspect/select speech models | `macparakeet-cli models list --json` / `macparakeet-cli models select parakeet-v3 --json` / `macparakeet-cli models select parakeet-v2 --json` / `macparakeet-cli models select nemotron-multilingual-1120ms --json` / `macparakeet-cli models select cohere-transcribe --json` |
+| Download optional speech models | `macparakeet-cli models download nemotron-multilingual-1120ms` / `macparakeet-cli models download cohere-transcribe` / `macparakeet-cli models download whisper-large-v3-v20240930-turbo-632MB` |
+| Configure shared defaults | `macparakeet-cli config set speaker-detection off --json`; `macparakeet-cli config set parakeet-model v3 --json`; `macparakeet-cli config set speech-engine nemotron --json`; `macparakeet-cli config set cohere-language ja --json` |
 | List recent transcriptions | `macparakeet-cli history transcriptions --json` |
 | Search transcriptions | `macparakeet-cli history search-transcriptions "<query>" --json` |
 | Search dictations | `macparakeet-cli history search "<query>" --json` |
@@ -73,6 +75,14 @@ schemas are stable within a major CLI version (semver, see
 UUID, UUID prefix (>= 4 chars), or case-insensitive name. Prompt and LLM
 wrappers should pass `--json` when the skill expects an envelope.
 
+Cohere is a batch-only accuracy engine. It can be used for dictation final
+transcription, file transcription, and meeting finalization, but it has no live
+dictation preview, no meeting live-preview chunks, and no word timestamps or
+speaker labels. The ~2.1 GB model must be downloaded explicitly before
+`--engine cohere`, `models select cohere-transcribe`, or app-default Cohere
+transcription will run; normal transcription paths do not implicitly download
+it.
+
 For the full vocabulary, schema details, and privacy posture, see
 [`../README.md`](../README.md).
 
@@ -89,9 +99,9 @@ name: macparakeet-stt
 version: <published-cli-version>
 author: <your-username>
 description: >
-  Local Parakeet TDT speech-to-text and meeting artifact access on Apple
-  Silicon. Wraps macparakeet-cli.
-tags: [stt, transcription, voice, apple-silicon, local, parakeet]
+  Local speech-to-text and meeting artifact access on Apple Silicon. Wraps
+  macparakeet-cli.
+tags: [stt, transcription, voice, apple-silicon, local, parakeet, cohere]
 metadata:
   openclaw:
     requires:
@@ -124,7 +134,7 @@ metadata:
 # macparakeet-stt
 
 Local STT and transcription for an OpenClaw agent on Apple Silicon.
-All execution local on the Apple Neural Engine; no cloud STT.
+All speech recognition runs locally; no cloud STT.
 
 ## Install
 

--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -35,9 +35,8 @@ macparakeet-cli health --json
 ```
 
 Requires macOS 14.2+ on Apple Silicon. The Homebrew formula installs FFmpeg
-and yt-dlp as runtime dependencies. Parakeet's CoreML cache is managed by
-FluidAudio, Nemotron and Cohere use FluidAudio's CoreML cache, and WhisperKit model
-downloads live under
+and yt-dlp as runtime dependencies. Parakeet, Nemotron, and Cohere CoreML
+model caches are managed by FluidAudio; WhisperKit model downloads live under
 `~/Library/Application Support/MacParakeet/models/stt/whisper/`.
 
 If MacParakeet.app is already installed, the bundled CLI is also available at

--- a/scripts/dev/run_app.sh
+++ b/scripts/dev/run_app.sh
@@ -203,7 +203,7 @@ GIT_COMMIT="$(git -C "$ROOT_DIR" rev-parse --short=12 HEAD 2>/dev/null || echo u
 BUILD_DATE_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 BUILD_SOURCE="dev-run-xcodebuild-$(echo "$CONFIG" | tr '[:upper:]' '[:lower:]')"
 
-echo "[4/5] Launching debug app…"
+echo "[4/5] Launching ${CONFIG} app…"
 MACPARAKEET_GIT_COMMIT="$GIT_COMMIT" \
 MACPARAKEET_BUILD_DATE_UTC="$BUILD_DATE_UTC" \
 MACPARAKEET_BUILD_SOURCE="$BUILD_SOURCE" \

--- a/scripts/dev/run_app.sh
+++ b/scripts/dev/run_app.sh
@@ -2,8 +2,12 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# Build configuration: Debug by default. Set MACPARAKEET_CONFIG=Release for an
+# optimized build (e.g. to feel-test true STT latency — Debug Swift is ~10x
+# slower for the Cohere decoder's per-step work).
+CONFIG="${MACPARAKEET_CONFIG:-Debug}"
 DERIVED_DATA_DIR="$ROOT_DIR/.build/xcode-dev"
-PRODUCT_DIR="$DERIVED_DATA_DIR/Build/Products/Debug"
+PRODUCT_DIR="$DERIVED_DATA_DIR/Build/Products/$CONFIG"
 APP_BIN="$PRODUCT_DIR/MacParakeet"
 APP_BUNDLE="$PRODUCT_DIR/MacParakeet-Dev.app"
 LOG_FILE="${TMPDIR:-/tmp}/macparakeet-dev.log"
@@ -75,10 +79,10 @@ binary_has_rpath() {
   return 1
 }
 
-echo "[1/5] Building debug app bundle (xcodebuild, target signing disabled)…"
+echo "[1/5] Building $CONFIG app bundle (xcodebuild, target signing disabled)…"
 if ! xcodebuild build \
   -scheme MacParakeet \
-  -configuration Debug \
+  -configuration "$CONFIG" \
   -destination "platform=OS X,arch=arm64" \
   -derivedDataPath "$DERIVED_DATA_DIR" \
   CODE_SIGNING_ALLOWED=NO \
@@ -197,7 +201,7 @@ sleep 1
 
 GIT_COMMIT="$(git -C "$ROOT_DIR" rev-parse --short=12 HEAD 2>/dev/null || echo unknown)"
 BUILD_DATE_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-BUILD_SOURCE="dev-run-xcodebuild-debug"
+BUILD_SOURCE="dev-run-xcodebuild-$(echo "$CONFIG" | tr '[:upper:]' '[:lower:]')"
 
 echo "[4/5] Launching debug app…"
 MACPARAKEET_GIT_COMMIT="$GIT_COMMIT" \

--- a/scripts/dev/run_app.sh
+++ b/scripts/dev/run_app.sh
@@ -194,7 +194,7 @@ echo "[3/5] Stopping existing MacParakeet processes…"
 pkill -f "/Applications/MacParakeet.app/Contents/MacOS/MacParakeet" || true
 pkill -f "$ROOT_DIR/dist/MacParakeet.app/Contents/MacOS/MacParakeet" || true
 pkill -f "MacParakeet-Dev.app/Contents/MacOS/MacParakeet" || true
-pkill -f "$DERIVED_DATA_DIR/Build/Products/Debug/MacParakeet" || true
+pkill -f "$PRODUCT_DIR/MacParakeet" || true
 pkill -f "$ROOT_DIR/.build/debug/MacParakeet" || true
 pkill -f "$ROOT_DIR/.build/arm64-apple-macosx/debug/MacParakeet" || true
 sleep 1

--- a/spec/00-vision.md
+++ b/spec/00-vision.md
@@ -54,7 +54,7 @@ No existing app nails all four: **Speed + Privacy + Simplicity + Fair Pricing**.
 
 Cloud services send your voice to remote servers, create accounts, charge monthly, and add server latency. Local apps either bury you in settings (MacWhisper has 50+ features) or charge a premium (Superwhisper at $250). Apple Dictation is free but slow, inaccurate, and has no custom vocabulary, no file transcription.
 
-**MacParakeet's answer:** Built from the ground up around Parakeet TDT for speed, with multilingual v3 as the default, English-only v2 as an opt-in TDT build, and Parakeet Unified as an opt-in English build with punctuation/capitalization, plus optional local Nemotron Beta and WhisperKit engines for broader language coverage. Fully local speech by default, with optional networked features. Three capture modes, plus Transforms for selected text. Simple and GPL open-source. Done.
+**MacParakeet's answer:** Built from the ground up around Parakeet TDT for speed, with multilingual v3 as the default, English-only v2 as an opt-in TDT build, and Parakeet Unified as an opt-in English build with punctuation/capitalization, plus optional local Nemotron Beta, Cohere Transcribe, and WhisperKit engines for broader language coverage and accuracy-focused batch work. Fully local speech by default, with optional networked features. Three capture modes, plus Transforms for selected text. Simple and GPL open-source. Done.
 
 ---
 
@@ -111,7 +111,7 @@ That does not mean monetization is permanently forbidden. GPL permits charging f
 | **Product type** | Native macOS app (menu bar + window) |
 | **Core function** | Voice dictation, file transcription, and meeting recording |
 | **Target users** | Developers, professionals, writers who want fast private voice input |
-| **Key differentiators** | Parakeet speed + optional local Nemotron/Whisper multilingual engines + free/open-source |
+| **Key differentiators** | Parakeet speed + optional local Nemotron/Cohere/Whisper engines + free/open-source |
 | **Business model** | Current public build is free/GPL/unlocked; official paid distribution, support, or hosted services remain possible |
 | **Platform** | macOS 14.2+, Apple Silicon only |
 
@@ -285,7 +285,7 @@ Writers who think better out loud. Podcasters who need episode transcripts. Cont
 
 | Feature | MacParakeet | WisprFlow | MacWhisper | Superwhisper | Apple Dictation |
 |---------|-------------|-----------|------------|--------------|-----------------|
-| **STT Engine** | Parakeet default + optional Nemotron/WhisperKit | Cloud AI | Whisper | Whisper | Apple Neural |
+| **STT Engine** | Parakeet default + optional Nemotron/Cohere/WhisperKit | Cloud AI | Whisper | Whisper | Apple Neural |
 | **Speed (60 min)** | ~23 sec | ~30 sec* | ~2-4 min | ~2-4 min | Real-time only |
 | **WER** | ~2.5% | ~5%** | 7-12% | 7-12% | ~10-15% |
 | **Privacy** | Local-first speech | Cloud | Local | Local | Mostly local |
@@ -313,14 +313,14 @@ Writers who think better out loud. Podcasters who need episode transcripts. Cont
 
 ### 1. Parakeet-First Architecture
 
-We are not a Whisper app that added Parakeet. We built the entire product around Parakeet TDT 0.6B-v3 from day one, later exposed v2 and Unified as English-only Parakeet options, then added WhisperKit and Nemotron explicitly as local opt-in engines for broader coverage and experimentation.
+We are not a Whisper app that added Parakeet. We built the entire product around Parakeet TDT 0.6B-v3 from day one, later exposed v2 and Unified as English-only Parakeet options, then added WhisperKit, Nemotron, and Cohere explicitly as local opt-in engines for broader coverage, experimentation, and accuracy-focused batch work.
 
 - **155x realtime** on the Neural Engine vs Whisper's 15-30x. Not an incremental improvement -- an order of magnitude.
 - **~2.5% WER** -- lower error rate than Whisper large-v3 at a fraction of the compute.
 - **Word-level timestamps** -- enables synced subtitles, precise seeking, confidence scoring.
 - **Technical vocabulary** -- better handling of code terms, acronyms, and proper nouns than Whisper.
 
-Competitors bolted Parakeet onto existing Whisper architectures. We optimized the default pipeline for Parakeet while routing optional Nemotron and Whisper through the same scheduler/runtime control plane.
+Competitors bolted Parakeet onto existing Whisper architectures. We optimized the default pipeline for Parakeet while routing optional Nemotron, Cohere, and Whisper through the same scheduler/runtime control plane.
 
 ### 2. Local-First, Zero-Compromise Speech
 
@@ -474,8 +474,8 @@ Ship-quality polish. Direct distribution via notarized DMG.
 - Live meeting pill + Notes / Transcript / Ask panel
 - Source-aware final transcription with prompt results and chat in the library
 - Parakeet model selection: v3 multilingual default, v2 English-only TDT opt-in, and Unified English opt-in
-- Optional local WhisperKit engine for languages outside Parakeet coverage
-- Settings speech-engine picker, Parakeet model picker, Nemotron controls, and Whisper language picker
+- Optional local WhisperKit and Cohere Transcribe engines for languages or accuracy needs outside the default Parakeet coverage
+- Settings speech-engine picker, Parakeet model picker, Nemotron controls, Cohere language picker, and Whisper language picker
 - CLI `transcribe --engine parakeet|nemotron|whisper|cohere --language --parakeet-model`
 - Meeting recordings pin engine/language for live preview, recovery, and finalization
 - Calendar auto-start is implemented and enabled (`AppFeatures.calendarEnabled = true`); defaults to opt-in mode `.off`. Calendar-driven auto-stop was removed (ADR-017 amendment); recordings stop manually

--- a/spec/00-vision.md
+++ b/spec/00-vision.md
@@ -476,7 +476,7 @@ Ship-quality polish. Direct distribution via notarized DMG.
 - Parakeet model selection: v3 multilingual default, v2 English-only TDT opt-in, and Unified English opt-in
 - Optional local WhisperKit engine for languages outside Parakeet coverage
 - Settings speech-engine picker, Parakeet model picker, Nemotron controls, and Whisper language picker
-- CLI `transcribe --engine parakeet|nemotron|whisper --language --parakeet-model`
+- CLI `transcribe --engine parakeet|nemotron|whisper|cohere --language --parakeet-model`
 - Meeting recordings pin engine/language for live preview, recovery, and finalization
 - Calendar auto-start is implemented and enabled (`AppFeatures.calendarEnabled = true`); defaults to opt-in mode `.off`. Calendar-driven auto-stop was removed (ADR-017 amendment); recordings stop manually
 
@@ -491,7 +491,7 @@ Ship-quality polish. Direct distribution via notarized DMG.
 | Decision | Choice | Rationale |
 |----------|--------|-----------|
 | **Platform** | macOS 14.2+, Apple Silicon only | FluidAudio CoreML requires Apple Silicon. |
-| **STT engine** | Parakeet TDT 0.6B-v3 by default; Parakeet v2 and Unified English opt-ins; optional Nemotron Beta and WhisperKit | Parakeet gives the latency target for supported languages; v2 avoids language auto-detect for English-only users; Unified offers a newer English punctuation/capitalization path; Nemotron is a fast local Beta path; WhisperKit keeps mature broader multilingual speech local. |
+| **STT engine** | Parakeet TDT 0.6B-v3 by default; Parakeet v2 and Unified English opt-ins; optional Nemotron Beta, WhisperKit, and Cohere Transcribe | Parakeet gives the latency target for supported languages; v2 avoids language auto-detect for English-only users; Unified offers a newer English punctuation/capitalization path; Nemotron is a fast local Beta path; WhisperKit keeps mature broader multilingual speech local; Cohere is a larger batch-only accuracy path. |
 | **YouTube downloads** | Standalone yt-dlp | macOS binary, auto-updates via `--update`. No Python needed. |
 | **UI framework** | SwiftUI | Native Mac experience. Menu bar + window. |
 | **Database** | SQLite (GRDB) | Single file. No server. Dictation history, custom words, settings. |

--- a/spec/02-features.md
+++ b/spec/02-features.md
@@ -68,7 +68,7 @@ See [00-vision.md](./00-vision.md) for positioning and market context.
                               ▼
 ┌─────────────────────────────────────────────────────────────────┐
 │  v0.6 - "Meeting Recording + Multilingual STT + Transforms"      │
-│  "Record meetings locally, add WhisperKit, rewrite selected text" │
+│  "Record meetings locally, add local engine options, rewrite selected text" │
 ├─────────────────────────────────────────────────────────────────┤
 │  • Meeting recording with selectable audio sources               │
 │  • Concurrent with dictation (ADR-015) — dictate during meetings │
@@ -78,8 +78,8 @@ See [00-vision.md](./00-vision.md) for positioning and market context.
 │  • Source-scoped permission flow                                  │
 │  • Headphones guidance copy for cleanest speaker separation       │
 │  • VAD-guided live-preview chunking with fixed fallback           │
-│  • Nemotron Beta + WhisperKit engine options                     │
-│  • Settings engine picker + Nemotron/Whisper controls            │
+│  • Nemotron Beta + Cohere + WhisperKit engine options            │
+│  • Settings engine picker + Nemotron/Cohere/Whisper controls     │
 │  • CLI --engine parakeet|nemotron|whisper|cohere --language      │
 │  • Meeting engine/language pinning for live + recovery + final   │
 │  • Transforms: Polish / Distill / Decide selected text anywhere  │
@@ -110,14 +110,14 @@ See [00-vision.md](./00-vision.md) for positioning and market context.
 **Goals:**
 - Reduce first-run friction (no mysterious permission failures).
 - Teach the core interaction model in under 60 seconds.
-- Download and warm up the right local speech stack on first run: Parakeet STT plus default-on speaker-detection assets for the normal path, or local Whisper plus speaker-detection assets when the user's macOS language is Korean, Japanese, Chinese, or Cantonese. Nemotron is opt-in after onboarding.
+- Download and warm up the right local speech stack on first run: Parakeet STT plus default-on speaker-detection assets for the normal path, or local Whisper plus speaker-detection assets when the user's macOS language is Korean, Japanese, Chinese, or Cantonese. Nemotron and Cohere are explicit opt-in engines after onboarding.
 
 **Flow (6 steps, dictation-first):**
 1. Welcome
 2. Microphone permission
 3. Accessibility permission
 4. Hotkey instructions (configurable trigger + Esc)
-5. Speech stack setup (Parakeet; speaker detection is an opt-in Settings toggle, off by default; locale-aware Whisper setup for CJK macOS languages; Nemotron remains an explicit Beta choice after setup)
+5. Speech stack setup (Parakeet; speaker detection is an opt-in Settings toggle, off by default; locale-aware Whisper setup for CJK macOS languages; Nemotron remains an explicit Beta choice after setup; Cohere remains an explicit batch-only choice after setup)
 6. Ready
 
 Meeting Recording and Calendar are opt-in and self-prompt on first use (see ADR-005 amendment, 2026-06-13).
@@ -276,7 +276,7 @@ Space is always reserved for the tooltip (opacity toggle, not conditional render
    - Waveform: 12 white bars, 3px wide, max 20px tall, center-peaking wave pattern, updates in real-time from audio level
    - Stop button: white square (10x10, cornerRadius 3) inside red circle, triggers stop
    - Recording timer displayed (e.g., "0:03") -- hover tooltips provide additional guidance
-   - **Live transcript preview (opt-in, `AppFeatures.liveDictationStreamingEnabled`, #517):** when enabled, a display-only stable rolling readout of in-progress text renders in a sibling panel *above* the pill (pill geometry unchanged): newest line pinned to the bottom, older lines rising and fading out at the top edge, with no mid-word truncation. The raw preview stream is stabilized into a monotonic append-only readout so shown words don't jump or disappear. It is decoupled from the paste — the final inserted text always comes from the stop-time transcription path. Per engine: Parakeet single-flight tail-window batch preview, both Nemotron builds native live partials, Whisper default-off. Toggle and preview text size live in Settings → Capture → Dictation (`showLiveDictationPreview`, default on). See `spec/05-audio-pipeline.md` → "Dictation Live Preview".
+   - **Live transcript preview (opt-in, `AppFeatures.liveDictationStreamingEnabled`, #517):** when enabled, a display-only stable rolling readout of in-progress text renders in a sibling panel *above* the pill (pill geometry unchanged): newest line pinned to the bottom, older lines rising and fading out at the top edge, with no mid-word truncation. The raw preview stream is stabilized into a monotonic append-only readout so shown words don't jump or disappear. It is decoupled from the paste — the final inserted text always comes from the stop-time transcription path. Per engine: Parakeet single-flight tail-window batch preview, both Nemotron builds native live partials, Whisper default-off, Cohere off because it is batch-only. Toggle and preview text size live in Settings → Capture → Dictation (`showLiveDictationPreview`, default on). See `spec/05-audio-pipeline.md` → "Dictation Live Preview".
 
 2. **Cancelled** -- `[countdown ring] [Undo button]` (~140px)
    - Countdown ring: circular progress indicator (accent color, depletes over 5 seconds) with remaining seconds number in center
@@ -362,7 +362,7 @@ User drops file(s) onto window or menu bar icon
          ▼
 ┌──────────────────┐
 │  Local STT       │ ── Transcribe with word-level timestamps
-│                  │    Parakeet default, Nemotron/Whisper optional
+│                  │    Parakeet default, Nemotron/Cohere/Whisper optional
 └────────┬─────────┘
          │
          ▼
@@ -697,11 +697,13 @@ Audio path is computed from ID by default. Files stored as WAV (16kHz mono). Use
 │                                                                  │
 │ SPEECH RECOGNITION                                               │
 │ ┌──────────────────────────────────────────────────────────────┐ │
-│ │ Engine: [ Parakeet ] [ Nemotron Beta ] [ Whisper ]           │ │
+│ │ Engine: [ Parakeet ] [ Nemotron Beta ] [ Cohere ] [ Whisper ]│ │
 │ │ Nemotron model: [ Multilingual Beta ] [ English Beta ]       │ │
+│ │ Cohere language: [ English ▾ ]                               │ │
 │ │ Whisper language: [ Auto-detect ▾ ]                          │ │
 │ │ Parakeet        Ready                         [Repair]       │ │
 │ │ Nemotron        Not Downloaded                [Download]     │ │
+│ │ Cohere          Not Downloaded                [Download]     │ │
 │ │ Whisper         Not Downloaded                [Download]     │ │
 │ └──────────────────────────────────────────────────────────────┘ │
 │                                                                  │
@@ -726,10 +728,11 @@ Audio path is computed from ID by default. Files stored as WAV (16kHz mono). Use
 | Save audio recordings | On / Off | On |
 | Keep downloaded YouTube audio | On / Off | On |
 | Meeting audio retention | Keep forever / Remove after N days / Remove audio after transcription | Keep forever |
-| Speech recognition engine | Parakeet / Nemotron Beta / Whisper | Parakeet |
+| Speech recognition engine | Parakeet / Nemotron Beta / Cohere / Whisper | Parakeet |
 | Nemotron model | Multilingual Beta (~1.5 GB) / English Beta (~600 MB, English-only) | Multilingual Beta |
+| Cohere language | Supported Cohere language code | English |
 | Whisper language | Auto-detect or language code | Auto-detect |
-| Speech model controls | Parakeet repair, Nemotron download/delete, Whisper download/delete | Available |
+| Speech model controls | Parakeet repair, Nemotron download/delete, Cohere download/delete, Whisper download/delete | Available |
 
 **Acceptance criteria:**
 - [x] All settings persist across app restarts (UserDefaults or GRDB)
@@ -740,7 +743,7 @@ Audio path is computed from ID by default. Files stored as WAV (16kHz mono). Use
 - [x] YouTube storage toggle controls whether downloaded URL audio is kept after transcription
 - [x] "Clear All" requires confirmation, deletes audio files and database entries
 - [x] Permission status shown with current grant state
-- [x] Speech Recognition panel shows Parakeet status/repair plus Nemotron and Whisper download/language controls
+- [x] Speech Recognition panel shows Parakeet status/repair plus Nemotron, Cohere, and Whisper download/language controls
 - [x] Nemotron Model card (Nemotron engine only) persists the selected build; Multilingual Beta is the default, English Beta is a smaller English-only download
 
 ---
@@ -1616,9 +1619,9 @@ exposes a terminal provider/model/token metadata envelope.
 
 ## v0.6 — Meeting Recording + Multilingual STT
 
-The v0.6 scope includes meeting capture with configurable source mode (microphone + system audio by default, microphone-only, or system-audio-only; ADR-014, ADR-015), the centralized STT runtime (ADR-016), optional Nemotron Beta (multilingual default plus a persisted English-only build option) and WhisperKit multilingual STT (ADR-001/ADR-021), VAD-guided live-preview chunking with fixed fallback, the live Ask tab (ADR-018), crash-resilient recording (ADR-019), and the live notepad plus `{{userNotes}}` plumbing from ADR-020. Calendar-driven auto-start (ADR-017) is implemented and enabled (`AppFeatures.calendarEnabled = true`), defaulting to opt-in mode `.off`. The full v0.6 backlog lives in `spec/README.md`; the F-numbered entries below cover the ADR-020 and meeting-hardening feature surface.
+The v0.6 scope includes meeting capture with configurable source mode (microphone + system audio by default, microphone-only, or system-audio-only; ADR-014, ADR-015), the centralized STT runtime (ADR-016), optional Nemotron Beta (multilingual default plus a persisted English-only build option), Cohere Transcribe, and WhisperKit multilingual STT (ADR-001/ADR-021), VAD-guided live-preview chunking with fixed fallback, the live Ask tab (ADR-018), crash-resilient recording (ADR-019), and the live notepad plus `{{userNotes}}` plumbing from ADR-020. Calendar-driven auto-start (ADR-017) is implemented and enabled (`AppFeatures.calendarEnabled = true`), defaulting to opt-in mode `.off`. The full v0.6 backlog lives in `spec/README.md`; the F-numbered entries below cover the ADR-020 and meeting-hardening feature surface.
 
-Meeting transcription uses the current speech engine captured at recording start. Parakeet remains the default; Nemotron Beta or WhisperKit can be selected before starting a meeting for broader local multilingual coverage.
+Meeting transcription uses the current speech engine captured at recording start. Parakeet remains the default; Nemotron Beta, Cohere, or WhisperKit can be selected before starting a meeting for broader local multilingual coverage or accuracy-focused batch transcription. Cohere meetings have no live-preview chunks and degrade to plain text because Cohere does not emit word timestamps or speaker labels.
 
 ### F36: Live Meeting Notepad
 
@@ -1829,12 +1832,12 @@ Read surrounding text from the active app via macOS Accessibility APIs (AXUIElem
 
 | Metric | Target | Notes |
 |--------|--------|-------|
-| Transcription speed | 155x realtime | Parakeet TDT on Apple Silicon (ANE via FluidAudio CoreML); Nemotron is Beta and WhisperKit is for coverage, not this default latency target |
+| Transcription speed | 155x realtime | Parakeet TDT on Apple Silicon (ANE via FluidAudio CoreML); Nemotron is Beta, Cohere is batch accuracy-focused, and WhisperKit is for coverage, not this default latency target |
 | Dictation latency | <500ms end-to-end | From Fn release to text appearing |
 | Clean pipeline | <1ms | Deterministic, pure string operations |
 | Memory usage (idle) | <200MB | Menu bar + default STT readiness path |
-| Memory usage (active) | Engine-dependent | Parakeet active slot is ~66 MB working RAM; Nemotron and Whisper depend on selected model/runtime |
-| App size | <100MB | Plus ~465 MB per Parakeet build, ~1.5 GB or ~600 MB optional Nemotron download (per selected build), and optional Whisper download |
+| Memory usage (active) | Engine-dependent | Parakeet active slot is ~66 MB working RAM; Nemotron, Cohere, and Whisper depend on selected model/runtime |
+| App size | <100MB | Plus ~465 MB per Parakeet build, ~1.5 GB or ~600 MB optional Nemotron download (per selected build), ~2.1 GB optional Cohere download, and optional Whisper download |
 | Startup time | <2s | Cold start to menu bar ready |
 | File transcription | 1 hour audio in <25s | On M1 or better (ANE via CoreML) |
 
@@ -1849,12 +1852,12 @@ MacParakeet's brand is privacy. These are non-negotiable.
 | Core offline operation | Dictation, file transcription, and meeting recording work fully offline after local model setup |
 | Opt-out telemetry | Self-hosted usage analytics and crash reporting can be disabled in Settings |
 | No accounts | No email, no login, no registration |
-| No cloud STT | All speech recognition runs locally on Apple Silicon; Parakeet is default and Nemotron/WhisperKit are optional |
+| No cloud STT | All speech recognition runs locally on Apple Silicon; Parakeet is default and Nemotron/Cohere/WhisperKit are optional |
 | User-controlled storage | File/YouTube/meeting audio is retained for playback/recovery unless deleted; dictation audio is opt-in |
 | Explicit network surfaces | Model download, update checks, optional LLM providers, optional telemetry/crash reporting, retained purchase activation endpoints if explicitly invoked, and YouTube download |
 
 **What "supports a fully local setup" means:**
-- Parakeet and Nemotron STT run locally via FluidAudio CoreML; WhisperKit also runs locally when selected
+- Parakeet, Nemotron, and Cohere STT run locally via FluidAudio CoreML; WhisperKit also runs locally when selected
 - Audio never leaves the device
 - Transcripts stay local unless the user explicitly enables external AI features
 - Users can remain fully local by sticking to offline/core features and local providers such as Ollama

--- a/spec/02-features.md
+++ b/spec/02-features.md
@@ -80,7 +80,7 @@ See [00-vision.md](./00-vision.md) for positioning and market context.
 │  • VAD-guided live-preview chunking with fixed fallback           │
 │  • Nemotron Beta + WhisperKit engine options                     │
 │  • Settings engine picker + Nemotron/Whisper controls            │
-│  • CLI --engine parakeet|nemotron|whisper --language             │
+│  • CLI --engine parakeet|nemotron|whisper|cohere --language      │
 │  • Meeting engine/language pinning for live + recovery + final   │
 │  • Transforms: Polish / Distill / Decide selected text anywhere  │
 │  • CLI transforms + local Transform history                      │

--- a/spec/03-architecture.md
+++ b/spec/03-architecture.md
@@ -80,6 +80,11 @@
 │  │   Multilingual + English     │                                                │
 │  └──────────────────────────────┘                                                │
 │  ┌──────────────────────────────┐                                                │
+│  │   Cohere STT (optional)      │                                                │
+│  │   FluidAudio CoreML batch    │                                                │
+│  │   Accuracy-focused           │                                                │
+│  └──────────────────────────────┘                                                │
+│  ┌──────────────────────────────┐                                                │
 │  │   WhisperKit STT (optional)  │                                                │
 │  │   Local multilingual engine  │                                                │
 │  │   Explicit model download    │                                                │
@@ -95,8 +100,9 @@
 │  └──────────┘  └──────────┘  └─────────────┘  └──────────────┘  └─────────┘│
 │                                                                                  │
 │  Parakeet working RAM: ~66 MB per active inference slot on ANE                  │
+│  Cohere cache: FluidAudio/Models/cohere-transcribe/q8                           │
 │  Whisper cache: ~/Library/Application Support/MacParakeet/models/stt/whisper/   │
-│  Recommended: 8 GB RAM (Apple Silicon only).                                    │
+│  Recommended: 8 GB RAM default path; Cohere has higher memory needs.            │
 └──────────────────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -505,12 +511,12 @@ struct TimestampedWord: Sendable {
 }
 ```
 
-**Dependencies:** FluidAudio SDK (CoreML, runs on ANE) for Parakeet and Nemotron, plus optional WhisperKit.
+**Dependencies:** FluidAudio SDK (CoreML, runs on ANE) for Parakeet, Nemotron, and Cohere, plus optional WhisperKit.
 
 **Architecture:**
 ```
 CPU:  MacParakeet app (UI, hotkeys, clipboard, history)
-ANE:  Parakeet/Nemotron STT (via FluidAudio/CoreML) — dedicated ML accelerator
+ANE:  Parakeet/Nemotron/Cohere STT (via FluidAudio/CoreML) — dedicated ML accelerator
 CPU/GPU/CoreML as selected by WhisperKit: optional multilingual STT
 ```
 
@@ -541,6 +547,7 @@ STTRuntime
     ├── Parakeet v2/v3 slot managers
     ├── Parakeet Unified engine
     ├── Nemotron multilingual / English engines
+    ├── optional CohereTranscribeEngine selected by routed jobs/preferences
     └── optional WhisperEngine selected by routed jobs/preferences
 ```
 
@@ -562,7 +569,7 @@ STTRuntime.warmUp() called (lazy, on first use or from onboarding)
     ▼
 Slot managers ready — scheduler admits transcription jobs
 
-Whisper is downloaded explicitly and does not block Parakeet readiness. Switching engines is refused while STT jobs are queued/running or a meeting speech-engine lease is active.
+Whisper and Cohere are downloaded explicitly and do not block Parakeet readiness. Switching engines is refused while STT jobs are queued/running or a meeting speech-engine lease is active.
 ```
 
 Product-level readiness can coordinate additional services beyond the two STT slots. In particular, speaker diarization remains outside the speech scheduler, but onboarding should still account for its required assets before declaring default-on file-transcription features fully ready.
@@ -698,7 +705,7 @@ protocol TranscriptionRepositoryProtocol: Sendable {
 
 ### 3. Local STT Engines
 
-Speech recognition runs in the app process. Parakeet via FluidAudio CoreML on the Neural Engine is the default engine family: v3 is the multilingual default, v2 is an English-only TDT opt-in, and Unified is an English-only opt-in with punctuation/capitalization. Two optional local engines extend coverage: Nemotron 3.5 (Beta), a fast FluidAudio CoreML streaming engine with a multilingual default build and an English-only build, and WhisperKit for broader language coverage.
+Speech recognition runs in the app process. Parakeet via FluidAudio CoreML on the Neural Engine is the default engine family: v3 is the multilingual default, v2 is an English-only TDT opt-in, and Unified is an English-only opt-in with punctuation/capitalization. Three optional local engines extend coverage: Nemotron 3.5 (Beta), a fast FluidAudio CoreML streaming engine with a multilingual default build and an English-only build; Cohere Transcribe, a batch-only FluidAudio CoreML accuracy engine; and WhisperKit for broader language coverage.
 
 **Responsibility:** Speech-to-text transcription using the user's selected local engine.
 
@@ -732,6 +739,15 @@ Speech recognition runs in the app process. Parakeet via FluidAudio CoreML on th
 | Model cache | `~/Library/Application Support/MacParakeet/models/stt/whisper/` |
 | Selection | Settings speech-engine picker or CLI `--engine whisper --language <code>` |
 
+| Optional Engine (Cohere Transcribe) | Value |
+|-----------------|-------|
+| Model | Cohere Transcribe 03-2026 q8 CoreML (`cohere-transcribe`) |
+| Runtime | FluidAudio `CoherePipeline` through `CohereTranscribeEngine` |
+| Languages | Supported Cohere language codes; no auto-detect |
+| Output | Plain transcript text; no word timestamps, speaker labels, or live partials |
+| Model cache | `~/Library/Application Support/FluidAudio/Models/cohere-transcribe/q8` |
+| Selection | Settings speech-engine picker or CLI `--engine cohere --language <code>` |
+
 **Why In-Process (Not Daemon)?**
 - FluidAudio provides native Swift async/await API — no IPC overhead
 - CoreML models run on the ANE, leaving GPU free for the rest of macOS
@@ -744,7 +760,7 @@ Speech recognition runs in the app process. Parakeet via FluidAudio CoreML on th
         └── stt/
             └── whisper/        # WhisperKit model cache
 
-Parakeet's FluidAudio cache is managed by FluidAudio per selected build. `models/stt/whisper/` is the MacParakeet-owned cache for WhisperKit downloads.
+Parakeet, Nemotron, and Cohere FluidAudio caches are managed by FluidAudio per selected build/engine. `models/stt/whisper/` is the MacParakeet-owned cache for WhisperKit downloads.
 ```
 
 ---
@@ -1025,6 +1041,7 @@ deleted.
 | Dictation audio | `~/Library/Application Support/MacParakeet/dictations/` |
 | Transcription exports | `~/Library/Application Support/MacParakeet/transcriptions/` |
 | Parakeet STT models | FluidAudio-managed CoreML cache (~465 MB per build) |
+| Cohere STT model | `~/Library/Application Support/FluidAudio/Models/cohere-transcribe/q8` |
 | Whisper STT models | `~/Library/Application Support/MacParakeet/models/stt/whisper/` |
 | yt-dlp binary | `~/Library/Application Support/MacParakeet/bin/yt-dlp` |
 | FFmpeg binary | `~/Library/Application Support/MacParakeet/bin/ffmpeg` |
@@ -1056,7 +1073,7 @@ deleted.
 
 | Package | SPM ID | Purpose | Notes |
 |---------|--------|---------|-------|
-| FluidAudio | `FluidAudio` | Default STT engine (Parakeet TDT via CoreML/ANE) + diarization | Apache 2.0. Use `FluidAudio` product only — NOT `FluidAudioEspeak` (GPL-3.0, would require open-sourcing). |
+| FluidAudio | `FluidAudio` | Default STT engine (Parakeet TDT via CoreML/ANE), optional Nemotron/Cohere engines, and diarization | Apache 2.0. Use `FluidAudio` product only — NOT `FluidAudioEspeak` (GPL-3.0, would require open-sourcing). |
 | WhisperKit | `argmax-oss-swift` | Optional local multilingual STT engine | Exact 0.18.0 when enabled; `MACPARAKEET_SKIP_WHISPERKIT=1` skips the package for compatibility checks. |
 | GRDB.swift | `GRDB` | SQLite database | v6.29.0+, single-file storage, migrations, Codable records |
 | swift-argument-parser | `ArgumentParser` | CLI (implemented) | `macparakeet-cli transcribe`, `history`, `health`, `models`, `vocab`, `transforms` |
@@ -1208,6 +1225,7 @@ Parakeet TDT 0.6B throughput varies by device class: v3 is approximately 155x re
 ### Memory Management
 
 - **Parakeet model:** One shared runtime owner keeps its managers initialized after first use. Budget ~66 MB working RAM per active inference slot on the ANE path. Real total memory depends on how many managers are loaded/active in the current implementation, whether the background capacity stays lazy in the final design, and whether diarization models are also resident.
+- **Cohere model:** Loaded only when selected; downloaded explicitly to the FluidAudio cache. It is batch-only and has a larger resident footprint than Parakeet, so it is not part of the default readiness path.
 - **Whisper model:** Loaded only when selected; model size and runtime memory are variant-dependent. Default cache is `models/stt/whisper/`.
 - **Audio buffers:** Dictation writes temp WAV on stop; meeting recording writes fragmented source M4A files and lock files during capture. Completed meeting audio is retained by default but can be detached from the transcript through GUI/CLI cleanup. No recording duration limit beyond disk space and practical UI constraints.
 - **Database:** GRDB uses WAL mode by default. No connection pooling needed (single-user app).

--- a/spec/03-architecture.md
+++ b/spec/03-architecture.md
@@ -151,7 +151,7 @@ The diagram below shows the ADR-015/ADR-016 architecture. Dictation and meeting 
 - **Centralized STT ownership** — one runtime owner manages lifecycle, warm-up, shutdown, and speech-engine dispatch.
 - **Explicit scheduling** — the STT stack uses a reserved dictation slot plus a shared background slot; within the background slot, finalize beats live preview, and file transcription waits.
 - **Meeting engine lease** — a recording pins the active speech engine/language at start and blocks engine switching until stop/cancel.
-- **Cohere is batch-only** — Cohere dictation records first and transcribes on stop; meetings use Cohere only for final transcription, not live preview chunks.
+- **Cohere is batch-only** — Cohere dictation records first and transcribes on stop; meetings use Cohere only for final transcription, not live preview chunks. The scheduler admits Cohere as one global single-flight resource because the engine owns one large batch pipeline rather than separate interactive/background managers.
 - **Menu bar icon priority** — meeting > dictation > file-transcription > idle.
 
 ---
@@ -548,7 +548,7 @@ STTRuntime
     ├── Parakeet v2/v3 slot managers
     ├── Parakeet Unified engine
     ├── Nemotron multilingual / English engines
-    ├── optional CohereTranscribeEngine selected by routed jobs/preferences
+    ├── optional single-flight CohereTranscribeEngine selected by routed jobs/preferences
     └── optional WhisperEngine selected by routed jobs/preferences
 ```
 

--- a/spec/03-architecture.md
+++ b/spec/03-architecture.md
@@ -135,7 +135,7 @@ The diagram below shows the ADR-015/ADR-016 architecture. Dictation and meeting 
       └── Background slot   → meeting + file transcription
                 │
                 ▼
-     STT Runtime (Parakeet/Nemotron/Whisper engines)
+     STT Runtime (Parakeet/Nemotron/Whisper/Cohere engines)
 ```
 
 - **Shared microphone engine** — dictation and meeting mic capture subscribe to one process-wide `SharedMicrophoneStream`; downstream feature pipelines stay independent after copying buffers.
@@ -144,6 +144,7 @@ The diagram below shows the ADR-015/ADR-016 architecture. Dictation and meeting 
 - **Centralized STT ownership** — one runtime owner manages lifecycle, warm-up, shutdown, and speech-engine dispatch.
 - **Explicit scheduling** — the STT stack uses a reserved dictation slot plus a shared background slot; within the background slot, finalize beats live preview, and file transcription waits.
 - **Meeting engine lease** — a recording pins the active speech engine/language at start and blocks engine switching until stop/cancel.
+- **Cohere is batch-only** — Cohere dictation records first and transcribes on stop; meetings use Cohere only for final transcription, not live preview chunks.
 - **Menu bar icon priority** — meeting > dictation > file-transcription > idle.
 
 ---

--- a/spec/03-architecture.md
+++ b/spec/03-architecture.md
@@ -100,7 +100,8 @@
 │  └──────────┘  └──────────┘  └─────────────┘  └──────────────┘  └─────────┘│
 │                                                                                  │
 │  Parakeet working RAM: ~66 MB per active inference slot on ANE                  │
-│  Cohere cache: FluidAudio/Models/cohere-transcribe/q8                           │
+│  Cohere cache: ~/Library/Application Support/FluidAudio/Models/                 │
+│                cohere-transcribe/q8                                             │
 │  Whisper cache: ~/Library/Application Support/MacParakeet/models/stt/whisper/   │
 │  Recommended: 8 GB RAM default path; Cohere has higher memory needs.            │
 └──────────────────────────────────────────────────────────────────────────────────┘

--- a/spec/05-audio-pipeline.md
+++ b/spec/05-audio-pipeline.md
@@ -353,7 +353,7 @@ alter the pasted text. See `docs/research/live-dictation-streaming.md`.
 
 ### Meeting Live Preview
 
-`CaptureOrchestrator` buffers audio into live-preview chunks and sends them through the scheduler using the meeting's captured speech engine during recording. The fixed fallback keeps the original 5s / 1s-overlap `AudioChunker` cadence. When `AppFeatures.meetingVadLiveChunkingEnabled` is true, launch-time prep tries to cache the Silero VAD model; if it is cached and the meeting uses Parakeet, the live path cuts chunks at speech boundaries per source. Nemotron and Whisper sessions currently use the fixed cadence. VAD unavailable/error cases fall back to the fixed cadence, and the final post-stop transcript is unchanged. This provides:
+`CaptureOrchestrator` buffers audio into live-preview chunks and sends them through the scheduler using the meeting's captured speech engine during recording when that engine supports live chunk transcription. The fixed fallback keeps the original 5s / 1s-overlap `AudioChunker` cadence. When `AppFeatures.meetingVadLiveChunkingEnabled` is true, launch-time prep tries to cache the Silero VAD model; if it is cached and the meeting uses Parakeet, the live path cuts chunks at speech boundaries per source. Nemotron and Whisper sessions currently use the fixed cadence. Cohere sessions skip live-preview chunks because Cohere is batch-only. VAD unavailable/error cases fall back to the fixed cadence, and the final post-stop transcript is unchanged. This provides:
 - Live transcript preview in the recording pill
 - Source-aware labels: mic chunks → "Me", system chunks → "Them"
 - Raw mic capture plus a residual safeguard that suppresses clearly system-dominant mic chunks in live preview windows

--- a/spec/06-stt-engine.md
+++ b/spec/06-stt-engine.md
@@ -82,10 +82,10 @@ Cohere Transcribe (`cohere-transcribe-03-2026`, 2B, Apache-2.0) was evaluated by
 | Accuracy | Most accurate on-device: English macro WER 2.07% (full LibriSpeech); best Japanese (FLEURS CER 5.56). Significant lead only on noisy English + Japanese; clean EN/KO/ZH are statistical ties (paired-bootstrap CIs) |
 | Output | Plain transcript text; no word timestamps, no speaker labels, no live partials |
 | Selection | Explicit in Settings or CLI (`--engine cohere --language <code>`); `models select cohere-transcribe`; no automatic fallback |
-| Download | ~2.1 GB, explicit Settings/CLI download (`models download cohere-transcribe`) before selecting as the shared default |
+| Download | ~2.1 GB, explicit Settings/CLI download (`models download cohere-transcribe`) before selection or transcription; normal transcription paths fail fast if the model is missing |
 | Compute | Defaults to Core ML CPU+Neural Engine (`ane`) to avoid the recurring per-launch GPU specialization cost; GPU remains an internal policy override |
 
-Cohere is batch-only. Dictation records first and transcribes after the user stops; it does not show live dictation preview. File transcription and meeting finalization can use Cohere, but meeting live preview chunks are disabled and meeting transcripts degrade to plain text because Cohere does not emit word timestamps. Parakeet v3 stays the default and WhisperKit remains the lighter broad-coverage option; Cohere is for users who explicitly accept the larger model and memory footprint for accuracy. Full benchmark methodology, CIs, and speed/memory tables: `benchmarks/asr/README.md`.
+Cohere is batch-only and single-flight inside the shared runtime. Dictation records first and transcribes after the user stops; it does not show live dictation preview. File transcription and meeting finalization can use Cohere, but meeting live preview chunks are disabled and meeting transcripts degrade to plain text because Cohere does not emit word timestamps. `STTScheduler` treats Cohere as a global serialized resource so an interactive Cohere dictation finalization is not hidden behind an engine-internal wait while another Cohere batch job is running; Parakeet and Nemotron keep the normal interactive/background split for low-latency dictation. Parakeet v3 stays the default and WhisperKit remains the lighter broad-coverage option; Cohere is for users who explicitly accept the larger model and memory footprint for accuracy. Full benchmark methodology, CIs, and speed/memory tables: `benchmarks/asr/README.md`.
 
 ### Three-Chip Architecture
 
@@ -97,7 +97,7 @@ ANE/CoreML: Parakeet STT, Nemotron Beta, and Cohere Transcribe (via FluidAudio/C
 CPU/GPU/CoreML as selected by WhisperKit: optional multilingual STT
 ```
 
-The default Parakeet path runs on dedicated silicon, leaving CPU and GPU free for the app and macOS. Nemotron uses FluidAudio's CoreML path with separate interactive/background managers backed by shared model weights. Cohere uses FluidAudio's CoreML batch path and serializes transcriptions through its loaded pipeline. WhisperKit uses the compute path selected by WhisperKit/CoreML for the downloaded model variant.
+The default Parakeet path runs on dedicated silicon, leaving CPU and GPU free for the app and macOS. Nemotron uses FluidAudio's CoreML path with separate interactive/background managers backed by shared model weights. Cohere uses FluidAudio's CoreML batch path and is admitted as a scheduler-level single-flight resource around its loaded pipeline. WhisperKit uses the compute path selected by WhisperKit/CoreML for the downloaded model variant.
 
 ---
 

--- a/spec/06-stt-engine.md
+++ b/spec/06-stt-engine.md
@@ -340,7 +340,7 @@ Backpressure and queueing rules:
 - Progress reporting must be fanned out per job, not broadcast globally from the raw runtime stream
 - Cancellation is checked before scheduler admission so fast user cancels do not race into successful transcriptions
 - Speaker diarization remains a separate service and is not part of the two-slot speech scheduler
-- Switching Parakeet/Nemotron/Whisper is rejected while jobs are queued/running or a meeting speech-engine lease is active
+- Switching Parakeet/Nemotron/Cohere/Whisper is rejected while jobs are queued/running or a meeting speech-engine lease is active
 
 ### Data Flow
 

--- a/spec/06-stt-engine.md
+++ b/spec/06-stt-engine.md
@@ -2,7 +2,7 @@
 
 > Status: **ACTIVE** - Authoritative, current
 
-MacParakeet's default speech engine family is Parakeet TDT 0.6B via FluidAudio CoreML on Apple's Neural Engine (ANE). Multilingual v3 is the default build; English-only v2 is an opt-in Parakeet build for users who want a faster no-auto-detect path; and an English-only Parakeet Unified build adds native streaming dictation with built-in punctuation and capitalization (it does not emit word-level timestamps, so v3 remains the choice for timed transcripts). Nemotron is available as an opt-in Beta local engine (multilingual Nemotron 3.5 by default, plus an English-only second build), and WhisperKit remains the mature optional fallback for languages Parakeet/Nemotron do not cover well enough. All speech engines run on-device; there is no cloud STT path.
+MacParakeet's default speech engine family is Parakeet TDT 0.6B via FluidAudio CoreML on Apple's Neural Engine (ANE). Multilingual v3 is the default build; English-only v2 is an opt-in Parakeet build for users who want a faster no-auto-detect path; and an English-only Parakeet Unified build adds native streaming dictation with built-in punctuation and capitalization (it does not emit word-level timestamps, so v3 remains the choice for timed transcripts). Nemotron is available as an opt-in Beta local engine (multilingual Nemotron 3.5 by default, plus an English-only second build), WhisperKit remains the mature optional fallback for languages Parakeet/Nemotron do not cover well enough, and Cohere Transcribe is an opt-in local accuracy engine for record-then-transcribe jobs. All speech engines run on-device; there is no cloud STT path.
 
 ---
 
@@ -55,7 +55,7 @@ Nemotron is shipped as Beta because it is fast and local but not yet proven as a
 
 Because Nemotron is a streaming engine, dictation on **both** Nemotron builds (multilingual and English) streams microphone samples into a live session: partial text appears in the dictation overlay while speaking, and the streamed final transcript is used as the dictation result. (File and meeting jobs on Nemotron still run batch-at-stop.) The recorded WAV is still always written; if the live session cannot start, fails mid-stream, drops samples under backpressure, or finishes empty, dictation transparently falls back to transcribing the recorded file (this fallback is within the Nemotron path — it is not an engine fallback, which remains explicitly user-selected per the table above).
 
-**Display-only live dictation preview.** Separately from the final paste path, an opt-in display-only preview (`AppFeatures.liveDictationStreamingEnabled`, #517) renders a stable rolling readout of in-progress text above the dictation pill. It never feeds the paste — the final inserted text always comes from the stop-time transcription path. Parakeet v2/v3 use a single-flight tail-window batch preview (reusing their `[Float]` batch path), Parakeet Unified uses FluidAudio's native `StreamingUnifiedAsrManager` (`parakeet-unified-2080ms`), the Nemotron builds reuse their native live partials, and Whisper stays default-off pending a per-pass latency probe. A per-session `LiveTranscriptStabilizer` turns the raw stream into a monotonic, append-only readout (settled body committed, last few words held as a volatile hypothesis) so shown words don't jump or disappear; the overlay renders it bottom-anchored with older lines fading out at the top edge (no mid-word truncation). Full behavior and lifecycle (single-flight/native session ownership, cancel/drain, engine-switch and shutdown ordering) are specified in `spec/05-audio-pipeline.md` → "Dictation Live Preview" and `docs/research/live-dictation-streaming.md`.
+**Display-only live dictation preview.** Separately from the final paste path, an opt-in display-only preview (`AppFeatures.liveDictationStreamingEnabled`, #517) renders a stable rolling readout of in-progress text above the dictation pill. It never feeds the paste — the final inserted text always comes from the stop-time transcription path. Parakeet v2/v3 use a single-flight tail-window batch preview (reusing their `[Float]` batch path), Parakeet Unified uses FluidAudio's native `StreamingUnifiedAsrManager` (`parakeet-unified-2080ms`), the Nemotron builds reuse their native live partials, Whisper stays default-off pending a per-pass latency probe, and Cohere stays off because it is batch-only. A per-session `LiveTranscriptStabilizer` turns the raw stream into a monotonic, append-only readout (settled body committed, last few words held as a volatile hypothesis) so shown words don't jump or disappear; the overlay renders it bottom-anchored with older lines fading out at the top edge (no mid-word truncation). Full behavior and lifecycle (single-flight/native session ownership, cancel/drain, engine-switch and shutdown ordering) are specified in `spec/05-audio-pipeline.md` → "Dictation Live Preview" and `docs/research/live-dictation-streaming.md`.
 
 ### WhisperKit Optional Engine
 
@@ -70,18 +70,22 @@ Because Nemotron is a streaming engine, dictation on **both** Nemotron builds (m
 
 Parakeet remains the default because it is faster, lower-latency, and lower-memory for supported languages. Nemotron is the faster experimental path (multilingual default build, English-only opt-in build); WhisperKit solves mature broad coverage while preserving the local-first speech boundary.
 
-### Cohere Transcribe (Evaluated Candidate — Not Yet Integrated)
+### Cohere Transcribe Optional Engine
 
-Cohere Transcribe (`cohere-transcribe-03-2026`, 2B, Apache-2.0) was evaluated by the gold-standard benchmark (`benchmarks/asr/`, PR #568) and is **recommended as a future opt-in engine, not yet shipped** (ADR-001 amendment 2026-06-19). It runs on-device through the **same FluidAudio CoreML SDK** as Parakeet/Nemotron — FluidAudio ≥ 0.15.4 exposes a public `CoherePipeline`; q8 model repo `FluidInference/cohere-transcribe-03-2026-coreml` — so **no MLX or new runtime is required**, unlike the deferred MLX-only candidates (Qwen3-ASR, Moonshine).
+Cohere Transcribe (`cohere-transcribe-03-2026`, 2B, Apache-2.0) was evaluated by the gold-standard benchmark (`benchmarks/asr/`, PR #568) and is shipped as an opt-in local engine for accuracy-critical record-then-transcribe work. It runs on-device through the same FluidAudio CoreML SDK as Parakeet/Nemotron — FluidAudio >= 0.15.4 exposes a public `CoherePipeline`; q8 model repo `FluidInference/cohere-transcribe-03-2026-coreml` — so no MLX or new runtime is required, unlike the deferred MLX-only candidates (Qwen3-ASR, Moonshine).
 
 | Property | Value |
 |----------|-------|
-| Status | Evaluated + recommended; **not integrated** |
+| Status | Shipped opt-in local engine; not the default |
+| Runtime | FluidAudio `CoherePipeline` through `CohereTranscribeEngine` |
+| Model cache | `~/Library/Application Support/FluidAudio/Models/cohere-transcribe/q8` |
 | Accuracy | Most accurate on-device: English macro WER 2.07% (full LibriSpeech); best Japanese (FLEURS CER 5.56). Significant lead only on noisy English + Japanese; clean EN/KO/ZH are statistical ties (paired-bootstrap CIs) |
-| Cost | **~11 GB peak RSS**, ~73 s one-time ANE compile, ~11× realtime, ~2.3 GB model |
-| If integrated | Opt-in Beta engine gated to ≥16 GB RAM, via a `CohereEngine` wrapping FluidAudio's `CoherePipeline` routed in `STTRuntime` (the Nemotron/Unified pattern) |
+| Output | Plain transcript text; no word timestamps, no speaker labels, no live partials |
+| Selection | Explicit in Settings or CLI (`--engine cohere --language <code>`); `models select cohere-transcribe`; no automatic fallback |
+| Download | ~2.1 GB, explicit Settings/CLI download (`models download cohere-transcribe`) before selecting as the shared default |
+| Compute | Defaults to Core ML CPU+Neural Engine (`ane`) to avoid the recurring per-launch GPU specialization cost; GPU remains an internal policy override |
 
-Recommendation: Parakeet v3 stays the default and WhisperKit the light multilingual option; Cohere would be surfaced for accuracy-critical / noisy / Japanese transcription on 16 GB+ Macs. Full methodology, CIs, and speed/memory tables: `benchmarks/asr/README.md`.
+Cohere is batch-only. Dictation records first and transcribes after the user stops; it does not show live dictation preview. File transcription and meeting finalization can use Cohere, but meeting live preview chunks are disabled and meeting transcripts degrade to plain text because Cohere does not emit word timestamps. Parakeet v3 stays the default and WhisperKit remains the lighter broad-coverage option; Cohere is for users who explicitly accept the larger model and memory footprint for accuracy. Full benchmark methodology, CIs, and speed/memory tables: `benchmarks/asr/README.md`.
 
 ### Three-Chip Architecture
 
@@ -89,11 +93,11 @@ Each ML workload runs on the chip it was designed for:
 
 ```
 CPU:  MacParakeet app (UI, shortcuts, clipboard, history)
-ANE/CoreML: Parakeet STT and Nemotron Beta (via FluidAudio/CoreML)
+ANE/CoreML: Parakeet STT, Nemotron Beta, and Cohere Transcribe (via FluidAudio/CoreML)
 CPU/GPU/CoreML as selected by WhisperKit: optional multilingual STT
 ```
 
-The default Parakeet path runs on dedicated silicon, leaving CPU and GPU free for the app and macOS. Nemotron uses FluidAudio's CoreML path with separate interactive/background managers backed by shared model weights. WhisperKit uses the compute path selected by WhisperKit/CoreML for the downloaded model variant.
+The default Parakeet path runs on dedicated silicon, leaving CPU and GPU free for the app and macOS. Nemotron uses FluidAudio's CoreML path with separate interactive/background managers backed by shared model weights. Cohere uses FluidAudio's CoreML batch path and serializes transcriptions through its loaded pipeline. WhisperKit uses the compute path selected by WhisperKit/CoreML for the downloaded model variant.
 
 ---
 
@@ -452,7 +456,7 @@ This replaces the previous Python venv bootstrap (~500 MB deps + ~2.5 GB model).
 - Support retry on network failure
 - Resume partial downloads where possible (HuggingFace supports range requests)
 - Verify model integrity after download where the provider exposes enough metadata
-- If the Nemotron or Whisper model is missing, keep Parakeet usable and direct the user to the explicit model download action
+- If the Nemotron, Cohere, or Whisper model is missing, keep Parakeet usable and direct the user to the explicit model download action
 
 ### CoreML Errors
 

--- a/spec/README.md
+++ b/spec/README.md
@@ -15,7 +15,7 @@
 | 03 | [Architecture](03-architecture.md) | System architecture, component diagram | Active |
 | 04 | [UI Patterns](04-ui-patterns.md) | UI components, overlay, settings | Active |
 | 05 | [Audio Pipeline](05-audio-pipeline.md) | Audio capture, processing, storage | Active |
-| 06 | [STT Engine](06-stt-engine.md) | Parakeet default engine, optional Nemotron/WhisperKit engines, scheduler | Active |
+| 06 | [STT Engine](06-stt-engine.md) | Parakeet default engine, optional Nemotron/Cohere/WhisperKit engines, scheduler | Active |
 | 07 | [Text Processing](07-text-processing.md) | Clean pipeline, custom words, snippets | Active |
 | 08 | [Error Handling](08-error-handling.md) | Error philosophy, categories, recovery | Active |
 | 09 | [Testing](09-testing.md) | Testing strategy, patterns, guidelines | Active |
@@ -75,6 +75,7 @@ Current `main` feature gates in `Sources/MacParakeetCore/AppFeatures.swift`:
 | `meetingCaptureReliabilityEnabled` | `true` | Default-on kill switch for ADR-025 Phase A mic-health telemetry watchdog |
 | `meetingActivityDetectionEnabled` | `false` | ADR-024 collectors/detector are compiled but runtime coordinator/UI remain gated |
 | `transformsEnabled` | `true` | Productized Transforms shipping surface |
+| `cohereEngineEnabled` | `true` | Settings exposes Cohere Transcribe as an opt-in, downloaded, batch-only local engine; no live preview/timestamps |
 | `meetingVadLiveChunkingEnabled` | `true` | VAD-guided meeting live-preview chunking; final post-stop transcript path unchanged |
 | `liveDictationStreamingEnabled` | `true` | Display-only live dictation preview enabled on `main`; final paste remains stop-time transcription |
 | `aiFormatterProfilesEnabled` | `false` | App-aware AI Formatter profiles are code-complete but held out of the current tagged release train |
@@ -85,7 +86,7 @@ All ADRs live in `spec/adr/`. These are locked -- they record decisions already 
 
 | ADR | Decision |
 |-----|----------|
-| [ADR-001](adr/001-parakeet-stt.md) | Parakeet TDT 0.6B-v3 as primary/default STT engine; v2 English-only opt-in by amendment |
+| [ADR-001](adr/001-parakeet-stt.md) | Parakeet TDT 0.6B-v3 as primary/default STT engine; optional local engines by amendment |
 | [ADR-002](adr/002-local-only.md) | Local processing with optional external AI/telemetry surfaces |
 | [ADR-003](adr/003-one-time-purchase.md) | Historical one-time purchase pricing; paid official distribution reference |
 | [ADR-004](adr/004-deterministic-pipeline.md) | Deterministic text processing pipeline |
@@ -120,7 +121,7 @@ All ADRs live in `spec/adr/`. These are locked -- they record decisions already 
 | v0.3 | YouTube & Export | YouTube transcription, export formats | **Implemented** |
 | v0.4 | Polish & Launch | Diarization, custom hotkey, non-blocking progress, direct distribution | **Implemented** |
 | v0.5 | Data, UI & Prompts | Private dictation, favorites, video player, split-pane detail, library grid, prompt library, multi-summary | **Implemented** |
-| v0.6 | Meeting Recording + Multilingual STT + Transforms | System audio + mic capture, concurrent with dictation, local transcription, VAD-guided live-preview chunking, library integration, optional Nemotron Beta and WhisperKit engines, system-wide selected-text rewrites, calendar auto-start | **Implemented** |
+| v0.6 | Meeting Recording + Multilingual STT + Transforms | System audio + mic capture, concurrent with dictation, local transcription, VAD-guided live-preview chunking, library integration, optional Nemotron Beta, Cohere Transcribe, and WhisperKit engines, system-wide selected-text rewrites, calendar auto-start | **Implemented** |
 | v0.7 | Post-v0.6 polish | Activity-based auto-stop (ADR-023 implemented behind default-off flag), meeting reliability (ADR-025 Phase A implemented behind default-on kill-switch), activity-based detection (ADR-024 Phases A+B implemented behind default-off flag), display-only live dictation transcript preview (`liveDictationStreamingEnabled`, enabled on `main`), meeting audio N-day retention, plus other follow-up polish | **Planned** |
 
 ## Version Progress
@@ -271,8 +272,9 @@ Calendar-related code is implemented and **enabled** (`AppFeatures.calendarEnabl
 - [x] WhisperKit dependency and `WhisperEngine` wrapper with local model cache at `~/Library/Application Support/MacParakeet/models/stt/whisper/`
 - [x] Nemotron 3.5 Beta engine via FluidAudio CoreML, surfaced as opt-in local multilingual ASR with explicit model download/delete/status controls
 - [x] Nemotron Speech Streaming EN 0.6B surfaced as a second opt-in English-only Beta build with persisted model selection (multilingual default) via the Settings Nemotron Model card, `config set nemotron-model`, `models select nemotron-english-1120ms`, and `transcribe --nemotron-model`; dictation streams live partials (live transcript preview) like the multilingual build, while file/meeting jobs run batch-at-stop
+- [x] Cohere Transcribe via FluidAudio CoreML, surfaced as an opt-in downloaded local accuracy engine for batch dictation, file transcription, and meeting finalization; no live preview, word timestamps, or speaker labels
 - [x] `SpeechEnginePreference`, `SpeechEngineSelection`, `ParakeetModelVariant`, and `NemotronModelVariant` persisted or modeled through `UserDefaults` where user-selectable
-- [x] Settings → Speech Recognition segmented engine picker plus Parakeet Model, Nemotron Beta, and Whisper Language cards/controls
+- [x] Settings → Speech Recognition segmented engine picker plus Parakeet Model, Nemotron Beta, Cohere Language, and Whisper Language cards/controls
 - [x] Engine switching blocked while jobs are queued/running or a meeting speech-engine lease is active
 - [x] CLI `transcribe --engine parakeet|nemotron|whisper|cohere --language <code> --parakeet-model app-default|v3|v2`, `config set parakeet-model`, `config set nemotron-language`, `config set cohere-language`, and `models download parakeet-v2|parakeet-v3|nemotron-multilingual-1120ms|nemotron-english-1120ms|cohere-transcribe|whisper-large-v3-v20240930-turbo-632MB`
 - [x] Meeting recordings capture the active engine/language at start and preserve it through metadata, lock files, crash recovery, and final transcription

--- a/spec/README.md
+++ b/spec/README.md
@@ -50,7 +50,7 @@ These decisions are final. Do not second-guess them.
 
 | Decision | Choice | Rationale |
 |----------|--------|-----------|
-| Local STT | Parakeet TDT 0.6B via FluidAudio CoreML/ANE (`v3` multilingual default, `v2` English-only opt-in); Nemotron 3.5 Beta and WhisperKit optional | Parakeet gives 155x realtime and low RAM for supported languages; v2 avoids language auto-detect for English-only use; Nemotron is a fast opt-in Beta path with multilingual (default) and English-only builds; Whisper adds mature broad multilingual coverage locally |
+| Local STT | Parakeet TDT 0.6B via FluidAudio CoreML/ANE (`v3` multilingual default, `v2` English-only opt-in); Nemotron 3.5 Beta, WhisperKit, and Cohere Transcribe optional | Parakeet gives 155x realtime and low RAM for supported languages; v2 avoids language auto-detect for English-only use; Nemotron is a fast opt-in Beta path with multilingual (default) and English-only builds; Whisper adds mature broad multilingual coverage locally; Cohere is a larger batch-only accuracy path |
 | Database | SQLite via GRDB | Single file, embedded, zero config |
 | Platform | macOS 14.2+ (Apple Silicon only) | FluidAudio requires Apple Silicon; Swift 6 language mode (tools-version 5.9) |
 | Business model | Current public build free/GPL/unlocked; official paid distribution/support remains possible | Originally $49 one-time (ADR-003), went free with open-source release in v0.5; retained purchase activation plumbing is future-option code |
@@ -274,7 +274,7 @@ Calendar-related code is implemented and **enabled** (`AppFeatures.calendarEnabl
 - [x] `SpeechEnginePreference`, `SpeechEngineSelection`, `ParakeetModelVariant`, and `NemotronModelVariant` persisted or modeled through `UserDefaults` where user-selectable
 - [x] Settings → Speech Recognition segmented engine picker plus Parakeet Model, Nemotron Beta, and Whisper Language cards/controls
 - [x] Engine switching blocked while jobs are queued/running or a meeting speech-engine lease is active
-- [x] CLI `transcribe --engine parakeet|nemotron|whisper --language <code> --parakeet-model app-default|v3|v2`, `config set parakeet-model`, `config set nemotron-language`, and `models download parakeet-v2|parakeet-v3|nemotron-multilingual-1120ms|nemotron-english-1120ms|whisper-large-v3-v20240930-turbo-632MB`
+- [x] CLI `transcribe --engine parakeet|nemotron|whisper|cohere --language <code> --parakeet-model app-default|v3|v2`, `config set parakeet-model`, `config set nemotron-language`, `config set cohere-language`, and `models download parakeet-v2|parakeet-v3|nemotron-multilingual-1120ms|nemotron-english-1120ms|cohere-transcribe|whisper-large-v3-v20240930-turbo-632MB`
 - [x] Meeting recordings capture the active engine/language at start and preserve it through metadata, lock files, crash recovery, and final transcription
 
 ### v0.6 Productized Transforms

--- a/spec/adr/001-parakeet-stt.md
+++ b/spec/adr/001-parakeet-stt.md
@@ -245,7 +245,7 @@ paired-bootstrap significance):
 - Cost is the decisive factor: **~11 GB peak resident memory** (constant across
   file counts → model-resident, measured via the FluidAudio reference harness),
   **~73 s one-time ANE compile**, **~11× realtime** (vs ~70× / ~120 MB for
-  Parakeet), ~2.3 GB download.
+  Parakeet), ~2.1 GB download.
 
 **Decision:** keep Parakeet v3 the default and WhisperKit the light multilingual
 option. Ship Cohere as an explicit opt-in engine with a clear download-size /

--- a/spec/adr/001-parakeet-stt.md
+++ b/spec/adr/001-parakeet-stt.md
@@ -10,7 +10,7 @@
 > Amendment (2026-06-11): Nemotron Speech Streaming EN 0.6B (`english-1120ms`) is added as a second opt-in Beta build under the Nemotron engine, a peer of the multilingual build the way Parakeet v2 is a peer of v3. Parakeet v3 remains the primary/default STT engine; promotion of either Nemotron build still requires real MacParakeet corpus benchmarks.
 > Amendment (2026-06-17): NVIDIA Parakeet Unified EN 0.6B (`unified`) is added as a third opt-in Parakeet build (English-only). Unlike the v2/v3 TDT builds it is a separate FluidAudio runtime (`UnifiedAsrManager`, no `AsrModelVersion`) served by a dedicated `ParakeetUnifiedEngine`, but it is presented to users as a Parakeet model. Parakeet v3 remains the primary/default; Unified provides strong English offline accuracy with punctuation/capitalization (FluidAudio v0.15.4 CoreML benchmark: 2.15% average / 1.68% aggregate WER on LibriSpeech test-clean; NVIDIA upstream card: 1.63% offline WER). Phase 1 ships offline-only; FluidAudio's native low-latency streaming build (`parakeet-unified-2080ms`) is the planned follow-up. Issue #520.
 > Amendment (2026-06-18): Parakeet Unified Phase 2 wires FluidAudio's native `StreamingUnifiedAsrManager` (`parakeet-unified-2080ms`) into live dictation preview while keeping file transcription, meeting finalization, and the final dictation paste on the higher-quality offline batch path. Unified remains English-only, opt-in, and non-default; it still exposes no word-level timings through MacParakeet.
-> Amendment (2026-06-19): Cohere Transcribe (`cohere-transcribe-03-2026`, 2B, Apache-2.0) is **evaluated and recommended as a future opt-in engine — not yet integrated**. It runs fully on-device through the **FluidAudio CoreML** SDK already vendored here (FluidAudio ≥ 0.15.4 exposes a public `CoherePipeline`/`CohereAsrConfig` and a q8 CoreML repo); **no MLX runtime or other new dependency is required** — unlike the MLX-only candidates (Qwen3-ASR, Moonshine), which stay deferred. The gold-standard benchmark (`benchmarks/asr/`, hardened + independently verified in PR #568) found Cohere the most accurate on-device engine (full-LibriSpeech macro WER 2.07% vs 2.38% Parakeet-unified; best Japanese), but with a decisive cost — **~11 GB peak RSS**, ~73 s one-time ANE compile, ~11× realtime, ~2.3 GB model — and, under paired-bootstrap CIs, a *significant* accuracy lead only on noisy English and Japanese (clean English, Korean, Chinese are ties). Decision: Parakeet v3 remains the primary/default; **if integrated, Cohere ships as an opt-in Beta engine gated to ≥16 GB RAM**, via a `CohereEngine` wrapping FluidAudio's `CoherePipeline` routed in `STTRuntime` (the Nemotron/Unified pattern). Integration is a separate, ADR-gated change. See the Cohere addendum below.
+> Amendment (2026-06-19, integrated 2026-06-27): Cohere Transcribe (`cohere-transcribe-03-2026`, 2B, Apache-2.0) is added as an opt-in local accuracy engine. It runs fully on-device through the FluidAudio CoreML SDK already vendored here (FluidAudio >= 0.15.4 exposes a public `CoherePipeline`/`CohereAsrConfig` and a q8 CoreML repo); no MLX runtime or other new dependency is required, unlike the MLX-only candidates (Qwen3-ASR, Moonshine), which stay deferred. The gold-standard benchmark (`benchmarks/asr/`, hardened + independently verified in PR #568) found Cohere the most accurate on-device engine (full-LibriSpeech macro WER 2.07% vs 2.38% Parakeet-unified; best Japanese), but with a decisive cost: high resident memory, heavier cold-start/model prep, and ~2.1 GB download. Decision: Parakeet v3 remains the primary/default; Cohere is explicit opt-in, batch-only, user-downloaded, warned in Settings for model size/memory, and routed through `STTRuntime` by `CohereTranscribeEngine`. It has no live dictation preview, no meeting live chunks, and no word timestamps.
 
 ## Context
 
@@ -216,23 +216,24 @@ upstream model is under the NVIDIA Open Model License Agreement, so — like eve
 other model — it stays a user-triggered download, never bundled. Fresh installs
 still default to Parakeet v3.
 
-## Addendum: Cohere Transcribe — Evaluated Candidate, Not Yet Integrated (June 2026)
+## Addendum: Cohere Transcribe Opt-In Engine (June 2026)
 
 > Date: 2026-06-19
-> Status: **Recommendation** (benchmark outcome; not implemented)
+> Status: **Accepted** (integrated 2026-06-27 as opt-in, batch-only)
 
 A gold-standard cross-engine benchmark (`benchmarks/asr/`, hardened and
 independently verified in PR #568) evaluated Cohere Transcribe
 (`cohere-transcribe-03-2026`, 2B params, Apache-2.0, #1 on the HF Open ASR
-Leaderboard) as a candidate on-device engine.
+Leaderboard) as a candidate on-device engine. PR #602 integrates it as an
+explicit opt-in engine for accuracy-critical record-then-transcribe work.
 
 **It is FluidAudio CoreML, not MLX.** FluidAudio ≥ 0.15.4 — the exact SDK
 MacParakeet already depends on — ships a public `CoherePipeline` actor and a q8
 CoreML model repo (`FluidInference/cohere-transcribe-03-2026-coreml`). So Cohere
-needs **no new runtime**: it would be integrated exactly like the Nemotron and
-Parakeet-Unified engines — a `CohereEngine` wrapping the FluidAudio pipeline,
-routed inside `STTRuntime`, with a user-triggered model download. This is what
-distinguishes it from the deferred MLX-only candidates (Qwen3-ASR, Moonshine).
+needs **no new runtime**: `CohereTranscribeEngine` wraps the FluidAudio pipeline,
+routes inside `STTRuntime`, and uses a user-triggered `cohere-transcribe` model
+download. This is what distinguishes it from the deferred MLX-only candidates
+(Qwen3-ASR, Moonshine).
 
 **Findings** (Apple M4 Pro; full LibriSpeech + FLEURS; one canonical normalizer;
 paired-bootstrap significance):
@@ -246,14 +247,15 @@ paired-bootstrap significance):
   **~73 s one-time ANE compile**, **~11× realtime** (vs ~70× / ~120 MB for
   Parakeet), ~2.3 GB download.
 
-**Recommendation (not a locked decision yet):** keep Parakeet v3 the default and
-WhisperKit the light multilingual option. **If** integrated, ship Cohere as an
-**opt-in Beta engine gated to ≥16 GB RAM** with a clear download-size /
-cold-start warning, surfaced for accuracy-critical, noisy, or Japanese
-transcription. Both Nemotron builds are dominated by Parakeet in this benchmark (settling
-#520). Actual integration — engine wrapper, model-download UX, Settings/CLI
-surfacing, the RAM gate, telemetry — is a separate, ADR-gated change, and like
-every model the weights stay a user-triggered download, never bundled.
+**Decision:** keep Parakeet v3 the default and WhisperKit the light multilingual
+option. Ship Cohere as an explicit opt-in engine with a clear download-size /
+memory warning, surfaced for accuracy-critical, noisy, or Japanese
+transcription. Do not hard-gate RAM in this integration; the Settings copy
+warns about higher memory use and the model is never bundled. Cohere is
+batch-only: dictation records first and transcribes on stop; meetings use
+Cohere only for final transcription, not live preview chunks; transcripts have
+no word timestamps or speaker alignment. Both Nemotron builds are dominated by
+Parakeet in this benchmark (settling #520).
 
 See `benchmarks/asr/README.md` (PR #568) for the full methodology, CIs, and
 speed/memory tables; `plans/active/asr-benchmark-and-model-expansion.md` for the
@@ -268,5 +270,5 @@ candidate landscape.
 - [parakeet-mlx](https://github.com/senstella/parakeet-mlx) -- MLX port (original runtime, superseded)
 - [ADR-021: WhisperKit as Optional Multilingual STT Engine](021-whisperkit-multilingual-stt.md)
 - [Nemotron 3.5 ASR Streaming 0.6B](https://huggingface.co/nvidia/nemotron-3.5-asr-streaming-0.6b)
-- [FluidInference/cohere-transcribe-03-2026-coreml](https://huggingface.co/FluidInference/cohere-transcribe-03-2026-coreml) -- q8 CoreML conversion of Cohere Transcribe (the on-device path; evaluated in PR #568, not yet integrated)
+- [FluidInference/cohere-transcribe-03-2026-coreml](https://huggingface.co/FluidInference/cohere-transcribe-03-2026-coreml) -- q8 CoreML conversion of Cohere Transcribe (the on-device path; evaluated in PR #568 and integrated as opt-in in PR #602)
 - Oatmeal project ADR-011 (prior art for Parakeet selection)

--- a/spec/adr/014-meeting-recording.md
+++ b/spec/adr/014-meeting-recording.md
@@ -2,7 +2,7 @@
 
 > Status: IMPLEMENTED
 > Date: 2026-04-05
-> Related: ADR-001 (Parakeet STT), ADR-007 (FluidAudio CoreML), ADR-010 (speaker diarization), ADR-021 (WhisperKit optional STT), [GitHub #57](https://github.com/moona3k/macparakeet/issues/57)
+> Related: ADR-001 (Parakeet STT + optional local STT amendments), ADR-007 (FluidAudio CoreML), ADR-010 (speaker diarization), ADR-021 (WhisperKit optional STT), [GitHub #57](https://github.com/moona3k/macparakeet/issues/57)
 > Amended: 2026-04-10 (historical: meeting mic echo mitigation via joined software AEC + observability hardening)
 > Amended: 2026-04-29 (replace Core Audio process taps with ScreenCaptureKit audio so optional VPIO no longer conflicts with system audio capture)
 > Amended: 2026-05-09 (pause/resume for active recordings — [issue #235](https://github.com/moona3k/macparakeet/issues/235))
@@ -10,10 +10,11 @@
 > Amended: 2026-05-29 (permission timing clarification: Screen & System Audio Recording can be granted from the optional onboarding step or requested on first system-audio meeting use; denied/missing permission blocks source modes that include system audio)
 > Amended: 2026-06-10 (echo hardening for [issue #480](https://github.com/moona3k/macparakeet/issues/480): confidence-independent simultaneous-echo rule in the final transcript filter, streaming AEC frame carry + reference-delay knob, VPIO experiments now disable AGC)
 > Amended: 2026-06-20 (meeting source mode is configurable per recording: microphone + system audio by default, microphone-only, or system-audio-only; permission prompts are scoped to the selected sources)
+> Amended: 2026-06-27 (Cohere Transcribe can be selected for final meeting transcription through the captured engine lease; it is batch-only, so meeting live-preview chunks stay disabled and finalized Cohere transcripts are plain text without word timestamps/speaker labels)
 
 ## Context
 
-MacParakeet has three co-equal modes: system-wide dictation, file transcription, and meeting recording (added by this ADR). Parakeet STT via FluidAudio CoreML is the default on-device transcription path; ADR-021 adds optional WhisperKit for broader local language coverage. Users have requested the ability to record live meetings and calls — capturing system audio, mic audio, or both, then transcribing the result.
+MacParakeet has three co-equal modes: system-wide dictation, file transcription, and meeting recording (added by this ADR). Parakeet STT via FluidAudio CoreML is the default on-device transcription path; ADR-021 adds optional WhisperKit for broader local language coverage, and ADR-001 amendments add opt-in Nemotron and Cohere engines. Users have requested the ability to record live meetings and calls — capturing system audio, mic audio, or both, then transcribing the result.
 
 This came from exploring [GitHub #52](https://github.com/moona3k/macparakeet/issues/52) (hotkey profiles). The core ask was different workflows for different use cases. Meeting recording is the direct answer — a third mode that extends MacParakeet's voice-to-text capability without changing the product's simplicity.
 
@@ -126,7 +127,7 @@ Keeping mic and system audio as separate streams enables source-aware attributio
 
 ### 9. Speech engine captured at recording start
 
-The meeting service captures the active `SpeechEngineSelection` at start and persists it in the session metadata/lock file. Live preview, final transcription, retranscription of archived source files, and crash recovery use that captured selection. Settings cannot switch engines while the meeting's speech-engine lease is active. For back-to-back recording, that lease ends at the durable stop boundary; queued finalization still uses the captured selection through the routed STT job.
+The meeting service captures the active `SpeechEngineSelection` at start and persists it in the session metadata/lock file. Live preview, final transcription, retranscription of archived source files, and crash recovery use that captured selection where the selected engine supports that phase. Cohere is batch-only, so Cohere meetings skip live-preview chunks and use the captured engine only for final/retranscribe work; because Cohere emits no word timestamps or speaker labels, finalized Cohere meeting transcripts degrade to plain text. Settings cannot switch engines while the meeting's speech-engine lease is active. For back-to-back recording, that lease ends at the durable stop boundary; queued finalization still uses the captured selection through the routed STT job.
 
 ### 10. Meeting mic echo mitigation (v0.6 hardening)
 

--- a/spec/adr/016-centralized-stt-runtime-scheduler.md
+++ b/spec/adr/016-centralized-stt-runtime-scheduler.md
@@ -7,7 +7,7 @@
 > Amendment 2026-06-08: Nemotron 3.5 joins the same routed scheduler/runtime as an opt-in Beta engine. The one-control-plane rule still holds; Nemotron does not create feature-owned STT runtimes.
 > Amendment 2026-06-11: The Nemotron engine routes between two builds (multilingual `NemotronEngine` / English-only `NemotronEnglishEngine`) on the persisted Nemotron model preference. Nemotron build swaps follow the same scheduler rules as Parakeet v2/v3 swaps — rejected while jobs run or a meeting lease is active.
 > Amendment 2026-06-18: Parakeet Unified routes inside the same control plane through a dedicated `ParakeetUnifiedEngine` selected by the persisted Parakeet model preference. Unified does not create a feature-owned STT runtime; live dictation preview uses its native streaming manager while final paste/file/meeting work stays on the offline path.
-> Amendment 2026-06-27: Cohere Transcribe routes through the same runtime owner as an opt-in, downloaded, batch-only FluidAudio CoreML engine. It is allowed for recorded dictation finalization, file transcription, and meeting finalization/retranscribe, but it must not enter live dictation preview or meeting live-chunk paths because it emits no live partials, word timestamps, or speaker labels.
+> Amendment 2026-06-27: Cohere Transcribe routes through the same runtime owner as an opt-in, explicitly downloaded, batch-only FluidAudio CoreML engine. It is allowed for recorded dictation finalization, file transcription, and meeting finalization/retranscribe, but it must not enter live dictation preview or meeting live-chunk paths because it emits no live partials, word timestamps, or speaker labels. Because the Cohere runtime is a single large batch pipeline rather than separate interactive/background managers, the scheduler treats Cohere as a global single-flight resource instead of hiding cross-slot waits inside the engine.
 
 ## Context
 
@@ -200,6 +200,7 @@ The control plane supports both unrouted and routed transcription calls:
 
 - Unrouted jobs use the runtime's current `SpeechEnginePreference`.
 - Routed jobs pass a `SpeechEngineSelection` (`parakeet`, `nemotron`, `cohere`, or `whisper`, with optional language where the selected engine/build supports it).
+- Cohere jobs are admitted as a scheduler-level single-flight resource across the interactive and background slots. Parakeet/Nemotron/Whisper keep the normal slot split; Cohere trades that low-latency isolation for its larger batch accuracy path.
 - `setSpeechEngine(_:)` is rejected while jobs are queued/running.
 - `beginSpeechEngineSession()` returns a lease containing the current selection; `endSpeechEngineSession(_:)` releases it.
 - Engine switching is rejected while any lease is active.

--- a/spec/adr/016-centralized-stt-runtime-scheduler.md
+++ b/spec/adr/016-centralized-stt-runtime-scheduler.md
@@ -2,11 +2,12 @@
 
 > Status: ACCEPTED
 > Date: 2026-04-06
-> Related: ADR-001 (Parakeet STT + Nemotron Beta amendment), ADR-007 (FluidAudio CoreML migration), ADR-014 (meeting recording), ADR-015 (concurrent dictation and meeting recording), ADR-021 (WhisperKit multilingual STT)
+> Related: ADR-001 (Parakeet STT + optional local STT amendments), ADR-007 (FluidAudio CoreML migration), ADR-014 (meeting recording), ADR-015 (concurrent dictation and meeting recording), ADR-021 (WhisperKit multilingual STT)
 > Amendment 2026-04-28: The scheduler is now engine-routed. Parakeet remains default; WhisperKit can be selected globally or per routed job. Meeting sessions hold a speech-engine lease so engine changes cannot split a meeting across engines.
 > Amendment 2026-06-08: Nemotron 3.5 joins the same routed scheduler/runtime as an opt-in Beta engine. The one-control-plane rule still holds; Nemotron does not create feature-owned STT runtimes.
 > Amendment 2026-06-11: The Nemotron engine routes between two builds (multilingual `NemotronEngine` / English-only `NemotronEnglishEngine`) on the persisted Nemotron model preference. Nemotron build swaps follow the same scheduler rules as Parakeet v2/v3 swaps — rejected while jobs run or a meeting lease is active.
 > Amendment 2026-06-18: Parakeet Unified routes inside the same control plane through a dedicated `ParakeetUnifiedEngine` selected by the persisted Parakeet model preference. Unified does not create a feature-owned STT runtime; live dictation preview uses its native streaming manager while final paste/file/meeting work stays on the offline path.
+> Amendment 2026-06-27: Cohere Transcribe routes through the same runtime owner as an opt-in, downloaded, batch-only FluidAudio CoreML engine. It is allowed for recorded dictation finalization, file transcription, and meeting finalization/retranscribe, but it must not enter live dictation preview or meeting live-chunk paths because it emits no live partials, word timestamps, or speaker labels.
 
 ## Context
 
@@ -48,13 +49,14 @@ Feature services submit jobs to the control plane; they do not own their own STT
 
 ### 2. One shared STT runtime owner
 
-The control plane coordinates one shared STT runtime owner for speech model lifecycle. Parakeet's FluidAudio managers, Parakeet Unified's dedicated FluidAudio engine, Nemotron's FluidAudio managers, and the optional WhisperKit engine live behind this owner; callers do not own model lifecycles directly.
+The control plane coordinates one shared STT runtime owner for speech model lifecycle. Parakeet's FluidAudio managers, Parakeet Unified's dedicated FluidAudio engine, Nemotron's FluidAudio managers, Cohere's FluidAudio pipeline, and the optional WhisperKit engine live behind this owner; callers do not own model lifecycles directly.
 
 That runtime is the sole owner of:
 
 - slot-scoped Parakeet v2/v3 `AsrManager` instances
 - the Parakeet Unified engine
 - the optional Beta Nemotron multilingual / English engine instances
+- the optional batch-only `CohereTranscribeEngine` instance
 - the optional `WhisperEngine` instance
 - model download / initialization / readiness
 - warm-up progress
@@ -197,12 +199,12 @@ This avoids crosstalk between:
 The control plane supports both unrouted and routed transcription calls:
 
 - Unrouted jobs use the runtime's current `SpeechEnginePreference`.
-- Routed jobs pass a `SpeechEngineSelection` (`parakeet`, `nemotron`, or `whisper`, with optional language where the selected engine/build supports it).
+- Routed jobs pass a `SpeechEngineSelection` (`parakeet`, `nemotron`, `cohere`, or `whisper`, with optional language where the selected engine/build supports it).
 - `setSpeechEngine(_:)` is rejected while jobs are queued/running.
 - `beginSpeechEngineSession()` returns a lease containing the current selection; `endSpeechEngineSession(_:)` releases it.
 - Engine switching is rejected while any lease is active.
 
-Meeting recording uses this lease at start. This prevents a long recording from starting with one engine for live preview and finishing with another. The captured engine/language is also persisted to meeting metadata and recovery lock files so interrupted sessions recover through the same engine.
+Meeting recording uses this lease at start. This prevents a long recording from starting with one engine for live preview and finishing with another. The captured engine/language is also persisted to meeting metadata and recovery lock files so interrupted sessions recover through the same engine. Batch-only engines can opt out of live phases while still preserving the same captured selection for finalization; Cohere does this deliberately.
 
 ## Consequences
 
@@ -214,7 +216,7 @@ Meeting recording uses this lease at start. This prevents a long recording from 
 - Meeting live preview degrades gracefully under pressure
 - File transcription is intentionally simple and low-risk in v1
 - The architecture leaves room for chunked batch work or a third slot later without returning to per-feature STT ownership
-- Whisper, Nemotron, and Parakeet Unified support fit the same control plane instead of creating parallel schedulers
+- Whisper, Nemotron, Cohere, and Parakeet Unified support fit the same control plane instead of creating parallel schedulers
 
 ### Negative
 


### PR DESCRIPTION
Follow-up to the Cohere Transcribe discussion: this PR adds Cohere as a real opt-in local speech engine while keeping Parakeet as the default live path.

## What this adds

A fourth speech engine, Cohere Transcribe (03-2026), via FluidAudio's `CoherePipeline` running on-device through Core ML. It is behind `AppFeatures.cohereEngineEnabled`, requires an explicit model download (~2.1 GB), and is selectable from Settings/CLI once installed.

## Design notes

- Batch-only dictation: Cohere records first and transcribes after stop. It does not provide live dictation preview, live meeting chunks, word timestamps, or speaker labels.
- Compute: ANE is the default to keep the GPU free for formatter work and avoid the GPU path's recurring per-launch specialization cost. A fresh process can still spend time while Core ML prepares the Cohere model, and the Settings copy now frames that as model setup rather than instant availability. GPU remains available through the Cohere compute-policy preference for faster warm latency.
- Truncation guard: Cohere's decoder can truncate dense/long audio in a single pass, so the engine falls back to overlapping chunk-and-stitch for long or token-cap-hit inputs.
- Language: Cohere has no auto-detect, so there is a 14-language picker and persisted `cohere-language`; CLI `--language` still overrides.
- Meetings: Cohere can be used for final meeting transcription, but live preview chunks remain disabled and finalized Cohere meetings degrade to plain text because Cohere exposes no word timestamps/speaker labels.

## Review hardening included

- Cohere is isolated from live dictation preview and meeting live-preview chunks.
- The visible Settings engine tile and Live transcript preview toggle now call out that Cohere is record-then-transcribe only: no live preview, word timestamps, or speaker labels.
- Normal Cohere prepare/transcribe/warm-up paths now fail fast when the model is missing; explicit `models download cohere-transcribe` / Settings download remains the only download path.
- `STTScheduler` pins default jobs to a `SpeechEngineSelection` and admits Cohere as a scheduler-level single-flight resource, so Cohere's single batch pipeline cannot create a hidden cross-slot wait inside the engine.
- `STTRuntime` can now construct the first Cohere engine while unrelated non-Cohere work is in flight; Cohere-vs-Cohere serialization stays owned by the scheduler instead of failing as `engineBusy` during first use.
- CJK overlap stitching is script-aware, handles mixed spaces, partial boundary words, avoids punctuation-only false matches, and only scans the tail of accumulated long transcripts.
- The old 64-chunk cap was removed so long file transcription cannot silently drop audio.
- Settings now derives Cohere model status from `EngineSettingsViewModel` instead of synchronous SwiftUI disk checks, reports Ready only when the active runtime is loaded, and includes Cohere download/retry/repair/delete actions in Local Models.
- Cohere model deletion is tracked as an in-flight state so concurrent delete/download requests cannot race while async disk cleanup is still running.
- Cohere engine switching is blocked while model deletion is in progress, avoiding activation against files being removed.
- Cohere model loading now uses an active load ID so a cancelled/stale initialization task cannot clear or publish over a newer load.
- Background model-status refreshes now preserve active Cohere download/delete UI state instead of replacing it with disk-cache status mid-operation.
- Cohere status refreshes that started during download/delete cannot later overwrite a failed or in-progress Cohere state after the operation flag changes.
- CLI supports `--engine cohere`, `config cohere-language`, and Cohere model lifecycle commands.
- README, OpenClaw integration docs, STT docs, feature/architecture specs, and ADR-014/ADR-016 are aligned with Cohere's opt-in, batch-only contract.
- A redundant CLI Cohere-language supported-code check raised by Gemini was removed; `normalizeCohereLanguage` remains the single validation source.
- Explicit CLI Cohere language overrides now fail fast for unsupported values like `--language auto`, avoiding a silent fallback to English.

## QA points

- Settings > Speech Engines: Cohere is opt-in, Parakeet remains default, and the Cohere tile clearly says record-then-transcribe only with no live preview, word timestamps, or speaker labels.
- Live transcript preview toggle: when Cohere is selected, the toggle copy explains that live preview is not available for Cohere; Parakeet live preview behavior is unchanged.
- Cohere dictation: after the model is downloaded, selecting Cohere records normally, shows no live preview, then pastes the final transcript after stop.
- Cohere meetings: recording can start/stop and produce a final transcript after processing, but no live meeting chunks, word timestamps, or speaker labels are expected.
- File/URL transcription and CLI: `--engine cohere` works when the model is installed, `--language <supported-code>` overrides the saved Cohere language, and unsupported values such as `--language auto` fail fast.
- Language picker/defaults: choosing a non-English Cohere language such as Japanese or Chinese persists and is used by app-default Cohere dictation/file transcription/retranscription.
- Long/dense audio: for >35s or dense CJK audio, verify the overlap region is not visibly duplicated at chunk boundaries.
- Model lifecycle: download, retry/repair, delete, and status refresh paths show coherent Local Models state; engine switching is blocked while Cohere deletion is in progress.
- Regression pass: Parakeet dictation, Parakeet live preview, and Parakeet meeting live chunks still work.
## Tests

Focused Cohere/STT/CLI/docs tests are green, and the full local suite is green on pushed head `aaeed8e15`:

- `git diff --check`
- `swift build --product MacParakeet`
- `swift test --filter SpecCommandTests`
- `swift test --filter ConfigCommandTests`
- `swift test --filter TranscribeCommandTests`
- `swift test --filter ModelLifecycleCommandTests`
- `swift test --filter CohereTranscribeEngineTests`
- `swift test --filter STTSchedulerTests`
- `swift test --filter SettingsViewModelTests`
- `swift test --filter SettingsStatusRulesTests`
- `swift test` -> 4100 XCTest cases, 11 skipped, 0 failures; 16 Swift Testing telemetry tests, 0 failures.