### PR TITLE
docs: codify agent memory governance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,9 @@ This repo often has many parallel worktrees.
 - Treat `.build*`, `.claude/worktrees`, `dist`, and
   `journal/x-agent/node_modules` as generated or archival unless the task
   specifically asks about them.
+- Default searches should avoid ignored/generated/private paths such as
+  `.claude/`, `.build*`, `dist`, `diagnostics`, `logs`, `journal/`, local env
+  files, and key material unless the task explicitly names them.
 
 ## Code Boundaries
 
@@ -87,6 +90,9 @@ have subsystem rules.
 ## Working Method
 
 - Start by finding the governing code, ADRs/specs, and tests for the task.
+- Treat agent memory, old chat, and old plans as hints. Verify live state from
+  code, tests, `git`, GitHub, release metadata, or the governing doc before
+  relying on it.
 - For behavior changes, define the intended scope and must-not-change
   invariants before editing.
 - Plans are useful working memory for substantial or long-running tasks, but
@@ -126,6 +132,7 @@ for significant work, not ceremony for every typo.
 - UI patterns: [`spec/04-ui-patterns.md`](./spec/04-ui-patterns.md)
 - Testing strategy: [`spec/09-testing.md`](./spec/09-testing.md)
 - Agent working method: [`spec/10-ai-coding-method.md`](./spec/10-ai-coding-method.md)
+- Agent memory governance: [`docs/agent-memory-governance.md`](./docs/agent-memory-governance.md)
 - Agent instruction research: [`docs/research/coding-agent-instructions-2026-06.md`](./docs/research/coding-agent-instructions-2026-06.md)
 - Active/completed plans: [`plans/README.md`](./plans/README.md)
 - Distribution/release steps: [`docs/distribution.md`](./docs/distribution.md)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,7 +96,7 @@ When editing a load-bearing Core subsystem, read its local README before code:
 - Start by finding the governing code, ADRs/specs, and tests for the task.
 - Treat agent memory, old chat, and old plans as hints. Verify live state from
   code, tests, `git`, GitHub, release metadata, or the governing doc before
-  relying on it.
+  relying on them.
 - For behavior changes, define the intended scope and must-not-change
   invariants before editing.
 - Plans are useful working memory for substantial or long-running tasks, but

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,12 +68,16 @@ This repo often has many parallel worktrees.
   without the GUI.
 - New I/O should use async/await. Avoid new completion-handler or Combine
   patterns.
+- When ordering or a result matters, make the API async and await it instead of
+  using fire-and-forget `Task`.
+- Keep `@MainActor` work short; move long-running I/O, model, process, and
+  audio work off the actor, then hop back for UI state.
 - Database access uses GRDB repositories, roughly one repository per table.
 - UI buttons use `.parakeetAction(...)`; do not tint whole hosting roots coral.
 
 When editing a load-bearing Core subsystem, read its local README before code:
-`Audio/`, `STT/`, `TextProcessing/`, `Database/`, and `Licensing/` currently
-have subsystem rules.
+`Audio/`, `STT/`, `TextProcessing/`, `Database/`, `Licensing/`, and
+`Services/System/` currently have subsystem rules.
 
 ## Product Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,135 +2,40 @@
 
 @AGENTS.md
 
-> Claude Code overlay for MacParakeet. Read [`AGENTS.md`](./AGENTS.md) first;
-> it is the canonical cross-agent startup guide. This file keeps the
-> Claude-specific reminders and high-risk repo lessons that are worth loading
-> every session.
+> Claude Code overlay for MacParakeet. Keep this file intentionally small:
+> [`AGENTS.md`](./AGENTS.md) is the canonical cross-agent startup guide and is
+> imported above.
 
-## Operating Style
+## Claude-Specific Rules
 
