### PR TITLE
Add CLI retranscribe for saved library records

### DIFF
--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -89,6 +89,17 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
 
 ## [Unreleased]
 
+### Added
+
+- Added `retranscribe <record> --update` to rerun STT against retained source
+  audio for an existing saved dictation, transcription, or meeting in place.
+  Records resolve by UUID/prefix, with exact transcription/meeting title
+  lookup where unambiguous; `--kind dictation|transcription|meeting` constrains
+  resolution. The command supports the same speech-engine, model, language,
+  processing-mode, and transcription/meeting speaker-detection overrides as
+  `transcribe` where applicable, and emits either `--json` or `--envelope`
+  machine-readable output.
+
 ## [2.11.0] -- 2026-06-28
 
 ### Added

--- a/Sources/CLI/Commands/CLIHelpers.swift
+++ b/Sources/CLI/Commands/CLIHelpers.swift
@@ -379,6 +379,16 @@ enum CLIErrorType {
                 return validation
             }
         }
+        if let retranscribe = error as? CLIRetranscribeError {
+            switch retranscribe {
+            case .noRetainedAudio, .missingAudio:
+                return inputMissing
+            case .ambiguousRecord, .noMatch:
+                return lookup
+            case .kindMismatch, .dictationDoesNotSupportSpeakerOptions:
+                return validation
+            }
+        }
         // ArgumentParser surfaces `validate()` failures as `ValidationError`.
         // The taxonomy has carried the `validation` value since 1.2.0; map
         // ValidationError to it so downstream agents can branch on user
