### PR TITLE
Meeting AEC: score LocalVQE models, choose v1.4 echo-only default (#605 U5)

### DIFF
--- a/Tests/MacParakeetTests/Services/Capture/MeetingAecModelScoringTests.swift
+++ b/Tests/MacParakeetTests/Services/Capture/MeetingAecModelScoringTests.swift
@@ -59,6 +59,8 @@ final class MeetingAecModelScoringTests: XCTestCase {
         /// same fixture. Reported, not gated (see fidelity caveat).
         let doubleTalkErrorDB: Double
         let doubleTalkPassthroughErrorDB: Double
+        /// Total frames successfully processed across far-end, near-end, and
+        /// double-talk runs.
         let processedFrames: Int
         /// Frames the processor failed (threw / wrong-sized output) and the
         /// suppressor served raw instead. Nonzero means the scores are polluted by
@@ -79,6 +81,14 @@ final class MeetingAecModelScoringTests: XCTestCase {
         let maxRetention: Float
         let meanNearError: Double
         let totalProcessingFailures: Int
+
+        var retentionDeviation: Float {
+            max(abs(minRetention - 1), abs(maxRetention - 1))
+        }
+
+        var isEchoOnlyV14: Bool {
+            label.localizedStandardContains("v1.4-aec")
+        }
     }
 
     func testLocalVQEModelDecisionGate() throws {
@@ -128,8 +138,7 @@ final class MeetingAecModelScoringTests: XCTestCase {
                     label: modelURL.lastPathComponent,
                     modelKey: modelURL.path,
                     echoLabel: echoLabel,
-                    libraryURL: libraryURL,
-                    modelURL: modelURL,
+                    conditioner: preflight,
                     echoPath: echoPath))
             }
         }
@@ -158,7 +167,10 @@ final class MeetingAecModelScoringTests: XCTestCase {
                 && $0.minRetention > Self.minRetention
                 && $0.maxRetention < Self.maxRetention
         }
