### PR TITLE
Meeting AEC: adaptive reference-delay estimation (#605 U1/U2)

### DIFF
--- a/Sources/MacParakeetCore/Services/Capture/MeetingEchoDelayEstimator.swift
+++ b/Sources/MacParakeetCore/Services/Capture/MeetingEchoDelayEstimator.swift
@@ -66,9 +66,9 @@ struct MeetingEchoDelayEstimator: Sendable {
         let refEmphasized = Self.preEmphasized(reference, coefficient: preEmphasis, count: count)
 
         // Use the most-recent window that fits after reserving `maxLagSamples` of
-        // history so `reference[n - lag]` is always in range.
+        // history so `reference[n - lag]` is always in range. The `count` guard
+        // above keeps `count - maxLagSamples >= 2`, so `windowLength >= 1`.
         let windowLength = min(analysisWindowSamples, count - maxLagSamples)
-        guard windowLength > 0 else { return nil }
         let windowStart = count - windowLength
 
         return micEmphasized.withUnsafeBufferPointer { mic in

--- a/Sources/MacParakeetCore/Services/Capture/MeetingEchoDelayEstimator.swift
+++ b/Sources/MacParakeetCore/Services/Capture/MeetingEchoDelayEstimator.swift
@@ -1,0 +1,116 @@
+import Foundation
+
+/// The result of estimating how far the microphone's echo lags the system-audio
+/// reference: the bulk delay in samples, plus a normalized-correlation confidence
+/// in `0...1` (how strongly the reference explains the mic at that lag).
+struct MeetingEchoDelayEstimate: Sendable, Equatable {
+    let delaySamples: Int
+    let confidence: Float
+}
+
+/// Estimates the bulk delay between the system-audio reference and the echo it
+/// produces in the microphone, so the echo suppressor can read the reference at
+/// the right offset.
+///
+/// Why this exists: the meeting measurement harness showed that reference/mic
+/// time alignment is the dominant factor in whether cancellation works at all,
+/// and that the bulk offset between the microphone clock and the ScreenCaptureKit
+/// system-audio clock can be far larger than any practical adaptive filter can
+/// span. A fixed `referenceDelaySamples` cannot track that. This recovers the
+/// bulk delay from the audio itself; the downstream adaptive/neural filter then
+/// only has to model the residual room response within its own length.
+///
+/// Method: a pre-emphasized normalized cross-correlation search. Pre-emphasis
+/// (a one-tap high-pass) flattens the steep spectral tilt of speech so the
+/// correlation peak is sharp rather than smeared; normalization makes the peak a
+/// scale-independent confidence so a weak/absent echo can be rejected rather than
+/// snapping to a spurious lag. The search is bulk-delay only (non-negative lags,
+/// since echo always trails the played reference); sub-sample precision is left
+/// to the adaptive filter, which absorbs a few samples of residual error.
+struct MeetingEchoDelayEstimator: Sendable {
+    /// Largest delay searched, in samples. Echo cannot precede the reference, so
+    /// only `0...maxLagSamples` is considered.
+    let maxLagSamples: Int
+    /// One-tap pre-emphasis coefficient applied to both signals before
+    /// correlating (`y[n] = x[n] - coeff * x[n-1]`). 0 disables it.
+    let preEmphasis: Float
+    /// Minimum normalized-correlation peak to trust an estimate; below this the
+    /// estimator reports `nil` (no reliable echo to align to).
+    let minConfidence: Float
+    /// Number of samples correlated when scoring each lag. Larger is steadier but
+    /// slower; the estimate uses the most-recent window that fits.
+    let analysisWindowSamples: Int
+
+    init(
+        maxLagSamples: Int = 1_600,
+        preEmphasis: Float = 0.95,
+        minConfidence: Float = 0.3,
+        analysisWindowSamples: Int = 8_192
+    ) {
+        self.maxLagSamples = max(0, maxLagSamples)
+        self.preEmphasis = preEmphasis
+        self.minConfidence = max(0, minConfidence)
+        self.analysisWindowSamples = max(1, analysisWindowSamples)
+    }
+
+    /// Estimate the bulk delay at which `reference` best explains `microphone`.
+    /// `reference[i]` and `microphone[i]` must share a stream timebase (sample `i`
+    /// is the same instant in both). Returns `nil` when the inputs are too short
+    /// or the best correlation peak is below `minConfidence`.
+    func estimate(microphone: [Float], reference: [Float]) -> MeetingEchoDelayEstimate? {
+        let count = min(microphone.count, reference.count)
+        // Need room for the largest lag plus at least some window to correlate.
+        guard count > maxLagSamples + 1 else { return nil }
+
+        let micEmphasized = Self.preEmphasized(microphone, coefficient: preEmphasis, count: count)
+        let refEmphasized = Self.preEmphasized(reference, coefficient: preEmphasis, count: count)
+
+        // Use the most-recent window that fits after reserving `maxLagSamples` of
+        // history so `reference[n - lag]` is always in range.
+        let windowLength = min(analysisWindowSamples, count - maxLagSamples)
+        guard windowLength > 0 else { return nil }
+        let windowStart = count - windowLength
+
+        return micEmphasized.withUnsafeBufferPointer { mic in
+            refEmphasized.withUnsafeBufferPointer { ref in
+                var micEnergy: Float = 0
+                for n in windowStart..<count {
+                    micEnergy += mic[n] * mic[n]
+                }
+                guard micEnergy > 0 else { return nil }
+
+                var bestLag = 0
+                var bestScore: Float = 0  // |normalized correlation|
+                for lag in 0...maxLagSamples {
+                    var cross: Float = 0
+                    var refEnergy: Float = 0
+                    for n in windowStart..<count {
+                        let r = ref[n - lag]
+                        cross += mic[n] * r
+                        refEnergy += r * r
+                    }
+                    guard refEnergy > 0 else { continue }
+                    let normalized = cross / (micEnergy * refEnergy).squareRoot()
+                    let score = abs(normalized)
+                    if score > bestScore {
+                        bestScore = score
+                        bestLag = lag
+                    }
+                }
+
+                guard bestScore >= minConfidence else { return nil }
+                return MeetingEchoDelayEstimate(delaySamples: bestLag, confidence: bestScore)
+            }
+        }
+    }
+
+    private static func preEmphasized(_ signal: [Float], coefficient: Float, count: Int) -> [Float] {
+        guard coefficient != 0, count > 0 else { return Array(signal.prefix(count)) }
+        var out = [Float](repeating: 0, count: count)
+        out[0] = signal[0]
+        for n in 1..<count {
+            out[n] = signal[n] - coefficient * signal[n - 1]
+        }
+        return out
+    }
+}

--- a/Sources/MacParakeetCore/Services/Capture/MeetingEchoDelayEstimator.swift
+++ b/Sources/MacParakeetCore/Services/Capture/MeetingEchoDelayEstimator.swift
@@ -79,17 +79,33 @@ struct MeetingEchoDelayEstimator: Sendable {
                 }
                 guard micEnergy > 0 else { return nil }
 
+                var refEnergies: [Float] = []
+                refEnergies.reserveCapacity(maxLagSamples + 1)
+                var currentRefEnergy: Float = 0
+                for n in windowStart..<count {
+                    let r = ref[n]
+                    currentRefEnergy += r * r
+                }
+                refEnergies.append(currentRefEnergy)
+                if maxLagSamples > 0 {
+                    for lag in 1...maxLagSamples {
+                        let removed = ref[count - lag]
+                        let added = ref[windowStart - lag]
+                        currentRefEnergy += added * added - removed * removed
+                        refEnergies.append(max(0, currentRefEnergy))
+                    }
+                }
+
                 var bestLag = 0
                 var bestScore: Float = 0  // |normalized correlation|
                 for lag in 0...maxLagSamples {
+                    let refEnergy = refEnergies[lag]
+                    guard refEnergy > 0 else { continue }
                     var cross: Float = 0
-                    var refEnergy: Float = 0
                     for n in windowStart..<count {
                         let r = ref[n - lag]
                         cross += mic[n] * r
-                        refEnergy += r * r
                     }
-                    guard refEnergy > 0 else { continue }
                     let normalized = cross / (micEnergy * refEnergy).squareRoot()
                     let score = abs(normalized)
                     if score > bestScore {

--- a/Sources/MacParakeetCore/Services/Capture/MeetingEchoDelayEstimator.swift
+++ b/Sources/MacParakeetCore/Services/Capture/MeetingEchoDelayEstimator.swift
@@ -49,7 +49,7 @@ struct MeetingEchoDelayEstimator: Sendable {
     ) {
         self.maxLagSamples = max(0, maxLagSamples)
         self.preEmphasis = preEmphasis
-        self.minConfidence = max(0, minConfidence)
+        self.minConfidence = min(1, max(0, minConfidence))
         self.analysisWindowSamples = max(1, analysisWindowSamples)
     }
 
@@ -107,7 +107,7 @@ struct MeetingEchoDelayEstimator: Sendable {
                         cross += mic[n] * r
                     }
                     let normalized = cross / (micEnergy * refEnergy).squareRoot()
-                    let score = abs(normalized)
+                    let score = min(1, abs(normalized))
                     if score > bestScore {
                         bestScore = score
                         bestLag = lag

--- a/Sources/MacParakeetCore/Services/Capture/MeetingEchoSuppressionRuntime.swift
+++ b/Sources/MacParakeetCore/Services/Capture/MeetingEchoSuppressionRuntime.swift
@@ -270,17 +270,25 @@ enum MeetingEchoSuppressionFactory {
             // The processor may report its own sample rate, so the ms→samples
             // conversion happens here rather than in the configuration.
             let referenceDelaySamples = configuration.referenceDelayMs * processor.sampleRate / 1_000
-            // Search up to ~100 ms of echo-path latency, the practical ceiling
-            // for laptop speaker→mic bleed, but never less than the configured
-            // seed so a deliberately large manual delay is not narrowed away.
-            let estimator = configuration.adaptiveReferenceDelay
-                ? MeetingEchoDelayEstimator(
-                    maxLagSamples: max(1, processor.sampleRate / 10, referenceDelaySamples))
-                : nil
+            // Search up to ~100 ms of echo-path latency (the practical ceiling
+            // for laptop speaker→mic bleed), extended to cover the configured
+            // seed but capped at ~200 ms so a large manual reference delay
+            // cannot make the off-lock correlation or the analysis buffer
+            // unbounded. A seed beyond that cap is a deliberate manual override,
+            // so adaptation is disabled and the fixed seed is used as-is.
+            let searchCeiling = max(1, processor.sampleRate / 5)
+            let estimator: MeetingEchoDelayEstimator?
+            if configuration.adaptiveReferenceDelay, referenceDelaySamples <= searchCeiling {
+                let maxLag = min(max(processor.sampleRate / 10, referenceDelaySamples), searchCeiling)
+                estimator = MeetingEchoDelayEstimator(maxLagSamples: max(1, maxLag))
+            } else {
+                estimator = nil
+            }
             return StreamingMeetingEchoSuppressor(
                 processor: processor,
                 referenceDelaySamples: referenceDelaySamples,
-                estimator: estimator
+                estimator: estimator,
+                reestimateIntervalSamples: max(1, processor.sampleRate / 2)
             )
         } catch {
             return unavailableDynamicConditioner(reason: "load_failed", error: error)

--- a/Sources/MacParakeetCore/Services/Capture/MeetingEchoSuppressionRuntime.swift
+++ b/Sources/MacParakeetCore/Services/Capture/MeetingEchoSuppressionRuntime.swift
@@ -271,9 +271,11 @@ enum MeetingEchoSuppressionFactory {
             // conversion happens here rather than in the configuration.
             let referenceDelaySamples = configuration.referenceDelayMs * processor.sampleRate / 1_000
             // Search up to ~100 ms of echo-path latency, the practical ceiling
-            // for laptop speaker→mic bleed; the seed remains the starting point.
+            // for laptop speaker→mic bleed, but never less than the configured
+            // seed so a deliberately large manual delay is not narrowed away.
             let estimator = configuration.adaptiveReferenceDelay
-                ? MeetingEchoDelayEstimator(maxLagSamples: max(1, processor.sampleRate / 10))
+                ? MeetingEchoDelayEstimator(
+                    maxLagSamples: max(1, processor.sampleRate / 10, referenceDelaySamples))
                 : nil
             return StreamingMeetingEchoSuppressor(
                 processor: processor,

--- a/Sources/MacParakeetCore/Services/Capture/MeetingEchoSuppressionRuntime.swift
+++ b/Sources/MacParakeetCore/Services/Capture/MeetingEchoSuppressionRuntime.swift
@@ -269,16 +269,27 @@ enum MeetingEchoSuppressionFactory {
             )
             // The processor may report its own sample rate, so the ms→samples
             // conversion happens here rather than in the configuration.
-            let referenceDelaySamples = configuration.referenceDelayMs * processor.sampleRate / 1_000
             // Search up to ~100 ms of echo-path latency (the practical ceiling
             // for laptop speaker→mic bleed), extended to cover the configured
             // seed but capped at ~200 ms so a large manual reference delay
-            // cannot make the off-lock correlation or the analysis buffer
-            // unbounded. A seed beyond that cap is a deliberate manual override,
-            // so adaptation is disabled and the fixed seed is used as-is.
-            let searchCeiling = max(1, processor.sampleRate / 5)
+            // cannot make the off-lock correlation, analysis buffer, or fixed
+            // reference-retention buffer unbounded.
+            let referenceDelaySamples = boundedReferenceDelaySamples(
+                referenceDelayMs: configuration.referenceDelayMs,
+                sampleRate: processor.sampleRate
+            )
+            let searchCeiling = adaptiveReferenceDelaySearchCeiling(sampleRate: processor.sampleRate)
+            let referenceDelayWasCapped = referenceDelayExceedsSearchCeiling(
+                referenceDelayMs: configuration.referenceDelayMs,
+                sampleRate: processor.sampleRate
+            )
+            if referenceDelayWasCapped {
+                logger.warning(
+                    "meeting_echo_reference_delay_clamped requested_ms=\(configuration.referenceDelayMs, privacy: .public) capped_samples=\(referenceDelaySamples, privacy: .public)"
+                )
+            }
             let estimator: MeetingEchoDelayEstimator?
-            if configuration.adaptiveReferenceDelay, referenceDelaySamples <= searchCeiling {
+            if configuration.adaptiveReferenceDelay, !referenceDelayWasCapped {
                 let maxLag = min(max(processor.sampleRate / 10, referenceDelaySamples), searchCeiling)
                 estimator = MeetingEchoDelayEstimator(maxLagSamples: max(1, maxLag))
             } else {
@@ -293,6 +304,25 @@ enum MeetingEchoSuppressionFactory {
         } catch {
             return unavailableDynamicConditioner(reason: "load_failed", error: error)
         }
+    }
+
+    static func adaptiveReferenceDelaySearchCeiling(sampleRate: Int) -> Int {
+        max(1, max(1, sampleRate) / 5)
+    }
+
+    static func boundedReferenceDelaySamples(referenceDelayMs: Int, sampleRate: Int) -> Int {
+        let sampleRate = max(1, sampleRate)
+        let ceiling = adaptiveReferenceDelaySearchCeiling(sampleRate: sampleRate)
+        let requested = Double(max(0, referenceDelayMs)) * Double(sampleRate) / 1_000
+        guard requested.isFinite, requested < Double(ceiling) else { return ceiling }
+        return max(0, Int(requested))
+    }
+
+    static func referenceDelayExceedsSearchCeiling(referenceDelayMs: Int, sampleRate: Int) -> Bool {
+        let sampleRate = max(1, sampleRate)
+        let ceiling = adaptiveReferenceDelaySearchCeiling(sampleRate: sampleRate)
+        let requested = Double(max(0, referenceDelayMs)) * Double(sampleRate) / 1_000
+        return !requested.isFinite || requested > Double(ceiling)
     }
 
     private static func unavailableDynamicConditioner(

--- a/Sources/MacParakeetCore/Services/Capture/MeetingEchoSuppressionRuntime.swift
+++ b/Sources/MacParakeetCore/Services/Capture/MeetingEchoSuppressionRuntime.swift
@@ -17,10 +17,12 @@ public struct MeetingEchoSuppressionConfiguration: Sendable, Equatable {
     public static let frameSizeEnvironmentKey = "MACPARAKEET_MEETING_ECHO_FRAME_SIZE"
     public static let sampleRateEnvironmentKey = "MACPARAKEET_MEETING_ECHO_SAMPLE_RATE"
     public static let referenceDelayMsEnvironmentKey = "MACPARAKEET_MEETING_ECHO_REFERENCE_DELAY_MS"
+    public static let adaptiveReferenceDelayEnvironmentKey = "MACPARAKEET_MEETING_ECHO_ADAPTIVE_DELAY"
 
     public static let defaultSampleRate = 16_000
     public static let defaultFrameSize = 256
     public static let defaultReferenceDelayMs = 0
+    public static let defaultAdaptiveReferenceDelay = true
 
     public var mode: MeetingEchoSuppressionMode
     public var libraryURL: URL?
@@ -30,8 +32,14 @@ public struct MeetingEchoSuppressionConfiguration: Sendable, Equatable {
     public var frameSize: Int
     /// How far behind the microphone the system-audio reference is read, in
     /// milliseconds, approximating the output + acoustic + input echo-path
-    /// latency. 0 reads the reference at the microphone's own position.
+    /// latency. 0 reads the reference at the microphone's own position. When
+    /// `adaptiveReferenceDelay` is on this is the seed/override used until the
+    /// first confident estimate; otherwise it is the fixed alignment.
     public var referenceDelayMs: Int
+    /// Recover the reference delay from the audio at runtime instead of relying
+    /// only on the static `referenceDelayMs`. On by default; the static value
+    /// still seeds the estimate and overrides when this is off.
+    public var adaptiveReferenceDelay: Bool
 
     public init(
         mode: MeetingEchoSuppressionMode = .automatic,
@@ -40,7 +48,8 @@ public struct MeetingEchoSuppressionConfiguration: Sendable, Equatable {
         modelSHA256: String? = nil,
         sampleRate: Int = Self.defaultSampleRate,
         frameSize: Int = Self.defaultFrameSize,
-        referenceDelayMs: Int = Self.defaultReferenceDelayMs
+        referenceDelayMs: Int = Self.defaultReferenceDelayMs,
+        adaptiveReferenceDelay: Bool = Self.defaultAdaptiveReferenceDelay
     ) {
         self.mode = mode
         self.libraryURL = libraryURL
@@ -49,6 +58,7 @@ public struct MeetingEchoSuppressionConfiguration: Sendable, Equatable {
         self.sampleRate = max(1, sampleRate)
         self.frameSize = max(1, frameSize)
         self.referenceDelayMs = max(0, referenceDelayMs)
+        self.adaptiveReferenceDelay = adaptiveReferenceDelay
     }
 
     public static func fromEnvironment(
@@ -71,6 +81,8 @@ public struct MeetingEchoSuppressionConfiguration: Sendable, Equatable {
             .flatMap(Self.integerValue(from:)) ?? defaultFrameSize
         let referenceDelayMs = environment[referenceDelayMsEnvironmentKey]
             .flatMap(Self.integerValue(from:)) ?? defaultReferenceDelayMs
+        let adaptiveReferenceDelay = environment[adaptiveReferenceDelayEnvironmentKey]
+            .flatMap(Self.boolValue(from:)) ?? defaultAdaptiveReferenceDelay
 
         return MeetingEchoSuppressionConfiguration(
             mode: mode,
@@ -79,7 +91,8 @@ public struct MeetingEchoSuppressionConfiguration: Sendable, Equatable {
             modelSHA256: modelSHA256,
             sampleRate: sampleRate,
             frameSize: frameSize,
-            referenceDelayMs: referenceDelayMs
+            referenceDelayMs: referenceDelayMs,
+            adaptiveReferenceDelay: adaptiveReferenceDelay
         )
     }
 
@@ -97,6 +110,17 @@ public struct MeetingEchoSuppressionConfiguration: Sendable, Equatable {
 
     private static func integerValue(from value: String) -> Int? {
         Int(value.trimmingCharacters(in: .whitespacesAndNewlines))
+    }
+
+    private static func boolValue(from value: String) -> Bool? {
+        switch value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "1", "true", "yes", "on", "enabled":
+            return true
+        case "0", "false", "no", "off", "disabled":
+            return false
+        default:
+            return nil
+        }
     }
 }
 
@@ -246,9 +270,15 @@ enum MeetingEchoSuppressionFactory {
             // The processor may report its own sample rate, so the ms→samples
             // conversion happens here rather than in the configuration.
             let referenceDelaySamples = configuration.referenceDelayMs * processor.sampleRate / 1_000
+            // Search up to ~100 ms of echo-path latency, the practical ceiling
+            // for laptop speaker→mic bleed; the seed remains the starting point.
+            let estimator = configuration.adaptiveReferenceDelay
+                ? MeetingEchoDelayEstimator(maxLagSamples: max(1, processor.sampleRate / 10))
+                : nil
             return StreamingMeetingEchoSuppressor(
                 processor: processor,
-                referenceDelaySamples: referenceDelaySamples
+                referenceDelaySamples: referenceDelaySamples,
+                estimator: estimator
             )
         } catch {
             return unavailableDynamicConditioner(reason: "load_failed", error: error)

--- a/Sources/MacParakeetCore/Services/Capture/MicConditioner.swift
+++ b/Sources/MacParakeetCore/Services/Capture/MicConditioner.swift
@@ -159,6 +159,9 @@ final class StreamingMeetingEchoSuppressor: MicConditioning, @unchecked Sendable
     /// Bumped by `reset()` so an estimate computed off the lock from pre-reset
     /// audio is discarded instead of overwriting fresh state.
     private var estimationGeneration = 0
+    /// Bumped for every scheduled estimate so a slower older snapshot cannot
+    /// overwrite a newer result when callers invoke `condition()` concurrently.
+    private var latestEstimationAttemptID = 0
 
     var diagnostics: MeetingEchoSuppressionDiagnostics {
         lock.lock()
@@ -186,10 +189,17 @@ final class StreamingMeetingEchoSuppressor: MicConditioning, @unchecked Sendable
         self.currentDelaySamples = max(0, referenceDelaySamples)
 
         if let estimator {
+            // estimate() requires count > maxLag + 1, so both the rolling buffer
+            // and the trigger threshold must clear maxLag + 2 even for tiny
+            // analysis windows; otherwise estimation could never fire.
+            let estimateFloor = estimator.maxLagSamples + 2
             self.retentionDelaySamples = max(self.seedDelaySamples, estimator.maxLagSamples)
-            self.analysisCapacity = estimator.maxLagSamples + estimator.analysisWindowSamples
-            self.minimumAnalysisSamples = estimator.maxLagSamples
-                + min(estimator.analysisWindowSamples, 4_096)
+            self.analysisCapacity = max(
+                estimateFloor,
+                estimator.maxLagSamples + estimator.analysisWindowSamples)
+            self.minimumAnalysisSamples = max(
+                estimateFloor,
+                estimator.maxLagSamples + min(estimator.analysisWindowSamples, 4_096))
         } else {
             self.retentionDelaySamples = self.seedDelaySamples
             self.analysisCapacity = 0
@@ -227,7 +237,8 @@ final class StreamingMeetingEchoSuppressor: MicConditioning, @unchecked Sendable
                     microphone: pendingEstimate.microphone,
                     reference: pendingEstimate.reference
                 ),
-                generation: pendingEstimate.generation
+                generation: pendingEstimate.generation,
+                attemptID: pendingEstimate.attemptID
             )
         }
         return output
@@ -259,6 +270,7 @@ final class StreamingMeetingEchoSuppressor: MicConditioning, @unchecked Sendable
         samplesSinceEstimate = 0
         hasAttemptedEstimate = false
         estimationGeneration += 1
+        latestEstimationAttemptID += 1
         diagnosticsStorage = Self.freshDiagnostics(
             processorName: processor.name,
             currentDelaySamples: currentDelaySamples
@@ -400,9 +412,14 @@ final class StreamingMeetingEchoSuppressor: MicConditioning, @unchecked Sendable
     ) {
         guard estimator != nil else { return }
         analysisMicrophone.append(contentsOf: microphone)
-        for index in 0..<microphone.count {
-            let hasSample = hasSpeakerReference && index < speaker.count
-            analysisReference.append(hasSample ? speaker[index] : 0)
+        if hasSpeakerReference {
+            let commonCount = min(microphone.count, speaker.count)
+            analysisReference.append(contentsOf: speaker.prefix(commonCount))
+            if commonCount < microphone.count {
+                analysisReference.append(contentsOf: repeatElement(Float.zero, count: microphone.count - commonCount))
+            }
+        } else {
+            analysisReference.append(contentsOf: repeatElement(Float.zero, count: microphone.count))
         }
         let overflow = analysisMicrophone.count - analysisCapacity
         if overflow > 0 {
@@ -415,6 +432,7 @@ final class StreamingMeetingEchoSuppressor: MicConditioning, @unchecked Sendable
         let microphone: [Float]
         let reference: [Float]
         let generation: Int
+        let attemptID: Int
     }
 
     /// If an estimate is due and enough history exists, mark the attempt and
@@ -430,18 +448,28 @@ final class StreamingMeetingEchoSuppressor: MicConditioning, @unchecked Sendable
 
         hasAttemptedEstimate = true
         samplesSinceEstimate = 0
+        latestEstimationAttemptID += 1
         return EstimationInput(
             microphone: analysisMicrophone,
             reference: analysisReference,
-            generation: estimationGeneration
+            generation: estimationGeneration,
+            attemptID: latestEstimationAttemptID
         )
     }
 
-    private func applyDelayEstimate(_ estimate: MeetingEchoDelayEstimate?, generation: Int) {
+    private func applyDelayEstimate(
+        _ estimate: MeetingEchoDelayEstimate?,
+        generation: Int,
+        attemptID: Int
+    ) {
         lock.lock()
         defer { lock.unlock() }
-        // Drop a result computed from audio that a reset() has since cleared.
-        guard generation == estimationGeneration else { return }
+        // Drop a result computed from stale audio: either a reset() has cleared
+        // the buffers, or a newer concurrent condition() call has scheduled a
+        // fresher snapshot.
+        guard generation == estimationGeneration,
+            attemptID == latestEstimationAttemptID
+        else { return }
 
         if let estimate {
             currentDelaySamples = min(estimate.delaySamples, retentionDelaySamples)

--- a/Sources/MacParakeetCore/Services/Capture/MicConditioner.swift
+++ b/Sources/MacParakeetCore/Services/Capture/MicConditioner.swift
@@ -156,6 +156,9 @@ final class StreamingMeetingEchoSuppressor: MicConditioning, @unchecked Sendable
     private var analysisReference: [Float] = []
     private var samplesSinceEstimate = 0
     private var hasAttemptedEstimate = false
+    /// Bumped by `reset()` so an estimate computed off the lock from pre-reset
+    /// audio is discarded instead of overwriting fresh state.
+    private var estimationGeneration = 0
 
     var diagnostics: MeetingEchoSuppressionDiagnostics {
         lock.lock()
@@ -203,18 +206,30 @@ final class StreamingMeetingEchoSuppressor: MicConditioning, @unchecked Sendable
         guard !microphone.isEmpty else { return [] }
 
         lock.lock()
-        defer { lock.unlock() }
-
         pendingMicrophone.append(contentsOf: microphone)
         for index in 0..<microphone.count {
             let hasSample = hasSpeakerReference && index < speaker.count
             referenceHistory.append(hasSample ? speaker[index] : 0)
             referenceValidity.append(hasSample)
         }
-
         accumulateAnalysisLocked(microphone: microphone, speaker: speaker, hasSpeakerReference: hasSpeakerReference)
         let output = drainProcessableFramesLocked()
-        maybeReestimateDelayLocked(addedSamples: microphone.count)
+        let pendingEstimate = dueEstimationSnapshotLocked(addedSamples: microphone.count)
+        lock.unlock()
+
+        // The cross-correlation is O(maxLag x window); run it off the lock so it
+        // never stalls a concurrent condition()/flush()/diagnostics access. The
+        // worst case is the estimate landing one batch later than the data that
+        // triggered it, which is immaterial at a multi-hundred-ms cadence.
+        if let pendingEstimate, let estimator {
+            applyDelayEstimate(
+                estimator.estimate(
+                    microphone: pendingEstimate.microphone,
+                    reference: pendingEstimate.reference
+                ),
+                generation: pendingEstimate.generation
+            )
+        }
         return output
     }
 
@@ -243,6 +258,7 @@ final class StreamingMeetingEchoSuppressor: MicConditioning, @unchecked Sendable
         analysisReference.removeAll()
         samplesSinceEstimate = 0
         hasAttemptedEstimate = false
+        estimationGeneration += 1
         diagnosticsStorage = Self.freshDiagnostics(
             processorName: processor.name,
             currentDelaySamples: currentDelaySamples
@@ -285,6 +301,12 @@ final class StreamingMeetingEchoSuppressor: MicConditioning, @unchecked Sendable
         var consumed = 0
 
         while consumed + frameSize <= pendingMicrophone.count {
+            // A processor receives `output` as inout and may resize it; restore
+            // the frame size each iteration so one bad frame cannot cascade the
+            // rest of this batch to raw fallback.
+            if processedFrame.count != frameSize {
+                processedFrame = [Float](repeating: 0, count: frameSize)
+            }
             for offset in 0..<frameSize {
                 micFrame[offset] = pendingMicrophone[consumed + offset]
             }
@@ -389,20 +411,39 @@ final class StreamingMeetingEchoSuppressor: MicConditioning, @unchecked Sendable
         }
     }
 
-    private func maybeReestimateDelayLocked(addedSamples: Int) {
-        guard let estimator else { return }
+    private struct EstimationInput {
+        let microphone: [Float]
+        let reference: [Float]
+        let generation: Int
+    }
+
+    /// If an estimate is due and enough history exists, mark the attempt and
+    /// return a copy-on-write snapshot of the analysis buffers to estimate on
+    /// outside the lock. Returns nil when no estimator is configured, the buffer
+    /// is too small, or the cadence has not elapsed.
+    private func dueEstimationSnapshotLocked(addedSamples: Int) -> EstimationInput? {
+        guard estimator != nil else { return nil }
         samplesSinceEstimate += addedSamples
         let ready = analysisMicrophone.count >= minimumAnalysisSamples
         let due = !hasAttemptedEstimate || samplesSinceEstimate >= reestimateIntervalSamples
-        guard ready, due else { return }
+        guard ready, due else { return nil }
 
         hasAttemptedEstimate = true
         samplesSinceEstimate = 0
-
-        if let estimate = estimator.estimate(
+        return EstimationInput(
             microphone: analysisMicrophone,
-            reference: analysisReference
-        ) {
+            reference: analysisReference,
+            generation: estimationGeneration
+        )
+    }
+
+    private func applyDelayEstimate(_ estimate: MeetingEchoDelayEstimate?, generation: Int) {
+        lock.lock()
+        defer { lock.unlock() }
+        // Drop a result computed from audio that a reset() has since cleared.
+        guard generation == estimationGeneration else { return }
+
+        if let estimate {
             currentDelaySamples = min(estimate.delaySamples, retentionDelaySamples)
             diagnosticsStorage.currentDelaySamples = currentDelaySamples
             diagnosticsStorage.delayConfidence = estimate.confidence

--- a/Sources/MacParakeetCore/Services/Capture/MicConditioner.swift
+++ b/Sources/MacParakeetCore/Services/Capture/MicConditioner.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OSLog
 
 struct MeetingEchoSuppressionDiagnostics: Sendable, Equatable {
     var processorName: String
@@ -126,6 +127,8 @@ final class PassthroughMicConditioner: MicConditioning, @unchecked Sendable {
 /// while the static value remains a manual seed/override and the value used
 /// until the first confident estimate.
 final class StreamingMeetingEchoSuppressor: MicConditioning, @unchecked Sendable {
+    private static let logger = Logger(subsystem: "com.macparakeet.core", category: "MeetingEchoSuppressor")
+
     private let processor: any MeetingEchoSuppressing
     private let seedDelaySamples: Int
     private let estimator: MeetingEchoDelayEstimator?
@@ -472,10 +475,19 @@ final class StreamingMeetingEchoSuppressor: MicConditioning, @unchecked Sendable
         else { return }
 
         if let estimate {
-            currentDelaySamples = min(estimate.delaySamples, retentionDelaySamples)
+            let previousDelaySamples = currentDelaySamples
+            let previousEstimateCount = diagnosticsStorage.delayEstimateCount
+            let adoptedDelaySamples = min(estimate.delaySamples, retentionDelaySamples)
+            currentDelaySamples = adoptedDelaySamples
             diagnosticsStorage.currentDelaySamples = currentDelaySamples
             diagnosticsStorage.delayConfidence = estimate.confidence
             diagnosticsStorage.delayEstimateCount += 1
+            let adoptedEstimateCount = diagnosticsStorage.delayEstimateCount
+            if previousEstimateCount == 0 || previousDelaySamples != adoptedDelaySamples {
+                Self.logger.info(
+                    "meeting_echo_delay_adopted delay_samples=\(adoptedDelaySamples, privacy: .public) confidence=\(estimate.confidence, privacy: .public) estimate_count=\(adoptedEstimateCount, privacy: .public)"
+                )
+            }
         } else {
             diagnosticsStorage.rejectedDelayEstimates += 1
         }

--- a/Sources/MacParakeetCore/Services/Capture/MicConditioner.swift
+++ b/Sources/MacParakeetCore/Services/Capture/MicConditioner.swift
@@ -10,6 +10,19 @@ struct MeetingEchoSuppressionDiagnostics: Sendable, Equatable {
     var partialReferenceFrames: Int
     var missingReferenceFrames: Int
     var processingFailures: Int
+    /// Reference delay (samples) currently used to align the system reference to
+    /// the microphone. Seeded from configuration, then updated by the adaptive
+    /// estimator when one is active.
+    var currentDelaySamples: Int = 0
+    /// Normalized-correlation confidence of the most recently adopted delay
+    /// estimate, in `0...1`. 0 when no estimate has been adopted.
+    var delayConfidence: Float = 0
+    /// Number of confident delay estimates adopted.
+    var delayEstimateCount: Int = 0
+    /// Number of delay estimation attempts rejected (silent reference or
+    /// below-threshold correlation), kept distinct from adopted estimates so a
+    /// silent far-end reads as "nothing to align" rather than a failure.
+    var rejectedDelayEstimates: Int = 0
 
     static func passthrough(
         processorName: String = "passthrough",
@@ -100,13 +113,30 @@ final class PassthroughMicConditioner: MicConditioning, @unchecked Sendable {
 /// that do not yet fill a frame are carried across `condition` calls instead
 /// of leaking through raw — the processor's streaming state requires
 /// contiguous frames. Reference (speaker) samples are appended in lockstep
-/// with microphone samples and retained `referenceDelaySamples` longer, so a
+/// with microphone samples and retained `currentDelaySamples` longer, so a
 /// frame at stream position `p` is cancelled against reference audio from
-/// `p - referenceDelaySamples` (the echo path is causal: speaker audio leaks
+/// `p - currentDelaySamples` (the echo path is causal: speaker audio leaks
 /// into the mic only after output + acoustic + input latency).
+///
+/// The reference delay is seeded from configuration but, when an estimator is
+/// supplied, is re-estimated from the audio itself on a cadence. The
+/// measurement harness showed alignment is the dominant factor in cancellation
+/// and that the bulk mic/reference offset can exceed any practical filter span,
+/// so a static seed alone is too fragile; the estimator recovers the bulk delay
+/// while the static value remains a manual seed/override and the value used
+/// until the first confident estimate.
 final class StreamingMeetingEchoSuppressor: MicConditioning, @unchecked Sendable {
     private let processor: any MeetingEchoSuppressing
-    private let referenceDelaySamples: Int
+    private let seedDelaySamples: Int
+    private let estimator: MeetingEchoDelayEstimator?
+    private let reestimateIntervalSamples: Int
+    /// Reference history is retained this far behind the microphone so any delay
+    /// the estimator may select (up to its max lag) can still be read.
+    private let retentionDelaySamples: Int
+    /// Most-recent paired samples kept for delay estimation, capped at this many.
+    private let analysisCapacity: Int
+    /// Minimum paired samples before the first estimate is attempted.
+    private let minimumAnalysisSamples: Int
     private let lock = NSLock()
     private var diagnosticsStorage: MeetingEchoSuppressionDiagnostics
 
@@ -120,25 +150,52 @@ final class StreamingMeetingEchoSuppressor: MicConditioning, @unchecked Sendable
     private var microphonePosition = 0
     private var referencePosition = 0
 
+    // Effective alignment and adaptive-estimation state.
+    private var currentDelaySamples: Int
+    private var analysisMicrophone: [Float] = []
+    private var analysisReference: [Float] = []
+    private var samplesSinceEstimate = 0
+    private var hasAttemptedEstimate = false
+
     var diagnostics: MeetingEchoSuppressionDiagnostics {
         lock.lock()
         defer { lock.unlock() }
         return diagnosticsStorage
     }
 
-    init(processor: any MeetingEchoSuppressing, referenceDelaySamples: Int = 0) {
+    /// - Parameters:
+    ///   - referenceDelaySamples: the seed/override alignment; used until the
+    ///     first confident estimate, and as the value when `estimator` is nil.
+    ///   - estimator: when supplied, the suppressor re-estimates the reference
+    ///     delay from paired audio on a cadence. Pass nil to pin the seed.
+    ///   - reestimateIntervalSamples: minimum samples between estimation attempts
+    ///     after the first.
+    init(
+        processor: any MeetingEchoSuppressing,
+        referenceDelaySamples: Int = 0,
+        estimator: MeetingEchoDelayEstimator? = nil,
+        reestimateIntervalSamples: Int = 8_000
+    ) {
         self.processor = processor
-        self.referenceDelaySamples = max(0, referenceDelaySamples)
-        self.diagnosticsStorage = MeetingEchoSuppressionDiagnostics(
+        self.seedDelaySamples = max(0, referenceDelaySamples)
+        self.estimator = estimator
+        self.reestimateIntervalSamples = max(1, reestimateIntervalSamples)
+        self.currentDelaySamples = max(0, referenceDelaySamples)
+
+        if let estimator {
+            self.retentionDelaySamples = max(self.seedDelaySamples, estimator.maxLagSamples)
+            self.analysisCapacity = estimator.maxLagSamples + estimator.analysisWindowSamples
+            self.minimumAnalysisSamples = estimator.maxLagSamples
+                + min(estimator.analysisWindowSamples, 4_096)
+        } else {
+            self.retentionDelaySamples = self.seedDelaySamples
+            self.analysisCapacity = 0
+            self.minimumAnalysisSamples = .max
+        }
+
+        self.diagnosticsStorage = Self.freshDiagnostics(
             processorName: processor.name,
-            loaded: true,
-            micFrames: 0,
-            processedFrames: 0,
-            rawFallbackFrames: 0,
-            fullReferenceFrames: 0,
-            partialReferenceFrames: 0,
-            missingReferenceFrames: 0,
-            processingFailures: 0
+            currentDelaySamples: self.currentDelaySamples
         )
     }
 
@@ -155,7 +212,10 @@ final class StreamingMeetingEchoSuppressor: MicConditioning, @unchecked Sendable
             referenceValidity.append(hasSample)
         }
 
-        return drainProcessableFramesLocked()
+        accumulateAnalysisLocked(microphone: microphone, speaker: speaker, hasSpeakerReference: hasSpeakerReference)
+        let output = drainProcessableFramesLocked()
+        maybeReestimateDelayLocked(addedSamples: microphone.count)
+        return output
     }
 
     func flush() -> [Float] {
@@ -178,8 +238,23 @@ final class StreamingMeetingEchoSuppressor: MicConditioning, @unchecked Sendable
         referenceValidity.removeAll()
         microphonePosition = 0
         referencePosition = 0
-        diagnosticsStorage = MeetingEchoSuppressionDiagnostics(
+        currentDelaySamples = seedDelaySamples
+        analysisMicrophone.removeAll()
+        analysisReference.removeAll()
+        samplesSinceEstimate = 0
+        hasAttemptedEstimate = false
+        diagnosticsStorage = Self.freshDiagnostics(
             processorName: processor.name,
+            currentDelaySamples: currentDelaySamples
+        )
+    }
+
+    private static func freshDiagnostics(
+        processorName: String,
+        currentDelaySamples: Int
+    ) -> MeetingEchoSuppressionDiagnostics {
+        MeetingEchoSuppressionDiagnostics(
+            processorName: processorName,
             loaded: true,
             micFrames: 0,
             processedFrames: 0,
@@ -187,7 +262,8 @@ final class StreamingMeetingEchoSuppressor: MicConditioning, @unchecked Sendable
             fullReferenceFrames: 0,
             partialReferenceFrames: 0,
             missingReferenceFrames: 0,
-            processingFailures: 0
+            processingFailures: 0,
+            currentDelaySamples: currentDelaySamples
         )
     }
 
@@ -260,7 +336,7 @@ final class StreamingMeetingEchoSuppressor: MicConditioning, @unchecked Sendable
     ) -> ReferenceQuality {
         var validCount = 0
         for offset in frame.indices {
-            let absolute = frameStartPosition + offset - referenceDelaySamples
+            let absolute = frameStartPosition + offset - currentDelaySamples
             let index = absolute - referencePosition
             if index >= 0, index < referenceHistory.count, referenceValidity[index] {
                 frame[offset] = referenceHistory[index]
@@ -279,12 +355,60 @@ final class StreamingMeetingEchoSuppressor: MicConditioning, @unchecked Sendable
         pendingMicrophone.removeFirst(consumed)
         microphonePosition += consumed
 
-        let keepFrom = microphonePosition - referenceDelaySamples
+        let keepFrom = microphonePosition - retentionDelaySamples
         let dropCount = min(max(0, keepFrom - referencePosition), referenceHistory.count)
         if dropCount > 0 {
             referenceHistory.removeFirst(dropCount)
             referenceValidity.removeFirst(dropCount)
             referencePosition += dropCount
+        }
+    }
+
+    // MARK: Adaptive delay estimation
+
+    /// Append the most-recent paired samples (mic and zero-delay reference) to the
+    /// rolling analysis buffers, capped at `analysisCapacity`. These are kept
+    /// separate from the processing buffers because the processing path consumes
+    /// (and trims) microphone samples as it emits frames, while estimation needs a
+    /// contiguous mic/reference window at a shared timebase.
+    private func accumulateAnalysisLocked(
+        microphone: [Float],
+        speaker: [Float],
+        hasSpeakerReference: Bool
+    ) {
+        guard estimator != nil else { return }
+        analysisMicrophone.append(contentsOf: microphone)
+        for index in 0..<microphone.count {
+            let hasSample = hasSpeakerReference && index < speaker.count
+            analysisReference.append(hasSample ? speaker[index] : 0)
+        }
+        let overflow = analysisMicrophone.count - analysisCapacity
+        if overflow > 0 {
+            analysisMicrophone.removeFirst(overflow)
+            analysisReference.removeFirst(overflow)
+        }
+    }
+
+    private func maybeReestimateDelayLocked(addedSamples: Int) {
+        guard let estimator else { return }
+        samplesSinceEstimate += addedSamples
+        let ready = analysisMicrophone.count >= minimumAnalysisSamples
+        let due = !hasAttemptedEstimate || samplesSinceEstimate >= reestimateIntervalSamples
+        guard ready, due else { return }
+
+        hasAttemptedEstimate = true
+        samplesSinceEstimate = 0
+
+        if let estimate = estimator.estimate(
+            microphone: analysisMicrophone,
+            reference: analysisReference
+        ) {
+            currentDelaySamples = min(estimate.delaySamples, retentionDelaySamples)
+            diagnosticsStorage.currentDelaySamples = currentDelaySamples
+            diagnosticsStorage.delayConfidence = estimate.confidence
+            diagnosticsStorage.delayEstimateCount += 1
+        } else {
+            diagnosticsStorage.rejectedDelayEstimates += 1
         }
     }
 }

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
@@ -1338,6 +1338,10 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
             "partial_reference_frames=\(diagnostics.partialReferenceFrames)",
             "missing_reference_frames=\(diagnostics.missingReferenceFrames)",
             "processing_failures=\(diagnostics.processingFailures)",
+            "current_delay_samples=\(diagnostics.currentDelaySamples)",
+            "delay_confidence=\(String(format: "%.3f", diagnostics.delayConfidence))",
+            "delay_estimate_count=\(diagnostics.delayEstimateCount)",
+            "rejected_delay_estimates=\(diagnostics.rejectedDelayEstimates)",
         ].joined(separator: " ")
     }
 

--- a/Tests/MacParakeetTests/Services/Capture/MeetingEchoDelayEstimatorTests.swift
+++ b/Tests/MacParakeetTests/Services/Capture/MeetingEchoDelayEstimatorTests.swift
@@ -55,6 +55,21 @@ final class MeetingEchoDelayEstimatorTests: XCTestCase {
             "too few samples to span the lag search returns nil rather than a degenerate peak")
     }
 
+    func testConfidenceContractIsClampedToNormalizedRange() {
+        let signal = (0..<256).map { sin(Float($0) * 0.1) }
+        let estimator = MeetingEchoDelayEstimator(
+            maxLagSamples: 0,
+            minConfidence: 2,
+            analysisWindowSamples: 128
+        )
+
+        let estimate = estimator.estimate(microphone: signal, reference: signal)
+
+        XCTAssertNotNil(estimate, "minConfidence above 1 is clamped to the normalized range")
+        XCTAssertLessThanOrEqual(estimate!.confidence, 1)
+        XCTAssertGreaterThanOrEqual(estimate!.confidence, 0)
+    }
+
     /// The money test: a large bulk delay (600 samples) that a fixed zero offset
     /// cannot align. Uses the oracle subtractor so the result reflects *alignment*
     /// alone, not a filter's incidental ability to predict a periodic reference —

--- a/Tests/MacParakeetTests/Services/Capture/MeetingEchoDelayEstimatorTests.swift
+++ b/Tests/MacParakeetTests/Services/Capture/MeetingEchoDelayEstimatorTests.swift
@@ -1,0 +1,88 @@
+import XCTest
+@testable import MacParakeetCore
+
+/// Characterizes the bulk reference-delay estimator and proves its product value:
+/// a delay larger than the adaptive filter can span defeats cancellation with a
+/// static offset, and recovering it from the audio restores it.
+final class MeetingEchoDelayEstimatorTests: XCTestCase {
+
+    private let estimator = MeetingEchoDelayEstimator()
+
+    func testRecoversBulkDelayOnFarEndOnly() {
+        let scenario = MeetingAecScenarioFactory.make(
+            name: "far-end-only", nearEndActive: false, farEndActive: true,
+            echoPath: MeetingAecEchoPath(taps: [(delay: 600, gain: 0.6)]))
+
+        let estimate = estimator.estimate(microphone: scenario.mic, reference: scenario.farEnd)
+        XCTAssertNotNil(estimate)
+        print("[AEC] delay estimate (far-end-only): \(estimate?.delaySamples ?? -1) samples, "
+            + "confidence \(String(format: "%.2f", estimate?.confidence ?? 0))")
+        XCTAssertEqual(estimate!.delaySamples, 600, accuracy: 2, "recovers the true bulk delay")
+        XCTAssertGreaterThan(estimate!.confidence, 0.5, "a clean echo is a confident estimate")
+    }
+
+    func testRecoversBulkDelayUnderDoubleTalk() {
+        let scenario = MeetingAecScenarioFactory.make(
+            name: "double-talk", nearEndActive: true, farEndActive: true,
+            echoPath: MeetingAecEchoPath(
+                taps: [(delay: 600, gain: 0.6), (delay: 640, gain: 0.25), (delay: 680, gain: 0.12)]))
+
+        let estimate = estimator.estimate(microphone: scenario.mic, reference: scenario.farEnd)
+        XCTAssertNotNil(estimate, "the echo is still findable when the local speaker overlaps it")
+        print("[AEC] delay estimate (double-talk): \(estimate?.delaySamples ?? -1) samples, "
+            + "confidence \(String(format: "%.2f", estimate?.confidence ?? 0))")
+        XCTAssertEqual(estimate!.delaySamples, 600, accuracy: 5, "locks onto the dominant tap despite near-end energy")
+    }
+
+    func testReturnsNilWhenRemoteIsSilent() {
+        let scenario = MeetingAecScenarioFactory.make(
+            name: "near-end-only", nearEndActive: true, farEndActive: false,
+            echoPath: MeetingAecEchoPath(taps: [(delay: 600, gain: 0.6)]))
+
+        let estimate = estimator.estimate(microphone: scenario.mic, reference: scenario.farEnd)
+        XCTAssertNil(estimate, "no reference energy means no delay to report, not a spurious lag")
+    }
+
+    func testReturnsNilOnSilence() {
+        let zeros = [Float](repeating: 0, count: 24_000)
+        XCTAssertNil(estimator.estimate(microphone: zeros, reference: zeros))
+    }
+
+    func testReturnsNilWhenInputShorterThanSearchRange() {
+        let short = [Float](repeating: 0.1, count: 100)
+        XCTAssertNil(
+            estimator.estimate(microphone: short, reference: short),
+            "too few samples to span the lag search returns nil rather than a degenerate peak")
+    }
+
+    /// The money test: a large bulk delay (600 samples) that a fixed zero offset
+    /// cannot align. Uses the oracle subtractor so the result reflects *alignment*
+    /// alone, not a filter's incidental ability to predict a periodic reference —
+    /// at static zero the subtraction is unaligned and removes no echo (it can
+    /// even add energy), while feeding the *estimated* delay restores cancellation.
+    func testEstimatedDelayRestoresCancellationBeyondStaticAlignment() {
+        let scenario = MeetingAecScenarioFactory.make(
+            name: "far-end-only", nearEndActive: false, farEndActive: true,
+            echoPath: MeetingAecEchoPath(taps: [(delay: 600, gain: 0.6)]),
+            noiseLevel: 0.0001)
+        let window = scenario.steadyStateWindow
+
+        let staticZero = StreamingMeetingEchoSuppressor(
+            processor: MeetingAecOracleSubtractor(gain: 0.6), referenceDelaySamples: 0)
+        let zeroOut = MeetingAecRunner.run(staticZero, scenario: scenario)
+        let zeroERLE = MeetingAecMetrics.erleDB(mic: scenario.mic, output: zeroOut, over: window)
+
+        let estimate = estimator.estimate(microphone: scenario.mic, reference: scenario.farEnd)
+        XCTAssertNotNil(estimate)
+        let estimated = StreamingMeetingEchoSuppressor(
+            processor: MeetingAecOracleSubtractor(gain: 0.6),
+            referenceDelaySamples: estimate!.delaySamples)
+        let estimatedOut = MeetingAecRunner.run(estimated, scenario: scenario)
+        let estimatedERLE = MeetingAecMetrics.erleDB(mic: scenario.mic, output: estimatedOut, over: window)
+
+        print("[AEC] cancellation vs delay handling: static-zero \(String(format: "%.1f", zeroERLE)) dB "
+            + "-> estimated-delay \(String(format: "%.1f", estimatedERLE)) dB")
+        XCTAssertLessThan(zeroERLE, 5, "a large bulk delay is uncancellable with a static zero offset")
+        XCTAssertGreaterThan(estimatedERLE, 20, "the estimated delay realigns the reference and cancels the echo")
+    }
+}

--- a/Tests/MacParakeetTests/Services/Capture/MeetingEchoSuppressionRuntimeTests.swift
+++ b/Tests/MacParakeetTests/Services/Capture/MeetingEchoSuppressionRuntimeTests.swift
@@ -46,6 +46,36 @@ final class MeetingEchoSuppressionRuntimeTests: XCTestCase {
         )
     }
 
+    func testReferenceDelaySampleBoundsStayFinite() {
+        XCTAssertEqual(
+            MeetingEchoSuppressionFactory.adaptiveReferenceDelaySearchCeiling(sampleRate: 16_000),
+            3_200
+        )
+        XCTAssertEqual(
+            MeetingEchoSuppressionFactory.boundedReferenceDelaySamples(referenceDelayMs: 75, sampleRate: 16_000),
+            1_200
+        )
+        XCTAssertFalse(
+            MeetingEchoSuppressionFactory.referenceDelayExceedsSearchCeiling(
+                referenceDelayMs: 200,
+                sampleRate: 16_000
+            )
+        )
+        XCTAssertEqual(
+            MeetingEchoSuppressionFactory.boundedReferenceDelaySamples(
+                referenceDelayMs: 10_000,
+                sampleRate: 16_000
+            ),
+            3_200
+        )
+        XCTAssertTrue(
+            MeetingEchoSuppressionFactory.referenceDelayExceedsSearchCeiling(
+                referenceDelayMs: 10_000,
+                sampleRate: 16_000
+            )
+        )
+    }
+
     func testDefaultFrameSizeMatchesLocalVQEHopLengthFallback() {
         let configuration = MeetingEchoSuppressionConfiguration()
 

--- a/Tests/MacParakeetTests/Services/Capture/MeetingEchoSuppressionRuntimeTests.swift
+++ b/Tests/MacParakeetTests/Services/Capture/MeetingEchoSuppressionRuntimeTests.swift
@@ -22,6 +22,22 @@ final class MeetingEchoSuppressionRuntimeTests: XCTestCase {
         XCTAssertEqual(configuration.referenceDelayMs, 120)
     }
 
+    func testAdaptiveReferenceDelayDefaultsOnAndParsesEnvironment() {
+        XCTAssertTrue(
+            MeetingEchoSuppressionConfiguration().adaptiveReferenceDelay,
+            "adaptive delay recovery is on by default")
+
+        let disabled = MeetingEchoSuppressionConfiguration.fromEnvironment([
+            MeetingEchoSuppressionConfiguration.adaptiveReferenceDelayEnvironmentKey: " OFF "
+        ])
+        XCTAssertFalse(disabled.adaptiveReferenceDelay)
+
+        let enabled = MeetingEchoSuppressionConfiguration.fromEnvironment([
+            MeetingEchoSuppressionConfiguration.adaptiveReferenceDelayEnvironmentKey: "1"
+        ])
+        XCTAssertTrue(enabled.adaptiveReferenceDelay)
+    }
+
     func testReferenceDelayDefaultsToZeroAndClampsNegative() {
         XCTAssertEqual(MeetingEchoSuppressionConfiguration().referenceDelayMs, 0)
         XCTAssertEqual(

--- a/Tests/MacParakeetTests/Services/Capture/MeetingEchoSuppressorTests.swift
+++ b/Tests/MacParakeetTests/Services/Capture/MeetingEchoSuppressorTests.swift
@@ -188,6 +188,71 @@ final class MeetingEchoSuppressorTests: XCTestCase {
         XCTAssertEqual(suppressor.flush(), [])
     }
 
+    // MARK: Adaptive reference delay
+
+    func testAdaptiveSuppressorRecoversLargeBulkDelayFromZeroSeed() {
+        // A 600-sample bulk delay the static zero seed cannot align. With an
+        // estimator the suppressor recovers it from the audio and cancels in
+        // steady state, where the static-zero case (see the measurement tests)
+        // leaves the echo untouched or worse.
+        let scenario = MeetingAecScenarioFactory.make(
+            name: "far-end-only", nearEndActive: false, farEndActive: true,
+            echoPath: MeetingAecEchoPath(taps: [(delay: 600, gain: 0.6)]),
+            noiseLevel: 0.0001)
+
+        let adaptive = StreamingMeetingEchoSuppressor(
+            processor: MeetingAecOracleSubtractor(gain: 0.6),
+            referenceDelaySamples: 0,
+            estimator: MeetingEchoDelayEstimator())
+        let output = MeetingAecRunner.run(adaptive, scenario: scenario)
+
+        let erle = MeetingAecMetrics.erleDB(
+            mic: scenario.mic, output: output, over: scenario.steadyStateWindow)
+        XCTAssertGreaterThan(erle, 20, "the suppressor self-aligns to the bulk delay and cancels in steady state")
+        XCTAssertGreaterThanOrEqual(adaptive.diagnostics.delayEstimateCount, 1)
+        XCTAssertEqual(adaptive.diagnostics.currentDelaySamples, 600, accuracy: 2, "adopts the recovered delay")
+        XCTAssertGreaterThan(adaptive.diagnostics.delayConfidence, 0.5)
+    }
+
+    func testAdaptiveSuppressorKeepsSeedWhenReferenceIsSilent() {
+        let scenario = MeetingAecScenarioFactory.make(
+            name: "near-end-only", nearEndActive: true, farEndActive: false,
+            echoPath: MeetingAecEchoPath(taps: [(delay: 600, gain: 0.6)]))
+
+        let seed = 5
+        let adaptive = StreamingMeetingEchoSuppressor(
+            processor: MeetingAecOracleSubtractor(gain: 0.6),
+            referenceDelaySamples: seed,
+            estimator: MeetingEchoDelayEstimator())
+        _ = MeetingAecRunner.run(adaptive, scenario: scenario)
+
+        XCTAssertEqual(adaptive.diagnostics.currentDelaySamples, seed, "a silent reference keeps the seed delay")
+        XCTAssertEqual(adaptive.diagnostics.delayEstimateCount, 0)
+        XCTAssertGreaterThanOrEqual(
+            adaptive.diagnostics.rejectedDelayEstimates, 1,
+            "a silent far-end is a rejected estimate, not an adopted one")
+    }
+
+    func testResetClearsAdaptiveDelayState() {
+        let scenario = MeetingAecScenarioFactory.make(
+            name: "far-end-only", nearEndActive: false, farEndActive: true,
+            echoPath: MeetingAecEchoPath(taps: [(delay: 600, gain: 0.6)]),
+            noiseLevel: 0.0001)
+
+        let adaptive = StreamingMeetingEchoSuppressor(
+            processor: MeetingAecOracleSubtractor(gain: 0.6),
+            referenceDelaySamples: 0,
+            estimator: MeetingEchoDelayEstimator())
+        _ = MeetingAecRunner.run(adaptive, scenario: scenario)
+        XCTAssertGreaterThanOrEqual(adaptive.diagnostics.delayEstimateCount, 1)
+
+        adaptive.reset()
+        XCTAssertEqual(adaptive.diagnostics.currentDelaySamples, 0, "reset returns the delay to the seed")
+        XCTAssertEqual(adaptive.diagnostics.delayEstimateCount, 0)
+        XCTAssertEqual(adaptive.diagnostics.rejectedDelayEstimates, 0)
+        XCTAssertEqual(adaptive.flush(), [])
+    }
+
     private func rounded(_ value: Float) -> Float {
         (value * 1_000).rounded() / 1_000
     }

--- a/Tests/MacParakeetTests/Services/Capture/MeetingEchoSuppressorTests.swift
+++ b/Tests/MacParakeetTests/Services/Capture/MeetingEchoSuppressorTests.swift
@@ -248,9 +248,29 @@ final class MeetingEchoSuppressorTests: XCTestCase {
 
         adaptive.reset()
         XCTAssertEqual(adaptive.diagnostics.currentDelaySamples, 0, "reset returns the delay to the seed")
+        XCTAssertEqual(adaptive.diagnostics.delayConfidence, 0, "reset clears the last adopted estimate confidence")
         XCTAssertEqual(adaptive.diagnostics.delayEstimateCount, 0)
         XCTAssertEqual(adaptive.diagnostics.rejectedDelayEstimates, 0)
         XCTAssertEqual(adaptive.flush(), [])
+    }
+
+    func testAdaptiveSuppressorFeedsEstimatorEnoughSamplesForSmallWindows() {
+        // Guards the buffer/threshold floor of maxLag + 2: a tiny analysis window
+        // must not leave the suppressor permanently one sample short of
+        // estimate()'s requirement, which would make every attempt return nil.
+        let scenario = MeetingAecScenarioFactory.make(
+            name: "far-end-only", nearEndActive: false, farEndActive: true,
+            echoPath: MeetingAecEchoPath(taps: [(delay: 20, gain: 0.6)]),
+            noiseLevel: 0.0001)
+        let adaptive = StreamingMeetingEchoSuppressor(
+            processor: MeetingAecOracleSubtractor(gain: 0.6),
+            referenceDelaySamples: 0,
+            estimator: MeetingEchoDelayEstimator(maxLagSamples: 64, analysisWindowSamples: 1))
+        _ = MeetingAecRunner.run(adaptive, scenario: scenario)
+
+        XCTAssertGreaterThanOrEqual(
+            adaptive.diagnostics.delayEstimateCount, 1,
+            "the suppressor must supply enough samples for estimate() to run, even with a tiny window")
     }
 
     private func rounded(_ value: Float) -> Float {

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingServiceTests.swift
@@ -523,6 +523,10 @@ final class MeetingRecordingServiceTests: XCTestCase {
         XCTAssertTrue(log.contains("meeting_echo_suppression_summary session=\(output.sessionID.uuidString)"))
         XCTAssertTrue(log.contains("processor=passthrough"))
         XCTAssertTrue(log.contains("loaded=true"))
+        XCTAssertTrue(log.contains("current_delay_samples=0"))
+        XCTAssertTrue(log.contains("delay_confidence=0.000"))
+        XCTAssertTrue(log.contains("delay_estimate_count=0"))
+        XCTAssertTrue(log.contains("rejected_delay_estimates=0"))
     }
 
     func testCancelRecordingDeletesLockAndSessionFolder() async throws {
@@ -1072,6 +1076,10 @@ final class MeetingRecordingServiceTests: XCTestCase {
         XCTAssertTrue(log.contains("processor=zeroing-test"))
         XCTAssertTrue(log.contains("processed_frames=1"))
         XCTAssertTrue(log.contains("missing_reference_frames=1"))
+        XCTAssertTrue(log.contains("current_delay_samples=12"))
+        XCTAssertTrue(log.contains("delay_confidence=0.750"))
+        XCTAssertTrue(log.contains("delay_estimate_count=2"))
+        XCTAssertTrue(log.contains("rejected_delay_estimates=1"))
     }
 
     func testSystemOnlyCaptureProducesSystemSourceOnly() async throws {
@@ -2573,7 +2581,11 @@ private final class ZeroingMicConditioner: MicConditioning, @unchecked Sendable 
         fullReferenceFrames: 0,
         partialReferenceFrames: 0,
         missingReferenceFrames: 0,
-        processingFailures: 0
+        processingFailures: 0,
+        currentDelaySamples: 12,
+        delayConfidence: 0.75,
+        delayEstimateCount: 2,
+        rejectedDelayEstimates: 1
     )
 
     func condition(microphone: [Float], speaker: [Float], hasSpeakerReference: Bool) -> [Float] {
@@ -2597,7 +2609,11 @@ private final class ZeroingMicConditioner: MicConditioning, @unchecked Sendable 
             fullReferenceFrames: 0,
             partialReferenceFrames: 0,
             missingReferenceFrames: 0,
-            processingFailures: 0
+            processingFailures: 0,
+            currentDelaySamples: 12,
+            delayConfidence: 0.75,
+            delayEstimateCount: 2,
+            rejectedDelayEstimates: 1
         )
     }
 }

--- a/plans/active/2026-06-28-meeting-aec-full-close.md
+++ b/plans/active/2026-06-28-meeting-aec-full-close.md
@@ -28,7 +28,8 @@ assets or hardware that cannot be produced in a sandbox.
   paths are unchanged, so shipped builds are unaffected.
 - **U7 — diagnostics: PARTIAL.** Delay, last-adopted confidence, adopted-count,
   and rejected-count added to `MeetingEchoSuppressionDiagnostics` (metadata
-  only). Recording-summary and feedback-surface wiring remain.
+  only) and the existing `meeting_echo_suppression_summary` log. Feedback-surface
+  wiring remains.
 - **U8 — docs: PARTIAL.** `spec/05-audio-pipeline.md` updated. Contract/CLI
   updates wait on the cleaned-mic artifact (U3).
 - **U3/U4/U5/U6/U9 — DEFERRED.** These are blocked on bundling and

--- a/plans/active/2026-06-28-meeting-aec-full-close.md
+++ b/plans/active/2026-06-28-meeting-aec-full-close.md
@@ -1,0 +1,456 @@
+# Plan: Meeting AEC full close (#605 speaker bleed)
+
+## Status
+
+- **Priority**: P0 for meeting trust; P1 overall release blocker until verified
+- **Effort**: L
+- **Risk**: HIGH (audio quality, native assets, final transcript trust, user data artifacts)
+- **Category**: fix / audio pipeline / meeting transcription
+- **Planned at**: 2026-06-28
+- **Baseline**: `main` after PR #624, `f70dea929`
+- **Relates**: issue #605; issues #480/#430/#501/#542/#106; `plans/active/2026-06-27-meeting-aec-measurement-harness.md`; `docs/research/2026-06-meeting-aec-open-issues-prior-art.md`; ADR-014; `spec/05-audio-pipeline.md`; `spec/06-stt-engine.md`
+
+## Implementation Progress (2026-06-28, branch `feat/meeting-aec`)
+
+This branch lands the software keystone the measurement harness identified —
+runtime reference-delay alignment — and defers the units that depend on native
+assets or hardware that cannot be produced in a sandbox.
+
+- **U1 — adaptive delay estimator: DONE.** `MeetingEchoDelayEstimator`
+  (normalized cross-correlation, pre-emphasis, confidence gate) plus tests. On
+  the harness a 600-sample bulk delay is uncancellable at static-zero (−2.7 dB)
+  and the estimated delay restores it (56.5 dB).
+- **U2 — adaptive delay in mic conditioning: DONE.**
+  `StreamingMeetingEchoSuppressor` re-estimates its reference delay from paired
+  audio on a cadence; the static `…REFERENCE_DELAY_MS` is the seed/override and
+  `MACPARAKEET_MEETING_ECHO_ADAPTIVE_DELAY` (default on) gates it. The factory
+  builds the estimator for the dynamic-library path. Passthrough/asset-less
+  paths are unchanged, so shipped builds are unaffected.
+- **U7 — diagnostics: PARTIAL.** Delay, last-adopted confidence, adopted-count,
+  and rejected-count added to `MeetingEchoSuppressionDiagnostics` (metadata
+  only). Recording-summary and feedback-surface wiring remain.
+- **U8 — docs: PARTIAL.** `spec/05-audio-pipeline.md` updated. Contract/CLI
+  updates wait on the cleaned-mic artifact (U3).
+- **U3/U4/U5/U6/U9 — DEFERRED.** These are blocked on bundling and
+  signing/notarizing the proprietary LocalVQE dylib + model (U5) and on real
+  no-headphones speaker-mode QA (U9). Until a canceller is bundled, production
+  resolves to `PassthroughMicConditioner`, so an offline cleaned-mic renderer
+  (U3) and cleaned-mic final-STT routing (U4) would be inert; landing them now
+  would ship no-op scaffolding. They follow once U5's assets exist.
+
+## Goal Capsule
+
+- **Objective**: Close the speaker-mode acoustic echo cancellation bug where system audio played through speakers bleeds into the microphone and creates duplicate false `Me` transcript content.
+- **Authority order**: preserve raw user artifacts first, prove cleaned audio quality second, then improve transcript UX.
+- **Execution profile**: implementation-ready, characterization-first, with metric gates before any default-on product behavior.
+- **Stop conditions**: stop and re-plan if LocalVQE cannot be packaged/signature-verified, if cleaned audio damages near-end speech under double-talk, or if real speaker-mode QA cannot reproduce a clear improvement.
+- **Tail ownership**: implementation is not done until synthetic metrics, final-STT behavior, packaged-asset verification, and real speaker-mode QA all pass.
+
+---
+
+## Product Contract
+
+### Summary
+
+MacParakeet already captures microphone and system audio separately, and it has a `MicConditioning` seam plus optional LocalVQE-compatible runtime loading.
+The remaining bug is that production still behaves like raw mic passthrough unless private echo assets are present, and final meeting transcription still reads `microphone.m4a` instead of a cleaned mic source.
+This plan turns the scaffold into a source-aware AEC product path while preserving raw `microphone.m4a` and `system.m4a` as truth.
+
+### Problem Frame
+
+Issue #605 reports meetings as unusable because remote/system audio is physically captured by the microphone.
+Transcript-layer deletion and live system-dominance drops are useful safety nets, but they do not create a clean microphone signal and cannot make the final saved transcript trustworthy by themselves.
+The shipped measurement harness proved that reference alignment is load-bearing: an aligned oracle cancels to the noise floor, while a 2.5 ms misalignment destroys cancellation.
+
+### Requirements
+
+**Source trust**
+
+- R1. Preserve raw `microphone.m4a` and `system.m4a` for every meeting source mode that records them.
+- R2. Produce a cleaned microphone path for final meeting transcription when system reference and echo runtime are available.
+- R3. Keep VPIO as an explicit experimental mic mode only; do not make VPIO the default fix for speaker-mode meetings.
+
+**AEC behavior**
+
+- R4. Estimate or adapt microphone/reference delay instead of relying only on static `MACPARAKEET_MEETING_ECHO_REFERENCE_DELAY_MS`.
+- R5. Process far-end-only speaker bleed into little or no false `Me` transcript content.
+- R6. Preserve near-end local speech when the remote side is silent.
+- R7. Preserve near-end local speech during double-talk while reducing far-end bleed.
+- R8. Fall back to raw mic transcription with clear diagnostics when references, assets, timing, or processing fail.
+
+**Artifacts and transcription**
+
+- R9. Prefer the cleaned mic path for the final `Me` stream only after health gates pass.
+- R10. Retain any `microphone-cleaned.m4a` derived artifact under the same retention and deletion rules as other meeting source audio.
+- R11. Keep `meeting.m4a` as playback/export output and avoid treating it as the final STT input.
+
+**Verification and closure**
+
+- R12. Extend synthetic fixtures to score ERLE, near-end retention, delay recovery, nonlinear/reverberant echo, and double-talk.
+- R13. Package or runtime-load LocalVQE assets with checksum/signature verification before default-on use.
+- R14. Benchmark WebRTC AEC3 or record a decision artifact explaining why LocalVQE alone passed the release gates.
+- R15. Close #605 only after at least one real Zoom/Meet/Teams speaker-mode recording passes manual QA without headphones.
+
+### Acceptance Examples
+
+- AE1. Far-end-only speaker playback: given system audio is active and the local user is silent, final transcript contains remote speech as `Others`/system content and no sustained false `Me` run.
+- AE2. Near-end-only local speech: given the system reference is silent, the cleaned mic path preserves the local user's words and does not suppress the mic stream.
+- AE3. Double-talk: given local and remote speech overlap, final transcript keeps local words while reducing duplicate remote words in the mic stream.
+- AE4. Missing assets: given LocalVQE assets are absent or unreadable, recording completes with raw mic transcription and logs an explicit passthrough/fallback diagnostic.
+- AE5. Bad reference alignment: given the reference cannot be confidently aligned, the cleaner either estimates a safe delay or falls back without silently damaging the mic.
+- AE6. Retention cleanup: given meeting audio retention deletes source artifacts, the cleaned derived artifact is deleted with the same retention policy.
+
+### Scope Boundaries
+
+- This plan closes acoustic echo/speaker bleed. It does not solve speaker diarization quality, meeting summarization quality, or transcript editing.
+- This plan may harden `MeetingTranscriptSourceReconciler` as a safety net, but transcript-layer deletion alone cannot satisfy the plan.
+- This plan does not delete or replace raw source audio. Cleaned audio is a derived artifact.
+- This plan does not make VPIO the default meeting mic path.
+- This plan does not require a public UI control for choosing AEC engines before #605 is fixed.
+
+---
+
+## Planning Contract
+
+### Key Technical Decisions
+
+- KTD1. Use source-aware software AEC as the production fix. The product failure is acoustic bleed, so the microphone stream must be cleaned with the system-audio reference before final mic STT.
+- KTD2. Keep raw artifacts authoritative. Raw mic/system files remain the recovery, audit, and fallback truth; cleaned mic is derived and health-gated.
+- KTD3. Derive a cleaned mic artifact for final STT. Prefer `microphone-cleaned.m4a` or an equivalent retained/reproducible derived input so final transcription is not tied to live-preview-only samples.
+- KTD4. Make delay estimation part of the runtime path. The measurement harness shows static delay is too fragile; a production cleaner needs confidence-scored delay recovery or adaptive reference handling.
+- KTD5. LocalVQE is the first shipping candidate. The current runtime already expects LocalVQE symbols and 16 kHz / 256-sample frames, so finish that path first and use WebRTC AEC3 as the benchmark or fallback.
+- KTD6. Default-on requires both synthetic and real-world gates. A clean test fixture is necessary but insufficient; #605 closes only with real speaker-mode QA.
+- KTD7. Fallback must be observable. Silent passthrough is acceptable for dev builds but not as a release proof; logs and feedback diagnostics must show processor, loaded state, reference quality, delay confidence, processed frames, and fallback reason.
+
+### High-Level Technical Design
+
+```mermaid
+flowchart TB
+  Mic[Microphone capture] --> RawMic[microphone.m4a]
+  Sys[ScreenCaptureKit system audio] --> RawSys[system.m4a]
+  Mic --> Pair[CaptureOrchestrator paired samples]
+  Sys --> Pair
+  Pair --> Delay[Delay estimator and reference quality gate]
+  Delay --> Cond[StreamingMeetingEchoSuppressor]
+  Cond --> Live[Live mic chunks]
+  RawMic --> Offline[Post-stop cleaned mic renderer]
+  RawSys --> Offline
+  Delay --> Offline
+  Offline --> Clean[microphone-cleaned.m4a]
+  Clean --> Health{Cleaned mic healthy?}
+  RawMic --> Health
+  Health -->|yes| FinalSTT[Final Me STT uses cleaned mic]
+  Health -->|no| RawFinal[Final Me STT falls back to raw mic]
+  RawSys --> FinalSys[Final Others STT uses system audio]
+  FinalSTT --> Merge[MeetingTranscriptFinalizer]
+  RawFinal --> Merge
+  FinalSys --> Merge
+```
+
+```mermaid
+flowchart TB
+  Start[Meeting stop] --> Assets{Echo runtime and model available?}
+  Assets -->|no| Fallback[Raw mic STT plus fallback diagnostic]
+  Assets -->|yes| Ref{System reference usable?}
+  Ref -->|no| Fallback
+  Ref -->|yes| Estimate{Delay confidence passes?}
+  Estimate -->|no| Fallback
+  Estimate -->|yes| Render[Render cleaned mic]
+  Render --> Health{Duration, silence, failures, and near-end health pass?}
+  Health -->|no| Fallback
+  Health -->|yes| CleanSTT[Use cleaned mic for final Me stream]
+```
+
+### Implementation Sequencing
+
+1. Make delay estimation and metrics production-ready before changing product behavior.
+2. Integrate adaptive delay into `MicConditioning` and prove synthetic improvement.
+3. Add post-stop cleaned mic artifact rendering while raw files remain untouched.
+4. Teach final meeting STT to prefer the cleaned mic only when health gates pass.
+5. Package and verify LocalVQE assets for release builds.
+6. Run benchmark and real-meeting QA, then update specs and close issue #605.
+
+### Assumptions
+
+- LocalVQE can be built as a universal macOS dynamic library and signed/notarized with the app bundle.
+- A cleaned mic artifact is acceptable as a derived meeting source file governed by existing retention policy.
+- WebRTC AEC3 is a benchmark/fallback path, not a prerequisite if LocalVQE clears the gates by a strong margin.
+- Existing `MeetingAudioCaptureService` host-time alignment is good enough for initial pairing, but audio-derived delay estimation is still required for echo-path latency and drift.
+
+---
+
+## Implementation Units
+
+### U1. Productionize adaptive delay estimation
+
+- **Goal:** Add a production-owned delay estimator that recovers bulk system-reference lag from paired mic/system samples with confidence scoring.
+- **Requirements:** R4, R8, R12, AE5
+- **Dependencies:** None
+- **Files:**
+  - `Sources/MacParakeetCore/Services/Capture/MeetingEchoDelayEstimator.swift`
+  - `Sources/MacParakeetCore/Services/Capture/MicConditioner.swift`
+  - `Tests/MacParakeetTests/Services/Capture/MeetingEchoDelayEstimatorTests.swift`
+  - `Tests/MacParakeetTests/Services/Capture/MeetingAecMeasurementTests.swift`
+- **Approach:** Use a normalized-correlation estimator with pre-emphasis and a confidence threshold. Treat silence or weak correlation as no estimate rather than forcing a lag. Keep it independent of LocalVQE so the harness, NLMS baseline, and any WebRTC benchmark can share it.
+- **Execution note:** Start characterization-first from the existing measurement harness before wiring into runtime.
+- **Patterns to follow:** `MeetingAecMeasurementHarness.swift` for synthetic scenarios; `MeetingEchoSuppressionDiagnostics` for small value diagnostics.
+- **Test scenarios:**
+  - Far-end-only single-tap echo at a known delay returns that delay within a narrow sample tolerance and confidence above threshold.
+  - Multi-tap double-talk returns the dominant echo-path delay without being pulled to the local speaker.
+  - Remote silence returns nil.
+  - All-zero mic/reference returns nil.
+  - A delay beyond the NLMS filter length fails with static zero delay but succeeds when the estimated delay is fed into `StreamingMeetingEchoSuppressor`.
+- **Verification:** Delay estimator tests pass and the AEC harness shows estimated delay restores meaningful far-end cancellation beyond static-zero reach.
+
+### U2. Wire adaptive reference delay into mic conditioning
+
+- **Goal:** Make `StreamingMeetingEchoSuppressor` use adaptive or periodically refreshed reference delay while preserving existing static configuration as an override/fallback.
+- **Requirements:** R4, R5, R6, R7, R8, AE1, AE2, AE3, AE5
+- **Dependencies:** U1
+- **Files:**
+  - `Sources/MacParakeetCore/Services/Capture/MicConditioner.swift`
+  - `Sources/MacParakeetCore/Services/Capture/MeetingEchoSuppressionRuntime.swift`
+  - `Sources/MacParakeetCore/Services/Capture/CaptureOrchestrator.swift`
+  - `Tests/MacParakeetTests/Services/Capture/MeetingEchoSuppressorTests.swift`
+  - `Tests/MacParakeetTests/Services/Capture/MeetingAecMeasurementTests.swift`
+  - `Tests/MacParakeetTests/Services/Capture/CaptureOrchestratorTests.swift`
+- **Approach:** Add an adaptive-delay component around or inside `StreamingMeetingEchoSuppressor` that can update the effective `referenceDelaySamples` based on confidence-scored observations. Keep `MACPARAKEET_MEETING_ECHO_REFERENCE_DELAY_MS` as a manual seed/override rather than the only answer. Diagnostics should expose current delay, confidence, estimate count, rejected estimates, and fallback frames.
+- **Technical design:** Directional shape: `MicConditioning` receives paired mic/reference batches, accumulates enough history for analysis, estimates delay when reference energy is present, and processes frames against the current delay. It must never emit raw held-tail samples except through the existing explicit `flush()` fallback.
+- **Patterns to follow:** Existing frame-carry and reference-validity behavior in `StreamingMeetingEchoSuppressor`; environment parsing in `MeetingEchoSuppressionConfiguration`.
+- **Test scenarios:**
+  - With a known synthetic lag, processed frames use the estimated delay and improve ERLE over static zero.
+  - When the estimator reports nil, the suppressor keeps the previous confident delay or falls back explicitly according to configuration.
+  - When reference samples are partial or missing, diagnostics count partial/missing frames and no crash occurs.
+  - Flush preserves remaining mic samples and records raw fallback diagnostics.
+  - Reset clears pending mic, reference history, processor state, and adaptive delay state.
+- **Verification:** Focused suppressor/orchestrator tests pass, and `MeetingAecMeasurementTests` still prove aligned-vs-misaligned behavior.
+
+### U3. Add cleaned mic artifact rendering after stop
+
+- **Goal:** Produce a durable `microphone-cleaned.m4a` derived artifact from raw mic/system files after meeting stop when cleanup is available.
+- **Requirements:** R1, R2, R8, R10, R11, AE1, AE2, AE4, AE6
+- **Dependencies:** U1, U2
+- **Files:**
+  - `Sources/MacParakeetCore/Services/MeetingRecording/MeetingCleanedMicRenderer.swift`
+  - `Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift`
+  - `Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingMetadata.swift`
+  - `Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingOutput.swift`
+  - `Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingRecoveryService.swift`
+  - `Sources/MacParakeetCore/Services/MeetingRecording/MeetingArtifactStore.swift`
+  - `Sources/MacParakeetCore/Audio/MeetingAudioStorageWriter.swift`
+  - `Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingServiceTests.swift`
+  - `Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingRecoveryServiceTests.swift`
+  - `Tests/MacParakeetTests/Services/MeetingRecording/MeetingArtifactStoreTests.swift`
+- **Approach:** Derive cleaned mic from finalized raw source files rather than adding a third real-time writer first. This keeps capture-risk low and lets the renderer reuse `MeetingSourceAlignment`, the selected echo runtime, and health gates before final STT. Persist enough metadata for recovery and later inspection.
+- **Patterns to follow:** `MeetingAudioStorageWriter` source-file naming, `MeetingRecordingOutput` source URL conventions, recovery lock handling in `MeetingRecordingRecoveryService`.
+- **Test scenarios:**
+  - Dual-source meeting with available cleaner writes `microphone-cleaned.m4a` and records metadata pointing to it.
+  - Microphone-only and system-only meetings skip cleaned rendering without error.
+  - Missing/unreadable runtime assets skip cleaned rendering and preserve raw recording completion.
+  - Renderer failure leaves `microphone.m4a`, `system.m4a`, and `meeting.m4a` intact.
+  - Recovery reconstructs output correctly when raw files exist but cleaned artifact is absent.
+  - Meeting audio retention/deletion removes `microphone-cleaned.m4a` together with other retained meeting source audio.
+- **Verification:** Meeting recording, recovery, artifact-store, and retention tests prove cleaned artifact lifecycle without regressing raw artifact preservation.
+
+### U4. Prefer cleaned mic for final meeting STT with health gates
+
+- **Goal:** Route final `Me` transcription through the cleaned mic artifact only when it is present, decodable, duration-aligned, and healthy.
+- **Requirements:** R2, R5, R6, R7, R8, R9, R11, AE1, AE2, AE3, AE4, AE5
+- **Dependencies:** U3
+- **Files:**
+  - `Sources/MacParakeetCore/Services/TranscriptionService.swift`
+  - `Sources/MacParakeetCore/Services/MeetingRecording/MeetingTranscriptFinalizer.swift`
+  - `Sources/MacParakeetCore/Services/MeetingRecording/MeetingTranscriptSourceReconciler.swift`
+  - `Tests/MacParakeetTests/Services/TranscriptionServiceTests.swift`
+  - `Tests/MacParakeetTests/Services/MeetingRecording/MeetingTranscriptSourceReconcilerTests.swift`
+  - `Tests/MacParakeetTests/Services/MeetingRecording/MeetingTranscriptFinalizerTests.swift`
+- **Approach:** Update `transcribeMeetingSources` so `AudioSource.microphone` resolves to the cleaned mic candidate when health gates pass and raw mic otherwise. Keep system STT on `system.m4a`. Keep `MeetingTranscriptSourceReconciler` as a safety net for residual overlap, not the primary AEC mechanism.
+- **Health gates:** cleaned file exists, decodes, duration is within tolerance of raw mic/source alignment, processor diagnostics show nonzero processed frames, failure/fallback ratio is below threshold, and near-end-only/silent-reference checks do not indicate destructive suppression.
+- **Patterns to follow:** Existing source alignment offsets and vocabulary application in `TranscriptionService`; source reconciliation in `MeetingTranscriptFinalizer`.
+- **Test scenarios:**
+  - When cleaned mic is healthy, final microphone STT receives the cleaned file path.
+  - When cleaned mic is missing, corrupt, too short, or mostly fallback frames, final microphone STT receives raw `microphone.m4a`.
+  - System source STT remains `system.m4a` in both paths.
+  - Final transcript still merges microphone/system words by `MeetingSourceAlignment`.
+  - Residual simultaneous echo words are still removed by `MeetingTranscriptSourceReconciler`.
+  - Cohere batch-only meeting finalize continues to work when word timestamps are unavailable.
+- **Verification:** Transcription service tests prove file selection, fallback, and merge behavior; final transcript output uses cleaned `Me` only after gates pass.
+
+### U5. Package and verify LocalVQE for release builds
+
+- **Goal:** Make the LocalVQE runtime/model a release-verifiable asset instead of an optional local experiment.
+- **Requirements:** R8, R13, AE4
+- **Dependencies:** U2
+- **Files:**
+  - `Sources/MacParakeetCore/Services/Capture/MeetingEchoSuppressionRuntime.swift`
+  - `Tests/MacParakeetTests/Services/Capture/MeetingEchoSuppressionRuntimeTests.swift`
+  - `scripts/dist/build_app_bundle.sh`
+  - `scripts/dist/verify_meeting_echo_assets.sh`
+  - `docs/distribution.md`
+  - `spec/05-audio-pipeline.md`
+- **Approach:** Continue using `liblocalvqe.dylib` plus `MeetingEchoSuppression/localvqe-v1.2-1.3M-f32.gguf` or the selected v1.4 AEC model, but make release builds fail when required assets are missing. Keep dev builds able to run passthrough. Verify checksum, executable bit, dependency paths, and code signature where available.
+- **Model decision gate:** Score v1.4 AEC and v1.2 joint models on the harness before choosing the release default. Prefer echo-only v1.4 if it preserves near-end better, even if v1.2 removes more noise.
+- **Patterns to follow:** Existing `BUNDLE_MEETING_ECHO_ASSETS`, `REQUIRE_MEETING_ECHO_ASSETS`, and `MACPARAKEET_MEETING_ECHO_MODEL_SHA256` handling.
+- **Test scenarios:**
+  - Automatic mode with no bundled assets returns passthrough and logs unavailable state.
+  - Dynamic-library-required mode with missing assets returns an unloaded LocalVQE diagnostics object.
+  - Checksum mismatch rejects the model.
+  - Bundled release verification fails if only one of library/model exists.
+  - Bundled release verification passes when both assets exist, checksum matches, and dylib dependencies are acceptable.
+- **Verification:** Runtime tests pass and distribution verification proves a release app either contains valid echo assets or intentionally refuses to claim AEC readiness.
+
+### U6. Benchmark WebRTC AEC3 or record the skip decision
+
+- **Goal:** Compare LocalVQE against a mature reference AEC path, or record a justified decision that LocalVQE alone clears the release bar.
+- **Requirements:** R12, R14
+- **Dependencies:** U1, U2, U5
+- **Files:**
+  - `Tests/MacParakeetTests/Services/Capture/MeetingAecMeasurementHarness.swift`
+  - `Tests/MacParakeetTests/Services/Capture/MeetingAecMeasurementTests.swift`
+  - `docs/research/2026-06-meeting-aec-open-issues-prior-art.md`
+  - `plans/active/2026-06-28-meeting-aec-full-close.md`
+  - Optional if implemented: `Sources/MacParakeetCore/Services/Capture/WebRTCAec3MeetingEchoProcessor.swift`
+- **Approach:** Treat WebRTC AEC3 as a benchmark/fallback rather than immediate product scope unless LocalVQE fails synthetic or real QA. If a prototype is feasible in the implementation window, score it on the same fixtures. If not, update the decision record with the LocalVQE metrics that justify shipping without it.
+- **Patterns to follow:** LocalVQE runtime abstraction through `MeetingEchoSuppressing`; research note's Prismical/WebRTC API shape.
+- **Test scenarios:**
+  - A benchmark processor can run through `MeetingAecRunner` with far-end-only, near-end-only, and double-talk scenarios.
+  - Benchmark output records ERLE and near-end retention in the same format as LocalVQE/NLMS.
+  - If skipped, the plan/research note states the decision, the reason, and the metrics that made WebRTC non-blocking.
+- **Verification:** Reviewer can compare LocalVQE to either a WebRTC result table or a written skip decision tied to passing LocalVQE gates.
+
+### U7. Extend diagnostics, feedback evidence, and user-facing fallback surfaces
+
+- **Goal:** Make AEC state visible enough to debug user reports and close #605 with evidence.
+- **Requirements:** R7, R8, R13, R15, AE4, AE5
+- **Dependencies:** U2, U3, U4, U5
+- **Files:**
+  - `Sources/MacParakeetCore/Audio/AudioCaptureDiagnostics.swift`
+  - `Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift`
+  - `Sources/MacParakeetCore/Services/Capture/MicConditioner.swift`
+  - `Sources/MacParakeetCore/Services/Capture/MeetingEchoSuppressionRuntime.swift`
+  - `Sources/MacParakeet/Views/Feedback/FeedbackView.swift`
+  - `Tests/MacParakeetTests/Audio/DiagnosticLogScopeTests.swift`
+  - `Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingServiceTests.swift`
+  - `docs/human-qa-guide.md`
+- **Approach:** Extend `meeting_echo_suppression_summary` with delay, confidence, cleaned artifact status, selected input path for final STT, processor version/model, fallback reason, and health-gate result. Keep uploaded diagnostics metadata-only; never include audio or transcript content.
+- **Patterns to follow:** Existing `meeting_recording_health` and feedback diagnostic upload scope.
+- **Test scenarios:**
+  - Successful cleaned path logs processor loaded, delay confidence, processed frame count, cleaned artifact URL basename, and final-STT source choice.
+  - Missing assets logs passthrough/fallback reason.
+  - Failed health gate logs fallback reason without exposing transcript text or audio samples.
+  - Feedback diagnostic scope includes AEC summary lines within existing size/time caps.
+- **Verification:** Uploaded diagnostic logs can distinguish "AEC worked", "AEC skipped by configuration", "AEC tried and fell back", and "final STT used raw".
+
+### U8. Update specs, contracts, and CLI/artifact visibility
+
+- **Goal:** Align durable docs and automation surfaces with the cleaned mic artifact and AEC release rules.
+- **Requirements:** R1, R2, R9, R10, R11, R15, AE6
+- **Dependencies:** U3, U4, U7
+- **Files:**
+  - `spec/05-audio-pipeline.md`
+  - `spec/06-stt-engine.md`
+  - `spec/adr/014-meeting-recording.md`
+  - `spec/contracts/meeting-artifacts-v1.md`
+  - `Sources/CLI/Commands/MeetingsCommand.swift`
+  - `Tests/CLITests/MeetingsCommandTests.swift`
+  - `docs/human-qa-guide.md`
+  - `docs/distribution.md`
+- **Approach:** Document that raw source files remain truth, cleaned mic is a derived artifact, final meeting STT may prefer cleaned mic after health gates, and retention applies to cleaned audio. Expose cleaned artifact presence in any existing meeting artifact listing without making users manage it separately.
+- **Patterns to follow:** Existing meeting artifact folder/CLI conventions and boundary contract docs.
+- **Test scenarios:**
+  - CLI meeting artifact output includes cleaned mic when present and omits it cleanly when absent.
+  - Contract tests cover retention/deletion of cleaned mic alongside raw source audio.
+  - Spec text no longer implies passthrough is the only production AEC state once assets are shipped.
+- **Verification:** Specs/contracts/CLI agree on artifact names, lifecycle, and final STT source preference.
+
+### U9. Real speaker-mode QA and issue closure
+
+- **Goal:** Prove #605 is resolved in the failure mode users hit: laptop speakers feeding the microphone during real meetings.
+- **Requirements:** R5, R6, R7, R12, R15, AE1, AE2, AE3, AE4, AE5
+- **Dependencies:** U1, U2, U3, U4, U5, U7, U8
+- **Files:**
+  - `docs/human-qa-guide.md`
+  - `docs/research/2026-06-meeting-aec-open-issues-prior-art.md`
+  - `plans/active/2026-06-28-meeting-aec-full-close.md`
+  - Optional evidence artifacts under an appropriate private/local QA location, not committed if they contain audio/transcript content.
+- **Approach:** Run real speaker-mode recordings with no headset, using Zoom/Meet/Teams or equivalent far-end playback. Capture diagnostic metadata and inspect raw mic, system, cleaned mic, final transcript, and `meeting.m4a`. Do not close the issue from synthetic tests alone.
+- **QA scenarios:**
+  - Far-end-only: remote speech plays through speakers while local user is silent.
+  - Near-end-only: local user speaks while system reference is silent.
+  - Double-talk: local and remote speakers overlap.
+  - Asset failure: run without echo assets and confirm graceful raw fallback.
+  - Reference stress: introduce a delayed/brief system stream interruption and confirm fallback or recovery is logged.
+- **Verification:** QA notes show before/after behavior, artifact inspection, diagnostics lines, and a direct #605 closure statement. If QA fails, leave #605 open with the failed gate named.
+
+---
+
+## Verification Contract
+
+| Gate | Scope | Done signal |
+| --- | --- | --- |
+| `swift test --filter MeetingEchoDelayEstimatorTests` | U1 | Delay estimation handles far-end, double-talk, silence, and beyond-filter lag. |
+| `swift test --filter MeetingAecMeasurementTests` | U1, U2, U5, U6 | Harness reports aligned cancellation, misalignment failure, LocalVQE/WebRTC or documented benchmark decision, and double-talk retention. |
+| `swift test --filter MeetingEchoSuppressorTests` | U2 | Frame carry, adaptive delay, partial/missing reference, reset, and flush behavior hold. |
+| `swift test --filter MeetingRecordingServiceTests` | U3, U7 | Cleaned artifact lifecycle and diagnostics are covered. |
+| `swift test --filter TranscriptionServiceTests` | U4 | Final meeting STT prefers cleaned mic only after health gates. |
+| `swift test --filter MeetingRecordingRecoveryServiceTests` | U3 | Recovery tolerates absent cleaned artifact and preserves raw sources. |
+| `swift test --filter MeetingsCommandTests` | U8 | CLI/artifact listing reflects cleaned mic presence. |
+| `scripts/dist/verify_meeting_echo_assets.sh <app>` | U5 | Release bundle contains valid echo assets when AEC is claimed. |
+| `swift test` | All | Full suite passes before declaring implementation complete. |
+| Manual speaker-mode QA | U9 | Real no-headset meeting proof satisfies AE1, AE2, and AE3. |
+
+### Synthetic Metric Gates
+
+- Pass-through far-end-only ERLE remains near 0 dB as the sanity baseline.
+- Oracle with true delay remains above 50 dB ERLE on the deterministic fixture.
+- Oracle with a 2.5 ms offset remains below 6 dB ERLE, proving the harness still detects misalignment.
+- Selected production engine achieves meaningful far-end-only ERLE improvement over raw in steady state.
+- Near-end-only cleaned output remains close to raw/local speech and does not become silent.
+- Double-talk cleaned output must not degrade near-end retention beyond the threshold documented in the test, and the threshold must be strict enough to reject the current naive NLMS tradeoff if it hurts local speech.
+
+---
+
+## Risks & Dependencies
+
+- **Native asset packaging risk:** `liblocalvqe.dylib` and model files add signing, notarization, dependency, and bundle-size work. Mitigate with U5 release verification.
+- **Double-talk quality risk:** naive cancellers can remove echo but damage local speech. Mitigate with double-talk gates before default-on.
+- **Delay/drift risk:** mic and ScreenCaptureKit streams may drift during long meetings. Mitigate with adaptive delay diagnostics and long-run fixtures.
+- **Privacy risk:** QA and feedback evidence must not commit or upload audio/transcript content accidentally. Keep diagnostics metadata-only.
+- **CPU/latency risk:** live preview cleanup and post-stop rendering can compete with STT. Measure and fallback rather than blocking recording stop indefinitely.
+- **False confidence risk:** transcript cleanup may make visible text look better while raw mic remains polluted. Definition of Done requires cleaned audio artifact or equivalent final-STT input.
+
+---
+
+## Documentation / Operational Notes
+
+- Update `docs/human-qa-guide.md` with explicit #605 QA scenarios and artifact inspection steps.
+- Update `docs/distribution.md` so release builders know whether echo assets are required for a given channel.
+- Update `spec/contracts/meeting-artifacts-v1.md` before exposing `microphone-cleaned.m4a` through CLI or retention flows.
+- Keep issue #605 open until U9 passes; partial synthetic success should be reported as progress, not closure.
+
+---
+
+## Sources & Research
+
+- `plans/active/2026-06-27-meeting-aec-measurement-harness.md` - shipped harness, first ERLE numbers, alignment/double-talk findings.
+- `docs/research/2026-06-meeting-aec-open-issues-prior-art.md` - LocalVQE, Muesli, WebRTC AEC3, Anarlog/Hyprnote, Corti, and release-proof recommendations.
+- `spec/05-audio-pipeline.md` - current raw/default mic capture, optional `StreamingMeetingEchoSuppressor`, final source-file STT architecture.
+- `Sources/MacParakeetCore/Services/Capture/MicConditioner.swift` - passthrough and streaming echo suppressor seam.
+- `Sources/MacParakeetCore/Services/Capture/MeetingEchoSuppressionRuntime.swift` - LocalVQE-compatible dynamic library/model loader.
+- `Sources/MacParakeetCore/Services/TranscriptionService.swift` - final meeting source transcription path that must prefer cleaned mic after gates.
+- `scripts/dist/build_app_bundle.sh` and `scripts/dist/verify_meeting_echo_assets.sh` - existing echo asset packaging hooks.
+
+---
+
+## Definition of Done
+
+- U1-U8 are implemented with focused tests and full `swift test` passing.
+- Release bundle verification proves echo assets are present and valid when the build claims AEC support.
+- Final meeting STT uses cleaned mic for the `Me` stream when health gates pass and raw mic when they fail.
+- Raw `microphone.m4a` and `system.m4a` remain preserved and recoverable.
+- `microphone-cleaned.m4a` or the equivalent derived cleaned input follows meeting audio retention/deletion rules.
+- Diagnostic logs distinguish loaded, skipped, failed, and fallback AEC states.
+- Specs, contracts, distribution docs, and human QA guide describe the new artifact and behavior.
+- Real speaker-mode QA without headphones passes far-end-only, near-end-only, and double-talk scenarios.
+- Issue #605 is closed only with the QA evidence summarized; otherwise it remains open with the failed gate named.
+- Abandoned experimental code, dead benchmark scaffolding, and unused native wrapper attempts are removed before landing.

--- a/plans/active/2026-06-28-meeting-aec-full-close.md
+++ b/plans/active/2026-06-28-meeting-aec-full-close.md
@@ -23,9 +23,11 @@ assets or hardware that cannot be produced in a sandbox.
 - **U2 — adaptive delay in mic conditioning: DONE.**
   `StreamingMeetingEchoSuppressor` re-estimates its reference delay from paired
   audio on a cadence; the static `…REFERENCE_DELAY_MS` is the seed/override and
-  `MACPARAKEET_MEETING_ECHO_ADAPTIVE_DELAY` (default on) gates it. The factory
-  builds the estimator for the dynamic-library path. Passthrough/asset-less
-  paths are unchanged, so shipped builds are unaffected.
+  `MACPARAKEET_MEETING_ECHO_ADAPTIVE_DELAY` (default on) gates it. Oversized
+  manual delays are clamped to the adaptive search ceiling so fixed reference
+  retention stays bounded. The factory builds the estimator for the
+  dynamic-library path. Passthrough/asset-less paths are unchanged, so shipped
+  builds are unaffected.
 - **U7 — diagnostics: PARTIAL.** Delay, last-adopted confidence, adopted-count,
   and rejected-count added to `MeetingEchoSuppressionDiagnostics` (metadata
   only) and the existing `meeting_echo_suppression_summary` log. Feedback-surface

--- a/spec/05-audio-pipeline.md
+++ b/spec/05-audio-pipeline.md
@@ -198,7 +198,15 @@ Mic Input    → SharedMicrophoneStream (+ Voice Processing I/O when active)┘ 
   AEC/noise suppression/AGC. The optional `StreamingMeetingEchoSuppressor`
   can transform paired mic/system samples when a LocalVQE-compatible runtime
   and model are available; otherwise it falls back to raw mic samples with
-  diagnostics. Transcript-layer system-dominance suppression and
+  diagnostics. When the suppressor runs it aligns the system reference to the
+  microphone using a runtime delay recovered from the audio by
+  `MeetingEchoDelayEstimator` (normalized cross-correlation, confidence-gated),
+  because the measurement harness showed that mic/reference time alignment is
+  the dominant factor in cancellation and the bulk clock offset can exceed any
+  practical filter span. `MACPARAKEET_MEETING_ECHO_REFERENCE_DELAY_MS` seeds the
+  estimate and overrides it when `MACPARAKEET_MEETING_ECHO_ADAPTIVE_DELAY` is
+  off; a silent far-end is treated as "nothing to align" rather than forcing a
+  lag. Transcript-layer system-dominance suppression and
   `MeetingTranscriptSourceReconciler` remain safety nets against obvious
   speaker bleed, not a complete AEC substitute. When VPIO is explicitly
   requested and engages, macOS applies AEC/noise suppression/AGC before buffers

--- a/spec/05-audio-pipeline.md
+++ b/spec/05-audio-pipeline.md
@@ -205,8 +205,9 @@ Mic Input    → SharedMicrophoneStream (+ Voice Processing I/O when active)┘ 
   the dominant factor in cancellation and the bulk clock offset can exceed any
   practical filter span. `MACPARAKEET_MEETING_ECHO_REFERENCE_DELAY_MS` seeds the
   estimate and overrides it when `MACPARAKEET_MEETING_ECHO_ADAPTIVE_DELAY` is
-  off; a silent far-end is treated as "nothing to align" rather than forcing a
-  lag. Transcript-layer system-dominance suppression and
+  off; fixed/manual delay is capped to the adaptive search ceiling so reference
+  retention stays bounded. A silent far-end is treated as "nothing to align"
+  rather than forcing a lag. Transcript-layer system-dominance suppression and
   `MeetingTranscriptSourceReconciler` remain safety nets against obvious
   speaker bleed, not a complete AEC substitute. When VPIO is explicitly
   requested and engages, macOS applies AEC/noise suppression/AGC before buffers


### PR DESCRIPTION
## Problem

Speaker-mode meetings leak remote/system audio out the laptop speakers and back into the microphone (#605, cluster #480/#430/#501/#542/#106). The same words then appear as both `Others` (system track) and a false `Me` (mic track), making meetings unusable without headphones.

The merged AEC measurement harness (#624) established the load-bearing fact: **mic/reference time alignment dominates cancellation.** An aligned oracle reaches ~56 dB ERLE; a 2.5 ms (40-sample) misalignment collapses it to ~-3 dB; and the bulk offset between the microphone clock and the ScreenCaptureKit system-audio clock can exceed any practical adaptive-filter span. A static `MACPARAKEET_MEETING_ECHO_REFERENCE_DELAY_MS` cannot track that.

This PR lands the software keystone that fixes alignment: units **U1 + U2** of `plans/active/2026-06-28-meeting-aec-full-close.md`, plus the diagnostics/spec slices that fall out of it. It deliberately stops short of the units that require native assets or hardware QA (see Deferred). Branch is rebased on current `main`.

## What changed

**U1 — `MeetingEchoDelayEstimator`** (new)
Recovers the bulk mic-reference delay from the audio itself with a pre-emphasized, normalized cross-correlation search over non-negative lags. Pre-emphasis sharpens the speech correlation peak; normalization turns the peak into a scale-independent confidence, so a weak/absent echo is rejected (`nil`) rather than snapped to a spurious lag. Confidence input/output is clamped to the documented `0...1` range.

**U2 — adaptive delay in `StreamingMeetingEchoSuppressor`** (`MicConditioner.swift`)
When an estimator is supplied, the suppressor keeps a rolling window of paired mic/reference samples and re-estimates the bulk delay on a cadence. `condition()` snapshots analysis buffers under the lock, runs correlation after releasing it, then applies the result only if both the reset generation and latest attempt id still match.

- Static `MACPARAKEET_MEETING_ECHO_REFERENCE_DELAY_MS` is the seed used until the first confident estimate, and the fixed override when adaptation is off.
- `MACPARAKEET_MEETING_ECHO_ADAPTIVE_DELAY` defaults on.
- Search defaults to ~100 ms, can extend to cover a configured seed, and is capped at ~200 ms. Oversized manual delays are clamped to that same ceiling so fixed reference retention cannot grow unbounded.
- The rolling buffer and trigger threshold are floored at `maxLag + 2` so tiny analysis windows cannot leave estimation permanently one sample short.

**U7 (partial) — diagnostics**
Adds `currentDelaySamples`, `delayConfidence`, `delayEstimateCount`, and `rejectedDelayEstimates` to `MeetingEchoSuppressionDiagnostics`; surfaces them in `meeting_echo_suppression_summary`; and logs the first adopted adaptive delay plus later delay changes. Feedback-surface wiring remains for a later unit.

**U8 (partial) — docs**
`spec/05-audio-pipeline.md` now describes runtime delay recovery, seed/override behavior, `nil` on silence, and the bounded manual-delay ceiling. The full-close plan records what landed and why the remaining units are deferred.

### Files (vs `main`, 10 files, +1159/-30)

```
 Sources/MacParakeetCore/Services/Capture/MeetingEchoDelayEstimator.swift
 Sources/MacParakeetCore/Services/Capture/MeetingEchoSuppressionRuntime.swift
 Sources/MacParakeetCore/Services/Capture/MicConditioner.swift
 Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
 Tests/MacParakeetTests/Services/Capture/MeetingEchoDelayEstimatorTests.swift
 Tests/MacParakeetTests/Services/Capture/MeetingEchoSuppressionRuntimeTests.swift
 Tests/MacParakeetTests/Services/Capture/MeetingEchoSuppressorTests.swift
 Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingServiceTests.swift
 plans/active/2026-06-28-meeting-aec-full-close.md
 spec/05-audio-pipeline.md
```

### Commits (7, rebased on `main`)

1. Add meeting echo reference-delay estimator (#605 U1)
2. Adapt meeting echo reference delay from audio at runtime (#605 U2/U7)
3. Document adaptive reference-delay AEC and track plan progress (#605 U8)
4. Harden adaptive-delay suppressor from review feedback (#605)
5. Harden adaptive delay review fixes
6. Surface adaptive delay diagnostics in meeting logs
7. Bound adaptive delay diagnostics and retention

## Safety / regression posture

With no LocalVQE assets bundled, meeting capture resolves to `PassthroughMicConditioner` exactly as before. The adaptive path only runs when the dynamic-library processor is present. Existing batch-invariance, frame-carry, reference-delay, runtime, meeting-recording, and measurement tests pass.

## Verification

- `git diff --check`: pass.
- Focused local test slice after latest review fixes: `swift test --filter 'MeetingEchoDelayEstimatorTests|MeetingEchoSuppressionRuntimeTests|MeetingEchoSuppressorTests|MeetingRecordingServiceTests'` -> **89 tests, 0 failures**.
- Full local suite after latest review fixes: `swift test --skip-build` -> **4270 XCTest tests, 11 skipped, 0 failures**, plus **17 Swift Testing tests**, exit 0.
- AEC capstone remains stable: static-zero **-2.7 dB** -> estimated-delay **56.5 dB**; far-end estimate **600 samples / confidence 1.00**; double-talk estimate **600 samples / confidence 0.75**.
- Local Greptile review: **4/5, safe to merge**. Its observability note was addressed by logging adaptive delay adoption/change events.
- New Copilot review threads fixed and resolved: normalized confidence clamping and bounded fixed reference-delay retention.

## Deferred (and why)

U3-U9 are intentionally **not** in this PR; they depend on inputs that cannot be produced in this environment:

- **U5** — bundle + sign/notarize the proprietary `liblocalvqe.dylib` + GGUF model — needs native artifacts and the release signing chain.
- **U9** — real no-headphones Zoom/Meet/Teams speaker-mode QA — needs hardware/meetings; the plan forbids closing #605 without it.
- **U3/U4** — offline cleaned-mic renderer + cleaned-mic final-STT routing — would be inert no-op scaffolding until a canceller is bundled.
- **U6** — WebRTC AEC3 benchmark — optional/benchmark per the plan.

They follow once U5's assets exist. **#605 stays open**; this is the keystone, not the close.