@@ -410,6 +420,18 @@ enum CLIErrorFix {
     static func message(for error: Error) -> String? {
         if error is CLILookupError {
             return "List nearby records with the matching command, then retry with a full UUID or longer UUID prefix."
+        }
+        if let retranscribe = error as? CLIRetranscribeError {
+            switch retranscribe {
+            case .noRetainedAudio, .missingAudio:
+                return "Retained source audio is required. Recreate or re-import the audio, then retry."
+            case .ambiguousRecord, .noMatch:
+                return "List history records and retry with --kind plus a full UUID or longer UUID prefix."
+            case .kindMismatch:
+                return "Retry with the record kind shown in the error message."
+            case .dictationDoesNotSupportSpeakerOptions:
+                return "Remove speaker-detection flags or choose a saved transcription/meeting."
+            }
         }
         if let input = error as? CLIInputError {
             switch input {
@@ -492,6 +514,9 @@ private func rethrowWithOptionalJSONEnvelope(_ error: Error, json: Bool) throws 
         throw CLIJSONEnvelopeExit(exitCode: cliValidationMisuseExitCode, originalError: error)
     }
     if let history = error as? CLITransformHistoryError, case .invalidPrefix = history {
+        throw CLIJSONEnvelopeExit(exitCode: cliValidationMisuseExitCode, originalError: error)
+    }
+    if let retranscribe = error as? CLIRetranscribeError, retranscribe.isValidationMisuse {
         throw CLIJSONEnvelopeExit(exitCode: cliValidationMisuseExitCode, originalError: error)
     }
     throw CLIJSONEnvelopeExit(exitCode: .failure, originalError: error)

--- a/Sources/CLI/Commands/RetranscribeCommand.swift
+++ b/Sources/CLI/Commands/RetranscribeCommand.swift
@@ -174,7 +174,7 @@ struct RetranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding 
     var cliTelemetryMetadata: CLITelemetry.OperationMetadata {
         CLITelemetry.OperationMetadata(
             command: Self.configuration.commandName ?? "retranscribe",
-            outputFormat: json ? "json" : nil,
+            outputFormat: (json || envelope) ? "json" : nil,
             json: json || envelope
         )
     }
@@ -364,7 +364,7 @@ struct RetranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding 
         updated.status = .completed
         updated.errorMessage = nil
         updated.updatedAt = Date()
-        updated.wordCount = finalText.split(whereSeparator: \.isWhitespace).count
+        updated.wordCount = Observability.wordCount(finalText)
         updated.engine = sttResult.engine.rawValue
         updated.engineVariant = sttResult.engineVariant
         updated.language = SpeechEnginePreference.normalizeKnownLanguage(sttResult.language)
@@ -589,8 +589,8 @@ struct RetranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding 
         updated.isFavorite = original.isFavorite
         updated.sourceType = original.sourceType
         updated.recoveredFromCrash = original.recoveredFromCrash
-        updated.userNotes = original.userNotes
-        updated.chatMessages = original.chatMessages
+        updated.userNotes = original.userNotes ?? result.userNotes
+        updated.chatMessages = original.chatMessages ?? result.chatMessages
         return updated
     }
 
@@ -626,7 +626,7 @@ struct RetranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding 
         if fallback > 0 {
             return fallback
         }
-        return result.text.split(separator: " ").count * 150
+        return Observability.wordCount(result.text) * 150
     }
 
     private static func progressHandler(prefix: String) -> (

--- a/Sources/CLI/Commands/RetranscribeCommand.swift
+++ b/Sources/CLI/Commands/RetranscribeCommand.swift
@@ -1,0 +1,678 @@
+import ArgumentParser
+import Foundation
+import MacParakeetCore
+import os
+
+enum RetranscribeRecordKind: String, ExpressibleByArgument, CaseIterable {
+    case auto
+    case dictation
+    case transcription
+    case meeting
+}
+
+enum CLIRetranscribeError: Error, LocalizedError {
+    case noRetainedAudio(kind: String, id: UUID)
+    case missingAudio(path: String)
+    case ambiguousRecord(String)
+    case noMatch(String)
+    case kindMismatch(expected: RetranscribeRecordKind, actual: RetranscribeRecordKind)
+    case dictationDoesNotSupportSpeakerOptions
+
+    var errorDescription: String? {
+        switch self {
+        case .noRetainedAudio(let kind, let id):
+            return "The \(kind) '\(id.uuidString)' has no retained source audio to retranscribe."
+        case .missingAudio(let path):
+            return "Retained source audio is missing: \(path)"
+        case .ambiguousRecord(let value):
+            return "Multiple saved records match '\(value)'. Retry with --kind or a longer UUID prefix."
+        case .noMatch(let value):
+            return "No saved dictation, transcription, or meeting matching '\(value)'."
+        case .kindMismatch(let expected, let actual):
+            return "Record is a \(actual.rawValue), not a \(expected.rawValue). Retry with --kind \(actual.rawValue)."
+        case .dictationDoesNotSupportSpeakerOptions:
+            return "Speaker-detection options apply only to saved transcriptions and meetings, not dictations."
+        }
+    }
+
+    var isValidationMisuse: Bool {
+        switch self {
+        case .kindMismatch, .dictationDoesNotSupportSpeakerOptions:
+            return true
+        case .noRetainedAudio, .missingAudio, .ambiguousRecord, .noMatch:
+            return false
+        }
+    }
+}
+
+enum RetranscribeTarget {
+    case dictation(Dictation)
+    case transcription(Transcription)
+    case meeting(Transcription)
+
+    var kind: RetranscribeRecordKind {
+        switch self {
+        case .dictation:
+            return .dictation
+        case .transcription:
+            return .transcription
+        case .meeting:
+            return .meeting
+        }
+    }
+
+    var id: UUID {
+        switch self {
+        case .dictation(let dictation):
+            return dictation.id
+        case .transcription(let transcription), .meeting(let transcription):
+            return transcription.id
+        }
+    }
+}
+
+enum RetranscribeRecordPayload: Encodable {
+    case dictation(Dictation)
+    case transcription(Transcription)
+
+    func encode(to encoder: Encoder) throws {
+        switch self {
+        case .dictation(let dictation):
+            try dictation.encode(to: encoder)
+        case .transcription(let transcription):
+            try transcription.encode(to: encoder)
+        }
+    }
+}
+
+struct RetranscribeResult: Encodable {
+    let kind: String
+    let id: UUID
+    let shortID: String
+    let sourcePath: String
+    let updatedAt: Date
+    let record: RetranscribeRecordPayload
+
+    init(kind: RetranscribeRecordKind, sourcePath: String, dictation: Dictation) {
+        self.kind = kind.rawValue
+        self.id = dictation.id
+        self.shortID = String(dictation.id.uuidString.prefix(8))
+        self.sourcePath = sourcePath
+        self.updatedAt = dictation.updatedAt
+        self.record = .dictation(dictation)
+    }
+
+    init(kind: RetranscribeRecordKind, sourcePath: String, transcription: Transcription) {
+        self.kind = kind.rawValue
+        self.id = transcription.id
+        self.shortID = String(transcription.id.uuidString.prefix(8))
+        self.sourcePath = sourcePath
+        self.updatedAt = transcription.updatedAt
+        self.record = .transcription(transcription)
+    }
+}
+
+struct RetranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
+    static let configuration = CommandConfiguration(
+        commandName: "retranscribe",
+        abstract: "Retranscribe retained source audio for an existing saved record in place.",
+        discussion: """
+        Resolves a saved dictation, transcription, or meeting by UUID, UUID \
+        prefix, or exact title/name where safe. The command requires --update \
+        because it replaces transcript-derived fields on the existing row.
+        """
+    )
+
+    @Argument(help: "Saved record UUID, UUID prefix, or exact transcription/meeting title.")
+    var record: String
+
+    @Option(help: "Record kind to resolve: auto, dictation, transcription, meeting.")
+    var kind: RetranscribeRecordKind = .auto
+
+    @Flag(help: "Required. Confirms this command updates the existing saved record in place.")
+    var update: Bool = false
+
+    @Flag(name: .long, help: "Emit the updated record as JSON.")
+    var json: Bool = false
+
+    @Flag(name: .long, help: "Emit a success/failure envelope.")
+    var envelope: Bool = false
+
+    @Option(help: "Text processing mode: raw, clean, app-default.")
+    var mode: TranscribeMode = .appDefault
+
+    @Option(help: "Speech engine: app-default, parakeet, nemotron, whisper, cohere. Default: parakeet; app-default follows the saved GUI preference.")
+    var engine: TranscribeSpeechEngine = .parakeet
+
+    @Option(help: "Language hint for Whisper, Nemotron, or Cohere, such as ko, en, or en-US. Parakeet and the English-only Nemotron build ignore this flag.")
+    var language: String?
+
+    @Option(name: .long, help: "Parakeet build: app-default, v3, v2, unified. Ignored for Nemotron, Cohere, and Whisper.")
+    var parakeetModel: TranscribeParakeetModel = .appDefault
+
+    @Option(name: .long, help: "Nemotron build: app-default, multilingual-1120ms, english-1120ms. Ignored for Parakeet, Cohere, and Whisper.")
+    var nemotronModel: TranscribeNemotronModel = .appDefault
+
+    @Option(name: .long, help: "Speaker detection for saved transcriptions/meetings: app-default, on, off.")
+    var speakerDetection: SpeakerDetectionOption = .appDefault
+
+    @Option(name: .long, help: "Exact speaker count for this retranscription. Mutually exclusive with --speaker-min/--speaker-max.")
+    var speakerCount: Int?
+
+    @Option(name: .long, help: "Minimum speaker count for this retranscription. Can be combined with --speaker-max.")
+    var speakerMin: Int?
+
+    @Option(name: .long, help: "Maximum speaker count for this retranscription. Can be combined with --speaker-min.")
+    var speakerMax: Int?
+
+    @Flag(help: "Compatibility alias for --speaker-detection off.")
+    var noDiarize: Bool = false
+
+    @Option(help: "Path to SQLite database file (defaults to the app database).")
+    var database: String?
+
+    var cliTelemetryMetadata: CLITelemetry.OperationMetadata {
+        CLITelemetry.OperationMetadata(
+            command: Self.configuration.commandName ?? "retranscribe",
+            outputFormat: json ? "json" : nil,
+            json: json || envelope
+        )
+    }
+
+    func validate() throws {
+        guard update else {
+            throw ValidationError("Pass --update to confirm replacing transcript fields on the existing saved record.")
+        }
+        if json && envelope {
+            throw ValidationError("--json and --envelope cannot be combined.")
+        }
+        try TranscribeCommand.validateSpeakerConstraintOptions(
+            speakerDetection: speakerDetection,
+            noDiarize: noDiarize,
+            speakerCount: speakerCount,
+            speakerMin: speakerMin,
+            speakerMax: speakerMax
+        )
+    }
+
+    func run() async throws {
+        let wantsMachineReadableOutput = json || envelope
+        let runResult: Result<RetranscribeResult, Error>
+        var sttClient: STTClient?
+
+        do {
+            try AppPaths.ensureDirectories()
+            let dbManager = try DatabaseManager(path: resolvedDatabasePath(database))
+            let transcriptionRepo = TranscriptionRepository(dbQueue: dbManager.dbQueue)
+            let dictationRepo = DictationRepository(dbQueue: dbManager.dbQueue)
+            let customWordRepo = CustomWordRepository(dbQueue: dbManager.dbQueue)
+            let snippetRepo = TextSnippetRepository(dbQueue: dbManager.dbQueue)
+            let promptResultRepo = PromptResultRepository(dbQueue: dbManager.dbQueue)
+            let defaults = macParakeetAppDefaults()
+            let target = try Self.resolveTarget(
+                record,
+                kind: kind,
+                transcriptionRepo: transcriptionRepo,
+                dictationRepo: dictationRepo
+            )
+            if case .dictation = target {
+                try validateDictationOnlyOptions()
+            }
+
+            let speechEngine = resolveSpeechEngine(defaults: defaults)
+            try TranscribeCommand.validateCohereLanguageOverride(language, speechEngine: speechEngine)
+            let parakeetVariant = TranscribeCommand.resolveParakeetModelVariant(
+                parakeetModel,
+                storedVariant: SpeechEnginePreference.parakeetModelVariant(defaults: defaults)
+            )
+            let nemotronVariant = TranscribeCommand.resolveNemotronModelVariant(
+                nemotronModel,
+                storedVariant: SpeechEnginePreference.nemotronModelVariant(defaults: defaults)
+            )
+            if speechEngine.engine == .nemotron, nemotronVariant.isEnglishOnly, language != nil {
+                printErr("Note: --language is ignored by the English-only Nemotron build.")
+            }
+
+            let client = STTClient(
+                parakeetModelVariant: parakeetVariant,
+                speechEngine: speechEngine.engine,
+                nemotronModelVariant: nemotronVariant,
+                defaults: defaults
+            )
+            sttClient = client
+
+            switch target {
+            case .dictation(let dictation):
+                let result = try await retranscribeDictation(
+                    dictation,
+                    sttClient: client,
+                    speechEngine: speechEngine,
+                    dictationRepo: dictationRepo,
+                    customWordRepo: customWordRepo,
+                    snippetRepo: snippetRepo,
+                    defaults: defaults
+                )
+                runResult = .success(result)
+            case .transcription(let transcription):
+                let result = try await retranscribeTranscription(
+                    transcription,
+                    speechEngine: speechEngine,
+                    transcriptionRepo: transcriptionRepo,
+                    promptResultRepo: promptResultRepo,
+                    customWordRepo: customWordRepo,
+                    snippetRepo: snippetRepo,
+                    defaults: defaults,
+                    sttTranscriber: client
+                )
+                runResult = .success(result)
+            case .meeting(let transcription):
+                let result = try await retranscribeMeeting(
+                    transcription,
+                    speechEngine: speechEngine,
+                    transcriptionRepo: transcriptionRepo,
+                    promptResultRepo: promptResultRepo,
+                    customWordRepo: customWordRepo,
+                    snippetRepo: snippetRepo,
+                    defaults: defaults,
+                    sttTranscriber: client
+                )
+                runResult = .success(result)
+            }
+        } catch {
+            runResult = .failure(error)
+        }
+
+        await sttClient?.shutdown()
+
+        try emitJSONOrRethrow(json: wantsMachineReadableOutput) {
+            let result = try runResult.get()
+            try printResult(result)
+        }
+    }
+
+    private func resolveSpeechEngine(defaults: UserDefaults) -> SpeechEngineSelection {
+        TranscribeCommand.resolveSpeechEngine(
+            engine,
+            storedEngine: defaults.string(forKey: SpeechEnginePreference.defaultsKey),
+            storedLanguage: SpeechEnginePreference.whisperDefaultLanguage(defaults: defaults),
+            storedNemotronLanguage: SpeechEnginePreference.nemotronDefaultLanguage(defaults: defaults),
+            storedCohereLanguage: SpeechEnginePreference.cohereDefaultLanguage(defaults: defaults),
+            explicitLanguage: language
+        )
+    }
+
+    private func validateDictationOnlyOptions() throws {
+        let hasSpeakerOption = speakerDetection != .appDefault
+            || noDiarize
+            || speakerCount != nil
+            || speakerMin != nil
+            || speakerMax != nil
+        if hasSpeakerOption {
+            throw CLIRetranscribeError.dictationDoesNotSupportSpeakerOptions
+        }
+    }
+
+    private func retranscribeDictation(
+        _ original: Dictation,
+        sttClient: STTClient,
+        speechEngine: SpeechEngineSelection,
+        dictationRepo: DictationRepository,
+        customWordRepo: CustomWordRepository,
+        snippetRepo: TextSnippetRepository,
+        defaults: UserDefaults
+    ) async throws -> RetranscribeResult {
+        let sourceURL = try Self.retainedAudioURL(path: original.audioPath, kind: "dictation", id: original.id)
+        let progress = Self.progressHandler(prefix: "Transcribing saved dictation")
+        printErr("Retranscribing dictation \(original.id.uuidString) with \(speechEngine.engine.rawValue)...")
+        let sttResult = try await sttClient.transcribe(
+            audioPath: sourceURL.path,
+            job: .dictation,
+            speechEngine: speechEngine,
+            onProgress: progress.sttProgress
+        )
+
+        let processingMode = TranscribeCommand.resolveProcessingMode(
+            mode,
+            storedMode: defaults.string(forKey: UserDefaultsAppRuntimePreferences.processingModeKey)
+        )
+        var customWords: [CustomWord] = []
+        var snippets: [TextSnippet] = []
+        if processingMode.usesDeterministicPipeline {
+            customWords = try customWordRepo.fetchEnabled()
+            snippets = try snippetRepo.fetchEnabled()
+        }
+        for trigger in UserDefaultsAppRuntimePreferences(defaults: defaults).voiceReturnTriggers {
+            snippets.append(TextSnippet(
+                trigger: trigger,
+                expansion: KeyAction.returnKey.label,
+                action: .returnKey
+            ))
+        }
+
+        let refinement = await TextRefinementService().refine(
+            rawText: sttResult.text,
+            mode: processingMode,
+            customWords: customWords,
+            snippets: snippets
+        )
+        let finalText = refinement.text ?? sttResult.text
+        var updated = Self.clearingDictationFormatterMetadata(original)
+        updated.durationMs = Self.dictationDurationMs(from: sttResult, fallback: original.durationMs)
+        updated.rawTranscript = sttResult.text
+        updated.cleanTranscript = refinement.text
+        updated.processingMode = processingMode
+        updated.status = .completed
+        updated.errorMessage = nil
+        updated.updatedAt = Date()
+        updated.wordCount = finalText.split(whereSeparator: \.isWhitespace).count
+        updated.engine = sttResult.engine.rawValue
+        updated.engineVariant = sttResult.engineVariant
+        updated.language = SpeechEnginePreference.normalizeKnownLanguage(sttResult.language)
+
+        try dictationRepo.save(updated)
+        if !refinement.expandedSnippetIDs.isEmpty {
+            try? snippetRepo.incrementUseCount(ids: refinement.expandedSnippetIDs)
+        }
+        return RetranscribeResult(kind: .dictation, sourcePath: sourceURL.path, dictation: updated)
+    }
+
+    static func clearingDictationFormatterMetadata(_ dictation: Dictation) -> Dictation {
+        var updated = dictation
+        updated.aiFormatterProfileID = nil
+        updated.aiFormatterProfileName = nil
+        updated.aiFormatterProfileMatchKind = nil
+        return updated
+    }
+
+    private func retranscribeTranscription(
+        _ original: Transcription,
+        speechEngine: SpeechEngineSelection,
+        transcriptionRepo: TranscriptionRepository,
+        promptResultRepo: PromptResultRepository,
+        customWordRepo: CustomWordRepository,
+        snippetRepo: TextSnippetRepository,
+        defaults: UserDefaults,
+        sttTranscriber: STTTranscribing
+    ) async throws -> RetranscribeResult {
+        let sourceURL = try Self.retainedAudioURL(path: original.filePath, kind: "transcription", id: original.id)
+        let service = makeTranscriptionService(
+            sttTranscriber: sttTranscriber,
+            transcriptionRepo: transcriptionRepo,
+            promptResultRepo: promptResultRepo,
+            customWordRepo: customWordRepo,
+            snippetRepo: snippetRepo,
+            defaults: defaults
+        )
+        printErr("Retranscribing \(original.fileName) with \(speechEngine.engine.rawValue)...")
+        let updated = try await service.retranscribe(
+            existing: original,
+            fileURL: sourceURL,
+            source: Self.telemetrySource(for: original.sourceType),
+            speechEngineOverride: speechEngine,
+            onProgress: Self.progressHandler(prefix: "Retranscribing").transcriptionProgress
+        )
+        let preserved = Self.preserveOriginalTranscriptionMetadata(updated, original: original)
+        try transcriptionRepo.save(preserved)
+        return RetranscribeResult(kind: .transcription, sourcePath: sourceURL.path, transcription: preserved)
+    }
+
+    private func retranscribeMeeting(
+        _ original: Transcription,
+        speechEngine: SpeechEngineSelection,
+        transcriptionRepo: TranscriptionRepository,
+        promptResultRepo: PromptResultRepository,
+        customWordRepo: CustomWordRepository,
+        snippetRepo: TextSnippetRepository,
+        defaults: UserDefaults,
+        sttTranscriber: STTTranscribing
+    ) async throws -> RetranscribeResult {
+        let mixedAudioURL = try Self.retainedAudioURL(path: original.filePath, kind: "meeting", id: original.id)
+        let service = makeTranscriptionService(
+            sttTranscriber: sttTranscriber,
+            transcriptionRepo: transcriptionRepo,
+            promptResultRepo: promptResultRepo,
+            customWordRepo: customWordRepo,
+            snippetRepo: snippetRepo,
+            defaults: defaults
+        )
+        printErr("Retranscribing meeting \(original.fileName) with \(speechEngine.engine.rawValue)...")
+        let progress = Self.progressHandler(prefix: "Retranscribing meeting")
+        let updated: Transcription
+        if let archived = Self.archivedMeetingRecording(for: original, mixedAudioURL: mixedAudioURL) {
+            updated = try await service.retranscribeMeeting(
+                existing: original,
+                recording: archived,
+                speechEngineOverride: speechEngine,
+                onProgress: progress.transcriptionProgress
+            )
+        } else {
+            updated = try await service.retranscribe(
+                existing: original,
+                fileURL: mixedAudioURL,
+                source: .meeting,
+                speechEngineOverride: speechEngine,
+                onProgress: progress.transcriptionProgress
+            )
+        }
+        let preserved = Self.preserveOriginalTranscriptionMetadata(updated, original: original)
+        try transcriptionRepo.save(preserved)
+        return RetranscribeResult(kind: .meeting, sourcePath: mixedAudioURL.path, transcription: preserved)
+    }
+
+    private func makeTranscriptionService(
+        sttTranscriber: STTTranscribing,
+        transcriptionRepo: TranscriptionRepository,
+        promptResultRepo: PromptResultRepository,
+        customWordRepo: CustomWordRepository,
+        snippetRepo: TextSnippetRepository,
+        defaults: UserDefaults
+    ) -> TranscriptionService {
+        let resolvedSpeakerDetection = TranscribeCommand.resolveSpeakerDetection(
+            speakerDetection,
+            storedEnabled: defaults.object(forKey: UserDefaultsAppRuntimePreferences.speakerDiarizationKey) as? Bool,
+            noDiarize: noDiarize,
+            speakerCount: speakerCount,
+            speakerMin: speakerMin,
+            speakerMax: speakerMax
+        )
+        let processingMode = TranscribeCommand.resolveProcessingMode(
+            mode,
+            storedMode: defaults.string(forKey: UserDefaultsAppRuntimePreferences.processingModeKey)
+        )
+        return TranscriptionService(
+            audioProcessor: AudioProcessor(),
+            sttTranscriber: sttTranscriber,
+            transcriptionRepo: transcriptionRepo,
+            promptResultRepo: promptResultRepo,
+            customWordRepo: customWordRepo,
+            snippetRepo: snippetRepo,
+            processingMode: { processingMode },
+            shouldDiarize: { resolvedSpeakerDetection.enabled },
+            diarizationService: TranscribeCommand.makeDiarizationService(for: resolvedSpeakerDetection)
+        )
+    }
+
+    static func resolveTarget(
+        _ value: String,
+        kind: RetranscribeRecordKind,
+        transcriptionRepo: TranscriptionRepository,
+        dictationRepo: DictationRepository
+    ) throws -> RetranscribeTarget {
+        switch kind {
+        case .dictation:
+            return .dictation(try findDictation(id: value, repo: dictationRepo))
+        case .meeting:
+            return .meeting(try findMeeting(idOrName: value, repo: transcriptionRepo))
+        case .transcription:
+            let transcription = try findTranscription(id: value, repo: transcriptionRepo)
+            guard transcription.sourceType != .meeting else {
+                throw CLIRetranscribeError.kindMismatch(expected: .transcription, actual: .meeting)
+            }
+            return .transcription(transcription)
+        case .auto:
+            return try resolveAutoTarget(value, transcriptionRepo: transcriptionRepo, dictationRepo: dictationRepo)
+        }
+    }
+
+    private static func resolveAutoTarget(
+        _ value: String,
+        transcriptionRepo: TranscriptionRepository,
+        dictationRepo: DictationRepository
+    ) throws -> RetranscribeTarget {
+        var matches: [RetranscribeTarget] = []
+        var deferredLookupError: CLILookupError?
+
+        do {
+            let transcription = try findTranscription(id: value, repo: transcriptionRepo)
+            matches.append(transcription.sourceType == .meeting ? .meeting(transcription) : .transcription(transcription))
+        } catch let error as CLILookupError {
+            switch error {
+            case .ambiguous:
+                throw error
+            case .emptyID, .shortUUIDPrefix:
+                deferredLookupError = error
+            case .notFound:
+                break
+            }
+        }
+
+        do {
+            matches.append(.dictation(try findDictation(id: value, repo: dictationRepo)))
+        } catch let error as CLILookupError {
+            switch error {
+            case .ambiguous:
+                throw error
+            case .emptyID, .shortUUIDPrefix:
+                deferredLookupError = deferredLookupError ?? error
+            case .notFound:
+                break
+            }
+        }
+
+        if matches.count == 1 {
+            return matches[0]
+        }
+        if matches.count > 1 {
+            throw CLIRetranscribeError.ambiguousRecord(value)
+        }
+        if let deferredLookupError {
+            throw deferredLookupError
+        }
+        throw CLIRetranscribeError.noMatch(value)
+    }
+
+    static func retainedAudioURL(path: String?, kind: String, id: UUID) throws -> URL {
+        guard let path, !path.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw CLIRetranscribeError.noRetainedAudio(kind: kind, id: id)
+        }
+        let url = URL(fileURLWithPath: expandTilde(path))
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            throw CLIRetranscribeError.missingAudio(path: url.path)
+        }
+        return url
+    }
+
+    static func preserveOriginalTranscriptionMetadata(
+        _ result: Transcription,
+        original: Transcription
+    ) -> Transcription {
+        var updated = result
+        updated.id = original.id
+        updated.createdAt = original.createdAt
+        updated.fileName = original.fileName
+        updated.filePath = original.filePath
+        updated.meetingArtifactFolderPath = original.meetingArtifactFolderPath
+        updated.sourceURL = original.sourceURL
+        updated.thumbnailURL = original.thumbnailURL
+        updated.channelName = original.channelName
+        updated.videoDescription = original.videoDescription
+        updated.isFavorite = original.isFavorite
+        updated.sourceType = original.sourceType
+        updated.recoveredFromCrash = original.recoveredFromCrash
+        updated.userNotes = original.userNotes
+        updated.chatMessages = original.chatMessages
+        return updated
+    }
+
+    private static func telemetrySource(for sourceType: Transcription.SourceType) -> TelemetryTranscriptionSource {
+        switch sourceType {
+        case .file:
+            return .file
+        case .youtube:
+            return .youtube
+        case .podcast:
+            return .podcast
+        case .meeting:
+            return .meeting
+        }
+    }
+
+    private static func archivedMeetingRecording(
+        for original: Transcription,
+        mixedAudioURL: URL
+    ) -> MeetingRecordingOutput? {
+        let durationSeconds = Double(original.durationMs ?? 0) / 1000.0
+        return try? MeetingRecordingOutput.loadArchived(
+            displayName: original.fileName,
+            mixedAudioURL: mixedAudioURL,
+            durationSeconds: durationSeconds
+        )
+    }
+
+    private static func dictationDurationMs(from result: STTResult, fallback: Int) -> Int {
+        if let lastWord = result.words.last {
+            return lastWord.endMs
+        }
+        if fallback > 0 {
+            return fallback
+        }
+        return result.text.split(separator: " ").count * 150
+    }
+
+    private static func progressHandler(prefix: String) -> (
+        transcriptionProgress: @Sendable (TranscriptionProgress) -> Void,
+        sttProgress: @Sendable (Int, Int) -> Void
+    ) {
+        let lastProgressLine = OSAllocatedUnfairLock(initialState: "")
+        @Sendable func printProgressLine(_ line: String) {
+            let shouldPrint = lastProgressLine.withLock { lastLine in
+                guard lastLine != line else { return false }
+                lastLine = line
+                return true
+            }
+            if shouldPrint { printErr(line) }
+        }
+        let transcriptionProgress: @Sendable (TranscriptionProgress) -> Void = { progress in
+            switch progress {
+            case .converting:
+                printProgressLine("Converting audio...")
+            case .downloading(let percent):
+                printProgressLine("Downloading audio... \(percent)%")
+            case .transcribing(let percent):
+                printProgressLine("\(prefix)... \(percent)%")
+            case .identifyingSpeakers:
+                printProgressLine("Identifying speakers...")
+            case .finalizing:
+                printProgressLine("Finalizing...")
+            }
+        }
+        let sttProgress: @Sendable (Int, Int) -> Void = { current, total in
+            let percent = total > 0 ? min(Int(Double(current) / Double(total) * 100), 99) : 0
+            printProgressLine("\(prefix)... \(percent)%")
+        }
+        return (transcriptionProgress, sttProgress)
+    }
+
+    private func printResult(_ result: RetranscribeResult) throws {
+        if envelope {
+            try printEnvelope(command: "retranscribe", data: result)
+            return
+        }
+        if json {
+            try printJSON(result)
+            return
+        }
+        print("Retranscribed \(result.kind) \(result.shortID).")
+        print("Source: \(result.sourcePath)")
+    }
+}

