### PR TITLE
Retranscribe: reflect and rerun the transcript's actual engine

### DIFF
--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
@@ -642,11 +642,15 @@ struct TranscriptResultView: View {
                         nemotronVariant: option.nemotronVariant,
                         parakeetVariant: option.parakeetVariant,
                         isPrimary: choice.isPrimary,
+                        primaryReflectsTranscriptEngine: option.primaryReflectsTranscriptEngine,
                         isAvailable: choice.isAvailable,
                         unavailableReason: choice.unavailableReason,
                         advisory: choice.advisory
                     ) {
-                        selectRetranscribeEngine(choice)
+                        selectRetranscribeEngine(
+                            choice,
+                            reflectsTranscriptEngine: option.primaryReflectsTranscriptEngine
+                        )
                     }
                 }
             }
@@ -661,9 +665,16 @@ struct TranscriptResultView: View {
     }
 
     private func selectRetranscribeEngine(
-        _ choice: TranscriptionViewModel.RetranscriptionEngineOption.Choice
+        _ choice: TranscriptionViewModel.RetranscriptionEngineOption.Choice,
+        reflectsTranscriptEngine: Bool
     ) {
-        let override: SpeechEngineSelection? = choice.isPrimary ? nil : choice.selection
+        // Pin the engine named on the card whenever it is a specific choice — an
+        // alternative engine, or the engine that actually produced this
+        // transcript. Only the legacy "Current" primary (a fall-back to the
+        // user's live default) reruns through the plain current-settings path,
+        // so its variant and language follow whatever the user has set now.
+        let override: SpeechEngineSelection? =
+            (choice.isPrimary && !reflectsTranscriptEngine) ? nil : choice.selection
         pendingRetranscribePick = RetranscribePick(transcriptionID: transcription.id, override: override)
         showingRetranscribeOptions = false
         // Confirmation alert is presented from the .onChange handler that
@@ -3039,6 +3050,10 @@ private struct EngineOptionCard: View {
     let nemotronVariant: NemotronModelVariant
     let parakeetVariant: ParakeetModelVariant
     let isPrimary: Bool
+    /// When this is the primary card, whether it names the engine that produced
+    /// the transcript ("Original") rather than a fall-back to the user's current
+    /// default ("Current"). Ignored on non-primary cards.
+    let primaryReflectsTranscriptEngine: Bool
     let isAvailable: Bool
     let unavailableReason: String?
     let advisory: String?
@@ -3099,7 +3114,10 @@ private struct EngineOptionCard: View {
                             .font(DesignSystem.Typography.body.weight(.semibold))
                             .foregroundStyle(titleColor)
                         if isPrimary {
-                            EngineBadge(text: "Current", tint: DesignSystem.Colors.accent)
+                            EngineBadge(
+                                text: primaryReflectsTranscriptEngine ? "Original" : "Current",
+                                tint: DesignSystem.Colors.accent
+                            )
                         }
                         if !isAvailable {
                             EngineBadge(text: "Unavailable", tint: DesignSystem.Colors.warningAmber)
@@ -3200,7 +3218,9 @@ private struct EngineOptionCard: View {
 
     private var accessibilityLabel: String {
         var parts = [selection.engine.displayName]
-        if isPrimary { parts.append("current engine") }
+        if isPrimary {
+            parts.append(primaryReflectsTranscriptEngine ? "engine used for this transcript" : "current engine")
+        }
         if !isAvailable { parts.append("unavailable") }
         return parts.joined(separator: ", ")
     }

--- a/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
@@ -29,6 +29,13 @@ public final class TranscriptionViewModel {
         /// posture (e.g. Unified is English-only and emits no word timestamps)
         /// rather than always advertising the multilingual v3 build.
         public let parakeetVariant: ParakeetModelVariant
+        /// Whether `primaryEngine` reflects the engine that actually produced
+        /// this transcript (a captured meeting engine, or the engine recorded on
+        /// the row) rather than a fall-back to the user's current default. The
+        /// menu badges the primary "Original" when this is `true` and "Current"
+        /// when it is `false` (legacy rows predating engine attribution), and
+        /// only the latter reruns through the plain current-settings path.
+        public let primaryReflectsTranscriptEngine: Bool
 
         public var title: String {
             "Retranscribe with speech engine"
@@ -435,7 +442,14 @@ public final class TranscriptionViewModel {
             return nil
         }
 
+        // The primary card should name the engine that actually produced this
+        // transcript, not the user's current default — otherwise a Cohere or
+        // Whisper transcript would surface "Parakeet" as its primary. Meetings
+        // carry the captured selection; file/URL transcripts carry the engine on
+        // the row (since the engine-attribution migration). Rows predating
+        // attribution have no engine and fall back to the current default.
         let primaryEngine: SpeechEngineSelection
+        let primaryReflectsTranscriptEngine: Bool
         if original.sourceType == .meeting,
            let archivedRecording = archivedMeetingRecording(
                for: original,
@@ -444,8 +458,13 @@ public final class TranscriptionViewModel {
            ),
            archivedRecording.speechEngineWasCaptured {
             primaryEngine = archivedRecording.speechEngine
+            primaryReflectsTranscriptEngine = true
+        } else if let recordedEngine = original.engine.flatMap(SpeechEnginePreference.init(rawValue:)) {
+            primaryEngine = SpeechEngineSelection(engine: recordedEngine, language: original.language)
+            primaryReflectsTranscriptEngine = true
         } else {
             primaryEngine = SpeechEngineSelection.current(defaults: defaults)
+            primaryReflectsTranscriptEngine = false
         }
 
         let choices = retranscriptionEngineOrder(primary: primaryEngine.engine).map { engine in
@@ -467,7 +486,8 @@ public final class TranscriptionViewModel {
             primaryEngine: primaryEngine,
             choices: choices,
             nemotronVariant: SpeechEnginePreference.nemotronModelVariant(defaults: defaults),
-            parakeetVariant: SpeechEnginePreference.parakeetModelVariant(defaults: defaults)
+            parakeetVariant: SpeechEnginePreference.parakeetModelVariant(defaults: defaults),
+            primaryReflectsTranscriptEngine: primaryReflectsTranscriptEngine
         )
     }
 

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
@@ -1791,6 +1791,123 @@ final class TranscriptionViewModelTests: XCTestCase {
         XCTAssertEqual(option.parakeetVariant, .unified)
     }
 
+    func testRetranscriptionEngineOptionUsesRecordedEngineForFileTranscript() throws {
+        let suiteName = "TranscriptionViewModelTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        // Current default is Parakeet — deliberately different from the engine
+        // that produced this file, so a leak of the current default would fail.
+        SpeechEnginePreference.parakeet.save(to: defaults)
+        viewModel = TranscriptionViewModel(
+            defaults: defaults,
+            isWhisperModelDownloaded: { true },
+            isNemotronModelDownloaded: { true },
+            isCohereModelDownloaded: { true }
+        )
+
+        let tmpFile = FileManager.default.temporaryDirectory
+            .appendingPathComponent("retranscribe-engine-cohere-\(UUID().uuidString).mp3")
+        FileManager.default.createFile(atPath: tmpFile.path, contents: Data([0]))
+        defer { try? FileManager.default.removeItem(at: tmpFile) }
+
+        let original = Transcription(
+            id: UUID(),
+            fileName: "Cohere File",
+            filePath: tmpFile.path,
+            durationMs: 2_000,
+            rawTranscript: "Old transcript",
+            language: "fr",
+            status: .completed,
+            sourceType: .file,
+            engine: SpeechEnginePreference.cohere.rawValue
+        )
+
+        let option = try XCTUnwrap(viewModel.retranscriptionEngineOption(for: original))
+
+        XCTAssertEqual(option.primaryEngine, SpeechEngineSelection(engine: .cohere, language: "fr"))
+        XCTAssertTrue(option.primaryReflectsTranscriptEngine)
+        XCTAssertEqual(option.choices.first?.selection.engine, .cohere)
+        XCTAssertTrue(try retranscriptionChoice(.cohere, in: option).isPrimary)
+        XCTAssertFalse(try retranscriptionChoice(.parakeet, in: option).isPrimary)
+    }
+
+    func testRetranscriptionEngineOptionKeepsCurrentVariantForRecordedParakeet() throws {
+        let suiteName = "TranscriptionViewModelTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        SpeechEnginePreference.parakeet.save(to: defaults)
+        // The transcript was made with the Unified build, but the user's current
+        // Parakeet build is v2. A rerun resolves the *persisted* variant at run
+        // start, so the card must describe v2 (what a rerun loads) — not the
+        // recorded Unified build, which the override cannot pin.
+        SpeechEnginePreference.saveParakeetModelVariant(.v2, defaults: defaults)
+        viewModel = TranscriptionViewModel(
+            defaults: defaults,
+            isWhisperModelDownloaded: { true },
+            isNemotronModelDownloaded: { true }
+        )
+
+        let tmpFile = FileManager.default.temporaryDirectory
+            .appendingPathComponent("retranscribe-engine-parakeet-\(UUID().uuidString).mp3")
+        FileManager.default.createFile(atPath: tmpFile.path, contents: Data([0]))
+        defer { try? FileManager.default.removeItem(at: tmpFile) }
+
+        let original = Transcription(
+            id: UUID(),
+            fileName: "Parakeet File",
+            filePath: tmpFile.path,
+            durationMs: 2_000,
+            rawTranscript: "Old transcript",
+            status: .completed,
+            sourceType: .file,
+            engine: SpeechEnginePreference.parakeet.rawValue,
+            engineVariant: ParakeetModelVariant.unified.rawValue
+        )
+
+        let option = try XCTUnwrap(viewModel.retranscriptionEngineOption(for: original))
+
+        XCTAssertEqual(option.primaryEngine, SpeechEngineSelection(engine: .parakeet))
+        XCTAssertTrue(option.primaryReflectsTranscriptEngine)
+        XCTAssertTrue(try retranscriptionChoice(.parakeet, in: option).isPrimary)
+        XCTAssertEqual(option.parakeetVariant, .v2)
+    }
+
+    func testRetranscriptionEngineOptionFallsBackToCurrentDefaultForLegacyFileTranscript() throws {
+        let suiteName = "TranscriptionViewModelTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        SpeechEnginePreference.whisper.save(to: defaults)
+        SpeechEnginePreference.saveWhisperDefaultLanguage("ko", defaults: defaults)
+        viewModel = TranscriptionViewModel(
+            defaults: defaults,
+            isWhisperModelDownloaded: { true },
+            isNemotronModelDownloaded: { true }
+        )
+
+        let tmpFile = FileManager.default.temporaryDirectory
+            .appendingPathComponent("retranscribe-engine-legacy-\(UUID().uuidString).mp3")
+        FileManager.default.createFile(atPath: tmpFile.path, contents: Data([0]))
+        defer { try? FileManager.default.removeItem(at: tmpFile) }
+
+        // Pre-attribution row: no engine recorded, so the menu falls back to the
+        // user's current default and badges it "Current", not "Original".
+        let original = Transcription(
+            id: UUID(),
+            fileName: "Legacy File",
+            filePath: tmpFile.path,
+            durationMs: 2_000,
+            rawTranscript: "Old transcript",
+            status: .completed,
+            sourceType: .file
+        )
+
+        let option = try XCTUnwrap(viewModel.retranscriptionEngineOption(for: original))
+
+        XCTAssertEqual(option.primaryEngine, SpeechEngineSelection(engine: .whisper, language: "ko"))
+        XCTAssertFalse(option.primaryReflectsTranscriptEngine)
+        XCTAssertTrue(try retranscriptionChoice(.whisper, in: option).isPrimary)
+    }
+
     func testRetranscriptionEngineOptionIncludesNemotronButDisablesItWhenMissing() throws {
         let archivedMeeting = try makeArchivedMeetingRecording(
             speechEngine: SpeechEngineSelection(engine: .parakeet)


### PR DESCRIPTION
## Why

The Retranscribe menu's **primary** card — ordered first and badged **Current** — was keyed off the user's *current default* engine, not the engine that produced the open transcript.

So a transcript made with **Cohere** or **Whisper** would surface "**Parakeet — Current**" as its primary, hiding its real origin. Worse, picking that primary re-ran with the current default instead of reproducing the transcript. This is the follow-up to #631, which only made the card's *subtitle* variant-aware.

## What changed

The primary now names the engine that **actually produced** the transcript:
- the captured meeting engine, or
- the engine recorded on the row (since the engine-attribution migration).

Rows predating attribution carry no engine and still fall back to the current default.

**Badge + accessibility**
- Reads **Original** when the primary reflects the transcript's engine, and **Current** only for the legacy current-default fallback.
- VoiceOver mirrors this: "engine used for this transcript" vs "current engine".

```
⚡ Cohere   [ Original ]                 ⚡ Parakeet   [ Current ]   ← legacy row, no
   High accuracy • On-device              Fast • 25 European …        engine recorded
```

**Rerun execution**
- Picking the primary now **pins** that engine (and the transcript's recorded language) so the rerun reproduces it. Only the legacy "Current" primary still reruns through the plain current-settings path. Non-default alternatives were already pinned, so this only changes the primary.

## Deliberately not changed

The card's **variant subtitle** (Parakeet v3/v2/Unified, Nemotron build) keeps describing the *current persisted* variant, not the recorded one. A rerun resolves the variant from settings at run start, and the engine override carries no sub-variant — so the subtitle must describe what a rerun will **load**, not what the transcript was made with. This keeps #631's "No word timestamps" warning truthful. A test locks this in (recorded Unified + current v2 → subtitle stays v2).

## Tests

`TranscriptionViewModelTests`:
- File transcript whose recorded engine differs from the default → Cohere is primary, `primaryReflectsTranscriptEngine` true, recorded language carried into the primary selection.
- Recorded Parakeet + Unified variant, current default v2 → primary Parakeet, subtitle variant stays **v2** (rerun semantics).
- Legacy nil-engine row → falls back to current default, `primaryReflectsTranscriptEngine` false.

Full `swift test` (4208 tests, 0 failures) and the Swift 6 language-mode gate are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Retranscribe menu so the primary card reflects and reproduces the engine that actually created the transcript, not the user’s current default. Reruns now faithfully match the original engine and language; legacy transcripts still use the current default.

- **Bug Fixes**
  - Primary picks the captured meeting engine or the recorded engine; falls back to the current default only for legacy rows without engine attribution.
  - Selecting the primary pins that engine and the transcript’s language; only the legacy “Current” primary runs via current settings.
  - Badge and accessibility: primary shows “Original” (actual engine) or “Current” (legacy fallback); VoiceOver mirrors this.
  - Variant subtitle continues to show the current persisted variant (e.g., Parakeet v2) to match rerun behavior; tests cover differing engine vs default, Parakeet variant semantics, and legacy fallback.

<sup>Written for commit 5d7ab1a8e87ee91ee0c8b141c53b6a348657ba87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/637?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