-Use judgment. MacParakeet benefits from agents that can plan, verify, and push
-back when a proposed path is too heavy or too loose.
+- Treat Claude auto memory, chat history, old plans, and local notes as leads,
+  not truth. Verify release, PR, CI, deploy, analytics, and current code state
+  live before relying on them.
+- Do not grow this file or auto memory by default. Promote durable lessons to
+  the narrowest versioned surface: `AGENTS.md`, a subsystem README, spec/ADR,
+  `docs/pr-review-workflow.md`, `docs/distribution.md`,
+  `integrations/README.md`, or a skill.
+- Use `.claude/rules/` or subdirectory `CLAUDE.md` only for Claude-specific
+  path-scoped rules that should not load globally.
+- When this file and `AGENTS.md` overlap, edit `AGENTS.md` unless the
+  instruction only matters to Claude Code.
+- If a rule must be enforced rather than merely suggested, prefer tests,
+  scripts, hooks, or product code over another instruction line.
 
-- For substantial work, make a short plan, define the scope/invariants, then
-  execute. For tiny edits, skip the ceremony and keep momentum.
-- Prefer current code, tests, ADRs, and live command output over stale plans or
-  old notes.
-- If the checkout is dirty or unrelated, preserve it. Use a fresh worktree for
-  branch/PR work rather than cleaning up changes you did not make.
-- When a task touches user data, privacy, audio capture, persistence,
-  telemetry, CLI contracts, or concurrency, slow down and verify with tests or
-  runtime evidence.
-- Keep product decisions grounded in the trust-first direction: reliable
-  capture, recovery, durable local artifacts, polished daily workflows, and
-  simple intuitive UX before broader feature sprawl.
+## Local-State Cautions
 
-## Current Context
+- Preserve dirty or unrelated worktrees. Fresh PR work belongs on a branch or
+  worktree based on `origin/main`.
+- Do not delete user databases, meeting session folders, source audio, lock
+  files, or ignored private files unless the task explicitly asks for a
+  recovery or discard flow.
+- Ignored paths such as `.claude/`, `journal/`, `.build*`, `dist/`,
+  `diagnostics/`, `logs/`, and local env/key files are not review scope unless
+  the task names them.
 
-MacParakeet is a local-first voice app for Apple Silicon Macs with dictation,
-file/media URL transcription, meeting recording, and selected-text Transforms.
-The app and CLI share `MacParakeetCore`; the CLI is also a public automation
-surface for agents and scripts.
+## References
 
