### PR TITLE
Verify LocalVQE release assets for meeting AEC

### DIFF
--- a/Sources/MacParakeetCore/Services/Capture/MeetingEchoSuppressionRuntime.swift
+++ b/Sources/MacParakeetCore/Services/Capture/MeetingEchoSuppressionRuntime.swift
@@ -144,6 +144,13 @@ enum MeetingEchoSuppressionFactory {
     static let defaultLibraryName = "liblocalvqe.dylib"
     static let defaultModelDirectoryName = "MeetingEchoSuppression"
     static let defaultModelName = "localvqe-v1.2-1.3M-f32.gguf"
+    static let bundledModelNames = [
+        "localvqe-v1.4-aec-200K-f32.gguf",
+        defaultModelName,
+        "localvqe-v1.3-4.8M-f32.gguf",
+        "localvqe-v1.4-aec-200K-bf16.gguf",
+        "localvqe-v1.4-aec-2.7K-f32.gguf",
+    ]
     private static let logger = Logger(
         subsystem: "com.macparakeet.core",
         category: "MeetingEchoSuppression"
@@ -218,17 +225,56 @@ enum MeetingEchoSuppressionFactory {
             fileManager: fileManager
         )
         let modelURL = existingFile(
-            candidates: [
-                configuration.modelURL,
-                bundle.resourceURL?
-                    .appendingPathComponent(defaultModelDirectoryName)
-                    .appendingPathComponent(defaultModelName),
-            ],
+            candidates: bundledModelCandidates(
+                configuration: configuration,
+                bundle: bundle,
+                fileManager: fileManager
+            ),
             fileManager: fileManager
         )
 
         guard let libraryURL, let modelURL else { return nil }
         return DynamicAssets(libraryURL: libraryURL, modelURL: modelURL)
+    }
+
+    static func bundledModelCandidates(
+        configuration: MeetingEchoSuppressionConfiguration,
+        bundle: Bundle,
+        fileManager: FileManager
+    ) -> [URL?] {
+        var candidates: [URL?] = [configuration.modelURL]
+        guard let modelDirectory = bundle.resourceURL?
+            .appendingPathComponent(defaultModelDirectoryName)
+        else {
+            return candidates
+        }
+
+        let knownNames = Set(bundledModelNames)
+        candidates += bundledModelNames.map { modelDirectory.appendingPathComponent($0) }
+
+        let discovered = (try? fileManager.contentsOfDirectory(
+            at: modelDirectory,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsHiddenFiles]
+        ))?
+            .filter { url in
+                guard url.pathExtension.lowercased() == "gguf",
+                      !knownNames.contains(url.lastPathComponent)
+                else {
+                    return false
+                }
+                return (try? url.resourceValues(forKeys: [.isRegularFileKey]).isRegularFile) == true
+            }
+            .sorted { $0.lastPathComponent < $1.lastPathComponent } ?? []
+        if discovered.count == 1 {
+            candidates += discovered
+        } else if discovered.count > 1 {
+            let names = discovered.map(\.lastPathComponent).joined(separator: ",")
+            logger.warning(
+                "meeting_echo_unknown_models_ambiguous count=\(discovered.count, privacy: .public) names=\(names, privacy: .public)"
+            )
+        }
+        return candidates
     }
 
     private static func existingFile(
@@ -346,7 +392,7 @@ private enum DynamicLibraryMeetingEchoProcessorError: Error, CustomStringConvert
     case libraryLoadFailed(String)
     case missingSymbol(String)
     case createFailed(String)
-    case invalidFrameSize(expected: Int, microphone: Int, reference: Int)
+    case invalidFrameSize(expected: Int, microphone: Int, reference: Int, output: Int)
     case processingFailed(code: Int32, message: String)
 
     var description: String {
@@ -357,8 +403,8 @@ private enum DynamicLibraryMeetingEchoProcessorError: Error, CustomStringConvert
             return "missing symbol: \(symbol)"
         case .createFailed(let message):
             return "create failed: \(message)"
-        case let .invalidFrameSize(expected, microphone, reference):
-            return "invalid frame size: expected=\(expected) microphone=\(microphone) reference=\(reference)"
+        case let .invalidFrameSize(expected, microphone, reference, output):
+            return "invalid frame size: expected=\(expected) microphone=\(microphone) reference=\(reference) output=\(output)"
         case let .processingFailed(code, message):
             return "processing failed: code=\(code) message=\(message)"
         }
@@ -461,7 +507,8 @@ final class DynamicLibraryMeetingEchoProcessor: MeetingEchoSuppressing, @uncheck
             throw DynamicLibraryMeetingEchoProcessorError.invalidFrameSize(
                 expected: frameSize,
                 microphone: microphone.count,
-                reference: reference.count
+                reference: reference.count,
+                output: output.count
             )
         }
 

--- a/Sources/MacParakeetCore/Services/Capture/MeetingEchoSuppressionRuntime.swift
+++ b/Sources/MacParakeetCore/Services/Capture/MeetingEchoSuppressionRuntime.swift
@@ -249,7 +249,7 @@ enum MeetingEchoSuppressionFactory {
             return candidates
         }
 
