### PR TITLE
fix(telemetry): dedup mic_stall_detected to once per recording per signature

### DIFF
--- a/Sources/MacParakeetCore/Audio/MeetingAudioCaptureService.swift
+++ b/Sources/MacParakeetCore/Audio/MeetingAudioCaptureService.swift
@@ -366,6 +366,14 @@ private final class MeetingMicHealthTelemetryObserver: @unchecked Sendable {
     private let featureEnabled: Bool
     private var monitor: MeetingMicHealthMonitor
     private var isObserving = false
+    /// ADR-025 Phase A specifies `mic_stall_detected` is "fired once per confirmed
+    /// stall trip" so the field can confirm *which* signatures occur. But the monitor
+    /// re-trips every time a near-silent mic momentarily crosses the non-silent
+    /// threshold — i.e. a participant who is listening, not speaking — so a single
+    /// recording re-detects the same signature continuously. We dedup to once per
+    /// recording per signature: enough to learn the signature's field incidence (the
+    /// Phase A goal) without the per-buffer firehose. Reset on every `start`.
+    private var reportedSignatures: Set<MeetingMicHealthMonitor.StallSignature> = []
 
     init(
         config: MeetingMicHealthMonitor.Config = .default,
@@ -381,6 +389,7 @@ private final class MeetingMicHealthTelemetryObserver: @unchecked Sendable {
     func start(observing sourceIncludesMicrophone: Bool) {
         lock.withLock {
             monitor = MeetingMicHealthMonitor(config: config)
+            reportedSignatures.removeAll()
             isObserving = featureEnabled && sourceIncludesMicrophone
         }
     }
@@ -388,6 +397,7 @@ private final class MeetingMicHealthTelemetryObserver: @unchecked Sendable {
     func stop() {
         lock.withLock {
             monitor.reset()
+            reportedSignatures.removeAll()
             isObserving = false
         }
     }
@@ -417,17 +427,26 @@ private final class MeetingMicHealthTelemetryObserver: @unchecked Sendable {
         systemSignal: MeetingMicHealthMonitor.AudioSignal?
     ) {
         let now = nowProvider()
-        let events = lock.withLock {
-            guard isObserving else { return [MeetingMicHealthMonitor.HealthEvent]() }
-            return monitor.ingest(micSignal: micSignal, systemSignal: systemSignal, now: now)
-        }
-
-        for event in events {
-            guard case let .stallSuspected(signature, elapsedMs) = event else {
+        // Resolve which signatures are newly reported *inside* the lock (the monitor
+        // state and the dedup set are both mutated from the audio callback thread),
+        // then emit telemetry outside it so `Telemetry.send` never runs under the lock.
+        let freshStalls: [(MeetingMicHealthMonitor.StallSignature, Int)] = lock.withLock {
+            guard isObserving else { return [] }
+            let events = monitor.ingest(micSignal: micSignal, systemSignal: systemSignal, now: now)
+            var fresh: [(MeetingMicHealthMonitor.StallSignature, Int)] = []
+            for event in events {
                 // ADR-025 Phase A emits only detection telemetry; warning and recovery
                 // surfaces consume `.recovered` in later phases.
-                continue
+                guard case let .stallSuspected(signature, elapsedMs) = event else { continue }
+                // First occurrence of this signature in the current recording only.
+                if reportedSignatures.insert(signature).inserted {
+                    fresh.append((signature, elapsedMs))
+                }
             }
+            return fresh
+        }
+
+        for (signature, elapsedMs) in freshStalls {
             Telemetry.send(.micStallDetected(signature: .init(signature), elapsedMs: elapsedMs))
         }
     }

--- a/Tests/MacParakeetTests/Audio/MeetingAudioCaptureServiceTests.swift
+++ b/Tests/MacParakeetTests/Audio/MeetingAudioCaptureServiceTests.swift
@@ -289,6 +289,49 @@ final class MeetingAudioCaptureServiceTests: XCTestCase {
         XCTAssertEqual(events.first?.props?["elapsed_ms"], "0")
     }
 
+    func testMicHealthTelemetryReportsFlappingSilentMicOnce() async throws {
+        // A listening (not speaking) participant produces a near-silent mic that
+        // momentarily crosses the non-silent threshold and back — the monitor
+        // recovers and re-trips `.micSilent` on every crossing. Without per-recording
+        // dedup this single recording emits hundreds of identical events (the field
+        // firehose: ~38k events from ~240 sessions). It must emit exactly once.
+        let microphone = MockMeetingMicrophoneCapture()
+        let systemCapture = MockMeetingSystemAudioCapture()
+        let telemetry = MeetingAudioTelemetrySpy()
+        Telemetry.configure(telemetry)
+        defer { Telemetry.configure(NoOpTelemetryService()) }
+
+        let now = MutableDateProvider(Date(timeIntervalSince1970: 1_800_000_000))
+        let service = MeetingAudioCaptureService(
+            microphoneCapture: microphone,
+            systemAudioCaptureFactory: { systemCapture },
+            micHealthConfig: .init(systemActiveConfirmationSeconds: 0),
+            micHealthNowProvider: { now.value() }
+        )
+
+        _ = try await service.start()
+        defer { Task { await service.stop() } }
+
+        let silent = try XCTUnwrap(makeInterleavedFloatStereoBuffer(samples: [0, 0, 0, 0]))
+        let loud = try XCTUnwrap(makeInterleavedFloatStereoBuffer(samples: [0.25, 0.25, 0.25, 0.25]))
+
+        // Mic delivers a silent buffer first (so the confirmed signature is mic_silent,
+        // not mic_missing), then system audio goes active and confirms the stall.
+        microphone.emit(buffer: silent, time: AVAudioTime(hostTime: 1))
+        systemCapture.emit(buffer: loud, time: AVAudioTime(hostTime: 1))
+
+        // Flap silent<->non-silent many times: each cycle recovers then re-trips
+        // `.micSilent`. Dedup must collapse all of these to the single first event.
+        for _ in 0..<10 {
+            microphone.emit(buffer: loud, time: AVAudioTime(hostTime: 1))
+            microphone.emit(buffer: silent, time: AVAudioTime(hostTime: 1))
+        }
+
+        let events = telemetry.snapshot().filter { $0.name == .micStallDetected }
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events.first?.props?["signature"], "mic_silent")
+    }
+
     func testMicHealthTelemetryDoesNotRunInSystemOnlyMode() async throws {
         let microphone = MockMeetingMicrophoneCapture()
         let systemCapture = MockMeetingSystemAudioCapture()

--- a/Tests/MacParakeetTests/Audio/MeetingAudioCaptureServiceTests.swift
+++ b/Tests/MacParakeetTests/Audio/MeetingAudioCaptureServiceTests.swift
@@ -310,7 +310,9 @@ final class MeetingAudioCaptureServiceTests: XCTestCase {
         )
 
         _ = try await service.start()
-        defer { Task { await service.stop() } }
+        // Async teardown so XCTest awaits stop() before the next test (no detached
+        // Task-in-defer race — this file has a history of timing-sensitive tests).
+        addTeardownBlock { await service.stop() }
 
         let silent = try XCTUnwrap(makeInterleavedFloatStereoBuffer(samples: [0, 0, 0, 0]))
         let loud = try XCTUnwrap(makeInterleavedFloatStereoBuffer(samples: [0.25, 0.25, 0.25, 0.25]))


### PR DESCRIPTION
## What

`mic_stall_detected` is the **#5 telemetry event by volume** — ~39k events in the last 14 days — yet they come from only **~240 meeting sessions** (~160 events/session), ~100% `mic_silent`, on 0.6.23/0.6.24. The meetings themselves complete at 96%, so these are not failures — they are a noisy detector, not a product regression.

## Root cause

`MeetingMicHealthMonitor` already latches one `.stallSuspected` per episode. But `.micSilent` **recovers on any single non-silent mic buffer**. A participant who is *listening, not speaking* has a near-silent mic that momentarily crosses the non-silent threshold and back, so the monitor recovers and re-trips on every crossing for the entire meeting.

ADR-025 (Telemetry) specifies the event is **"fired once per confirmed stall trip"** for the explicit Phase-A purpose of *confirming the signature in the field*. The per-buffer firehose makes that incidence unreadable (it outweighs even `app_launched`).

## Fix

Dedup at the **telemetry-emission layer** (`MeetingMicHealthTelemetryObserver`) — once per recording per signature, reset on every `start()`. Deliberately **not** in the monitor: its per-episode detection is left intact so the future Phase-B warning UI and recovery surfaces still observe every `.stallSuspected` / `.recovered`.

Emission-only: **no change** to the capture graph, the detector state machine, or any user-facing behavior. Collapses ~38k flaps to ~one event per affected session per signature — the clean field signal ADR-025 wanted.

## Test

`testMicHealthTelemetryReportsFlappingSilentMicOnce`: the flapping loop emits 11 events without the dedup, exactly **1** with it. Full `swift test` green locally.

## Deliberately not in this PR

Expanding the `TelemetryAppCategory` bundle-ID map (to shrink the 43%-of-dictation `other` bucket) was left out on purpose: `TelemetryAppCategory` also drives the **AI Formatter's** per-app smart-default prompt at dictation runtime (`AIFormatterProfileMatcher.resolve` → `AIFormatterSmartDefaults.categoryDefault`), so reclassifying apps would silently change formatting for users with the AI Formatter enabled. That belongs in its own change where the behavior shift is the reviewed headline, not a side effect of a telemetry cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates `mic_stall_detected` so it fires once per recording per signature, collapsing the flapping firehose into a single event per session. Detection logic and UI behavior are unchanged; this restores clean field signal per ADR‑025.

- **Bug Fixes**
  - Added per-recording signature dedup in `MeetingMicHealthTelemetryObserver`; resets on `start()`/`stop()`.
  - Resolves new stalls inside the lock and emits telemetry outside it; only for `.stallSuspected` so `Telemetry.send` never runs under the lock. Monitor’s per-episode detection remains intact.
  - New test `testMicHealthTelemetryReportsFlappingSilentMicOnce` confirms flapping collapses to one `mic_silent` event; teardown now awaits `stop()` via `addTeardownBlock` to avoid races.
  - No changes to the capture graph or user behavior; reduces ~160 duplicate events per affected session to one.

<sup>Written for commit 01b32e340332a69eeba96f4bd42a87509fe711dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/645?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

