### PR TITLE
fix: tighten CLI contract and mic watchdog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,10 @@ jobs:
               for command in spec["commands"]
           }
           export = commands[("meetings", "export")]
-          assert export["jsonMode"] == "--stdout --format json"
+          if export["jsonMode"] != "--stdout --format json":
+              raise SystemExit(
+                  f"Unexpected meetings export jsonMode: {export['jsonMode']!r}"
+              )
           PY
 
       - name: Release Bundle Smoke

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,11 @@ on:
   push:
     paths-ignore:
       - "docs/**"
+      - "plans/**"
   pull_request:
     paths-ignore:
       - "docs/**"
+      - "plans/**"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,13 +4,9 @@ on:
   push:
     paths-ignore:
       - "docs/**"
-      - "spec/**"
-      - "**/*.md"
   pull_request:
     paths-ignore:
       - "docs/**"
-      - "spec/**"
-      - "**/*.md"
   workflow_dispatch:
 
 concurrency:
@@ -68,6 +64,30 @@ jobs:
           mkdir -p .ci-logs
           set -o pipefail
           swift build -c release 2>&1 | tee .ci-logs/swift-build-release.log
+
+      - name: CLI Contract Smoke
+        timeout-minutes: 2
+        env:
+          MACPARAKEET_TELEMETRY: "0"
+        run: |
+          mkdir -p .ci-logs
+          set -o pipefail
+          .build/release/macparakeet-cli --help > .ci-logs/cli-help.txt
+          .build/release/macparakeet-cli spec --json > .ci-logs/cli-spec.json
+          python3 -m json.tool .ci-logs/cli-spec.json > /dev/null
+          python3 - <<'PY'
+          import json
+
+          with open(".ci-logs/cli-spec.json", encoding="utf-8") as f:
+              spec = json.load(f)
+
+          commands = {
+              tuple(command["path"]): command
+              for command in spec["commands"]
+          }
+          export = commands[("meetings", "export")]
+          assert export["jsonMode"] == "--stdout --format json"
+          PY
 
       - name: Release Bundle Smoke
         timeout-minutes: 15

--- a/Package.swift
+++ b/Package.swift
@@ -65,7 +65,7 @@ let package = Package(
                 .product(name: "ArgumentParser", package: "swift-argument-parser")
             ],
             path: "Sources/CLI",
-            exclude: ["CHANGELOG.md"]
+            exclude: ["CHANGELOG.md", "README.md"]
         ),
         // Objective-C shim target for catching NSException in Swift.
         // Swift's `do/try/catch` cannot catch Objective-C exceptions raised by

--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -424,10 +424,13 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
 - `meetings results list|add` exposes saved meeting PromptResults through the
   CLI. `add` stores externally generated output as a `PromptResult` without
   invoking an LLM, preserving the meeting transcript as the canonical object.
-- `meetings list --json`, `meetings show --json`, and `meetings export --format json`
-  now include `hasPromptResults` and `promptResultCount`, and Markdown exports
-  include the same count in metadata, so agents can tell whether structured
-  meeting outputs already exist before fetching result rows.
+- `meetings list --json`, `meetings show --json`, and `meetings export` with
+  `--stdout --format json` now include `hasPromptResults` and
+  `promptResultCount`, and Markdown exports include the same count in metadata,
+  so agents can tell whether structured meeting outputs already exist before
+  fetching result rows.
+- `spec --json` now documents `meetings export` JSON stdout mode as
+  `--stdout --format json`, matching the command's file-output default.
 - `llm` commands using `--provider lmstudio` now honor optional LM Studio API
   tokens via `--api-key`, `--api-key-env`, or `LM_API_TOKEN`.
 - `vocab snippets edit <id> --trigger ... --expansion ...` updates an existing

--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -100,6 +100,13 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
   `transcribe` where applicable, and emits either `--json` or `--envelope`
   machine-readable output.
 
