### PR TITLE
Fix SIGTRAP crash from nil EKEvent.eventIdentifier in calendar sync

### DIFF
--- a/Sources/MacParakeetCore/Calendar/CalendarService.swift
+++ b/Sources/MacParakeetCore/Calendar/CalendarService.swift
@@ -173,8 +173,14 @@ public actor CalendarService {
     // MARK: - EKEvent → CalendarEvent
 
     private func convertEvent(_ ekEvent: EKEvent) -> CalendarEvent? {
+        // `eventIdentifier` is declared `String!` by EventKit but is nil for
+        // some events (unsaved/ephemeral, certain birthday/holiday/subscription
+        // calendars, detached recurrences). Force-unwrapping it into the
+        // non-optional `CalendarEvent.id` crashed (SIGTRAP); drop the event
+        // instead — without a stable identifier we can't track it anyway.
         guard let startDate = ekEvent.startDate,
-              let endDate = ekEvent.endDate else {
+              let endDate = ekEvent.endDate,
+              let id = ekEvent.eventIdentifier else {
             return nil
         }
 
@@ -218,7 +224,7 @@ public actor CalendarService {
         )
 
         return CalendarEvent(
-            id: ekEvent.eventIdentifier,
+            id: id,
             title: ekEvent.title ?? "Untitled",
             startTime: startDate,
             endTime: endDate,


### PR DESCRIPTION
## What

`CalendarService.convertEvent` force-unwrapped EventKit's `eventIdentifier` (a `String!`) into the non-optional `CalendarEvent.id`. EventKit returns nil for some events — unsaved/ephemeral instances, certain birthday/holiday/subscription calendars, and detached recurrences — so any such event crashed the app with a **SIGTRAP**.

Fix: guard `eventIdentifier` alongside the existing start/end-date guard and drop the event when it's missing. `convertEvent` already returns `CalendarEvent?` consumed via `compactMap`, and an event with no stable identifier can't be tracked/deduplicated for meeting suggestions or auto-start anyway.

## Why this is real (telemetry-verified)

Live crash cluster in D1 `macparakeet-telemetry`: the SIGTRAP signature symbolicates to `CalendarService.convertEvent` — verified with `atos` against the **0.6.22 and 0.6.23 release DMGs** (UUIDs matched), resolving to `CalendarService.swift:221` (`id: ekEvent.eventIdentifier`). Spread across macOS 15/26/27; reachable whenever calendar features fetch events.

## Testing

`swift build --target MacParakeetCore` ✓.

No unit test added: `convertEvent` is `private` and depends on a live `EKEventStore` with no injection seam; producing a nil-identifier `EKEvent` requires EventKit entitlement and is flaky in CI. The guard is self-evidently sufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a SIGTRAP crash in calendar sync by guarding nil EventKit event identifiers and skipping those events. Stops crashes from unsaved/ephemeral, subscription, birthday/holiday, and detached recurrence events.

- **Bug Fixes**
  - Added an identifier guard in `convertEvent` alongside start/end date checks.
  - Returns `nil` for events without an id; existing `compactMap` filters them out.

<sup>Written for commit 2876237b02f5f875ec8bcc459ec22a7f128b5d14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/633?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