--- a/Sources/CLI/Commands/SpecCommand.swift
+++ b/Sources/CLI/Commands/SpecCommand.swift
@@ -231,6 +231,7 @@ private extension CLISpecCommand {
                 CLISpecParameter.option("--speaker-count", valueName: "N", summary: "Exact known speaker count for saved transcriptions and meetings."),
                 CLISpecParameter.option("--speaker-min", valueName: "N", summary: "Minimum speaker count bound for saved transcriptions and meetings."),
                 CLISpecParameter.option("--speaker-max", valueName: "N", summary: "Maximum speaker count bound for saved transcriptions and meetings."),
+                CLISpecParameter.flag("--no-diarize", summary: "Compatibility alias for --speaker-detection off."),
                 databaseOption,
             ],
             output: "RetranscribeResult with kind, id, sourcePath, updatedAt, and the updated Dictation or Transcription record."

--- a/Sources/CLI/Commands/SpecCommand.swift
+++ b/Sources/CLI/Commands/SpecCommand.swift
@@ -210,6 +210,32 @@ private extension CLISpecCommand {
             output: "Single Transcription object for stdout mode; one transcript file per input in batch/output-dir mode."
         ),
         CLISpecCommand(
+            ["retranscribe"],
+            summary: "Retranscribe retained source audio for an existing saved dictation, transcription, or meeting in place.",
+            readOnly: false,
+            jsonMode: "--json|--envelope",
+            arguments: [
+                .argument("record", summary: "Saved record UUID, UUID prefix, or exact transcription/meeting title."),
+            ],
+            options: [
+                CLISpecParameter.option("--kind", valueName: "auto|dictation|transcription|meeting", summary: "Constrain record resolution; auto fails on ambiguous matches."),
+                CLISpecParameter.flag("--update", summary: "Required confirmation that the command updates the existing saved record in place."),
+                CLISpecParameter.flag("--json", summary: "Emit the updated record payload as JSON."),
+                CLISpecParameter.flag("--envelope", summary: "Emit a success/failure envelope."),
+                CLISpecParameter.option("--mode", valueName: "raw|clean|app-default", summary: "Text processing mode for this rerun."),
+                CLISpecParameter.option("--engine", valueName: "parakeet|nemotron|whisper|cohere|app-default", summary: "Speech engine for this rerun."),
+                CLISpecParameter.option("--language", valueName: "CODE", summary: "Language hint for Nemotron, Whisper, or Cohere; the English-only Nemotron build ignores it."),
+                CLISpecParameter.option("--parakeet-model", valueName: "app-default|v3|v2|unified", summary: "Parakeet build for this rerun; ignored for Nemotron, Cohere, and Whisper."),
+                CLISpecParameter.option("--nemotron-model", valueName: "app-default|multilingual-1120ms|english-1120ms", summary: "Nemotron build for this rerun; ignored for Parakeet, Cohere, and Whisper."),
+                CLISpecParameter.option("--speaker-detection", valueName: "app-default|on|off", summary: "Speaker detection for saved transcriptions and meetings."),
+                CLISpecParameter.option("--speaker-count", valueName: "N", summary: "Exact known speaker count for saved transcriptions and meetings."),
+                CLISpecParameter.option("--speaker-min", valueName: "N", summary: "Minimum speaker count bound for saved transcriptions and meetings."),
+                CLISpecParameter.option("--speaker-max", valueName: "N", summary: "Maximum speaker count bound for saved transcriptions and meetings."),
+                databaseOption,
+            ],
+            output: "RetranscribeResult with kind, id, sourcePath, updatedAt, and the updated Dictation or Transcription record."
+        ),
+        CLISpecCommand(
             ["config", "list"],
             summary: "List shared app/CLI configuration values.",
             output: "Dictionary of canonical configuration keys to values."

--- a/Sources/CLI/MacParakeetCLI.swift
+++ b/Sources/CLI/MacParakeetCLI.swift
@@ -16,6 +16,7 @@ struct CLI: AsyncParsableCommand {
         version: cliVersion,
         subcommands: [
             TranscribeCommand.self,
+            RetranscribeCommand.self,
             HistoryCommand.self,
             ExportCommand.self,
             StatsCommand.self,

--- a/Sources/MacParakeet/App/DictationFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/DictationFlowCoordinator.swift
@@ -786,6 +786,10 @@ final class DictationFlowCoordinator {
         overlayViewModel?.state
     }
 
+    var flowStateForTesting: DictationFlowState {
+        stateMachine.state
+    }
+
     private func armProcessingLoadCaption() {
         captionGeneration += 1
         let generation = captionGeneration

--- a/Sources/MacParakeetCore/Services/Telemetry/Observability.swift
+++ b/Sources/MacParakeetCore/Services/Telemetry/Observability.swift
@@ -155,7 +155,17 @@ public enum Observability {
     }
 
     public static func wordCount(_ text: String) -> Int {
-        text.split(whereSeparator: \.isWhitespace).count
+        var count = 0
+        var inWord = false
+        for character in text {
+            if character.isWhitespace {
+                inWord = false
+            } else if !inWord {
+                count += 1
+                inWord = true
+            }
+        }
+        return count
     }
 
     private static let audioExtensions: Set<String> = [

--- a/Tests/CLITests/CLITelemetryTests.swift
+++ b/Tests/CLITests/CLITelemetryTests.swift
@@ -217,6 +217,21 @@ final class CLITelemetryTests: XCTestCase {
         XCTAssertEqual(metadata.json, true)
     }
 
+    func testRetranscribeEnvelopeMetadataUsesJSONOutputFormat() throws {
+        let command = try CLI.parseAsRoot([
+            "retranscribe",
+            "abcd",
+            "--update",
+            "--envelope",
+        ])
+
+        let metadata = CLITelemetry.metadata(for: command)
+
+        XCTAssertEqual(metadata.command, "retranscribe")
+        XCTAssertEqual(metadata.outputFormat, "json")
+        XCTAssertEqual(metadata.json, true)
+    }
+
     func testTranscribeMetadataClassifiesApplePodcastsInputKind() throws {
         let command = try CLI.parseAsRoot([
             "transcribe",

--- a/Tests/CLITests/RetranscribeCommandTests.swift
+++ b/Tests/CLITests/RetranscribeCommandTests.swift
@@ -203,6 +203,7 @@ final class RetranscribeCommandTests: XCTestCase {
             filePath: "/tmp/original.m4a",
             meetingArtifactFolderPath: "/tmp/artifact",
             rawTranscript: "old",
+            chatMessages: [ChatMessage(role: .user, content: "keep chat")],
             status: .completed,
             sourceURL: "https://example.com/source",
             thumbnailURL: "https://example.com/thumb.jpg",
@@ -222,8 +223,10 @@ final class RetranscribeCommandTests: XCTestCase {
             durationMs: 2_000,
             rawTranscript: "new raw",
             cleanTranscript: "new clean",
+            chatMessages: [ChatMessage(role: .assistant, content: "new chat")],
             status: .completed,
             sourceType: .file,
+            userNotes: "recovered notes",
             engine: "cohere",
             engineVariant: "ane",
             derivedTitle: "New",
@@ -245,10 +248,34 @@ final class RetranscribeCommandTests: XCTestCase {
         XCTAssertEqual(preserved.sourceType, .meeting)
         XCTAssertTrue(preserved.recoveredFromCrash)
         XCTAssertEqual(preserved.userNotes, "keep notes")
+        XCTAssertEqual(preserved.chatMessages, [ChatMessage(role: .user, content: "keep chat")])
         XCTAssertEqual(preserved.rawTranscript, "new raw")
         XCTAssertEqual(preserved.cleanTranscript, "new clean")
         XCTAssertEqual(preserved.engine, "cohere")
         XCTAssertEqual(preserved.engineVariant, "ane")
+    }
+
+    func testPreservesRecoveredMeetingNotesWhenOriginalRowHasNoUserData() {
+        let original = Transcription(
+            fileName: "Meeting",
+            filePath: "/tmp/meeting.m4a",
+            rawTranscript: "old",
+            status: .completed,
+            sourceType: .meeting
+        )
+        let result = Transcription(
+            fileName: "Generated",
+            filePath: "/tmp/generated.m4a",
+            rawTranscript: "new raw",
+            chatMessages: [ChatMessage(role: .assistant, content: "recovered chat")],
+            status: .completed,
+            userNotes: "recovered notes"
+        )
+
+        let preserved = RetranscribeCommand.preserveOriginalTranscriptionMetadata(result, original: original)
+
+        XCTAssertEqual(preserved.userNotes, "recovered notes")
+        XCTAssertEqual(preserved.chatMessages, [ChatMessage(role: .assistant, content: "recovered chat")])
     }
 
     func testClearsDictationFormatterAttributionForLocalRerun() {

--- a/Tests/CLITests/RetranscribeCommandTests.swift
+++ b/Tests/CLITests/RetranscribeCommandTests.swift
@@ -1,0 +1,336 @@
+import ArgumentParser
+import XCTest
+@testable import CLI
+@testable import MacParakeetCore
+
+final class RetranscribeCommandTests: XCTestCase {
+    func testRequiresExplicitUpdateConfirmation() {
+        XCTAssertThrowsError(try RetranscribeCommand.parse(["abcd"])) { error in
+            XCTAssertTrue(String(describing: error).contains("Pass --update"), String(describing: error))
+        }
+    }
+
+    func testParsesEngineModelLanguageAndEnvelopeOptions() throws {
+        let command = try RetranscribeCommand.parse([
+            "abcd",
+            "--update",
+            "--kind", "meeting",
+            "--engine", "cohere",
+            "--language", "ja",
+            "--parakeet-model", "unified",
+            "--nemotron-model", "english-1120ms",
+            "--speaker-count", "2",
+            "--envelope",
+        ])
+
+        XCTAssertEqual(command.kind, .meeting)
+        XCTAssertEqual(command.engine, .cohere)
+        XCTAssertEqual(command.language, "ja")
+        XCTAssertEqual(command.parakeetModel, .unified)
+        XCTAssertEqual(command.nemotronModel, .english)
+        XCTAssertEqual(command.speakerCount, 2)
+        XCTAssertTrue(command.envelope)
+    }
+
+    func testRejectsJSONAndEnvelopeTogether() {
+        XCTAssertThrowsError(try RetranscribeCommand.parse([
+            "abcd",
+            "--update",
+            "--json",
+            "--envelope",
+        ])) { error in
+            XCTAssertTrue(String(describing: error).contains("--json and --envelope cannot be combined"))
+        }
+    }
+
+    func testResolveAutoFindsTranscriptionByExactTitle() throws {
+        let harness = try makeHarness()
+        defer { harness.cleanup() }
+        let id = UUID(uuidString: "A1111111-1111-1111-1111-111111111111")!
+        try harness.transcriptions.save(Transcription(
+            id: id,
+            fileName: "Client Review.m4a",
+            filePath: "/tmp/client-review.m4a",
+            rawTranscript: "old",
+            status: .completed,
+            sourceType: .file
+        ))
+
+        let target = try RetranscribeCommand.resolveTarget(
+            "Client Review.m4a",
+            kind: .auto,
+            transcriptionRepo: harness.transcriptions,
+            dictationRepo: harness.dictations
+        )
+
+        guard case .transcription(let transcription) = target else {
+            return XCTFail("Expected transcription target, got \(target.kind)")
+        }
+        XCTAssertEqual(transcription.id, id)
+    }
+
+    func testResolveAutoClassifiesMeetingRowsSeparately() throws {
+        let harness = try makeHarness()
+        defer { harness.cleanup() }
+        let id = UUID(uuidString: "B2222222-2222-2222-2222-222222222222")!
+        try harness.transcriptions.save(Transcription(
+            id: id,
+            fileName: "Weekly Sync",
+            filePath: "/tmp/weekly-sync.m4a",
+            rawTranscript: "old",
+            status: .completed,
+            sourceType: .meeting
+        ))
+
+        let target = try RetranscribeCommand.resolveTarget(
+            "Weekly Sync",
+            kind: .auto,
+            transcriptionRepo: harness.transcriptions,
+            dictationRepo: harness.dictations
+        )
+
+        guard case .meeting(let transcription) = target else {
+            return XCTFail("Expected meeting target, got \(target.kind)")
+        }
+        XCTAssertEqual(transcription.id, id)
+    }
+
+    func testResolveAutoFindsDictationByPrefix() throws {
+        let harness = try makeHarness()
+        defer { harness.cleanup() }
+        let id = UUID(uuidString: "C3333333-3333-3333-3333-333333333333")!
+        try harness.dictations.save(Dictation(
+            id: id,
+            durationMs: 1_000,
+            rawTranscript: "old dictation",
+            audioPath: "/tmp/dictation.wav",
+            wordCount: 2
+        ))
+
+        let target = try RetranscribeCommand.resolveTarget(
+            "c333",
+            kind: .auto,
+            transcriptionRepo: harness.transcriptions,
+            dictationRepo: harness.dictations
+        )
+
+        guard case .dictation(let dictation) = target else {
+            return XCTFail("Expected dictation target, got \(target.kind)")
+        }
+        XCTAssertEqual(dictation.id, id)
+    }
+
+    func testResolveAutoRejectsCrossTablePrefixAmbiguity() throws {
+        let harness = try makeHarness()
+        defer { harness.cleanup() }
+        try harness.transcriptions.save(Transcription(
+            id: UUID(uuidString: "D4440000-1111-1111-1111-111111111111")!,
+            fileName: "Ambiguous.m4a",
+            filePath: "/tmp/ambiguous.m4a",
+            rawTranscript: "old",
+            status: .completed
+        ))
+        try harness.dictations.save(Dictation(
+            id: UUID(uuidString: "D4449999-2222-2222-2222-222222222222")!,
+            durationMs: 1_000,
+            rawTranscript: "old dictation",
+            audioPath: "/tmp/dictation.wav",
+            wordCount: 2
+        ))
+
+        XCTAssertThrowsError(try RetranscribeCommand.resolveTarget(
+            "d444",
+            kind: .auto,
+            transcriptionRepo: harness.transcriptions,
+            dictationRepo: harness.dictations
+        )) { error in
+            guard case CLIRetranscribeError.ambiguousRecord = error else {
+                return XCTFail("Expected ambiguousRecord, got \(error)")
+            }
+        }
+    }
+
+    func testResolveAutoPreservesShortUUIDPrefixError() throws {
+        let harness = try makeHarness()
+        defer { harness.cleanup() }
+
+        XCTAssertThrowsError(try RetranscribeCommand.resolveTarget(
+            "abc",
+            kind: .auto,
+            transcriptionRepo: harness.transcriptions,
+            dictationRepo: harness.dictations
+        )) { error in
+            guard case CLILookupError.shortUUIDPrefix(let minimumLength) = error else {
+                return XCTFail("Expected shortUUIDPrefix, got \(error)")
+            }
+            XCTAssertEqual(minimumLength, 4)
+        }
+    }
+
+    func testRetainedAudioURLRequiresStoredPathAndExistingFile() throws {
+        let id = UUID(uuidString: "E5555555-5555-5555-5555-555555555555")!
+        XCTAssertThrowsError(try RetranscribeCommand.retainedAudioURL(path: nil, kind: "transcription", id: id)) { error in
+            guard case CLIRetranscribeError.noRetainedAudio = error else {
+                return XCTFail("Expected noRetainedAudio, got \(error)")
+            }
+        }
+
+        let missing = FileManager.default.temporaryDirectory
+            .appendingPathComponent("missing-\(UUID().uuidString).wav")
+        XCTAssertThrowsError(try RetranscribeCommand.retainedAudioURL(path: missing.path, kind: "transcription", id: id)) { error in
+            guard case CLIRetranscribeError.missingAudio = error else {
+                return XCTFail("Expected missingAudio, got \(error)")
+            }
+        }
+
+        let existing = FileManager.default.temporaryDirectory
+            .appendingPathComponent("existing-\(UUID().uuidString).wav")
+        FileManager.default.createFile(atPath: existing.path, contents: Data())
+        defer { try? FileManager.default.removeItem(at: existing) }
+        XCTAssertEqual(
+            try RetranscribeCommand.retainedAudioURL(path: existing.path, kind: "transcription", id: id),
+            existing
+        )
+    }
+
+    func testPreservesOriginalTranscriptionMetadataWhileKeepingNewTranscriptFields() {
+        let id = UUID(uuidString: "F6666666-6666-6666-6666-666666666666")!
+        let createdAt = Date(timeIntervalSince1970: 1_000)
+        let original = Transcription(
+            id: id,
+            createdAt: createdAt,
+            fileName: "Original Title",
+            filePath: "/tmp/original.m4a",
+            meetingArtifactFolderPath: "/tmp/artifact",
+            rawTranscript: "old",
+            status: .completed,
+            sourceURL: "https://example.com/source",
+            thumbnailURL: "https://example.com/thumb.jpg",
+            channelName: "Channel",
+            videoDescription: "Description",
+            isFavorite: true,
+            sourceType: .meeting,
+            recoveredFromCrash: true,
+            userNotes: "keep notes",
+            engine: "parakeet"
+        )
+        let result = Transcription(
+            id: UUID(),
+            createdAt: Date(),
+            fileName: "Generated Title",
+            filePath: "/tmp/new.m4a",
+            durationMs: 2_000,
+            rawTranscript: "new raw",
+            cleanTranscript: "new clean",
+            status: .completed,
+            sourceType: .file,
+            engine: "cohere",
+            engineVariant: "ane",
+            derivedTitle: "New",
+            derivedSnippet: "Snippet"
+        )
+
+        let preserved = RetranscribeCommand.preserveOriginalTranscriptionMetadata(result, original: original)
+
+        XCTAssertEqual(preserved.id, id)
+        XCTAssertEqual(preserved.createdAt, createdAt)
+        XCTAssertEqual(preserved.fileName, "Original Title")
+        XCTAssertEqual(preserved.filePath, "/tmp/original.m4a")
+        XCTAssertEqual(preserved.meetingArtifactFolderPath, "/tmp/artifact")
+        XCTAssertEqual(preserved.sourceURL, "https://example.com/source")
+        XCTAssertEqual(preserved.thumbnailURL, "https://example.com/thumb.jpg")
+        XCTAssertEqual(preserved.channelName, "Channel")
+        XCTAssertEqual(preserved.videoDescription, "Description")
+        XCTAssertTrue(preserved.isFavorite)
+        XCTAssertEqual(preserved.sourceType, .meeting)
+        XCTAssertTrue(preserved.recoveredFromCrash)
+        XCTAssertEqual(preserved.userNotes, "keep notes")
+        XCTAssertEqual(preserved.rawTranscript, "new raw")
+        XCTAssertEqual(preserved.cleanTranscript, "new clean")
+        XCTAssertEqual(preserved.engine, "cohere")
+        XCTAssertEqual(preserved.engineVariant, "ane")
+    }
+
+    func testClearsDictationFormatterAttributionForLocalRerun() {
+        let dictation = Dictation(
+            id: UUID(),
+            durationMs: 1_000,
+            rawTranscript: "old",
+            cleanTranscript: "formatted old",
+            audioPath: "/tmp/dictation.wav",
+            wordCount: 2,
+            aiFormatterProfileID: UUID(),
+            aiFormatterProfileName: "Profile",
+            aiFormatterProfileMatchKind: .global
+        )
+
+        let updated = RetranscribeCommand.clearingDictationFormatterMetadata(dictation)
+
+        XCTAssertNil(updated.aiFormatterProfileID)
+        XCTAssertNil(updated.aiFormatterProfileName)
+        XCTAssertNil(updated.aiFormatterProfileMatchKind)
+        XCTAssertEqual(updated.id, dictation.id)
+        XCTAssertEqual(updated.audioPath, dictation.audioPath)
+        XCTAssertEqual(updated.rawTranscript, dictation.rawTranscript)
+    }
+
+    func testJSONFailureEnvelopeForMissingRetainedAudio() async throws {
+        let harness = try makeHarness()
+        defer { harness.cleanup() }
+        let id = UUID(uuidString: "A7777777-7777-7777-7777-777777777777")!
+        try harness.transcriptions.save(Transcription(
+            id: id,
+            fileName: "No Audio",
+            rawTranscript: "old",
+            status: .completed
+        ))
+        let command = try RetranscribeCommand.parse([
+            id.uuidString,
+            "--kind", "transcription",
+            "--update",
+            "--json",
+            "--database", harness.dbURL.path,
+        ])
+
+        var thrownError: Error?
+        let output = try await captureStandardOutput {
+            do {
+                try await command.run()
+            } catch {
+                thrownError = error
+            }
+        }
+
+        let error = try XCTUnwrap(thrownError)
+        XCTAssertTrue(error is CLIJSONEnvelopeExit)
+        XCTAssertEqual(CLI.normalizedExitCode(for: error), .failure)
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(output.utf8)) as? [String: Any]
+        )
+        XCTAssertEqual(object["ok"] as? Bool, false)
+        XCTAssertEqual(object["errorType"] as? String, "input_missing")
+        XCTAssertTrue((object["error"] as? String)?.contains("no retained source audio") == true)
+    }
+
+    private func makeHarness() throws -> Harness {
+        let dbURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("macparakeet-cli-retranscribe-\(UUID().uuidString).db")
+        let manager = try DatabaseManager(path: dbURL.path)
+        return Harness(
+            dbURL: dbURL,
+            transcriptions: TranscriptionRepository(dbQueue: manager.dbQueue),
+            dictations: DictationRepository(dbQueue: manager.dbQueue)
+        )
+    }
+
+    private struct Harness {
+        let dbURL: URL
+        let transcriptions: TranscriptionRepository
+        let dictations: DictationRepository
+
+        func cleanup() {
+            try? FileManager.default.removeItem(at: dbURL)
+            try? FileManager.default.removeItem(atPath: dbURL.path + ".migration.lock")
+        }
+    }
+}

--- a/Tests/CLITests/SpecCommandTests.swift
+++ b/Tests/CLITests/SpecCommandTests.swift
@@ -111,6 +111,7 @@ final class SpecCommandTests: XCTestCase {
                 "models",
                 "prompts",
                 "quick-prompts",
+                "retranscribe",
                 "spec",
                 "stats",
                 "transcribe",
@@ -180,6 +181,7 @@ final class SpecCommandTests: XCTestCase {
             ["vocab", "import"],
             ["history", "favorite"],
             ["history", "delete-meeting-audio"],
+            ["retranscribe"],
             ["stats"],
             ["export"],
             ["calendar", "upcoming"],
@@ -313,6 +315,37 @@ final class SpecCommandTests: XCTestCase {
             language["summary"] as? String,
             "Language hint for Nemotron, Whisper, or Cohere; the English-only Nemotron build ignores it."
         )
+    }
+
+    func testRetranscribeSpecDocumentsCurrentSurface() throws {
+        let payload = try specPayload()
+        let commands = try XCTUnwrap(payload["commands"] as? [[String: Any]])
+        let retranscribe = try XCTUnwrap(commands.first { ($0["path"] as? [String]) == ["retranscribe"] })
+
+        XCTAssertEqual(
+            retranscribe["summary"] as? String,
+            "Retranscribe retained source audio for an existing saved dictation, transcription, or meeting in place."
+        )
+        XCTAssertEqual(retranscribe["readOnly"] as? Bool, false)
+        XCTAssertEqual(retranscribe["jsonMode"] as? String, "--json|--envelope")
+
+        let arguments = try XCTUnwrap(retranscribe["arguments"] as? [[String: Any]])
+        XCTAssertEqual(arguments.first?["name"] as? String, "record")
+
+        let options = try XCTUnwrap(retranscribe["options"] as? [[String: Any]])
+        let optionNames = Set(options.compactMap { $0["name"] as? String })
+        XCTAssertTrue(optionNames.contains("--kind"))
+        XCTAssertTrue(optionNames.contains("--update"))
+        XCTAssertTrue(optionNames.contains("--json"))
+        XCTAssertTrue(optionNames.contains("--envelope"))
+        XCTAssertTrue(optionNames.contains("--engine"))
+        XCTAssertTrue(optionNames.contains("--language"))
+        XCTAssertTrue(optionNames.contains("--parakeet-model"))
+        XCTAssertTrue(optionNames.contains("--nemotron-model"))
+        XCTAssertTrue(optionNames.contains("--speaker-count"))
+        XCTAssertTrue(optionNames.contains("--speaker-min"))
+        XCTAssertTrue(optionNames.contains("--speaker-max"))
+        XCTAssertTrue(optionNames.contains("--database"))
     }
 
     func testSpecDocumentsConfigAndModelsCommands() throws {

--- a/Tests/CLITests/SpecCommandTests.swift
+++ b/Tests/CLITests/SpecCommandTests.swift
@@ -338,14 +338,20 @@ final class SpecCommandTests: XCTestCase {
         XCTAssertTrue(optionNames.contains("--update"))
         XCTAssertTrue(optionNames.contains("--json"))
         XCTAssertTrue(optionNames.contains("--envelope"))
+        XCTAssertTrue(optionNames.contains("--mode"))
         XCTAssertTrue(optionNames.contains("--engine"))
         XCTAssertTrue(optionNames.contains("--language"))
         XCTAssertTrue(optionNames.contains("--parakeet-model"))
         XCTAssertTrue(optionNames.contains("--nemotron-model"))
+        XCTAssertTrue(optionNames.contains("--speaker-detection"))
         XCTAssertTrue(optionNames.contains("--speaker-count"))
         XCTAssertTrue(optionNames.contains("--speaker-min"))
         XCTAssertTrue(optionNames.contains("--speaker-max"))
+        XCTAssertTrue(optionNames.contains("--no-diarize"))
         XCTAssertTrue(optionNames.contains("--database"))
+
+        let speakerDetection = try XCTUnwrap(options.first { ($0["name"] as? String) == "--speaker-detection" })
+        XCTAssertEqual(speakerDetection["valueName"] as? String, "app-default|on|off")
     }
 
     func testSpecDocumentsConfigAndModelsCommands() throws {

--- a/Tests/MacParakeetTests/DictationFlow/DictationFlowCoordinatorTests.swift
+++ b/Tests/MacParakeetTests/DictationFlow/DictationFlowCoordinatorTests.swift
@@ -12,7 +12,7 @@ final class DictationFlowCoordinatorTests: XCTestCase {
 
         harness.coordinator.startDictation(mode: .persistent, trigger: .pillClick)
 
-        let started = await waitUntil { self.isRecording(harness.coordinator.overlayStateForTesting) }
+        let started = await waitUntil { self.isFlowRecording(harness.coordinator.flowStateForTesting) }
         XCTAssertTrue(started)
         XCTAssertEqual(
             fnManager.modifierFlagsChangedOutputsForTesting(
@@ -313,8 +313,7 @@ final class DictationFlowCoordinatorTests: XCTestCase {
         return condition()
     }
 
-    private func isRecording(_ state: DictationOverlayViewModel.OverlayState?) -> Bool {
-        guard let state else { return false }
+    private func isFlowRecording(_ state: DictationFlowState) -> Bool {
         if case .recording = state { return true }
         return false
     }

--- a/Tests/MacParakeetTests/Services/Telemetry/ObservabilityTests.swift
+++ b/Tests/MacParakeetTests/Services/Telemetry/ObservabilityTests.swift
@@ -1,0 +1,14 @@
+import Testing
+@testable import MacParakeetCore
+
+@Suite("Observability")
+struct ObservabilityTests {
+    @Test("wordCount counts whitespace-delimited words without changing semantics")
+    func wordCountWhitespaceSemantics() {
+        #expect(Observability.wordCount("") == 0)
+        #expect(Observability.wordCount("   \n\t  ") == 0)
+        #expect(Observability.wordCount("one two") == 2)
+        #expect(Observability.wordCount(" one\t two\nthree ") == 3)
+        #expect(Observability.wordCount("hello-world") == 1)
+    }
+}

--- a/docs/cli-testing.md
+++ b/docs/cli-testing.md
@@ -263,9 +263,10 @@ swift run macparakeet-cli retranscribe "<MEETING_ID>" \
 
 The command updates the existing row in place, so `--update` is required. It
 fails cleanly when source audio was not retained or has been deleted. Use
-`--kind dictation|transcription|meeting` when a UUID prefix or title is
-ambiguous. Speaker-detection flags apply to saved transcriptions and meetings;
-dictations reject those flags.
+a full UUID, or a longer UUID prefix for prefix matches, when a record
+identifier is ambiguous. Use `--kind dictation|transcription|meeting` only to
+disambiguate cross-kind matches. Speaker-detection flags apply to saved
+transcriptions and meetings; dictations reject those flags.
 
 ### Speaker Diarization
 

--- a/docs/cli-testing.md
+++ b/docs/cli-testing.md
@@ -244,6 +244,29 @@ language. Cohere has no auto-detect; `--engine cohere` uses the saved
 app-default` resolves to Nemotron, Whisper, or Cohere, an explicit `--language`
 overrides the saved language for that invocation.
 
+### Retranscribe Existing Records
+
+Use `retranscribe` when a support or agent workflow needs to rerun STT against
+source audio that MacParakeet already retained for a saved row:
+
+```bash
+swift run macparakeet-cli retranscribe "<ID_OR_TITLE>" --update --json
+swift run macparakeet-cli retranscribe "<MEETING_ID>" \
+  --kind meeting \
+  --update \
+  --engine app-default \
+  --parakeet-model app-default \
+  --speaker-detection app-default \
+  --mode app-default \
+  --envelope
+```
+
+The command updates the existing row in place, so `--update` is required. It
+fails cleanly when source audio was not retained or has been deleted. Use
+`--kind dictation|transcription|meeting` when a UUID prefix or title is
+ambiguous. Speaker-detection flags apply to saved transcriptions and meetings;
+dictations reject those flags.
+
 ### Speaker Diarization
 
 Speaker detection follows the saved app/CLI preference by default. A fresh

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -190,7 +190,8 @@ macparakeet-cli retranscribe <id> --kind meeting --update --engine cohere --lang
 `retranscribe` resolves dictations by UUID/prefix, transcriptions by
 UUID/prefix or exact name, and meetings by UUID/prefix or exact title. Auto
 resolution fails if the identifier matches more than one saved record; retry
-with `--kind dictation|transcription|meeting` or a longer UUID prefix. It
+with a full UUID, or a longer UUID prefix for prefix matches. Use
+`--kind dictation|transcription|meeting` only to disambiguate cross-kind matches. It
 supports the same speech-engine, model, language, and processing-mode flags as
 `transcribe`; speaker-detection flags apply only to saved transcriptions and
 meetings.

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -177,6 +177,24 @@ macparakeet-cli history transcriptions          # note the subcommand; lists ids
 macparakeet-cli export <id> --format vtt
 ```
 
+To rerun STT for an existing saved item without creating a new library row,
+use `retranscribe`. It requires retained source audio and an explicit
+`--update` confirmation because it replaces transcript-derived fields on the
+existing record:
+
+```bash
+macparakeet-cli retranscribe <id-or-prefix-or-title> --update --json
+macparakeet-cli retranscribe <id> --kind meeting --update --engine cohere --language ja --envelope
+```
+
+`retranscribe` resolves dictations by UUID/prefix, transcriptions by
+UUID/prefix or exact name, and meetings by UUID/prefix or exact title. Auto
+resolution fails if the identifier matches more than one saved record; retry
+with `--kind dictation|transcription|meeting` or a longer UUID prefix. It
+supports the same speech-engine, model, language, and processing-mode flags as
+`transcribe`; speaker-detection flags apply only to saved transcriptions and
+meetings.
+
 `--no-history` avoids retaining the completed transcription in the shared
 MacParakeet history. For media URL and podcast inputs, downloaded audio is
 temporary when `--no-history` is set.


### PR DESCRIPTION
## Summary
- Add `macparakeet-cli retranscribe <record> --update` for saved dictations, transcriptions, and meetings with retained source audio.
- Resolve records by UUID/prefix or exact transcription/meeting title, while preserving existing row identity and user-owned metadata.
- Document the command in CLI spec/docs/changelog and add JSON/envelope error handling.
- Harden a dictation coordinator test that was racing the async hotkey-sync transition under hosted `swift test --parallel`.

Closes #627.

## Verification
- `swift test --filter 'RetranscribeCommandTests|SpecCommandTests'`
- `swift test --filter CLITests`
- `swift test` (PR head before test-hardening commit: 4221 tests, 11 skipped, 0 failures; plus 16 Swift Testing checks)
- `swift test --parallel`
- `git diff --check`
- `swift run macparakeet-cli spec --json`