+### Changed
+
+- `spec --json` now documents `meetings export` JSON stdout mode as
+  `--stdout --format json`, matching the command's file-output default.
+- Plain-text `retranscribe` validation/misuse failures now use exit code `2`,
+  matching the JSON envelope path and the public exit-code contract.
+
 ## [2.11.0] -- 2026-06-28
 
 ### Added
@@ -429,8 +436,6 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
   `promptResultCount`, and Markdown exports include the same count in metadata,
   so agents can tell whether structured meeting outputs already exist before
   fetching result rows.
-- `spec --json` now documents `meetings export` JSON stdout mode as
-  `--stdout --format json`, matching the command's file-output default.
 - `llm` commands using `--provider lmstudio` now honor optional LM Studio API
   tokens via `--api-key`, `--api-key-env`, or `LM_API_TOKEN`.
 - `vocab snippets edit <id> --trigger ... --expansion ...` updates an existing
@@ -443,8 +448,6 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
   `cli_operation` event. `transcribe` keeps its extra coarse input/output
   metadata; other commands report only command path, outcome, duration, exit
   code, and error type.
-- Plain-text `retranscribe` validation/misuse failures now use exit code `2`,
-  matching the JSON envelope path and the public exit-code contract.
 - `transcribe` now defaults `--speaker-detection` to `app-default`, so bare
   CLI transcription follows the saved GUI/CLI speaker-detection preference.
   Use `--speaker-detection on` to force diarization for one run, or

--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -443,6 +443,8 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
   `cli_operation` event. `transcribe` keeps its extra coarse input/output
   metadata; other commands report only command path, outcome, duration, exit
   code, and error type.
+- Plain-text `retranscribe` validation/misuse failures now use exit code `2`,
+  matching the JSON envelope path and the public exit-code contract.
 - `transcribe` now defaults `--speaker-detection` to `app-default`, so bare
   CLI transcription follows the saved GUI/CLI speaker-detection preference.
   Use `--speaker-detection on` to force diarization for one run, or

--- a/Sources/CLI/Commands/CLIHelpers.swift
+++ b/Sources/CLI/Commands/CLIHelpers.swift
@@ -507,17 +507,24 @@ private func rethrowWithOptionalJSONEnvelope(_ error: Error, json: Bool) throws 
     guard json else { throw error }
     let envelope = CLIErrorEnvelope(error: error)
     try? printJSON(envelope)
-    if error is ValidationError || error is CLIInputError {
-        throw CLIJSONEnvelopeExit(exitCode: cliValidationMisuseExitCode, originalError: error)
-    }
-    if let transforms = error as? CLITransformsError, transforms.isValidationMisuse {
-        throw CLIJSONEnvelopeExit(exitCode: cliValidationMisuseExitCode, originalError: error)
-    }
-    if let history = error as? CLITransformHistoryError, case .invalidPrefix = history {
-        throw CLIJSONEnvelopeExit(exitCode: cliValidationMisuseExitCode, originalError: error)
-    }
-    if let retranscribe = error as? CLIRetranscribeError, retranscribe.isValidationMisuse {
+    if isCLIValidationMisuse(error) {
         throw CLIJSONEnvelopeExit(exitCode: cliValidationMisuseExitCode, originalError: error)
     }
     throw CLIJSONEnvelopeExit(exitCode: .failure, originalError: error)
+}
+
+func isCLIValidationMisuse(_ error: Error) -> Bool {
+    if error is ValidationError || error is CLIInputError {
+        return true
+    }
+    if let transforms = error as? CLITransformsError, transforms.isValidationMisuse {
+        return true
+    }
+    if let history = error as? CLITransformHistoryError, case .invalidPrefix = history {
+        return true
+    }
+    if let retranscribe = error as? CLIRetranscribeError, retranscribe.isValidationMisuse {
+        return true
+    }
+    return false
 }

