### PR TITLE
Pin Parakeet TDT inference gating in STTRuntime

### DIFF
--- a/Sources/MacParakeetCore/STT/README.md
+++ b/Sources/MacParakeetCore/STT/README.md
@@ -185,13 +185,15 @@ empty, or too-long clip yields no samples and falls through to the URL path, whi
 transcription errors propagate from whichever path ran. Don't "simplify"
 dictation back onto the shared URL path without restoring this trailing context.
 
-**All Parakeet TDT inference is gated.** The pad, URL, and preview paths each run
-their `AsrManager.transcribe(...)` through `STTRuntime.gatedParakeetTranscribe`,
+**All Parakeet TDT inference is gated.** The pad, URL, and preview paths each
+wrap their `AsrManager.transcribe(...)` in `inferenceGate.withExclusiveAccess`,
 which serializes Neural Engine inference on macOS 14 (`ANEInferenceGate`; a no-op
-on macOS 15+) to avoid the concurrent-inference SIGBUS (FluidAudio #661). A new
-call site that invokes `AsrManager.transcribe` directly **must** go through that
-helper — calling the manager bare reopens the crash for whichever lane runs
-unguarded.
+on macOS 15+) to avoid the concurrent-inference SIGBUS (FluidAudio #661). The gate
+is applied inline at each site rather than via a shared helper because the closure
+captures the actor-owned, non-Sendable `AsrManager`, which Swift 6 only lets the
+gate close over inline. A new call site that invokes `AsrManager.transcribe`
+directly **must** wrap it the same way — calling the manager bare reopens the
+crash for whichever lane runs unguarded.
 
 **Engine routing is per-job.** Parakeet stays default. The selected Parakeet
 build is `v3` unless the user opts into `v2` through Settings or the CLI

--- a/Sources/MacParakeetCore/STT/README.md
+++ b/Sources/MacParakeetCore/STT/README.md
@@ -185,6 +185,14 @@ empty, or too-long clip yields no samples and falls through to the URL path, whi
 transcription errors propagate from whichever path ran. Don't "simplify"
 dictation back onto the shared URL path without restoring this trailing context.
 
+**All Parakeet TDT inference is gated.** The pad, URL, and preview paths each run
+their `AsrManager.transcribe(...)` through `STTRuntime.gatedParakeetTranscribe`,
+which serializes Neural Engine inference on macOS 14 (`ANEInferenceGate`; a no-op
+on macOS 15+) to avoid the concurrent-inference SIGBUS (FluidAudio #661). A new
+call site that invokes `AsrManager.transcribe` directly **must** go through that
+helper — calling the manager bare reopens the crash for whichever lane runs
+unguarded.
+
 **Engine routing is per-job.** Parakeet stays default. The selected Parakeet
 build is `v3` unless the user opts into `v2` through Settings or the CLI
 (`config set parakeet-model`, `models select parakeet-v2`, or

--- a/Sources/MacParakeetCore/STT/STTRuntime.swift
+++ b/Sources/MacParakeetCore/STT/STTRuntime.swift
@@ -73,6 +73,13 @@ public actor STTRuntime: STTRuntimeProtocol {
 
     private let logger = Logger(subsystem: "com.macparakeet.core", category: "STTRuntime")
 
+    /// Serializes Parakeet TDT Neural Engine inference on macOS 14 (no-op on
+    /// 15+); see ``ANEInferenceGate``. Injected so the serialization invariant
+    /// is unit-testable on any host, and defaults to the shared process gate so
+    /// every STT engine and lane contends on one Neural Engine mutex in
+    /// production.
+    private let inferenceGate: ANEInferenceGate
+
     private var interactiveManager: AsrManager?
     private var backgroundManager: AsrManager?
     private var models: AsrModels?
@@ -139,7 +146,8 @@ public actor STTRuntime: STTRuntimeProtocol {
         speechEngine: SpeechEnginePreference = .parakeet,
         nemotronModelVariant: NemotronModelVariant = SpeechEnginePreference.defaultNemotronModelVariant,
         whisperModelVariant: String = SpeechEnginePreference.defaultWhisperModelVariant,
-        defaults: UserDefaults = .standard
+        defaults: UserDefaults = .standard,
+        inferenceGate: ANEInferenceGate = .shared
     ) {
         self.currentParakeetVariant = parakeetModelVariant
         // `.unified` has no TDT version; the TDT path is never taken for it, so a
@@ -150,6 +158,19 @@ public actor STTRuntime: STTRuntimeProtocol {
         self.nemotronModelVariant = nemotronModelVariant
         self.whisperModelVariant = WhisperEngine.normalizeModelVariant(whisperModelVariant)
         self.defaults = defaults
+        self.inferenceGate = inferenceGate
+    }
+
+    /// Runs one Parakeet TDT Neural Engine inference under ``inferenceGate``.
+    ///
+    /// Every `AsrManager.transcribe(...)` call in this runtime MUST go through
+    /// here. On macOS 14 the gate serializes inference to avoid the concurrent
+    /// Neural Engine SIGBUS (FluidAudio #661); a call site that bypasses it
+    /// reopens that crash for whichever lane runs unguarded. No-op on macOS 15+.
+    func gatedParakeetTranscribe<T>(
+        _ body: () async throws -> T
+    ) async throws -> T {
+        try await inferenceGate.withExclusiveAccess(body)
     }
 
     func transcribe(
@@ -473,7 +494,11 @@ public actor STTRuntime: STTRuntimeProtocol {
                     var decoderState = TdtDecoderState.make(decoderLayers: decoderLayers)
                     try Task.checkCancellation()
                     onProgress?(0, 100)
-                    let result = try await ANEInferenceGate.shared.withExclusiveAccess {
+                    // Same Neural Engine serialization as the URL and preview
+                    // paths below: this short-clip finalize is the common
+                    // dictation case, so leaving it ungated lets it race a
+                    // concurrent background transcription and SIGBUS on macOS 14.
+                    let result = try await gatedParakeetTranscribe {
                         try await manager.transcribe(paddedSamples, decoderState: &decoderState)
                     }
                     onProgress?(100, 100)
@@ -523,7 +548,7 @@ public actor STTRuntime: STTRuntimeProtocol {
             // macOS 15+). Model setup and progress plumbing stay outside the
             // hardware mutex so unsupported or preprocessing-only work does not
             // delay interactive inference.
-            let result = try await ANEInferenceGate.shared.withExclusiveAccess {
+            let result = try await gatedParakeetTranscribe {
                 try await manager.transcribe(audioURL, decoderState: &decoderState)
             }
             let words = STTWordTimingBuilder.words(from: result.tokenTimings)
@@ -656,7 +681,7 @@ public actor STTRuntime: STTRuntimeProtocol {
             try Task.checkCancellation()
             var decoderState = TdtDecoderState.make(decoderLayers: decoderLayers)
             try Task.checkCancellation()
-            let result = try await ANEInferenceGate.shared.withExclusiveAccess {
+            let result = try await gatedParakeetTranscribe {
                 try await manager.transcribe(samples, decoderState: &decoderState)
             }
             return STTResult(

--- a/Sources/MacParakeetCore/STT/STTRuntime.swift
+++ b/Sources/MacParakeetCore/STT/STTRuntime.swift
@@ -161,17 +161,19 @@ public actor STTRuntime: STTRuntimeProtocol {
         self.inferenceGate = inferenceGate
     }
 
-    /// Runs one Parakeet TDT Neural Engine inference under ``inferenceGate``.
-    ///
-    /// Every `AsrManager.transcribe(...)` call in this runtime MUST go through
-    /// here. On macOS 14 the gate serializes inference to avoid the concurrent
-    /// Neural Engine SIGBUS (FluidAudio #661); a call site that bypasses it
-    /// reopens that crash for whichever lane runs unguarded. No-op on macOS 15+.
-    func gatedParakeetTranscribe<T>(
-        _ body: () async throws -> T
-    ) async throws -> T {
+    #if DEBUG
+    /// Test seam: runs `body` under the runtime's injected ``inferenceGate`` so a
+    /// test can prove the runtime serializes Neural Engine work on macOS 14
+    /// without a CoreML model present. Production inference can't funnel through a
+    /// shared helper — its closure captures the actor-owned, non-Sendable
+    /// `AsrManager`, which Swift 6 only lets the gate close over inline — so each
+    /// `manager.transcribe(...)` site inlines `inferenceGate.withExclusiveAccess`
+    /// instead. Every such site MUST be gated; a bare call reopens the concurrent
+    /// Neural Engine SIGBUS (FluidAudio #661) for whichever lane runs unguarded.
+    func runUnderInferenceGate<T: Sendable>(_ body: @Sendable () async throws -> T) async throws -> T {
         try await inferenceGate.withExclusiveAccess(body)
     }
+    #endif
 
     func transcribe(
         audioPath: String,
@@ -498,7 +500,7 @@ public actor STTRuntime: STTRuntimeProtocol {
                     // paths below: this short-clip finalize is the common
                     // dictation case, so leaving it ungated lets it race a
                     // concurrent background transcription and SIGBUS on macOS 14.
-                    let result = try await gatedParakeetTranscribe {
+                    let result = try await inferenceGate.withExclusiveAccess {
                         try await manager.transcribe(paddedSamples, decoderState: &decoderState)
                     }
                     onProgress?(100, 100)
@@ -548,7 +550,7 @@ public actor STTRuntime: STTRuntimeProtocol {
             // macOS 15+). Model setup and progress plumbing stay outside the
             // hardware mutex so unsupported or preprocessing-only work does not
             // delay interactive inference.
-            let result = try await gatedParakeetTranscribe {
+            let result = try await inferenceGate.withExclusiveAccess {
                 try await manager.transcribe(audioURL, decoderState: &decoderState)
             }
             let words = STTWordTimingBuilder.words(from: result.tokenTimings)
@@ -681,7 +683,7 @@ public actor STTRuntime: STTRuntimeProtocol {
             try Task.checkCancellation()
             var decoderState = TdtDecoderState.make(decoderLayers: decoderLayers)
             try Task.checkCancellation()
-            let result = try await gatedParakeetTranscribe {
+            let result = try await inferenceGate.withExclusiveAccess {
                 try await manager.transcribe(samples, decoderState: &decoderState)
             }
             return STTResult(

--- a/Tests/MacParakeetTests/STT/STTRuntimeInferenceGatingTests.swift
+++ b/Tests/MacParakeetTests/STT/STTRuntimeInferenceGatingTests.swift
@@ -55,6 +55,14 @@ final class STTRuntimeInferenceGatingTests: XCTestCase {
     /// On macOS 14 (`serializationRequired: true`) concurrent work driven through
     /// the runtime's injected gate must never overlap — the whole point of the
     /// gate that the dictation pad path originally bypassed.
+    ///
+    /// Unlike the pass-through test below — which deadlocks the group if the gate
+    /// wrongly serializes, so a false pass is impossible — this direction is
+    /// probabilistic: a broken (non-serializing) gate would almost certainly let
+    /// some of the 8 held tasks overlap (`peak > 1`), but a scheduler that happened
+    /// to run them sequentially could in principle still yield `peak == 1`. The
+    /// 2 ms hold across 8 tasks makes that astronomically unlikely; this mirrors
+    /// `ANEInferenceGateTests.testSerializesConcurrentAccessWhenRequired`.
     func testRuntimeSerializesParakeetInferenceWhenRequired() async {
         let runtime = STTRuntime(inferenceGate: ANEInferenceGate(serializationRequired: true))
         let tracker = ConcurrencyTracker()

--- a/Tests/MacParakeetTests/STT/STTRuntimeInferenceGatingTests.swift
+++ b/Tests/MacParakeetTests/STT/STTRuntimeInferenceGatingTests.swift
@@ -1,16 +1,17 @@
 import XCTest
 @testable import MacParakeetCore
 
-/// Pins the macOS-14 SIGBUS invariant at the `STTRuntime` boundary: every
-/// Parakeet TDT inference funnels through ``STTRuntime/gatedParakeetTranscribe``
-/// and therefore through the injected ``ANEInferenceGate``.
+/// Pins the macOS-14 SIGBUS invariant at the `STTRuntime` boundary: work run
+/// through the runtime's injected ``ANEInferenceGate`` serializes.
 ///
 /// `ANEInferenceGateTests` proves the gate primitive serializes; this proves the
-/// runtime actually routes through it. The real `transcribe(job:)` paths can't
-/// run in CI (CoreML/Parakeet models are unavailable), so the gate is injected
-/// with `serializationRequired: true` and exercised through the same chokepoint
-/// the production call sites use — which is why a future call site that bypasses
-/// `gatedParakeetTranscribe` would not be covered, and must not be added.
+/// runtime's injected gate is wired and serializing. The real `transcribe(job:)`
+/// paths can't run in CI (CoreML/Parakeet models are unavailable) and inline the
+/// gate inside actor-isolated closures that can't be reached from a test, so the
+/// test exercises the same injected gate through the `runUnderInferenceGate`
+/// seam. Production correctness — that every `manager.transcribe(...)` site wraps
+/// `inferenceGate.withExclusiveAccess` — is enforced by review + the STT README,
+/// not this test.
 final class STTRuntimeInferenceGatingTests: XCTestCase {
 
     /// Tracks how many closures are inside the gate simultaneously.
@@ -51,11 +52,9 @@ final class STTRuntimeInferenceGatingTests: XCTestCase {
         }
     }
 
-    /// On macOS 14 (`serializationRequired: true`) concurrent Parakeet inference
-    /// driven through the runtime's chokepoint must never overlap — the whole
-    /// point of the gate. A regression that bypasses `gatedParakeetTranscribe`
-    /// (as the dictation pad path originally did) reopens the concurrent
-    /// Neural Engine SIGBUS.
+    /// On macOS 14 (`serializationRequired: true`) concurrent work driven through
+    /// the runtime's injected gate must never overlap — the whole point of the
+    /// gate that the dictation pad path originally bypassed.
     func testRuntimeSerializesParakeetInferenceWhenRequired() async {
         let runtime = STTRuntime(inferenceGate: ANEInferenceGate(serializationRequired: true))
         let tracker = ConcurrencyTracker()
@@ -63,7 +62,7 @@ final class STTRuntimeInferenceGatingTests: XCTestCase {
         await withTaskGroup(of: Void.self) { group in
             for _ in 0..<8 {
                 group.addTask {
-                    try? await runtime.gatedParakeetTranscribe {
+                    try? await runtime.runUnderInferenceGate {
                         await tracker.enter()
                         // Hold briefly so any overlap would be observable.
                         try? await Task.sleep(nanoseconds: 2_000_000)
@@ -89,7 +88,7 @@ final class STTRuntimeInferenceGatingTests: XCTestCase {
         await withTaskGroup(of: Void.self) { group in
             for _ in 0..<2 {
                 group.addTask {
-                    try? await runtime.gatedParakeetTranscribe {
+                    try? await runtime.runUnderInferenceGate {
                         await rendezvous.arrive()
                     }
                 }

--- a/Tests/MacParakeetTests/STT/STTRuntimeInferenceGatingTests.swift
+++ b/Tests/MacParakeetTests/STT/STTRuntimeInferenceGatingTests.swift
@@ -1,0 +1,102 @@
+import XCTest
+@testable import MacParakeetCore
+
+/// Pins the macOS-14 SIGBUS invariant at the `STTRuntime` boundary: every
+/// Parakeet TDT inference funnels through ``STTRuntime/gatedParakeetTranscribe``
+/// and therefore through the injected ``ANEInferenceGate``.
+///
+/// `ANEInferenceGateTests` proves the gate primitive serializes; this proves the
+/// runtime actually routes through it. The real `transcribe(job:)` paths can't
+/// run in CI (CoreML/Parakeet models are unavailable), so the gate is injected
+/// with `serializationRequired: true` and exercised through the same chokepoint
+/// the production call sites use — which is why a future call site that bypasses
+/// `gatedParakeetTranscribe` would not be covered, and must not be added.
+final class STTRuntimeInferenceGatingTests: XCTestCase {
+
+    /// Tracks how many closures are inside the gate simultaneously.
+    private actor ConcurrencyTracker {
+        private(set) var peak = 0
+        private var current = 0
+        func enter() {
+            current += 1
+            peak = max(peak, current)
+        }
+        func leave() {
+            current -= 1
+        }
+    }
+
+    /// Releases its parties only once `partyCount` of them are inside at the same
+    /// time, so the concurrency test proves overlap with no timing assumptions:
+    /// if the runtime (wrongly) serialized the callers the second never arrives,
+    /// the task group never completes, and the test fails by timing out.
+    private actor Rendezvous {
+        private let partyCount: Int
+        private var waiting: [CheckedContinuation<Void, Never>] = []
+        private(set) var releasedPartyCount = 0
+
+        init(partyCount: Int) {
+            self.partyCount = partyCount
+        }
+
+        func arrive() async {
+            await withCheckedContinuation { continuation in
+                waiting.append(continuation)
+                guard waiting.count >= partyCount else { return }
+                releasedPartyCount += waiting.count
+                let parties = waiting
+                waiting.removeAll()
+                for party in parties { party.resume() }
+            }
+        }
+    }
+
+    /// On macOS 14 (`serializationRequired: true`) concurrent Parakeet inference
+    /// driven through the runtime's chokepoint must never overlap — the whole
+    /// point of the gate. A regression that bypasses `gatedParakeetTranscribe`
+    /// (as the dictation pad path originally did) reopens the concurrent
+    /// Neural Engine SIGBUS.
+    func testRuntimeSerializesParakeetInferenceWhenRequired() async {
+        let runtime = STTRuntime(inferenceGate: ANEInferenceGate(serializationRequired: true))
+        let tracker = ConcurrencyTracker()
+
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0..<8 {
+                group.addTask {
+                    try? await runtime.gatedParakeetTranscribe {
+                        await tracker.enter()
+                        // Hold briefly so any overlap would be observable.
+                        try? await Task.sleep(nanoseconds: 2_000_000)
+                        await tracker.leave()
+                    }
+                }
+            }
+        }
+
+        let peak = await tracker.peak
+        XCTAssertEqual(peak, 1, "STTRuntime must serialize Parakeet inference through the gate when serialization is required")
+    }
+
+    /// On macOS 15+ (`serializationRequired: false`) the gate is a pass-through,
+    /// so the runtime keeps full lane concurrency and pays nothing. Both closures
+    /// must be inside the gate at once to clear the rendezvous; if the runtime
+    /// serialized them the second would never arrive and the group would hang to
+    /// a test timeout — so this can't pass by accident and has no timing flake.
+    func testRuntimeRunsConcurrentlyWhenSerializationNotRequired() async {
+        let runtime = STTRuntime(inferenceGate: ANEInferenceGate(serializationRequired: false))
+        let rendezvous = Rendezvous(partyCount: 2)
+
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0..<2 {
+                group.addTask {
+                    try? await runtime.gatedParakeetTranscribe {
+                        await rendezvous.arrive()
+                    }
+                }
+            }
+        }
+
+        let released = await rendezvous.releasedPartyCount
+        XCTAssertEqual(released, 2, "With serialization disabled both inferences must enter the gate concurrently")
+    }
+}

--- a/Tests/MacParakeetTests/STT/STTRuntimeInferenceGatingTests.swift
+++ b/Tests/MacParakeetTests/STT/STTRuntimeInferenceGatingTests.swift
@@ -72,9 +72,14 @@ final class STTRuntimeInferenceGatingTests: XCTestCase {
                 group.addTask {
                     try await runtime.runUnderInferenceGate {
                         await tracker.enter()
-                        // Hold briefly so any overlap would be observable.
-                        try await Task.sleep(nanoseconds: 2_000_000)
-                        await tracker.leave()
+                        do {
+                            // Hold briefly so any overlap would be observable.
+                            try await Task.sleep(nanoseconds: 2_000_000)
+                            await tracker.leave()
+                        } catch {
+                            await tracker.leave()
+                            throw error
+                        }
                     }
                 }
             }

--- a/Tests/MacParakeetTests/STT/STTRuntimeInferenceGatingTests.swift
+++ b/Tests/MacParakeetTests/STT/STTRuntimeInferenceGatingTests.swift
@@ -63,21 +63,22 @@ final class STTRuntimeInferenceGatingTests: XCTestCase {
     /// to run them sequentially could in principle still yield `peak == 1`. The
     /// 2 ms hold across 8 tasks makes that astronomically unlikely; this mirrors
     /// `ANEInferenceGateTests.testSerializesConcurrentAccessWhenRequired`.
-    func testRuntimeSerializesParakeetInferenceWhenRequired() async {
+    func testRuntimeSerializesParakeetInferenceWhenRequired() async throws {
         let runtime = STTRuntime(inferenceGate: ANEInferenceGate(serializationRequired: true))
         let tracker = ConcurrencyTracker()
 
-        await withTaskGroup(of: Void.self) { group in
+        try await withThrowingTaskGroup(of: Void.self) { group in
             for _ in 0..<8 {
                 group.addTask {
-                    try? await runtime.runUnderInferenceGate {
+                    try await runtime.runUnderInferenceGate {
                         await tracker.enter()
                         // Hold briefly so any overlap would be observable.
-                        try? await Task.sleep(nanoseconds: 2_000_000)
+                        try await Task.sleep(nanoseconds: 2_000_000)
                         await tracker.leave()
                     }
                 }
             }
+            try await group.waitForAll()
         }
 
         let peak = await tracker.peak
@@ -89,18 +90,19 @@ final class STTRuntimeInferenceGatingTests: XCTestCase {
     /// must be inside the gate at once to clear the rendezvous; if the runtime
     /// serialized them the second would never arrive and the group would hang to
     /// a test timeout — so this can't pass by accident and has no timing flake.
-    func testRuntimeRunsConcurrentlyWhenSerializationNotRequired() async {
+    func testRuntimeRunsConcurrentlyWhenSerializationNotRequired() async throws {
         let runtime = STTRuntime(inferenceGate: ANEInferenceGate(serializationRequired: false))
         let rendezvous = Rendezvous(partyCount: 2)
 
-        await withTaskGroup(of: Void.self) { group in
+        try await withThrowingTaskGroup(of: Void.self) { group in
             for _ in 0..<2 {
                 group.addTask {
-                    try? await runtime.runUnderInferenceGate {
+                    try await runtime.runUnderInferenceGate {
                         await rendezvous.arrive()
                     }
                 }
             }
+            try await group.waitForAll()
         }
 
         let released = await rendezvous.releasedPartyCount

--- a/Tests/MacParakeetTests/STT/STTRuntimeInferenceGatingTests.swift
+++ b/Tests/MacParakeetTests/STT/STTRuntimeInferenceGatingTests.swift
@@ -30,25 +30,37 @@ final class STTRuntimeInferenceGatingTests: XCTestCase {
     /// Releases its parties only once `partyCount` of them are inside at the same
     /// time, so the concurrency test proves overlap with no timing assumptions:
     /// if the runtime (wrongly) serialized the callers the second never arrives,
-    /// the task group never completes, and the test fails by timing out.
+    /// and the first throws a local timeout error instead of stalling the suite.
     private actor Rendezvous {
         private let partyCount: Int
-        private var waiting: [CheckedContinuation<Void, Never>] = []
+        private var arrived = 0
+        private var released = false
         private(set) var releasedPartyCount = 0
 
         init(partyCount: Int) {
             self.partyCount = partyCount
         }
 
-        func arrive() async {
-            await withCheckedContinuation { continuation in
-                waiting.append(continuation)
-                guard waiting.count >= partyCount else { return }
-                releasedPartyCount += waiting.count
-                let parties = waiting
-                waiting.removeAll()
-                for party in parties { party.resume() }
+        func arrive(timeout: Duration = .milliseconds(200)) async throws {
+            arrived += 1
+            if arrived >= partyCount {
+                released = true
+                releasedPartyCount = arrived
             }
+
+            let start = ContinuousClock.now
+            while !released {
+                if start.duration(to: .now) > timeout {
+                    throw RendezvousTimeoutError()
+                }
+                try await Task.sleep(for: .milliseconds(5))
+            }
+        }
+    }
+
+    private struct RendezvousTimeoutError: LocalizedError {
+        var errorDescription: String? {
+            "Timed out waiting for both inference tasks to enter the pass-through gate concurrently"
         }
     }
 
@@ -93,8 +105,9 @@ final class STTRuntimeInferenceGatingTests: XCTestCase {
     /// On macOS 15+ (`serializationRequired: false`) the gate is a pass-through,
     /// so the runtime keeps full lane concurrency and pays nothing. Both closures
     /// must be inside the gate at once to clear the rendezvous; if the runtime
-    /// serialized them the second would never arrive and the group would hang to
-    /// a test timeout — so this can't pass by accident and has no timing flake.
+    /// serialized them the second would never arrive and the first fails fast
+    /// with a clear timeout error, so this can't pass by accident and has no
+    /// timing flake.
     func testRuntimeRunsConcurrentlyWhenSerializationNotRequired() async throws {
         let runtime = STTRuntime(inferenceGate: ANEInferenceGate(serializationRequired: false))
         let rendezvous = Rendezvous(partyCount: 2)
@@ -103,7 +116,7 @@ final class STTRuntimeInferenceGatingTests: XCTestCase {
             for _ in 0..<2 {
                 group.addTask {
                     try await runtime.runUnderInferenceGate {
-                        await rendezvous.arrive()
+                        try await rendezvous.arrive()
                     }
                 }
             }


### PR DESCRIPTION
## Summary

The minimal missing-gate fix has already landed on `main` through the post-merge audit, so this PR now hardens that repair: Parakeet TDT inference in `STTRuntime` uses an injected `ANEInferenceGate`, the runtime has a CI-safe seam for proving serialization behavior, and the STT README documents the invariant that every `AsrManager.transcribe(...)` site must be gated.

This keeps production behavior the same: the injected default is still `ANEInferenceGate.shared`, so all STT engines and lanes contend on the same process-wide Neural Engine mutex on macOS 14, while macOS 15+ remains a no-op. The short-dictation pad path, URL/file path, and preview path all continue to wrap only the leaf inference call.

## Validation

- `git diff --check`
- `swift test --filter STTRuntimeInferenceGatingTests`
- `swift test --skip-build --filter STTRuntimeDictationPadTests`
- `swift test --skip-build --filter ANEInferenceGateTests`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
