### PR TITLE
Fix export option toggles to show effective state; show Parakeet variant in Retranscribe

### DIFF
--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
@@ -2807,9 +2807,10 @@ struct TranscriptResultView: View {
                 }
             }
 
-            // Options only apply to Text/Markdown; subtitle, JSON, and document
-            // formats embed timing/speakers/metadata by definition, so showing
-            // greyed toggles for them would just be noise.
+            // The Options toggles apply only to Text/Markdown. SRT/VTT are
+            // cue-only, and JSON/PDF/DOCX always include whatever the transcript
+            // has — so none of those take these toggles; showing them greyed
+            // would just be noise.
             if selectedExportFormat.supportsTranscriptOptions {
                 VStack(alignment: .leading, spacing: DesignSystem.Spacing.xs) {
                     Text("Options")

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
@@ -640,6 +640,7 @@ struct TranscriptResultView: View {
                     EngineOptionCard(
                         selection: choice.selection,
                         nemotronVariant: option.nemotronVariant,
+                        parakeetVariant: option.parakeetVariant,
                         isPrimary: choice.isPrimary,
                         isAvailable: choice.isAvailable,
                         unavailableReason: choice.unavailableReason,
@@ -2688,8 +2689,7 @@ struct TranscriptResultView: View {
     }
 
     private var hasTimestamps: Bool {
-        guard let words = activeTranscription.wordTimestamps else { return false }
-        return !words.isEmpty
+        activeTranscription.hasWordTimestamps
     }
 
     private var hasAlignedTimestampsForExport: Bool {
@@ -2697,21 +2697,44 @@ struct TranscriptResultView: View {
     }
 
     private var hasSpeakerLabelsForExport: Bool {
-        guard !hasEditedTranscript else { return false }
-        guard let speakers = activeTranscription.speakers, !speakers.isEmpty,
-              let words = activeTranscription.wordTimestamps else { return false }
-        return words.contains { $0.speakerId != nil }
+        !hasEditedTranscript && activeTranscription.hasSpeakerLabeledWords
+    }
+
+    /// Whether "Include timestamps" applies to the current selection: the format
+    /// must take transcript options *and* the transcript must have aligned
+    /// timestamps to include.
+    private var canIncludeTimestampsOption: Bool {
+        selectedExportFormat.supportsTranscriptOptions && hasAlignedTimestampsForExport
+    }
+
+    private var canIncludeSpeakerLabelsOption: Bool {
+        selectedExportFormat.supportsTranscriptOptions && hasSpeakerLabelsForExport
+    }
+
+    /// Caption shown under a disabled "Include timestamps" toggle. `nil` when the
+    /// option is available, or when the format takes no options (the section is
+    /// hidden in that case, so no caption is needed).
+    private var timestampsUnavailableReason: String? {
+        guard selectedExportFormat.supportsTranscriptOptions,
+              !hasAlignedTimestampsForExport else { return nil }
+        if !hasTimestamps { return "This transcript has no word timestamps." }
+        return "Unavailable after editing the transcript text."
+    }
+
+    private var speakerLabelsUnavailableReason: String? {
+        guard selectedExportFormat.supportsTranscriptOptions,
+              !hasSpeakerLabelsForExport else { return nil }
+        if activeTranscription.hasSpeakerLabeledWords {
+            return "Unavailable after editing the transcript text."
+        }
+        return "This transcript has no speaker labels."
     }
 
     private var resolvedTranscriptExportOptions: TranscriptExportOptions {
-        var options = transcriptExportOptions
-        if !hasAlignedTimestampsForExport {
-            options.includeTimestamps = false
-        }
-        if !hasSpeakerLabelsForExport {
-            options.includeSpeakerLabels = false
-        }
-        return options
+        transcriptExportOptions.resolved(
+            canIncludeTimestamps: hasAlignedTimestampsForExport,
+            canIncludeSpeakerLabels: hasSpeakerLabelsForExport
+        )
     }
 
     private var exportFormatOrder: [TranscriptExportFormat] {
@@ -2784,19 +2807,31 @@ struct TranscriptResultView: View {
                 }
             }
 
-            VStack(alignment: .leading, spacing: DesignSystem.Spacing.xs) {
-                Text("Options")
-                    .font(DesignSystem.Typography.caption.weight(.medium))
-                    .foregroundStyle(DesignSystem.Colors.textSecondary)
+            // Options only apply to Text/Markdown; subtitle, JSON, and document
+            // formats embed timing/speakers/metadata by definition, so showing
+            // greyed toggles for them would just be noise.
+            if selectedExportFormat.supportsTranscriptOptions {
+                VStack(alignment: .leading, spacing: DesignSystem.Spacing.xs) {
+                    Text("Options")
+                        .font(DesignSystem.Typography.caption.weight(.medium))
+                        .foregroundStyle(DesignSystem.Colors.textSecondary)
 
-                Toggle("Include timestamps", isOn: $transcriptExportOptions.includeTimestamps)
-                    .disabled(!selectedExportFormat.supportsTranscriptOptions || !hasAlignedTimestampsForExport)
+                    exportOptionToggle(
+                        "Include timestamps",
+                        isOn: $transcriptExportOptions.includeTimestamps,
+                        isEnabled: canIncludeTimestampsOption,
+                        unavailableReason: timestampsUnavailableReason
+                    )
 
-                Toggle("Include speaker labels", isOn: $transcriptExportOptions.includeSpeakerLabels)
-                    .disabled(!selectedExportFormat.supportsTranscriptOptions || !hasSpeakerLabelsForExport)
+                    exportOptionToggle(
+                        "Include speaker labels",
+                        isOn: $transcriptExportOptions.includeSpeakerLabels,
+                        isEnabled: canIncludeSpeakerLabelsOption,
+                        unavailableReason: speakerLabelsUnavailableReason
+                    )
 
-                Toggle("Include metadata", isOn: $transcriptExportOptions.includeMetadata)
-                    .disabled(!selectedExportFormat.supportsTranscriptOptions)
+                    Toggle("Include metadata", isOn: $transcriptExportOptions.includeMetadata)
+                }
             }
 
             Divider()
@@ -2815,6 +2850,32 @@ struct TranscriptResultView: View {
         }
         .padding(DesignSystem.Spacing.md)
         .frame(width: 380)
+    }
+
+    /// An export option toggle that shows its *effective* state. When the option
+    /// is unavailable it renders unchecked and disabled — rather than checked and
+    /// greyed, which reads as "forced on" and contradicts the export, which omits
+    /// the missing data. An optional caption explains why it is unavailable.
+    @ViewBuilder
+    private func exportOptionToggle(
+        _ title: String,
+        isOn: Binding<Bool>,
+        isEnabled: Bool,
+        unavailableReason: String?
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Toggle(title, isOn: Binding(
+                get: { isEnabled && isOn.wrappedValue },
+                set: { isOn.wrappedValue = $0 }
+            ))
+            .disabled(!isEnabled)
+
+            if let unavailableReason {
+                Text(unavailableReason)
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundStyle(DesignSystem.Colors.textTertiary)
+            }
+        }
     }
 
     // MARK: - Export Confirmation Popover
@@ -2975,6 +3036,7 @@ struct TranscriptResultView: View {
 private struct EngineOptionCard: View {
     let selection: SpeechEngineSelection
     let nemotronVariant: NemotronModelVariant
+    let parakeetVariant: ParakeetModelVariant
     let isPrimary: Bool
     let isAvailable: Bool
     let unavailableReason: String?
@@ -2995,7 +3057,11 @@ private struct EngineOptionCard: View {
     private var subtitle: String {
         switch selection.engine {
         case .parakeet:
-            "Fast • 25 European languages, including English"
+            switch parakeetVariant {
+            case .v3: "Fast • 25 European languages, including English"
+            case .v2: "Fast • English only"
+            case .unified: "Fast • English only, punctuated. No word timestamps."
+            }
         case .nemotron:
             nemotronVariant.isEnglishOnly
                 ? "Beta • Nemotron Speech EN streaming"

--- a/Sources/MacParakeetCore/Models/Transcription.swift
+++ b/Sources/MacParakeetCore/Models/Transcription.swift
@@ -139,6 +139,28 @@ public struct Transcription: Codable, Identifiable, Sendable {
     }
 }
 
+extension Transcription {
+    /// Whether this transcription carries word-level timing. This is the source
+    /// of truth for the "Timed" transcript view and for whether timestamps can
+    /// be exported. Plain-text engines (Parakeet Unified, Cohere) and older
+    /// pre-timestamp records leave this `false`.
+    public var hasWordTimestamps: Bool {
+        guard let wordTimestamps else { return false }
+        return !wordTimestamps.isEmpty
+    }
+
+    /// Whether words carry diarized speaker IDs that can be exported as speaker
+    /// labels. Requires both a non-empty `speakers` roster and at least one word
+    /// attributed to a speaker. A transcript can list `speakers` without any word
+    /// being attributed — e.g. older records where diarization ran on an engine
+    /// that produced no word timings — so the speaker count alone is not enough.
+    public var hasSpeakerLabeledWords: Bool {
+        guard let speakers, !speakers.isEmpty,
+              let wordTimestamps else { return false }
+        return wordTimestamps.contains { $0.speakerId != nil }
+    }
+}
+
 public struct WordTimestamp: Codable, Sendable, Equatable {
     public var word: String
     public var startMs: Int

--- a/Sources/MacParakeetCore/Services/ExportService.swift
+++ b/Sources/MacParakeetCore/Services/ExportService.swift
@@ -34,6 +34,21 @@ public struct TranscriptExportOptions: Sendable, Equatable {
     }
 
     public static let `default` = TranscriptExportOptions()
+
+    /// Returns a copy with unavailable options forced off, so an export can never
+    /// claim to include timing or speaker labels that the transcript lacks. The
+    /// export UI and the export itself resolve through this single helper, so the
+    /// checkbox state and the written file can never disagree. `includeMetadata`
+    /// has no data dependency and is never forced off here.
+    public func resolved(
+        canIncludeTimestamps: Bool,
+        canIncludeSpeakerLabels: Bool
+    ) -> TranscriptExportOptions {
+        var resolved = self
+        if !canIncludeTimestamps { resolved.includeTimestamps = false }
+        if !canIncludeSpeakerLabels { resolved.includeSpeakerLabels = false }
+        return resolved
+    }
 }
 
 /// Handles exporting transcriptions to files and clipboard.

--- a/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
@@ -24,6 +24,11 @@ public final class TranscriptionViewModel {
         /// Persisted Nemotron build a Nemotron rerun would load (STTRuntime
         /// resolves the persisted variant at run start).
         public let nemotronVariant: NemotronModelVariant
+        /// Persisted Parakeet build a Parakeet rerun would load. Drives the
+        /// engine card's subtitle so it reflects the actual v3/v2/Unified
+        /// posture (e.g. Unified is English-only and emits no word timestamps)
+        /// rather than always advertising the multilingual v3 build.
+        public let parakeetVariant: ParakeetModelVariant
 
         public var title: String {
             "Retranscribe with speech engine"
@@ -461,7 +466,8 @@ public final class TranscriptionViewModel {
         return RetranscriptionEngineOption(
             primaryEngine: primaryEngine,
             choices: choices,
-            nemotronVariant: SpeechEnginePreference.nemotronModelVariant(defaults: defaults)
+            nemotronVariant: SpeechEnginePreference.nemotronModelVariant(defaults: defaults),
+            parakeetVariant: SpeechEnginePreference.parakeetModelVariant(defaults: defaults)
         )
     }
 

--- a/Tests/MacParakeetTests/Services/TranscriptExportOptionsTests.swift
+++ b/Tests/MacParakeetTests/Services/TranscriptExportOptionsTests.swift
@@ -47,13 +47,28 @@ final class TranscriptExportOptionsTests: XCTestCase {
         XCTAssertTrue(t.hasSpeakerLabeledWords)
     }
 
-    /// The legacy / plain-text-engine state: a `speakers` roster exists (so the
-    /// header shows "N speakers") but no word carries a `speakerId`. Speaker
-    /// labels cannot be exported, so this must be false.
-    func testHasSpeakerLabeledWordsFalseWhenSpeakersButNoAttributedWords() {
+    /// Words are present but none carries a `speakerId` (diarization ran but
+    /// attributed nothing). Speaker labels cannot be exported, so this is false.
+    /// Exercises the `contains { speakerId != nil }` branch.
+    func testHasSpeakerLabeledWordsFalseWhenWordsHaveNoSpeakerId() {
         let t = Transcription(
             fileName: "a.mp3",
             wordTimestamps: words(withSpeaker: false),
+            speakerCount: 3,
+            speakers: [SpeakerInfo(id: "S1", label: "Speaker 1")]
+        )
+        XCTAssertFalse(t.hasSpeakerLabeledWords)
+    }
+
+    /// The motivating legacy / plain-text-engine state: a `speakers` roster
+    /// exists (so the header shows "N speakers") but the engine emitted no word
+    /// timings at all — Parakeet Unified / Cohere, or pre-#623 diarized records.
+    /// Speaker labels cannot be exported, so this must be false. Exercises the
+    /// `guard let wordTimestamps` branch.
+    func testHasSpeakerLabeledWordsFalseWhenSpeakersButNoWordTimestamps() {
+        let t = Transcription(
+            fileName: "a.mp3",
+            wordTimestamps: nil,
             speakerCount: 3,
             speakers: [SpeakerInfo(id: "S1", label: "Speaker 1")]
         )

--- a/Tests/MacParakeetTests/Services/TranscriptExportOptionsTests.swift
+++ b/Tests/MacParakeetTests/Services/TranscriptExportOptionsTests.swift
@@ -1,0 +1,120 @@
+import XCTest
+@testable import MacParakeetCore
+
+/// Covers the availability + resolution logic behind the export dialog's
+/// "Include timestamps"/"Include speaker labels" toggles. The view resolves the
+/// user's options through `TranscriptExportOptions.resolved(...)` using these
+/// `Transcription` predicates, so the displayed checkbox state and the written
+/// file always agree.
+@MainActor
+final class TranscriptExportOptionsTests: XCTestCase {
+    private let exportService = ExportService()
+
+    private func words(withSpeaker: Bool) -> [WordTimestamp] {
+        [
+            WordTimestamp(word: "Hello", startMs: 0, endMs: 500, confidence: 0.9,
+                          speakerId: withSpeaker ? "S1" : nil),
+            WordTimestamp(word: "world", startMs: 500, endMs: 1000, confidence: 0.9,
+                          speakerId: withSpeaker ? "S1" : nil),
+        ]
+    }
+
+    // MARK: - hasWordTimestamps
+
+    func testHasWordTimestampsTrueWithWords() {
+        let t = Transcription(fileName: "a.mp3", wordTimestamps: words(withSpeaker: false))
+        XCTAssertTrue(t.hasWordTimestamps)
+    }
+
+    func testHasWordTimestampsFalseWhenNil() {
+        let t = Transcription(fileName: "a.mp3", wordTimestamps: nil)
+        XCTAssertFalse(t.hasWordTimestamps)
+    }
+
+    func testHasWordTimestampsFalseWhenEmpty() {
+        let t = Transcription(fileName: "a.mp3", wordTimestamps: [])
+        XCTAssertFalse(t.hasWordTimestamps)
+    }
+
+    // MARK: - hasSpeakerLabeledWords
+
+    func testHasSpeakerLabeledWordsTrueWhenAttributed() {
+        let t = Transcription(
+            fileName: "a.mp3",
+            wordTimestamps: words(withSpeaker: true),
+            speakers: [SpeakerInfo(id: "S1", label: "Speaker 1")]
+        )
+        XCTAssertTrue(t.hasSpeakerLabeledWords)
+    }
+
+    /// The legacy / plain-text-engine state: a `speakers` roster exists (so the
+    /// header shows "N speakers") but no word carries a `speakerId`. Speaker
+    /// labels cannot be exported, so this must be false.
+    func testHasSpeakerLabeledWordsFalseWhenSpeakersButNoAttributedWords() {
+        let t = Transcription(
+            fileName: "a.mp3",
+            wordTimestamps: words(withSpeaker: false),
+            speakerCount: 3,
+            speakers: [SpeakerInfo(id: "S1", label: "Speaker 1")]
+        )
+        XCTAssertFalse(t.hasSpeakerLabeledWords)
+    }
+
+    func testHasSpeakerLabeledWordsFalseWhenNoSpeakers() {
+        let t = Transcription(fileName: "a.mp3", wordTimestamps: words(withSpeaker: true), speakers: nil)
+        XCTAssertFalse(t.hasSpeakerLabeledWords)
+    }
+
+    // MARK: - TranscriptExportOptions.resolved
+
+    func testResolvedForcesUnavailableOptionsOff() {
+        let resolved = TranscriptExportOptions().resolved(
+            canIncludeTimestamps: false,
+            canIncludeSpeakerLabels: false
+        )
+        XCTAssertFalse(resolved.includeTimestamps)
+        XCTAssertFalse(resolved.includeSpeakerLabels)
+        // Metadata has no data dependency and must never be forced off.
+        XCTAssertTrue(resolved.includeMetadata)
+    }
+
+    func testResolvedKeepsAvailableOptionsOn() {
+        let resolved = TranscriptExportOptions().resolved(
+            canIncludeTimestamps: true,
+            canIncludeSpeakerLabels: true
+        )
+        XCTAssertTrue(resolved.includeTimestamps)
+        XCTAssertTrue(resolved.includeSpeakerLabels)
+        XCTAssertTrue(resolved.includeMetadata)
+    }
+
+    func testResolvedRespectsUserOptOutEvenWhenAvailable() {
+        let opts = TranscriptExportOptions(includeTimestamps: false, includeSpeakerLabels: false)
+        let resolved = opts.resolved(canIncludeTimestamps: true, canIncludeSpeakerLabels: true)
+        XCTAssertFalse(resolved.includeTimestamps)
+        XCTAssertFalse(resolved.includeSpeakerLabels)
+    }
+
+    // MARK: - End-to-end: resolution controls the written file
+
+    func testResolvedOptionsDriveMarkdownTimestamps() {
+        let t = Transcription(
+            fileName: "a.mp3",
+            rawTranscript: "Hello world",
+            wordTimestamps: words(withSpeaker: false),
+            status: .completed
+        )
+
+        let withTimestamps = exportService.formatMarkdown(
+            transcription: t,
+            options: TranscriptExportOptions().resolved(canIncludeTimestamps: true, canIncludeSpeakerLabels: false)
+        )
+        XCTAssertTrue(withTimestamps.contains("**["), "Expected timestamp markers when timestamps are included")
+
+        let withoutTimestamps = exportService.formatMarkdown(
+            transcription: t,
+            options: TranscriptExportOptions().resolved(canIncludeTimestamps: false, canIncludeSpeakerLabels: false)
+        )
+        XCTAssertFalse(withoutTimestamps.contains("**["), "Expected no timestamp markers once resolved off")
+    }
+}

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
@@ -1758,6 +1758,7 @@ final class TranscriptionViewModelTests: XCTestCase {
         SpeechEnginePreference.whisper.save(to: defaults)
         SpeechEnginePreference.saveWhisperDefaultLanguage("ja", defaults: defaults)
         SpeechEnginePreference.saveNemotronModelVariant(.english1120, defaults: defaults)
+        SpeechEnginePreference.saveParakeetModelVariant(.unified, defaults: defaults)
         viewModel = TranscriptionViewModel(
             defaults: defaults,
             isWhisperModelDownloaded: { true },
@@ -1787,6 +1788,7 @@ final class TranscriptionViewModelTests: XCTestCase {
             SpeechEngineSelection(engine: .parakeet)
         )
         XCTAssertEqual(option.nemotronVariant, .english1120)
+        XCTAssertEqual(option.parakeetVariant, .unified)
     }
 
     func testRetranscriptionEngineOptionIncludesNemotronButDisablesItWhenMissing() throws {


### PR DESCRIPTION
## Why

The transcript export dialog showed **Include timestamps** and **Include speaker labels** as *checked-but-disabled* whenever the transcript had no word timestamps or no speaker-labeled words — e.g. transcripts made with **Parakeet Unified** or **Cohere** (both emit no word timings), or older diarized-but-untimestamped records.

A checked + disabled checkbox reads as "this is forced **on** and locked." The truth is the opposite: the export omits the missing data (`resolvedTranscriptExportOptions` already forces those options off). So the visual state contradicted the behavior, which is exactly what a user flagged.

## What changed

**Export dialog (presentation only — behavior was already correct):**
- An unavailable option now renders **unchecked + disabled** via an effective-state binding, instead of checked-and-greyed.
- A one-line caption explains *why* it's unavailable ("This transcript has no word timestamps." / "...no speaker labels." / "Unavailable after editing the transcript text.").
- The **Options** section is hidden entirely for formats that take no options (SRT/VTT/JSON/PDF/DOCX embed timing/speakers/metadata by definition), removing a row of greyed phantom toggles.

**Pure, testable core helpers** (so the checkbox state and the written file resolve through one path and can never disagree):
- `Transcription.hasWordTimestamps` / `Transcription.hasSpeakerLabeledWords`
- `TranscriptExportOptions.resolved(canIncludeTimestamps:canIncludeSpeakerLabels:)`

**Retranscribe engine card subtitle:** previously always advertised Parakeet as "25 European languages, including English" regardless of the selected build. It now reflects the actual variant:
- v3 → "Fast • 25 European languages, including English"
- v2 → "Fast • English only"
- Unified → "Fast • English only, punctuated. No word timestamps."

This matters because the card's "Current" badge reflects the *current default* engine, not the engine that produced the open transcript — so without the right subtitle a user could re-run "Parakeet" (Unified) expecting timestamps and get none again.

## Not changed
- Export *behavior*: `resolvedTranscriptExportOptions` already forced unavailable options off, and SRT/VTT already fall back to a single full-length cue. This PR only makes the UI tell the truth and extracts the logic for testing.

## Tests
- New `TranscriptExportOptionsTests`: the two `Transcription` predicates (including the legacy "speakers present but no attributed words" case), `resolved(...)` force-off / keep-on / respect-opt-out, and an end-to-end markdown check that resolution drives the written output.
- `TranscriptionViewModelTests`: asserts the Parakeet variant pass-through on the retranscribe option.
- `swift build`, full `swift test` (4195 tests, 0 failures), and the Swift 6 language-mode gate all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes export dialog toggles to reflect the real, effective state and explain why options are unavailable. Updates Retranscribe to show the actual Parakeet variant so users aren’t misled about timestamp support.

- **Bug Fixes**
  - Export dialog now shows unavailable options as unchecked and disabled with a short reason; hides the Options section for formats that don’t take transcript options. Centralizes logic via `Transcription.hasWordTimestamps`, `Transcription.hasSpeakerLabeledWords`, and `TranscriptExportOptions.resolved(...)` so UI and exported files stay in sync.
  - Retranscribe engine card now displays the selected Parakeet variant: `v3` (multilingual), `v2` (English only), or `Unified` (English only, punctuated, no word timestamps).

- **Tests**
  - Adds tests for export option resolution, including the legacy “speakers present but no word timestamps” case; asserts Parakeet variant pass-through in the retranscribe option.

<sup>Written for commit 08619b7eb83c7675c22b5d3a47676d8689f845ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/631?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

