### PR TITLE
Add local Greptile CLI review workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@ swift test --filter TextProcessingPipelineTests
 scripts/dev/check.sh [TestFilter]
 scripts/dev/format.sh
 scripts/dev/ci_local.sh
+scripts/dev/greptile_review.sh [BaseBranch]
 scripts/dev/run_app.sh
 swift run macparakeet-cli --help
 swift run macparakeet-cli health
@@ -108,7 +109,9 @@ for old references only; do not add new REQ IDs as part of normal work.
 Use [`docs/pr-review-workflow.md`](./docs/pr-review-workflow.md) for substantial
 changes. Scale review to risk: trivial edits can go straight in; small contained
 fixes need focused verification; substantial changes benefit from branch-first
-PRs, CI, and independent review until findings converge.
+PRs, CI, local Greptile CLI review, and independent review until findings
+converge. Greptile CLI reviews committed branch changes only; uncommitted
+changes are ignored, so run it from the clean worktree/branch that owns the PR.
 
 Commit messages should help a future reader understand the change. The rich
 format in [`docs/commit-guidelines.md`](./docs/commit-guidelines.md) is a tool

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,10 @@ to risk:
 - Trivial: direct commit is fine.
 - Small: focused tests and one fresh-eye pass are usually enough.
 - Substantial: branch from `origin/main`, open a PR, run CI, use independent
-  review, and converge on findings rather than obeying every model suggestion.
+  review, run local Greptile CLI review with
+  `scripts/dev/greptile_review.sh origin/main`, and converge on findings rather
+  than obeying every model suggestion. Greptile CLI ignores uncommitted changes,
+  so use a clean PR worktree with committed changes before treating it as signal.
 
 ### Commit Messages
 

--- a/docs/pr-review-workflow.md
+++ b/docs/pr-review-workflow.md
@@ -53,16 +53,27 @@ trust.
    review on push. They re-review on new commits; if one goes quiet, re-trigger
    it (`/gemini review`, or re-request the reviewer) — and watch for it landing
    rather than assuming silence means approval.
-4. **Run fresh-eye agent review in parallel** on the exact diff — independent
+4. **Run local Greptile CLI review** from the PR worktree after the relevant
+   changes are committed:
+
+   ```bash
+   scripts/dev/greptile_review.sh origin/main
+   ```
+
+   This wraps `greptile review -b <base> --agent --no-color` so the output
+   is easy for agents to read. Install/login once with `npm i -g greptile`,
+   `greptile login`, and confirm with `greptile whoami`. Greptile CLI reviews
+   committed branch changes only; uncommitted changes are ignored.
+5. **Run fresh-eye agent review in parallel** on the exact diff — independent
    of the bots. Pick lenses by what the diff touches (see "Agent review").
