### PR TITLE
Polish macparakeet-cli for release: fixes, docs, 2.11.0 cut

### DIFF
--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -163,6 +163,20 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
 - `prompts restore-defaults` continues to re-show hidden built-in Transforms
   during the 2.x compatibility window. Use `transforms restore-defaults` for the
   newer Transform-specific restore/reset surface.
+- `meeting-vad-sim` is now hidden from `--help`. It is an internal Phase-0
+  diagnostic that was never part of the `spec --json` agent surface; hiding it
+  aligns the human command listing with the machine catalog. The command still
+  runs when invoked by name.
+
+### Fixed
+
+- `prompts add --from-file <path>` and `transforms create --from-file <path>`
+  now expand a leading `~` in the path, matching `quick-prompts add --from-file`.
+  Previously `~/notes/prompt.md` failed with a "no such file" error.
+- `vocab words delete <id>` now applies the same trimming and minimum
+  4-character prefix guard as `vocab words set`. An empty or too-short id is
+  rejected with a validation error (exit `2`) instead of falling through to a
+  bare-prefix match that could delete the only word in the list.
 
 ## [2.10.0] -- 2026-06-17
 

--- a/Sources/CLI/Commands/FeedbackCommand.swift
+++ b/Sources/CLI/Commands/FeedbackCommand.swift
@@ -32,12 +32,13 @@ struct FeedbackCommand: AsyncParsableCommand {
     @Option(name: .shortAndLong, help: "Your email (optional, for follow-up).")
     var email: String?
 
-    func run() async throws {
-        guard !message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            printErr("Error: Feedback message must not be empty.")
-            throw ExitCode.validationFailure
+    func validate() throws {
+        if message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            throw ValidationError("Feedback message must not be empty.")
         }
+    }
 
+    func run() async throws {
         let systemInfo = SystemInfo.current
 
         let payload = FeedbackPayload(

--- a/Sources/CLI/Commands/MeetingVADSimCommand.swift
+++ b/Sources/CLI/Commands/MeetingVADSimCommand.swift
@@ -11,7 +11,11 @@ import MacParakeetCore
 struct MeetingVADSimCommand: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "meeting-vad-sim",
-        abstract: "Replay meeting live-chunking (fixed vs VAD) on an audio file and report boundaries + realtime factor."
+        abstract: "Replay meeting live-chunking (fixed vs VAD) on an audio file and report boundaries + realtime factor.",
+        // Internal Phase-0 diagnostic, not part of the public agent surface
+        // (deliberately absent from `spec --json`). Hidden from `--help` so the
+        // human listing and the machine catalog agree; still invokable by name.
+        shouldDisplay: false
     )
 
     @Argument(help: "Path to an audio file (wav/m4a/mp3/caf/aiff).")

--- a/Sources/CLI/Commands/PromptsCommand.swift
+++ b/Sources/CLI/Commands/PromptsCommand.swift
@@ -180,7 +180,7 @@ extension PromptsCommand {
             if let content {
                 body = content
             } else if let fromFile {
-                body = try String(contentsOfFile: fromFile, encoding: .utf8)
+                body = try String(contentsOfFile: expandTilde(fromFile), encoding: .utf8)
             } else {
                 body = readStdinUTF8()
             }

--- a/Sources/CLI/Commands/TransformsCommand.swift
+++ b/Sources/CLI/Commands/TransformsCommand.swift
@@ -263,7 +263,7 @@ extension TransformsCommand {
                 if let p = prompt {
                     body = p
                 } else if let path = fromFile {
-                    body = try String(contentsOfFile: path, encoding: .utf8)
+                    body = try String(contentsOfFile: expandTilde(path), encoding: .utf8)
                 } else {
                     throw ValidationError("Provide a prompt body via --prompt or --from-file.")
                 }

--- a/Sources/CLI/Commands/VocabWordsCommand.swift
+++ b/Sources/CLI/Commands/VocabWordsCommand.swift
@@ -169,17 +169,10 @@ struct VocabWordsCommand: AsyncParsableCommand {
             let dbManager = try DatabaseManager(path: resolvedDatabasePath(database))
             let repo = CustomWordRepository(dbQueue: dbManager.dbQueue)
 
-            // Support UUID prefix matching
-            let words = try repo.fetchAll()
-            let matches = words.filter { $0.id.uuidString.lowercased().hasPrefix(id.lowercased()) }
-
-            guard let word = matches.first else {
-                throw VocabError.notFound("No word matching '\(id)'")
-            }
-            guard matches.count == 1 else {
-                throw VocabError.ambiguous("Multiple words match '\(id)'. Be more specific.")
-            }
-
+            // Resolve through the shared lookup so delete enforces the same
+            // trimming and minimum-prefix guard as `set` — an empty or too-short
+            // id must not silently match (and delete) the only word in the list.
+            let word = try VocabWordsCommand.resolveWord(id: id, words: try repo.fetchAll())
             _ = try repo.delete(id: word.id)
             print("Deleted: \(word.word)")
         }

--- a/Sources/CLI/README.md
+++ b/Sources/CLI/README.md
@@ -1,0 +1,101 @@
+# `macparakeet-cli` — maintainer guide
+
+This directory is the `macparakeet-cli` target: a Swift [ArgumentParser]
+CLI that shares all real logic with `MacParakeetCore`. It is a **public
+automation contract**, not a GUI mirror — humans, shell scripts, CI, and AI
+agents depend on its commands, flags, JSON shapes, and exit codes.
+
+This file is for people **changing** the CLI. If you instead want to *call* it
+from an agent, read [`integrations/README.md`](../../integrations/README.md).
+
+## Where things live
+
+```
+Sources/CLI/
+├── MacParakeetCLI.swift        # @main entry: root command, subcommand list,
+│                               #   cliVersion, exit-code normalization
+├── CHANGELOG.md                # the public ledger + compatibility policy
+└── Commands/
+    ├── CLIHelpers.swift        # shared lookups, JSON envelopes, errorType
+    │                           #   taxonomy, emitJSONOrRethrow wrappers
+    ├── CLITelemetry.swift      # opt-out/CI/DO_NOT_TRACK-gated instrumentation
+    ├── SpecCommand.swift       # `spec --json`: the machine-readable catalog
+    └── <Feature>Command.swift  # one file per top-level command / family
+```
+
+Each command is a `ParsableCommand` / `AsyncParsableCommand`. Command families
+(`vocab`, `prompts`, `transforms`, `meetings`, `llm`) nest subcommands through
+`CommandConfiguration.subcommands`.
+
+## The contract, in three documents
+
+- **[`CHANGELOG.md`](./CHANGELOG.md)** — what changed and the semver policy. The
+  surface is versioned: removing a command/flag/JSON field or changing an
+  exit-code meaning is **MAJOR**; additive changes are **MINOR**.
+- **[`spec/contracts/cli-json-v1.md`](../../spec/contracts/cli-json-v1.md)** —
+  the canonical stdout/stderr, envelope, and exit-code contract.
+- **`spec --json`** (from `SpecCommand.swift`) — the same contract as live,
+  machine-readable data, plus a hand-maintained catalog of the agent-facing
+  command surface.
+
+## Conventions (don't reinvent these)
+
+- **stdout is for machines, stderr is for humans.** Payloads and `--json`
+  output go to stdout; progress/status lines go to stderr via `printErr(...)`
+  so piping `--json` through `jq` stays clean.
+- **Exit codes:** `0` success, `1` runtime failure (work attempted, failed),
+  `2` validation/misuse (bad invocation before work started), `130` SIGINT.
+  Normalization lives in `MacParakeetCLI.normalizedExitCode(for:)`; validation
+  failures map to `2`.
+- **JSON output:** use `printJSON(_:)` / `printEnvelope(...)` (both use the
+  shared `cliJSONEncoder`: ISO-8601 dates, sorted keys, pretty-printed).
+  Field names are camelCase. (`transforms` JSON predates this and emits
+  snake_case keys — see the note in `cli-json-v1.md`; do not copy it.)
+- **`--json` failures:** wrap a `--json`-aware body in `emitJSONOrRethrow(json:)`
+  so post-parse failures emit the `{ ok: false, error, errorType, fix, meta }`
+  envelope on stdout and exit non-zero. New error classes get a new stable
+  `errorType` string in `CLIErrorType` (and a CHANGELOG note) — never silently
+  reuse one.
+- **Record lookup:** resolve ids through the shared helpers in `CLIHelpers.swift`
+  (`findTranscription`, `findPrompt`, …) or a family's `resolve*`. They accept
+  an exact UUID, a ≥4-char UUID prefix, or a name, and produce consistent
+  ambiguity/not-found errors. Don't hand-roll `hasPrefix` matching.
+- **Database access:** open via `DatabaseManager(path: resolvedDatabasePath(database))`
+  after `try AppPaths.ensureDirectories()`, then a GRDB repository. Prefer
+  repository fetch/update over raw SQL (GRDB UUID storage may not equal
+  `uuidString`).
+- **Concurrency:** new I/O is async/await; mark the body `async` and `await` it
+  rather than spawning a detached `Task` the caller depends on.
+
+## Adding or changing a command
+
+1. **Implement** the command/flag in its `*Command.swift` (follow the nearest
+   sibling; reuse the shared helpers and envelope wrappers above).
+2. **Catalog** it in `SpecCommand.swift` if it is agent-facing. The catalog
+   duplicates the ArgumentParser tree, so it must move in lockstep —
+   `SpecCommandTests` fails if a documented path no longer resolves, but it
+   cannot detect a *new* command you forgot to add.
+3. **Document** the change in [`CHANGELOG.md`](./CHANGELOG.md) under
+   `[Unreleased]` with the right Added/Changed/Fixed bucket and semver impact.
+4. **Version** at release time: promote `[Unreleased]` to a dated
+   `## [x.y.z]` section and bump `CLI.cliVersion` in `MacParakeetCLI.swift` to
+   match. `CLIVersionTests` pins the binary version to the latest *released*
+   header.
+5. **Test** in `Tests/CLITests/`. Lock anything an external caller branches on:
+   JSON keys, exit codes, `errorType`, the presence of a command in `spec`.
+6. **Contract** — if you touched stdout/stderr shape, envelopes, or exit-code
+   meaning, update [`spec/contracts/cli-json-v1.md`](../../spec/contracts/cli-json-v1.md)
+   in the same change.
+
+## Testing
+
+```bash
+swift build --product macparakeet-cli
+swift test --filter CLITests
+swift run macparakeet-cli --help
+swift run macparakeet-cli spec --json | jq .
+```
+
+Manual/QA matrix and provider notes: [`docs/cli-testing.md`](../../docs/cli-testing.md).
+
+[ArgumentParser]: https://github.com/apple/swift-argument-parser

--- a/Sources/CLI/README.md
+++ b/Sources/CLI/README.md
@@ -58,8 +58,10 @@ Each command is a `ParsableCommand` / `AsyncParsableCommand`. Command families
   reuse one.
 - **Record lookup:** resolve ids through the shared helpers in `CLIHelpers.swift`
   (`findTranscription`, `findPrompt`, …) or a family's `resolve*`. They accept
-  an exact UUID, a ≥4-char UUID prefix, or a name, and produce consistent
-  ambiguity/not-found errors. Don't hand-roll `hasPrefix` matching.
+  an exact UUID and a ≥4-char UUID prefix; the helpers for named records
+  (`findTranscription`, `findMeeting`, `findPrompt`) also accept a
+  case-insensitive name. All produce consistent ambiguity/not-found errors.
+  Don't hand-roll `hasPrefix` matching.
 - **Database access:** open via `DatabaseManager(path: resolvedDatabasePath(database))`
   after `try AppPaths.ensureDirectories()`, then a GRDB repository. Prefer
   repository fetch/update over raw SQL (GRDB UUID storage may not equal

--- a/Tests/CLITests/SpecCommandTests.swift
+++ b/Tests/CLITests/SpecCommandTests.swift
@@ -128,6 +128,36 @@ final class SpecCommandTests: XCTestCase {
         }
     }
 
+    /// Every documented spec path must resolve in the real ArgumentParser tree.
+    /// The catalog in `SpecCommand` is hand-maintained and duplicates the command
+    /// tree, so a renamed or removed subcommand could otherwise keep being
+    /// advertised to agents while no longer existing. Resolving each path with
+    /// `--help` short-circuits before any work runs: a known path throws a help
+    /// request (exit `0`); an unknown subcommand throws a parse error (exit `2`).
+    func testEveryDocumentedSpecPathResolvesInTheCommandTree() throws {
+        let payload = try specPayload()
+        let commands = try XCTUnwrap(payload["commands"] as? [[String: Any]])
+        let paths = try commands.map { try XCTUnwrap($0["path"] as? [String]) }
+        XCTAssertFalse(paths.isEmpty, "spec catalog should document at least one command")
+
+        for path in paths {
+            do {
+                _ = try CLI.parseAsRoot(path + ["--help"])
+                // Parsed without throwing: the path resolved and had no required
+                // arguments to complain about. Still a valid resolution.
+            } catch {
+                XCTAssertTrue(
+                    CLI.exitCode(for: error).isSuccess,
+                    """
+                    Spec catalog documents '\(path.joined(separator: " "))' but it \
+                    does not resolve in the real command tree: \
+                    \(CLI.fullMessage(for: error))
+                    """
+                )
+            }
+        }
+    }
+
     func testSpecCatalogDocumentsAgentAutomationFamilies() throws {
         let payload = try specPayload()
         let commands = try XCTUnwrap(payload["commands"] as? [[String: Any]])

--- a/docs/cli-testing.md
+++ b/docs/cli-testing.md
@@ -546,10 +546,10 @@ when its server-side authentication is enabled.
 | Provider | Default Model | API Key Required |
 |----------|--------------|-----------------|
 | `anthropic` | claude-sonnet-4-6 | Yes |
-| `openai` | gpt-4.1 | Yes |
+| `openai` | gpt-5.5 | Yes |
 | `openai-compatible` | user-selected endpoint/model | Optional |
-| `gemini` | gemini-2.5-flash | Yes |
-| `openrouter` | anthropic/claude-sonnet-4 | Yes |
+| `gemini` | gemini-3.5-flash | Yes |
+| `openrouter` | anthropic/claude-sonnet-4.6 | Yes |
 | `ollama` | qwen3.5:4b | No (local) |
 | `lmstudio` | user-selected in LM Studio | Optional (local) |
 | `cli` | N/A (tool decides) | No (tool manages auth) |

--- a/spec/README.md
+++ b/spec/README.md
@@ -140,7 +140,7 @@ Dictation + transcription + history + settings. Get audio in, text out, pasted i
 - [x] Menu bar app with main window
 - [x] Basic export (TXT/Markdown/SRT/VTT + copy to clipboard)
 - [x] SQLite database (GRDB, dictations + transcriptions + substring search)
-- [x] Internal dev CLI tool (`macparakeet-cli transcribe`, `history`, `health`, `models`, `vocab`)
+- [x] CLI tool (`macparakeet-cli transcribe`, `history`, `health`, `models`, `vocab`)
 - [x] Test suite passing (`swift test` green)
 
 ### v0.2 Clean Pipeline (Implemented)

--- a/spec/contracts/cli-json-v1.md
+++ b/spec/contracts/cli-json-v1.md
@@ -34,6 +34,10 @@ with human progress/status kept off stdout.
 - `--envelope` success output uses `{ ok, command, data, meta }` and does not
   change an existing command's plain `--json` success shape.
 - Commands that expose both `--json` and `--envelope` reject the combination.
+- JSON object keys are camelCase. The one exception is the `transforms` family
+  (`is_built_in`, `created_at`), which predates this convention; its keys are
+  frozen for v1 and would only change at a major boundary. New commands use
+  camelCase.
 
 ## Failure Envelope
 


### PR DESCRIPTION
## Summary

Deep-dive review of the **`macparakeet-cli`** surface — structure, code quality, ergonomics, docs/contract accuracy, and test coverage — to bring it to a release-ready state. The CLI is already a mature public contract (JSON envelope system, stable `errorType` taxonomy, 0/1/2/130 exit codes, `spec --json` machine catalog, telemetry gating). This PR closes the concrete correctness/consistency gaps the review found and cuts the **2.11.0** release. It is intentionally **low-churn**: larger refactors that would touch the public surface or need a major bump are deferred (see *Deliberately deferred*).

Review was run as four parallel passes: (1) code structure/quality, (2) command-surface ergonomics, (3) docs/spec/ADR/contract accuracy, (4) tests + telemetry/contract correctness. Every actioned finding below was re-verified against the code before changing.

## Fixes (real bugs)

- **`--from-file` tilde expansion** — `prompts add` and `transforms create` read `--from-file` without expanding `~`, unlike `quick-prompts add`. `~/notes/prompt.md` failed with "no such file". Now consistent. Verified end-to-end.
- **`vocab words delete` footgun** — `DeleteWord` used an inline `hasPrefix` with no trimming and no minimum-prefix guard, so `delete ""` matched and **deleted the only word** in the list. Now routes through the shared `resolveWord` lookup (same trim + ≥4-char guard as `vocab words set`); empty/short ids are rejected with exit `2`. Verified end-to-end.

## Surface / ergonomics

- **`meeting-vad-sim` hidden from `--help`** — it's an internal Phase-0 diagnostic that was never in the `spec --json` agent catalog, so the human listing and machine catalog disagreed. Now `shouldDisplay: false`; still invokable by name.
- **`feedback` validation** — empty-message check moved from a manual `printErr` + `ExitCode.validationFailure` inside `run()` to an idiomatic `validate()` + `ValidationError`. Exit code unchanged (`2`).

## Release

- **Cut `[Unreleased]` → `[2.11.0]`** and bumped `CLI.cliVersion` to `2.11.0`. The shipped 2.10.0 binary already exposed the entire `[Unreleased]` additive surface (`--engine cohere`, `--format srt|vtt`, new `config` keys, `prompts set --source`, `transforms restore-defaults`, `vocab words set`), so `--version`/`spec --json` were under-reporting it. `CLIVersionTests` pins the binary version to the latest released header, now green at 2.11.0.

## Docs / contract

- **New `Sources/CLI/README.md`** — maintainer guide: module map + an "add/change a command" checklist (implement → `spec` catalog → CHANGELOG → version bump → `CLITests` → contract) + conventions. Links out to `integrations/README.md` (callers), `cli-json-v1.md` (contract), and `docs/cli-testing.md` (QA) rather than duplicating them.
- **`spec/contracts/cli-json-v1.md`** — documents the camelCase key convention and the one `transforms` snake_case exception (frozen for v1).
- **`docs/cli-testing.md`** — refreshed the stale LLM default-model table (`gpt-5.5`, `gemini-3.5-flash`, `anthropic/claude-sonnet-4.6`).
- **`spec/README.md`** — dropped the stale "internal dev" framing for the CLI.

## Tests

- **New `SpecCommandTests` case** asserts every documented `spec` catalog path resolves in the real ArgumentParser tree. The catalog is hand-maintained and duplicates the command tree; this catches a renamed/removed subcommand the catalog would otherwise keep advertising to agents.

## Deliberately deferred (not done here, by design)

These are real but either major-bump-requiring, a larger feature, or a refactor with regression risk — wrong for a release-prep PR:

- **ID-resolver / DB-bootstrap duplication** — ~6 near-duplicate UUID/prefix/name resolvers and repeated repository setup. Consolidating risks subtle behavior drift in a public contract; the `vocab words delete` fix removes the one instance that was an actual bug.
- **Destructive-op confirmation** — a uniform TTY-gated `--yes` across deletes/clears would be additive but is a feature, not a fix.
- **`transforms` snake_case → camelCase** — a breaking change; documented now, normalize at the next major.
- **Additive aliases / wider `--envelope` adoption** — next-major ergonomics, deferred to avoid surface bloat.

## Verification

- `swift build` ✓
- `swift test` ✓ (full suite green; `CLITests` 407 passing incl. the new contract test)
- Ground-truth: `--version` → `2.11.0`; `meeting-vad-sim` absent from `--help` but invokable; `spec --json` reports 2.11.0; the two bug fixes verified against a temp DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preps `macparakeet-cli` for the 2.11.0 release with two safety fixes, aligned help/spec output, and refreshed docs/tests. Cuts the `2.11.0` version while keeping public behavior stable.

- **Bug Fixes**
  - `prompts add --from-file` and `transforms create --from-file` now expand `~` (e.g., `~/notes/prompt.md`).
  - `vocab words delete <id>` uses the shared resolver with trim + >=4‑char prefix guard; invalid ids fail with exit `2`.

- **Release & Contract**
  - Hide `meeting-vad-sim` from `--help` (still invokable) to match `spec --json`; move `feedback` empty-message check to `validate()` (exit code unchanged).
  - Bump CLI version to `2.11.0` and cut CHANGELOG section; `spec --json` now reports `2.11.0`.
  - Add `Sources/CLI/README.md` maintainer guide and clarify record-lookup rules (only named-record helpers accept names; others use UUID/prefix); document camelCase keys with the `transforms` snake_case exception; refresh default model table; drop “internal dev” wording in `spec/README.md`.
  - New test asserts every documented `spec` path resolves in the real command tree.

<sup>Written for commit 90167e97fdb2e7dd97ea6af1254e8fd67b48b3fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/630?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