-        let knownNames = Set(bundledModelNames)
+        let knownNames = Set(bundledModelNames.map { $0.lowercased() })
         candidates += bundledModelNames.map { modelDirectory.appendingPathComponent($0) }
 
         let discovered = (try? fileManager.contentsOfDirectory(
@@ -259,7 +259,7 @@ enum MeetingEchoSuppressionFactory {
         ))?
             .filter { url in
                 guard url.pathExtension.lowercased() == "gguf",
-                      !knownNames.contains(url.lastPathComponent)
+                      !knownNames.contains(url.lastPathComponent.lowercased())
                 else {
                     return false
                 }

--- a/Tests/MacParakeetTests/Services/Capture/MeetingEchoSuppressionRuntimeTests.swift
+++ b/Tests/MacParakeetTests/Services/Capture/MeetingEchoSuppressionRuntimeTests.swift
@@ -408,6 +408,23 @@ final class MeetingEchoSuppressionRuntimeTests: XCTestCase {
         XCTAssertTrue(result.output.contains("missing required LocalVQE symbols"))
     }
 
+    func testDistributionVerifierAcceptsUniversalRuntime() throws {
+        let appURL = try Self.makeEchoAssetAppBundle(
+            modelName: "localvqe-v1.4-aec-200K-f32.gguf",
+            modelData: Data("model".utf8),
+            includeLibrary: true,
+            universalLibrary: true
+        )
+        defer { try? FileManager.default.removeItem(at: appURL.deletingLastPathComponent()) }
+        let result = try Self.runVerifier(
+            appURL: appURL,
+            environment: ["REQUIRE_MEETING_ECHO_ASSETS": "1"]
+        )
+
+        XCTAssertEqual(result.status, 0, result.output)
+        XCTAssertTrue(result.output.contains("Meeting echo assets verified"))
+    }
+
     private static func makeEmptyAppBundle() throws -> URL {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -423,7 +440,8 @@ final class MeetingEchoSuppressionRuntimeTests: XCTestCase {
         modelName: String,
         modelData: Data,
         includeLibrary: Bool,
-        includeRequiredSymbols: Bool = true
+        includeRequiredSymbols: Bool = true,
+        universalLibrary: Bool = false
     ) throws -> URL {
         let appURL = try makeEmptyAppBundle()
         let frameworksURL = appURL.appendingPathComponent("Contents/Frameworks", isDirectory: true)
@@ -443,7 +461,8 @@ final class MeetingEchoSuppressionRuntimeTests: XCTestCase {
         if includeLibrary {
             try writeLocalVQEDylib(
                 to: frameworksURL.appendingPathComponent("liblocalvqe.dylib"),
-                includeRequiredSymbols: includeRequiredSymbols
+                includeRequiredSymbols: includeRequiredSymbols,
+                universal: universalLibrary
             )
         }
         return appURL
@@ -451,7 +470,8 @@ final class MeetingEchoSuppressionRuntimeTests: XCTestCase {
 
     private static func writeLocalVQEDylib(
         to libraryURL: URL,
-        includeRequiredSymbols: Bool = true
+        includeRequiredSymbols: Bool = true,
+        universal: Bool = false
     ) throws {
         guard FileManager.default.isExecutableFile(atPath: "/usr/bin/clang") else {
             throw XCTSkip("clang is required to compile the LocalVQE ABI test runtime.")
@@ -485,14 +505,12 @@ final class MeetingEchoSuppressionRuntimeTests: XCTestCase {
 
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/clang")
-        process.arguments = [
-            "-dynamiclib",
-            sourceURL.path,
-            "-install_name",
-            "@rpath/liblocalvqe.dylib",
-            "-o",
-            libraryURL.path,
-        ]
+        var arguments = ["-dynamiclib", sourceURL.path]
+        if universal {
+            arguments += ["-arch", "arm64", "-arch", "x86_64"]
+        }
+        arguments += ["-install_name", "@rpath/liblocalvqe.dylib", "-o", libraryURL.path]
+        process.arguments = arguments
         let pipe = Pipe()
         process.standardOutput = pipe
         process.standardError = pipe
@@ -502,6 +520,9 @@ final class MeetingEchoSuppressionRuntimeTests: XCTestCase {
             data: pipe.fileHandleForReading.readDataToEndOfFile(),
             encoding: .utf8
         ) ?? ""
+        if universal && process.terminationStatus != 0 {
+            throw XCTSkip("Universal (arm64+x86_64) cross-compile unavailable: \(output)")
+        }
         XCTAssertEqual(process.terminationStatus, 0, output)
     }
 
@@ -535,7 +556,15 @@ final class MeetingEchoSuppressionRuntimeTests: XCTestCase {
 
     private static func repoRoot(filePath: String = #filePath) throws -> URL {
         var url = URL(fileURLWithPath: filePath)
-        while url.lastPathComponent != "Tests" {
+        if !url.hasDirectoryPath {
+            url.deleteLastPathComponent()
+        }
+        while true {
+            if FileManager.default.fileExists(
+                atPath: url.appendingPathComponent("Package.swift").path
+            ) {
+                return url
+            }
             let parent = url.deletingLastPathComponent()
             guard parent.path != url.path else {
                 throw NSError(
@@ -543,12 +572,11 @@ final class MeetingEchoSuppressionRuntimeTests: XCTestCase {
                     code: 1,
                     userInfo: [
                         NSLocalizedDescriptionKey:
-                            "Could not find repo root from test file path: \(filePath)"
+                            "Could not find Package.swift from test file path: \(filePath)"
                     ]
                 )
             }
             url = parent
         }
-        return url.deletingLastPathComponent()
     }
 }

--- a/Tests/MacParakeetTests/Services/Capture/MeetingEchoSuppressionRuntimeTests.swift
+++ b/Tests/MacParakeetTests/Services/Capture/MeetingEchoSuppressionRuntimeTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import XCTest
 @testable import MacParakeetCore
 
@@ -155,5 +156,399 @@ final class MeetingEchoSuppressionRuntimeTests: XCTestCase {
             try MeetingEchoSuppressionFactory.sha256Hex(for: fileURL),
             "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
         )
+    }
+
+    func testBundledModelCandidatesPreferKnownEchoModelsAndDiscoverUnknownSingleModel() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let bundleURL = root.appendingPathComponent("EchoAssets.bundle", isDirectory: true)
+        let resourcesURL = bundleURL.appendingPathComponent("Contents/Resources", isDirectory: true)
+        let modelDirectory = resourcesURL
+            .appendingPathComponent(
+                MeetingEchoSuppressionFactory.defaultModelDirectoryName,
+                isDirectory: true
+            )
+        try FileManager.default.createDirectory(
+            at: modelDirectory,
+            withIntermediateDirectories: true
+        )
+        try """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+          <key>CFBundleIdentifier</key>
+          <string>com.macparakeet.tests.EchoAssets</string>
+          <key>CFBundlePackageType</key>
+          <string>BNDL</string>
+        </dict>
+        </plist>
+        """.write(
+            to: bundleURL.appendingPathComponent("Contents/Info.plist"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try Data("v12".utf8).write(
+            to: modelDirectory.appendingPathComponent(
+                MeetingEchoSuppressionFactory.defaultModelName
+            )
+        )
+        try Data("v14".utf8).write(
+            to: modelDirectory.appendingPathComponent("localvqe-v1.4-aec-200K-f32.gguf")
+        )
+        try Data("custom".utf8).write(
+            to: modelDirectory.appendingPathComponent("custom-localvqe-test.gguf")
+        )
+        let nonModelURL = modelDirectory.appendingPathComponent("not-a-model.txt")
+        try Data("not a model".utf8).write(to: nonModelURL)
+        try FileManager.default.createSymbolicLink(
+            at: modelDirectory.appendingPathComponent("linked-localvqe-test.gguf"),
+            withDestinationURL: nonModelURL
+        )
+
+        let bundle = try XCTUnwrap(Bundle(url: bundleURL))
+        let candidateURLs = MeetingEchoSuppressionFactory.bundledModelCandidates(
+            configuration: MeetingEchoSuppressionConfiguration(),
+            bundle: bundle,
+            fileManager: .default
+        )
+        let candidates = candidateURLs.compactMap { $0?.lastPathComponent }
+
+        let firstCandidate = try XCTUnwrap(candidateURLs.first)
+        XCTAssertNil(firstCandidate)
+        XCTAssertEqual(candidates[0], "localvqe-v1.4-aec-200K-f32.gguf")
+        XCTAssertTrue(candidates.contains(MeetingEchoSuppressionFactory.defaultModelName))
+        XCTAssertEqual(candidates.last, "custom-localvqe-test.gguf")
+        XCTAssertFalse(candidates.contains("linked-localvqe-test.gguf"))
+    }
+
+    func testDynamicModeLoadsABICompatibleRuntimeAndProcessesInsteadOfPassthrough() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let libraryURL = root.appendingPathComponent("liblocalvqe.dylib")
+        let modelURL = root.appendingPathComponent("localvqe-v1.4-aec-200K-f32.gguf")
+        try Self.writeLocalVQEDylib(to: libraryURL)
+        try Data("stub model".utf8).write(to: modelURL)
+
+        let conditioner = MeetingEchoSuppressionFactory.makeConditioner(
+            configuration: MeetingEchoSuppressionConfiguration(
+                mode: .dynamicLibrary,
+                libraryURL: libraryURL,
+                modelURL: modelURL,
+                modelSHA256: try MeetingEchoSuppressionFactory.sha256Hex(for: modelURL)
+            ),
+            bundle: Bundle(for: Self.self)
+        )
+
+        let microphone = [Float](repeating: 1.0, count: 256)
+        let speaker = [Float](repeating: 0.25, count: 256)
+        let output = conditioner.condition(
+            microphone: microphone,
+            speaker: speaker,
+            hasSpeakerReference: true
+        )
+
+        XCTAssertEqual(conditioner.diagnostics.processorName, "localvqe")
+        XCTAssertTrue(conditioner.diagnostics.loaded)
+        XCTAssertEqual(output.count, microphone.count)
+        XCTAssertEqual(output.first ?? .nan, 0.75, accuracy: 0.0001)
+        XCTAssertEqual(conditioner.diagnostics.processedFrames, 1)
+    }
+
+    func testRealLocalVQERuntimeLoadsWhenTestAssetsAreProvided() throws {
+        let environment = ProcessInfo.processInfo.environment
+        guard let libraryPath = environment["MACPARAKEET_TEST_LOCALVQE_LIBRARY"],
+              let modelPath = environment["MACPARAKEET_TEST_LOCALVQE_MODEL"]
+        else {
+            throw XCTSkip(
+                "Set MACPARAKEET_TEST_LOCALVQE_LIBRARY and MACPARAKEET_TEST_LOCALVQE_MODEL to run real LocalVQE load verification."
+            )
+        }
+
+        let conditioner = MeetingEchoSuppressionFactory.makeConditioner(
+            configuration: MeetingEchoSuppressionConfiguration(
+                mode: .dynamicLibrary,
+                libraryURL: URL(fileURLWithPath: libraryPath),
+                modelURL: URL(fileURLWithPath: modelPath),
+                modelSHA256: environment["MACPARAKEET_TEST_LOCALVQE_MODEL_SHA256"]
+            ),
+            bundle: Bundle(for: Self.self)
+        )
+
+        let microphone = (0..<256).map { Float($0 % 17) / 17.0 }
+        let speaker = (0..<256).map { Float(($0 + 3) % 19) / 38.0 }
+        let output = conditioner.condition(
+            microphone: microphone,
+            speaker: speaker,
+            hasSpeakerReference: true
+        )
+
+        XCTAssertEqual(conditioner.diagnostics.processorName, "localvqe")
+        XCTAssertTrue(conditioner.diagnostics.loaded)
+        XCTAssertEqual(output.count, microphone.count)
+        XCTAssertEqual(conditioner.diagnostics.processedFrames, 1)
+    }
+
+    func testDistributionVerifierAcceptsSelectedModelNameWithValidRuntime() throws {
+        let appURL = try Self.makeEchoAssetAppBundle(
+            modelName: "localvqe-v1.4-aec-200K-f32.gguf",
+            modelData: Data("model".utf8),
+            includeLibrary: true
+        )
+        defer { try? FileManager.default.removeItem(at: appURL.deletingLastPathComponent()) }
+        let modelURL = appURL.appendingPathComponent(
+            "Contents/Resources/MeetingEchoSuppression/localvqe-v1.4-aec-200K-f32.gguf"
+        )
+
+        let result = try Self.runVerifier(
+            appURL: appURL,
+            environment: [
+                "REQUIRE_MEETING_ECHO_ASSETS": "1",
+                "MACPARAKEET_MEETING_ECHO_MODEL_NAME": "localvqe-v1.4-aec-200K-f32.gguf",
+                "MACPARAKEET_MEETING_ECHO_MODEL_SHA256": try MeetingEchoSuppressionFactory.sha256Hex(
+                    for: modelURL
+                ).uppercased(),
+            ]
+        )
+
+        XCTAssertEqual(result.status, 0, result.output)
+        XCTAssertTrue(result.output.contains("Meeting echo assets verified"))
+    }
+
+    func testDistributionVerifierFailsWhenRequiredAssetsAreMissing() throws {
+        let appURL = try Self.makeEmptyAppBundle()
+        defer { try? FileManager.default.removeItem(at: appURL.deletingLastPathComponent()) }
+        let result = try Self.runVerifier(
+            appURL: appURL,
+            environment: ["REQUIRE_MEETING_ECHO_ASSETS": "1"]
+        )
+
+        XCTAssertNotEqual(result.status, 0)
+        XCTAssertTrue(result.output.contains("meeting echo assets are required"))
+    }
+
+    func testDistributionVerifierFailsWhenOnlyOneAssetExists() throws {
+        let appURL = try Self.makeEchoAssetAppBundle(
+            modelName: "localvqe-v1.4-aec-200K-f32.gguf",
+            modelData: Data("model".utf8),
+            includeLibrary: false
+        )
+        defer { try? FileManager.default.removeItem(at: appURL.deletingLastPathComponent()) }
+        let result = try Self.runVerifier(
+            appURL: appURL,
+            environment: ["REQUIRE_MEETING_ECHO_ASSETS": "1"]
+        )
+
+        XCTAssertNotEqual(result.status, 0)
+        XCTAssertTrue(result.output.contains("must be bundled together"))
+    }
+
+    func testDistributionVerifierRejectsAmbiguousBundledModelsEvenWithSelectedName() throws {
+        let appURL = try Self.makeEchoAssetAppBundle(
+            modelName: "localvqe-v1.4-aec-200K-f32.gguf",
+            modelData: Data("model".utf8),
+            includeLibrary: true
+        )
+        defer { try? FileManager.default.removeItem(at: appURL.deletingLastPathComponent()) }
+        let secondModelURL = appURL.appendingPathComponent(
+            "Contents/Resources/MeetingEchoSuppression/" +
+                MeetingEchoSuppressionFactory.defaultModelName
+        )
+        try Data("second model".utf8).write(to: secondModelURL)
+
+        let result = try Self.runVerifier(
+            appURL: appURL,
+            environment: [
+                "REQUIRE_MEETING_ECHO_ASSETS": "1",
+                "MACPARAKEET_MEETING_ECHO_MODEL_NAME": "localvqe-v1.4-aec-200K-f32.gguf",
+            ]
+        )
+
+        XCTAssertNotEqual(result.status, 0)
+        XCTAssertTrue(result.output.contains("exactly one meeting echo model must be bundled"))
+    }
+
+    func testDistributionVerifierRejectsChecksumMismatch() throws {
+        let appURL = try Self.makeEchoAssetAppBundle(
+            modelName: MeetingEchoSuppressionFactory.defaultModelName,
+            modelData: Data("model".utf8),
+            includeLibrary: true
+        )
+        defer { try? FileManager.default.removeItem(at: appURL.deletingLastPathComponent()) }
+        let result = try Self.runVerifier(
+            appURL: appURL,
+            environment: [
+                "REQUIRE_MEETING_ECHO_ASSETS": "1",
+                "MACPARAKEET_MEETING_ECHO_MODEL_SHA256": String(repeating: "0", count: 64),
+            ]
+        )
+
+        XCTAssertNotEqual(result.status, 0)
+        XCTAssertTrue(result.output.contains("SHA256 mismatch"))
+    }
+
+    func testDistributionVerifierRejectsRuntimeMissingRequiredSymbols() throws {
+        let appURL = try Self.makeEchoAssetAppBundle(
+            modelName: MeetingEchoSuppressionFactory.defaultModelName,
+            modelData: Data("model".utf8),
+            includeLibrary: true,
+            includeRequiredSymbols: false
+        )
+        defer { try? FileManager.default.removeItem(at: appURL.deletingLastPathComponent()) }
+        let result = try Self.runVerifier(
+            appURL: appURL,
+            environment: ["REQUIRE_MEETING_ECHO_ASSETS": "1"]
+        )
+
+        XCTAssertNotEqual(result.status, 0)
+        XCTAssertTrue(result.output.contains("missing required LocalVQE symbols"))
+    }
+
+    private static func makeEmptyAppBundle() throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let appURL = root.appendingPathComponent("MacParakeet.app", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: appURL.appendingPathComponent("Contents", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        return appURL
+    }
+
+    private static func makeEchoAssetAppBundle(
+        modelName: String,
+        modelData: Data,
+        includeLibrary: Bool,
+        includeRequiredSymbols: Bool = true
+    ) throws -> URL {
+        let appURL = try makeEmptyAppBundle()
+        let frameworksURL = appURL.appendingPathComponent("Contents/Frameworks", isDirectory: true)
+        let modelDirectory = appURL.appendingPathComponent(
+            "Contents/Resources/MeetingEchoSuppression",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(
+            at: frameworksURL,
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: modelDirectory,
+            withIntermediateDirectories: true
+        )
+        try modelData.write(to: modelDirectory.appendingPathComponent(modelName))
+        if includeLibrary {
+            try writeLocalVQEDylib(
+                to: frameworksURL.appendingPathComponent("liblocalvqe.dylib"),
+                includeRequiredSymbols: includeRequiredSymbols
+            )
+        }
+        return appURL
+    }
+
+    private static func writeLocalVQEDylib(
+        to libraryURL: URL,
+        includeRequiredSymbols: Bool = true
+    ) throws {
+        guard FileManager.default.isExecutableFile(atPath: "/usr/bin/clang") else {
+            throw XCTSkip("clang is required to compile the LocalVQE ABI test runtime.")
+        }
+
+        let sourceURL = libraryURL.deletingLastPathComponent()
+            .appendingPathComponent("localvqe_stub.c")
+        let source: String
+        if includeRequiredSymbols {
+            source = """
+            #include <stdint.h>
+            uintptr_t localvqe_new(const char *path) { return path ? 1 : 0; }
+            int32_t localvqe_process_frame_f32(
+              uintptr_t ctx,
+              const float *mic,
+              const float *ref,
+              int32_t n,
+              float *out
+            ) {
+              if (!ctx || !mic || !ref || !out) { return -1; }
+              for (int32_t i = 0; i < n; i++) { out[i] = mic[i] - ref[i]; }
+              return 0;
+            }
+            void localvqe_reset(uintptr_t ctx) { (void)ctx; }
+            void localvqe_free(uintptr_t ctx) { (void)ctx; }
+            """
+        } else {
+            source = "int localvqe_unrelated_symbol(void) { return 1; }\n"
+        }
+        try source.write(to: sourceURL, atomically: true, encoding: .utf8)
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/clang")
+        process.arguments = [
+            "-dynamiclib",
+            sourceURL.path,
+            "-install_name",
+            "@rpath/liblocalvqe.dylib",
+            "-o",
+            libraryURL.path,
+        ]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+        try process.run()
+        process.waitUntilExit()
+        let output = String(
+            data: pipe.fileHandleForReading.readDataToEndOfFile(),
+            encoding: .utf8
+        ) ?? ""
+        XCTAssertEqual(process.terminationStatus, 0, output)
+    }
+
+    private static func runVerifier(
+        appURL: URL,
+        environment: [String: String] = [:]
+    ) throws -> (status: Int32, output: String) {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/bash")
+        let verifierURL = try repoRoot()
+            .appendingPathComponent("scripts/dist/verify_meeting_echo_assets.sh")
+        process.arguments = [
+            verifierURL.path,
+            appURL.path,
+        ]
+        process.environment = [
+            "PATH": "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
+            "HOME": NSHomeDirectory(),
+        ].merging(environment) { _, new in new }
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+        try process.run()
+        process.waitUntilExit()
+        let output = String(
+            data: pipe.fileHandleForReading.readDataToEndOfFile(),
+            encoding: .utf8
+        ) ?? ""
+        return (process.terminationStatus, output)
+    }
+
+    private static func repoRoot(filePath: String = #filePath) throws -> URL {
+        var url = URL(fileURLWithPath: filePath)
+        while url.lastPathComponent != "Tests" {
+            let parent = url.deletingLastPathComponent()
+            guard parent.path != url.path else {
+                throw NSError(
+                    domain: "MeetingEchoSuppressionRuntimeTests",
+                    code: 1,
+                    userInfo: [
+                        NSLocalizedDescriptionKey:
+                            "Could not find repo root from test file path: \(filePath)"
+                    ]
+                )
+            }
+            url = parent
+        }
+        return url.deletingLastPathComponent()
     }
 }

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -33,6 +33,34 @@ transcription so future helper updates never mutate the signed app bundle. To
 use a pre-fetched helper in release builds, set `YTDLP_PATH`; set
 `BUNDLE_YTDLP=0` only for diagnostic builds.
 
+Meeting echo suppression assets are optional for local/dev bundles, but any
+build that claims speaker-mode AEC readiness must bundle and verify both native
+assets:
+
+```bash
+export MACPARAKEET_MEETING_ECHO_LIBRARY=/absolute/path/to/liblocalvqe.dylib
+export MACPARAKEET_MEETING_ECHO_MODEL=/absolute/path/to/localvqe-v1.4-aec-200K-f32.gguf
+export MACPARAKEET_MEETING_ECHO_MODEL_SHA256=b6e43138588a83bfe903ab5e143b4020b91c1e1629f5a575ac5855ff0003c731
+export REQUIRE_MEETING_ECHO_ASSETS=1
+VERSION=X.Y.Z scripts/dist/build_app_bundle.sh
+```
+
+`build_app_bundle.sh` preserves the source GGUF filename by default; override
+with `MACPARAKEET_MEETING_ECHO_MODEL_NAME=<filename>.gguf` only when the source
+path is not the intended bundled name. The bundled runtime is copied to
+`Contents/Frameworks/liblocalvqe.dylib`; the selected model is copied under
+`Contents/Resources/MeetingEchoSuppression/`. Release bundles must contain
+exactly one GGUF model so asset verification and runtime model resolution cannot
+drift.
+
+`scripts/dist/verify_meeting_echo_assets.sh dist/MacParakeet.app` is the release
+gate. With `REQUIRE_MEETING_ECHO_ASSETS=1`, it fails if either asset is missing,
+if the model checksum does not match, if `liblocalvqe.dylib` is not executable,
+if required LocalVQE C symbols are not exported, or if `otool -L` shows
+non-portable dylib references outside `@rpath`, `@loader_path`, `/System/Library`,
+or `/usr/lib`. Without `REQUIRE_MEETING_ECHO_ASSETS=1`, missing assets are
+accepted and the app intentionally runs the meeting echo path as passthrough.
+
 Retained purchase activation config (normally unset in current free builds):
 
 ```bash
@@ -160,7 +188,13 @@ scripts/dist/build_app_bundle.sh                   # local/dev only: VERSION def
 VERSION=X.Y.Z scripts/dist/build_app_bundle.sh
 ```
 
-Verify: Look for `Embedded Sparkle.framework` and `Adding @executable_path/../Frameworks to rpath` in the output. The script will `exit 1` if Sparkle is missing.
+Verify: Look for `Embedded Sparkle.framework` and `Adding @executable_path/../Frameworks to rpath` in the output. For AEC-ready releases, also look for `Meeting echo assets verified`; the explicit post-build check is:
+
+```bash
+REQUIRE_MEETING_ECHO_ASSETS=1 scripts/dist/verify_meeting_echo_assets.sh dist/MacParakeet.app
+```
+
+The script will `exit 1` if Sparkle is missing or required echo assets fail verification.
 
 ### Step 2: Sign + notarize
 

--- a/scripts/dist/build_app_bundle.sh
+++ b/scripts/dist/build_app_bundle.sh
@@ -36,6 +36,7 @@ set -euo pipefail
 #   MACPARAKEET_MEETING_ECHO_LIBRARY source dylib for meeting echo suppression
 #   MACPARAKEET_MEETING_ECHO_DYLIB_DIR optional directory of dependent dylibs to copy into Frameworks
 #   MACPARAKEET_MEETING_ECHO_MODEL source GGUF model for meeting echo suppression
+#   MACPARAKEET_MEETING_ECHO_MODEL_NAME optional bundled GGUF filename (default: source basename)
 #   MACPARAKEET_MEETING_ECHO_MODEL_SHA256 optional expected model SHA256
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -435,10 +436,18 @@ bundle_meeting_echo_assets() {
     exit 1
   fi
 
+  local model_name="${MACPARAKEET_MEETING_ECHO_MODEL_NAME:-$(basename "$model_src")}"
+  if [[ -z "$model_name" || "$model_name" == */* || "$model_name" != *.gguf ]]; then
+    echo "Error: MACPARAKEET_MEETING_ECHO_MODEL_NAME must be a GGUF filename, not a path." >&2
+    exit 1
+  fi
+
   if [[ -n "${MACPARAKEET_MEETING_ECHO_MODEL_SHA256:-}" ]]; then
     local actual_sha
+    local expected_sha_lc
     actual_sha="$(shasum -a 256 "$model_src" | awk '{print $1}')"
-    if [[ "$actual_sha" != "$MACPARAKEET_MEETING_ECHO_MODEL_SHA256" ]]; then
+    expected_sha_lc="$(printf '%s' "$MACPARAKEET_MEETING_ECHO_MODEL_SHA256" | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')"
+    if [[ "$actual_sha" != "$expected_sha_lc" ]]; then
       echo "Error: meeting echo model SHA256 verification failed." >&2
       echo "  Expected: $MACPARAKEET_MEETING_ECHO_MODEL_SHA256" >&2
       echo "  Actual:   $actual_sha" >&2
@@ -458,12 +467,17 @@ bundle_meeting_echo_assets() {
   fi
 
   install -m 0755 "$library_src" "$FRAMEWORKS_DIR/liblocalvqe.dylib"
+  if command -v install_name_tool >/dev/null 2>&1; then
+    install_name_tool -id "@rpath/liblocalvqe.dylib" "$FRAMEWORKS_DIR/liblocalvqe.dylib"
+  else
+    echo "Warning: install_name_tool is not available; leaving meeting echo runtime install name unchanged." >&2
+  fi
   mkdir -p "$RESOURCES_DIR/MeetingEchoSuppression"
-  install -m 0644 "$model_src" "$RESOURCES_DIR/MeetingEchoSuppression/localvqe-v1.2-1.3M-f32.gguf"
+  install -m 0644 "$model_src" "$RESOURCES_DIR/MeetingEchoSuppression/$model_name"
   echo "Bundled meeting echo runtime: $FRAMEWORKS_DIR/liblocalvqe.dylib"
-  echo "Bundled meeting echo model: $RESOURCES_DIR/MeetingEchoSuppression/localvqe-v1.2-1.3M-f32.gguf"
+  echo "Bundled meeting echo model: $RESOURCES_DIR/MeetingEchoSuppression/$model_name"
 
-  "$ROOT_DIR/scripts/dist/verify_meeting_echo_assets.sh" "$APP_DIR"
+  MACPARAKEET_MEETING_ECHO_MODEL_NAME="$model_name" "$ROOT_DIR/scripts/dist/verify_meeting_echo_assets.sh" "$APP_DIR"
 }
 
 bundle_meeting_echo_assets

--- a/scripts/dist/build_app_bundle.sh
+++ b/scripts/dist/build_app_bundle.sh
@@ -437,7 +437,9 @@ bundle_meeting_echo_assets() {
   fi
 
   local model_name="${MACPARAKEET_MEETING_ECHO_MODEL_NAME:-$(basename "$model_src")}"
-  if [[ -z "$model_name" || "$model_name" == */* || "$model_name" != *.gguf ]]; then
+  local model_name_lc
+  model_name_lc="$(printf '%s' "$model_name" | tr '[:upper:]' '[:lower:]')"
+  if [[ -z "$model_name" || "$model_name" == */* || "$model_name_lc" != *.gguf ]]; then
     echo "Error: MACPARAKEET_MEETING_ECHO_MODEL_NAME must be a GGUF filename, not a path." >&2
     exit 1
   fi

--- a/scripts/dist/verify_meeting_echo_assets.sh
+++ b/scripts/dist/verify_meeting_echo_assets.sh
@@ -5,9 +5,27 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 APP_PATH="${1:-${APP_PATH:-$ROOT_DIR/dist/MacParakeet.app}}"
 REQUIRE_MEETING_ECHO_ASSETS="${REQUIRE_MEETING_ECHO_ASSETS:-0}"
 VERIFY_CODE_SIGNATURES="${VERIFY_CODE_SIGNATURES:-0}"
+STRICT_MEETING_ECHO_ASSETS="${STRICT_MEETING_ECHO_ASSETS:-$REQUIRE_MEETING_ECHO_ASSETS}"
 
 LIB_PATH="$APP_PATH/Contents/Frameworks/liblocalvqe.dylib"
-MODEL_PATH="$APP_PATH/Contents/Resources/MeetingEchoSuppression/localvqe-v1.2-1.3M-f32.gguf"
+MODEL_DIR="$APP_PATH/Contents/Resources/MeetingEchoSuppression"
+MODEL_PATH=""
+REQUIRED_SYMBOLS=(
+  "_localvqe_new"
+  "_localvqe_process_frame_f32"
+  "_localvqe_reset"
+  "_localvqe_free"
+)
+
+missing_tool() {
+  local tool="$1"
+  local check="$2"
+  if [[ "$STRICT_MEETING_ECHO_ASSETS" == "1" ]]; then
+    echo "Error: cannot verify ${check}; '${tool}' is not available." >&2
+    exit 1
+  fi
+  echo "Warning: skipped ${check}; '${tool}' is not available." >&2
+}
 
 if [[ ! -d "$APP_PATH" ]]; then
   echo "Missing app bundle: $APP_PATH" >&2
@@ -17,7 +35,29 @@ fi
 lib_present=0
 model_present=0
 [[ -f "$LIB_PATH" ]] && lib_present=1
-[[ -f "$MODEL_PATH" ]] && model_present=1
+
+if [[ -d "$MODEL_DIR" ]]; then
+  discovered_count=0
+  while IFS= read -r -d '' candidate; do
+    MODEL_PATH="$candidate"
+    discovered_count=$((discovered_count + 1))
+  done < <(find "$MODEL_DIR" -maxdepth 1 -type f -name '*.gguf' -print0)
+  if [[ "$discovered_count" -gt 1 ]]; then
+    echo "Error: exactly one meeting echo model must be bundled." >&2
+    exit 1
+  fi
+fi
+
+if [[ -n "${MACPARAKEET_MEETING_ECHO_MODEL_NAME:-}" ]]; then
+  if [[ "$MACPARAKEET_MEETING_ECHO_MODEL_NAME" == */* ||
+        "$MACPARAKEET_MEETING_ECHO_MODEL_NAME" != *.gguf ]]; then
+    echo "Error: MACPARAKEET_MEETING_ECHO_MODEL_NAME must be a GGUF filename, not a path." >&2
+    exit 1
+  fi
+  MODEL_PATH="$MODEL_DIR/$MACPARAKEET_MEETING_ECHO_MODEL_NAME"
+fi
+
+[[ -n "$MODEL_PATH" && -f "$MODEL_PATH" ]] && model_present=1
 
 if [[ "$lib_present" == "0" && "$model_present" == "0" ]]; then
   if [[ "$REQUIRE_MEETING_ECHO_ASSETS" == "1" ]]; then
@@ -31,8 +71,17 @@ fi
 if [[ "$lib_present" != "$model_present" ]]; then
   echo "Error: meeting echo assets must be bundled together." >&2
   echo "  Library: $LIB_PATH ($lib_present)" >&2
-  echo "  Model:   $MODEL_PATH ($model_present)" >&2
+  echo "  Model:   ${MODEL_PATH:-$MODEL_DIR/*.gguf} ($model_present)" >&2
   exit 1
+fi
+
+if command -v file >/dev/null 2>&1; then
+  if ! file "$LIB_PATH" | grep -Fq "Mach-O"; then
+    echo "Error: meeting echo runtime is not a Mach-O binary: $LIB_PATH" >&2
+    exit 1
+  fi
+else
+  missing_tool "file" "meeting echo runtime Mach-O type"
 fi
 
 if [[ ! -x "$LIB_PATH" ]]; then
@@ -40,9 +89,27 @@ if [[ ! -x "$LIB_PATH" ]]; then
   exit 1
 fi
 
+if command -v nm >/dev/null 2>&1; then
+  exported_symbols="$(nm -gU "$LIB_PATH" 2>/dev/null | awk '{print $NF}' || true)"
+  missing_symbols=()
+  for symbol in "${REQUIRED_SYMBOLS[@]}"; do
+    if ! grep -qFx "$symbol" <<<"$exported_symbols"; then
+      missing_symbols+=("$symbol")
+    fi
+  done
+  if [[ "${#missing_symbols[@]}" -gt 0 ]]; then
+    echo "Error: meeting echo runtime is missing required LocalVQE symbols:" >&2
+    printf '  %s\n' "${missing_symbols[@]}" >&2
+    exit 1
+  fi
+else
+  missing_tool "nm" "meeting echo runtime LocalVQE symbols"
+fi
+
 if [[ -n "${MACPARAKEET_MEETING_ECHO_MODEL_SHA256:-}" ]]; then
   actual_sha="$(shasum -a 256 "$MODEL_PATH" | awk '{print $1}')"
-  if [[ "$actual_sha" != "$MACPARAKEET_MEETING_ECHO_MODEL_SHA256" ]]; then
+  expected_sha_lc="$(printf '%s' "$MACPARAKEET_MEETING_ECHO_MODEL_SHA256" | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')"
+  if [[ "$actual_sha" != "$expected_sha_lc" ]]; then
     echo "Error: bundled meeting echo model SHA256 mismatch." >&2
     echo "  Expected: $MACPARAKEET_MEETING_ECHO_MODEL_SHA256" >&2
     echo "  Actual:   $actual_sha" >&2
@@ -59,13 +126,21 @@ if command -v otool >/dev/null 2>&1; then
       grep -Ev '^@rpath/|^@loader_path/|^/System/Library/|^/usr/lib/|^\(' || true
   )"
   if [[ -n "$unresolved_deps" ]]; then
-    echo "Warning: meeting echo runtime has non-system dylib references; ensure they are bundled and use @rpath/@loader_path:" >&2
-    echo "$unresolved_deps" >&2
+    if [[ "$STRICT_MEETING_ECHO_ASSETS" == "1" ]]; then
+      echo "Error: meeting echo runtime has non-portable dylib references:" >&2
+      echo "$unresolved_deps" >&2
+      exit 1
+    else
+      echo "Warning: meeting echo runtime has non-system dylib references; ensure they are bundled and use @rpath/@loader_path:" >&2
+      echo "$unresolved_deps" >&2
+    fi
   fi
+else
+  missing_tool "otool" "meeting echo runtime dylib references"
 fi
 
 if [[ "$VERIFY_CODE_SIGNATURES" == "1" ]]; then
   codesign --verify --strict --verbose=2 "$LIB_PATH"
 fi
 
-echo "Meeting echo assets verified."
+echo "Meeting echo assets verified: $(basename "$MODEL_PATH")"

--- a/scripts/dist/verify_meeting_echo_assets.sh
+++ b/scripts/dist/verify_meeting_echo_assets.sh
@@ -41,7 +41,7 @@ if [[ -d "$MODEL_DIR" ]]; then
   while IFS= read -r -d '' candidate; do
     MODEL_PATH="$candidate"
     discovered_count=$((discovered_count + 1))
-  done < <(find "$MODEL_DIR" -maxdepth 1 -type f -name '*.gguf' -print0)
+  done < <(find "$MODEL_DIR" -maxdepth 1 -type f -iname '*.gguf' -print0)
   if [[ "$discovered_count" -gt 1 ]]; then
     echo "Error: exactly one meeting echo model must be bundled." >&2
     exit 1
@@ -49,8 +49,9 @@ if [[ -d "$MODEL_DIR" ]]; then
 fi
 
 if [[ -n "${MACPARAKEET_MEETING_ECHO_MODEL_NAME:-}" ]]; then
+  model_name_lc="$(printf '%s' "$MACPARAKEET_MEETING_ECHO_MODEL_NAME" | tr '[:upper:]' '[:lower:]')"
   if [[ "$MACPARAKEET_MEETING_ECHO_MODEL_NAME" == */* ||
-        "$MACPARAKEET_MEETING_ECHO_MODEL_NAME" != *.gguf ]]; then
+        "$model_name_lc" != *.gguf ]]; then
     echo "Error: MACPARAKEET_MEETING_ECHO_MODEL_NAME must be a GGUF filename, not a path." >&2
     exit 1
   fi
@@ -119,11 +120,15 @@ if [[ -n "${MACPARAKEET_MEETING_ECHO_MODEL_SHA256:-}" ]]; then
 fi
 
 if command -v otool >/dev/null 2>&1; then
+  # otool -L emits an unindented header per arch (e.g. "lib (architecture arm64):"),
+  # followed by tab-indented dependency lines. Select only indented lines so
+  # universal (fat) binaries with multiple arch headers parse correctly; a plain
+  # `tail -n +2` drops only the first header and misreads later arch headers as
+  # non-portable references, wrongly failing strict verification.
   unresolved_deps="$(
     otool -L "$LIB_PATH" |
-      tail -n +2 |
-      awk '{print $1}' |
-      grep -Ev '^@rpath/|^@loader_path/|^/System/Library/|^/usr/lib/|^\(' || true
+      awk '/^[[:space:]]/ {print $1}' |
+      grep -Ev '^@rpath/|^@loader_path/|^/System/Library/|^/usr/lib/' || true
   )"
   if [[ -n "$unresolved_deps" ]]; then
     if [[ "$STRICT_MEETING_ECHO_ASSETS" == "1" ]]; then

--- a/spec/05-audio-pipeline.md
+++ b/spec/05-audio-pipeline.md
@@ -198,7 +198,12 @@ Mic Input    → SharedMicrophoneStream (+ Voice Processing I/O when active)┘ 
   AEC/noise suppression/AGC. The optional `StreamingMeetingEchoSuppressor`
   can transform paired mic/system samples when a LocalVQE-compatible runtime
   and model are available; otherwise it falls back to raw mic samples with
-  diagnostics. When the suppressor runs it aligns the system reference to the
+  diagnostics. Release bundles that claim meeting AEC readiness must include
+  `Contents/Frameworks/liblocalvqe.dylib` plus exactly one selected GGUF under
+  `Contents/Resources/MeetingEchoSuppression/`; distribution verification
+  checks the model checksum, required LocalVQE C symbols, executable bit, and
+  portable dylib references before the app can claim that path. When the
+  suppressor runs it aligns the system reference to the
   microphone using a runtime delay recovered from the audio by
   `MeetingEchoDelayEstimator` (normalized cross-correlation, confidence-gated),
   because the measurement harness showed that mic/reference time alignment is


### PR DESCRIPTION
## Summary

Strict release-asset verification for the meeting AEC (LocalVQE) path. A build that claims
speaker-mode AEC readiness must bundle `liblocalvqe.dylib` plus exactly one GGUF model; the
verifier then gates the release on Mach-O type, the executable bit, the required
`_localvqe_*` ABI symbols, the model checksum, and portable dylib references (only
`@rpath`/`@loader_path`/system paths) — and accepts both thin and universal (fat) runtimes.
Dev/local builds without the assets keep running as passthrough. Runtime model resolution
and the AEC-ready asset contract (`docs/distribution.md`, `spec/05-audio-pipeline.md`) are
updated to match. See the cubic summary below for the per-file change list.

## Scope

- **U5 of #605 only** — release/runtime asset packaging and verification for the LocalVQE
  dynamic path.
- Does not commit any LocalVQE binaries or models to the repo.
- Does **not** close #605 — U9 real no-headphones Zoom/Meet/Teams QA still required.

## Verification

- Full `swift test` suite green, 0 failures (focused `MeetingEchoSuppressionRuntimeTests`:
  20 tests, 1 env-gated skip).
- Verifier exercised end-to-end against temp app bundles: accepts a valid **thin and
  universal** runtime; rejects missing/half/ambiguous bundles, checksum mismatch,
  non-Mach-O, missing ABI symbols, and non-portable dylib references.
- Real LocalVQE env-gated load test passed (CPU backend, DAF front-end active, graph model
  loaded).
- `bash -n` clean on both dist scripts; `git diff --check` clean.

## Releasing an AEC-ready build

Set the asset env vars and run the bundler (it auto-runs the verifier); full steps and the
exact contract live in `docs/distribution.md`. Under `REQUIRE_MEETING_ECHO_ASSETS=1` the
gate prints `Meeting echo assets verified: <model>.gguf` and fails fast otherwise. Watch
logs for `meeting_echo_processor_unavailable` and `meeting_echo_unknown_models_ambiguous`;
if the verifier rejects valid assets or the runtime reports LocalVQE unavailable, rebuild
with the correct dylib/model/SHA.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds strict verification of `liblocalvqe.dylib` and exactly one GGUF model for AEC-ready releases, tightens build-time checks, improves runtime model resolution, and now accepts universal (fat) dylibs. Delivers U5 of #605 for LocalVQE release/runtime packaging and verification.

- **New Features**
  - Runtime: resolve models by explicit path, known model names (case-insensitive), or a single discovered GGUF; warn on ambiguous bundles; keep dev passthrough; frame-size error now includes output length.
  - Verifier (`scripts/dist/verify_meeting_echo_assets.sh`): require both assets and exactly one model; allow `MACPARAKEET_MEETING_ECHO_MODEL_NAME`; check Mach-O + executable bit; enforce required `_localvqe_*` symbols via `nm`; case-insensitive SHA; error on non-portable dylib refs in strict mode; strict mode fails if `file`/`nm`/`otool` are missing; prints “Meeting echo assets verified: <model>”.
  - Build (`scripts/dist/build_app_bundle.sh`): support `MACPARAKEET_MEETING_ECHO_MODEL_NAME` (filename-only, must end with `.gguf`, case-insensitive); case-insensitive SHA check; set dylib install name to `@rpath/liblocalvqe.dylib`; auto-run verifier with the selected model name.

- **Bug Fixes**
  - Verifier accepts universal `liblocalvqe.dylib` by selecting only tab-indented `otool -L` dependency lines.
  - Case-insensitive `.gguf` handling across build, verifier, and runtime; “exactly one model” guard uses `find -iname`.
  - Tests: locate repo root via `Package.swift`; add regression test for universal dylib acceptance.

<sup>Written for commit 78380a25b312051cef8b50cb76d53f12d076f186. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/646?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