--- a/Sources/CLI/Commands/SpecCommand.swift
+++ b/Sources/CLI/Commands/SpecCommand.swift
@@ -990,7 +990,7 @@ private extension CLISpecCommand {
             ["meetings", "export"],
             summary: "Export a deterministic local meeting artifact.",
             readOnly: false,
-            jsonMode: "--format json",
+            jsonMode: "--stdout --format json",
             arguments: [.argument("meeting", summary: "Meeting UUID, UUID prefix, or exact title.")],
             options: [
                 CLISpecParameter.option("--format", valueName: "md|json", summary: "Export format."),
@@ -998,7 +998,7 @@ private extension CLISpecCommand {
                 CLISpecParameter.flag("--stdout", summary: "Print export content to stdout."),
                 databaseOption,
             ],
-            output: "Markdown text or MeetingRecord JSON with prompt-result count."
+            output: "Markdown text or MeetingRecord JSON with prompt-result count when --stdout is present; otherwise writes a file and prints its path."
         ),
     ]
 }

--- a/Sources/CLI/MacParakeetCLI.swift
+++ b/Sources/CLI/MacParakeetCLI.swift
@@ -57,6 +57,9 @@ struct CLI: AsyncParsableCommand {
         if let exitCode = error as? ExitCode {
             return normalizedExitCode(for: exitCode)
         }
+        if isCLIValidationMisuse(error) {
+            return cliValidationMisuseExitCode
+        }
         return normalizedExitCode(for: exitCode(for: error))
     }
 

