### PR TITLE
Fix hold-to-talk final-word tail

### DIFF
--- a/Sources/MacParakeet/App/AppHotkeyCoordinator.swift
+++ b/Sources/MacParakeet/App/AppHotkeyCoordinator.swift
@@ -4,6 +4,8 @@ import MacParakeetViewModels
 
 @MainActor
 final class AppHotkeyCoordinator {
+    static let holdToTalkStopTailMs = 200
+
     private let settingsViewModel: SettingsViewModel
     private let onStartDictation: (FnKeyStateMachine.RecordingMode) -> Void
     private let onStopDictation: () -> Void
@@ -77,15 +79,18 @@ final class AppHotkeyCoordinator {
             let trigger: HotkeyTrigger
             let gestureMode: HotkeyGestureController.Mode
             let startupDebounceMs: Int
+            let holdToTalkStopTailMs: Int
 
             init(
                 trigger: HotkeyTrigger,
                 gestureMode: HotkeyGestureController.Mode,
-                startupDebounceMs: Int = FnKeyStateMachine.defaultStartupDebounceMs
+                startupDebounceMs: Int = FnKeyStateMachine.defaultStartupDebounceMs,
+                holdToTalkStopTailMs: Int = 0
             ) {
                 self.trigger = trigger
                 self.gestureMode = gestureMode
                 self.startupDebounceMs = startupDebounceMs
+                self.holdToTalkStopTailMs = max(0, holdToTalkStopTailMs)
             }
         }
 
@@ -150,7 +155,8 @@ final class AppHotkeyCoordinator {
                 specs: [
                     DictationHotkeyPlan.Spec(
                         trigger: handsFreeTrigger,
-                        gestureMode: .doubleTapAndHold
+                        gestureMode: .doubleTapAndHold,
+                        holdToTalkStopTailMs: holdToTalkStopTailMs
                     ),
                 ],
                 conflict: nil
@@ -191,7 +197,8 @@ final class AppHotkeyCoordinator {
                     startupDebounceMs: pushToTalkStartupDebounceMs(
                         handsFree: handsFreeTrigger,
                         pushToTalk: pushToTalkTrigger
-                    )
+                    ),
+                    holdToTalkStopTailMs: holdToTalkStopTailMs
                 )
             )
         }
@@ -226,6 +233,7 @@ final class AppHotkeyCoordinator {
                 trigger: spec.trigger,
                 gestureMode: spec.gestureMode,
                 startupDebounceMs: spec.startupDebounceMs,
+                holdToTalkStopTailMs: spec.holdToTalkStopTailMs,
                 resumeMode: Self.resumeMode(activeRecordingMode, for: spec.gestureMode),
                 suppressUntilReset: Self.shouldSuppressPeer(activeRecordingMode, for: spec.gestureMode)
             )