-5. **Drive to LGTM** — address every *valid* finding (with judgment, next
+6. **Drive to LGTM** — address every *valid* finding (with judgment, next
    section), re-push, let reviewers re-review. Greptile's confidence score is
    the headline bar (target **5/5**); treat all the bots' inline comments —
    Greptile, Gemini, Copilot — as input, not orders.
-6. **Converge.** Loop until findings are trivial/duplicative (the readiness
+7. **Converge.** Loop until findings are trivial/duplicative (the readiness
    signal). Reviewers contradicting each other or themselves = you're done
    deciding, not them.
-7. **Merge** into `main` with a clean message. Delete the branch.
+8. **Merge** into `main` with a clean message. Delete the branch.
 
 ## Addressing review comments: judgment, not obedience
 
@@ -120,6 +131,7 @@ Write it for a smart reader who wasn't in the room.
 - [ ] Branch off `origin/main`; real PR open
 - [ ] `swift test` green; build clean (Swift 6 language mode)
 - [ ] Tests cover the new behavior *and* its failure modes
+- [ ] Local Greptile CLI review run from the PR worktree on committed changes
 - [ ] Automated review at LGTM (Greptile target 5/5); every inline comment
       resolved or explicitly declined with reasoning
 - [ ] Fresh-eye agent pass(es) done; findings converged to trivial

--- a/scripts/dev/greptile_review.sh
+++ b/scripts/dev/greptile_review.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 # Run Greptile's local code review in agent-friendly plain text.
 # Usage: scripts/dev/greptile_review.sh [base-branch] [extra greptile args...]
+# If the first argument starts with "-", origin/main remains the base and all
+# arguments are forwarded to Greptile.
 #
 # Greptile reviews committed branch changes only; uncommitted changes are
 # ignored. Run it from the worktree/branch that owns the PR.
@@ -14,8 +16,9 @@ if ! command -v greptile >/dev/null 2>&1; then
   exit 127
 fi
 
-base="${1:-origin/main}"
-if [[ $# -gt 0 ]]; then
+base="origin/main"
+if [[ $# -gt 0 && "$1" != -* ]]; then
+  base="$1"
   shift
 fi
 
@@ -25,6 +28,8 @@ if [[ "$base" == */* ]]; then
   if git remote get-url "$remote" >/dev/null 2>&1; then
     git fetch "$remote" "$remote_branch" \
       || echo "Warning: git fetch failed; reviewing against local $base" >&2
+  else
+    echo "Warning: remote '$remote' not found; reviewing against local $base" >&2
   fi
 fi
 

--- a/scripts/dev/greptile_review.sh
+++ b/scripts/dev/greptile_review.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run Greptile's local code review in agent-friendly plain text.
+# Usage: scripts/dev/greptile_review.sh [base-branch] [extra greptile args...]
+#
+# Greptile reviews committed branch changes only; uncommitted changes are
+# ignored. Run it from the worktree/branch that owns the PR.
+
+cd "$(dirname "$0")/../.."
+
+if ! command -v greptile >/dev/null 2>&1; then
+  echo "greptile CLI not found. Install with: npm i -g greptile" >&2
+  exit 127
+fi
+
+base="${1:-origin/main}"
+if [[ $# -gt 0 ]]; then
+  shift
+fi
+
+if [[ "$base" == */* ]]; then
+  remote="${base%%/*}"
+  remote_branch="${base#*/}"
+  if git remote get-url "$remote" >/dev/null 2>&1; then
+    git fetch "$remote" "$remote_branch" \
+      || echo "Warning: git fetch failed; reviewing against local $base" >&2
+  fi
+fi
+
+printf '==> greptile review -b %q --agent --no-color' "$base"
+if [[ $# -gt 0 ]]; then
+  printf ' %q' "$@"
+fi
+printf '\n'
+greptile review -b "$base" --agent --no-color "$@"


### PR DESCRIPTION
## What changed

- Adds `scripts/dev/greptile_review.sh`, a small wrapper around `greptile review` for agent-friendly local PR review output.
- Documents local Greptile CLI review in `docs/pr-review-workflow.md`.
- Adds the command and caveat to `AGENTS.md` and `CLAUDE.md`.

## Notes

Greptile CLI reviews committed branch changes only; uncommitted edits are ignored. The wrapper defaults to `origin/main`, fetches configured remote bases best-effort, and emits plain `--agent --no-color` output.

## Verification

- `bash -n scripts/dev/greptile_review.sh`
- `git diff --check`
- `greptile whoami`
- `scripts/dev/greptile_review.sh origin/main` ran successfully and produced actionable feedback; addressed the valid findings in the final commit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a local Greptile CLI review workflow via `scripts/dev/greptile_review.sh` to run agent-friendly reviews against a base (defaults to `origin/main`). Updates docs with usage and clarifies that only committed changes are reviewed.

- **New Features**
  - Added `scripts/dev/greptile_review.sh` wrapping `greptile review -b <base> --agent --no-color`, defaulting to `origin/main`, best-effort fetching `remote/branch`, and forwarding extra `greptile` args.
  - Updated `docs/pr-review-workflow.md`, `AGENTS.md`, and `CLAUDE.md` with setup, the command (`scripts/dev/greptile_review.sh origin/main`), a checklist item, and guidance to run from a clean PR worktree.

- **Bug Fixes**
  - Fixed wrapper option parsing to keep the default base when the first arg is a flag (e.g., `-v`) and pass all flags through.

<sup>Written for commit b636490b01ee4eae743a81cf5be3f757474877fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

