### PR TITLE
Gate Cohere engine selection and download behind a 16 GB memory floor

### DIFF
--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -2275,7 +2275,7 @@ struct SettingsView: View {
                                 "Record-then-transcribe dictation, files, and final meeting transcripts",
                                 "No live preview, word timestamps, or speaker labels"
                             ],
-                            helpText: "Cohere Transcribe (03-2026) running fully on-device via Core ML — the highest accuracy of the available engines, at the cost of a ~2.1 GB model download and higher memory use than the default engines. Powers record-then-transcribe dictation, file transcription, and final meeting transcription. Note: Cohere produces no word timestamps, so meetings transcribed with it are plain text without live preview or speaker labels — switch to Parakeet for speaker-labeled, timestamped meetings.",
+                            helpText: "Cohere Transcribe (03-2026) running fully on-device via Core ML — the highest accuracy of the available engines, at the cost of a ~2.1 GB model download and higher memory use than the default engines. Requires 16 GB of memory or more. Powers record-then-transcribe dictation, file transcription, and final meeting transcription. Note: Cohere produces no word timestamps, so meetings transcribed with it are plain text without live preview or speaker labels — switch to Parakeet for speaker-labeled, timestamped meetings.",
                             modelStatus: displayedCohereModelStatus,
                             isSelected: viewModel.engine.speechEnginePreference == .cohere,
                             isBusy: viewModel.engine.speechEngineSwitching,
