### PR TITLE
Prefer built-in mic when audio output is Bluetooth (#481/#541/#409)

### DIFF
--- a/Sources/MacParakeet/App/AppEnvironment.swift
+++ b/Sources/MacParakeet/App/AppEnvironment.swift
@@ -92,9 +92,16 @@ final class AppEnvironment {
         // explicit experiments, but enabling it during live calls can degrade
         // the outgoing mic heard by other participants.
         let meetingMicProcessingMode: MeetingMicProcessingMode = .raw
+        let preferBuiltInForBluetoothOutputProvider: @Sendable () -> Bool = { [runtimePreferences] in
+            runtimePreferences.preferBuiltInMicWhenBluetoothOutput
+        }
         // Build the device-attempt chain lazily on each engine start so a
         // user changing their mic in Settings between meetings sees the new
-        // selection.
+        // selection. When output is routed to a Bluetooth headset and no mic
+        // is explicitly selected, the chain prefers the built-in mic so
+        // opening capture doesn't force the headset into HFP/SCO (issues
+        // #481/#541/#409); the Bluetooth-output query runs lazily, only when
+        // the preference is on and the input is system-default.
         let attemptsBuilder: AVAudioEngineMicrophonePlatform.DeviceAttemptsBuilder = {
             let selectedUID = AudioDeviceManager.normalizedUID(selectedInputDeviceUIDProvider())
             let selectedID = selectedUID.flatMap { AudioDeviceManager.inputDeviceID(forUID: $0) }
@@ -104,7 +111,9 @@ final class AppEnvironment {
                 selectedUID: selectedUID,
                 selectedInputDeviceID: { _ in selectedID },
                 defaultInputDevice: { defaultID },
-                builtInMicrophone: { builtInID }
+                builtInMicrophone: { builtInID },
+                preferBuiltInWhenOutputIsBluetooth: preferBuiltInForBluetoothOutputProvider(),
+                outputIsBluetooth: { AudioDeviceManager.isDefaultOutputBluetooth() }
             )
         }
         sharedMicStream = SharedMicrophoneStream(

--- a/Sources/MacParakeet/App/AppEnvironment.swift
+++ b/Sources/MacParakeet/App/AppEnvironment.swift
@@ -97,12 +97,12 @@ final class AppEnvironment {
         }
         // Build the device-attempt chain lazily on each engine start so a
         // user changing their mic in Settings between meetings sees the new
-        // selection. When output is routed to a Bluetooth headset, no mic is
-        // explicitly selected, and the system-default input is also Bluetooth,
-        // the chain prefers the built-in mic so opening capture doesn't force
-        // the headset into HFP/SCO (issues #481/#541/#409); the Bluetooth-
-        // output query runs lazily, only when the preference is on and the
-        // input is system-default Bluetooth or unresolved.
+        // selection. When output is routed to a Bluetooth headset and the
+        // unpinned system-default input is risky (Bluetooth, unresolved, or
+        // built-in but not pinned), the chain pins the built-in mic before
+        // that fallback so opening capture doesn't force the headset into
+        // HFP/SCO (issues #481/#541/#409); the Bluetooth-output query runs
+        // lazily, only after the cheaper input guards pass.
         let attemptsBuilder: AVAudioEngineMicrophonePlatform.DeviceAttemptsBuilder = {
             let selectedUID = AudioDeviceManager.normalizedUID(selectedInputDeviceUIDProvider())
             let selectedID = selectedUID.flatMap { AudioDeviceManager.inputDeviceID(forUID: $0) }

--- a/Sources/MacParakeet/App/AppEnvironment.swift
+++ b/Sources/MacParakeet/App/AppEnvironment.swift
@@ -97,11 +97,12 @@ final class AppEnvironment {
         }
         // Build the device-attempt chain lazily on each engine start so a
         // user changing their mic in Settings between meetings sees the new
-        // selection. When output is routed to a Bluetooth headset and no mic
-        // is explicitly selected, the chain prefers the built-in mic so
-        // opening capture doesn't force the headset into HFP/SCO (issues
-        // #481/#541/#409); the Bluetooth-output query runs lazily, only when
-        // the preference is on and the input is system-default.
+        // selection. When output is routed to a Bluetooth headset, no mic is
+        // explicitly selected, and the system-default input is also Bluetooth,
+        // the chain prefers the built-in mic so opening capture doesn't force
+        // the headset into HFP/SCO (issues #481/#541/#409); the Bluetooth-
+        // output query runs lazily, only when the preference is on and the
+        // input is system-default Bluetooth or unresolved.
         let attemptsBuilder: AVAudioEngineMicrophonePlatform.DeviceAttemptsBuilder = {
             let selectedUID = AudioDeviceManager.normalizedUID(selectedInputDeviceUIDProvider())
             let selectedID = selectedUID.flatMap { AudioDeviceManager.inputDeviceID(forUID: $0) }
@@ -113,6 +114,7 @@ final class AppEnvironment {
                 defaultInputDevice: { defaultID },
                 builtInMicrophone: { builtInID },
                 preferBuiltInWhenOutputIsBluetooth: preferBuiltInForBluetoothOutputProvider(),
+                defaultInputIsBluetooth: { AudioDeviceManager.isBluetoothInput($0) },
                 outputIsBluetooth: { AudioDeviceManager.isDefaultOutputBluetooth() }
             )
         }

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -1044,7 +1044,7 @@ struct SettingsView: View {
 
                 settingsToggleRow(
                     title: "Use built-in mic with Bluetooth headphones",
-                    detail: "When sound is playing to AirPods or other Bluetooth headphones, dictation records from the built-in mic instead of the headset. Keeps playback in full quality and avoids the brief Bluetooth mode switch that can drop your first words or capture silence. Turn off to always record from your headset's mic. Ignored when you pick a specific microphone above.",
+                    detail: "When sound is playing to AirPods or other Bluetooth headphones, dictation records from the built-in mic instead of the headset. Keeps playback in full quality and avoids the brief Bluetooth mode switch that can drop your first words or capture silence. Turn off to always record from your headset's mic. If you pick a specific microphone above, MacParakeet tries it first.",
                     isOn: $viewModel.preferBuiltInMicWhenBluetoothOutput
                 )
 

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -1043,6 +1043,14 @@ struct SettingsView: View {
                 Divider()
 
                 settingsToggleRow(
+                    title: "Use built-in mic with Bluetooth headphones",
+                    detail: "When sound is playing to AirPods or other Bluetooth headphones, dictation records from the built-in mic instead of the headset. Keeps playback in full quality and avoids the brief Bluetooth mode switch that can drop your first words or capture silence. Turn off to always record from your headset's mic. Ignored when you pick a specific microphone above.",
+                    isOn: $viewModel.preferBuiltInMicWhenBluetoothOutput
+                )
+
+                Divider()
+
+                settingsToggleRow(
                     title: "Live transcript preview",
                     detail: "Shows a running transcript above the dictation pill as you speak. Works with Parakeet and Nemotron; not yet available with Whisper.",
                     isBeta: true,

--- a/Sources/MacParakeetCore/AppRuntimePreferences.swift
+++ b/Sources/MacParakeetCore/AppRuntimePreferences.swift
@@ -21,6 +21,7 @@ public protocol AppRuntimePreferencesProtocol: Sendable {
     var meetingAudioSourceMode: MeetingAudioSourceMode { get }
     var pauseMediaDuringDictation: Bool { get }
     var instantDictationEnabled: Bool { get }
+    var preferBuiltInMicWhenBluetoothOutput: Bool { get }
     var showLiveDictationPreview: Bool { get }
     var dictationPreviewTextSize: DictationPreviewTextSize { get }
     var dictationUndoCountdown: DictationUndoCountdown { get }
@@ -487,6 +488,12 @@ public final class UserDefaultsAppRuntimePreferences: AppRuntimePreferencesProto
     public static let meetingAutoStopEnabledKey = "meetingAutoStopEnabled"
     public static let pauseMediaDuringDictationKey = "pauseMediaDuringDictation"
     public static let instantDictationEnabledKey = "instantDictationEnabled"
+    /// When on (default), dictation/meeting capture prefers the built-in mic
+    /// while audio output is routed to a Bluetooth headset, so opening the mic
+    /// doesn't force the headset into HFP/SCO (degraded playback + silent-
+    /// capture race, issues #481/#541/#409). Only applies on the system-
+    /// default input; an explicit mic selection is always honored.
+    public static let preferBuiltInMicWhenBluetoothOutputKey = "preferBuiltInMicWhenBluetoothOutput"
     public static let showLiveDictationPreviewKey = "showLiveDictationPreview"
     public static let dictationPreviewTextSizeKey = "dictationPreviewTextSize"
     public static let dictationUndoCountdownKey = "dictationUndoCountdown"
@@ -594,6 +601,10 @@ public final class UserDefaultsAppRuntimePreferences: AppRuntimePreferencesProto
 
     public var instantDictationEnabled: Bool {
         defaults.object(forKey: Self.instantDictationEnabledKey) as? Bool ?? false
+    }
+
+    public var preferBuiltInMicWhenBluetoothOutput: Bool {
+        defaults.object(forKey: Self.preferBuiltInMicWhenBluetoothOutputKey) as? Bool ?? true
     }
 
     public var showLiveDictationPreview: Bool {

--- a/Sources/MacParakeetCore/AppRuntimePreferences.swift
+++ b/Sources/MacParakeetCore/AppRuntimePreferences.swift
@@ -491,8 +491,9 @@ public final class UserDefaultsAppRuntimePreferences: AppRuntimePreferencesProto
     /// When on (default), dictation/meeting capture prefers the built-in mic
     /// while audio output is routed to a Bluetooth headset, so opening the mic
     /// doesn't force the headset into HFP/SCO (degraded playback + silent-
-    /// capture race, issues #481/#541/#409). Only applies on the system-
-    /// default input; an explicit mic selection is always honored.
+    /// capture race, issues #481/#541/#409). Explicit mic selections remain
+    /// first; this only changes the system-default path or the fallback behind
+    /// a failed explicit attempt.
     public static let preferBuiltInMicWhenBluetoothOutputKey = "preferBuiltInMicWhenBluetoothOutput"
     public static let showLiveDictationPreviewKey = "showLiveDictationPreview"
     public static let dictationPreviewTextSizeKey = "dictationPreviewTextSize"

--- a/Sources/MacParakeetCore/Audio/AudioDeviceManager.swift
+++ b/Sources/MacParakeetCore/Audio/AudioDeviceManager.swift
@@ -136,6 +136,42 @@ public enum AudioDeviceManager {
         return deviceInfo(id)
     }
 
+    /// Returns the current system default *output* device ID.
+    public static func defaultOutputDevice() -> AudioDeviceID? {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDefaultOutputDevice,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var deviceID: AudioDeviceID = 0
+        var size = UInt32(MemoryLayout<AudioDeviceID>.size)
+        let status = AudioObjectGetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject),
+            &address, 0, nil, &size, &deviceID
+        )
+        guard status == noErr, deviceID != kAudioObjectUnknown else { return nil }
+        return deviceID
+    }
+
+    /// True when audio output is currently routed to a Bluetooth device.
+    ///
+    /// This is the trigger for preferring the built-in microphone during
+    /// dictation/meeting capture: opening a Bluetooth headset's microphone
+    /// forces it out of high-quality A2DP into bidirectional HFP/SCO, which
+    /// both degrades the playback the user is hearing and races the profile
+    /// switch — capture can start before the SCO link delivers audio and read
+    /// silence (issues #481 / #541 / #409). Mirrors `isBluetoothInput`,
+    /// including the aggregate sub-device scan, since a Bluetooth endpoint can
+    /// surface behind a CoreAudio aggregate.
+    public static func isDefaultOutputBluetooth() -> Bool {
+        guard let deviceID = defaultOutputDevice() else { return false }
+        let transport = transportType(deviceID)
+        let subTransports = transport == kAudioDeviceTransportTypeAggregate
+            ? activeSubDeviceIDs(deviceID).map(transportType)
+            : []
+        return isBluetoothInput(transport: transport, activeSubDeviceTransports: subTransports)
+    }
+
     /// Resolves a persistent CoreAudio device UID to the current process-local
     /// `AudioDeviceID`. Device IDs are not stable across boots or hardware
     /// topology changes, so app preferences should store UIDs and resolve late.

--- a/Sources/MacParakeetCore/Audio/MicrophoneCapture.swift
+++ b/Sources/MacParakeetCore/Audio/MicrophoneCapture.swift
@@ -71,11 +71,28 @@ extension MeetingInputDeviceAttempt.Source {
     }
 }
 
+/// Builds the ordered device-attempt chain the shared mic engine walks on
+/// every start (selected → system default → built-in), deduplicated by
+/// device ID.
+///
+/// `preferBuiltInWhenOutputIsBluetooth` opts into the Bluetooth-output
+/// avoidance rule: when the user is on the *system-default* input (no explicit
+/// device chosen) and audio output is currently routed to a Bluetooth headset,
+/// the built-in microphone is moved to the front so opening the mic does not
+/// force the headset from A2DP into HFP/SCO — which degrades the playback the
+/// user is hearing and races the profile switch into silent capture
+/// (issues #481 / #541 / #409). An explicit device selection is always
+/// respected, and the rest of the chain remains as fallback so capture is
+/// never blocked. `outputIsBluetooth` is only consulted when the rule could
+/// apply, so the HAL query is skipped when the feature is off or a device is
+/// explicitly selected.
 public func meetingInputDeviceAttempts(
     selectedUID: String?,
     selectedInputDeviceID: (String) -> AudioDeviceID?,
     defaultInputDevice: () -> AudioDeviceID?,
-    builtInMicrophone: () -> AudioDeviceID?
+    builtInMicrophone: () -> AudioDeviceID?,
+    preferBuiltInWhenOutputIsBluetooth: Bool = false,
+    outputIsBluetooth: () -> Bool = { false }
 ) -> [MeetingInputDeviceAttempt] {
     var attempts: [MeetingInputDeviceAttempt] = []
     var seenDeviceIDs = Set<AudioDeviceID>()
@@ -96,6 +113,20 @@ public func meetingInputDeviceAttempts(
     attempts.append(.implicitSystemDefault(resolvedDeviceID: defaultDeviceID))
 
     appendExplicit(.builtIn, deviceID: builtInMicrophone())
+
+    // Bluetooth-output avoidance: only when no device is explicitly selected
+    // and output is on a Bluetooth headset. The `&&` chain short-circuits so
+    // `outputIsBluetooth()` (a HAL query) runs only after the cheap guards.
+    // If the built-in mic is already the primary attempt (e.g. it is also the
+    // system default), there is nothing to reorder.
+    if preferBuiltInWhenOutputIsBluetooth,
+        selectedUID == nil,
+        outputIsBluetooth(),
+        let builtInIndex = attempts.firstIndex(where: { $0.source == .builtIn }),
+        builtInIndex != 0 {
+        let builtIn = attempts.remove(at: builtInIndex)
+        attempts.insert(builtIn, at: 0)
+    }
 
     return attempts
 }

--- a/Sources/MacParakeetCore/Audio/MicrophoneCapture.swift
+++ b/Sources/MacParakeetCore/Audio/MicrophoneCapture.swift
@@ -72,26 +72,25 @@ extension MeetingInputDeviceAttempt.Source {
 }
 
 /// Builds the ordered device-attempt chain the shared mic engine walks on
-/// every start (selected → system default → built-in), deduplicated by
-/// device ID.
+/// every start, deduplicated by device ID unless a pinned built-in fallback is
+/// needed to avoid an unpinned Bluetooth system default.
 ///
 /// `preferBuiltInWhenOutputIsBluetooth` opts into the Bluetooth-output
-/// avoidance rule: when the user is not using a resolvable explicitly-selected
-/// microphone and the system-default input is itself a Bluetooth input, or no
-/// default input resolved, while audio output is currently routed to a
-/// Bluetooth headset, the built-in microphone is moved to the front so opening
-/// the mic does not force the headset from A2DP into HFP/SCO — which degrades
-/// the playback the user is hearing and races the profile switch into silent capture
-/// (issues #481 / #541 / #409). The rule is gated on whether a `.selected`
-/// attempt actually resolved, not just on `selectedUID`: a saved-but-
-/// unavailable selection falls through to this rule rather than landing on a
-/// Bluetooth system default. A non-Bluetooth system-default input, such as a
-/// USB desk mic, is left alone. A resolvable explicit selection is always
-/// respected, and the rest of the chain remains as fallback so capture is never
-/// blocked. `outputIsBluetooth` is consulted last, only once the cheap guards
-/// confirm the rule could fire, so the HAL query is skipped when the feature is
-/// off, a mic is explicitly selected, the default input is not Bluetooth, or
-/// there is no built-in mic to promote.
+/// avoidance rule. When audio output is currently routed to a Bluetooth
+/// headset and the unpinned system-default input is Bluetooth, unresolved, or
+/// the built-in mic itself, the built-in microphone is pinned before that
+/// default fallback so opening the mic does not force the headset from A2DP
+/// into HFP/SCO — which degrades playback and races the profile switch into
+/// silent capture (issues #481 / #541 / #409). A resolvable explicit
+/// selection stays first; the rule only changes the fallback behind it. The
+/// rule is gated on whether a `.selected` attempt actually resolved, not just
+/// on `selectedUID`: a saved-but-unavailable selection falls through to this
+/// rule rather than landing on a Bluetooth system default. A non-Bluetooth
+/// system-default input, such as a USB desk mic, is left alone.
+/// `outputIsBluetooth` is consulted last, only once the cheap guards confirm
+/// the rule could improve the chain, so the HAL query is skipped when the
+/// feature is off, the default input is non-Bluetooth, or there is no built-in
+/// mic to pin.
 public func meetingInputDeviceAttempts(
     selectedUID: String?,
     selectedInputDeviceID: (String) -> AudioDeviceID?,
@@ -114,12 +113,13 @@ public func meetingInputDeviceAttempts(
     }
 
     let defaultDeviceID = defaultInputDevice()
+    let builtInDeviceID = builtInMicrophone()
     if let defaultDeviceID {
         seenDeviceIDs.insert(defaultDeviceID)
     }
     attempts.append(.implicitSystemDefault(resolvedDeviceID: defaultDeviceID))
 
-    appendExplicit(.builtIn, deviceID: builtInMicrophone())
+    appendExplicit(.builtIn, deviceID: builtInDeviceID)
 
     // Bluetooth-output avoidance. Gate on whether a `.selected` attempt
     // actually resolved (not just on `selectedUID`): a saved selection whose
@@ -128,22 +128,63 @@ public func meetingInputDeviceAttempts(
     // the race. Leave non-Bluetooth system-default inputs (for example a USB
     // desk mic) alone; opening them does not force the headset output into
     // HFP/SCO. The cheap structural guards run before any transport query so
-    // the HAL is consulted only when the reorder could actually happen.
+    // the HAL is consulted only when the chain can actually be made safer.
     let hasResolvedSelection = attempts.contains { attempt in
         if case .selected = attempt.source { return true }
         return false
     }
     if preferBuiltInWhenOutputIsBluetooth,
-        !hasResolvedSelection,
-        let builtInIndex = attempts.firstIndex(where: { attempt in
-            attempt.source == .builtIn
-        }),
-        builtInIndex != 0
+        let builtInDeviceID
     {
-        let shouldAvoidDefaultInput = defaultDeviceID.map(defaultInputIsBluetooth) ?? true
+        let shouldAvoidDefaultInput: Bool = {
+            guard let defaultDeviceID else { return true }
+            if defaultDeviceID == builtInDeviceID { return true }
+            return defaultInputIsBluetooth(defaultDeviceID)
+        }()
+
         if shouldAvoidDefaultInput, outputIsBluetooth() {
-            let builtIn = attempts.remove(at: builtInIndex)
-            attempts.insert(builtIn, at: 0)
+            let selectedDeviceID = attempts.first { attempt in
+                if case .selected = attempt.source { return true }
+                return false
+            }?.deviceID
+            let defaultIndex = attempts.firstIndex(where: \.usesImplicitSystemDefault)
+
+            func removeImplicitDefaultFallback() {
+                if let defaultIndex = attempts.firstIndex(where: \.usesImplicitSystemDefault) {
+                    attempts.remove(at: defaultIndex)
+                }
+            }
+
+            func moveOrInsertBuiltIn(at index: Int) {
+                if let existingIndex = attempts.firstIndex(where: { $0.source == .builtIn }) {
+                    let builtIn = attempts.remove(at: existingIndex)
+                    attempts.insert(builtIn, at: existingIndex < index ? index - 1 : index)
+                } else if selectedDeviceID != builtInDeviceID {
+                    attempts.insert(
+                        MeetingInputDeviceAttempt(source: .builtIn, deviceID: builtInDeviceID),
+                        at: index
+                    )
+                }
+            }
+
+            if hasResolvedSelection {
+                if selectedDeviceID == builtInDeviceID {
+                    removeImplicitDefaultFallback()
+                } else if let defaultIndex {
+                    moveOrInsertBuiltIn(at: defaultIndex)
+                    if defaultDeviceID == builtInDeviceID {
+                        removeImplicitDefaultFallback()
+                    }
+                }
+            } else if let builtInIndex = attempts.firstIndex(where: { $0.source == .builtIn }) {
+                if builtInIndex != 0 {
+                    let builtIn = attempts.remove(at: builtInIndex)
+                    attempts.insert(builtIn, at: 0)
+                }
+            } else if defaultDeviceID == builtInDeviceID {
+                removeImplicitDefaultFallback()
+                attempts.insert(MeetingInputDeviceAttempt(source: .builtIn, deviceID: builtInDeviceID), at: 0)
+            }
         }
     }
 

--- a/Sources/MacParakeetCore/Audio/MicrophoneCapture.swift
+++ b/Sources/MacParakeetCore/Audio/MicrophoneCapture.swift
@@ -76,16 +76,20 @@ extension MeetingInputDeviceAttempt.Source {
 /// device ID.
 ///
 /// `preferBuiltInWhenOutputIsBluetooth` opts into the Bluetooth-output
-/// avoidance rule: when the user is on the *system-default* input (no explicit
-/// device chosen) and audio output is currently routed to a Bluetooth headset,
-/// the built-in microphone is moved to the front so opening the mic does not
-/// force the headset from A2DP into HFP/SCO — which degrades the playback the
-/// user is hearing and races the profile switch into silent capture
-/// (issues #481 / #541 / #409). An explicit device selection is always
-/// respected, and the rest of the chain remains as fallback so capture is
-/// never blocked. `outputIsBluetooth` is only consulted when the rule could
-/// apply, so the HAL query is skipped when the feature is off or a device is
-/// explicitly selected.
+/// avoidance rule: when the user is not using a resolvable explicitly-selected
+/// microphone and audio output is currently routed to a Bluetooth headset, the
+/// built-in microphone is moved to the front so opening the mic does not force
+/// the headset from A2DP into HFP/SCO — which degrades the playback the user is
+/// hearing and races the profile switch into silent capture
+/// (issues #481 / #541 / #409). The rule is gated on whether a `.selected`
+/// attempt actually resolved, not just on `selectedUID`: a saved-but-
+/// unavailable selection falls through to this rule rather than landing on a
+/// (possibly Bluetooth) system default. A resolvable explicit selection is
+/// always respected, and the rest of the chain remains as fallback so capture
+/// is never blocked. `outputIsBluetooth` is consulted last, only once the
+/// cheap guards confirm the rule could fire, so the HAL query is skipped when
+/// the feature is off, a mic is explicitly selected, or there is no built-in
+/// mic to promote.
 public func meetingInputDeviceAttempts(
     selectedUID: String?,
     selectedInputDeviceID: (String) -> AudioDeviceID?,
@@ -114,16 +118,22 @@ public func meetingInputDeviceAttempts(
 
     appendExplicit(.builtIn, deviceID: builtInMicrophone())
 
-    // Bluetooth-output avoidance: only when no device is explicitly selected
-    // and output is on a Bluetooth headset. The `&&` chain short-circuits so
-    // `outputIsBluetooth()` (a HAL query) runs only after the cheap guards.
-    // If the built-in mic is already the primary attempt (e.g. it is also the
-    // system default), there is nothing to reorder.
+    // Bluetooth-output avoidance. Gate on whether a `.selected` attempt
+    // actually resolved (not just on `selectedUID`): a saved selection whose
+    // device is currently unavailable produces no `.selected` attempt and
+    // would otherwise fall back to a Bluetooth system default and still hit
+    // the race. The cheap guards — no resolved selection, a built-in mic that
+    // exists and isn't already primary — run before `outputIsBluetooth()` so
+    // the HAL query fires only when the reorder could actually happen.
+    let hasResolvedSelection = attempts.contains { attempt in
+        if case .selected = attempt.source { return true }
+        return false
+    }
     if preferBuiltInWhenOutputIsBluetooth,
-        selectedUID == nil,
-        outputIsBluetooth(),
+        !hasResolvedSelection,
         let builtInIndex = attempts.firstIndex(where: { $0.source == .builtIn }),
-        builtInIndex != 0 {
+        builtInIndex != 0,
+        outputIsBluetooth() {
         let builtIn = attempts.remove(at: builtInIndex)
         attempts.insert(builtIn, at: 0)
     }

--- a/Sources/MacParakeetCore/Audio/MicrophoneCapture.swift
+++ b/Sources/MacParakeetCore/Audio/MicrophoneCapture.swift
@@ -77,25 +77,28 @@ extension MeetingInputDeviceAttempt.Source {
 ///
 /// `preferBuiltInWhenOutputIsBluetooth` opts into the Bluetooth-output
 /// avoidance rule: when the user is not using a resolvable explicitly-selected
-/// microphone and audio output is currently routed to a Bluetooth headset, the
-/// built-in microphone is moved to the front so opening the mic does not force
-/// the headset from A2DP into HFP/SCO — which degrades the playback the user is
-/// hearing and races the profile switch into silent capture
+/// microphone and the system-default input is itself a Bluetooth input, or no
+/// default input resolved, while audio output is currently routed to a
+/// Bluetooth headset, the built-in microphone is moved to the front so opening
+/// the mic does not force the headset from A2DP into HFP/SCO — which degrades
+/// the playback the user is hearing and races the profile switch into silent capture
 /// (issues #481 / #541 / #409). The rule is gated on whether a `.selected`
 /// attempt actually resolved, not just on `selectedUID`: a saved-but-
 /// unavailable selection falls through to this rule rather than landing on a
-/// (possibly Bluetooth) system default. A resolvable explicit selection is
-/// always respected, and the rest of the chain remains as fallback so capture
-/// is never blocked. `outputIsBluetooth` is consulted last, only once the
-/// cheap guards confirm the rule could fire, so the HAL query is skipped when
-/// the feature is off, a mic is explicitly selected, or there is no built-in
-/// mic to promote.
+/// Bluetooth system default. A non-Bluetooth system-default input, such as a
+/// USB desk mic, is left alone. A resolvable explicit selection is always
+/// respected, and the rest of the chain remains as fallback so capture is never
+/// blocked. `outputIsBluetooth` is consulted last, only once the cheap guards
+/// confirm the rule could fire, so the HAL query is skipped when the feature is
+/// off, a mic is explicitly selected, the default input is not Bluetooth, or
+/// there is no built-in mic to promote.
 public func meetingInputDeviceAttempts(
     selectedUID: String?,
     selectedInputDeviceID: (String) -> AudioDeviceID?,
     defaultInputDevice: () -> AudioDeviceID?,
     builtInMicrophone: () -> AudioDeviceID?,
     preferBuiltInWhenOutputIsBluetooth: Bool = false,
+    defaultInputIsBluetooth: (AudioDeviceID) -> Bool = { _ in true },
     outputIsBluetooth: () -> Bool = { false }
 ) -> [MeetingInputDeviceAttempt] {
     var attempts: [MeetingInputDeviceAttempt] = []
@@ -122,20 +125,26 @@ public func meetingInputDeviceAttempts(
     // actually resolved (not just on `selectedUID`): a saved selection whose
     // device is currently unavailable produces no `.selected` attempt and
     // would otherwise fall back to a Bluetooth system default and still hit
-    // the race. The cheap guards — no resolved selection, a built-in mic that
-    // exists and isn't already primary — run before `outputIsBluetooth()` so
-    // the HAL query fires only when the reorder could actually happen.
+    // the race. Leave non-Bluetooth system-default inputs (for example a USB
+    // desk mic) alone; opening them does not force the headset output into
+    // HFP/SCO. The cheap structural guards run before any transport query so
+    // the HAL is consulted only when the reorder could actually happen.
     let hasResolvedSelection = attempts.contains { attempt in
         if case .selected = attempt.source { return true }
         return false
     }
     if preferBuiltInWhenOutputIsBluetooth,
         !hasResolvedSelection,
-        let builtInIndex = attempts.firstIndex(where: { $0.source == .builtIn }),
-        builtInIndex != 0,
-        outputIsBluetooth() {
-        let builtIn = attempts.remove(at: builtInIndex)
-        attempts.insert(builtIn, at: 0)
+        let builtInIndex = attempts.firstIndex(where: { attempt in
+            attempt.source == .builtIn
+        }),
+        builtInIndex != 0
+    {
+        let shouldAvoidDefaultInput = defaultDeviceID.map(defaultInputIsBluetooth) ?? true
+        if shouldAvoidDefaultInput, outputIsBluetooth() {
+            let builtIn = attempts.remove(at: builtInIndex)
+            attempts.insert(builtIn, at: 0)
+        }
     }
 
     return attempts

--- a/Sources/MacParakeetCore/Audio/README.md
+++ b/Sources/MacParakeetCore/Audio/README.md
@@ -208,15 +208,17 @@ SCO link delivers audio and capture reads zero or pure-silent buffers
 endpoint, so it does not fix this). The device-attempt builder in
 `AppEnvironment` therefore consults
 `AudioDeviceManager.isDefaultOutputBluetooth()` and, when the user is on
-the *system-default* input (no explicit mic chosen) and output is on a
-Bluetooth device, `meetingInputDeviceAttempts` promotes the built-in mic
-to the front of the chain (governed by the
+the *system-default* input (no explicit mic chosen), that default input is
+Bluetooth or no default input resolved, and output is on a Bluetooth device,
+`meetingInputDeviceAttempts` promotes the built-in mic to the front of the
+chain (governed by the
 `preferBuiltInMicWhenBluetoothOutput` preference, default on; toggle in
 Settings → Dictation). The Bluetooth device stays in the chain as a
-fallback, an explicit mic selection is always honored, and the
-`outputIsBluetooth` query is skipped unless the rule could apply. This
-keeps playback in A2DP and sidesteps the SCO race rather than fighting
-it. *Verify on real Bluetooth hardware before relying on it — the
+fallback, non-Bluetooth system-default inputs such as USB desk mics are left
+alone, an explicit mic selection is always honored, and the `outputIsBluetooth`
+query is skipped unless the rule could apply. This keeps playback in A2DP and
+sidesteps the SCO race rather than fighting it. *Verify on real Bluetooth
+hardware before relying on it — the
 behavior is hardware-timing-dependent and is not exercised by the unit
 suite.*
 

--- a/Sources/MacParakeetCore/Audio/README.md
+++ b/Sources/MacParakeetCore/Audio/README.md
@@ -207,20 +207,19 @@ SCO link delivers audio and capture reads zero or pure-silent buffers
 (the self-heal restarts the engine but rebinds to the same not-yet-ready
 endpoint, so it does not fix this). The device-attempt builder in
 `AppEnvironment` therefore consults
-`AudioDeviceManager.isDefaultOutputBluetooth()` and, when the user is on
-the *system-default* input (no explicit mic chosen), that default input is
-Bluetooth or no default input resolved, and output is on a Bluetooth device,
-`meetingInputDeviceAttempts` promotes the built-in mic to the front of the
-chain (governed by the
-`preferBuiltInMicWhenBluetoothOutput` preference, default on; toggle in
-Settings → Dictation). The Bluetooth device stays in the chain as a
-fallback, non-Bluetooth system-default inputs such as USB desk mics are left
-alone, an explicit mic selection is always honored, and the `outputIsBluetooth`
-query is skipped unless the rule could apply. This keeps playback in A2DP and
-sidesteps the SCO race rather than fighting it. *Verify on real Bluetooth
-hardware before relying on it — the
-behavior is hardware-timing-dependent and is not exercised by the unit
-suite.*
+`AudioDeviceManager.isDefaultOutputBluetooth()` and, when the unpinned
+system-default input is Bluetooth, unresolved, or the built-in mic itself,
+`meetingInputDeviceAttempts` pins the built-in mic before that default fallback
+(governed by the `preferBuiltInMicWhenBluetoothOutput` preference, default on;
+toggle in Settings → Dictation). With no explicit mic chosen, built-in becomes
+the primary attempt. With an explicit mic chosen, that selection remains first,
+but a failed selected attempt no longer falls through to an unpinned Bluetooth
+default before trying built-in. Non-Bluetooth system-default inputs such as USB
+desk mics are left alone, and the `outputIsBluetooth` query is skipped unless
+the rule could improve the chain. This keeps playback in A2DP and sidesteps the
+SCO race rather than fighting it. *Verify on real Bluetooth hardware before
+relying on it — the behavior is hardware-timing-dependent and is not exercised
+by the unit suite.*
 
 **Diagnostics stay narrow.** The recording heartbeat in `AudioRecorder`
 remains observability-only. The first-buffer watchdog is now also a

--- a/Sources/MacParakeetCore/Audio/README.md
+++ b/Sources/MacParakeetCore/Audio/README.md
@@ -199,6 +199,27 @@ debounce (0.5 s in `AppEnvironment`, 0 = disabled for direct
 constructions) keyed by a supersession generation; superseded or
 cancelled sleepers exit before touching any engine or pre-roll state.
 
+**Capture prefers the built-in mic when output is Bluetooth (issues
+#481/#541/#409).** Opening a Bluetooth headset's microphone forces it
+out of A2DP into HFP/SCO. That both degrades the playback the user is
+hearing and races the profile switch: the engine can start before the
+SCO link delivers audio and capture reads zero or pure-silent buffers
+(the self-heal restarts the engine but rebinds to the same not-yet-ready
+endpoint, so it does not fix this). The device-attempt builder in
+`AppEnvironment` therefore consults
+`AudioDeviceManager.isDefaultOutputBluetooth()` and, when the user is on
+the *system-default* input (no explicit mic chosen) and output is on a
+Bluetooth device, `meetingInputDeviceAttempts` promotes the built-in mic
+to the front of the chain (governed by the
+`preferBuiltInMicWhenBluetoothOutput` preference, default on; toggle in
+Settings → Dictation). The Bluetooth device stays in the chain as a
+fallback, an explicit mic selection is always honored, and the
+`outputIsBluetooth` query is skipped unless the rule could apply. This
+keeps playback in A2DP and sidesteps the SCO race rather than fighting
+it. *Verify on real Bluetooth hardware before relying on it — the
+behavior is hardware-timing-dependent and is not exercised by the unit
+suite.*
+
 **Diagnostics stay narrow.** The recording heartbeat in `AudioRecorder`
 remains observability-only. The first-buffer watchdog is now also a
 startup readiness signal: `start()` does not report a healthy recording until

--- a/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
+++ b/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
@@ -502,6 +502,7 @@ public enum TelemetrySettingName: String, Sendable, Equatable {
     case meetingAutoStop = "meeting_auto_stop"
     case pauseMediaDuringDictation = "pause_media_during_dictation"
     case instantDictation = "instant_dictation"
+    case preferBuiltInMicBluetoothOutput = "prefer_builtin_mic_bluetooth_output"
     case liveDictationPreview = "live_dictation_preview"
     case dictationUndoCountdown = "dictation_undo_countdown"
     case dictationInsertionStyle = "dictation_insertion_style"

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -213,6 +213,15 @@ public final class SettingsViewModel {
             Telemetry.send(.settingChanged(setting: .instantDictation))
         }
     }
+    public var preferBuiltInMicWhenBluetoothOutput: Bool {
+        didSet {
+            defaults.set(
+                preferBuiltInMicWhenBluetoothOutput,
+                forKey: UserDefaultsAppRuntimePreferences.preferBuiltInMicWhenBluetoothOutputKey
+            )
+            Telemetry.send(.settingChanged(setting: .preferBuiltInMicBluetoothOutput))
+        }
+    }
     public var showLiveDictationPreview: Bool {
         didSet {
             defaults.set(
@@ -640,6 +649,9 @@ public final class SettingsViewModel {
         instantDictationEnabled = defaults.object(
             forKey: UserDefaultsAppRuntimePreferences.instantDictationEnabledKey
         ) as? Bool ?? false
+        preferBuiltInMicWhenBluetoothOutput = defaults.object(
+            forKey: UserDefaultsAppRuntimePreferences.preferBuiltInMicWhenBluetoothOutputKey
+        ) as? Bool ?? true
         showLiveDictationPreview = defaults.object(
             forKey: UserDefaultsAppRuntimePreferences.showLiveDictationPreviewKey
         ) as? Bool ?? true

--- a/Tests/MacParakeetTests/Audio/MicrophoneCaptureTests.swift
+++ b/Tests/MacParakeetTests/Audio/MicrophoneCaptureTests.swift
@@ -487,8 +487,32 @@ final class MicrophoneCaptureTests: XCTestCase {
         )
     }
 
-    func testBluetoothOutputRespectsExplicitMicrophoneSelection() {
-        // An explicit selection is never overridden, even with Bluetooth output.
+    func testBluetoothOutputKeepsExplicitSelectionFirstAndPinsBuiltInBeforeDefaultFallback() {
+        // An explicit selection remains first, but if it fails during Bluetooth
+        // route churn we still avoid floating to the unpinned headset default
+        // before trying the pinned built-in mic.
+        let attempts = meetingInputDeviceAttempts(
+            selectedUID: "usb-mic",
+            selectedInputDeviceID: { uid in uid == "usb-mic" ? AudioDeviceID(10) : nil },
+            defaultInputDevice: { AudioDeviceID(20) },
+            builtInMicrophone: { AudioDeviceID(30) },
+            preferBuiltInWhenOutputIsBluetooth: true,
+            outputIsBluetooth: { true }
+        )
+
+        XCTAssertEqual(
+            attempts,
+            [
+                MeetingInputDeviceAttempt(source: .selected(uid: "usb-mic"), deviceID: 10),
+                MeetingInputDeviceAttempt(source: .builtIn, deviceID: 30),
+                .implicitSystemDefault(resolvedDeviceID: 20),
+            ],
+            "Explicit selection must stay first, with built-in pinned before the Bluetooth default fallback"
+        )
+    }
+
+    func testBluetoothOutputLeavesExplicitSelectionFallbackUntouchedForNonBluetoothDefaultInput() {
+        var queriedDefaultInput = false
         var queriedOutput = false
         let attempts = meetingInputDeviceAttempts(
             selectedUID: "usb-mic",
@@ -496,22 +520,80 @@ final class MicrophoneCaptureTests: XCTestCase {
             defaultInputDevice: { AudioDeviceID(20) },
             builtInMicrophone: { AudioDeviceID(30) },
             preferBuiltInWhenOutputIsBluetooth: true,
+            defaultInputIsBluetooth: { deviceID in
+                queriedDefaultInput = true
+                XCTAssertEqual(deviceID, 20)
+                return false
+            },
             outputIsBluetooth: {
                 queriedOutput = true
                 return true
             }
         )
 
-        XCTAssertEqual(attempts.first?.source, .selected(uid: "usb-mic"))
+        XCTAssertEqual(
+            attempts,
+            [
+                MeetingInputDeviceAttempt(source: .selected(uid: "usb-mic"), deviceID: 10),
+                .implicitSystemDefault(resolvedDeviceID: 20),
+                MeetingInputDeviceAttempt(source: .builtIn, deviceID: 30),
+            ],
+            "A non-Bluetooth default input remains the first fallback behind an explicit selection"
+        )
+        XCTAssertTrue(queriedDefaultInput)
         XCTAssertFalse(
             queriedOutput,
-            "The output transport must not be queried when a device is explicitly selected"
+            "The output transport must not be queried when the default input is not Bluetooth"
         )
     }
 
-    func testBluetoothOutputNoReorderWhenBuiltInIsAlreadyDefault() {
-        // System default already is the built-in mic (id 30) — nothing to move,
-        // and capture is already on a safe input.
+    func testBluetoothOutputDropsBluetoothDefaultFallbackWhenExplicitSelectionIsBuiltIn() {
+        let attempts = meetingInputDeviceAttempts(
+            selectedUID: "built-in-mic",
+            selectedInputDeviceID: { uid in uid == "built-in-mic" ? AudioDeviceID(30) : nil },
+            defaultInputDevice: { AudioDeviceID(20) },
+            builtInMicrophone: { AudioDeviceID(30) },
+            preferBuiltInWhenOutputIsBluetooth: true,
+            outputIsBluetooth: { true }
+        )
+
+        XCTAssertEqual(
+            attempts,
+            [
+                MeetingInputDeviceAttempt(source: .selected(uid: "built-in-mic"), deviceID: 30),
+            ],
+            "Explicit built-in selection must not fall through to an unpinned Bluetooth default"
+        )
+    }
+
+    func testBluetoothOutputPinsBuiltInFallbackWhenBuiltInDefaultFollowsExplicitSelection() {
+        let attempts = meetingInputDeviceAttempts(
+            selectedUID: "usb-mic",
+            selectedInputDeviceID: { uid in uid == "usb-mic" ? AudioDeviceID(10) : nil },
+            defaultInputDevice: { AudioDeviceID(30) },
+            builtInMicrophone: { AudioDeviceID(30) },
+            preferBuiltInWhenOutputIsBluetooth: true,
+            defaultInputIsBluetooth: { _ in
+                XCTFail("Built-in default should not need a Bluetooth input query")
+                return true
+            },
+            outputIsBluetooth: { true }
+        )
+
+        XCTAssertEqual(
+            attempts,
+            [
+                MeetingInputDeviceAttempt(source: .selected(uid: "usb-mic"), deviceID: 10),
+                MeetingInputDeviceAttempt(source: .builtIn, deviceID: 30),
+            ],
+            "Built-in should be pinned behind the explicit selection without keeping a duplicate implicit default"
+        )
+    }
+
+    func testBluetoothOutputPinsBuiltInWhenBuiltInIsAlreadyDefault() {
+        // System default resolves to the built-in mic. Pin it explicitly under
+        // Bluetooth output so a route-change flap cannot float the implicit
+        // default onto the headset.
         let attempts = meetingInputDeviceAttempts(
             selectedUID: nil,
             selectedInputDeviceID: { _ in nil },
@@ -521,7 +603,12 @@ final class MicrophoneCaptureTests: XCTestCase {
             outputIsBluetooth: { true }
         )
 
-        XCTAssertEqual(attempts, [.implicitSystemDefault(resolvedDeviceID: 30)])
+        XCTAssertEqual(
+            attempts,
+            [
+                MeetingInputDeviceAttempt(source: .builtIn, deviceID: 30),
+            ]
+        )
     }
 
     func testBluetoothOutputRuleDisabledLeavesChainUntouched() {

--- a/Tests/MacParakeetTests/Audio/MicrophoneCaptureTests.swift
+++ b/Tests/MacParakeetTests/Audio/MicrophoneCaptureTests.swift
@@ -507,6 +507,50 @@ final class MicrophoneCaptureTests: XCTestCase {
         XCTAssertFalse(queriedOutput, "Disabled rule must not query the output transport")
     }
 
+    func testBluetoothOutputPromotesBuiltInWhenSavedSelectionUnresolvable() {
+        // A mic was selected once (saved UID) but is currently unplugged, so it
+        // doesn't resolve to a device. We fall back to the system default —
+        // which here is the Bluetooth headset — so the avoidance rule must
+        // still promote the built-in mic rather than landing on the race.
+        let attempts = meetingInputDeviceAttempts(
+            selectedUID: "unplugged-usb-mic",
+            selectedInputDeviceID: { _ in nil },
+            defaultInputDevice: { AudioDeviceID(20) },
+            builtInMicrophone: { AudioDeviceID(30) },
+            preferBuiltInWhenOutputIsBluetooth: true,
+            outputIsBluetooth: { true }
+        )
+
+        XCTAssertEqual(
+            attempts,
+            [
+                MeetingInputDeviceAttempt(source: .builtIn, deviceID: 30),
+                .implicitSystemDefault(resolvedDeviceID: 20),
+            ],
+            "A saved-but-unresolvable selection must not block Bluetooth-output avoidance"
+        )
+    }
+
+    func testBluetoothOutputNoBuiltInMicLeavesChainAndSkipsQuery() {
+        // No built-in mic (e.g. Mac mini / Mac Studio): nothing to promote, so
+        // the chain is unchanged and the output-transport HAL query is skipped.
+        var queriedOutput = false
+        let attempts = meetingInputDeviceAttempts(
+            selectedUID: nil,
+            selectedInputDeviceID: { _ in nil },
+            defaultInputDevice: { AudioDeviceID(20) },
+            builtInMicrophone: { nil },
+            preferBuiltInWhenOutputIsBluetooth: true,
+            outputIsBluetooth: { queriedOutput = true; return true }
+        )
+
+        XCTAssertEqual(attempts, [.implicitSystemDefault(resolvedDeviceID: 20)])
+        XCTAssertFalse(
+            queriedOutput,
+            "With no built-in mic to promote, the output transport query must be skipped"
+        )
+    }
+
     func testPlatformSkipsInputDeviceSetterForImplicitSystemDefaultAttempt() throws {
         let recorder = MicrophoneCaptureInputDeviceSetterRecorder()
         let platform = AVAudioEngineMicrophonePlatform(

--- a/Tests/MacParakeetTests/Audio/MicrophoneCaptureTests.swift
+++ b/Tests/MacParakeetTests/Audio/MicrophoneCaptureTests.swift
@@ -408,6 +408,105 @@ final class MicrophoneCaptureTests: XCTestCase {
         XCTAssertEqual(attempt.explicitDeviceID, 20)
     }
 
+    // MARK: - Bluetooth-output avoidance (issues #481/#541/#409)
+
+    func testBluetoothOutputPrefersBuiltInWhenOnSystemDefault() {
+        // System default input is the Bluetooth headset (id 20); built-in is
+        // id 30. With output on Bluetooth and no explicit selection, built-in
+        // is promoted to the front so capture doesn't force HFP/SCO.
+        let attempts = meetingInputDeviceAttempts(
+            selectedUID: nil,
+            selectedInputDeviceID: { _ in nil },
+            defaultInputDevice: { AudioDeviceID(20) },
+            builtInMicrophone: { AudioDeviceID(30) },
+            preferBuiltInWhenOutputIsBluetooth: true,
+            outputIsBluetooth: { true }
+        )
+
+        XCTAssertEqual(
+            attempts,
+            [
+                MeetingInputDeviceAttempt(source: .builtIn, deviceID: 30),
+                .implicitSystemDefault(resolvedDeviceID: 20),
+            ],
+            "Built-in must lead, with the Bluetooth system default kept as fallback"
+        )
+    }
+
+    func testBluetoothOutputDoesNotReorderWhenOutputIsNotBluetooth() {
+        let attempts = meetingInputDeviceAttempts(
+            selectedUID: nil,
+            selectedInputDeviceID: { _ in nil },
+            defaultInputDevice: { AudioDeviceID(20) },
+            builtInMicrophone: { AudioDeviceID(30) },
+            preferBuiltInWhenOutputIsBluetooth: true,
+            outputIsBluetooth: { false }
+        )
+
+        XCTAssertEqual(
+            attempts,
+            [
+                .implicitSystemDefault(resolvedDeviceID: 20),
+                MeetingInputDeviceAttempt(source: .builtIn, deviceID: 30),
+            ]
+        )
+    }
+
+    func testBluetoothOutputRespectsExplicitMicrophoneSelection() {
+        // An explicit selection is never overridden, even with Bluetooth output.
+        var queriedOutput = false
+        let attempts = meetingInputDeviceAttempts(
+            selectedUID: "usb-mic",
+            selectedInputDeviceID: { uid in uid == "usb-mic" ? AudioDeviceID(10) : nil },
+            defaultInputDevice: { AudioDeviceID(20) },
+            builtInMicrophone: { AudioDeviceID(30) },
+            preferBuiltInWhenOutputIsBluetooth: true,
+            outputIsBluetooth: { queriedOutput = true; return true }
+        )
+
+        XCTAssertEqual(attempts.first?.source, .selected(uid: "usb-mic"))
+        XCTAssertFalse(
+            queriedOutput,
+            "The output transport must not be queried when a device is explicitly selected"
+        )
+    }
+
+    func testBluetoothOutputNoReorderWhenBuiltInIsAlreadyDefault() {
+        // System default already is the built-in mic (id 30) — nothing to move,
+        // and capture is already on a safe input.
+        let attempts = meetingInputDeviceAttempts(
+            selectedUID: nil,
+            selectedInputDeviceID: { _ in nil },
+            defaultInputDevice: { AudioDeviceID(30) },
+            builtInMicrophone: { AudioDeviceID(30) },
+            preferBuiltInWhenOutputIsBluetooth: true,
+            outputIsBluetooth: { true }
+        )
+
+        XCTAssertEqual(attempts, [.implicitSystemDefault(resolvedDeviceID: 30)])
+    }
+
+    func testBluetoothOutputRuleDisabledLeavesChainUntouched() {
+        var queriedOutput = false
+        let attempts = meetingInputDeviceAttempts(
+            selectedUID: nil,
+            selectedInputDeviceID: { _ in nil },
+            defaultInputDevice: { AudioDeviceID(20) },
+            builtInMicrophone: { AudioDeviceID(30) },
+            preferBuiltInWhenOutputIsBluetooth: false,
+            outputIsBluetooth: { queriedOutput = true; return true }
+        )
+
+        XCTAssertEqual(
+            attempts,
+            [
+                .implicitSystemDefault(resolvedDeviceID: 20),
+                MeetingInputDeviceAttempt(source: .builtIn, deviceID: 30),
+            ]
+        )
+        XCTAssertFalse(queriedOutput, "Disabled rule must not query the output transport")
+    }
+
     func testPlatformSkipsInputDeviceSetterForImplicitSystemDefaultAttempt() throws {
         let recorder = MicrophoneCaptureInputDeviceSetterRecorder()
         let platform = AVAudioEngineMicrophonePlatform(

--- a/Tests/MacParakeetTests/Audio/MicrophoneCaptureTests.swift
+++ b/Tests/MacParakeetTests/Audio/MicrophoneCaptureTests.swift
@@ -452,6 +452,41 @@ final class MicrophoneCaptureTests: XCTestCase {
         )
     }
 
+    func testBluetoothOutputDoesNotOverrideNonBluetoothSystemDefaultInput() {
+        var queriedDefaultInput = false
+        var queriedOutput = false
+        let attempts = meetingInputDeviceAttempts(
+            selectedUID: nil,
+            selectedInputDeviceID: { _ in nil },
+            defaultInputDevice: { AudioDeviceID(20) },
+            builtInMicrophone: { AudioDeviceID(30) },
+            preferBuiltInWhenOutputIsBluetooth: true,
+            defaultInputIsBluetooth: { deviceID in
+                queriedDefaultInput = true
+                XCTAssertEqual(deviceID, 20)
+                return false
+            },
+            outputIsBluetooth: {
+                queriedOutput = true
+                return true
+            }
+        )
+
+        XCTAssertEqual(
+            attempts,
+            [
+                .implicitSystemDefault(resolvedDeviceID: 20),
+                MeetingInputDeviceAttempt(source: .builtIn, deviceID: 30),
+            ],
+            "A non-Bluetooth system-default input such as a USB desk mic must not be displaced"
+        )
+        XCTAssertTrue(queriedDefaultInput)
+        XCTAssertFalse(
+            queriedOutput,
+            "The output transport must not be queried when the default input is not Bluetooth"
+        )
+    }
+
     func testBluetoothOutputRespectsExplicitMicrophoneSelection() {
         // An explicit selection is never overridden, even with Bluetooth output.
         var queriedOutput = false
@@ -461,7 +496,10 @@ final class MicrophoneCaptureTests: XCTestCase {
             defaultInputDevice: { AudioDeviceID(20) },
             builtInMicrophone: { AudioDeviceID(30) },
             preferBuiltInWhenOutputIsBluetooth: true,
-            outputIsBluetooth: { queriedOutput = true; return true }
+            outputIsBluetooth: {
+                queriedOutput = true
+                return true
+            }
         )
 
         XCTAssertEqual(attempts.first?.source, .selected(uid: "usb-mic"))
@@ -494,7 +532,10 @@ final class MicrophoneCaptureTests: XCTestCase {
             defaultInputDevice: { AudioDeviceID(20) },
             builtInMicrophone: { AudioDeviceID(30) },
             preferBuiltInWhenOutputIsBluetooth: false,
-            outputIsBluetooth: { queriedOutput = true; return true }
+            outputIsBluetooth: {
+                queriedOutput = true
+                return true
+            }
         )
 
         XCTAssertEqual(
@@ -534,6 +575,7 @@ final class MicrophoneCaptureTests: XCTestCase {
     func testBluetoothOutputNoBuiltInMicLeavesChainAndSkipsQuery() {
         // No built-in mic (e.g. Mac mini / Mac Studio): nothing to promote, so
         // the chain is unchanged and the output-transport HAL query is skipped.
+        var queriedDefaultInput = false
         var queriedOutput = false
         let attempts = meetingInputDeviceAttempts(
             selectedUID: nil,
@@ -541,10 +583,21 @@ final class MicrophoneCaptureTests: XCTestCase {
             defaultInputDevice: { AudioDeviceID(20) },
             builtInMicrophone: { nil },
             preferBuiltInWhenOutputIsBluetooth: true,
-            outputIsBluetooth: { queriedOutput = true; return true }
+            defaultInputIsBluetooth: { _ in
+                queriedDefaultInput = true
+                return true
+            },
+            outputIsBluetooth: {
+                queriedOutput = true
+                return true
+            }
         )
 
         XCTAssertEqual(attempts, [.implicitSystemDefault(resolvedDeviceID: 20)])
+        XCTAssertFalse(
+            queriedDefaultInput,
+            "With no built-in mic to promote, the default input transport must not be queried"
+        )
         XCTAssertFalse(
             queriedOutput,
             "With no built-in mic to promote, the output transport query must be skipped"

--- a/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
@@ -161,6 +161,10 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.meetingHotkeyTrigger, .chord(modifiers: ["command", "shift"], keyCode: 46))
         XCTAssertEqual(viewModel.meetingAudioSourceMode, .microphoneAndSystem)
         XCTAssertFalse(viewModel.meetingAutoStopEnabled, "meeting auto-stop should default to false")
+        XCTAssertTrue(
+            viewModel.preferBuiltInMicWhenBluetoothOutput,
+            "Bluetooth-output built-in mic preference should default to true"
+        )
         XCTAssertEqual(
             viewModel.selectedMicrophoneDeviceUID,
             SettingsViewModel.systemDefaultMicrophoneSelection,
@@ -197,6 +201,7 @@ final class SettingsViewModelTests: XCTestCase {
         testDefaults.set(true, forKey: UserDefaultsAppRuntimePreferences.meetingAutoStopEnabledKey)
         testDefaults.set(true, forKey: UserDefaultsAppRuntimePreferences.pauseMediaDuringDictationKey)
         testDefaults.set(true, forKey: UserDefaultsAppRuntimePreferences.instantDictationEnabledKey)
+        testDefaults.set(false, forKey: UserDefaultsAppRuntimePreferences.preferBuiltInMicWhenBluetoothOutputKey)
         testDefaults.set(false, forKey: UserDefaultsAppRuntimePreferences.showLiveDictationPreviewKey)
         HotkeyTrigger.chord(modifiers: ["control", "option"], keyCode: 46)
             .save(to: testDefaults, defaultsKey: HotkeyTrigger.meetingDefaultsKey)
@@ -222,6 +227,7 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertTrue(vm.meetingAutoStopEnabled)
         XCTAssertTrue(vm.pauseMediaDuringDictation)
         XCTAssertTrue(vm.instantDictationEnabled)
+        XCTAssertFalse(vm.preferBuiltInMicWhenBluetoothOutput)
         XCTAssertFalse(vm.showLiveDictationPreview)
         XCTAssertEqual(vm.meetingHotkeyTrigger, .chord(modifiers: ["control", "option"], keyCode: 46))
     }
@@ -307,6 +313,31 @@ final class SettingsViewModelTests: XCTestCase {
             return setting
         }
         XCTAssertEqual(settings, [.instantDictation])
+    }
+
+    func testPreferBuiltInMicWhenBluetoothOutputPersistsAndEmitsTelemetry() {
+        let telemetry = SettingsTelemetrySpy()
+        Telemetry.configure(telemetry)
+
+        viewModel.preferBuiltInMicWhenBluetoothOutput = false
+
+        XCTAssertFalse(
+            testDefaults.bool(forKey: UserDefaultsAppRuntimePreferences.preferBuiltInMicWhenBluetoothOutputKey)
+        )
+
+        viewModel.preferBuiltInMicWhenBluetoothOutput = true
+
+        XCTAssertTrue(
+            testDefaults.bool(forKey: UserDefaultsAppRuntimePreferences.preferBuiltInMicWhenBluetoothOutputKey)
+        )
+        let settings = telemetry.snapshot().compactMap { event -> TelemetrySettingName? in
+            guard case .settingChanged(let setting) = event else { return nil }
+            return setting
+        }
+        XCTAssertEqual(
+            settings,
+            [.preferBuiltInMicBluetoothOutput, .preferBuiltInMicBluetoothOutput]
+        )
     }
 
     func testLiveDictationPreviewPersistsAndEmitsTelemetry() {

--- a/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
@@ -321,14 +321,20 @@ final class SettingsViewModelTests: XCTestCase {
 
         viewModel.preferBuiltInMicWhenBluetoothOutput = false
 
-        XCTAssertFalse(
-            testDefaults.bool(forKey: UserDefaultsAppRuntimePreferences.preferBuiltInMicWhenBluetoothOutputKey)
+        XCTAssertEqual(
+            testDefaults.object(
+                forKey: UserDefaultsAppRuntimePreferences.preferBuiltInMicWhenBluetoothOutputKey
+            ) as? Bool,
+            false
         )
 
         viewModel.preferBuiltInMicWhenBluetoothOutput = true
 
-        XCTAssertTrue(
-            testDefaults.bool(forKey: UserDefaultsAppRuntimePreferences.preferBuiltInMicWhenBluetoothOutputKey)
+        XCTAssertEqual(
+            testDefaults.object(
+                forKey: UserDefaultsAppRuntimePreferences.preferBuiltInMicWhenBluetoothOutputKey
+            ) as? Bool,
+            true
         )
         let settings = telemetry.snapshot().compactMap { event -> TelemetrySettingName? in
             guard case .settingChanged(let setting) = event else { return nil }


### PR DESCRIPTION
## Summary

Addresses the Bluetooth headset dictation failures behind #481, #541, and #409.

Bluetooth headsets cannot use high-quality output (A2DP) and mic input (HFP/SCO) at the same time. When MacParakeet opens the headset mic while audio is playing, macOS switches Bluetooth modes; during that transition capture can start on silence or miss the first words, and playback drops into lower-quality "VOIP mode."

This PR avoids opening the headset mic in the default case. If output is Bluetooth, no explicit mic is selected, and the system-default input is Bluetooth or unresolved, MacParakeet tries the built-in mic first.

## Behavior

- Applies only when the user is on the macOS system-default mic selection.
- Explicit mic selections are always honored.
- Non-Bluetooth system-default inputs, such as USB desk mics, are not displaced.
- The original Bluetooth/default input remains in the fallback chain, so capture is not blocked.
- The Bluetooth output HAL query runs only after cheaper guards prove the reorder could apply.
- New setting: `preferBuiltInMicWhenBluetoothOutput`, default on, with a Settings -> Dictation toggle.

## Changes

- Adds `AudioDeviceManager.defaultOutputDevice()` and `isDefaultOutputBluetooth()`.
- Extends `meetingInputDeviceAttempts` with the Bluetooth-output built-in-mic preference rule.
- Wires the rule into `AppEnvironment`.
- Adds the Settings toggle, persistence, and `setting_changed` telemetry name.
- Updates `Audio/README.md`.
- Adds routing and settings tests for promotion, explicit mic selection, USB/non-Bluetooth defaults, missing built-in mic, saved-but-unavailable selections, persistence, and telemetry.

## Verification

- `git diff --check`
- `swift test --filter MicrophoneCaptureTests`
- `swift test --filter SettingsViewModelTests`
- Full `swift test` (4,031 tests, 10 skipped, 0 failures)
- GitHub `swift-test` x2 passed on `1e3223bc`
- Cubic passed on `1e3223bc`
- Greptile re-reviewed `1e3223bc` with Confidence Score 5/5

## Hardware Smoke Before Merge

This fix is hardware-timing-dependent, so unit tests cannot fully prove it. Before merge, test with AirPods or another Bluetooth headset:

1. Connect Bluetooth headset and play media.
2. Leave MacParakeet on system-default mic selection.
3. Dictate several times and confirm capture is non-silent.
4. Confirm playback stays high quality.
5. Turn the new setting off and confirm headset-mic capture is restored.
6. Explicitly select the headset mic and confirm that explicit selection is honored.
