### PR TITLE
Add multiple Voice Return trigger phrases

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ You choose between two **processing modes**:
 
 1. **Filler removal** — Strips "um", "uh", and sentence-start fillers like "so", "well", "like"
 2. **Custom words** — Applies your word replacement rules (e.g., "aye pee eye" becomes "API", or "kubernetes" gets capitalized to "Kubernetes"). Case-insensitive, whole-word matching. Words can be toggled on/off without deleting.
-3. **Voice Return** — If you've defined a trigger phrase (e.g., "press return") and speak it at the end of a dictation, it's stripped from the output and a Return keypress is simulated after paste
+3. **Voice Return** — If you've defined one or more trigger phrases (e.g., "press return" or "zatwierdź") and speak one at the end of a dictation, it's stripped from the output and a Return keypress is simulated after paste
 4. **Snippet expansion** — Replaces short trigger phrases with longer text (e.g., "my signature" expands to "Best regards, David"). Triggers are natural language phrases because that's what the speech engine outputs. Matched longest-first to prevent collisions.
 5. **Whitespace cleanup** — Collapses spaces, fixes punctuation spacing, capitalizes the first letter
 

--- a/Sources/MacParakeet/App/AppEnvironment.swift
+++ b/Sources/MacParakeet/App/AppEnvironment.swift
@@ -203,8 +203,8 @@ final class AppEnvironment {
         }
         diarizationService = DiarizationService()
 
-        let voiceReturnTriggerClosure: @Sendable () -> String? = { [runtimePreferences] in
-            runtimePreferences.voiceReturnTrigger
+        let voiceReturnTriggersClosure: @Sendable () -> [String] = { [runtimePreferences] in
+            runtimePreferences.voiceReturnTriggers
         }
 
         // File/meeting transcripts gate the AI Formatter on BOTH the
@@ -270,7 +270,7 @@ final class AppEnvironment {
             entitlements: entitlementsService,
             customWordRepo: customWordRepo,
             snippetRepo: snippetRepo,
-            voiceReturnTrigger: voiceReturnTriggerClosure,
+            voiceReturnTriggers: voiceReturnTriggersClosure,
             processingMode: processingModeClosure,
             dictationInsertionStyle: dictationInsertionStyleClosure,
             llmService: llmService,

--- a/Sources/MacParakeet/Views/Vocabulary/VocabularyView.swift
+++ b/Sources/MacParakeet/Views/Vocabulary/VocabularyView.swift
@@ -235,17 +235,24 @@ struct VocabularyView: View {
                 }
 
                 if settingsViewModel.voiceReturnEnabled {
-                    VStack(alignment: .leading, spacing: DesignSystem.Spacing.xs) {
-                        Text("Trigger phrase")
+                    VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+                        Text("Trigger phrases")
                             .font(DesignSystem.Typography.caption)
                             .foregroundStyle(.secondary)
-                        ParakeetTextField(placeholder: "press return", text: $settingsViewModel.voiceReturnTrigger)
-                            .frame(maxWidth: 250)
-                        if settingsViewModel.voiceReturnTrigger.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                            Text("Enter a trigger phrase to activate Voice Return.")
+
+                        if settingsViewModel.voiceReturnTriggers.isEmpty {
+                            Text("Add at least one trigger phrase to activate Voice Return.")
                                 .font(DesignSystem.Typography.micro)
                                 .foregroundStyle(DesignSystem.Colors.warningAmber)
+                        } else {
+                            VStack(alignment: .leading, spacing: DesignSystem.Spacing.xs) {
+                                ForEach(Array(settingsViewModel.voiceReturnTriggers.enumerated()), id: \.element) { index, trigger in
+                                    voiceReturnTriggerRow(trigger: trigger, index: index)
+                                }
+                            }
                         }
+
+                        voiceReturnAddRow
                     }
 
                     VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
@@ -253,15 +260,18 @@ struct VocabularyView: View {
                             Image(systemName: "info.circle")
                                 .font(.system(size: 12, weight: .semibold))
                                 .foregroundStyle(.secondary)
-                            Text("Say your exact trigger phrase at the end of a dictation to simulate a Return keypress. The trigger must be the last words spoken — if it appears mid-sentence, it's pasted as normal text.")
+                            Text("Say any listed phrase at the end of a dictation to simulate a Return keypress. The trigger must be the last words spoken — if it appears mid-sentence, it's pasted as normal text.")
                                 .font(DesignSystem.Typography.caption)
                                 .foregroundStyle(.secondary)
                         }
 
-                        let trigger = settingsViewModel.voiceReturnTrigger.isEmpty ? "press return" : settingsViewModel.voiceReturnTrigger
+                        let trigger = settingsViewModel.voiceReturnExampleTrigger
                         VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
                             exampleRow(input: "git status \(trigger)", result: "Pastes \"git status\" + presses ⏎", fires: true)
                             exampleRow(input: "\(trigger)", result: "Just presses ⏎ (nothing to paste)", fires: true)
+                            if let secondaryTrigger = settingsViewModel.voiceReturnTriggers.dropFirst().first {
+                                exampleRow(input: "git status \(secondaryTrigger)", result: "Also presses ⏎", fires: true)
+                            }
                             exampleRow(input: "the \(trigger) was broken", result: "Pastes as-is — trigger is mid-sentence", fires: false)
                             exampleRow(input: "git status", result: "Pastes as-is — no trigger spoken", fires: false)
                         }
@@ -269,6 +279,68 @@ struct VocabularyView: View {
                     }
 
                 }
+            }
+        }
+    }
+
+    private func voiceReturnTriggerRow(trigger: String, index: Int) -> some View {
+        HStack(spacing: DesignSystem.Spacing.sm) {
+            Image(systemName: "return")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(.secondary)
+                .frame(width: 16)
+            Text(trigger)
+                .font(DesignSystem.Typography.caption.monospaced())
+                .foregroundStyle(.primary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+            Spacer(minLength: DesignSystem.Spacing.sm)
+            DeleteIconButton(
+                helpText: settingsViewModel.voiceReturnTriggers.count > 1
+                    ? "Remove trigger phrase"
+                    : "Voice Return needs at least one trigger phrase",
+                accessibilityName: "Remove \(trigger)"
+            ) {
+                settingsViewModel.deleteVoiceReturnTrigger(at: index)
+            }
+            .disabled(settingsViewModel.voiceReturnTriggers.count <= 1)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .frame(maxWidth: 360)
+        .background(
+            RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius)
+                .fill(DesignSystem.Colors.surfaceElevated)
+        )
+    }
+
+    private var voiceReturnAddRow: some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.xs) {
+            HStack(spacing: DesignSystem.Spacing.sm) {
+                ParakeetTextField(
+                    placeholder: "Add phrase",
+                    text: $settingsViewModel.voiceReturnNewTrigger,
+                    onSubmit: { settingsViewModel.addVoiceReturnTrigger() }
+                )
+                .frame(maxWidth: 250)
+
+                Button {
+                    settingsViewModel.addVoiceReturnTrigger()
+                } label: {
+                    Label("Add", systemImage: "plus")
+                }
+                .parakeetAction(.secondary)
+                .disabled(
+                    settingsViewModel.voiceReturnNewTrigger
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
+                        .isEmpty
+                )
+            }
+
+            if let message = settingsViewModel.voiceReturnErrorMessage {
+                Text(message)
+                    .font(DesignSystem.Typography.micro)
+                    .foregroundStyle(DesignSystem.Colors.warningAmber)
             }
         }
     }

