### PR TITLE
Fix dropped final word in dictation by padding trailing silence (#562)

### DIFF
--- a/Sources/MacParakeetCore/STT/README.md
+++ b/Sources/MacParakeetCore/STT/README.md
@@ -155,6 +155,18 @@ final paste path still proceeds after its bounded display-preview drain. Runtime
 quiesce paths such as shutdown and cache clear wait for preview drain under the
 unhealthy-runtime watchdog before unloading or clearing model state.
 
+**Dictation finalize pads trailing silence (issue #562).** The Parakeet TDT
+final pass for `job == .dictation` decodes the recorded WAV to 16 kHz mono
+samples, appends `dictationTrailingSilenceSeconds` of silence, and transcribes
+through the samples API instead of `manager.transcribe(audioURL:)`. Without the
+pad the TDT decoder can drop a fast final word that lands right on the end of
+the recording even though the audio was captured. This is scoped deliberately:
+file/meeting jobs keep the URL path (FluidAudio streams / disk-backs long
+audio), and Whisper is never padded (trailing silence can trigger hallucinated
+text). The decode is best-effort — any failure falls through to the URL path so
+a dictation is never lost. Don't "simplify" dictation back onto the shared URL
+path without restoring this trailing context.
+
 **Engine routing is per-job.** Parakeet stays default. The selected Parakeet
 build is `v3` unless the user opts into `v2` through Settings or the CLI
 (`config set parakeet-model`, `models select parakeet-v2`, or

--- a/Sources/MacParakeetCore/STT/README.md
+++ b/Sources/MacParakeetCore/STT/README.md
@@ -160,12 +160,17 @@ final pass for `job == .dictation` decodes the recorded WAV to 16 kHz mono
 samples, appends `dictationTrailingSilenceSeconds` of silence, and transcribes
 through the samples API instead of `manager.transcribe(audioURL:)`. Without the
 pad the TDT decoder can drop a fast final word that lands right on the end of
-the recording even though the audio was captured. This is scoped deliberately:
-file/meeting jobs keep the URL path (FluidAudio streams / disk-backs long
-audio), and Whisper is never padded (trailing silence can trigger hallucinated
-text). The decode is best-effort — any failure falls through to the URL path so
-a dictation is never lost. Don't "simplify" dictation back onto the shared URL
-path without restoring this trailing context.
+the recording even though the audio was captured. FluidAudio's own fixed-size
+input padding does not help because the decode is bounded to the real (pre-pad)
+audio length, so only *real* trailing samples extend the decode window. This is
+scoped deliberately: the pad path is taken only for short clips that fit
+FluidAudio's single-window tier (`maxModelSamples`); longer dictations and
+file/meeting jobs keep the URL path (FluidAudio disk-backs long audio for
+constant memory), and Whisper is never padded (trailing silence can trigger
+hallucinated text). Decode/pad preparation is best-effort: an unreadable,
+empty, or too-long clip yields no samples and falls through to the URL path, while
+transcription errors propagate from whichever path ran. Don't "simplify"
+dictation back onto the shared URL path without restoring this trailing context.
 
 **Engine routing is per-job.** Parakeet stays default. The selected Parakeet
 build is `v3` unless the user opts into `v2` through Settings or the CLI

--- a/Sources/MacParakeetCore/STT/STTRuntime.swift
+++ b/Sources/MacParakeetCore/STT/STTRuntime.swift
@@ -399,33 +399,37 @@ public actor STTRuntime: STTRuntimeProtocol {
             throw STTError.modelNotLoaded
         }
 
-        // Dictation finalizes a short, in-memory clip. Pad a little trailing
+        // Dictation finalizes a short, single-window clip. Pad a little trailing
         // silence onto the samples so the Parakeet TDT decoder has enough
         // context to emit a fast final word that lands right on the end of the
-        // recording (issue #562). Without it the last token can be dropped even
-        // though the audio is fully captured. File/meeting jobs keep FluidAudio's
-        // URL path (which streams / disk-backs long audio); Whisper is unaffected
-        // (trailing silence there can trigger hallucinated text). If the decode
-        // fails for any reason we fall through to the URL path rather than lose
-        // the dictation.
-        if job == .dictation,
-           let paddedSamples = try? Self.paddedDictationSamples(audioPath: audioPath),
-           !paddedSamples.isEmpty
-        {
-            do {
-                try Task.checkCancellation()
-                var decoderState = TdtDecoderState.make(decoderLayers: decoderLayers)
-                try Task.checkCancellation()
-                let result = try await manager.transcribe(paddedSamples, decoderState: &decoderState)
-                return STTResult(
-                    text: result.text,
-                    words: STTWordTimingBuilder.words(from: result.tokenTimings),
-                    language: "en",
-                    engine: .parakeet,
-                    engineVariant: ParakeetModelVariant(asrModelVersion: modelVersion).rawValue
-                )
-            } catch {
-                throw try Self.mapTranscriptionError(error)
+        // recording (issue #562). The decode is bounded to the real (pre-pad)
+        // audio length, so FluidAudio's own fixed-size input padding does not
+        // extend it: only real trailing samples do. File/meeting jobs and long
+        // dictations keep FluidAudio's URL path (which disk-backs long audio for
+        // constant memory); Whisper is unaffected (trailing silence there can
+        // trigger hallucinated text). An unreadable, empty, or long clip yields
+        // no padded samples and falls through to the URL path below;
+        // transcription errors themselves propagate from either path.
+        if job == .dictation {
+            let paddedSamples = Self.paddedDictationSamples(audioPath: audioPath)
+            if !paddedSamples.isEmpty {
+                do {
+                    try Task.checkCancellation()
+                    var decoderState = TdtDecoderState.make(decoderLayers: decoderLayers)
+                    try Task.checkCancellation()
+                    onProgress?(0, 100)
+                    let result = try await manager.transcribe(paddedSamples, decoderState: &decoderState)
+                    onProgress?(100, 100)
+                    return STTResult(
+                        text: result.text,
+                        words: STTWordTimingBuilder.words(from: result.tokenTimings),
+                        language: "en",
+                        engine: .parakeet,
+                        engineVariant: ParakeetModelVariant(asrModelVersion: modelVersion).rawValue
+                    )
+                } catch {
+                    throw try Self.mapTranscriptionError(error)
+                }
             }
         }
 
@@ -481,18 +485,33 @@ public actor STTRuntime: STTRuntimeProtocol {
 
     // MARK: - Dictation trailing-silence pad (issue #562)
 
-    /// How much trailing silence to append to a dictation clip before the final
-    /// Parakeet transcription. Enough to give the TDT decoder a few extra
-    /// encoder frames so it emits a fast final word, but small enough that it
-    /// adds no perceptible stop latency.
-    static let dictationTrailingSilenceSeconds = 0.5
+    /// Trailing silence appended to a dictation clip before the final Parakeet
+    /// transcription. Enough to give the TDT decoder a few extra encoder frames
+    /// so it emits a fast final word (the decode is bounded to the real, pre-pad
+    /// length — FluidAudio's fixed-size input padding does not extend it), but
+    /// small enough to add no perceptible stop latency.
+    static let dictationTrailingSilenceSeconds: Double = 0.5
 
-    /// Decode the recorded dictation WAV and append trailing silence. Returns an
-    /// empty array when there is nothing to transcribe (the caller then falls
-    /// back to the URL path).
-    static func paddedDictationSamples(audioPath: String) throws -> [Float] {
-        let samples = try loadDictationSamples16k(path: audioPath)
-        guard !samples.isEmpty else { return [] }
+    /// Decode the recorded dictation WAV and append trailing silence — but only
+    /// for short, single-window clips. Returns an empty array (so the caller
+    /// keeps the URL path) for an unreadable/empty clip, or one long enough that
+    /// FluidAudio would chunk it: long audio stays on the disk-backed URL path,
+    /// which holds memory constant, while this helper stays focused on the
+    /// reported short-clip failure mode.
+    static func paddedDictationSamples(audioPath: String) -> [Float] {
+        let padSamples = Int(dictationTrailingSilenceSeconds * Double(ASRConstants.sampleRate))
+        // Keep the *padded* clip inside FluidAudio's single-window tier
+        // (`maxModelSamples`). Bounding the pre-pad length here also means a long
+        // file is never read fully into memory just to be discarded.
+        guard
+            let samples = loadShortDictationSamples16k(
+                path: audioPath,
+                maxSamples: max(0, ASRConstants.maxModelSamples - padSamples)
+            ),
+            !samples.isEmpty
+        else {
+            return []
+        }
         return appendingTrailingSilence(
             samples,
             seconds: dictationTrailingSilenceSeconds,
@@ -518,18 +537,33 @@ public actor STTRuntime: STTRuntimeProtocol {
 
     /// Decode a recorded dictation WAV to 16 kHz mono Float samples, mirroring
     /// the capture pipeline's downmix + resample (`AudioChunker.extractAndResample`).
-    /// Dictation clips are short, so the file is read in a single buffer.
-    static func loadDictationSamples16k(path: String) throws -> [Float] {
-        let url = URL(fileURLWithPath: path)
-        let file = try AVAudioFile(forReading: url)
-        let frameCount = AVAudioFrameCount(file.length)
-        guard frameCount > 0,
-              let buffer = AVAudioPCMBuffer(pcmFormat: file.processingFormat, frameCapacity: frameCount)
+    /// Returns nil for an unreadable or empty file, or one whose 16 kHz length
+    /// exceeds `maxSamples` — checked before reading, so a long file is not
+    /// loaded into memory (the caller keeps FluidAudio's disk-backed URL path).
+    /// Dictation clips are short, so a qualifying file is read in one buffer.
+    static func loadShortDictationSamples16k(path: String, maxSamples: Int) -> [Float]? {
+        guard let file = try? AVAudioFile(forReading: URL(fileURLWithPath: path)) else { return nil }
+        let sourceRate = file.processingFormat.sampleRate
+        guard
+            sourceRate > 0,
+            let frameCount = AVAudioFrameCount(exactly: file.length),
+            frameCount > 0
         else {
-            return []
+            return nil
         }
-        try file.read(into: buffer)
-        return AudioChunker.extractAndResample(from: buffer) ?? []
+        // Dictation WAVs are written at 16 kHz mono; estimate the 16 kHz length
+        // so the guard holds even if that capture format ever changes.
+        let estimated16kSamples = Int(
+            (Double(file.length) * Double(ASRConstants.sampleRate) / sourceRate).rounded(.up)
+        )
+        guard
+            estimated16kSamples <= maxSamples,
+            let buffer = AVAudioPCMBuffer(pcmFormat: file.processingFormat, frameCapacity: frameCount),
+            (try? file.read(into: buffer)) != nil
+        else {
+            return nil
+        }
+        return AudioChunker.extractAndResample(from: buffer)
     }
 
     private func transcribeParakeetPreview(samples: [Float]) async throws -> STTResult {

--- a/Sources/MacParakeetCore/STT/STTRuntime.swift
+++ b/Sources/MacParakeetCore/STT/STTRuntime.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import FluidAudio
 import Foundation
 import os
@@ -398,6 +399,36 @@ public actor STTRuntime: STTRuntimeProtocol {
             throw STTError.modelNotLoaded
         }
 
+        // Dictation finalizes a short, in-memory clip. Pad a little trailing
+        // silence onto the samples so the Parakeet TDT decoder has enough
+        // context to emit a fast final word that lands right on the end of the
+        // recording (issue #562). Without it the last token can be dropped even
+        // though the audio is fully captured. File/meeting jobs keep FluidAudio's
+        // URL path (which streams / disk-backs long audio); Whisper is unaffected
+        // (trailing silence there can trigger hallucinated text). If the decode
+        // fails for any reason we fall through to the URL path rather than lose
+        // the dictation.
+        if job == .dictation,
+           let paddedSamples = try? Self.paddedDictationSamples(audioPath: audioPath),
+           !paddedSamples.isEmpty
+        {
+            do {
+                try Task.checkCancellation()
+                var decoderState = TdtDecoderState.make(decoderLayers: decoderLayers)
+                try Task.checkCancellation()
+                let result = try await manager.transcribe(paddedSamples, decoderState: &decoderState)
+                return STTResult(
+                    text: result.text,
+                    words: STTWordTimingBuilder.words(from: result.tokenTimings),
+                    language: "en",
+                    engine: .parakeet,
+                    engineVariant: ParakeetModelVariant(asrModelVersion: modelVersion).rawValue
+                )
+            } catch {
+                throw try Self.mapTranscriptionError(error)
+            }
+        }
+
         let audioURL = URL(fileURLWithPath: audioPath)
         let transcriptionProgressTask: Task<Void, Never>? = if let onProgress {
             Task {
@@ -446,6 +477,59 @@ public actor STTRuntime: STTRuntimeProtocol {
         } catch {
             throw try Self.mapTranscriptionError(error)
         }
+    }
+
+    // MARK: - Dictation trailing-silence pad (issue #562)
+
+    /// How much trailing silence to append to a dictation clip before the final
+    /// Parakeet transcription. Enough to give the TDT decoder a few extra
+    /// encoder frames so it emits a fast final word, but small enough that it
+    /// adds no perceptible stop latency.
+    static let dictationTrailingSilenceSeconds = 0.5
+
+    /// Decode the recorded dictation WAV and append trailing silence. Returns an
+    /// empty array when there is nothing to transcribe (the caller then falls
+    /// back to the URL path).
+    static func paddedDictationSamples(audioPath: String) throws -> [Float] {
+        let samples = try loadDictationSamples16k(path: audioPath)
+        guard !samples.isEmpty else { return [] }
+        return appendingTrailingSilence(
+            samples,
+            seconds: dictationTrailingSilenceSeconds,
+            sampleRate: ASRConstants.sampleRate
+        )
+    }
+
+    /// Append `seconds` of silence (zero samples) to the end of `samples`.
+    /// Pure and allocation-bounded; a no-op for empty input or a non-positive
+    /// pad so callers can apply it unconditionally.
+    static func appendingTrailingSilence(
+        _ samples: [Float],
+        seconds: Double,
+        sampleRate: Int
+    ) -> [Float] {
+        guard seconds > 0, sampleRate > 0, !samples.isEmpty else { return samples }
+        let padCount = Int(seconds * Double(sampleRate))
+        guard padCount > 0 else { return samples }
+        var padded = samples
+        padded.append(contentsOf: repeatElement(0, count: padCount))
+        return padded
+    }
+
+    /// Decode a recorded dictation WAV to 16 kHz mono Float samples, mirroring
+    /// the capture pipeline's downmix + resample (`AudioChunker.extractAndResample`).
+    /// Dictation clips are short, so the file is read in a single buffer.
+    static func loadDictationSamples16k(path: String) throws -> [Float] {
+        let url = URL(fileURLWithPath: path)
+        let file = try AVAudioFile(forReading: url)
+        let frameCount = AVAudioFrameCount(file.length)
+        guard frameCount > 0,
+              let buffer = AVAudioPCMBuffer(pcmFormat: file.processingFormat, frameCapacity: frameCount)
+        else {
+            return []
+        }
+        try file.read(into: buffer)
+        return AudioChunker.extractAndResample(from: buffer) ?? []
     }
 
     private func transcribeParakeetPreview(samples: [Float]) async throws -> STTResult {

--- a/Tests/MacParakeetTests/STT/STTRuntimeDictationPadTests.swift
+++ b/Tests/MacParakeetTests/STT/STTRuntimeDictationPadTests.swift
@@ -1,0 +1,91 @@
+import AVFoundation
+import FluidAudio
+@testable import MacParakeetCore
+import XCTest
+
+/// Unit coverage for the dictation trailing-silence pad (issue #562). The
+/// CoreML Parakeet model cannot run in CI, so these exercise the padding
+/// mechanism and the WAV decode round-trip that feed it, not the WER outcome.
+final class STTRuntimeDictationPadTests: XCTestCase {
+    // MARK: - appendingTrailingSilence
+
+    func testAppendingTrailingSilenceAddsZeroPaddedTail() {
+        let samples: [Float] = [0.1, -0.2, 0.3, -0.4]
+        let padded = STTRuntime.appendingTrailingSilence(samples, seconds: 0.5, sampleRate: 16_000)
+
+        XCTAssertEqual(padded.count, samples.count + 8_000)
+        XCTAssertEqual(Array(padded.prefix(samples.count)), samples)
+        XCTAssertTrue(padded.suffix(8_000).allSatisfy { $0 == 0 })
+    }
+
+    func testAppendingTrailingSilenceUsesProductionDuration() {
+        let samples = [Float](repeating: 0.5, count: 1_000)
+        let padded = STTRuntime.appendingTrailingSilence(
+            samples,
+            seconds: STTRuntime.dictationTrailingSilenceSeconds,
+            sampleRate: ASRConstants.sampleRate
+        )
+        let expectedPad = Int(STTRuntime.dictationTrailingSilenceSeconds * Double(ASRConstants.sampleRate))
+
+        XCTAssertEqual(padded.count, samples.count + expectedPad)
+    }
+
+    func testAppendingTrailingSilenceIsNoOpForEmptyOrNonPositiveInputs() {
+        XCTAssertTrue(STTRuntime.appendingTrailingSilence([], seconds: 0.5, sampleRate: 16_000).isEmpty)
+
+        let samples: [Float] = [0.1, 0.2]
+        XCTAssertEqual(STTRuntime.appendingTrailingSilence(samples, seconds: 0, sampleRate: 16_000), samples)
+        XCTAssertEqual(STTRuntime.appendingTrailingSilence(samples, seconds: -1, sampleRate: 16_000), samples)
+        XCTAssertEqual(STTRuntime.appendingTrailingSilence(samples, seconds: 0.5, sampleRate: 0), samples)
+    }
+
+    // MARK: - decode + pad round-trip
+
+    func testPaddedDictationSamplesDecodesWavAndAppendsSilence() throws {
+        let realSampleCount = 4_800  // 0.3 s at 16 kHz
+        let url = try writeMonoFloatWav(
+            sampleCount: realSampleCount,
+            sampleRate: 16_000,
+            valueAt: { Float(sin(Double($0) * 0.05)) }
+        )
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let decoded = try STTRuntime.loadDictationSamples16k(path: url.path)
+        XCTAssertEqual(decoded.count, realSampleCount)
+
+        let padded = try STTRuntime.paddedDictationSamples(audioPath: url.path)
+        let expectedPad = Int(STTRuntime.dictationTrailingSilenceSeconds * Double(ASRConstants.sampleRate))
+        XCTAssertEqual(padded.count, realSampleCount + expectedPad)
+        XCTAssertTrue(padded.suffix(expectedPad).allSatisfy { $0 == 0 })
+        // The real audio is preserved ahead of the silence.
+        XCTAssertFalse(padded.prefix(realSampleCount).allSatisfy { $0 == 0 })
+    }
+
+    // MARK: - helpers
+
+    /// Writes a 16 kHz mono Float32 WAV, matching `AudioRecorder`'s dictation
+    /// output format, so the decode path under test sees a realistic file.
+    private func writeMonoFloatWav(
+        sampleCount: Int,
+        sampleRate: Double,
+        valueAt: (Int) -> Float
+    ) throws -> URL {
+        let format = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: sampleRate,
+            channels: 1,
+            interleaved: false
+        )!
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(UUID().uuidString).wav")
+        let file = try AVAudioFile(forWriting: url, settings: format.settings)
+        let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: AVAudioFrameCount(sampleCount))!
+        buffer.frameLength = AVAudioFrameCount(sampleCount)
+        let channel = buffer.floatChannelData![0]
+        for index in 0..<sampleCount {
+            channel[index] = valueAt(index)
+        }
+        try file.write(from: buffer)
+        return url
+    }
+}

--- a/Tests/MacParakeetTests/STT/STTRuntimeDictationPadTests.swift
+++ b/Tests/MacParakeetTests/STT/STTRuntimeDictationPadTests.swift
@@ -50,15 +50,43 @@ final class STTRuntimeDictationPadTests: XCTestCase {
         )
         defer { try? FileManager.default.removeItem(at: url) }
 
-        let decoded = try STTRuntime.loadDictationSamples16k(path: url.path)
-        XCTAssertEqual(decoded.count, realSampleCount)
+        let decoded = STTRuntime.loadShortDictationSamples16k(path: url.path, maxSamples: ASRConstants.maxModelSamples)
+        XCTAssertEqual(decoded?.count, realSampleCount)
 
-        let padded = try STTRuntime.paddedDictationSamples(audioPath: url.path)
+        let padded = STTRuntime.paddedDictationSamples(audioPath: url.path)
         let expectedPad = Int(STTRuntime.dictationTrailingSilenceSeconds * Double(ASRConstants.sampleRate))
         XCTAssertEqual(padded.count, realSampleCount + expectedPad)
         XCTAssertTrue(padded.suffix(expectedPad).allSatisfy { $0 == 0 })
         // The real audio is preserved ahead of the silence.
         XCTAssertFalse(padded.prefix(realSampleCount).allSatisfy { $0 == 0 })
+    }
+
+    func testPaddedDictationSamplesFallsThroughWhenPadWouldExceedSingleWindow() throws {
+        // A clip whose padded length would cross the single-window limit must
+        // stay on FluidAudio's URL path instead of being loaded and padded in
+        // memory.
+        let padSamples = Int(STTRuntime.dictationTrailingSilenceSeconds * Double(ASRConstants.sampleRate))
+        let longSampleCount = ASRConstants.maxModelSamples - padSamples + 1
+        let url = try writeMonoFloatWav(
+            sampleCount: longSampleCount,
+            sampleRate: 16_000,
+            valueAt: { _ in 0.1 }
+        )
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        XCTAssertNotNil(STTRuntime.loadShortDictationSamples16k(path: url.path, maxSamples: ASRConstants.maxModelSamples))
+        XCTAssertNil(STTRuntime.loadShortDictationSamples16k(
+            path: url.path,
+            maxSamples: ASRConstants.maxModelSamples - padSamples
+        ))
+        XCTAssertTrue(STTRuntime.paddedDictationSamples(audioPath: url.path).isEmpty)
+    }
+
+    func testPaddedDictationSamplesIsEmptyForMissingFile() {
+        let missing = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(UUID().uuidString).wav")
+        XCTAssertTrue(STTRuntime.paddedDictationSamples(audioPath: missing.path).isEmpty)
+        XCTAssertNil(STTRuntime.loadShortDictationSamples16k(path: missing.path, maxSamples: ASRConstants.maxModelSamples))
     }
 
     // MARK: - helpers


### PR DESCRIPTION
## Problem

Closes #562. With the AI Formatter off (raw model output), a word spoken quickly right before stopping dictation is sometimes **missing from the transcript even though it is clearly present in the saved audio**. Examples from the issue: a sentence ending in "...gesprochen **wird?**" transcribed as "...gesprochen"; a ~1 s clip coming out as just "Yeah."

The capture is complete. The **Parakeet TDT decoder can drop the final token** when a short recording ends right on the last word because the transducer needs a few trailing encoder frames to emit it.

## Fix

Fix the **finalize step, not the mic**. For short Parakeet TDT dictation jobs, decode the recorded WAV to 16 kHz samples, append ~0.5 s of trailing silence in memory, and transcribe through the existing samples API (`manager.transcribe(_:decoderState:)`) instead of the URL path.

The pad path is deliberately bounded to clips whose padded length still fits FluidAudio's single-window tier. Longer dictations, file jobs, and meeting jobs keep the URL path so FluidAudio can preserve its streaming/disk-backed behavior.

### Scope
- **Only `job == .dictation` and Parakeet TDT single-window clips.**
- **Whisper is never padded** (trailing silence can trigger hallucinated text). Parakeet Unified and Nemotron are unaffected.
- **The saved WAV/history audio is untouched**; the pad exists only in memory.
- **Decode/pad preparation is best-effort**: unreadable, missing, empty, or too-long clips fall through to the URL path. Transcription errors propagate from whichever path runs.
- The padded path now emits the same coarse terminal progress callbacks (`0/100`, `100/100`) as the URL path.

## Tests
- Pure pad helper (`appendingTrailingSilence`): correct zero-padded tail, original preserved, no-op for empty / non-positive inputs.
- WAV decode + pad round-trip (`paddedDictationSamples` / `loadShortDictationSamples16k`) against a synthesized 16 kHz mono WAV.
- Boundary/fallback coverage for clips whose padded length would exceed `ASRConstants.maxModelSamples` and for missing files.
- Local full suite: `swift test --skip-build` passed (4028 XCTest tests, 10 skipped, 0 failures) plus 16 Swift Testing tests passed.

> Note: the CoreML Parakeet model cannot run in CI, so the tests cover the padding **mechanism**, not the WER outcome. The end-to-end "final word survives" behavior should still be confirmed against the reporter's real audio before release.

## Docs

Documents the dictation-vs-file divergence as an invariant in `STT/README.md` so it is not simplified back onto the shared URL path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dropped final words in dictation by padding ~0.5 s of trailing silence during finalize for Parakeet TDT, so fast end-of-utterance words are emitted. Addresses #562 without touching saved audio or other job types; applies to short dictations only.

- Bug Fixes
  - For `job == .dictation`, decode the recorded 16 kHz WAV to samples, append ~0.5 s silence, and transcribe via `manager.transcribe(_:decoderState:)` instead of `manager.transcribe(audioURL:)`; fires `onProgress` 0% and 100% on this path.
  - Scope: Parakeet TDT only; Whisper is never padded. Only for short, single-window clips (`ASRConstants.maxModelSamples`); longer dictations and file/meeting jobs stay on the URL path for streaming/constant memory.
  - Safe fallback: unreadable, missing, or too-long clips fall through to the URL path; transcription errors propagate from whichever path runs.
  - Tests/docs: unit tests for the pad helper, WAV decode+pad round-trip, long-clip fallthrough, and missing-file fallback; documented the dictation-specific finalize path and scope in `STT/README.md`.

<sup>Written for commit 8321fd7ab9c255d55cd3219766ffe2430cd6aab1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/615?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


