### PR TITLE
Fix transcript detail post-merge review nits

### DIFF
--- a/Sources/MacParakeet/Views/Transcription/TranscriptFindBar.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptFindBar.swift
@@ -78,7 +78,7 @@ struct TranscriptFindBar: View {
     @ViewBuilder
     private var counter: some View {
         ZStack(alignment: .trailing) {
-            Text("No results")
+            Text("000 of 000")
                 .hidden()
 
             if let position {

--- a/Sources/MacParakeet/Views/Transcription/TranscriptFindBar.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptFindBar.swift
@@ -80,7 +80,7 @@ struct TranscriptFindBar: View {
         ZStack(alignment: .trailing) {
             Text("No results")
                 .hidden()
-            Text("0000 of 0000")
+            Text("00000 of 00000")
                 .hidden()
 
             if let position {

--- a/Sources/MacParakeet/Views/Transcription/TranscriptFindBar.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptFindBar.swift
@@ -78,6 +78,8 @@ struct TranscriptFindBar: View {
     @ViewBuilder
     private var counter: some View {
         ZStack(alignment: .trailing) {
+            Text("No results")
+                .hidden()
             Text("000 of 000")
                 .hidden()
 

--- a/Sources/MacParakeet/Views/Transcription/TranscriptFindBar.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptFindBar.swift
@@ -80,7 +80,7 @@ struct TranscriptFindBar: View {
         ZStack(alignment: .trailing) {
             Text("No results")
                 .hidden()
-            Text("000 of 000")
+            Text("0000 of 0000")
                 .hidden()
 
             if let position {

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
@@ -146,6 +146,7 @@ struct TranscriptResultView: View {
     // Cached transcript data — recomputed only when transcription.id changes, not on every playback tick
     @State private var cachedSegments: [TranscriptSegment] = []
     @State private var cachedTurns: [SpeakerTurn] = []
+    @State private var cachedIdentifiedTurns: [IdentifiedSpeakerTurn] = []
     @State private var cachedHasSpeakers: Bool = false
     @State private var cachedSpeakerColorMap: [String: Color] = [:]
     @State private var cachedSpeakerLabelMap: [String: String] = [:]
@@ -2766,7 +2767,7 @@ struct TranscriptResultView: View {
         let current = findCurrentHighlight
         TranscriptTimestampedContentView(
             hasSpeakers: cachedHasSpeakers,
-            turns: cachedTurns,
+            identifiedTurns: cachedIdentifiedTurns,
             segments: cachedSegments,
             speakerColorMap: cachedSpeakerColorMap,
             speakerLabelForID: { cachedSpeakerLabelMap[$0] ?? "Unknown" },
@@ -2930,6 +2931,7 @@ struct TranscriptResultView: View {
         guard let words = activeTranscription.wordTimestamps, !words.isEmpty else {
             cachedSegments = []
             cachedTurns = []
+            cachedIdentifiedTurns = []
             cachedHasSpeakers = false
             cachedSpeakerColorMap = [:]
             cachedSpeakerLabelMap = [:]
@@ -2947,15 +2949,18 @@ struct TranscriptResultView: View {
         cachedSegmentStartMs = segments.map(\.startMs)
 
         if hasSpeakers {
-            cachedTurns = TranscriptSegmenter.groupIntoSpeakerTurns(
+            let turns = TranscriptSegmenter.groupIntoSpeakerTurns(
                 segments: segments,
                 speakerLabelProvider: { speakerID in
                     guard let speakerID else { return "Unknown" }
                     return cachedSpeakerLabelMap[speakerID] ?? "Unknown"
                 }
             )
+            cachedTurns = turns
+            cachedIdentifiedTurns = identifiedSpeakerTurns(turns)
         } else {
             cachedTurns = []
+            cachedIdentifiedTurns = []
         }
     }
 

--- a/Sources/MacParakeet/Views/Transcription/TranscriptTimestampedContentView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptTimestampedContentView.swift
@@ -51,16 +51,12 @@ private func indexedSegments(_ segments: [TranscriptSegment]) -> [IndexedTranscr
 private struct SpeakerTurnIdentity: Hashable {
     let speakerId: String
     let firstStartMs: Int?
-    let lastStartMs: Int?
-    let segmentCount: Int
     let duplicateOrdinal: Int
 }
 
 private struct SpeakerTurnIdentityBase: Hashable {
     let speakerId: String
     let firstStartMs: Int?
-    let lastStartMs: Int?
-    let segmentCount: Int
 }
 
 private struct IdentifiedSpeakerTurn: Identifiable {
@@ -77,9 +73,7 @@ private func identifiedSpeakerTurns(_ turns: [SpeakerTurn]) -> [IdentifiedSpeake
     return turns.map { turn in
         let base = SpeakerTurnIdentityBase(
             speakerId: turn.speakerId,
-            firstStartMs: turn.segments.first?.startMs,
-            lastStartMs: turn.segments.last?.startMs,
-            segmentCount: turn.segments.count
+            firstStartMs: turn.segments.first?.startMs
         )
         let ordinal = duplicateCounts[base, default: 0]
         duplicateCounts[base] = ordinal + 1
@@ -88,8 +82,6 @@ private func identifiedSpeakerTurns(_ turns: [SpeakerTurn]) -> [IdentifiedSpeake
             identity: SpeakerTurnIdentity(
                 speakerId: turn.speakerId,
                 firstStartMs: base.firstStartMs,
-                lastStartMs: base.lastStartMs,
-                segmentCount: base.segmentCount,
                 duplicateOrdinal: ordinal
             )
         )
@@ -114,9 +106,13 @@ struct TranscriptTimestampedContentView: View {
     /// The single emphasized ("current") match, identified by its row `startMs`.
     var currentHighlight: (id: Int, range: NSRange)?
 
+    private var identifiedTurns: [IdentifiedSpeakerTurn] {
+        identifiedSpeakerTurns(turns)
+    }
+
     var body: some View {
         if hasSpeakers {
-            ForEach(identifiedSpeakerTurns(turns)) { identified in
+            ForEach(identifiedTurns) { identified in
                 let turn = identified.turn
                 TranscriptTurnCardView(
                     speakerLabel: speakerLabelForID(turn.speakerId),

--- a/Sources/MacParakeet/Views/Transcription/TranscriptTimestampedContentView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptTimestampedContentView.swift
@@ -48,7 +48,7 @@ private func indexedSegments(_ segments: [TranscriptSegment]) -> [IndexedTranscr
     }
 }
 
-private struct SpeakerTurnIdentity: Hashable {
+struct SpeakerTurnIdentity: Hashable {
     let speakerId: String
     let firstStartMs: Int?
     let duplicateOrdinal: Int
@@ -59,7 +59,7 @@ private struct SpeakerTurnIdentityBase: Hashable {
     let firstStartMs: Int?
 }
 
-private struct IdentifiedSpeakerTurn: Identifiable {
+struct IdentifiedSpeakerTurn: Identifiable {
     let turn: SpeakerTurn
     let identity: SpeakerTurnIdentity
 
@@ -68,7 +68,7 @@ private struct IdentifiedSpeakerTurn: Identifiable {
     }
 }
 
-private func identifiedSpeakerTurns(_ turns: [SpeakerTurn]) -> [IdentifiedSpeakerTurn] {
+func identifiedSpeakerTurns(_ turns: [SpeakerTurn]) -> [IdentifiedSpeakerTurn] {
     var duplicateCounts: [SpeakerTurnIdentityBase: Int] = [:]
     return turns.map { turn in
         let base = SpeakerTurnIdentityBase(
@@ -90,7 +90,7 @@ private func identifiedSpeakerTurns(_ turns: [SpeakerTurn]) -> [IdentifiedSpeake
 
 struct TranscriptTimestampedContentView: View {
     let hasSpeakers: Bool
-    let turns: [SpeakerTurn]
+    let identifiedTurns: [IdentifiedSpeakerTurn]
     let segments: [TranscriptSegment]
     let speakerColorMap: [String: Color]
     let speakerLabelForID: (String) -> String
@@ -105,10 +105,6 @@ struct TranscriptTimestampedContentView: View {
     var highlightRangesByStartMs: [Int: [NSRange]] = [:]
     /// The single emphasized ("current") match, identified by its row `startMs`.
     var currentHighlight: (id: Int, range: NSRange)?
-
-    private var identifiedTurns: [IdentifiedSpeakerTurn] {
-        identifiedSpeakerTurns(turns)
-    }
 
     var body: some View {
         if hasSpeakers {

--- a/Tests/MacParakeetTests/Views/SpeakerTurnIdentityTests.swift
+++ b/Tests/MacParakeetTests/Views/SpeakerTurnIdentityTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+import MacParakeetCore
+@testable import MacParakeet
+
+/// Guards the `ForEach` identity used for speaker-turn cards in the transcript
+/// detail view. The identity must stay stable while a live turn grows, and
+/// distinct turns must never collide — otherwise SwiftUI tears down growing
+/// cards or hits duplicate-id undefined behavior.
+final class SpeakerTurnIdentityTests: XCTestCase {
+
+    private func segment(_ startMs: Int, speaker: String = "spk_0") -> TranscriptSegment {
+        TranscriptSegment(startMs: startMs, text: "word", speakerId: speaker)
+    }
+
+    private func turn(speaker: String = "spk_0", segments: [TranscriptSegment]) -> SpeakerTurn {
+        SpeakerTurn(speakerId: speaker, speakerLabel: speaker, segments: segments)
+    }
+
+    /// A live turn keeps its identity as new segments are appended. Before the
+    /// fix the identity carried `lastStartMs`/`segmentCount`, so every appended
+    /// word produced a "new" identity and SwiftUI rebuilt the growing card.
+    func testIdentityStaysStableWhileTurnGrows() {
+        let small = turn(segments: [segment(1000)])
+        let grown = turn(segments: [segment(1000), segment(2000), segment(3000)])
+
+        let smallID = identifiedSpeakerTurns([small])[0].id
+        let grownID = identifiedSpeakerTurns([grown])[0].id
+
+        XCTAssertEqual(smallID, grownID)
+    }
+
+    /// Two turns that share `(speakerId, firstStartMs)` still receive distinct
+    /// ids via the duplicate ordinal, so `ForEach` never sees a collision.
+    func testTurnsSharingBaseKeyGetUniqueIDs() {
+        let a = turn(segments: [segment(1000)])
+        let b = turn(segments: [segment(1000), segment(2000)])
+
+        let ids = identifiedSpeakerTurns([a, b]).map(\.id)
+
+        XCTAssertEqual(ids.count, 2)
+        XCTAssertNotEqual(ids[0], ids[1])
+    }
+}


### PR DESCRIPTION
Follow-up to #634. This closes the remaining transcript-detail review polish after the main transcript refresh merged.

## Summary
- Prevent transcript find-counter width jitter by reserving space for both `No results` and large numeric counts.
- Keep speaker-turn cards stable while a live speaker turn grows, so SwiftUI does not treat the same in-progress turn as a new card on every appended segment.
- Move identified speaker-turn generation into the existing transcript cache and add focused tests for stable IDs and duplicate-turn uniqueness.

## Verification
- `swift build --product MacParakeet`
- `swift test --filter 'SpeakerTurnIdentityTests|TranscriptSegmentClipboardTests'`
- `git diff --check`
- Greptile: 5/5, no comments on final head `5c77511d6`
- GitHub: Cubic passed; both hosted `swift-test` jobs passed