--- a/Sources/MacParakeetCore/AppRuntimePreferences.swift
+++ b/Sources/MacParakeetCore/AppRuntimePreferences.swift
@@ -452,8 +452,33 @@ public enum MeetingAudioSourceMode: String, CaseIterable, Hashable, Sendable, Eq
     }
 }
 
+public enum VoiceReturnTriggerPhrases: Sendable {
+    public static let defaultTrigger = "press return"
+
+    public static func normalized(_ rawTriggers: [String]) -> [String] {
+        var seenKeys = Set<String>()
+        var triggers: [String] = []
+
+        for rawTrigger in rawTriggers {
+            let trigger = rawTrigger.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trigger.isEmpty else { continue }
+
+            let key = trigger.lowercased()
+            guard seenKeys.insert(key).inserted else { continue }
+            triggers.append(trigger)
+        }
+
+        return triggers
+    }
+
+    public static func normalizedOrDefault(_ rawTriggers: [String]) -> [String] {
+        let triggers = normalized(rawTriggers)
+        return triggers.isEmpty ? [defaultTrigger] : triggers
+    }
+}
+
 public final class UserDefaultsAppRuntimePreferences: AppRuntimePreferencesProtocol, @unchecked Sendable {
-    public static let defaultVoiceReturnTrigger = "press return"
+    public static let defaultVoiceReturnTrigger = VoiceReturnTriggerPhrases.defaultTrigger
     public static let showIdlePillKey = "showIdlePill"
     public static let silenceAutoStopKey = "silenceAutoStop"
     public static let silenceDelayKey = "silenceDelay"
@@ -506,28 +531,24 @@ public final class UserDefaultsAppRuntimePreferences: AppRuntimePreferencesProto
     }
 
     public static func normalizedVoiceReturnTriggers(_ rawTriggers: [String]) -> [String] {
-        var seenKeys = Set<String>()
-        var triggers: [String] = []
-
-        for rawTrigger in rawTriggers {
-            let trigger = rawTrigger.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !trigger.isEmpty else { continue }
-
-            let key = trigger.lowercased()
-            guard seenKeys.insert(key).inserted else { continue }
-            triggers.append(trigger)
-        }
-
-        return triggers
+        VoiceReturnTriggerPhrases.normalized(rawTriggers)
     }
 
     public static func voiceReturnTriggerList(defaults: UserDefaults = .standard) -> [String] {
         if defaults.object(forKey: voiceReturnTriggersKey) != nil {
-            return normalizedVoiceReturnTriggers(defaults.stringArray(forKey: voiceReturnTriggersKey) ?? [])
+            let triggers = VoiceReturnTriggerPhrases.normalized(
+                defaults.stringArray(forKey: voiceReturnTriggersKey) ?? []
+            )
+            if !triggers.isEmpty {
+                return triggers
+            }
         }
 
         if let legacyTrigger = defaults.string(forKey: voiceReturnTriggerKey) {
-            return normalizedVoiceReturnTriggers([legacyTrigger])
+            let triggers = VoiceReturnTriggerPhrases.normalized([legacyTrigger])
+            if !triggers.isEmpty {
+                return triggers
+            }
         }
 
         return [defaultVoiceReturnTrigger]

--- a/Sources/MacParakeetCore/AppRuntimePreferences.swift
+++ b/Sources/MacParakeetCore/AppRuntimePreferences.swift
@@ -3,6 +3,7 @@ import Foundation
 public protocol AppRuntimePreferencesProtocol: Sendable {
     var processingMode: Dictation.ProcessingMode { get }
     var dictationInsertionStyle: DictationInsertionStyle { get }
+    var voiceReturnTriggers: [String] { get }
     var voiceReturnTrigger: String? { get }
     var shouldSaveAudioRecordings: Bool { get }
     var shouldSaveDictationHistory: Bool { get }
@@ -452,11 +453,13 @@ public enum MeetingAudioSourceMode: String, CaseIterable, Hashable, Sendable, Eq
 }
 
 public final class UserDefaultsAppRuntimePreferences: AppRuntimePreferencesProtocol, @unchecked Sendable {
+    public static let defaultVoiceReturnTrigger = "press return"
     public static let showIdlePillKey = "showIdlePill"
     public static let silenceAutoStopKey = "silenceAutoStop"
     public static let silenceDelayKey = "silenceDelay"
     public static let voiceReturnEnabledKey = "voiceReturnEnabled"
     public static let voiceReturnTriggerKey = "voiceReturnTrigger"
+    public static let voiceReturnTriggersKey = "voiceReturnTriggers"
     public static let processingModeKey = "processingMode"
     public static let dictationInsertionStyleKey = "dictationInsertionStyle"
     public static let saveDictationHistoryKey = "saveDictationHistory"
@@ -502,6 +505,34 @@ public final class UserDefaultsAppRuntimePreferences: AppRuntimePreferencesProto
         self.defaults = defaults
     }
 
+    public static func normalizedVoiceReturnTriggers(_ rawTriggers: [String]) -> [String] {
+        var seenKeys = Set<String>()
+        var triggers: [String] = []
+
+        for rawTrigger in rawTriggers {
+            let trigger = rawTrigger.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trigger.isEmpty else { continue }
+
+            let key = trigger.lowercased()
+            guard seenKeys.insert(key).inserted else { continue }
+            triggers.append(trigger)
+        }
+
+        return triggers
+    }
+
+    public static func voiceReturnTriggerList(defaults: UserDefaults = .standard) -> [String] {
+        if defaults.object(forKey: voiceReturnTriggersKey) != nil {
+            return normalizedVoiceReturnTriggers(defaults.stringArray(forKey: voiceReturnTriggersKey) ?? [])
+        }
+
+        if let legacyTrigger = defaults.string(forKey: voiceReturnTriggerKey) {
+            return normalizedVoiceReturnTriggers([legacyTrigger])
+        }
+
+        return [defaultVoiceReturnTrigger]
+    }
+
     public var processingMode: Dictation.ProcessingMode {
         let raw = defaults.string(forKey: Self.processingModeKey)
         return Dictation.ProcessingMode(rawValue: raw ?? Dictation.ProcessingMode.raw.rawValue) ?? .raw
@@ -511,11 +542,13 @@ public final class UserDefaultsAppRuntimePreferences: AppRuntimePreferencesProto
         DictationInsertionStyle.current(defaults: defaults)
     }
 
+    public var voiceReturnTriggers: [String] {
+        guard defaults.bool(forKey: Self.voiceReturnEnabledKey) else { return [] }
+        return Self.voiceReturnTriggerList(defaults: defaults)
+    }
+
     public var voiceReturnTrigger: String? {
-        guard defaults.bool(forKey: Self.voiceReturnEnabledKey) else { return nil }
-        let trigger = (defaults.string(forKey: Self.voiceReturnTriggerKey) ?? "press return")
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        return trigger.isEmpty ? nil : trigger
+        voiceReturnTriggers.first
     }
 
     public var shouldSaveAudioRecordings: Bool {

--- a/Sources/MacParakeetCore/Services/Dictation/DictationService.swift
+++ b/Sources/MacParakeetCore/Services/Dictation/DictationService.swift
@@ -99,7 +99,7 @@ public actor DictationService: DictationServiceProtocol {
     private let entitlements: EntitlementsChecking?
     private let customWordRepo: CustomWordRepositoryProtocol?
     private let snippetRepo: TextSnippetRepositoryProtocol?
-    private let voiceReturnTrigger: @Sendable () -> String?
+    private let voiceReturnTriggers: @Sendable () -> [String]
     private let processingMode: @Sendable () -> Dictation.ProcessingMode
     private let dictationInsertionStyle: @Sendable () -> DictationInsertionStyle
     private let textRefinementService: TextRefinementService
@@ -158,6 +158,7 @@ public actor DictationService: DictationServiceProtocol {
         entitlements: EntitlementsChecking? = nil,
         customWordRepo: CustomWordRepositoryProtocol? = nil,
         snippetRepo: TextSnippetRepositoryProtocol? = nil,
+        voiceReturnTriggers: (@Sendable () -> [String])? = nil,
         voiceReturnTrigger: (@Sendable () -> String?)? = nil,
         processingMode: (@Sendable () -> Dictation.ProcessingMode)? = nil,
         dictationInsertionStyle: (@Sendable () -> DictationInsertionStyle)? = nil,
@@ -183,7 +184,16 @@ public actor DictationService: DictationServiceProtocol {
         self.entitlements = entitlements
         self.customWordRepo = customWordRepo
         self.snippetRepo = snippetRepo
-        self.voiceReturnTrigger = voiceReturnTrigger ?? { nil }
+        if let voiceReturnTriggers {
+            self.voiceReturnTriggers = voiceReturnTriggers
+        } else if let voiceReturnTrigger {
+            self.voiceReturnTriggers = {
+                guard let trigger = voiceReturnTrigger() else { return [] }
+                return [trigger]
+            }
+        } else {
+            self.voiceReturnTriggers = { [] }
+        }
         self.processingMode = processingMode ?? { .raw }
         self.dictationInsertionStyle = dictationInsertionStyle ?? { .sentence }
         self.textRefinementService = TextRefinementService()
@@ -1177,7 +1187,7 @@ public actor DictationService: DictationServiceProtocol {
 
         // Voice Return: inject synthetic action snippet regardless of mode
         // (raw mode extracts trailing action without running the full pipeline)
-        if let trigger = voiceReturnTrigger(), !trigger.isEmpty {
+        for trigger in UserDefaultsAppRuntimePreferences.normalizedVoiceReturnTriggers(voiceReturnTriggers()) {
             snippets.append(TextSnippet(
                 trigger: trigger,
                 expansion: KeyAction.returnKey.label,

--- a/Sources/MacParakeetCore/Services/Dictation/DictationService.swift
+++ b/Sources/MacParakeetCore/Services/Dictation/DictationService.swift
@@ -1187,7 +1187,7 @@ public actor DictationService: DictationServiceProtocol {
 
         // Voice Return: inject synthetic action snippet regardless of mode
         // (raw mode extracts trailing action without running the full pipeline)
-        for trigger in UserDefaultsAppRuntimePreferences.normalizedVoiceReturnTriggers(voiceReturnTriggers()) {
+        for trigger in VoiceReturnTriggerPhrases.normalized(voiceReturnTriggers()) {
             snippets.append(TextSnippet(
                 trigger: trigger,
                 expansion: KeyAction.returnKey.label,

--- a/Sources/MacParakeetCore/TextProcessing/TextProcessingPipeline.swift
+++ b/Sources/MacParakeetCore/TextProcessing/TextProcessingPipeline.swift
@@ -113,11 +113,11 @@ public struct TextProcessingPipeline: Sendable {
             .sorted { $0.trigger.count > $1.trigger.count }
 
         for snippet in sorted {
-            // Punctuation-tolerant: match trigger at end with optional trailing punctuation.
+            // Punctuation-tolerant: match a separate trigger at end with optional trailing Unicode punctuation.
             // Normalize literal spaces to \s+ so filler removal gaps (double spaces) still match.
             let escaped = NSRegularExpression.escapedPattern(for: snippet.trigger)
             let spaceNormalized = escaped.replacingOccurrences(of: " ", with: "\\s+")
-            let pattern = "\\b\(spaceNormalized)[.!?,;:]*\\s*$"
+            let pattern = "(?<!\\S)\(spaceNormalized)\\p{P}*\\s*$"
             guard let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive) else {
                 continue
             }

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -282,8 +282,58 @@ public final class SettingsViewModel {
             Telemetry.send(.settingChanged(setting: .voiceReturn))
         }
     }
+    public private(set) var voiceReturnTriggers: [String]
+    public var voiceReturnNewTrigger = "" {
+        didSet {
+            if voiceReturnNewTrigger != oldValue {
+                voiceReturnErrorMessage = nil
+            }
+        }
+    }
+    public var voiceReturnErrorMessage: String?
     public var voiceReturnTrigger: String {
-        didSet { defaults.set(voiceReturnTrigger, forKey: UserDefaultsAppRuntimePreferences.voiceReturnTriggerKey) }
+        get { voiceReturnTriggers.first ?? "" }
+        set { setVoiceReturnTriggers([newValue]) }
+    }
+
+    public var voiceReturnExampleTrigger: String {
+        voiceReturnTriggers.first ?? UserDefaultsAppRuntimePreferences.defaultVoiceReturnTrigger
+    }
+
+    public func addVoiceReturnTrigger() {
+        let normalized = UserDefaultsAppRuntimePreferences.normalizedVoiceReturnTriggers([voiceReturnNewTrigger])
+        guard let trigger = normalized.first else {
+            voiceReturnErrorMessage = "Enter a trigger phrase."
+            return
+        }
+        guard !voiceReturnTriggers.contains(where: { $0.caseInsensitiveCompare(trigger) == .orderedSame }) else {
+            voiceReturnErrorMessage = "That trigger phrase is already in the list."
+            return
+        }
+
+        setVoiceReturnTriggers(voiceReturnTriggers + [trigger])
+        voiceReturnNewTrigger = ""
+        voiceReturnErrorMessage = nil
+    }
+
+    public func deleteVoiceReturnTrigger(at index: Int) {
+        guard voiceReturnTriggers.indices.contains(index) else { return }
+        guard voiceReturnTriggers.count > 1 else {
+            voiceReturnErrorMessage = "Voice Return needs at least one trigger phrase."
+            return
+        }
+
+        var updated = voiceReturnTriggers
+        updated.remove(at: index)
+        setVoiceReturnTriggers(updated)
+        voiceReturnErrorMessage = nil
+    }
+
+    private func setVoiceReturnTriggers(_ rawTriggers: [String]) {
+        let normalized = UserDefaultsAppRuntimePreferences.normalizedVoiceReturnTriggers(rawTriggers)
+        voiceReturnTriggers = normalized
+        defaults.set(normalized, forKey: UserDefaultsAppRuntimePreferences.voiceReturnTriggersKey)
+        defaults.set(normalized.first ?? "", forKey: UserDefaultsAppRuntimePreferences.voiceReturnTriggerKey)
     }
 
     // Processing
@@ -646,7 +696,7 @@ public final class SettingsViewModel {
         dictationPreviewTextSize = DictationPreviewTextSize.current(defaults: defaults)
         dictationUndoCountdown = DictationUndoCountdown.current(defaults: defaults)
         voiceReturnEnabled = defaults.bool(forKey: UserDefaultsAppRuntimePreferences.voiceReturnEnabledKey)
-        voiceReturnTrigger = defaults.string(forKey: UserDefaultsAppRuntimePreferences.voiceReturnTriggerKey) ?? "press return"
+        voiceReturnTriggers = UserDefaultsAppRuntimePreferences.voiceReturnTriggerList(defaults: defaults)
         processingMode = Self.normalizedProcessingMode(defaults.string(forKey: UserDefaultsAppRuntimePreferences.processingModeKey))
         dictationInsertionStyle = DictationInsertionStyle.current(defaults: defaults)
         saveDictationHistory = defaults.object(forKey: UserDefaultsAppRuntimePreferences.saveDictationHistoryKey) as? Bool ?? true

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -297,11 +297,11 @@ public final class SettingsViewModel {
     }
 
     public var voiceReturnExampleTrigger: String {
-        voiceReturnTriggers.first ?? UserDefaultsAppRuntimePreferences.defaultVoiceReturnTrigger
+        voiceReturnTriggers.first ?? VoiceReturnTriggerPhrases.defaultTrigger
     }
 
     public func addVoiceReturnTrigger() {
-        let normalized = UserDefaultsAppRuntimePreferences.normalizedVoiceReturnTriggers([voiceReturnNewTrigger])
+        let normalized = VoiceReturnTriggerPhrases.normalized([voiceReturnNewTrigger])
         guard let trigger = normalized.first else {
             voiceReturnErrorMessage = "Enter a trigger phrase."
             return
@@ -330,10 +330,10 @@ public final class SettingsViewModel {
     }
 
     private func setVoiceReturnTriggers(_ rawTriggers: [String]) {
-        let normalized = UserDefaultsAppRuntimePreferences.normalizedVoiceReturnTriggers(rawTriggers)
+        let normalized = VoiceReturnTriggerPhrases.normalizedOrDefault(rawTriggers)
         voiceReturnTriggers = normalized
         defaults.set(normalized, forKey: UserDefaultsAppRuntimePreferences.voiceReturnTriggersKey)
-        defaults.set(normalized.first ?? "", forKey: UserDefaultsAppRuntimePreferences.voiceReturnTriggerKey)
+        defaults.set(normalized.first, forKey: UserDefaultsAppRuntimePreferences.voiceReturnTriggerKey)
     }
 
     // Processing

--- a/Tests/MacParakeetTests/AppRuntimePreferencesTests.swift
+++ b/Tests/MacParakeetTests/AppRuntimePreferencesTests.swift
@@ -39,6 +39,50 @@ final class AppRuntimePreferencesTests: XCTestCase {
         XCTAssertTrue(preferences.shouldKeepDictationOnClipboard)
     }
 
+    func testVoiceReturnTriggersAreDisabledWhenToggleIsOff() {
+        let suite = "app-runtime-prefs-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.set(["press return"], forKey: UserDefaultsAppRuntimePreferences.voiceReturnTriggersKey)
+
+        let preferences = UserDefaultsAppRuntimePreferences(defaults: defaults)
+        XCTAssertEqual(preferences.voiceReturnTriggers, [])
+        XCTAssertNil(preferences.voiceReturnTrigger)
+    }
+
+    func testVoiceReturnTriggersDefaultWhenEnabledWithoutStoredValue() {
+        let suite = "app-runtime-prefs-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.set(true, forKey: UserDefaultsAppRuntimePreferences.voiceReturnEnabledKey)
+
+        let preferences = UserDefaultsAppRuntimePreferences(defaults: defaults)
+        XCTAssertEqual(preferences.voiceReturnTriggers, [UserDefaultsAppRuntimePreferences.defaultVoiceReturnTrigger])
+        XCTAssertEqual(preferences.voiceReturnTrigger, UserDefaultsAppRuntimePreferences.defaultVoiceReturnTrigger)
+    }
+
+    func testVoiceReturnTriggersReadLegacySingleTrigger() {
+        let suite = "app-runtime-prefs-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.set(true, forKey: UserDefaultsAppRuntimePreferences.voiceReturnEnabledKey)
+        defaults.set(" zatwierdź ", forKey: UserDefaultsAppRuntimePreferences.voiceReturnTriggerKey)
+
+        let preferences = UserDefaultsAppRuntimePreferences(defaults: defaults)
+        XCTAssertEqual(preferences.voiceReturnTriggers, ["zatwierdź"])
+        XCTAssertEqual(preferences.voiceReturnTrigger, "zatwierdź")
+    }
+
+    func testVoiceReturnTriggersNormalizeStoredList() {
+        let suite = "app-runtime-prefs-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.set(true, forKey: UserDefaultsAppRuntimePreferences.voiceReturnEnabledKey)
+        defaults.set(
+            [" press return ", "PRESS RETURN", "", "zatwierdź"],
+            forKey: UserDefaultsAppRuntimePreferences.voiceReturnTriggersKey
+        )
+
+        let preferences = UserDefaultsAppRuntimePreferences(defaults: defaults)
+        XCTAssertEqual(preferences.voiceReturnTriggers, ["press return", "zatwierdź"])
+    }
+
     func testDictationUndoCountdownDefaultsToFiveSeconds() {
         let preferences = makePreferences()
         XCTAssertEqual(preferences.dictationUndoCountdown, .fiveSeconds)

--- a/Tests/MacParakeetTests/AppRuntimePreferencesTests.swift
+++ b/Tests/MacParakeetTests/AppRuntimePreferencesTests.swift
@@ -83,6 +83,28 @@ final class AppRuntimePreferencesTests: XCTestCase {
         XCTAssertEqual(preferences.voiceReturnTriggers, ["press return", "zatwierdź"])
     }
 
+    func testVoiceReturnTriggersFallBackToLegacyWhenStoredListNormalizesEmpty() {
+        let suite = "app-runtime-prefs-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.set(true, forKey: UserDefaultsAppRuntimePreferences.voiceReturnEnabledKey)
+        defaults.set([" ", ""], forKey: UserDefaultsAppRuntimePreferences.voiceReturnTriggersKey)
+        defaults.set(" zatwierdź ", forKey: UserDefaultsAppRuntimePreferences.voiceReturnTriggerKey)
+
+        let preferences = UserDefaultsAppRuntimePreferences(defaults: defaults)
+        XCTAssertEqual(preferences.voiceReturnTriggers, ["zatwierdź"])
+    }
+
+    func testVoiceReturnTriggersFallBackToDefaultWhenStoredValuesNormalizeEmpty() {
+        let suite = "app-runtime-prefs-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.set(true, forKey: UserDefaultsAppRuntimePreferences.voiceReturnEnabledKey)
+        defaults.set([" ", ""], forKey: UserDefaultsAppRuntimePreferences.voiceReturnTriggersKey)
+        defaults.set(" ", forKey: UserDefaultsAppRuntimePreferences.voiceReturnTriggerKey)
+
+        let preferences = UserDefaultsAppRuntimePreferences(defaults: defaults)
+        XCTAssertEqual(preferences.voiceReturnTriggers, [UserDefaultsAppRuntimePreferences.defaultVoiceReturnTrigger])
+    }
+
     func testDictationUndoCountdownDefaultsToFiveSeconds() {
         let preferences = makePreferences()
         XCTAssertEqual(preferences.dictationUndoCountdown, .fiveSeconds)

--- a/Tests/MacParakeetTests/Services/Dictation/DictationServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/Dictation/DictationServiceTests.swift
@@ -310,6 +310,23 @@ final class DictationServiceTests: XCTestCase {
         XCTAssertEqual(operation["language"], "ko")
     }
 
+    func testStopRecordingInjectsMultipleVoiceReturnTriggersInRawMode() async throws {
+        await mockSTT.configure(result: STTResult(text: "git status zatwierdź"))
+        service = DictationService(
+            audioProcessor: mockAudio,
+            sttTranscriber: mockSTT,
+            dictationRepo: dictationRepo,
+            voiceReturnTriggers: { ["press return", "zatwierdź"] }
+        )
+
+        try await service.startRecording()
+        let result = try await service.stopRecording()
+
+        XCTAssertEqual(result.dictation.rawTranscript, "git status zatwierdź")
+        XCTAssertEqual(result.dictation.cleanTranscript, "git status")
+        XCTAssertEqual(result.postPasteAction, .returnKey)
+    }
+
     func testSilentCaptureHealthFailsBeforeSTTAndEmitsFailureTelemetry() async throws {
         let telemetry = DictationTelemetrySpy()
         Telemetry.configure(telemetry)

--- a/Tests/MacParakeetTests/TextProcessing/TextProcessingPipelineTests.swift
+++ b/Tests/MacParakeetTests/TextProcessing/TextProcessingPipelineTests.swift
@@ -455,6 +455,48 @@ final class TextProcessingPipelineTests: XCTestCase {
         XCTAssertEqual(result.postPasteAction, .returnKey)
     }
 
+    func testActionSnippetWithUnicodeTrailingPunctuation() {
+        let snippets = [
+            TextSnippet(trigger: "zatwierdź", expansion: "return", action: .returnKey)
+        ]
+        let result = pipeline.process(text: "git status zatwierdź！", customWords: [], snippets: snippets)
+        XCTAssertEqual(result.text, "Git status")
+        XCTAssertEqual(result.postPasteAction, .returnKey)
+    }
+
+    func testActionSnippetRequiresSeparateTerminalPhrase() {
+        let snippets = [
+            TextSnippet(trigger: "return", expansion: "return", action: .returnKey)
+        ]
+        let result = pipeline.process(text: "hello pre-return", customWords: [], snippets: snippets)
+        XCTAssertEqual(result.text, "Hello pre-return")
+        XCTAssertNil(result.postPasteAction)
+    }
+
+    func testActionSnippetSupportsPunctuationPrefixedTrigger() {
+        let snippets = [
+            TextSnippet(trigger: "/return", expansion: "return", action: .returnKey)
+        ]
+        let result = pipeline.process(text: "git status /return", customWords: [], snippets: snippets)
+        XCTAssertEqual(result.text, "Git status")
+        XCTAssertEqual(result.postPasteAction, .returnKey)
+    }
+
+    func testMultipleActionSnippetTriggersUseAnyTerminalPhrase() {
+        let snippets = [
+            TextSnippet(trigger: "press return", expansion: "return", action: .returnKey),
+            TextSnippet(trigger: "zatwierdź", expansion: "return", action: .returnKey),
+        ]
+
+        let english = pipeline.process(text: "git status press return", customWords: [], snippets: snippets)
+        XCTAssertEqual(english.text, "Git status")
+        XCTAssertEqual(english.postPasteAction, .returnKey)
+
+        let polish = pipeline.process(text: "git status zatwierdź", customWords: [], snippets: snippets)
+        XCTAssertEqual(polish.text, "Git status")
+        XCTAssertEqual(polish.postPasteAction, .returnKey)
+    }
+
     func testActionSnippetTracksExpandedID() {
         let snippet = TextSnippet(trigger: "return", expansion: "return", action: .returnKey)
         let result = pipeline.process(text: "hello return", customWords: [], snippets: [snippet])

--- a/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
@@ -172,6 +172,20 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.voiceReturnErrorMessage, "Voice Return needs at least one trigger phrase.")
     }
 
+    func testLegacyVoiceReturnTriggerSetterPersistsDefaultForBlankPhrase() {
+        viewModel.voiceReturnTrigger = "   "
+
+        XCTAssertEqual(viewModel.voiceReturnTriggers, [UserDefaultsAppRuntimePreferences.defaultVoiceReturnTrigger])
+        XCTAssertEqual(
+            testDefaults.stringArray(forKey: UserDefaultsAppRuntimePreferences.voiceReturnTriggersKey),
+            [UserDefaultsAppRuntimePreferences.defaultVoiceReturnTrigger]
+        )
+        XCTAssertEqual(
+            testDefaults.string(forKey: UserDefaultsAppRuntimePreferences.voiceReturnTriggerKey),
+            UserDefaultsAppRuntimePreferences.defaultVoiceReturnTrigger
+        )
+    }
+
     // MARK: - Whisper cold/warm status
 
     func testWhisperHasBeenOptimizedReflectsPersistedFlag() {

--- a/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
@@ -115,6 +115,63 @@ final class SettingsViewModelTests: XCTestCase {
         testDefaultsSuiteName = nil
     }
 
+    // MARK: - Voice Return
+
+    func testVoiceReturnTriggersLoadLegacySingleTrigger() {
+        testDefaults.set(" zatwierdź ", forKey: UserDefaultsAppRuntimePreferences.voiceReturnTriggerKey)
+
+        let vm = SettingsViewModel(defaults: testDefaults)
+
+        XCTAssertEqual(vm.voiceReturnTriggers, ["zatwierdź"])
+        XCTAssertEqual(vm.voiceReturnTrigger, "zatwierdź")
+    }
+
+    func testAddVoiceReturnTriggerTrimsPersistsAndSyncsLegacyKey() {
+        viewModel.voiceReturnNewTrigger = " zatwierdź "
+
+        viewModel.addVoiceReturnTrigger()
+
+        XCTAssertEqual(viewModel.voiceReturnTriggers, ["press return", "zatwierdź"])
+        XCTAssertEqual(
+            testDefaults.stringArray(forKey: UserDefaultsAppRuntimePreferences.voiceReturnTriggersKey),
+            ["press return", "zatwierdź"]
+        )
+        XCTAssertEqual(
+            testDefaults.string(forKey: UserDefaultsAppRuntimePreferences.voiceReturnTriggerKey),
+            "press return"
+        )
+        XCTAssertEqual(viewModel.voiceReturnNewTrigger, "")
+        XCTAssertNil(viewModel.voiceReturnErrorMessage)
+    }
+
+    func testAddVoiceReturnTriggerRejectsDuplicateCaseInsensitivePhrase() {
+        viewModel.voiceReturnNewTrigger = " PRESS RETURN "
+
+        viewModel.addVoiceReturnTrigger()
+
+        XCTAssertEqual(viewModel.voiceReturnTriggers, ["press return"])
+        XCTAssertEqual(viewModel.voiceReturnErrorMessage, "That trigger phrase is already in the list.")
+    }
+
+    func testDeleteVoiceReturnTriggerPersistsAndKeepsAtLeastOnePhrase() {
+        viewModel.voiceReturnNewTrigger = "zatwierdź"
+        viewModel.addVoiceReturnTrigger()
+
+        viewModel.deleteVoiceReturnTrigger(at: 0)
+
+        XCTAssertEqual(viewModel.voiceReturnTriggers, ["zatwierdź"])
+        XCTAssertEqual(
+            testDefaults.stringArray(forKey: UserDefaultsAppRuntimePreferences.voiceReturnTriggersKey),
+            ["zatwierdź"]
+        )
+        XCTAssertEqual(testDefaults.string(forKey: UserDefaultsAppRuntimePreferences.voiceReturnTriggerKey), "zatwierdź")
+
+        viewModel.deleteVoiceReturnTrigger(at: 0)
+
+        XCTAssertEqual(viewModel.voiceReturnTriggers, ["zatwierdź"])
+        XCTAssertEqual(viewModel.voiceReturnErrorMessage, "Voice Return needs at least one trigger phrase.")
+    }
+
     // MARK: - Whisper cold/warm status
 
     func testWhisperHasBeenOptimizedReflectsPersistedFlag() {

--- a/spec/02-features.md
+++ b/spec/02-features.md
@@ -810,7 +810,7 @@ Each custom word is a `(word, replacement)` pair with an enabled/disabled toggle
 
 **Step 3: Trailing action extraction**
 
-Action snippets with a terminal trigger phrase are stripped from the transcript and returned as a post-paste action. This is how Voice Return can press Return after paste without leaving the trigger text in the output. Raw mode skips full cleanup but still performs terminal action extraction.
+Action snippets with a terminal trigger phrase are stripped from the transcript and returned as a post-paste action. This is how Voice Return can press Return after paste without leaving the trigger text in the output. Voice Return can expose multiple user-configured phrases that all map to the same Return action. Raw mode skips full cleanup but still performs terminal action extraction.
 
 **Step 4: Snippet expansion**
 

--- a/spec/07-text-processing.md
+++ b/spec/07-text-processing.md
@@ -50,9 +50,10 @@ matching logic lives in `CustomWordReplacer`; the meeting entry point is
 
 ### Step 3: Trailing Action Extraction
 
-If the user's text ends with an enabled action-snippet trigger, the trigger is stripped and the action is returned through `TextProcessingResult.postPasteAction`. This is how Voice Return-style behavior can simulate Return after paste without leaving "press return" in the transcript.
+If the user's text ends with an enabled action-snippet trigger, the trigger is stripped and the action is returned through `TextProcessingResult.postPasteAction`. This is how Voice Return-style behavior can simulate Return after paste without leaving a configured trigger phrase such as "press return" or "zatwierdź" in the transcript.
 
 - Action snippets are matched longest-first, case-insensitive, and punctuation-tolerant at the end of the text.
+- Voice Return can inject multiple configured trigger phrases for the same Return action.
 - Extraction happens before normal snippet expansion so a plain snippet cannot consume or rewrite the action trigger.
 - Raw mode skips the full clean pipeline, but still performs this terminal action extraction so Voice Return works in both Raw and Clean.
 

--- a/spec/adr/004-deterministic-pipeline.md
+++ b/spec/adr/004-deterministic-pipeline.md
@@ -78,7 +78,7 @@ The deterministic pipeline includes two user-configurable features:
 
 - **Custom words**: Users define vocabulary anchors (ensure "PostgreSQL" not "post gress q l") and corrections (always replace "kube" with "Kubernetes"). These are predictable and immediate.
 - **Text snippets**: Users define natural language trigger phrases ("my address" expands to their full address, "my signature" expands to their email sign-off). Triggers are spoken phrases — not abbreviations — because STT outputs natural speech. These are instant and deterministic.
-- **Trailing action snippets**: Users can attach a post-paste action such as Voice Return to a terminal trigger phrase. The pipeline strips the trigger before normal snippet expansion and surfaces the action to the paste layer.
+- **Trailing action snippets**: Users can attach a post-paste action such as Voice Return to one or more terminal trigger phrases. The pipeline strips the trigger before normal snippet expansion and surfaces the action to the paste layer.
 
 An LLM-based approach would require prompt engineering to respect user-defined words and snippets, with no guarantee of compliance.
 


### PR DESCRIPTION
## Summary
- Add a persisted Voice Return trigger phrase list with legacy single-trigger fallback.
- Update the Vocabulary UI to add/remove trigger phrases while keeping at least one phrase.
- Inject all configured phrases into Voice Return action extraction, including Raw mode.
- Tighten terminal matching so separate terminal phrases trigger Return while mid-word suffixes do not.
- Update feature and pipeline docs.

Closes #607

## Screenshots / Recordings

PR build launch smoke:

![MacParakeet Dev idle pill](https://files.catbox.moe/jv2jwd.png)

Voice Return generated-speech smoke:

- [Generated WAV: "test one two press enter"](https://files.catbox.moe/2l56ee.wav)
- [Smoke notes and exact commands](https://gist.github.com/moona3k/08a194d581f5a6bb62ded0a5054838ed)

The generated recording transcribed through Parakeet Unified as:

```text
Test 1-2 press Enter.
```

Note: the screenshot only proves the PR dev app launched. I could not capture the Vocabulary screen or record a full Terminal/cmux dictation run from this agent session because macOS assistive access was not available for driving app menus/windows. The deterministic Return command path is covered by focused unit/integration tests below.

## Verification
- Live PR state checked at head `cd5aebbf18123d2821047423dce481cdddef5679`.
- GitHub CI is green: two `swift-test` checks passed, plus the cubic review check passed.
- Prior automated review feedback was rechecked and addressed:
  - Gemini's SwiftUI identity feedback is fixed with stable element identity.
  - cubic's empty/corrupt trigger-list fallback findings are fixed.
  - Greptile's concrete-preferences coupling concern is fixed by using the shared trigger normalization helper.
- Local runtime smoke:
  - Built and launched `MacParakeet-Dev.app` from this PR head.
  - `swift run macparakeet-cli health` passed.
  - Generated machine-voice audio was transcribed by the real local Parakeet Unified path.

## Tests
- `git diff --check`
- `swift test --filter AppRuntimePreferencesTests`
- `swift test --filter TextProcessingPipelineTests`
- `swift test --filter SettingsViewModelTests`
- `swift test --filter DictationServiceTests/testStopRecordingInjectsMultipleVoiceReturnTriggersInRawMode`
- `swift test --filter TextRefinementServiceTests`
- `swift test`

Full local suite result: `4044` tests, `10` skipped, `0` failures.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add support for multiple Voice Return trigger phrases managed in Vocabulary, with a robust fallback and persistence flow. We inject all phrases into action extraction (including Raw mode) and tighten end-of-text matching.

- **New Features**
  - Persist a trigger phrase list with default "press return"; normalize/dedupe; read legacy single-trigger and keep it in sync (first phrase); disabled when Voice Return is off; fall back to legacy or default when stored lists normalize empty/corrupt.
  - Vocabulary UI to list/add/remove phrases; requires at least one; inline validation for empty/duplicates; updated examples (shows secondary phrase).
  - Dictation injects all configured triggers as action snippets; works in Raw and Clean modes; backward-compatible if only the legacy trigger is present.
  - Terminal matching is Unicode-punctuation tolerant and requires a separate terminal phrase (e.g., matches "/return", not "pre-return").

<sup>Written for commit cd5aebbf18123d2821047423dce481cdddef5679. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
