### PR TITLE
Gate releases on the Sparkle update-signature trust anchor

### DIFF
--- a/scripts/dist/build_app_bundle.sh
+++ b/scripts/dist/build_app_bundle.sh
@@ -537,6 +537,14 @@ echo "Bundled legal notices: $LEGAL_DIR"
 
 echo "[3/4] Writing Info.plist…"
 INFO_PLIST="$CONTENTS_DIR/Info.plist"
+# Sparkle auto-update trust anchor (issue #564, finding S-3). The public EdDSA
+# key MUST ship non-empty in Info.plist or Sparkle 2.x cannot verify update
+# signatures, and the feed MUST be HTTPS so the appcast itself can't be
+# tampered with in transit. These are the single source of truth for the
+# values written below; the release gate after the plist is written reads them
+# back from the artifact and refuses to ship if they drift or go missing.
+SU_PUBLIC_ED_KEY="2aqRU0Agz+xxZwt0kLybmKz/SAvZUsyn+z9fU0I6ynY="
+SU_FEED_URL="https://macparakeet.com/appcast.xml"
 CHECKOUT_URL="${MACPARAKEET_CHECKOUT_URL:-}"
 LS_VARIANT_ID="${MACPARAKEET_LS_VARIANT_ID:-}"
 LICENSING_PLIST=""
@@ -590,15 +598,39 @@ cat >"$INFO_PLIST" <<EOF
   <key>NSCalendarsFullAccessUsageDescription</key>
   <string>MacParakeet reads your calendar so it can remind you before a meeting starts and (optionally) begin recording for you. Events stay on your Mac.</string>
   <key>SUFeedURL</key>
-  <string>https://macparakeet.com/appcast.xml</string>
+  <string>${SU_FEED_URL}</string>
   <key>SUEnableAutomaticChecks</key>
   <true/>
   <key>SUPublicEDKey</key>
-  <string>2aqRU0Agz+xxZwt0kLybmKz/SAvZUsyn+z9fU0I6ynY=</string>
+  <string>${SU_PUBLIC_ED_KEY}</string>
 $(printf "%b" "$LICENSING_PLIST")
 </dict>
 </plist>
 EOF