@@ -2791,6 +2791,9 @@ struct SettingsView: View {
 
     private func engineSwitchUnavailableReason(for engine: SpeechEnginePreference) -> String? {
         guard viewModel.engine.speechEnginePreference != engine else { return nil }
+        if engine == .cohere, !viewModel.engine.cohereMeetsMemoryRequirement {
+            return EngineSettingsViewModel.cohereInsufficientMemoryMessage
+        }
         return viewModel.engine.speechEngineSwitchUnavailableMessage
     }
 
@@ -3119,6 +3122,10 @@ struct SettingsView: View {
     }
 
     private var coherePrimaryAction: ModelRowAction? {
+        // No download/retry affordance on a Mac that can't run Cohere; the engine
+        // tile already explains the 16 GB requirement, and the VM guards the
+        // download path regardless.
+        guard viewModel.engine.cohereMeetsMemoryRequirement else { return nil }
         switch viewModel.engine.cohereModelStatus {
         case .notDownloaded:
             return ModelRowAction(

--- a/Sources/MacParakeetCore/STT/README.md
+++ b/Sources/MacParakeetCore/STT/README.md
@@ -66,7 +66,10 @@ to one `STTRuntime`; callers do not own model lifecycles directly.
   meeting-finalize jobs run offline, live dictation preview stays off, and
   meeting live preview chunks are not routed to Cohere. No word timings;
   meetings degrade to plain text. Loads only an explicitly downloaded model
-  cache; it does not download from normal transcription/warm-up paths.
+  cache; it does not download from normal transcription/warm-up paths. Its
+  CoreML model has a large runtime footprint, so Settings gates both selecting
+  Cohere and downloading its model to machines with at least
+  `EngineSettingsViewModel.cohereMinimumMemoryBytes` (16 GB) of RAM.
 - `NativeLiveDictating.swift` — internal protocol the native streaming engines
   conform to so `STTRuntime` can route a live dictation session to the active
   Nemotron or Parakeet Unified build without knowing the concrete engine type.

--- a/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
+++ b/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
@@ -237,6 +237,7 @@ public enum TelemetryModelOperationStage: String, Sendable, Equatable {
 
 public enum TelemetrySpeechEngineSwitchBlockedReason: String, Sendable, Equatable {
     case modelNotDownloaded = "model_not_downloaded"
+    case insufficientMemory = "insufficient_memory"
     case engineBusy = "engine_busy"
     case meetingActive = "meeting_active"
     case transcribing

--- a/Sources/MacParakeetViewModels/EngineSettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/EngineSettingsViewModel.swift
@@ -107,6 +107,16 @@ public final class EngineSettingsViewModel {
     public var isCohereModelDownloaded: Bool {
         cohereModelStatus == .ready || cohereModelStatus == .notLoaded
     }
+    /// Cohere's CoreML model has a large runtime footprint; on a low-memory Mac
+    /// it risks an OS jetsam kill mid-transcription that no `catch` can recover.
+    /// Selecting Cohere or downloading its model is gated to machines with at
+    /// least ``cohereMinimumMemoryBytes`` of RAM.
+    public static let cohereMinimumMemoryBytes: UInt64 = 16 * 1024 * 1024 * 1024
+    public static let cohereInsufficientMemoryMessage =
+        "Cohere Transcribe needs 16 GB of memory or more — this Mac has less."
+    public var cohereMeetsMemoryRequirement: Bool {
+        physicalMemoryBytes() >= Self.cohereMinimumMemoryBytes
+    }
     private var shouldBlockCohereSwitchForModelStatus: Bool {
         if cohereDeleting { return true }
         switch cohereModelStatus {
@@ -160,6 +170,9 @@ public final class EngineSettingsViewModel {
     private let deleteNemotronModelOnDisk: @Sendable (NemotronModelVariant, String?) -> Bool
     private let deleteWhisperModelOnDisk: @Sendable (String) -> Bool
     private let deleteCohereModelOnDisk: @Sendable () -> Bool
+    /// Installed physical memory in bytes. Injected so the Cohere memory gate is
+    /// testable on any host; defaults to this machine's RAM.
+    private let physicalMemoryBytes: @Sendable () -> UInt64
     private var isApplyingSpeechEngineState = false
     private var isApplyingParakeetVariantState = false
     private var isApplyingNemotronVariantState = false
@@ -194,6 +207,9 @@ public final class EngineSettingsViewModel {
         },
         deleteCohereModelOnDisk: @escaping @Sendable () -> Bool = {
             CohereTranscribeEngine.deleteModel()
+        },
+        physicalMemoryBytes: @escaping @Sendable () -> UInt64 = {
+            ProcessInfo.processInfo.physicalMemory
         }
     ) {
         self.defaults = defaults
@@ -205,6 +221,7 @@ public final class EngineSettingsViewModel {
         self.deleteNemotronModelOnDisk = deleteNemotronModelOnDisk
         self.deleteWhisperModelOnDisk = deleteWhisperModelOnDisk
         self.deleteCohereModelOnDisk = deleteCohereModelOnDisk
+        self.physicalMemoryBytes = physicalMemoryBytes
         speechEnginePreference = SpeechEnginePreference.current(defaults: defaults)
         parakeetModelVariant = SpeechEnginePreference.parakeetModelVariant(defaults: defaults)
         nemotronModelVariant = SpeechEnginePreference.nemotronModelVariant(defaults: defaults)
@@ -690,6 +707,10 @@ public final class EngineSettingsViewModel {
     public func downloadCohereModel() {
         guard !speechEngineSwitching else { return }
         guard !cohereDownloading, !cohereDeleting else { return }
+        guard cohereMeetsMemoryRequirement else {
+            speechEngineError = Self.cohereInsufficientMemoryMessage
+            return
+        }
         speechEngineError = nil
         cohereDownloading = true
         cohereModelStatus = .repairing
@@ -814,6 +835,25 @@ public final class EngineSettingsViewModel {
                 durationSeconds: Observability.durationSeconds(since: operationContext.startedAt),
                 blockedReason: .modelNotDownloaded,
                 errorType: "model_not_downloaded",
+                wasCold: switchWasCold
+            ))
+            isApplyingSpeechEngineState = true
+            speechEnginePreference = previousPreference
+            isApplyingSpeechEngineState = false
+            return
+        }
+
+        if preference == .cohere && !cohereMeetsMemoryRequirement {
+            speechEngineError = Self.cohereInsufficientMemoryMessage
+            Telemetry.send(.speechEngineSwitchOperation(
+                operationID: operationContext.operationID,
+                operationContext: operationContext,
+                fromEngine: previousPreference,
+                toEngine: preference,
+                outcome: .unavailable,
+                durationSeconds: Observability.durationSeconds(since: operationContext.startedAt),
+                blockedReason: .insufficientMemory,
+                errorType: "insufficient_memory",
                 wasCold: switchWasCold
             ))
             isApplyingSpeechEngineState = true

--- a/Tests/MacParakeetTests/ViewModels/EngineSettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/EngineSettingsViewModelTests.swift
@@ -28,7 +28,10 @@ final class EngineSettingsViewModelTests: XCTestCase {
         deleteParakeet: @escaping @Sendable (ParakeetModelVariant) -> Bool = { _ in false },
         deleteNemotron: @escaping @Sendable (NemotronModelVariant, String?) -> Bool = { _, _ in false },
         deleteWhisper: @escaping @Sendable (String) -> Bool = { _ in false },
-        deleteCohere: @escaping @Sendable () -> Bool = { false }
+        deleteCohere: @escaping @Sendable () -> Bool = { false },
+        // Default well above the Cohere gate so non-memory tests are unaffected
+        // by the host's actual RAM (CI runners can be < 16 GB).
+        physicalMemoryBytes: @escaping @Sendable () -> UInt64 = { 32 * 1024 * 1024 * 1024 }
     ) -> EngineSettingsViewModel {
         EngineSettingsViewModel(
             defaults: defaults,
@@ -39,7 +42,8 @@ final class EngineSettingsViewModelTests: XCTestCase {
             deleteParakeetModelOnDisk: deleteParakeet,
             deleteNemotronModelOnDisk: deleteNemotron,
             deleteWhisperModelOnDisk: deleteWhisper,
-            deleteCohereModelOnDisk: deleteCohere
+            deleteCohereModelOnDisk: deleteCohere,
+            physicalMemoryBytes: physicalMemoryBytes
         )
     }
 
@@ -275,6 +279,48 @@ final class EngineSettingsViewModelTests: XCTestCase {
         XCTAssertEqual(vm.speechEngineError, "Download Cohere Transcribe before switching engines.")
         XCTAssertFalse(vm.speechEngineSwitching)
         XCTAssertNil(vm.speechEngineSwitchTarget)
+    }
+
+    // MARK: - Cohere memory gate
+
+    func testCohereMeetsMemoryRequirementReflectsInstalledMemory() {
+        let gib: UInt64 = 1024 * 1024 * 1024
+        XCTAssertFalse(makeViewModel(physicalMemoryBytes: { 8 * gib }).cohereMeetsMemoryRequirement)
+        XCTAssertFalse(makeViewModel(physicalMemoryBytes: { 15 * gib }).cohereMeetsMemoryRequirement)
+        XCTAssertTrue(makeViewModel(physicalMemoryBytes: { 16 * gib }).cohereMeetsMemoryRequirement)
+        XCTAssertTrue(makeViewModel(physicalMemoryBytes: { 32 * gib }).cohereMeetsMemoryRequirement)
+    }
+
+    func testDownloadCohereModelIsBlockedBelowMemoryThreshold() {
+        let vm = makeViewModel(physicalMemoryBytes: { 8 * 1024 * 1024 * 1024 })
+        vm.downloadCohereModel()
+        XCTAssertFalse(vm.cohereDownloading)
+        XCTAssertEqual(vm.speechEngineError, EngineSettingsViewModel.cohereInsufficientMemoryMessage)
+    }
+
+    func testConfirmPendingSwitchBlocksCohereBelowMemoryThreshold() {
+        // Model is present, so only the memory gate can block the switch.
+        let vm = makeViewModel(cohereCached: { true }, physicalMemoryBytes: { 8 * 1024 * 1024 * 1024 })
+        vm.cohereModelStatus = .notLoaded
+        vm.requestSpeechEngineSwitchConfirmation(to: .cohere)
+
+        vm.confirmPendingSpeechEngineSwitch()
+
+        XCTAssertNil(vm.pendingSpeechEngineSwitchConfirmation)
+        XCTAssertEqual(vm.speechEnginePreference, .parakeet)
+        XCTAssertEqual(SpeechEnginePreference.current(defaults: defaults), .parakeet)
+        XCTAssertEqual(vm.speechEngineError, EngineSettingsViewModel.cohereInsufficientMemoryMessage)
+    }
+
+    func testConfirmPendingSwitchAllowsCohereAtMemoryThreshold() {
+        let vm = makeViewModel(cohereCached: { true }, physicalMemoryBytes: { 16 * 1024 * 1024 * 1024 })
+        vm.cohereModelStatus = .notLoaded
+        vm.requestSpeechEngineSwitchConfirmation(to: .cohere)
+
+        vm.confirmPendingSpeechEngineSwitch()
+
+        XCTAssertEqual(vm.speechEnginePreference, .cohere)
+        XCTAssertEqual(SpeechEnginePreference.current(defaults: defaults), .cohere)
     }
 
     func testSwitchUnavailableMessageReturnsNilWhenAvailable() {


### PR DESCRIPTION
## Problem

Cohere Transcribe (#602) shipped **default-on** (`AppFeatures.cohereEngineEnabled = true`) with **no memory gating**, despite its CoreML model's large runtime footprint. On an 8 GB Mac a user can download the ~2.1 GB model and select the engine, then hit CoreML memory pressure that the OS resolves with a **jetsam kill** no `catch` can recover — an app-killing failure on a default feature of a trust-first local product.

The "opt-in, 16 GB+" posture existed in planning but was never enforced in code (confirmed: no `physicalMemory`/`hw.memsize` check anywhere in `Sources/`). The only mitigation shipped was advisory help text. Surfaced during a release-readiness review.

## Fix

Inject a `physicalMemory` provider into `EngineSettingsViewModel` and gate the two Settings paths a user can reach:

- **Download** — `downloadCohereModel()` refuses below the threshold (`cohereMinimumMemoryBytes` = 16 GB), with a clear message.
- **Selection** — `applySpeechEngineChange` blocks switching to Cohere below the threshold, reverts to the prior engine, and records the block with a new `insufficient_memory` `blocked_reason` value (rides the existing `speech_engine_switch` event — no website ALLOWED_EVENTS change needed).
- **UI** — the engine tile shows "Unavailable" with the reason (disabling selection via the existing `unavailableReason` path), the Local Models row drops its download/retry button on sub-16 GB machines, and the help text states the requirement.

## Tests

The memory provider is injected so the gate is testable on any host (CI macOS runners can be < 16 GB). The test helper defaults to 32 GB so unrelated engine tests are unaffected. New `EngineSettingsViewModelTests` cover the threshold boundary (15/16 GB), a blocked download, a blocked switch, and an allowed switch at exactly 16 GB.

- `swift build` clean; full `swift test` green (4,189 tests, 0 failures).

## Scope / follow-up

- Out of scope: the CLI (`config set`) is a deliberate power-user surface and is **not** gated here; the discoverable Settings path is. A CLI guard could be a follow-up if desired.
- Threshold (16 GB) is a single named constant if it needs tuning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate Cohere Transcribe behind a 16 GB RAM requirement to prevent crashes on low-memory Macs. Blocks engine selection and model download in Settings with clear messaging and telemetry.

- **Bug Fixes**
  - Added a memory gate in `EngineSettingsViewModel` with `cohereMinimumMemoryBytes = 16 GB` via injectable `physicalMemoryBytes`.
  - Enforce gate in `downloadCohereModel()` and engine switching; revert on blocked switch and show `cohereInsufficientMemoryMessage`.
  - UI: show “Unavailable” with reason on the Cohere tile, remove download/retry action, and update help text to state the 16 GB requirement.
  - Telemetry: new `insufficient_memory` in `TelemetrySpeechEngineSwitchBlockedReason`; tests cover 15/16 GB boundary, blocked download/switch, and allowed switch at 16 GB.

<sup>Written for commit c250d347a7e397e4910ec568547e2de701d7c414. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/628?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