-For current feature/release state, use:
-
-- Release channels and feature flags: [`spec/README.md`](./spec/README.md#release-channels-and-feature-flags)
-- Spec index and roadmap: [`spec/README.md`](./spec/README.md)
-- Accepted decisions: [`spec/adr/`](./spec/adr/)
-- Feature behavior: [`spec/02-features.md`](./spec/02-features.md)
-- Architecture: [`spec/03-architecture.md`](./spec/03-architecture.md)
-- CLI compatibility: [`Sources/CLI/CHANGELOG.md`](./Sources/CLI/CHANGELOG.md)
-
-Do not restate volatile release flags in new docs unless the task is explicitly
-about release notes or feature gating. Link to the source instead.
-
-## Source Of Truth
-
-When artifacts conflict:
-
-1. Accepted ADRs in `spec/adr/`
-2. Narrative specs listed in `spec/README.md`
-3. Active plans, when the task is executing that plan
-4. Current code and tests
-
-If a higher-precedence doc is wrong, update it deliberately and explain why.
-The old manual requirements/traceability workflow is retired; legacy REQ IDs
-are archived at
-[`docs/historical/requirements-legacy.yaml`](./docs/historical/requirements-legacy.yaml)
-only to make old references understandable.
-
-## Workflows
-
-### Normal Code Work
-
-1. Inspect `git status --short`.
-2. Find the governing code, ADR/spec, and tests.
-3. Name the scope and must-not-change invariants for behavior changes.
-4. Edit narrowly, following existing patterns.
-5. Run focused tests, then broader tests proportional to risk.
-6. Update docs only when behavior, public contracts, release framing, privacy,
-   persistence, or user workflows changed.
-
-Plans are working memory for agents, not a process tax. Create/update a plan
-for multi-step or long-running work when it will prevent drift; skip plans for
-small fixes.
-
-### PR Review
-
-Use [`docs/pr-review-workflow.md`](./docs/pr-review-workflow.md). Scale the loop
-to risk:
-
-- Trivial: direct commit is fine.
-- Small: focused tests and one fresh-eye pass are usually enough.
-- Substantial: branch from `origin/main`, open a PR, run CI, use independent
-  review, run local Greptile CLI review with
-  `scripts/dev/greptile_review.sh origin/main`, and converge on findings rather
-  than obeying every model suggestion. Greptile CLI ignores uncommitted changes,
-  so use a clean PR worktree with committed changes before treating it as signal.
-
-### Commit Messages
-
-Use [`docs/commit-guidelines.md`](./docs/commit-guidelines.md). Rich commit
-messages are for meaningful changes; concise messages are fine when they carry
-the future-reader context.
-
-## Hard-Won Pitfalls
-
-- Base new worktrees on `origin/main`, not local `main`.
-- Build/test from the worktree that owns the branch.
-- Ignore `.build*`, `.claude/worktrees`, `dist`, and
-  `journal/x-agent/node_modules` unless intentionally inspecting generated or
-  archival output.
-- Do not delete the user database, meeting session folders, lock files, or
-  source audio outside explicit recovery/discard flows.
-- Read subsystem READMEs before editing load-bearing Core areas:
-  `Audio/`, `STT/`, `TextProcessing/`, `Database/`, `Licensing/`.
-- GRDB UUID storage may not match `uuidString`; prefer repository/fetch-update
-  patterns over raw SQL `WHERE id = ?` with string UUIDs.
-- `PermissionService` is instantiated; it is not `.shared`.
-- Avoid fire-and-forget `Task` when the caller needs the result. Make the
-  function async and await it.
-- Avoid blocking `@MainActor` with long-running work.
-- `UTType(filenameExtension:)` can be nil.
-- Tooltips/hover behavior on non-activating panels often needs AppKit-level
-  tracking, not only SwiftUI `.help()` or `.onHover`.
-- `DictationFlowCoordinatorLoadCaptionTests` has historically had a short
-  timing race in CI. Rerun once before treating a single failure as a product
-  regression; investigate if it is reproducible or frequent.
-- CLI behavior is a public contract for external-facing commands. Update
-  `Sources/CLI/CHANGELOG.md` for compatibility-relevant changes.
-
-## Verification Defaults
-
-```bash
-swift build
-swift test --filter TextProcessingPipelineTests
-swift test
-scripts/dev/check.sh [TestFilter]
-scripts/dev/run_app.sh
-swift run macparakeet-cli health
-```
-
-Use the smallest command that proves the change while iterating. Before calling
-code work complete, run `swift test` unless the user explicitly narrows the
-verification scope or the environment blocks it.
+- Agent memory/instruction governance:
+  [`docs/agent-memory-governance.md`](./docs/agent-memory-governance.md)
+- Current feature/release state: [`spec/README.md`](./spec/README.md)
+- PR workflow: [`docs/pr-review-workflow.md`](./docs/pr-review-workflow.md)

--- a/Package.swift
+++ b/Package.swift
@@ -86,6 +86,7 @@ let package = Package(
                 "Database/README.md",
                 "Licensing/README.md",
                 "Resources",
+                "Services/System/README.md",
                 "STT/README.md",
                 "TextProcessing/README.md",
             ]

--- a/Sources/MacParakeetCore/Services/System/README.md
+++ b/Sources/MacParakeetCore/Services/System/README.md
@@ -1,0 +1,56 @@
+# System Services
+
+> Thin wrappers around macOS system surfaces: permissions, clipboard,
+> accessibility selection, paste replacement, focused-app context, media
+> control, and launch-at-login.
+
+## Entry Point
+
+Use the protocol for the surface you need and inject the concrete service from
+the app environment. These services touch AppKit, Accessibility, CoreGraphics,
+or other process-global macOS APIs; keep call sites explicit so tests can
+replace them with mocks.
+
+## What Is Here
+
+- `PermissionService.swift` -- microphone, screen recording, and Accessibility
+  checks/prompts/settings links.
+- `ClipboardService.swift` -- pasteboard writes and restore behavior.
+- `SelectionCaptureService.swift` and `SelectionReplacementService.swift` --
+  Accessibility-backed selected-text capture and replacement.
+- `FocusedAppContextService.swift` -- frontmost app metadata for contextual
+  transforms.
+- `SystemMediaController.swift` -- media pause/resume bridge used before
+  dictation capture.
+- `LaunchAtLoginService.swift` -- launch-at-login integration.
+
+## What To Know Before Editing
+
+**Services are instance-owned and protocol-backed.** `PermissionService` is not
+a singleton and has no `.shared`. Depend on `PermissionServiceProtocol` and
+construct/inject a concrete `PermissionService` from the app layer or a mock
+from tests.
+
+**Permission prompts are user-visible product surfaces.** Screen recording,
+microphone, and Accessibility flows affect onboarding, Settings, dictation, and
+meeting capture. Update the governing UI/spec docs and tests when prompt
+timing, copy, or recovery behavior changes.
+
+**Do not hide ordered work in detached tasks.** If a caller needs the result,
+error, or ordering of a system operation, make the path async and await it.
+Fire-and-forget tasks are only appropriate for deliberately detached cleanup,
+best-effort telemetry, or UI effects whose cancellation is harmless.
+
+**Keep `@MainActor` work short.** AppKit and Accessibility entry points often
+start on the main actor, but long-running I/O, process execution, model work,
+and waits should move off the actor and publish results back to UI state.
+
+## How To Verify A Change
+
+- Permission/onboarding behavior: `swift test --filter OnboardingViewModelTests`
+  plus the relevant dictation or meeting flow tests.
+- Selection/Transform behavior: `swift test --filter TransformExecutorTests`
+  and `swift test --filter TransformsHotkeyRegistryTests`.
+- Clipboard/paste behavior: run the focused service/view-model test that owns
+  the edited call path, then `swift test` for broad coverage before merging a
+  behavior change.

--- a/docs/agent-memory-governance.md
+++ b/docs/agent-memory-governance.md
@@ -30,8 +30,8 @@ Anthropic's current Claude Code guidance draws the boundary this way:
   the right bridge when the repo already has cross-agent instructions.
 - Multi-step or narrow-context procedures should move to skills, path-scoped
   rules, or local subsystem docs instead of root startup files.
-- `autoMemoryEnabled: false`, `/memory`, or
-  `CLAUDE_CODE_DISABLE_AUTO_MEMORY=1` disable both reading and writing auto
+- Setting `autoMemoryEnabled: false`, toggling `/memory`, or setting
+  `CLAUDE_CODE_DISABLE_AUTO_MEMORY=1` disables both reading and writing auto
   memory.
 
 Use hooks, scripts, tests, permissions, or product code when something must be
@@ -82,6 +82,8 @@ nearly every session.
 - Permissions, clipboard, Accessibility selection/replacement, focused-app
   context, media control, and launch-at-login:
   `Sources/MacParakeetCore/Services/System/README.md`.
+- Test timing, flake triage, and CI-reliability notes: `spec/09-testing.md` or
+  the focused test file's header comments.
 - Public CLI behavior: `integrations/README.md`, `Sources/CLI/README.md`,
   `Sources/CLI/CHANGELOG.md`, and CLI tests.
 - Release, signing, notarization, Sparkle, and DMG details:

--- a/docs/agent-memory-governance.md
+++ b/docs/agent-memory-governance.md
@@ -1,0 +1,113 @@
+# Agent Memory Governance
+
+> Status: **ACTIVE** -- how MacParakeet keeps agent instructions useful without
+> turning every session into a long-context tax.
+
+## Verdict
+
+The sensible move is not "delete all memory." It is to stop treating
+always-loaded memory as a knowledge base.
+
+MacParakeet should keep a small push layer that loads every session and move
+everything else to pull surfaces the agent reads only when relevant. Durable,
+single-subsystem lessons belong in code, tests, subsystem READMEs, specs, or
+skills. Volatile state belongs behind live commands and canonical sources, not
+in startup instructions.
+
+## What Loads
+
+Anthropic's current Claude Code guidance draws the boundary this way:
+
+- `CLAUDE.md` files and auto memory both load at the start of a session as
+  context, not enforced configuration.
+- Claude follows concise, specific instructions more reliably than long,
+  conflicting ones.
+- Each `CLAUDE.md` should stay under 200 lines. Imports help organization but
+  still load into startup context.
+- Auto memory loads only the first 200 lines or 25 KB of `MEMORY.md`, whichever
+  comes first. Topic files are pull-only unless Claude reads them.
+- Claude reads `CLAUDE.md`, not `AGENTS.md`. A one-line `@AGENTS.md` import is
+  the right bridge when the repo already has cross-agent instructions.
+- Multi-step or narrow-context procedures should move to skills, path-scoped
+  rules, or local subsystem docs instead of root startup files.
+- `autoMemoryEnabled: false`, `/memory`, or
+  `CLAUDE_CODE_DISABLE_AUTO_MEMORY=1` disable both reading and writing auto
+  memory.
+
+Use hooks, scripts, tests, permissions, or product code when something must be
+enforced. Startup instructions only shape model behavior.
+
+## Repo Policy
+
+Use the smallest durable surface that can carry the lesson:
+
+| Surface | Put here | Do not put here |
+| --- | --- | --- |
+| `AGENTS.md` | Cross-agent commands, repo invariants, source-of-truth links, worktree rules | Claude-only details or volatile release facts |
+| `CLAUDE.md` | `@AGENTS.md` plus Claude-specific memory/rule behavior | Repeated copies of commands, specs, review workflow, or subsystem gotchas |
+| Specs/ADRs | Product behavior, accepted decisions, public contracts | One-off agent notes |
+| Subsystem READMEs | Local implementation hazards and edit rules | Whole-repo workflow guidance |
+| `docs/pr-review-workflow.md` | Review and merge-readiness process | Feature-specific implementation notes |
+| Skills | Reusable multi-step workflows or tool recipes | Always-true repo facts |
+| Claude auto memory | Machine-local hints that are useful to retrieve on demand | Source of truth for releases, PRs, CI, deploys, analytics, or secrets |
+
+## Audit Buckets
+
+When reviewing `CLAUDE.md`, `AGENTS.md`, or local auto memory, bucket each entry:
+
+1. **Finished-work record**: delete it. Git history, PRs, and plans carry this.
+2. **Volatile live state**: replace it with the command or canonical source to
+   verify live.
+3. **Single-subsystem lesson**: move it to the subsystem README, governing spec,
+   a focused test, or a skill.
+4. **Reusable workflow**: move it to a skill or workflow doc.
+5. **Cross-cutting safety rail**: keep it in `AGENTS.md` or the small
+   Claude-specific overlay only if it changes behavior in many tasks.
+
+An entry earns startup context only if it changes a likely next decision in
+nearly every session.
+
+## Promotion Map
+
+- Database migrations, GRDB UUID storage, or repository access patterns:
+  `Sources/MacParakeetCore/Database/README.md` and `spec/01-data-model.md`.
+- STT scheduling, engine routing, and runtime constraints:
+  `Sources/MacParakeetCore/STT/README.md`, `spec/06-stt-engine.md`, and focused
+  tests.
+- Audio capture, meeting artifacts, and recovery:
+  `Sources/MacParakeetCore/Audio/README.md`, `spec/05-audio-pipeline.md`,
+  `spec/contracts/`, and recovery tests.
+- UI hover, panel, and visual interaction rules: `spec/04-ui-patterns.md` or
+  local view/controller comments when the behavior is highly localized.
+- Public CLI behavior: `integrations/README.md`, `Sources/CLI/README.md`,
+  `Sources/CLI/CHANGELOG.md`, and CLI tests.
+- Release, signing, notarization, Sparkle, and DMG details:
+  `docs/distribution.md` and `spec/README.md`.
+- PR review, worktree safety, and merge readiness:
+  `AGENTS.md` and `docs/pr-review-workflow.md`.
+- Security-sensitive local facts, env vars, and private keys: do not commit.
+  Store them outside the repo or in an approved secret manager.
+
+## Maintenance Checklist
+
+Run this check when agent behavior starts drifting or a memory file gets noisy:
+
+```bash
+wc -l CLAUDE.md AGENTS.md
+git diff -- CLAUDE.md AGENTS.md docs/agent-memory-governance.md
+```
+
+For Claude auto memory, inspect it locally with `/memory`. Back it up outside
+the auto-loaded directory before pruning, then delete or promote entries using
+the buckets above. Do not commit the local memory store.
+
+## Sources
+
+- Anthropic Claude Code memory:
+  https://docs.anthropic.com/en/docs/claude-code/memory
+- Anthropic Claude Code settings:
+  https://docs.anthropic.com/en/docs/claude-code/settings
+- Anthropic Claude Code skills:
+  https://docs.anthropic.com/en/docs/claude-code/skills
+- Anthropic Claude Code subagents:
+  https://docs.anthropic.com/en/docs/claude-code/sub-agents

--- a/docs/agent-memory-governance.md
+++ b/docs/agent-memory-governance.md
@@ -79,6 +79,9 @@ nearly every session.
   `spec/contracts/`, and recovery tests.
 - UI hover, panel, and visual interaction rules: `spec/04-ui-patterns.md` or
   local view/controller comments when the behavior is highly localized.
+- Permissions, clipboard, Accessibility selection/replacement, focused-app
+  context, media control, and launch-at-login:
+  `Sources/MacParakeetCore/Services/System/README.md`.
 - Public CLI behavior: `integrations/README.md`, `Sources/CLI/README.md`,
   `Sources/CLI/CHANGELOG.md`, and CLI tests.
 - Release, signing, notarization, Sparkle, and DMG details:

--- a/docs/research/coding-agent-instructions-2026-06.md
+++ b/docs/research/coding-agent-instructions-2026-06.md
@@ -10,6 +10,9 @@ test, navigate, and avoid known project hazards. Volatile feature catalogs,
 release deltas, long plans, and historical requirement indexes should live in
 linked docs that agents load only when relevant.
 
+The operating policy for memory and instruction placement lives in
+[`../agent-memory-governance.md`](../agent-memory-governance.md).
+
 This supports the current split:
 
 - `AGENTS.md` is the canonical cross-agent startup guide.
@@ -21,15 +24,29 @@ This supports the current split:
 
 ### Anthropic Claude Code
 
-Anthropic describes `CLAUDE.md` as persistent context loaded into sessions, not
-enforced configuration. Their guidance says concise, specific instructions are
-followed more consistently, and recommends adding material when it represents
-something Claude would otherwise need re-explained: repeated mistakes, review
-feedback, recurring clarifications, or context a new teammate needs. It also
-suggests moving multi-step or narrow-context procedures out of the always-loaded
-file into more specific mechanisms.
+Anthropic describes `CLAUDE.md` and auto memory as context loaded at session
+start, not enforced configuration. Their guidance says concise, specific
+instructions are followed more consistently, recommends keeping each
+`CLAUDE.md` under 200 lines, and notes that imported files still enter startup
+context. Claude loads `CLAUDE.md`, not `AGENTS.md`, so an `@AGENTS.md` import
+is the intended bridge for repos that already have a cross-agent guide.
 
-Source: https://code.claude.com/docs/en/memory
+Auto memory is a separate machine-local layer. Claude loads only the first 200
+lines or 25 KB of `MEMORY.md` at startup; topic files are read on demand. The
+settings docs also make the tradeoff explicit: disabling auto memory via
+`autoMemoryEnabled`, `/memory`, or `CLAUDE_CODE_DISABLE_AUTO_MEMORY=1` disables
+both reading and writing.
+
+Anthropic's recommended escape hatches are path-scoped `.claude/rules/`, skills
+for reusable procedures, subagents for context-isolated work, and hooks or
+settings when behavior must be enforced rather than suggested.
+
+Sources:
+
+- https://docs.anthropic.com/en/docs/claude-code/memory
+- https://docs.anthropic.com/en/docs/claude-code/settings
+- https://docs.anthropic.com/en/docs/claude-code/skills
+- https://docs.anthropic.com/en/docs/claude-code/sub-agents
 
 ### OpenAI Codex
 
@@ -108,8 +125,8 @@ Source: https://arxiv.org/html/2506.12286v1
    file when possible.
 2. Put commands, worktree rules, product constraints, and verification defaults
    in `AGENTS.md`.
-3. Keep `CLAUDE.md` real but narrow: Claude-specific operating style,
-   high-risk pitfalls, and links to current sources.
+3. Keep `CLAUDE.md` real but narrow: Claude-specific memory behavior,
+   local-state cautions, and links to current sources.
 4. Link to specs and ADRs for feature state instead of duplicating release
    flags in startup context.
 5. Treat plans as useful agent working memory for substantial tasks, not a
@@ -118,3 +135,7 @@ Source: https://arxiv.org/html/2506.12286v1
    search, and `git` history for current implementation discovery.
 7. Use independent review and convergence for substantial changes, but keep the
    review loop proportional to risk.
+8. Treat auto memory as a stale-prone hint store, not a source of truth for
+   release, PR, CI, deploy, analytics, or current product state.
+9. Promote single-subsystem lessons out of global memory into subsystem READMEs,
+   specs, tests, workflow docs, or skills.

--- a/spec/04-ui-patterns.md
+++ b/spec/04-ui-patterns.md
@@ -627,6 +627,8 @@ Drop zone components:
 - "Browse Files" button: .borderedProminent style
 - Supported formats text: caption, tertiary
 - Drop zone height: 200pt (DesignSystem.Layout.dropZoneHeight)
+- Open-panel type filters should guard `UTType(filenameExtension:)` results;
+  supported extension strings can still produce `nil`.
 ```
 
 ### Processing State

--- a/spec/09-testing.md
+++ b/spec/09-testing.md
@@ -83,6 +83,14 @@ The suite includes targeted regressions for progress behavior in URL transcripti
 - `TranscriptionServiceTests`: download-phase percentages are forwarded to `onProgress`
 - `TranscriptionViewModelTests`: phase text percent parsing updates UI progress and resets on non-percent phases
 
+### Dictation Flow Timing Tests
+
+`DictationFlowCoordinatorLoadCaptionTests` uses intentionally compressed async
+timing windows to keep first-install/model-load caption coverage fast. If one
+of those tests fails once in CI, rerun it before calling it a product
+regression; if it fails reproducibly or frequently, investigate the coordinator
+timing instead of ignoring it.
+
 ### Meeting Recording Tests
 
 **What:** Meeting recording flow, state machine transitions, chunk ordering, audio pipeline.


### PR DESCRIPTION
## Summary

Agent startup instructions now follow the push-vs-pull boundary from current Anthropic Claude Code docs: `CLAUDE.md` stays as a small Claude-specific overlay that imports `AGENTS.md`, while the deeper memory policy lives in a pull-on-demand governance doc.

## What changed

- Shrinks `CLAUDE.md` from 136 lines to 41 lines, removing duplicated workflow guidance already covered by `AGENTS.md`, specs, and local READMEs.
- Adds `docs/agent-memory-governance.md` with audit buckets, a promotion map, and sourced guidance for `CLAUDE.md`, auto memory, skills, path-scoped rules, and subagents.
- Promotes the old hard-won pitfalls into narrower durable homes: System services README, `AGENTS.md` concurrency rules, UI patterns for `UTType(filenameExtension:)`, and the testing spec for the dictation-caption timing note.
- Updates `AGENTS.md` and the June instruction research note so agents treat memory and old notes as hints, verify live state from canonical sources, and avoid ignored/generated/private paths unless the task names them.

## Why

Always-loaded instructions are the most expensive context in an agent session because every run pays for them. This keeps global context focused on rules that change decisions in many tasks, and gives single-subsystem lessons a clearer path into subsystem docs, specs, tests, workflow docs, or skills.

## Verification

- `git diff --check`
- Local path sanity for referenced repo docs
- `scripts/dev/check.sh` -- debug `swift build` passed; report-only `swift-format lint` emitted existing Swift warnings outside this change
- `swift build` after the review-response commit -- passed; remaining SwiftPM unhandled-file warnings are pre-existing (`Sources/CLI/README.md` and FluidAudio checkout markdown)
- GitHub CI `swift-test` -- passed: release build, bundle smoke, Swift concurrency safety, Swift 6 language mode, and full Swift tests
- Cubic AI reviewer -- passed
- Greptile and Gemini comments addressed; all review threads resolved

## Sources

- Anthropic Claude Code memory: https://docs.anthropic.com/en/docs/claude-code/memory
- Anthropic Claude Code settings: https://docs.anthropic.com/en/docs/claude-code/settings
- Anthropic Claude Code skills: https://docs.anthropic.com/en/docs/claude-code/skills
- Anthropic Claude Code subagents: https://docs.anthropic.com/en/docs/claude-code/sub-agents

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/model-GPT--5-000000)