--- a/Sources/MacParakeetCore/Audio/MicrophoneCapture.swift
+++ b/Sources/MacParakeetCore/Audio/MicrophoneCapture.swift
@@ -219,7 +219,10 @@ public final class MicrophoneCapture: @unchecked Sendable {
     private var state: LifecycleState = .idle
     private var bufferHandler: AudioBufferHandler?
     private var stallObserver: StallObserver?
-    private var firstBufferReceived = false
+    /// Buffer callbacks can arrive before `start()` returns and arms the watchdog.
+    /// Generation state keeps those early callbacks tied to the correct start attempt.
+    private var watchdogGeneration = 0
+    private var firstBufferSeenGeneration: Int?
     private var watchdogWorkItem: DispatchWorkItem?
     /// Active subscription token. Snapshotted by `stop()` and `deinit` so
     /// unsubscribe can fire without holding `self`.
@@ -286,14 +289,6 @@ public final class MicrophoneCapture: @unchecked Sendable {
             stallObserver = onStall
         }
 
-        let bufferDispatch: SharedMicrophoneStream.BufferHandler = { [weak self] buffer, time in
-            guard let self else { return }
-            self.dispatchBuffer(
-                buffer,
-                time: time,
-                extractVPIOChannelZero: self.sharedStream.isVPIOEngaged
-            )
-        }
         let deathDispatch: SharedMicrophoneStream.EngineDeathHandler = { [weak self] in
             guard let self else { return }
             let observer = self.handlerLock.withLock { self.stallObserver }
@@ -312,11 +307,12 @@ public final class MicrophoneCapture: @unchecked Sendable {
 
         let token: SharedMicrophoneStream.SubscriberToken
         var effectiveMode: MeetingMicProcessingEffectiveMode
+        var activeWatchdogGeneration = nextWatchdogGeneration()
         do {
             token = try await sharedStream.subscribe(
                 wantsVPIO: wantsVPIO,
                 onEngineDeath: deathDispatch,
-                handler: bufferDispatch
+                handler: makeBufferDispatch(generation: activeWatchdogGeneration)
             )
             // The effective mode reflects what the engine is actually
             // producing right now — `vpioEngaged=false` while a non-VPIO
@@ -335,10 +331,11 @@ public final class MicrophoneCapture: @unchecked Sendable {
                     "meeting_mic_processing_fallback requested=vpioPreferred effective=raw \(AudioCaptureDiagnostics.errorFields(error))"
                 )
                 do {
+                    activeWatchdogGeneration = nextWatchdogGeneration()
                     token = try await sharedStream.subscribe(
                         wantsVPIO: false,
                         onEngineDeath: deathDispatch,
-                        handler: bufferDispatch
+                        handler: makeBufferDispatch(generation: activeWatchdogGeneration)
                     )
                     effectiveMode = .raw
                 } catch let fallbackError {
@@ -408,7 +405,7 @@ public final class MicrophoneCapture: @unchecked Sendable {
         // Watchdog must start AFTER the subscription is owned. Scheduling
         // earlier risks firing while a slow device-fallback chain is still
         // running through the platform.
-        scheduleSilentBufferWatchdog()
+        scheduleSilentBufferWatchdog(generation: activeWatchdogGeneration)
 
         AudioCaptureDiagnostics.append(
             "meeting_mic_processing mode=\(effectiveMode.rawValue)"
@@ -477,9 +474,10 @@ public final class MicrophoneCapture: @unchecked Sendable {
     private func dispatchBuffer(
         _ buffer: AVAudioPCMBuffer,
         time: AVAudioTime,
-        extractVPIOChannelZero: Bool
+        extractVPIOChannelZero: Bool,
+        generation: Int
     ) {
-        markFirstBufferReceived()
+        markFirstBufferReceived(generation: generation)
         let deliveredBuffer: AVAudioPCMBuffer
         deliveredBuffer = microphoneCaptureMonoBuffer(
             from: buffer,
@@ -489,13 +487,42 @@ public final class MicrophoneCapture: @unchecked Sendable {
         callback?(deliveredBuffer, time)
     }
 
-    private func scheduleSilentBufferWatchdog() {
-        let workItem = watchdogLock.withLock { () -> DispatchWorkItem in
-            firstBufferReceived = false
+    private func makeBufferDispatch(generation: Int) -> SharedMicrophoneStream.BufferHandler {
+        { [weak self] buffer, time in
+            guard let self else { return }
+            self.dispatchBuffer(
+                buffer,
+                time: time,
+                extractVPIOChannelZero: self.sharedStream.isVPIOEngaged,
+                generation: generation
+            )
+        }
+    }
+
+    private func nextWatchdogGeneration() -> Int {
+        watchdogLock.withLock {
+            watchdogGeneration += 1
+            firstBufferSeenGeneration = nil
+            watchdogWorkItem?.cancel()
+            watchdogWorkItem = nil
+            return watchdogGeneration
+        }
+    }
+
+    private func scheduleSilentBufferWatchdog(generation: Int) {
+        let workItem = watchdogLock.withLock { () -> DispatchWorkItem? in
+            guard firstBufferSeenGeneration != generation else {
+                watchdogWorkItem?.cancel()
+                watchdogWorkItem = nil
+                return nil
+            }
             watchdogWorkItem?.cancel()
             let item = DispatchWorkItem { [weak self] in
                 guard let self else { return }
-                let shouldLog = self.watchdogLock.withLock { !self.firstBufferReceived }
+                let shouldLog = self.watchdogLock.withLock {
+                    self.watchdogGeneration == generation
+                        && self.firstBufferSeenGeneration != generation
+                }
                 guard shouldLog else { return }
                 let error = MeetingAudioError.captureRuntimeFailure(
                     "microphone capture started but delivered no buffers within 2 seconds"
@@ -506,13 +533,16 @@ public final class MicrophoneCapture: @unchecked Sendable {
             watchdogWorkItem = item
             return item
         }
-        watchdogQueue.asyncAfter(deadline: .now() + 2, execute: workItem)
+        if let workItem {
+            watchdogQueue.asyncAfter(deadline: .now() + 2, execute: workItem)
+        }
     }
 
-    private func markFirstBufferReceived() {
+    private func markFirstBufferReceived(generation: Int) {
         let shouldLog = watchdogLock.withLock {
-            guard !firstBufferReceived else { return false }
-            firstBufferReceived = true
+            guard watchdogGeneration == generation else { return false }
+            guard firstBufferSeenGeneration != generation else { return false }
+            firstBufferSeenGeneration = generation
             watchdogWorkItem?.cancel()
             watchdogWorkItem = nil
             return true
@@ -533,7 +563,8 @@ public final class MicrophoneCapture: @unchecked Sendable {
 
     private func resetDiagnosticsState() {
         watchdogLock.withLock {
-            firstBufferReceived = false
+            watchdogGeneration += 1
+            firstBufferSeenGeneration = nil
             watchdogWorkItem?.cancel()
             watchdogWorkItem = nil
         }

--- a/Tests/CLITests/LLMJSONOutputTests.swift
+++ b/Tests/CLITests/LLMJSONOutputTests.swift
@@ -245,6 +245,19 @@ final class LLMJSONOutputTests: XCTestCase {
     func testCLINormalizesArgumentParserValidationExitCodeToPublicContract() {
         XCTAssertEqual(CLI.normalizedExitCode(for: ExitCode.validationFailure).rawValue, 2)
         XCTAssertEqual(CLI.normalizedExitCode(for: ValidationError("bad combo")).rawValue, 2)
+        XCTAssertEqual(
+            CLI.normalizedExitCode(for: CLIRetranscribeError.kindMismatch(expected: .transcription, actual: .meeting))
+                .rawValue,
+            2
+        )
+        XCTAssertEqual(
+            CLI.normalizedExitCode(for: CLIRetranscribeError.dictationDoesNotSupportSpeakerOptions).rawValue,
+            2
+        )
+        XCTAssertEqual(
+            CLI.normalizedExitCode(for: CLIRetranscribeError.noRetainedAudio(kind: "dictation", id: UUID())),
+            .failure
+        )
         XCTAssertEqual(CLI.normalizedExitCode(for: ExitCode.failure), .failure)
     }
 

--- a/Tests/CLITests/SpecCommandTests.swift
+++ b/Tests/CLITests/SpecCommandTests.swift
@@ -384,7 +384,7 @@ final class SpecCommandTests: XCTestCase {
 
         let export = try XCTUnwrap(commands.first { ($0["path"] as? [String]) == ["meetings", "export"] })
         XCTAssertEqual(export["readOnly"] as? Bool, false)
-        XCTAssertEqual(export["jsonMode"] as? String, "--format json")
+        XCTAssertEqual(export["jsonMode"] as? String, "--stdout --format json")
         let exportOptions = try XCTUnwrap(export["options"] as? [[String: Any]])
         XCTAssertTrue(exportOptions.contains { ($0["name"] as? String) == "--output" })
         XCTAssertTrue(exportOptions.contains { ($0["name"] as? String) == "--stdout" })

--- a/Tests/MacParakeetTests/Audio/MicrophoneCaptureTests.swift
+++ b/Tests/MacParakeetTests/Audio/MicrophoneCaptureTests.swift
@@ -69,6 +69,33 @@ final class MicrophoneCaptureTests: XCTestCase {
         XCTAssertEqual(counter.value, 2)
     }
 
+    func testEarlyFirstBufferBeforeWatchdogArmedDoesNotReportStall() async throws {
+        let platform = SharedMicTestPlatform()
+        let stream = SharedMicrophoneStream(platform: platform, bufferSize: 1024)
+        let capture = MicrophoneCapture(
+            sharedStream: stream,
+            permissionProvider: { true }
+        )
+        let stallBox = MicrophoneCaptureTestStallBox()
+        let earlyBuffer = UncheckedSendableAudioPCMBuffer(makeSharedTestBuffer())
+        platform.afterConfigureAndStartHook = {
+            platform.deliverBuffer(earlyBuffer.buffer, time: AVAudioTime(hostTime: 0))
+        }
+
+        _ = try await capture.start(
+            processingMode: .raw,
+            handler: { _, _ in },
+            onStall: { error in stallBox.record(error) }
+        )
+        defer { capture.stop() }
+
+        try await Task.sleep(for: .milliseconds(2200))
+        XCTAssertNil(
+            stallBox.recordedError,
+            "A first buffer delivered before start() arms the watchdog must still disarm the watchdog."
+        )
+    }
+
     func testSharedModeVPIOForwardsChannelZeroOnly() async throws {
         let platform = SharedMicTestPlatform()
         let stream = SharedMicrophoneStream(platform: platform, bufferSize: 1024)
@@ -869,9 +896,14 @@ private final class SharedMicTestPlatform: MicrophoneEnginePlatform, @unchecked 
     /// into the platform without deadlocking.
     private let hookLock = NSLock()
     private var _configureAndStartHook: (@Sendable () -> Void)?
+    private var _afterConfigureAndStartHook: (@Sendable () -> Void)?
     var configureAndStartHook: (@Sendable () -> Void)? {
         get { hookLock.withLock { _configureAndStartHook } }
         set { hookLock.withLock { _configureAndStartHook = newValue } }
+    }
+    var afterConfigureAndStartHook: (@Sendable () -> Void)? {
+        get { hookLock.withLock { _afterConfigureAndStartHook } }
+        set { hookLock.withLock { _afterConfigureAndStartHook = newValue } }
     }
 
     var isEngineRunning: Bool {
@@ -912,6 +944,7 @@ private final class SharedMicTestPlatform: MicrophoneEnginePlatform, @unchecked 
             _isRunning = true
             _tapHandler = tapHandler
         }
+        afterConfigureAndStartHook?()
     }
 
     func stopEngine() {

--- a/docs/cli-testing.md
+++ b/docs/cli-testing.md
@@ -410,7 +410,7 @@ swift run macparakeet-cli export <ID> --format txt --output transcript.txt
 swift run macparakeet-cli export <ID> --format srt --output subtitles.srt
 swift run macparakeet-cli export <ID> --format vtt
 swift run macparakeet-cli export <ID> --format markdown
-swift run macparakeet-cli export <ID> --format json
+swift run macparakeet-cli export <ID> --format json --stdout
 
 # Print to stdout instead of writing a file
 swift run macparakeet-cli export <ID> --format srt --stdout

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -542,7 +542,10 @@ macparakeet-cli prompts run "<prompt-name>" \
 ## Operating Rules
 
 - Branch on process exit code first.
-- Parse stdout as JSON for `--json` / `--format json` commands.
+- Parse stdout as JSON for `--json` commands and for format-selecting commands
+  when the command's documented JSON mode sends the payload to stdout. For
+  `meetings export`, that mode is `--stdout --format json`; `--format json`
+  without `--stdout` writes a JSON file and prints the path.
 - Treat exit code `2` as invocation misuse; fix the command before retrying.
 - Treat lookup ambiguity as normal; ask for or choose a more specific ID.
 - Never delete user database records unless the user explicitly requests it.
@@ -578,10 +581,11 @@ macparakeet-cli prompts run "<prompt-name>" \
   `--allow-insecure-http`; the CLI writes a stderr warning and keeps stdout
   machine-readable.
 - **JSON flag shape:** read-only query commands take `--json` (a binary flag);
-  `transcribe` and `export` take `--format json` because they emit one of
-  several formats (txt / markdown / srt / vtt / json). Both produce stable
-  JSON schemas. The split is deliberate -- see
-  `Sources/CLI/CHANGELOG.md` for the compatibility note.
+  format-selecting commands take `--format json` because they emit one of
+  several formats (txt / markdown / srt / vtt / json). Commands that normally
+  write files, such as `meetings export`, also require `--stdout` when you want
+  JSON on stdout. The split is deliberate -- see `Sources/CLI/CHANGELOG.md`
+  for the compatibility note.
 - **Lookups:** records that take an `<id-or-name>` argument accept full UUID,
   UUID prefix (>= 4 chars), or case-insensitive name. Ambiguous prefixes
   produce a `.ambiguous` error; missing records produce `.notFound`.

--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -67,9 +67,11 @@ If MacParakeet.app is already installed, the bundled CLI is also available at
 
 ## Conventions
 
-JSON to stdout when `--json` (or `--format json` for `transcribe`/`export`)
-is set; human-readable errors to stderr; non-zero exit on failure. JSON
-schemas are stable within a major CLI version (semver, see
+JSON to stdout when `--json` is set, or when a format-selecting command's
+documented JSON stdout mode is used. For `meetings export`, that mode is
+`--stdout --format json`; `--format json` without `--stdout` writes a file and
+prints the path. Human-readable errors go to stderr; commands exit non-zero on
+failure. JSON schemas are stable within a major CLI version (semver, see
 [`CHANGELOG.md`](../../Sources/CLI/CHANGELOG.md)). Lookup args accept full
 UUID, UUID prefix (>= 4 chars), or case-insensitive name. Prompt and LLM
 wrappers should pass `--json` when the skill expects an envelope.

--- a/plans/README.md
+++ b/plans/README.md
@@ -73,14 +73,14 @@
 
 ## Execute next (recommended order)
 
-1. **Ship dictation-first onboarding (Part A).** Biggest activation lever, low risk, telemetry-backed. Plan is executor-grade as of 2026-06-13 — dispatchable now. (Funnel is already instrumented via `onboarding_step`; the lift is confirmed by post-ship analysis, not new telemetry — see the plan's "Verifying the lift".)
-2. **Dispatch the two P1/P2 executor-ready test plans** (onboarding-stall-watchdog → june-churn regression). They close the named coverage gaps in the highest-incident area.
-3. **Dispatch boundary contract docs + contract tests** before destructive meeting-retention work or broader meeting workspace automation. It makes artifact, recovery/retention, and CLI JSON boundaries explicit and test-linked.
+1. **Finish the meeting AEC measurement harness.** It is the current P1 because it gates the #605 echo/bleed cluster before any wider meeting-audio change should ship.
+2. **Verify then archive the shipped onboarding and settings cleanup plans** (`dictation-first-onboarding`, `onboarding-stall-watchdog`, `dx-format-lint-baseline`, and the `2026-06-15-settings-*` trio) so the active board stops carrying completed work.
+3. **Dispatch the remaining P2 test-hardening plans** (`june-churn-regression-tests`, then `refinement-validator`). They close named coverage gaps in high-churn audio/STT and formatter paths.
 4. **Land the telemetry-allowlist CI guard**, then add the `WEBSITE_REPO_TOKEN` secret to enforce it.
 
 ## Dependency notes
 
-- No hard blockers between active plans. Soft sequencing: land the onboarding-stall watchdog test (#2) before/with the onboarding rework (#1) so the warm-up path has a safety net under it.
+- No hard blockers between active plans. Soft sequencing: keep meeting-audio changes behind the measurement harness, and prefer the remaining audio/STT regression tests before another broad capture/STT change.
 - The two engine-switch plans are a pair: `ux-revamp` (Stage A, partial) is the parent; `stage-b` is its on-hold continuation. Both gate on the A3 cold-switch telemetry before the reactive flow is greenlit.
 
 ## Recently archived → `completed/` (2026-06-21)

--- a/plans/active/2026-06-14-meeting-auto-stop.md
+++ b/plans/active/2026-06-14-meeting-auto-stop.md
@@ -1,6 +1,6 @@
 # Activity-Based Meeting Auto-Stop
 
-**Status:** Implemented for Phases A+B on 2026-06-14; default off / opt-in behind `AppFeatures.meetingAutoStopEnabled = false`. Phase C remains active/deferred until ADR-024 per-process attribution exists.
+**Status:** Implemented for Phases A+B on 2026-06-14; compile-time flag on `main`, per-user setting default off / opt-in. Phase C remains active/deferred until ADR-024 per-process attribution exists.
 **Date:** 2026-06-14
 **ADRs:** ADR-023 (activity-based meeting auto-stop), ADR-017 (calendar auto-start — §5 deferred this), ADR-014/015/016 (meeting recording, concurrency, scheduler)
 **Requirement:** REQ-MEET-015 (v0.7, implemented behind default-off flag)
@@ -83,7 +83,7 @@ Rules: `.keepRecording` if `!isRecording || isPaused`. App-quit fires only when 
 - **App:** `Sources/MacParakeet/App/MeetingAutoStopCoordinator.swift` — snapshot running recognized apps at start; `NSWorkspace.didTerminateApplicationNotification` observer; grace clock + reversal; veto countdown; stop via `MeetingRecordingFlowCoordinator` with the `.autoStop` operation trigger. Wire in `AppEnvironmentConfigurer.swift`.
 - **Flow:** distinguish recording-start triggers from stop operation triggers so auto-stop is attributed without becoming a recording-start source.
 - **Settings:** `meetingAutoStopEnabled` on `SettingsViewModel` (namespaced key) + `.macParakeetMeetingAutoStopDidChange` in `AppNotifications.swift` + toggle in the Meeting Recording settings card + `SettingsSearchIndex` entry.
-- **Gate:** `AppFeatures.meetingAutoStopEnabled` (default off).
+- **Gate:** `AppFeatures.meetingAutoStopEnabled` (on for `main` dogfooding; per-user setting default off).
 - **Telemetry:** `meeting_auto_stop_proposed/confirmed/vetoed{reason}` + `.settingChanged(setting:.meetingAutoStop)` → mirror to `macparakeet-website/functions/api/telemetry.ts` `ALLOWED_EVENTS`.
 
 ### Phase B — sustained dual-channel silence signal (implemented 2026-06-14)

--- a/spec/contracts/cli-json-v1.md
+++ b/spec/contracts/cli-json-v1.md
@@ -13,7 +13,8 @@ with human progress/status kept off stdout.
 - `CLIHelpers.printJSON`
 - `CLIHelpers.printEnvelope`
 - `CLIHelpers.emitJSONOrRethrow`
-- Commands that expose `--json`, `--format json`, or `--envelope`
+- Commands that expose JSON-on-stdout modes through `--json`, `--format json`,
+  or `--envelope`
 - `SpecCommand`
 
 ## Consumers
@@ -26,7 +27,13 @@ with human progress/status kept off stdout.
 
 ## Stable Conventions
 
-- JSON payloads are written to stdout.
+- JSON payloads are written to stdout for the command's documented JSON stdout
+  mode.
+- Export-style commands can also write JSON files. For those commands,
+  `--format json` alone may write a file and print the path; use the command's
+  documented stdout mode from `macparakeet-cli spec --json` when a caller needs
+  parseable JSON on stdout. For `meetings export`, that mode is
+  `--stdout --format json`.
 - Human progress/status is written to stderr.
 - JSON uses ISO-8601 dates, sorted keys, and pretty printing through the shared
   encoder.


### PR DESCRIPTION
## Summary

This fixes two review findings from the latest-main audit: meeting mic capture no longer reports a false first-buffer stall when audio arrives before the startup watchdog is armed, and the public CLI contract now matches the shipped `meetings export` behavior.

The CLI cleanup also normalizes plain-text `retranscribe` validation/misuse errors to exit code `2`, matching the JSON-envelope path and the documented automation contract. CI now runs a release-built CLI spec smoke so drift in the published JSON contract is caught before merge, while docs/plans were brought back in line with current behavior.

## Validation

- `swift test --parallel`
- `swift test --filter MicrophoneCaptureTests`
- `swift test --filter SpecCommandTests`
- `swift test --filter LLMJSONOutputTests`
- `swift test --filter RetranscribeCommandTests`
- `swift build -c release` plus release CLI `--help` and `spec --json` smoke
- `scripts/dev/check.sh`
- `git diff --check HEAD`

Known existing noise: `scripts/dev/check.sh` still reports report-only `swift-format` warnings, and SwiftPM still reports the upstream FluidAudio unhandled-file warning.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a false microphone stall on startup and aligns the CLI JSON contract: `meetings export` JSON-on-stdout is `--stdout --format json` and misuse exits return code 2. Updates docs/spec and hardens a CI smoke to pin the released CLI JSON spec.

- **Bug Fixes**
  - Meeting mic: the startup watchdog no longer reports a stall when a first buffer arrives before `start()` finishes; a generation-based watchdog ties early buffers to the correct start attempt.
  - CLI: enforces `meetings export` JSON stdout mode as `--stdout --format json`; plain-text `retranscribe` validation/misuse now exits with code 2 to match the public contract, and CI fails if the documented `jsonMode` drifts.

<sup>Written for commit b523ed1407162df701063e7466f8233ad43da340. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/643?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