+
+# Release gate: prove the Sparkle auto-update trust anchor actually shipped
+# (issue #564, finding S-3). A missing or empty SUPublicEDKey would let Sparkle
+# accept an unsigned update, and a non-HTTPS feed would let the appcast itself
+# be MITM'd — both are silent failures the user only discovers when a malicious
+# update lands. Read the values back from the written plist (not the variables)
+# so a malformed plist or a future heredoc refactor that drops the keys fails
+# the build loudly instead of shipping a defenseless updater.
+echo "Verifying Sparkle update-signature trust anchor…"
+WRITTEN_ED_KEY="$(/usr/libexec/PlistBuddy -c 'Print :SUPublicEDKey' "$INFO_PLIST" 2>/dev/null || true)"
+WRITTEN_FEED_URL="$(/usr/libexec/PlistBuddy -c 'Print :SUFeedURL' "$INFO_PLIST" 2>/dev/null || true)"
+if [[ -z "$WRITTEN_ED_KEY" ]]; then
+  echo "FATAL: SUPublicEDKey is missing or empty in $INFO_PLIST — Sparkle could not verify update signatures. Refusing to ship." >&2
+  exit 1
+fi
+if [[ "$WRITTEN_ED_KEY" != "$SU_PUBLIC_ED_KEY" ]]; then
+  echo "FATAL: SUPublicEDKey in $INFO_PLIST does not match the expected release key. Refusing to ship." >&2
+  exit 1
+fi
+if [[ "$WRITTEN_FEED_URL" != https://* ]]; then
+  echo "FATAL: SUFeedURL is not HTTPS ('$WRITTEN_FEED_URL') — the appcast could be MITM'd. Refusing to ship." >&2
+  exit 1
+fi
+echo "Sparkle trust anchor OK: SUPublicEDKey present and matches, feed is HTTPS."
 
 # Archive dSYM for crash symbolication.
 #

--- a/scripts/dist/build_app_bundle.sh
+++ b/scripts/dist/build_app_bundle.sh
@@ -540,11 +540,18 @@ INFO_PLIST="$CONTENTS_DIR/Info.plist"
 # Sparkle auto-update trust anchor (issue #564, finding S-3). The public EdDSA
 # key MUST ship non-empty in Info.plist or Sparkle 2.x cannot verify update
 # signatures, and the feed MUST be HTTPS so the appcast itself can't be
-# tampered with in transit. These are the single source of truth for the
-# values written below; the release gate after the plist is written reads them
+# tampered with in transit. SU_PUBLIC_ED_KEY / SU_FEED_URL are the values
+# written into the plist below; the release gate after the write reads them
 # back from the artifact and refuses to ship if they drift or go missing.
 SU_PUBLIC_ED_KEY="2aqRU0Agz+xxZwt0kLybmKz/SAvZUsyn+z9fU0I6ynY="
 SU_FEED_URL="https://macparakeet.com/appcast.xml"
+# Expected key the gate asserts the written plist actually carries. Deliberately
+# a second, independent copy: verifying the artifact against the same variable
+# used to write it would pass even if that variable were edited to a wrong
+# value, so the trust anchor is pinned in two places. A real key rotation must
+# update BOTH — the build fails until they agree, which is the intended
+# confirmation step.
+EXPECTED_SU_PUBLIC_ED_KEY="2aqRU0Agz+xxZwt0kLybmKz/SAvZUsyn+z9fU0I6ynY="
 CHECKOUT_URL="${MACPARAKEET_CHECKOUT_URL:-}"
 LS_VARIANT_ID="${MACPARAKEET_LS_VARIANT_ID:-}"
 LICENSING_PLIST=""
@@ -622,8 +629,12 @@ if [[ -z "$WRITTEN_ED_KEY" ]]; then
   echo "FATAL: SUPublicEDKey is missing or empty in $INFO_PLIST — Sparkle could not verify update signatures. Refusing to ship." >&2
   exit 1
 fi
-if [[ "$WRITTEN_ED_KEY" != "$SU_PUBLIC_ED_KEY" ]]; then
+if [[ "$WRITTEN_ED_KEY" != "$EXPECTED_SU_PUBLIC_ED_KEY" ]]; then
   echo "FATAL: SUPublicEDKey in $INFO_PLIST does not match the expected release key. Refusing to ship." >&2
+  exit 1
+fi
+if [[ -z "$WRITTEN_FEED_URL" ]]; then
+  echo "FATAL: SUFeedURL is missing or empty in $INFO_PLIST — Sparkle has no appcast to check. Refusing to ship." >&2
   exit 1
 fi
 if [[ "$WRITTEN_FEED_URL" != https://* ]]; then


### PR DESCRIPTION
## What

Adds a release gate to `scripts/dist/build_app_bundle.sh` that verifies the Sparkle auto-update trust anchor right after the `Info.plist` is written:

- `SUPublicEDKey` is present, non-empty, and matches the expected release key
- `SUFeedURL` is HTTPS

The build fails loudly if any check fails.

## Why

Addresses **S-3** from #564. The key has always shipped and the appcast is EdDSA-signed, so update verification is already enforced — but it wasn't confirmable from source (the plist is build-generated, not committed) and nothing guarded against a future heredoc refactor silently dropping or blanking the key. A defenseless updater would only surface when a malicious appcast slipped an unsigned update through. This makes the guarantee both externally verifiable and regression-proof.

## Verification

- Real shipped plist → passes
- Blanked key / wrong key / `http://` feed → build fails as expected

Thanks to @sanjeevpenupala for the finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gates macOS releases on the Sparkle update-signature trust anchor by verifying the `SUPublicEDKey` and HTTPS `SUFeedURL` in the generated Info.plist, preventing shipping an updater that could accept unsigned or MITM’d updates. Addresses S-3 from #564.

- New Features
  - Adds a release gate in `scripts/dist/build_app_bundle.sh` that reads `SUPublicEDKey` and `SUFeedURL` back from the written Info.plist and fails the build if the key is missing/empty/wrong or the feed isn’t HTTPS.
  - Pins the expected key independently via `EXPECTED_SU_PUBLIC_ED_KEY` to prevent self-check bypass, and adds an explicit missing-feed check with clear errors.

<sup>Written for commit 49f36934dc58677590a214e26996e6caa6cd1a18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

