### PR TITLE
fix: dedupe CJK Cohere seam drift

### DIFF
--- a/Sources/MacParakeetCore/STT/CohereTranscribeEngine.swift
+++ b/Sources/MacParakeetCore/STT/CohereTranscribeEngine.swift
@@ -448,11 +448,6 @@ public actor CohereTranscribeEngine: STTTranscribing {
         guard minimumLength >= 8 else { return false }
         guard hasStableApproximateOverlapAnchor(aNormalized, bNormalized) else { return false }
 
-        let aMarker = leadingNumberMarker(aNormalized)
-        let bMarker = leadingNumberMarker(bNormalized)
-        if aMarker != bMarker {
-            return false
-        }
         let aTrailingMarker = trailingNumberMarker(aNormalized)
         let bTrailingMarker = trailingNumberMarker(bNormalized)
         if aTrailingMarker != bTrailingMarker {

--- a/Sources/MacParakeetCore/STT/CohereTranscribeEngine.swift
+++ b/Sources/MacParakeetCore/STT/CohereTranscribeEngine.swift
@@ -358,7 +358,8 @@ public actor CohereTranscribeEngine: STTTranscribing {
                 a: a.map(String.init),
                 b: b.map(String.init),
                 maxOverlap: maxOverlap * 3,
-                separator: ""
+                separator: "",
+                allowApproximateCharacterOverlap: !containsWhitespace(a) && !containsWhitespace(b)
             )
         }
 
@@ -366,7 +367,8 @@ public actor CohereTranscribeEngine: STTTranscribing {
             a: a.split(whereSeparator: { $0.isWhitespace }).map(String.init),
             b: b.split(whereSeparator: { $0.isWhitespace }).map(String.init),
             maxOverlap: maxOverlap,
-            separator: " "
+            separator: " ",
+            allowApproximateCharacterOverlap: false
         )
     }
 