@@ -244,6 +252,7 @@ final class AppHotkeyCoordinator {
         trigger: HotkeyTrigger,
         gestureMode: HotkeyGestureController.Mode,
         startupDebounceMs: Int = FnKeyStateMachine.defaultStartupDebounceMs,
+        holdToTalkStopTailMs: Int = 0,
         resumeMode: FnKeyStateMachine.RecordingMode? = nil,
         suppressUntilReset: Bool = false
     ) -> HotkeyManager? {
@@ -252,7 +261,8 @@ final class AppHotkeyCoordinator {
         let manager = HotkeyManager(
             trigger: trigger,
             gestureMode: gestureMode,
-            startupDebounceMs: startupDebounceMs
+            startupDebounceMs: startupDebounceMs,
+            holdToTalkStopTailMs: holdToTalkStopTailMs
         )
         manager.onStartRecording = { [weak self, weak manager] mode in
             if let manager {

--- a/Sources/MacParakeet/App/DictationFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/DictationFlowCoordinator.swift
@@ -544,9 +544,9 @@ final class DictationFlowCoordinator {
             let sessionID = serviceSession.reserveNextSessionID()
             startRecordingTask(mode: mode, generation: stateMachine.generation, sessionID: sessionID)
 
-        case .stopRecordingAndTranscribe:
+        case .stopRecordingAndTranscribe(let mode):
             let sessionID = serviceSession.currentSessionID
-            stopRecordingTask(generation: stateMachine.generation, sessionID: sessionID)
+            stopRecordingTask(generation: stateMachine.generation, sessionID: sessionID, mode: mode)
 
         case .cancelRecording(let reason):
             let sessionID = serviceSession.currentSessionID
@@ -1070,12 +1070,19 @@ final class DictationFlowCoordinator {
         return alert.runModal()
     }
 
-    private func stopRecordingTask(generation: Int, sessionID: Int) {
+    private func stopRecordingTask(
+        generation: Int,
+        sessionID: Int,
+        mode: FnKeyStateMachine.RecordingMode
+    ) {
         actionTask = Task { @MainActor in
             do {
                 let serviceState = await self.serviceSession.state
                 self.dictationLog.notice(
-                    "stop_recording_requested gen=\(generation) session=\(sessionID) flowState=\(self.describeState(self.stateMachine.state), privacy: .public) serviceState=\(self.describeServiceState(serviceState), privacy: .public)"
+                    "stop_recording_requested gen=\(generation) session=\(sessionID) mode=\(self.describeRecordingMode(mode), privacy: .public) flowState=\(self.describeState(self.stateMachine.state), privacy: .public) serviceState=\(self.describeServiceState(serviceState), privacy: .public)"
+                )
+                AudioCaptureDiagnostics.append(
+                    "dictation_stop_requested mode=\(self.diagnosticRecordingMode(mode)) session=\(sessionID)"
                 )
                 let finishContext = self.focusedAppContextService.currentContext()
                 await self.serviceSession.updateTelemetryAppCategory(
@@ -1222,6 +1229,24 @@ final class DictationFlowCoordinator {
         case .cancelled: return "cancelled"
         case .success: return "success"
         case .error: return "error"
+        }
+    }
+
+    private func describeRecordingMode(_ mode: FnKeyStateMachine.RecordingMode) -> String {
+        switch mode {
+        case .holdToTalk:
+            return "holdToTalk"
+        case .persistent:
+            return "persistent"
+        }
+    }
+
+    private func diagnosticRecordingMode(_ mode: FnKeyStateMachine.RecordingMode) -> String {
+        switch mode {
+        case .holdToTalk:
+            return "hold_to_talk"
+        case .persistent:
+            return "persistent"
         }
     }
 }

--- a/Sources/MacParakeet/Hotkey/HotkeyManager.swift
+++ b/Sources/MacParakeet/Hotkey/HotkeyManager.swift
@@ -21,11 +21,13 @@ public final class HotkeyManager {
     private let gestureController: HotkeyGestureController
     private let trigger: HotkeyTrigger
     private let gestureMode: HotkeyGestureController.Mode
+    private let holdToTalkStopTailMs: Int
     private let targetMask: CGEventFlags?
     public let tapThresholdMs: Int
     private var eventTap: CFMachPort?
     private var startupTimer: DispatchWorkItem?
     private var holdTimer: DispatchWorkItem?
+    private var stopTailTimer: DispatchWorkItem?
     private var runLoopSource: CFRunLoopSource?
     /// Retained reference to self passed to the CGEvent tap callback.
     /// Prevents use-after-free if the tap fires during deallocation.
@@ -61,10 +63,12 @@ public final class HotkeyManager {
         trigger: HotkeyTrigger = .fn,
         gestureMode: HotkeyGestureController.Mode = .doubleTapAndHold,
         tapThresholdMs: Int = FnKeyStateMachine.defaultTapThresholdMs,
-        startupDebounceMs: Int = FnKeyStateMachine.defaultStartupDebounceMs
+        startupDebounceMs: Int = FnKeyStateMachine.defaultStartupDebounceMs,
+        holdToTalkStopTailMs: Int = 0
     ) {
         self.trigger = trigger
         self.gestureMode = gestureMode
+        self.holdToTalkStopTailMs = max(0, holdToTalkStopTailMs)
         self.gestureController = HotkeyGestureController(
             mode: gestureMode,
             tapThresholdMs: tapThresholdMs,
@@ -87,6 +91,7 @@ public final class HotkeyManager {
         retainedSelf?.release()
         startupTimer?.cancel()
         holdTimer?.cancel()
+        stopTailTimer?.cancel()
     }
 
     /// Start listening for key events. Requires Accessibility permission.
@@ -154,6 +159,7 @@ public final class HotkeyManager {
         retainedSelf = nil
         startupTimer?.cancel()
         holdTimer?.cancel()
+        stopTailTimer?.cancel()
         eventTap = nil
         runLoopSource = nil
         installedRunLoop = nil
@@ -712,6 +718,7 @@ public final class HotkeyManager {
     /// Notify state machine that cancel was triggered via UI (not Esc).
     /// Blocks hotkey during the cancel countdown window.
     public func notifyCancelledByUI() {
+        cancelStopTailTimer()
         gestureController.notifyCancelledByUI()
         activeRecordingMode = nil
     }
@@ -719,6 +726,7 @@ public final class HotkeyManager {
     public func suppressUntilReset() {
         cancelStartupTimer()
         cancelHoldTimer()
+        cancelStopTailTimer()
         gestureController.suppressUntilReset()
         activeRecordingMode = nil
     }
@@ -1023,17 +1031,21 @@ public final class HotkeyManager {
     }
 
     private func handleOutputs(_ outputs: [HotkeyGestureController.Output]) {
+        let recordingModeBeforeOutputs = activeRecordingMode
         rememberRecordingState(for: outputs)
 
         for output in outputs {
             switch output {
             case .startRecording(let mode):
+                cancelStopTailTimer()
                 onStartRecording?(mode)
             case .stopRecording:
-                onStopRecording?()
+                handleStopRecordingOutput(recordingModeBeforeOutputs: recordingModeBeforeOutputs)
             case .cancelRecording:
+                cancelStopTailTimer()
                 onCancelRecording?()
             case .discardRecording(let showReadyPill):
+                cancelStopTailTimer()
                 onDiscardRecording?(showReadyPill)
             case .showReadyForSecondTap:
                 onReadyForSecondTap?()
@@ -1048,6 +1060,48 @@ public final class HotkeyManager {
             case .cancelHoldWindow:
                 cancelHoldTimer()
             }
+        }
+    }
+
+    private func handleStopRecordingOutput(
+        recordingModeBeforeOutputs: FnKeyStateMachine.RecordingMode?
+    ) {
+        cancelStopTailTimer()
+        guard recordingModeBeforeOutputs == .holdToTalk, holdToTalkStopTailMs > 0 else {
+            AudioCaptureDiagnostics.append(
+                "dictation_hotkey_stop mode=\(diagnosticMode(recordingModeBeforeOutputs)) tail_ms=0"
+            )
+            onStopRecording?()
+            return
+        }
+
+        let tailMs = holdToTalkStopTailMs
+        AudioCaptureDiagnostics.append(
+            "dictation_hotkey_stop_tail_scheduled mode=hold_to_talk tail_ms=\(tailMs)"
+        )
+        let timer = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            self.stopTailTimer = nil
+            AudioCaptureDiagnostics.append(
+                "dictation_hotkey_stop_tail_fired mode=hold_to_talk tail_ms=\(tailMs)"
+            )
+            self.onStopRecording?()
+        }
+        stopTailTimer = timer
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + .milliseconds(tailMs),
+            execute: timer
+        )
+    }
+
+    private func diagnosticMode(_ mode: FnKeyStateMachine.RecordingMode?) -> String {
+        switch mode {
+        case .holdToTalk:
+            return "hold_to_talk"
+        case .persistent:
+            return "persistent"
+        case nil:
+            return "unknown"
         }
     }
 
@@ -1088,6 +1142,11 @@ public final class HotkeyManager {
             deadline: .now() + .milliseconds(milliseconds),
             execute: timer
         )
+    }
+
+    private func cancelStopTailTimer() {
+        stopTailTimer?.cancel()
+        stopTailTimer = nil
     }
 
     private func cancelStartupTimer() {

--- a/Sources/MacParakeetCore/DictationFlow/DictationFlowStateMachine.swift
+++ b/Sources/MacParakeetCore/DictationFlow/DictationFlowStateMachine.swift
@@ -109,7 +109,7 @@ public enum DictationFlowEffect: Equatable, Sendable {
     // Audio/service
     case checkEntitlements
     case startRecording(mode: FnKeyStateMachine.RecordingMode)
-    case stopRecordingAndTranscribe
+    case stopRecordingAndTranscribe(mode: FnKeyStateMachine.RecordingMode)
     case cancelRecording(reason: DictationFlowCancelReason)
     case discardRecording
     /// Confirm a pending cancel. Pass a reason only when cancel telemetry has
@@ -277,10 +277,10 @@ public struct DictationFlowStateMachine: Sendable, Equatable {
 
         // MARK: Recording
 
-        case (.recording, .stopRequested):
+        case (.recording(let mode), .stopRequested):
             state = .processing
             return [
-                .cancelRecordingTask, .stopRecordingAndTranscribe,
+                .cancelRecordingTask, .stopRecordingAndTranscribe(mode: mode),
                 .showProcessingState, .updateMenuBar(.processing),
             ]
 
@@ -350,10 +350,10 @@ public struct DictationFlowStateMachine: Sendable, Equatable {
                 .hideOverlay, .hideIdlePill, .checkEntitlements,
             ]
 
-        case (.pendingStop, .recordingStarted(let gen)):
+        case (.pendingStop(let mode), .recordingStarted(let gen)):
             guard gen == generation else { return [] }
             state = .processing
-            return [.cancelRecordingTask, .stopRecordingAndTranscribe, .showProcessingState, .updateMenuBar(.processing)]
+            return [.cancelRecordingTask, .stopRecordingAndTranscribe(mode: mode), .showProcessingState, .updateMenuBar(.processing)]
 
         case (.pendingStop, .startFailed(let gen, let message)):
             guard gen == generation else { return [] }

--- a/Sources/MacParakeetCore/STT/ParakeetUnifiedEngine.swift
+++ b/Sources/MacParakeetCore/STT/ParakeetUnifiedEngine.swift
@@ -76,9 +76,10 @@ public actor ParakeetUnifiedEngine: STTTranscribing, NativeLiveDictating {
 
             onProgress?(0, 100)
             try Task.checkCancellation()
-            let samples = try await Task.detached(priority: .userInitiated) {
+            let recordedSamples = try await Task.detached(priority: .userInitiated) {
                 try AudioConverter().resampleAudioFile(audioURL)
             }.value
+            let samples = Self.samplesForOfflineTranscription(recordedSamples, job: job)
             onProgress?(20, 100)
 
             try Task.checkCancellation()
@@ -104,6 +105,18 @@ public actor ParakeetUnifiedEngine: STTTranscribing, NativeLiveDictating {
         } catch {
             throw try Self.mapTranscriptionError(error)
         }
+    }
+
+    static func samplesForOfflineTranscription(
+        _ samples: [Float],
+        job: STTJobKind
+    ) -> [Float] {
+        guard job == .dictation else { return samples }
+        return STTRuntime.appendingTrailingSilence(
+            samples,
+            seconds: STTRuntime.dictationTrailingSilenceSeconds,
+            sampleRate: ASRConstants.sampleRate
+        )
     }
 
     // MARK: - Live dictation

--- a/Tests/MacParakeetTests/App/AppHotkeyCoordinatorTests.swift
+++ b/Tests/MacParakeetTests/App/AppHotkeyCoordinatorTests.swift
@@ -117,7 +117,11 @@ final class AppHotkeyCoordinatorTests: XCTestCase {
             plan,
             AppHotkeyCoordinator.DictationHotkeyPlan(
                 specs: [
-                    .init(trigger: .fn, gestureMode: .doubleTapAndHold),
+                    .init(
+                        trigger: .fn,
+                        gestureMode: .doubleTapAndHold,
+                        holdToTalkStopTailMs: AppHotkeyCoordinator.holdToTalkStopTailMs
+                    )
                 ],
                 conflict: nil
             )
@@ -135,7 +139,11 @@ final class AppHotkeyCoordinatorTests: XCTestCase {
             plan,
             AppHotkeyCoordinator.DictationHotkeyPlan(
                 specs: [
-                    .init(trigger: rightCommand, gestureMode: .doubleTapAndHold),
+                    .init(
+                        trigger: rightCommand,
+                        gestureMode: .doubleTapAndHold,
+                        holdToTalkStopTailMs: AppHotkeyCoordinator.holdToTalkStopTailMs
+                    )
                 ],
                 conflict: nil
             )
@@ -153,7 +161,11 @@ final class AppHotkeyCoordinatorTests: XCTestCase {
             AppHotkeyCoordinator.DictationHotkeyPlan(
                 specs: [
                     .init(trigger: .control, gestureMode: .singleTapToggle),
-                    .init(trigger: .option, gestureMode: .holdOnly),
+                    .init(
+                        trigger: .option,
+                        gestureMode: .holdOnly,
+                        holdToTalkStopTailMs: AppHotkeyCoordinator.holdToTalkStopTailMs
+                    ),
                 ],
                 conflict: nil
             )
@@ -170,7 +182,11 @@ final class AppHotkeyCoordinatorTests: XCTestCase {
             plan,
             AppHotkeyCoordinator.DictationHotkeyPlan(
                 specs: [
-                    .init(trigger: .defaultDictation, gestureMode: .doubleTapAndHold),
+                    .init(
+                        trigger: .defaultDictation,
+                        gestureMode: .doubleTapAndHold,
+                        holdToTalkStopTailMs: AppHotkeyCoordinator.holdToTalkStopTailMs
+                    )
                 ],
                 conflict: nil
             )
@@ -188,7 +204,8 @@ final class AppHotkeyCoordinatorTests: XCTestCase {
             .init(
                 trigger: .defaultPushToTalk,
                 gestureMode: .holdOnly,
-                startupDebounceMs: FnKeyStateMachine.defaultStartupDebounceMs
+                startupDebounceMs: FnKeyStateMachine.defaultStartupDebounceMs,
+                holdToTalkStopTailMs: AppHotkeyCoordinator.holdToTalkStopTailMs
             )
         )
     }
@@ -219,7 +236,11 @@ final class AppHotkeyCoordinatorTests: XCTestCase {
             ),
             AppHotkeyCoordinator.DictationHotkeyPlan(
                 specs: [
-                    .init(trigger: .option, gestureMode: .holdOnly),
+                    .init(
+                        trigger: .option,
+                        gestureMode: .holdOnly,
+                        holdToTalkStopTailMs: AppHotkeyCoordinator.holdToTalkStopTailMs
+                    )
                 ],
                 conflict: nil
             )

--- a/Tests/MacParakeetTests/DictationFlow/DictationFlowStateMachineTests.swift
+++ b/Tests/MacParakeetTests/DictationFlow/DictationFlowStateMachineTests.swift
@@ -359,9 +359,17 @@ final class DictationFlowStateMachineTests: XCTestCase {
         let effects = m.handle(.stopRequested)
         XCTAssertEqual(m.state, .processing)
         XCTAssertTrue(effects.contains(.cancelRecordingTask))
-        XCTAssertTrue(effects.contains(.stopRecordingAndTranscribe))
+        XCTAssertTrue(effects.contains(.stopRecordingAndTranscribe(mode: .persistent)))
         XCTAssertTrue(effects.contains(.showProcessingState))
         XCTAssertTrue(effects.contains(.updateMenuBar(.processing)))
+    }
+
+    func testRecordingHoldStopCarriesMode() {
+        var m = machineInRecording(mode: .holdToTalk)
+
+        let effects = m.handle(.stopRequested)
+        XCTAssertEqual(m.state, .processing)
+        XCTAssertTrue(effects.contains(.stopRecordingAndTranscribe(mode: .holdToTalk)))
     }
 
     func testRecordingCancelRequestedEscape() {
@@ -493,9 +501,22 @@ final class DictationFlowStateMachineTests: XCTestCase {
         let effects = m.handle(.recordingStarted(generation: gen))
         XCTAssertEqual(m.state, .processing)
         XCTAssertTrue(effects.contains(.cancelRecordingTask))
-        XCTAssertTrue(effects.contains(.stopRecordingAndTranscribe))
+        XCTAssertTrue(effects.contains(.stopRecordingAndTranscribe(mode: .persistent)))
         XCTAssertTrue(effects.contains(.showProcessingState))
         XCTAssertTrue(effects.contains(.updateMenuBar(.processing)))
+    }
+
+    func testPendingStopHoldRecordingStartedCarriesMode() {
+        var m = makeMachine()
+        _ = m.handle(.startRequested(mode: .holdToTalk))
+        let gen = m.generation
+        _ = m.handle(.entitlementsGranted(generation: gen))
+        _ = m.handle(.stopRequested)
+        XCTAssertEqual(m.state, .pendingStop(mode: .holdToTalk))
+
+        let effects = m.handle(.recordingStarted(generation: gen))
+        XCTAssertEqual(m.state, .processing)
+        XCTAssertTrue(effects.contains(.stopRecordingAndTranscribe(mode: .holdToTalk)))
     }
 
     func testPendingStopStartFailed() {
@@ -1059,7 +1080,7 @@ final class DictationFlowStateMachineTests: XCTestCase {
         // Recording starts → auto-transitions to processing
         let effects = m.handle(.recordingStarted(generation: gen))
         XCTAssertEqual(m.state, .processing)
-        XCTAssertTrue(effects.contains(.stopRecordingAndTranscribe))
+        XCTAssertTrue(effects.contains(.stopRecordingAndTranscribe(mode: .persistent)))
 
         // Complete transcription
         _ = m.handle(.transcriptionCompleted(generation: gen))

--- a/Tests/MacParakeetTests/Hotkey/HotkeyManagerTests.swift
+++ b/Tests/MacParakeetTests/Hotkey/HotkeyManagerTests.swift
@@ -599,6 +599,45 @@ final class HotkeyManagerTests: XCTestCase {
         )
     }
 
+    func testHoldToTalkStopTailDelaysStopCallback() {
+        let manager = HotkeyManager(
+            trigger: .fn,
+            holdToTalkStopTailMs: 20
+        )
+        var stopCount = 0
+        let stopExpectation = expectation(description: "stop callback fires after tail")
+        manager.onStopRecording = {
+            stopCount += 1
+            stopExpectation.fulfill()
+        }
+
+        _ = manager.modifierFlagsChangedOutputsForTesting(
+            flags: [.maskSecondaryFn],
+            timestampMs: 1_000
+        )
+        XCTAssertEqual(
+            manager.startupDebounceElapsedForTesting(),
+            [.startRecording(mode: .holdToTalk)]
+        )
+
+        XCTAssertEqual(
+            manager.recoverFromDisabledTapForTesting(
+                flags: [],
+                timestampMs: 1_500
+            ),
+            [
+                .cancelStartupDebounce,
+                .cancelHoldWindow,
+                .stopRecording,
+            ]
+        )
+        XCTAssertEqual(stopCount, 0)
+        manager.resetToIdle(flags: [])
+
+        wait(for: [stopExpectation], timeout: 1.0)
+        XCTAssertEqual(stopCount, 1)
+    }
+
     func testTapRecoveryDuringActiveHoldWithAdditionalModifierCancelsOnRelease() {
         let manager = HotkeyManager(trigger: .fn)
 

--- a/Tests/MacParakeetTests/STT/ParakeetUnifiedEngineDictationPadTests.swift
+++ b/Tests/MacParakeetTests/STT/ParakeetUnifiedEngineDictationPadTests.swift
@@ -1,0 +1,30 @@
+import FluidAudio
+@testable import MacParakeetCore
+import XCTest
+
+final class ParakeetUnifiedEngineDictationPadTests: XCTestCase {
+    func testDictationSamplesAppendTrailingSilence() {
+        let samples: [Float] = [0.1, -0.2, 0.3]
+
+        let padded = ParakeetUnifiedEngine.samplesForOfflineTranscription(
+            samples,
+            job: .dictation
+        )
+
+        let expectedPad = Int(STTRuntime.dictationTrailingSilenceSeconds * Double(ASRConstants.sampleRate))
+        XCTAssertEqual(padded.count, samples.count + expectedPad)
+        XCTAssertEqual(Array(padded.prefix(samples.count)), samples)
+        XCTAssertTrue(padded.suffix(expectedPad).allSatisfy { $0 == 0 })
+    }
+
+    func testNonDictationSamplesAreUnchanged() {
+        let samples: [Float] = [0.1, -0.2, 0.3]
+
+        let meetingSamples = ParakeetUnifiedEngine.samplesForOfflineTranscription(
+            samples,
+            job: .meetingFinalize
+        )
+
+        XCTAssertEqual(meetingSamples, samples)
+    }
+}


### PR DESCRIPTION
## Summary
Hold-to-talk dictation now keeps a short release tail before stopping production capture, so releasing the trigger no longer creates a harder end boundary than persistent dictation. Unified Parakeet offline dictation also gets the same trailing-silence padding that already protected the TDT path, while meeting and file transcription stay unchanged.

Stop diagnostics now record whether the session was `hold_to_talk` or `persistent`, plus whether a hold tail was scheduled and fired, so future diagnostic logs can distinguish the hotkey boundary from the final STT path.

## Validation
- `git diff --check`
- `swift test --filter 'AppHotkeyCoordinatorTests|DictationFlowStateMachineTests|ParakeetUnifiedEngineDictationPadTests|STTRuntimeDictationPadTests|HotkeyManagerTests/testHoldToTalkStopTailDelaysStopCallback|HotkeyManagerTests/testTapRecoveryDuringActiveHoldToTalkStopsOnRelease'` — 113 tests, 0 failures
- `swift test` — 4,194 tests, 11 skipped, 0 failures

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a short release tail to hold‑to‑talk dictation so releasing the key doesn’t clip the final word. Also pads offline dictation with trailing silence and records dictation mode in stop logs for clearer diagnostics.

- **Bug Fixes**
  - Added `holdToTalkStopTailMs` (200 ms) in `HotkeyManager`, configured via `AppHotkeyCoordinator`; tail applies only to hold‑to‑talk, logs scheduled/fired, and cancels on start/cancel/discard.
  - Carried recording mode through `.stopRecordingAndTranscribe(mode:)` in the state machine; `DictationFlowCoordinator` logs stop requests with mode and appends `dictation_stop_requested` diagnostics.
  - Appended trailing silence for offline `.dictation` in `ParakeetUnifiedEngine`; meetings/file transcription unchanged.

<sup>Written for commit 59d8c7d0fa8ef52df0d391ba429c2d795552da0d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/632?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