-        guard let chosen = viable.min(by: { $0.meanDoubleTalkError < $1.meanDoubleTalkError }) else {
+        // Rule: best near-end retention at acceptable ERLE. If the robust axes tie,
+        // prefer echo-only v1.4, then higher ERLE. Synthetic double-talk error is
+        // reported, not selected on, because tone reshaping cannot certify fidelity.
+        guard let chosen = viable.sorted(by: Self.prefersReleaseDefault).first else {
             XCTFail("No candidate both removed far-end echo (>\(Self.minFarEndERLE) dB ERLE) and "
                 + "preserved the near-end voice (retain "
                 + "\(Self.minRetention)–\(Self.maxRetention)). Re-plan / consider WebRTC AEC3 (plan U6).")
@@ -174,23 +186,22 @@ final class MeetingAecModelScoringTests: XCTestCase {
         label: String,
         modelKey: String,
         echoLabel: String,
-        libraryURL: URL,
-        modelURL: URL,
+        conditioner: any MicConditioning,
         echoPath: MeetingAecEchoPath
     ) -> ModelScore {
         // Far-end-only → ERLE (any mic energy is echo by construction).
         let farScenario = MeetingAecScenarioFactory.make(
             name: "far-end-only", nearEndActive: false, farEndActive: true, echoPath: echoPath)
-        let farOut = MeetingAecRunner.run(
-            makeConditioner(libraryURL: libraryURL, modelURL: modelURL), scenario: farScenario)
+        let farOut = MeetingAecRunner.run(conditioner, scenario: farScenario)
+        let farDiagnostics = conditioner.diagnostics
         let farERLE = MeetingAecMetrics.erleDB(
             mic: farScenario.mic, output: farOut, over: farScenario.steadyStateWindow)
 
         // Near-end-only → must preserve the local voice's energy and not go silent.
         let nearScenario = MeetingAecScenarioFactory.make(
             name: "near-end-only", nearEndActive: true, farEndActive: false, echoPath: echoPath)
-        let nearOut = MeetingAecRunner.run(
-            makeConditioner(libraryURL: libraryURL, modelURL: modelURL), scenario: nearScenario)
+        let nearOut = MeetingAecRunner.run(conditioner, scenario: nearScenario)
+        let nearDiagnostics = conditioner.diagnostics
         let nearWindow = nearScenario.steadyStateWindow
         let nearErr = MeetingAecMetrics.nearEndErrorDB(
             output: nearOut, nearEnd: nearScenario.nearEnd, over: nearWindow)
@@ -199,18 +210,15 @@ final class MeetingAecModelScoringTests: XCTestCase {
         // Double-talk → near-end error vs passthrough (reported, not gated).
         let dtScenario = MeetingAecScenarioFactory.make(
             name: "double-talk", nearEndActive: true, farEndActive: true, echoPath: echoPath)
-        let dtConditioner = makeConditioner(libraryURL: libraryURL, modelURL: modelURL)
-        let dtOut = MeetingAecRunner.run(dtConditioner, scenario: dtScenario)
+        let dtOut = MeetingAecRunner.run(conditioner, scenario: dtScenario)
+        let dtDiagnostics = conditioner.diagnostics
         let dtWindow = dtScenario.steadyStateWindow
         let dtErr = MeetingAecMetrics.nearEndErrorDB(
             output: dtOut, nearEnd: dtScenario.nearEnd, over: dtWindow)
         let dtPass = MeetingAecRunner.run(PassthroughMicConditioner(), scenario: dtScenario)
         let dtPassErr = MeetingAecMetrics.nearEndErrorDB(
             output: dtPass, nearEnd: dtScenario.nearEnd, over: dtWindow)
-        // Diagnostics from the double-talk run, where both signals are present so
-        // the adaptive delay estimator has reference energy to lock onto, and the
-        // processor exercises the full mic+reference path.
-        let diag = dtConditioner.diagnostics
+        let diagnostics = [farDiagnostics, nearDiagnostics, dtDiagnostics]
 
         return ModelScore(
             label: label, modelKey: modelKey, echoLabel: echoLabel,
@@ -218,8 +226,9 @@ final class MeetingAecModelScoringTests: XCTestCase {
             nearEndErrorDB: nearErr,
             nearEndRetentionRatio: retention,
             doubleTalkErrorDB: dtErr, doubleTalkPassthroughErrorDB: dtPassErr,
-            processedFrames: diag.processedFrames, processingFailures: diag.processingFailures,
-            delaySamples: diag.currentDelaySamples)
+            processedFrames: diagnostics.reduce(0) { $0 + $1.processedFrames },
+            processingFailures: diagnostics.reduce(0) { $0 + $1.processingFailures },
+            delaySamples: dtDiagnostics.currentDelaySamples)
     }
 
     private func makeConditioner(libraryURL: URL, modelURL: URL) -> any MicConditioning {
@@ -259,6 +268,19 @@ final class MeetingAecModelScoringTests: XCTestCase {
                 meanNearError: group.reduce(0) { $0 + $1.nearEndErrorDB } / n,
                 totalProcessingFailures: group.reduce(0) { $0 + $1.processingFailures })
         }
+    }
+
+    private static func prefersReleaseDefault(_ lhs: ModelAggregate, _ rhs: ModelAggregate) -> Bool {
+        if lhs.retentionDeviation != rhs.retentionDeviation {
+            return lhs.retentionDeviation < rhs.retentionDeviation
+        }
+        if lhs.isEchoOnlyV14 != rhs.isEchoOnlyV14 {
+            return lhs.isEchoOnlyV14
+        }
+        if lhs.meanFarERLE != rhs.meanFarERLE {
+            return lhs.meanFarERLE > rhs.meanFarERLE
+        }
+        return lhs.label.localizedStandardCompare(rhs.label) == .orderedAscending
     }
 
     private func printScoreTable(_ scores: [ModelScore]) {

--- a/Tests/MacParakeetTests/Services/Capture/MeetingAecModelScoringTests.swift
+++ b/Tests/MacParakeetTests/Services/Capture/MeetingAecModelScoringTests.swift
@@ -1,0 +1,295 @@
+import XCTest
+@testable import MacParakeetCore
+
+/// Env-gated LocalVQE **model decision gate** for meeting AEC (issue #605, plan
+/// unit U5). Scores candidate echo-cancellation GGUF models on the synthetic
+/// measurement harness so the release default can be chosen by the plan's rule:
+/// best near-end retention at acceptable far-end ERLE, ties broken toward the
+/// echo-only `v1.4-aec` model.
+///
+/// The test is **skipped** unless the private LocalVQE assets are pointed at via
+/// environment, so the full suite stays green in CI without them. Run locally:
+///
+///   MACPARAKEET_TEST_LOCALVQE_LIBRARY=/path/to/liblocalvqe.dylib \
+///   MACPARAKEET_TEST_LOCALVQE_MODELS=/path/a.gguf:/path/b.gguf \
+///   swift test --filter MeetingAecModelScoringTests
+///
+/// `MACPARAKEET_TEST_LOCALVQE_MODELS` is a `:`- or newline-separated list of
+/// absolute `.gguf` paths; missing files are reported and skipped.
+///
+/// **What the harness can and cannot prove.** The near-end is decorrelated,
+/// voiced-like *tones*, not speech. So the gate asserts only on the axes the
+/// fixture measures reliably — far-end echo removal (ERLE) and near-end *energy*
+/// retention — and merely *reports* the waveform-fidelity numbers (near-end
+/// error, double-talk improvement), because a neural model trained on real speech
+/// reshapes synthetic tones in ways that penalize exact-waveform error whether or
+/// not it would damage real speech. Real speaker-mode QA (plan unit U9) owns
+/// fidelity and remains the binding gate before any default-on.
+final class MeetingAecModelScoringTests: XCTestCase {
+    private static let libraryKey = "MACPARAKEET_TEST_LOCALVQE_LIBRARY"
+    private static let modelsKey = "MACPARAKEET_TEST_LOCALVQE_MODELS"
+
+    // Robust-axis gates (calibrated with margin to the chosen v1.4 candidate:
+    // ERLE 35.6 dB, retain 1.02). A shippable model must remove strong echo and
+    // preserve the local voice's energy without amplifying it.
+    private static let minFarEndERLE = 15.0
+    private static let minRetention: Float = 0.8
+    private static let maxRetention: Float = 1.5
+
+    // Single dominant tap and a short multi-tap room response — the same echo
+    // paths the measurement tests use, so the scoring is on familiar fixtures.
+    private let singleTapEcho = MeetingAecEchoPath(taps: [(delay: 120, gain: 0.6)])
+    private let multiTapEcho = MeetingAecEchoPath(
+        taps: [(delay: 120, gain: 0.6), (delay: 180, gain: 0.25), (delay: 240, gain: 0.12)]
+    )
+
+    private struct ModelScore {
+        let label: String      // display name (filename)
+        let modelKey: String   // full path — dedup key so same-named models don't merge
+        let echoLabel: String
+        /// Far-end-only steady-state ERLE (dB). Higher = more echo removed.
+        let farEndERLE: Double
+        /// Near-end-only error vs the ideal local voice (dB). Reported, not gated:
+        /// a neural model reshapes synthetic tones, so this is unreliable here.
+        let nearEndErrorDB: Double
+        /// Output-vs-mic RMS ratio on near-end-only. ~1.0 = local voice energy
+        /// preserved; near 0 = the model went silent / gutted the local voice.
+        let nearEndRetentionRatio: Float
+        /// Double-talk near-end error (dB) and the passthrough baseline on the
+        /// same fixture. Reported, not gated (see fidelity caveat).
+        let doubleTalkErrorDB: Double
+        let doubleTalkPassthroughErrorDB: Double
+        let processedFrames: Int
+        /// Frames the processor failed (threw / wrong-sized output) and the
+        /// suppressor served raw instead. Nonzero means the scores are polluted by
+        /// raw-fallback frames, so the gate rejects it.
+        let processingFailures: Int
+        let delaySamples: Int
+
+        /// Positive = the model reduced near-end error under double-talk vs raw.
+        var doubleTalkImprovement: Double { doubleTalkPassthroughErrorDB - doubleTalkErrorDB }
+    }
+
+    private struct ModelAggregate {
+        let label: String
+        let meanFarERLE: Double
+        let meanDoubleTalkError: Double
+        let meanDoubleTalkImprovement: Double
+        let minRetention: Float
+        let maxRetention: Float
+        let meanNearError: Double
+        let totalProcessingFailures: Int
+    }
+
+    func testLocalVQEModelDecisionGate() throws {
+        let env = ProcessInfo.processInfo.environment
+        guard let libraryPath = env[Self.libraryKey]?
+            .trimmingCharacters(in: .whitespacesAndNewlines), !libraryPath.isEmpty else {
+            throw XCTSkip("Set \(Self.libraryKey) and \(Self.modelsKey) to score real LocalVQE models.")
+        }
+        guard let modelsRaw = env[Self.modelsKey], !modelsRaw.isEmpty else {
+            throw XCTSkip("Set \(Self.modelsKey) to a :-separated list of .gguf paths.")
+        }
+
+        let libraryURL = URL(fileURLWithPath: libraryPath)
+        try XCTSkipUnless(
+            FileManager.default.fileExists(atPath: libraryURL.path),
+            "LocalVQE library not found: \(libraryURL.path)")
+
+        let modelURLs = modelsRaw
+            .split(whereSeparator: { $0 == ":" || $0 == "\n" })
+            .map { URL(fileURLWithPath: $0.trimmingCharacters(in: .whitespaces)) }
+            .filter { url in
+                let exists = FileManager.default.fileExists(atPath: url.path)
+                if !exists { print("[AEC-SCORE] skipping missing model: \(url.path)") }
+                return exists
+            }
+        try XCTSkipIf(modelURLs.isEmpty, "No existing model files in \(Self.modelsKey).")
+
+        let echoPaths: [(String, MeetingAecEchoPath)] = [
+            ("single-tap", singleTapEcho),
+            ("multi-tap", multiTapEcho),
+        ]
+
+        var scores: [ModelScore] = []
+        for modelURL in modelURLs {
+            // Preflight: the factory falls back to an unavailable passthrough
+            // (loaded == false) when the dylib/model can't instantiate. Fail with
+            // one crisp message rather than scoring a bogus passthrough as the model.
+            let preflight = makeConditioner(libraryURL: libraryURL, modelURL: modelURL)
+            guard preflight.diagnostics.loaded,
+                  preflight.diagnostics.processorName == MeetingEchoSuppressionFactory.processorName else {
+                XCTFail("\(modelURL.lastPathComponent): not a loadable LocalVQE model — the runtime "
+                    + "fell back to passthrough. Exclude it from \(Self.modelsKey) or rebuild the asset.")
+                continue
+            }
+            for (echoLabel, echoPath) in echoPaths {
+                scores.append(scoreModel(
+                    label: modelURL.lastPathComponent,
+                    modelKey: modelURL.path,
+                    echoLabel: echoLabel,
+                    libraryURL: libraryURL,
+                    modelURL: modelURL,
+                    echoPath: echoPath))
+            }
+        }
+        try XCTSkipIf(scores.isEmpty, "No candidate models loaded successfully.")
+
+        printScoreTable(scores)
+        let aggregates = aggregate(scores)
+        printAggregates(aggregates)
+
+        // No silent contamination: a loaded processor that throws on frames falls
+        // back to raw mic, which inflates retention and pollutes ERLE/near-end. And
+        // every model must actually process frames, not sit at passthrough.
+        for s in scores {
+            XCTAssertEqual(s.processingFailures, 0,
+                "\(s.label)/\(s.echoLabel): \(s.processingFailures) processing failures — "
+                + "scores include raw-fallback frames and cannot be trusted")
+            XCTAssertGreaterThan(s.processedFrames, 0,
+                "\(s.label)/\(s.echoLabel): no frames processed — asset failed to load")
+        }
+
+        // Teeth on the ROBUST axes only (see the type doc). A shippable model must
+        // remove strong far-end echo AND keep the local voice's energy without
+        // amplifying it; fidelity under double-talk is U9's call, not asserted here.
+        let viable = aggregates.filter {
+            $0.meanFarERLE > Self.minFarEndERLE
+                && $0.minRetention > Self.minRetention
+                && $0.maxRetention < Self.maxRetention
+        }
+        guard let chosen = viable.min(by: { $0.meanDoubleTalkError < $1.meanDoubleTalkError }) else {
+            XCTFail("No candidate both removed far-end echo (>\(Self.minFarEndERLE) dB ERLE) and "
+                + "preserved the near-end voice (retain "
+                + "\(Self.minRetention)–\(Self.maxRetention)). Re-plan / consider WebRTC AEC3 (plan U6).")
+            return
+        }
+        print("[AEC-SCORE] recommended release default: \(chosen.label) — removes echo, preserves the "
+            + "local voice. Double-talk fidelity pending real-speech QA (plan U9).")
+    }
+
+    // MARK: Scoring
+
+    private func scoreModel(
+        label: String,
+        modelKey: String,
+        echoLabel: String,
+        libraryURL: URL,
+        modelURL: URL,
+        echoPath: MeetingAecEchoPath
+    ) -> ModelScore {
+        // Far-end-only → ERLE (any mic energy is echo by construction).
+        let farScenario = MeetingAecScenarioFactory.make(
+            name: "far-end-only", nearEndActive: false, farEndActive: true, echoPath: echoPath)
+        let farOut = MeetingAecRunner.run(
+            makeConditioner(libraryURL: libraryURL, modelURL: modelURL), scenario: farScenario)
+        let farERLE = MeetingAecMetrics.erleDB(
+            mic: farScenario.mic, output: farOut, over: farScenario.steadyStateWindow)
+
+        // Near-end-only → must preserve the local voice's energy and not go silent.
+        let nearScenario = MeetingAecScenarioFactory.make(
+            name: "near-end-only", nearEndActive: true, farEndActive: false, echoPath: echoPath)
+        let nearOut = MeetingAecRunner.run(
+            makeConditioner(libraryURL: libraryURL, modelURL: modelURL), scenario: nearScenario)
+        let nearWindow = nearScenario.steadyStateWindow
+        let nearErr = MeetingAecMetrics.nearEndErrorDB(
+            output: nearOut, nearEnd: nearScenario.nearEnd, over: nearWindow)
+        let retention = rmsRatio(nearOut, scenario: nearScenario, over: nearWindow)
+
+        // Double-talk → near-end error vs passthrough (reported, not gated).
+        let dtScenario = MeetingAecScenarioFactory.make(
+            name: "double-talk", nearEndActive: true, farEndActive: true, echoPath: echoPath)
+        let dtConditioner = makeConditioner(libraryURL: libraryURL, modelURL: modelURL)
+        let dtOut = MeetingAecRunner.run(dtConditioner, scenario: dtScenario)
+        let dtWindow = dtScenario.steadyStateWindow
+        let dtErr = MeetingAecMetrics.nearEndErrorDB(
+            output: dtOut, nearEnd: dtScenario.nearEnd, over: dtWindow)
+        let dtPass = MeetingAecRunner.run(PassthroughMicConditioner(), scenario: dtScenario)
+        let dtPassErr = MeetingAecMetrics.nearEndErrorDB(
+            output: dtPass, nearEnd: dtScenario.nearEnd, over: dtWindow)
+        // Diagnostics from the double-talk run, where both signals are present so
+        // the adaptive delay estimator has reference energy to lock onto, and the
+        // processor exercises the full mic+reference path.
+        let diag = dtConditioner.diagnostics
+
+        return ModelScore(
+            label: label, modelKey: modelKey, echoLabel: echoLabel,
+            farEndERLE: farERLE,
+            nearEndErrorDB: nearErr,
+            nearEndRetentionRatio: retention,
+            doubleTalkErrorDB: dtErr, doubleTalkPassthroughErrorDB: dtPassErr,
+            processedFrames: diag.processedFrames, processingFailures: diag.processingFailures,
+            delaySamples: diag.currentDelaySamples)
+    }
+
+    private func makeConditioner(libraryURL: URL, modelURL: URL) -> any MicConditioning {
+        MeetingEchoSuppressionFactory.makeConditioner(
+            configuration: MeetingEchoSuppressionConfiguration(
+                mode: .dynamicLibrary,
+                libraryURL: libraryURL,
+                modelURL: modelURL),
+            bundle: Bundle(for: Self.self))
+    }
+
+    private func rmsRatio(
+        _ output: [Float], scenario: MeetingAecScenario, over window: Range<Int>
+    ) -> Float {
+        let outPower = MeetingAecMetrics.power(output, over: window)
+        let micPower = MeetingAecMetrics.power(scenario.mic, over: window)
+        guard micPower > 0 else { return 0 }
+        return Float((outPower / micPower).squareRoot())
+    }
+
+    // MARK: Aggregation + reporting
+
+    private func aggregate(_ scores: [ModelScore]) -> [ModelAggregate] {
+        // Group by full path, not filename, so a rebuilt model with the same
+        // basename in another directory doesn't silently merge with the original.
+        let byModel = Dictionary(grouping: scores, by: { $0.modelKey })
+        return byModel.values.map { group -> ModelAggregate in
+            let n = Double(group.count)
+            let retentions = group.map { $0.nearEndRetentionRatio }
+            return ModelAggregate(
+                label: group.first?.label ?? "?",
+                meanFarERLE: group.reduce(0) { $0 + $1.farEndERLE } / n,
+                meanDoubleTalkError: group.reduce(0) { $0 + $1.doubleTalkErrorDB } / n,
+                meanDoubleTalkImprovement: group.reduce(0) { $0 + $1.doubleTalkImprovement } / n,
+                minRetention: retentions.min() ?? 0,
+                maxRetention: retentions.max() ?? 0,
+                meanNearError: group.reduce(0) { $0 + $1.nearEndErrorDB } / n,
+                totalProcessingFailures: group.reduce(0) { $0 + $1.processingFailures })
+        }
+    }
+
+    private func printScoreTable(_ scores: [ModelScore]) {
+        print("[AEC-SCORE] LocalVQE model decision gate — synthetic harness")
+        print("[AEC-SCORE] GATED: ERLE higher better, retain in 0.8–1.5 | REPORTED only:"
+            + " nearErr/dtErr/dtImpr (synthetic tones can't certify fidelity)")
+        print(String(
+            format: "  %-34@ %-11@ %9@ %10@ %10@ %10@ %9@ %7@ %6@ %5@",
+            "model" as CVarArg, "echo" as CVarArg, "ERLE" as CVarArg,
+            "nearErr" as CVarArg, "dtErr" as CVarArg, "dtRaw" as CVarArg,
+            "dtImpr" as CVarArg, "retain" as CVarArg, "delay" as CVarArg, "fail" as CVarArg))
+        for s in scores {
+            print(String(
+                format: "  %-34@ %-11@ %8.1f %9.1f %9.1f %9.1f %8.1f %6.2f %5ld %4ld",
+                s.label as CVarArg, s.echoLabel as CVarArg,
+                s.farEndERLE, s.nearEndErrorDB, s.doubleTalkErrorDB,
+                s.doubleTalkPassthroughErrorDB, s.doubleTalkImprovement,
+                Double(s.nearEndRetentionRatio), s.delaySamples, s.processingFailures))
+        }
+        print("[AEC-SCORE] (dtImpr = passthrough dtErr − model dtErr; positive = model helped"
+            + " under double-talk. fail = frames that fell back to raw mic.)")
+    }
+
+    private func printAggregates(_ aggregates: [ModelAggregate]) {
+        print("[AEC-SCORE] per-model aggregate (mean across echo paths):")
+        for a in aggregates.sorted(by: { $0.meanFarERLE > $1.meanFarERLE }) {
+            print(String(
+                format: "  %-34@ farERLE %5.1f  dtErr %5.1f  dtImpr %5.1f  nearErr %5.1f  retain %.2f–%.2f  fails %ld",
+                a.label as CVarArg, a.meanFarERLE, a.meanDoubleTalkError,
+                a.meanDoubleTalkImprovement, a.meanNearError,
+                Double(a.minRetention), Double(a.maxRetention), a.totalProcessingFailures))
+        }
+    }
+}

--- a/plans/active/2026-06-28-meeting-aec-full-close.md
+++ b/plans/active/2026-06-28-meeting-aec-full-close.md
@@ -34,12 +34,22 @@ assets or hardware that cannot be produced in a sandbox.
   wiring remains.
 - **U8 — docs: PARTIAL.** `spec/05-audio-pipeline.md` updated. Contract/CLI
   updates wait on the cleaned-mic artifact (U3).
-- **U3/U4/U5/U6/U9 — DEFERRED.** These are blocked on bundling and
-  signing/notarizing the proprietary LocalVQE dylib + model (U5) and on real
-  no-headphones speaker-mode QA (U9). Until a canceller is bundled, production
-  resolves to `PassthroughMicConditioner`, so an offline cleaned-mic renderer
-  (U3) and cleaned-mic final-STT routing (U4) would be inert; landing them now
-  would ship no-op scaffolding. They follow once U5's assets exist.
+- **U5 — release verification + model decision gate: IN PROGRESS.** The
+  packaging/verification half landed in PR #646
+  (`scripts/dist/verify_meeting_echo_assets.sh`, runtime asset gates). The model
+  decision gate is now scored on the synthetic harness (branch
+  `feat/localvqe-u5-model-gate`, `MeetingAecModelScoringTests`): **echo-only
+  `localvqe-v1.4-aec-200K-f32` is the chosen release default candidate** because the
+  joint `v1.2` model zeroes the near-end voice (retain 0.00) while v1.4 preserves it
+  (retain ~1.0) at 35.6 dB ERLE — see "Model decision gate — result (2026-06-28)"
+  under U5. Remaining U5: build/sign/notarize the proprietary universal
+  `liblocalvqe.dylib` + bundle the chosen model, then flip `defaultModelName`.
+- **U3/U4/U6/U9 — DEFERRED.** These are blocked on bundling and
+  signing/notarizing the proprietary LocalVQE dylib + model (the remaining U5
+  binary work) and on real no-headphones speaker-mode QA (U9). Until a canceller is
+  bundled, production resolves to `PassthroughMicConditioner`, so an offline
+  cleaned-mic renderer (U3) and cleaned-mic final-STT routing (U4) would be inert;
+  landing them now would ship no-op scaffolding. They follow once U5's assets exist.
 
 ## Goal Capsule
 
@@ -301,6 +311,74 @@ flowchart TB
   - Bundled release verification fails if only one of library/model exists.
   - Bundled release verification passes when both assets exist, checksum matches, and dylib dependencies are acceptable.
 - **Verification:** Runtime tests pass and distribution verification proves a release app either contains valid echo assets or intentionally refuses to claim AEC readiness.
+
+#### Model decision gate — result (2026-06-28)
+
+Scored the two real LocalVQE candidates through the **production-faithful**
+conditioner (`MeetingEchoSuppressionFactory.makeConditioner(mode: .dynamicLibrary, …)`,
+adaptive delay estimator on) on the synthetic harness, via the new env-gated
+`MeetingAecModelScoringTests`. Deterministic and reproducible:
+
+| model | far-end ERLE | near-end retain | double-talk vs raw (dtImpr) |
+| --- | --- | --- | --- |
+| `localvqe-v1.4-aec-200K-f32` (echo-only) | 35.6 dB | **1.02 — voice preserved** | −6.1 dB\* |
+| `localvqe-v1.2-1.3M-f32` (joint AEC+denoise) | 66.2 dB | **0.00 — voice removed** | −3.5 dB\* |
+
+`retain` = output/mic RMS on the near-end-only scenario (~1.0 keeps the local voice,
+0 = silent). The adaptive estimator locked the true 120-sample echo delay for both.
+
+**Decision: ship `localvqe-v1.4-aec-200K-f32` (echo-only) as the release default
+candidate**, by the gate's rule (best near-end retention at acceptable far-end ERLE;
+prefer echo-only v1.4 on a tie):
+
+- The joint **v1.2 model zeroes the near-end voice** (retain 0.00) when the remote is
+  silent — its denoise front-end acts on the microphone regardless of the reference, so
+  it treats the local talker as noise. Its 66 dB ERLE is *real* echo removal, but it is
+  achieved by **non-selective muting**: the same model also zeroes the output in the
+  near-end-only and double-talk scenarios (retain 0.00, with **zero processing
+  failures** — this is genuine model behavior, not raw-fallback frames). This is the
+  disqualifying "chews up the user's own voice" failure the gate exists to catch, and it
+  is **structural, not a tone artifact**: an echo-only canceller cannot remove the
+  near-end when the reference is silent, a joint denoiser will.
+- The echo-only **v1.4 model preserves near-end energy** (retain ~1.0, zero processing
+  failures) while still removing strong far-end echo (35.6 dB) — ample to suppress the
+  speaker bleed that produces false `Me` text.
+
+\***Caveat — the honest limit of this gate (sharpened by independent review).** Both
+models show a *negative* synthetic double-talk improvement, and v1.4's near-end error is
+positive (+4.5 dB). This is **consistent with** synthetic-tone reshaping — the harness
+near-end is decorrelated formant tones, not speech, and a neural enhancer trained on real
+speech reshapes those tones so that exact-waveform error is penalized even when energy is
+preserved. But the harness **cannot distinguish** that benign hypothesis from genuine
+waveform damage (spectral coloring, phase/group-delay smear) that would also hurt real
+speech. So the gate **negatively screens** (it cleanly rejects v1.2's unambiguous
+near-end destruction) but **cannot positively certify** double-talk fidelity for *either*
+model. This decision selects v1.4 as the candidate to **bundle and QA**; it does **not**
+establish that v1.4's near-end is safe. Real speaker-mode QA (U9) is the binding gate
+before any default-on, per KTD6, and must confirm on real speech that (a) the local voice
+stays intelligible and undistorted and (b) far-end echo does not appear in the `Me`
+transcript. If v1.4's double-talk near-end is still damaged on real speech, the
+echo-only-vs-joint choice — or LocalVQE itself (WebRTC AEC3, plan U6) — must be revisited.
+
+**Follow-up (its own reviewed change, not done in the scoring branch).** When a
+canceller is bundled, set `MeetingEchoSuppressionFactory.defaultModelName` to
+`localvqe-v1.4-aec-200K-f32.gguf` (currently `localvqe-v1.2-1.3M-f32.gguf`) and bundle
+that file via `MACPARAKEET_MEETING_ECHO_MODEL_SRC`/`_NAME`. The runtime resolves
+`Resources/MeetingEchoSuppression/<defaultModelName>`, so the constant and the bundled
+basename must match.
+
+**Reproduce:**
+
+```bash
+MACPARAKEET_TEST_LOCALVQE_LIBRARY=/path/to/liblocalvqe.dylib \
+MACPARAKEET_TEST_LOCALVQE_MODELS=/path/to/v1.4-aec.gguf:/path/to/v1.2.gguf \
+swift test --filter MeetingAecModelScoringTests
+```
+
+Scored assets (sha256): `localvqe-v1.4-aec-200K-f32` `b6e43138…3c731`;
+`localvqe-v1.2-1.3M-f32` `4856ecf5…2ba9ce`. The repo-internal `gtcrn_aec.gguf` is not a
+loadable LocalVQE model in this runtime and is excluded by the test's load preflight. The
+test skips when the env vars are unset, so CI stays green without the private assets.
 
 ### U6. Benchmark WebRTC AEC3 or record the skip decision
 


### PR DESCRIPTION
## Summary

U5 "model decision gate" from the meeting-AEC plan. Adds an env-gated measurement test that scores candidate LocalVQE echo-cancellation models on the synthetic AEC harness through the production-faithful conditioner (adaptive delay estimator on), and records the release-default decision in the plan.

No production behavior changes: this is a test plus the plan's decision artifact. The test is skipped unless the private LocalVQE assets are provided via env (`MACPARAKEET_TEST_LOCALVQE_LIBRARY`/`_MODELS`), so CI stays green without them.

## Result

Scored the two real candidates on Apple Silicon:

| model | far-end ERLE | near-end retain | proc-fail |
| --- | --- | --- | --- |
| `v1.4-aec-200K-f32` (echo-only) | 35.6 dB | 1.02 (voice kept) | 0 |
| `v1.2-1.3M-f32` (joint) | 66.2 dB | 0.00 (voice removed) | 0 |

**Decision: ship `localvqe-v1.4-aec-200K-f32` (echo-only).** The joint v1.2 model zeroes the near-end voice when the remote is silent (retain 0.00, with zero processing failures, so it is genuine non-selective muting) — the disqualifying "chews up the user's own voice" failure the gate exists to catch. v1.4 preserves near-end energy while still removing strong echo.

## Honest limit

The synthetic near-end is tones, not speech, so the gate asserts only on the robust axes (echo removal + energy retention) and merely reports the waveform-fidelity numbers. v1.4 is the better-screened candidate, not a proven-safe default — double-talk fidelity is deferred to real speaker-mode QA (U9). Rationale, table, and reproduction under U5 "Model decision gate — result" in `plans/active/2026-06-28-meeting-aec-full-close.md`.

## Follow-up (separate reviewed change)

When the proprietary `liblocalvqe.dylib` + model are bundled/signed, set `MeetingEchoSuppressionFactory.defaultModelName` to the chosen model and bundle that file.

## Verification

- `swift test --filter MeetingAecModelScoringTests` — green with assets; skips cleanly without (CI-safe).
- Full suite green (one unrelated flaky `AudioRecorderFormatChangeTests` timing test passes on isolated re-run).
- Independently red-teamed via Codex; its findings hardened the test (teeth on robust axes, processing-failure contamination check, full-path dedup) and sharpened the decision record's fidelity caveat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an env-gated scoring test for LocalVQE AEC models to decide the U5 (#605) release default. Chooses echo‑only `localvqe-v1.4-aec-200K-f32` and aligns selection with the robust‑axis rule; no production behavior changes.

- **New Features**
  - Added `MeetingAecModelScoringTests` that loads assets via `MACPARAKEET_TEST_LOCALVQE_LIBRARY` and `MACPARAKEET_TEST_LOCALVQE_MODELS`; skips cleanly if unset. Scores via `MeetingEchoSuppressionFactory` with gates: far-end ERLE > 15 dB and near-end retention 0.8–1.5; prints per-path and per-model aggregates.
  - Hardened test logic: accounts for per-scenario processing failures and rejects contaminated scores; reuses the same loaded conditioner while snapshotting diagnostics; release-default selection now follows the documented rule (best retention at acceptable ERLE, tie-break to echo‑only `v1.4`, then higher ERLE). Updated the plan to record the decision and U5 follow-ups.

- **Migration**
  - When assets are bundled, set `MeetingEchoSuppressionFactory.defaultModelName` to `localvqe-v1.4-aec-200K-f32.gguf` and bundle that file.

<sup>Written for commit ed06f46e05cc20231db3d42539934bb58facbc83. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/650?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