@@ -374,7 +376,8 @@ public actor CohereTranscribeEngine: STTTranscribing {
         a: [String],
         b: [String],
         maxOverlap: Int,
-        separator: String
+        separator: String,
+        allowApproximateCharacterOverlap: Bool
     ) -> String {
         guard !a.isEmpty else { return b.joined(separator: separator) }
         guard !b.isEmpty else { return a.joined(separator: separator) }
@@ -383,7 +386,12 @@ public actor CohereTranscribeEngine: STTTranscribing {
         var bestK = 0
         var k = limit
         while k >= 1 {
-            if overlapMatches(a: Array(a.suffix(k)), b: Array(b.prefix(k))) {
+            let aSuffix = Array(a.suffix(k))
+            let bPrefix = Array(b.prefix(k))
+            if overlapMatches(a: aSuffix, b: bPrefix)
+                || (allowApproximateCharacterOverlap
+                    && approximateCharacterOverlapMatches(a: aSuffix, b: bPrefix))
+            {
                 bestK = k
                 break
             }
@@ -424,6 +432,123 @@ public actor CohereTranscribeEngine: STTTranscribing {
             return false
         }
         return matchedLexicalUnit
+    }
+
+    private static func approximateCharacterOverlapMatches(a: [String], b: [String]) -> Bool {
+        let rawA = a.joined()
+        let rawB = b.joined()
+        guard containsCJK(rawA) || containsCJK(rawB) || containsHangul(rawA) || containsHangul(rawB)
+        else {
+            return false
+        }
+
+        let aNormalized = normalizedOverlapSequence(a)
+        let bNormalized = normalizedOverlapSequence(b)
+        let minimumLength = min(aNormalized.count, bNormalized.count)
+        guard minimumLength >= 8 else { return false }
+        guard hasStableApproximateOverlapAnchor(aNormalized, bNormalized) else { return false }
+
+        let aMarker = leadingNumberMarker(aNormalized)
+        let bMarker = leadingNumberMarker(bNormalized)
+        if aMarker != bMarker {
+            return false
+        }
+        let aTrailingMarker = trailingNumberMarker(aNormalized)
+        let bTrailingMarker = trailingNumberMarker(bNormalized)
+        if aTrailingMarker != bTrailingMarker {
+            return false
+        }
+
+        let maximumLength = max(aNormalized.count, bNormalized.count)
+        let allowedDistance = max(2, Int((Double(maximumLength) * 0.25).rounded(.down)))
+        return boundedEditDistance(aNormalized, bNormalized, maxDistance: allowedDistance) <= allowedDistance
+    }
+
+    private static func normalizedOverlapSequence(_ units: [String]) -> String {
+        units.compactMap { normalizedOverlapUnit($0) }.joined()
+    }
+
+    private static func hasStableApproximateOverlapAnchor(_ a: String, _ b: String) -> Bool {
+        if let aMarker = leadingNumberMarker(a), let bMarker = leadingNumberMarker(b) {
+            return aMarker == bMarker
+        }
+        if leadingNumberMarker(a) != nil || leadingNumberMarker(b) != nil {
+            return false
+        }
+        return commonPrefixLength(a, b) >= 3
+    }
+
+    private static func leadingNumberMarker(_ string: String) -> String? {
+        var marker = ""
+        for scalar in string.unicodeScalars {
+            if CharacterSet.decimalDigits.contains(scalar) {
+                marker.unicodeScalars.append(scalar)
+            } else {
+                break
+            }
+        }
+        return marker.isEmpty ? nil : marker
+    }
+
+    private static func trailingNumberMarker(_ string: String) -> String? {
+        var markerScalars: [UnicodeScalar] = []
+        for scalar in string.unicodeScalars.reversed() {
+            if CharacterSet.decimalDigits.contains(scalar) {
+                markerScalars.append(scalar)
+            } else {
+                break
+            }
+        }
+        guard !markerScalars.isEmpty else { return nil }
+        return String(String.UnicodeScalarView(markerScalars.reversed()))
+    }
+
+    private static func commonPrefixLength(_ a: String, _ b: String) -> Int {
+        var count = 0
+        var aIndex = a.startIndex
+        var bIndex = b.startIndex
+        while aIndex < a.endIndex && bIndex < b.endIndex {
+            guard a[aIndex] == b[bIndex] else { break }
+            count += 1
+            aIndex = a.index(after: aIndex)
+            bIndex = b.index(after: bIndex)
+        }
+        return count
+    }
+
+    private static func boundedEditDistance(_ a: String, _ b: String, maxDistance: Int) -> Int {
+        let aCharacters = Array(a)
+        let bCharacters = Array(b)
+        guard abs(aCharacters.count - bCharacters.count) <= maxDistance else {
+            return maxDistance + 1
+        }
+        if aCharacters.isEmpty { return bCharacters.count }
+        if bCharacters.isEmpty { return aCharacters.count }
+
+        var previous = Array(0...bCharacters.count)
+        var current = Array(repeating: 0, count: bCharacters.count + 1)
+
+        for (aOffset, aCharacter) in aCharacters.enumerated() {
+            current[0] = aOffset + 1
+            var rowMinimum = current[0]
+
+            for (bOffset, bCharacter) in bCharacters.enumerated() {
+                let substitutionCost = aCharacter == bCharacter ? 0 : 1
+                current[bOffset + 1] = min(
+                    previous[bOffset + 1] + 1,
+                    current[bOffset] + 1,
+                    previous[bOffset] + substitutionCost
+                )
+                rowMinimum = min(rowMinimum, current[bOffset + 1])
+            }
+
+            if rowMinimum > maxDistance {
+                return maxDistance + 1
+            }
+            swap(&previous, &current)
+        }
+
+        return previous[bCharacters.count]
     }
 
     private static func isLeadingPartial(unit: String, completedBy fullUnit: String) -> Bool {

--- a/Tests/MacParakeetTests/STT/CohereTranscribeEngineTests.swift
+++ b/Tests/MacParakeetTests/STT/CohereTranscribeEngineTests.swift
@@ -118,6 +118,50 @@ final class CohereTranscribeEngineTests: XCTestCase {
         XCTAssertEqual(merged, "开头内容" + overlap + "结尾内容")
     }
 
+    func testMergeDropsApproximateJapaneseOverlapWithRecognizerDrift() {
+        let merged = CohereTranscribeEngine.mergeOnOverlap(
+            "6番マックスパラキートで確認しています。7番コヒアの日本語テストです。",
+            "7番コヒアの2本5テストです。8番最後まで静かに録音します。"
+        )
+
+        XCTAssertEqual(
+            merged,
+            "6番マックスパラキートで確認しています。7番コヒアの日本語テストです。8番最後まで静かに録音します。"
+        )
+        XCTAssertEqual(merged.components(separatedBy: "7番").count - 1, 1)
+    }
+
+    func testMergeDropsApproximateJapaneseNumberedOverlapWithKanaDrift() {
+        let merged = CohereTranscribeEngine.mergeOnOverlap(
+            "16番最後まで静かに録音します。17番今日はいい天気です。",
+            "17番きょうはいい天気です。おはこあしたも晴れるでしょう。"
+        )
+
+        XCTAssertEqual(
+            merged,
+            "16番最後まで静かに録音します。17番今日はいい天気です。おはこあしたも晴れるでしょう。"
+        )
+        XCTAssertEqual(merged.components(separatedBy: "17番").count - 1, 1)
+    }
+
+    func testMergeDoesNotApproximateDifferentNumberedJapanesePhrases() {
+        let merged = CohereTranscribeEngine.mergeOnOverlap(
+            "1番今日はいい天気です。",
+            "2番今日はいい天気です。"
+        )
+
+        XCTAssertEqual(merged, "1番今日はいい天気です。2番今日はいい天気です。")
+    }
+
+    func testMergeDropsApproximateChineseOverlapWithRecognizerDrift() {
+        let merged = CohereTranscribeEngine.mergeOnOverlap(
+            "前半内容然后去商店买东西",
+            "然后去商店买东息结尾内容"
+        )
+
+        XCTAssertEqual(merged, "前半内容然后去商店买东西结尾内容")
+    }
+
     func testMergeDropsCJKCompatibilityIdeographOverlapWithoutInsertingSpace() throws {
         let first = try XCTUnwrap(UnicodeScalar(0xF900).map(String.init))
         let second = try XCTUnwrap(UnicodeScalar(0xF901).map(String.init))

--- a/Tests/MacParakeetTests/STT/CohereTranscribeEngineTests.swift
+++ b/Tests/MacParakeetTests/STT/CohereTranscribeEngineTests.swift
@@ -162,6 +162,15 @@ final class CohereTranscribeEngineTests: XCTestCase {
         XCTAssertEqual(merged, "前半内容然后去商店买东西结尾内容")
     }
 
+    func testMergeDropsApproximateHangulOverlapWithRecognizerDrift() {
+        let merged = CohereTranscribeEngine.mergeOnOverlap(
+            "앞부분오늘날씨가정말좋습니다",
+            "오늘날씨가정말조습니다끝부분"
+        )
+
+        XCTAssertEqual(merged, "앞부분오늘날씨가정말좋습니다끝부분")
+    }
+
     func testMergeDropsCJKCompatibilityIdeographOverlapWithoutInsertingSpace() throws {
         let first = try XCTUnwrap(UnicodeScalar(0xF900).map(String.init))
         let second = try XCTUnwrap(UnicodeScalar(0xF901).map(String.init))


### PR DESCRIPTION
## Summary

Long Cohere CJK transcriptions no longer leave duplicated phrases at chunk seams when the overlapped audio is recognized with small wording drift. In real QA after macparakeet#602, a 60.6s Japanese sample produced repeated `7番...` and `17番...` phrases; the same sample now keeps those phrases once while preserving the next sentence marker.

The stitcher still uses exact matching for normal word-delimited and mixed-space paths. Approximate matching is limited to whitespace-free CJK/Hangul fragments, requires a stable prefix/number anchor, and refuses candidates that would swallow adjacent numbered phrase boundaries.

## Validation

- Downloaded `cohere-transcribe` locally: 21/21 model files, `Cohere: ready`.
- Release CLI English smoke: `--engine cohere --language en --format json --speaker-detection off` returned the expected transcript, `engine: cohere`, `engineVariant: ane`, and empty `wordTimestamps`.
- Release CLI Japanese short smoke: `--engine cohere --language ja` returned a plausible Japanese transcript with no inserted spaces.
- Release CLI Japanese long smoke: 60.6s WAV forced Cohere chunk/stitch; before this fix it duplicated `7番` and `17番`, after this fix those duplicates are gone.
- `git diff --check`
- `swift test --filter CohereTranscribeEngineTests`
- `swift test --filter STTSchedulerTests`
- `swift test --filter TranscribeCommandTests`
- `swift build -c release --product macparakeet-cli`
- `swift test` -> 4110 XCTest tests, 11 skipped, 0 failures; 16 Swift Testing tests, 0 failures

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes duplicated phrases at chunk seams in Cohere CJK transcriptions by adding conservative approximate overlap matching for whitespace-free CJK/Hangul text. Removes repeats like "7番" and "17番" in long audio while keeping sentence and number boundaries intact.

- **Bug Fixes**
  - Add approximate character overlap in `CohereTranscribeEngine` for whitespace-free CJK/Hangul seams; extend the overlap window.
  - Enforce stable anchors (common prefix or same leading number), matching trailing numbers, and bounded edit distance; block merges across numbered boundaries.
  - Preserve exact matching for word-delimited and mixed-space paths.
  - Expand tests to Japanese, Chinese, and Hangul seam drift; remove a redundant leading-marker check.

<sup>Written for commit c0fe2b0f213817c8d66a0e50257e6ca0d097d45b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/620?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

