### PR TITLE
Meeting AEC: wire cleaned mic into finalize, STT, retention, recovery (#605 U3/U4)

### DIFF
--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingCleanedMicRenderer.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingCleanedMicRenderer.swift
@@ -1,5 +1,6 @@
 import AVFoundation
 import Foundation
+import os
 import OSLog
 
 /// Post-stop renderer that derives a cleaned microphone artifact
@@ -312,15 +313,19 @@ final class MeetingCleanedMicRenderer {
                 throw MeetingAudioError.storageFailed("decode output buffer alloc failed")
             }
 
-            var consumed = false
             var conversionError: NSError?
             let inputWrapper = UncheckedSendableAudioPCMBuffer(inputBuffer)
+            let inputConsumed = OSAllocatedUnfairLock(initialState: false)
             let status = converter.convert(to: outputBuffer, error: &conversionError) { _, outStatus in
-                if consumed {
+                let shouldProvideInput = inputConsumed.withLock { consumed -> Bool in
+                    guard !consumed else { return false }
+                    consumed = true
+                    return true
+                }
+                if !shouldProvideInput {
                     outStatus.pointee = .noDataNow
                     return nil
                 }
-                consumed = true
                 outStatus.pointee = .haveData
                 return inputWrapper.buffer
             }

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingCleanedMicRenderer.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingCleanedMicRenderer.swift
@@ -98,12 +98,12 @@ final class MeetingCleanedMicRenderer {
         let system: [Float]
         do {
             try Task.checkCancellation()
-            microphone = try Self.decodeMonoFloat(
+            microphone = try await Self.decodeMonoFloat(
                 url: microphoneURL,
                 sampleRate: Self.renderSampleRate,
                 maxFrames: Self.maxDecodedFrames)
             try Task.checkCancellation()
-            system = try Self.decodeMonoFloat(
+            system = try await Self.decodeMonoFloat(
                 url: systemURL,
                 sampleRate: Self.renderSampleRate,
                 maxFrames: Self.maxDecodedFrames)
@@ -254,7 +254,7 @@ final class MeetingCleanedMicRenderer {
         url: URL,
         sampleRate: Int,
         maxFrames: Int? = nil
-    ) throws -> [Float] {
+    ) async throws -> [Float] {
         let file = try AVAudioFile(forReading: url)
         guard let targetFormat = AVAudioFormat(
             commonFormat: .pcmFormatFloat32,
@@ -325,6 +325,7 @@ final class MeetingCleanedMicRenderer {
                     frameCount: samples.count,
                     maxFrames: maxFrames)
             }
+            await Task.yield()
             if providedFrames < readFrames { reachedEnd = true }
         }
 
@@ -345,6 +346,7 @@ final class MeetingCleanedMicRenderer {
                         frameCount: samples.count,
                         maxFrames: maxFrames)
                 }
+                await Task.yield()
             }
         }
         return samples

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingCleanedMicRenderer.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingCleanedMicRenderer.swift
@@ -122,13 +122,20 @@ final class MeetingCleanedMicRenderer {
         }
         try Task.checkCancellation()
 
-        let conditioned = Self.alignAndCondition(
-            microphone: microphone,
-            system: system,
-            microphoneStartOffsetMs: sourceAlignment.microphone?.startOffsetMs ?? 0,
-            systemStartOffsetMs: sourceAlignment.system?.startOffsetMs ?? 0,
-            sampleRate: Self.renderSampleRate,
-            conditioner: conditioner)
+        let conditioned: ConditionedOutput
+        do {
+            conditioned = try Self.alignAndCondition(
+                microphone: microphone,
+                system: system,
+                microphoneStartOffsetMs: sourceAlignment.microphone?.startOffsetMs ?? 0,
+                systemStartOffsetMs: sourceAlignment.system?.startOffsetMs ?? 0,
+                sampleRate: Self.renderSampleRate,
+                conditioner: conditioner)
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            return .skipped(.renderFailed(String(describing: error)))
+        }
         try Task.checkCancellation()
 
         do {
@@ -176,7 +183,7 @@ final class MeetingCleanedMicRenderer {
         systemStartOffsetMs: Int,
         sampleRate: Int,
         conditioner: any MicConditioning
-    ) -> ConditionedOutput {
+    ) throws -> ConditionedOutput {
         // Finalize/recovery pass freshly built conditioners today; keep this
         // defensive reset so direct tests or future callers cannot reuse stale
         // adaptive filter state accidentally.
@@ -195,6 +202,7 @@ final class MeetingCleanedMicRenderer {
         let chunkSize = 4_096
         var cursor = 0
         while cursor < microphone.count {
+            try Task.checkCancellation()
             let end = min(cursor + chunkSize, microphone.count)
             let micChunk = Array(microphone[cursor..<end])
             var refChunk: [Float] = []
@@ -388,9 +396,8 @@ final class MeetingCleanedMicRenderer {
             throw MeetingAudioError.storageFailed(
                 writer.error?.localizedDescription ?? "cleaned mic writer start failed")
         }
-        var writerCompleted = false
         defer {
-            if !writerCompleted {
+            if writer.status == .writing {
                 writer.cancelWriting()
             }
         }
@@ -440,7 +447,6 @@ final class MeetingCleanedMicRenderer {
             throw MeetingAudioError.storageFailed(
                 writer.error?.localizedDescription ?? "cleaned mic finalize failed")
         }
-        writerCompleted = true
     }
 
     private static func finishWriting(_ writer: AVAssetWriter) async {

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingCleanedMicRenderer.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingCleanedMicRenderer.swift
@@ -218,6 +218,7 @@ final class MeetingCleanedMicRenderer {
                 microphone: micChunk, speaker: refChunk, hasSpeakerReference: true)
             cursor = end
         }
+        try Task.checkCancellation()
         output += conditioner.flush()
         // `flush()` rounds the final partial frame up, so the conditioner can
         // emit a few samples past the mic length; trim them so the cleaned file
@@ -338,24 +339,28 @@ final class MeetingCleanedMicRenderer {
         }
 
         // Flush any samples the converter is holding (e.g. resampler tail).
-        if let outputBuffer = AVAudioPCMBuffer(pcmFormat: targetFormat, frameCapacity: readFrames) {
-            try Task.checkCancellation()
-            var flushError: NSError?
-            let status = converter.convert(to: outputBuffer, error: &flushError) { _, outStatus in
-                outStatus.pointee = .endOfStream
-                return nil
+        guard let outputBuffer = AVAudioPCMBuffer(
+            pcmFormat: targetFormat,
+            frameCapacity: readFrames
+        ) else {
+            throw MeetingAudioError.storageFailed("decode flush buffer alloc failed")
+        }
+        try Task.checkCancellation()
+        var flushError: NSError?
+        let status = converter.convert(to: outputBuffer, error: &flushError) { _, outStatus in
+            outStatus.pointee = .endOfStream
+            return nil
+        }
+        if status != .error, let channel = outputBuffer.floatChannelData?.pointee,
+           outputBuffer.frameLength > 0 {
+            samples.append(contentsOf: UnsafeBufferPointer(
+                start: channel, count: Int(outputBuffer.frameLength)))
+            if let maxFrames, samples.count > maxFrames {
+                throw DecodeLimitExceeded.tooManyFrames(
+                    frameCount: samples.count,
+                    maxFrames: maxFrames)
             }
-            if status != .error, let channel = outputBuffer.floatChannelData?.pointee,
-               outputBuffer.frameLength > 0 {
-                samples.append(contentsOf: UnsafeBufferPointer(
-                    start: channel, count: Int(outputBuffer.frameLength)))
-                if let maxFrames, samples.count > maxFrames {
-                    throw DecodeLimitExceeded.tooManyFrames(
-                        frameCount: samples.count,
-                        maxFrames: maxFrames)
-                }
-                await Task.yield()
-            }
+            await Task.yield()
         }
         return samples
     }

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingCleanedMicRenderer.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingCleanedMicRenderer.swift
@@ -234,7 +234,10 @@ final class MeetingCleanedMicRenderer {
 
         var samples: [Float] = []
         let sourceRate = file.processingFormat.sampleRate
-        let ratio = targetFormat.sampleRate / max(sourceRate, 1)
+        // Corrupt files should not explode output-buffer sizing with zero or
+        // sub-Hz source rates; floor at 1.0 Hz and fail gracefully downstream if
+        // allocation/conversion still cannot proceed.
+        let ratio = targetFormat.sampleRate / max(sourceRate, 1.0)
         let readFrames: AVAudioFrameCount = 16_384
         var reachedEnd = false
 

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingCleanedMicRenderer.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingCleanedMicRenderer.swift
@@ -386,6 +386,12 @@ final class MeetingCleanedMicRenderer {
             throw MeetingAudioError.storageFailed(
                 writer.error?.localizedDescription ?? "cleaned mic writer start failed")
         }
+        var writerCompleted = false
+        defer {
+            if !writerCompleted {
+                writer.cancelWriting()
+            }
+        }
         writer.startSession(atSourceTime: .zero)
 
         let sampleBufferFactory = PCMBufferToSampleBuffer()
@@ -432,6 +438,7 @@ final class MeetingCleanedMicRenderer {
             throw MeetingAudioError.storageFailed(
                 writer.error?.localizedDescription ?? "cleaned mic finalize failed")
         }
+        writerCompleted = true
     }
 
     private static func finishWriting(_ writer: AVAssetWriter) async {

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingCleanedMicRenderer.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingCleanedMicRenderer.swift
@@ -227,6 +227,12 @@ final class MeetingCleanedMicRenderer {
         if output.count > microphone.count {
             output.removeLast(output.count - microphone.count)
         }
+        if output.count < microphone.count {
+            // A conditioner that under-flushes must not shorten the derived STT
+            // artifact; keep the 1:1 duration contract by falling back to the
+            // raw mic tail for any missing samples.
+            output.append(contentsOf: microphone[output.count..<microphone.count])
+        }
 
         let diagnostics = conditioner.diagnostics
         return ConditionedOutput(
@@ -350,6 +356,10 @@ final class MeetingCleanedMicRenderer {
         let status = converter.convert(to: outputBuffer, error: &flushError) { _, outStatus in
             outStatus.pointee = .endOfStream
             return nil
+        }
+        if status == .error {
+            throw MeetingAudioError.storageFailed(
+                flushError?.localizedDescription ?? "decode flush conversion failed")
         }
         if status != .error, let channel = outputBuffer.floatChannelData?.pointee,
            outputBuffer.frameLength > 0 {

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingCleanedMicRenderer.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingCleanedMicRenderer.swift
@@ -271,6 +271,9 @@ final class MeetingCleanedMicRenderer {
                 throw MeetingAudioError.storageFailed(
                     conversionError?.localizedDescription ?? "decode conversion failed")
             }
+            if status == .endOfStream {
+                reachedEnd = true
+            }
             if let channel = outputBuffer.floatChannelData?.pointee {
                 samples.append(contentsOf: UnsafeBufferPointer(
                     start: channel, count: Int(outputBuffer.frameLength)))

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingCleanedMicRenderer.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingCleanedMicRenderer.swift
@@ -13,15 +13,16 @@ import OSLog
 /// `MicConditioning` seam the live path uses (so the bundled echo suppressor and
 /// its adaptive delay estimator do the cancellation), and encodes the result.
 ///
-/// It never throws into the recording-finalize path: every failure resolves to a
-/// `.skipped(reason)` outcome and leaves the raw sources intact, so a meeting
-/// always completes even when cleaning is unavailable or fails.
+/// Non-cancellation failures never throw into the recording-finalize path: they
+/// resolve to a `.skipped(reason)` outcome and leave the raw sources intact, so
+/// a meeting completes even when cleaning is unavailable or fails.
 final class MeetingCleanedMicRenderer {
     static let cleanedMicrophoneFileName = "microphone-cleaned.m4a"
 
     /// Sample rate the echo suppressor expects; the cleaned artifact is a derived
     /// STT input (not the playback/export `meeting.m4a`), so 16 kHz mono is fine.
     static let renderSampleRate = 16_000
+    static let maxDecodedFrames = renderSampleRate * 4 * 3_600
 
     private static let logger = Logger(
         subsystem: "com.macparakeet.core", category: "MeetingCleanedMicRenderer")
@@ -52,6 +53,7 @@ final class MeetingCleanedMicRenderer {
         case missingMicrophoneSource
         case missingSystemReference
         case emptyMicrophone
+        case inputTooLong(frameCount: Int, maxFrames: Int)
         case decodeFailed(String)
         case renderFailed(String)
     }
@@ -69,14 +71,15 @@ final class MeetingCleanedMicRenderer {
 
     /// Render the cleaned mic. `conditioner` is the live factory's product; the
     /// caller passes a freshly built one. Do the heavy decode/encode off the
-    /// main actor.
+    /// main actor. Normal render failures return `.skipped`; cooperative
+    /// cancellation is rethrown so detached callers can be interrupted.
     func render(
         microphoneURL: URL,
         systemURL: URL,
         sourceAlignment: MeetingSourceAlignment,
         outputURL: URL,
         conditioner: any MicConditioning
-    ) async -> Outcome {
+    ) async throws -> Outcome {
         // Only derive when a real echo processor loaded. Passthrough (no assets)
         // and unavailable (load failed) both leave the raw mic as the truth.
         let diagnostics = conditioner.diagnostics
@@ -94,12 +97,30 @@ final class MeetingCleanedMicRenderer {
         let microphone: [Float]
         let system: [Float]
         do {
-            microphone = try Self.decodeMonoFloat(url: microphoneURL, sampleRate: Self.renderSampleRate)
-            system = try Self.decodeMonoFloat(url: systemURL, sampleRate: Self.renderSampleRate)
+            try Task.checkCancellation()
+            microphone = try Self.decodeMonoFloat(
+                url: microphoneURL,
+                sampleRate: Self.renderSampleRate,
+                maxFrames: Self.maxDecodedFrames)
+            try Task.checkCancellation()
+            system = try Self.decodeMonoFloat(
+                url: systemURL,
+                sampleRate: Self.renderSampleRate,
+                maxFrames: Self.maxDecodedFrames)
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch DecodeLimitExceeded.tooManyFrames(let frameCount, let maxFrames) {
+            return .skipped(.inputTooLong(frameCount: frameCount, maxFrames: maxFrames))
         } catch {
             return .skipped(.decodeFailed(String(describing: error)))
         }
         guard !microphone.isEmpty else { return .skipped(.emptyMicrophone) }
+        guard max(microphone.count, system.count) <= Self.maxDecodedFrames else {
+            return .skipped(.inputTooLong(
+                frameCount: max(microphone.count, system.count),
+                maxFrames: Self.maxDecodedFrames))
+        }
+        try Task.checkCancellation()
 
         let conditioned = Self.alignAndCondition(
             microphone: microphone,
@@ -108,11 +129,15 @@ final class MeetingCleanedMicRenderer {
             systemStartOffsetMs: sourceAlignment.system?.startOffsetMs ?? 0,
             sampleRate: Self.renderSampleRate,
             conditioner: conditioner)
+        try Task.checkCancellation()
 
         do {
             try await Self.encodeMonoFloat(
                 conditioned.output, sampleRate: Self.renderSampleRate, to: outputURL,
                 fileManager: fileManager)
+        } catch is CancellationError {
+            try? fileManager.removeItem(at: outputURL)
+            throw CancellationError()
         } catch {
             try? fileManager.removeItem(at: outputURL)
             return .skipped(.renderFailed(String(describing: error)))
@@ -221,7 +246,15 @@ final class MeetingCleanedMicRenderer {
     /// acceptable for a bounded, off-actor, post-stop one-shot render. If
     /// multi-hour meetings prove this too heavy, stream decode→condition→encode
     /// in chunks instead (deferred; the path is inert until U5 bundles assets).
-    static func decodeMonoFloat(url: URL, sampleRate: Int) throws -> [Float] {
+    enum DecodeLimitExceeded: Error, Equatable {
+        case tooManyFrames(frameCount: Int, maxFrames: Int)
+    }
+
+    static func decodeMonoFloat(
+        url: URL,
+        sampleRate: Int,
+        maxFrames: Int? = nil
+    ) throws -> [Float] {
         let file = try AVAudioFile(forReading: url)
         guard let targetFormat = AVAudioFormat(
             commonFormat: .pcmFormatFloat32,
@@ -247,6 +280,7 @@ final class MeetingCleanedMicRenderer {
         var reachedEnd = false
 
         while !reachedEnd {
+            try Task.checkCancellation()
             guard let inputBuffer = AVAudioPCMBuffer(
                 pcmFormat: file.processingFormat, frameCapacity: readFrames
             ) else {
@@ -286,11 +320,17 @@ final class MeetingCleanedMicRenderer {
                 samples.append(contentsOf: UnsafeBufferPointer(
                     start: channel, count: Int(outputBuffer.frameLength)))
             }
+            if let maxFrames, samples.count > maxFrames {
+                throw DecodeLimitExceeded.tooManyFrames(
+                    frameCount: samples.count,
+                    maxFrames: maxFrames)
+            }
             if providedFrames < readFrames { reachedEnd = true }
         }
 
         // Flush any samples the converter is holding (e.g. resampler tail).
         if let outputBuffer = AVAudioPCMBuffer(pcmFormat: targetFormat, frameCapacity: readFrames) {
+            try Task.checkCancellation()
             var flushError: NSError?
             let status = converter.convert(to: outputBuffer, error: &flushError) { _, outStatus in
                 outStatus.pointee = .endOfStream
@@ -300,6 +340,11 @@ final class MeetingCleanedMicRenderer {
                outputBuffer.frameLength > 0 {
                 samples.append(contentsOf: UnsafeBufferPointer(
                     start: channel, count: Int(outputBuffer.frameLength)))
+                if let maxFrames, samples.count > maxFrames {
+                    throw DecodeLimitExceeded.tooManyFrames(
+                        frameCount: samples.count,
+                        maxFrames: maxFrames)
+                }
             }
         }
         return samples
@@ -348,6 +393,7 @@ final class MeetingCleanedMicRenderer {
         var written: Int64 = 0
         var cursor = 0
         while cursor < samples.count {
+            try Task.checkCancellation()
             let end = min(cursor + blockFrames, samples.count)
             let frameCount = AVAudioFrameCount(end - cursor)
             guard let buffer = AVAudioPCMBuffer(pcmFormat: pcmFormat, frameCapacity: frameCount),

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingCleanedMicRenderer.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingCleanedMicRenderer.swift
@@ -377,7 +377,7 @@ final class MeetingCleanedMicRenderer {
 
         input.markAsFinished()
         await finishWriting(writer)
-        if writer.status == .failed {
+        if writer.status != .completed {
             throw MeetingAudioError.storageFailed(
                 writer.error?.localizedDescription ?? "cleaned mic finalize failed")
         }
@@ -395,7 +395,7 @@ final class MeetingCleanedMicRenderer {
 
 /// Minimal Sendable box so the non-Sendable `AVAssetWriter` can be referenced
 /// from `finishWriting`'s `@Sendable` completion without capturing `self`.
-private struct UncheckedSendableBox<T>: @unchecked Sendable {
+struct UncheckedSendableBox<T>: @unchecked Sendable {
     let value: T
     init(_ value: T) { self.value = value }
 }

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingCleanedMicRenderer.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingCleanedMicRenderer.swift
@@ -152,6 +152,9 @@ final class MeetingCleanedMicRenderer {
         sampleRate: Int,
         conditioner: any MicConditioning
     ) -> ConditionedOutput {
+        // Finalize/recovery pass freshly built conditioners today; keep this
+        // defensive reset so direct tests or future callers cannot reuse stale
+        // adaptive filter state accidentally.
         conditioner.reset()
         // Place the system reference on the microphone's timeline: a sample at
         // mic position p must be cancelled against the system audio at the same

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingCleanedMicRenderer.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingCleanedMicRenderer.swift
@@ -178,6 +178,13 @@ final class MeetingCleanedMicRenderer {
             cursor = end
         }
         output += conditioner.flush()
+        // `flush()` rounds the final partial frame up, so the conditioner can
+        // emit a few samples past the mic length; trim them so the cleaned file
+        // is never longer than the raw mic (the 1:1 guarantee above) and its
+        // reported duration matches the source.
+        if output.count > microphone.count {
+            output.removeLast(output.count - microphone.count)
+        }
 
         let diagnostics = conditioner.diagnostics
         return ConditionedOutput(
@@ -219,7 +226,10 @@ final class MeetingCleanedMicRenderer {
     // MARK: Audio I/O
 
     /// Decode an audio file to mono Float32 at `sampleRate`, fully in memory.
-    /// A post-stop one-shot render; the live path is the memory-sensitive one.
+    /// Peak scales with meeting length (~230 MB/hour/track at 16 kHz), which is
+    /// acceptable for a bounded, off-actor, post-stop one-shot render. If
+    /// multi-hour meetings prove this too heavy, stream decode→condition→encode
+    /// in chunks instead (deferred; the path is inert until U5 bundles assets).
     static func decodeMonoFloat(url: URL, sampleRate: Int) throws -> [Float] {
         let file = try AVAudioFile(forReading: url)
         guard let targetFormat = AVAudioFormat(
@@ -352,6 +362,15 @@ final class MeetingCleanedMicRenderer {
             let sampleBuffer = try sampleBufferFactory.makeSampleBuffer(
                 from: buffer, presentationTimeSamples: written)
             while !input.isReadyForMoreMediaData {
+                // A failed writer (disk full, sandbox I/O error) can leave
+                // `isReadyForMoreMediaData` false forever; bail instead of
+                // spinning so finalize/recovery never hang on a broken render.
+                // Mirrors the live storage writer, which also gates on
+                // `writer.status == .writing`.
+                guard writer.status == .writing else {
+                    throw MeetingAudioError.storageFailed(
+                        writer.error?.localizedDescription ?? "cleaned mic writer failed while waiting")
+                }
                 Thread.sleep(forTimeInterval: 0.001)
             }
             guard input.append(sampleBuffer) else {

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingCleanedMicRenderer.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingCleanedMicRenderer.swift
@@ -1,0 +1,379 @@
+import AVFoundation
+import Foundation
+import OSLog
+
+/// Post-stop renderer that derives a cleaned microphone artifact
+/// (`microphone-cleaned.m4a`) from the finalized raw `microphone.m4a` +
+/// `system.m4a` source files (plan #605 unit U3).
+///
+/// The raw source files are preserved untouched; the cleaned file is a derived
+/// artifact. Rendering reads both raw sources back as 16 kHz mono PCM, aligns
+/// the system reference to the microphone using the recorded
+/// `MeetingSourceAlignment` start offsets, streams the pair through the same
+/// `MicConditioning` seam the live path uses (so the bundled echo suppressor and
+/// its adaptive delay estimator do the cancellation), and encodes the result.
+///
+/// It never throws into the recording-finalize path: every failure resolves to a
+/// `.skipped(reason)` outcome and leaves the raw sources intact, so a meeting
+/// always completes even when cleaning is unavailable or fails.
+final class MeetingCleanedMicRenderer {
+    static let cleanedMicrophoneFileName = "microphone-cleaned.m4a"
+
+    /// Sample rate the echo suppressor expects; the cleaned artifact is a derived
+    /// STT input (not the playback/export `meeting.m4a`), so 16 kHz mono is fine.
+    static let renderSampleRate = 16_000
+
+    private static let logger = Logger(
+        subsystem: "com.macparakeet.core", category: "MeetingCleanedMicRenderer")
+
+    struct Result: Sendable, Equatable {
+        let outputURL: URL
+        let durationSeconds: Double
+        /// Frames the processor cleaned vs. served raw (a processor that throws
+        /// falls back to raw); both feed U4's health gate.
+        let processedFrames: Int
+        let rawFallbackFrames: Int
+        let processingFailures: Int
+        /// Output RMS / raw-mic RMS over the analysed span. ~1.0 keeps the local
+        /// voice; near 0 means the cleaner gutted the mic — a health-gate signal.
+        let outputToRawRmsRatio: Float
+    }
+
+    enum SkipReason: Sendable, Equatable {
+        /// The conditioner is passthrough or failed to load — cleaning would just
+        /// re-encode the raw mic, so there is nothing to derive.
+        case conditionerUnavailable
+        case missingMicrophoneSource
+        case missingSystemReference
+        case emptyMicrophone
+        case decodeFailed(String)
+        case renderFailed(String)
+    }
+
+    enum Outcome: Sendable, Equatable {
+        case rendered(Result)
+        case skipped(SkipReason)
+    }
+
+    private let fileManager: FileManager
+
+    init(fileManager: FileManager = .default) {
+        self.fileManager = fileManager
+    }
+
+    /// Render the cleaned mic. `conditioner` is the live factory's product; the
+    /// caller passes a freshly built one. Synchronous: do blocking decode/encode
+    /// off the main actor.
+    func render(
+        microphoneURL: URL,
+        systemURL: URL,
+        sourceAlignment: MeetingSourceAlignment,
+        outputURL: URL,
+        conditioner: any MicConditioning
+    ) -> Outcome {
+        // Only derive when a real echo processor loaded. Passthrough (no assets)
+        // and unavailable (load failed) both leave the raw mic as the truth.
+        let diagnostics = conditioner.diagnostics
+        guard diagnostics.loaded,
+              diagnostics.processorName != PassthroughMicConditioner().diagnostics.processorName else {
+            return .skipped(.conditionerUnavailable)
+        }
+        guard fileManager.fileExists(atPath: microphoneURL.path) else {
+            return .skipped(.missingMicrophoneSource)
+        }
+        guard fileManager.fileExists(atPath: systemURL.path) else {
+            return .skipped(.missingSystemReference)
+        }
+
+        let microphone: [Float]
+        let system: [Float]
+        do {
+            microphone = try Self.decodeMonoFloat(url: microphoneURL, sampleRate: Self.renderSampleRate)
+            system = try Self.decodeMonoFloat(url: systemURL, sampleRate: Self.renderSampleRate)
+        } catch {
+            return .skipped(.decodeFailed(String(describing: error)))
+        }
+        guard !microphone.isEmpty else { return .skipped(.emptyMicrophone) }
+
+        let conditioned = Self.alignAndCondition(
+            microphone: microphone,
+            system: system,
+            microphoneStartOffsetMs: sourceAlignment.microphone?.startOffsetMs ?? 0,
+            systemStartOffsetMs: sourceAlignment.system?.startOffsetMs ?? 0,
+            sampleRate: Self.renderSampleRate,
+            conditioner: conditioner)
+
+        do {
+            try Self.encodeMonoFloat(
+                conditioned.output, sampleRate: Self.renderSampleRate, to: outputURL,
+                fileManager: fileManager)
+        } catch {
+            try? fileManager.removeItem(at: outputURL)
+            return .skipped(.renderFailed(String(describing: error)))
+        }
+
+        let duration = Double(conditioned.output.count) / Double(Self.renderSampleRate)
+        let ratio = Self.rmsRatio(conditioned.output, microphone)
+        Self.logger.info(
+            "meeting_cleaned_mic_rendered duration_s=\(duration, format: .fixed(precision: 1), privacy: .public) processed_frames=\(conditioned.processedFrames, privacy: .public) raw_fallback_frames=\(conditioned.rawFallbackFrames, privacy: .public) failures=\(conditioned.processingFailures, privacy: .public) rms_ratio=\(ratio, format: .fixed(precision: 2), privacy: .public)")
+        return .rendered(Result(
+            outputURL: outputURL,
+            durationSeconds: duration,
+            processedFrames: conditioned.processedFrames,
+            rawFallbackFrames: conditioned.rawFallbackFrames,
+            processingFailures: conditioned.processingFailures,
+            outputToRawRmsRatio: ratio))
+    }
+
+    // MARK: DSP core (pure; unit-tested independently of audio codecs)
+
+    struct ConditionedOutput: Sendable, Equatable {
+        let output: [Float]
+        let processedFrames: Int
+        let rawFallbackFrames: Int
+        let processingFailures: Int
+    }
+
+    /// Align the system reference to the microphone by their recorded start
+    /// offsets, then stream the pair through the conditioner. Output is aligned
+    /// 1:1 with the microphone samples (the conditioner's `flush()` drains any
+    /// held tail), so the cleaned file has the same duration as the raw mic.
+    static func alignAndCondition(
+        microphone: [Float],
+        system: [Float],
+        microphoneStartOffsetMs: Int,
+        systemStartOffsetMs: Int,
+        sampleRate: Int,
+        conditioner: any MicConditioning
+    ) -> ConditionedOutput {
+        conditioner.reset()
+        // Place the system reference on the microphone's timeline: a sample at
+        // mic position p must be cancelled against the system audio at the same
+        // wall-clock instant. relativeShift > 0 means system started later than
+        // the mic, so the mic's opening has no reference (leading zeros); < 0
+        // means system started earlier, so its head is dropped.
+        let sampleRate = max(1, sampleRate)
+        let relativeShiftSamples = Int(
+            (Double(systemStartOffsetMs - microphoneStartOffsetMs) / 1000.0
+                * Double(sampleRate)).rounded())
+        let alignedReference = shiftReference(
+            system, by: relativeShiftSamples, toMatchCount: microphone.count)
+
+        var output: [Float] = []
+        output.reserveCapacity(microphone.count)
+        let chunkSize = 4_096
+        var cursor = 0
+        while cursor < microphone.count {
+            let end = min(cursor + chunkSize, microphone.count)
+            let micChunk = Array(microphone[cursor..<end])
+            let refChunk = Array(alignedReference[cursor..<end])
+            output += conditioner.condition(
+                microphone: micChunk, speaker: refChunk, hasSpeakerReference: true)
+            cursor = end
+        }
+        output += conditioner.flush()
+
+        let diagnostics = conditioner.diagnostics
+        return ConditionedOutput(
+            output: output,
+            processedFrames: diagnostics.processedFrames,
+            rawFallbackFrames: diagnostics.rawFallbackFrames,
+            processingFailures: diagnostics.processingFailures)
+    }
+
+    /// Reposition `reference` so index i lines up with the microphone's index i,
+    /// padding/truncating to exactly `count` samples (the reference is read at the
+    /// mic's own position; the conditioner applies the echo-path delay on top).
+    private static func shiftReference(
+        _ reference: [Float], by shiftSamples: Int, toMatchCount count: Int
+    ) -> [Float] {
+        var aligned = [Float](repeating: 0, count: count)
+        // Destination index d corresponds to source index (d - shiftSamples).
+        for d in 0..<count {
+            let s = d - shiftSamples
+            if s >= 0, s < reference.count {
+                aligned[d] = reference[s]
+            }
+        }
+        return aligned
+    }
+
+    private static func rmsRatio(_ a: [Float], _ b: [Float]) -> Float {
+        func power(_ s: [Float]) -> Double {
+            guard !s.isEmpty else { return 0 }
+            var acc = 0.0
+            for v in s { acc += Double(v) * Double(v) }
+            return acc / Double(s.count)
+        }
+        let bp = power(b)
+        guard bp > 0 else { return 0 }
+        return Float((power(a) / bp).squareRoot())
+    }
+
+    // MARK: Audio I/O
+
+    /// Decode an audio file to mono Float32 at `sampleRate`, fully in memory.
+    /// A post-stop one-shot render; the live path is the memory-sensitive one.
+    static func decodeMonoFloat(url: URL, sampleRate: Int) throws -> [Float] {
+        let file = try AVAudioFile(forReading: url)
+        guard let targetFormat = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: Double(sampleRate),
+            channels: 1,
+            interleaved: false
+        ) else {
+            throw MeetingAudioError.storageFailed("invalid decode format")
+        }
+        guard let converter = AVAudioConverter(from: file.processingFormat, to: targetFormat) else {
+            throw MeetingAudioError.storageFailed("decode converter unavailable")
+        }
+
+        var samples: [Float] = []
+        let sourceRate = file.processingFormat.sampleRate
+        let ratio = targetFormat.sampleRate / max(sourceRate, 1)
+        let readFrames: AVAudioFrameCount = 16_384
+        var reachedEnd = false
+
+        while !reachedEnd {
+            guard let inputBuffer = AVAudioPCMBuffer(
+                pcmFormat: file.processingFormat, frameCapacity: readFrames
+            ) else {
+                throw MeetingAudioError.storageFailed("decode input buffer alloc failed")
+            }
+            try file.read(into: inputBuffer, frameCount: readFrames)
+            let providedFrames = inputBuffer.frameLength
+            if providedFrames == 0 { break }
+
+            let capacity = AVAudioFrameCount(Double(providedFrames) * ratio) + 64
+            guard let outputBuffer = AVAudioPCMBuffer(
+                pcmFormat: targetFormat, frameCapacity: max(capacity, 1)
+            ) else {
+                throw MeetingAudioError.storageFailed("decode output buffer alloc failed")
+            }
+
+            var consumed = false
+            var conversionError: NSError?
+            let inputWrapper = UncheckedSendableAudioPCMBuffer(inputBuffer)
+            let status = converter.convert(to: outputBuffer, error: &conversionError) { _, outStatus in
+                if consumed {
+                    outStatus.pointee = .noDataNow
+                    return nil
+                }
+                consumed = true
+                outStatus.pointee = .haveData
+                return inputWrapper.buffer
+            }
+            if status == .error {
+                throw MeetingAudioError.storageFailed(
+                    conversionError?.localizedDescription ?? "decode conversion failed")
+            }
+            if let channel = outputBuffer.floatChannelData?.pointee {
+                samples.append(contentsOf: UnsafeBufferPointer(
+                    start: channel, count: Int(outputBuffer.frameLength)))
+            }
+            if providedFrames < readFrames { reachedEnd = true }
+        }
+
+        // Flush any samples the converter is holding (e.g. resampler tail).
+        if let outputBuffer = AVAudioPCMBuffer(pcmFormat: targetFormat, frameCapacity: readFrames) {
+            var flushError: NSError?
+            let status = converter.convert(to: outputBuffer, error: &flushError) { _, outStatus in
+                outStatus.pointee = .endOfStream
+                return nil
+            }
+            if status != .error, let channel = outputBuffer.floatChannelData?.pointee,
+               outputBuffer.frameLength > 0 {
+                samples.append(contentsOf: UnsafeBufferPointer(
+                    start: channel, count: Int(outputBuffer.frameLength)))
+            }
+        }
+        return samples
+    }
+
+    /// Encode mono Float32 samples to an AAC `.m4a` at `sampleRate`.
+    static func encodeMonoFloat(
+        _ samples: [Float], sampleRate: Int, to outputURL: URL, fileManager: FileManager
+    ) throws {
+        try? fileManager.removeItem(at: outputURL)
+        guard let pcmFormat = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: Double(sampleRate),
+            channels: 1,
+            interleaved: false
+        ) else {
+            throw MeetingAudioError.storageFailed("invalid encode format")
+        }
+
+        let writer = try AVAssetWriter(outputURL: outputURL, fileType: .m4a)
+        // No explicit bitrate: 64 kbps is above AAC-LC's allowed ceiling for
+        // 16 kHz mono and makes the encoder reject the media. Let AVFoundation
+        // pick a valid rate for the (sampleRate, channels) pair.
+        let outputSettings: [String: Any] = [
+            AVFormatIDKey: kAudioFormatMPEG4AAC,
+            AVSampleRateKey: Double(sampleRate),
+            AVNumberOfChannelsKey: 1,
+        ]
+        let input = AVAssetWriterInput(mediaType: .audio, outputSettings: outputSettings)
+        // Match the proven live storage writer: direct appends gated on
+        // `isReadyForMoreMediaData`, no offline `requestMediaDataWhenReady` pump
+        // needed for a bounded one-shot render.
+        input.expectsMediaDataInRealTime = true
+        guard writer.canAdd(input) else {
+            throw MeetingAudioError.storageFailed("cleaned mic writer cannot add input")
+        }
+        writer.add(input)
+        guard writer.startWriting() else {
+            throw MeetingAudioError.storageFailed(
+                writer.error?.localizedDescription ?? "cleaned mic writer start failed")
+        }
+        writer.startSession(atSourceTime: .zero)
+
+        let sampleBufferFactory = PCMBufferToSampleBuffer()
+        let blockFrames = 16_384
+        var written: Int64 = 0
+        var cursor = 0
+        while cursor < samples.count {
+            let end = min(cursor + blockFrames, samples.count)
+            let frameCount = AVAudioFrameCount(end - cursor)
+            guard let buffer = AVAudioPCMBuffer(pcmFormat: pcmFormat, frameCapacity: frameCount),
+                  let channel = buffer.floatChannelData?.pointee else {
+                throw MeetingAudioError.storageFailed("cleaned mic buffer alloc failed")
+            }
+            buffer.frameLength = frameCount
+            samples.withUnsafeBufferPointer { src in
+                channel.update(from: src.baseAddress! + cursor, count: Int(frameCount))
+            }
+            let sampleBuffer = try sampleBufferFactory.makeSampleBuffer(
+                from: buffer, presentationTimeSamples: written)
+            while !input.isReadyForMoreMediaData {
+                Thread.sleep(forTimeInterval: 0.001)
+            }
+            guard input.append(sampleBuffer) else {
+                throw MeetingAudioError.storageFailed(
+                    writer.error?.localizedDescription ?? "cleaned mic append failed")
+            }
+            written += Int64(frameCount)
+            cursor = end
+        }
+
+        input.markAsFinished()
+        let semaphore = DispatchSemaphore(value: 0)
+        let box = UncheckedSendableBox(writer)
+        writer.finishWriting {
+            semaphore.signal()
+            _ = box
+        }
+        semaphore.wait()
+        if writer.status == .failed {
+            throw MeetingAudioError.storageFailed(
+                writer.error?.localizedDescription ?? "cleaned mic finalize failed")
+        }
+    }
+}
+
+/// Minimal Sendable box so the non-Sendable `AVAssetWriter` can be referenced
+/// from `finishWriting`'s `@Sendable` completion without capturing `self`.
+private struct UncheckedSendableBox<T>: @unchecked Sendable {
+    let value: T
+    init(_ value: T) { self.value = value }
+}

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingCleanedMicRenderer.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingCleanedMicRenderer.swift
@@ -32,7 +32,7 @@ final class MeetingCleanedMicRenderer {
         /// Frames the processor cleaned vs. served raw (a processor that throws
         /// falls back to raw). Emitted as diagnostics for U9 QA and telemetry,
         /// not a routing gate — U4 prefers the cleaned mic purely on its
-        /// existence on disk (see `outputToRawRmsRatio`).
+        /// valid artifact (see `outputToRawRmsRatio`).
         let processedFrames: Int
         let rawFallbackFrames: Int
         let processingFailures: Int
@@ -68,15 +68,15 @@ final class MeetingCleanedMicRenderer {
     }
 
     /// Render the cleaned mic. `conditioner` is the live factory's product; the
-    /// caller passes a freshly built one. Synchronous: do blocking decode/encode
-    /// off the main actor.
+    /// caller passes a freshly built one. Do the heavy decode/encode off the
+    /// main actor.
     func render(
         microphoneURL: URL,
         systemURL: URL,
         sourceAlignment: MeetingSourceAlignment,
         outputURL: URL,
         conditioner: any MicConditioning
-    ) -> Outcome {
+    ) async -> Outcome {
         // Only derive when a real echo processor loaded. Passthrough (no assets)
         // and unavailable (load failed) both leave the raw mic as the truth.
         let diagnostics = conditioner.diagnostics
@@ -110,7 +110,7 @@ final class MeetingCleanedMicRenderer {
             conditioner: conditioner)
 
         do {
-            try Self.encodeMonoFloat(
+            try await Self.encodeMonoFloat(
                 conditioned.output, sampleRate: Self.renderSampleRate, to: outputURL,
                 fileManager: fileManager)
         } catch {
@@ -309,7 +309,7 @@ final class MeetingCleanedMicRenderer {
     /// Encode mono Float32 samples to an AAC `.m4a` at `sampleRate`.
     static func encodeMonoFloat(
         _ samples: [Float], sampleRate: Int, to outputURL: URL, fileManager: FileManager
-    ) throws {
+    ) async throws {
         try? fileManager.removeItem(at: outputURL)
         guard let pcmFormat = AVAudioFormat(
             commonFormat: .pcmFormatFloat32,
@@ -371,7 +371,7 @@ final class MeetingCleanedMicRenderer {
                     throw MeetingAudioError.storageFailed(
                         writer.error?.localizedDescription ?? "cleaned mic writer failed while waiting")
                 }
-                Thread.sleep(forTimeInterval: 0.001)
+                try await Task.sleep(nanoseconds: 1_000_000)
             }
             guard input.append(sampleBuffer) else {
                 throw MeetingAudioError.storageFailed(
@@ -382,16 +382,19 @@ final class MeetingCleanedMicRenderer {
         }
 
         input.markAsFinished()
-        let semaphore = DispatchSemaphore(value: 0)
-        let box = UncheckedSendableBox(writer)
-        writer.finishWriting {
-            semaphore.signal()
-            _ = box
-        }
-        semaphore.wait()
+        await finishWriting(writer)
         if writer.status == .failed {
             throw MeetingAudioError.storageFailed(
                 writer.error?.localizedDescription ?? "cleaned mic finalize failed")
+        }
+    }
+
+    private static func finishWriting(_ writer: AVAssetWriter) async {
+        let box = UncheckedSendableBox(writer)
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            box.value.finishWriting {
+                continuation.resume()
+            }
         }
     }
 }

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingCleanedMicRenderer.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingCleanedMicRenderer.swift
@@ -162,9 +162,6 @@ final class MeetingCleanedMicRenderer {
         let relativeShiftSamples = Int(
             (Double(systemStartOffsetMs - microphoneStartOffsetMs) / 1000.0
                 * Double(sampleRate)).rounded())
-        let alignedReference = shiftReference(
-            system, by: relativeShiftSamples, toMatchCount: microphone.count)
-
         var output: [Float] = []
         output.reserveCapacity(microphone.count)
         let chunkSize = 4_096
@@ -172,7 +169,15 @@ final class MeetingCleanedMicRenderer {
         while cursor < microphone.count {
             let end = min(cursor + chunkSize, microphone.count)
             let micChunk = Array(microphone[cursor..<end])
-            let refChunk = Array(alignedReference[cursor..<end])
+            var refChunk: [Float] = []
+            refChunk.reserveCapacity(end - cursor)
+            for destinationIndex in cursor..<end {
+                let sourceIndex = destinationIndex - relativeShiftSamples
+                refChunk.append(
+                    sourceIndex >= 0 && sourceIndex < system.count
+                    ? system[sourceIndex]
+                    : 0)
+            }
             output += conditioner.condition(
                 microphone: micChunk, speaker: refChunk, hasSpeakerReference: true)
             cursor = end
@@ -192,23 +197,6 @@ final class MeetingCleanedMicRenderer {
             processedFrames: diagnostics.processedFrames,
             rawFallbackFrames: diagnostics.rawFallbackFrames,
             processingFailures: diagnostics.processingFailures)
-    }
-
-    /// Reposition `reference` so index i lines up with the microphone's index i,
-    /// padding/truncating to exactly `count` samples (the reference is read at the
-    /// mic's own position; the conditioner applies the echo-path delay on top).
-    private static func shiftReference(
-        _ reference: [Float], by shiftSamples: Int, toMatchCount count: Int
-    ) -> [Float] {
-        var aligned = [Float](repeating: 0, count: count)
-        // Destination index d corresponds to source index (d - shiftSamples).
-        for d in 0..<count {
-            let s = d - shiftSamples
-            if s >= 0, s < reference.count {
-                aligned[d] = reference[s]
-            }
-        }
-        return aligned
     }
 
     private static func rmsRatio(_ a: [Float], _ b: [Float]) -> Float {

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingCleanedMicRenderer.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingCleanedMicRenderer.swift
@@ -81,7 +81,7 @@ final class MeetingCleanedMicRenderer {
         // and unavailable (load failed) both leave the raw mic as the truth.
         let diagnostics = conditioner.diagnostics
         guard diagnostics.loaded,
-              diagnostics.processorName != PassthroughMicConditioner().diagnostics.processorName else {
+              !(conditioner is PassthroughMicConditioner) else {
             return .skipped(.conditionerUnavailable)
         }
         guard fileManager.fileExists(atPath: microphoneURL.path) else {

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingCleanedMicRenderer.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingCleanedMicRenderer.swift
@@ -234,10 +234,12 @@ final class MeetingCleanedMicRenderer {
 
         var samples: [Float] = []
         let sourceRate = file.processingFormat.sampleRate
-        // Corrupt files should not explode output-buffer sizing with zero or
-        // sub-Hz source rates; floor at 1.0 Hz and fail gracefully downstream if
-        // allocation/conversion still cannot proceed.
-        let ratio = targetFormat.sampleRate / max(sourceRate, 1.0)
+        // Corrupt files can report zero/sub-Hz source rates; fail before ratio
+        // math so output-buffer sizing cannot explode into OOM-scale requests.
+        guard sourceRate.isFinite, sourceRate >= 1_000 else {
+            throw MeetingAudioError.storageFailed("invalid source sample rate")
+        }
+        let ratio = targetFormat.sampleRate / sourceRate
         let readFrames: AVAudioFrameCount = 16_384
         var reachedEnd = false
 

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingCleanedMicRenderer.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingCleanedMicRenderer.swift
@@ -30,12 +30,18 @@ final class MeetingCleanedMicRenderer {
         let outputURL: URL
         let durationSeconds: Double
         /// Frames the processor cleaned vs. served raw (a processor that throws
-        /// falls back to raw); both feed U4's health gate.
+        /// falls back to raw). Emitted as diagnostics for U9 QA and telemetry,
+        /// not a routing gate — U4 prefers the cleaned mic purely on its
+        /// existence on disk (see `outputToRawRmsRatio`).
         let processedFrames: Int
         let rawFallbackFrames: Int
         let processingFailures: Int
-        /// Output RMS / raw-mic RMS over the analysed span. ~1.0 keeps the local
-        /// voice; near 0 means the cleaner gutted the mic — a health-gate signal.
+        /// Output RMS / raw-mic RMS over the render. ~1.0 keeps the local voice;
+        /// near 0 means the cleaner gutted the mic. Diagnostic only — it cannot
+        /// gate routing: a near-0 ratio is ambiguous between a correctly silenced
+        /// mic (near-end stayed quiet) and a gutted one, and falling back to raw
+        /// on a low ratio would reintroduce the #605 bleed for listen-heavy
+        /// meetings. Near-end fidelity is owned by model choice (v1.4) + U9 QA.
         let outputToRawRmsRatio: Float
     }
 

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingMetadata.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingMetadata.swift
@@ -93,10 +93,11 @@ enum MeetingRecordingMetadataStore {
         fileManager: FileManager = .default
     ) throws -> MeetingRecordingMetadata {
         let url = metadataURL(for: folderURL)
-        guard let data = fileManager.contents(atPath: url.path) else {
+        guard fileManager.fileExists(atPath: url.path) else {
             throw MeetingAudioError.storageFailed(
                 "Missing archived meeting metadata: \(MeetingRecordingMetadata.fileName)")
         }
+        let data = try Data(contentsOf: url)
         return try JSONDecoder.meetingRecordingMetadata.decode(MeetingRecordingMetadata.self, from: data)
     }
 }

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingMetadata.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingMetadata.swift
@@ -88,8 +88,15 @@ enum MeetingRecordingMetadataStore {
         try data.write(to: metadataURL(for: folderURL), options: .atomic)
     }
 
-    static func load(from folderURL: URL) throws -> MeetingRecordingMetadata {
-        let data = try Data(contentsOf: metadataURL(for: folderURL))
+    static func load(
+        from folderURL: URL,
+        fileManager: FileManager = .default
+    ) throws -> MeetingRecordingMetadata {
+        let url = metadataURL(for: folderURL)
+        guard let data = fileManager.contents(atPath: url.path) else {
+            throw MeetingAudioError.storageFailed(
+                "Missing archived meeting metadata: \(MeetingRecordingMetadata.fileName)")
+        }
         return try JSONDecoder.meetingRecordingMetadata.decode(MeetingRecordingMetadata.self, from: data)
     }
 }

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingMetadata.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingMetadata.swift
@@ -97,7 +97,10 @@ enum MeetingRecordingMetadataStore {
             throw MeetingAudioError.storageFailed(
                 "Missing archived meeting metadata: \(MeetingRecordingMetadata.fileName)")
         }
-        let data = try Data(contentsOf: url)
+        guard let data = fileManager.contents(atPath: url.path) else {
+            throw MeetingAudioError.storageFailed(
+                "Unable to read archived meeting metadata: \(MeetingRecordingMetadata.fileName)")
+        }
         return try JSONDecoder.meetingRecordingMetadata.decode(MeetingRecordingMetadata.self, from: data)
     }
 }

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingOutput.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingOutput.swift
@@ -94,7 +94,9 @@ public struct MeetingRecordingOutput: Sendable, Equatable {
         fileManager: FileManager = .default
     ) throws -> MeetingRecordingOutput {
         let folderURL = mixedAudioURL.deletingLastPathComponent()
-        let metadata = try MeetingRecordingMetadataStore.load(from: folderURL)
+        let metadata = try MeetingRecordingMetadataStore.load(
+            from: folderURL,
+            fileManager: fileManager)
         let microphoneAudioURL = folderURL.appendingPathComponent("microphone.m4a")
         let systemAudioURL = folderURL.appendingPathComponent("system.m4a")
         let cleanedURL = folderURL.appendingPathComponent(

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingOutput.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingOutput.swift
@@ -53,10 +53,21 @@ public struct MeetingRecordingOutput: Sendable, Equatable {
     }
 
     /// The microphone audio to transcribe for the local ("Me") track: the
-    /// echo-cancelled artifact when it was derived and remains decodable,
-    /// otherwise the raw mic. Centralizes the #605 cleaned-mic preference so
-    /// finalize-time transcription and recovery agree on one rule.
+    /// echo-cancelled artifact when it was derived and is non-empty, otherwise
+    /// the raw mic. This public helper is intentionally cheap for UI/list paths;
+    /// STT routing uses `validatedMicrophoneTranscriptionURL(fileManager:)`.
     public func microphoneTranscriptionURL(fileManager: FileManager = .default) -> URL {
+        if let cleanedMicrophoneAudioURL,
+           Self.hasNonEmptyFile(at: cleanedMicrophoneAudioURL, fileManager: fileManager) {
+            return cleanedMicrophoneAudioURL
+        }
+        return microphoneAudioURL
+    }
+
+    /// The microphone audio to transcribe for the local ("Me") STT track. This
+    /// performs a synchronous decodability probe and should be called from
+    /// background/actor transcription paths, not UI list population.
+    func validatedMicrophoneTranscriptionURL(fileManager: FileManager = .default) -> URL {
         if let cleanedMicrophoneAudioURL,
            Self.isViableCleanedMicrophoneFile(at: cleanedMicrophoneAudioURL, fileManager: fileManager) {
             return cleanedMicrophoneAudioURL

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingOutput.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingOutput.swift
@@ -57,10 +57,18 @@ public struct MeetingRecordingOutput: Sendable, Equatable {
     /// finalize-time transcription and recovery agree on one rule.
     public func microphoneTranscriptionURL(fileManager: FileManager = .default) -> URL {
         if let cleanedMicrophoneAudioURL,
-           fileManager.fileExists(atPath: cleanedMicrophoneAudioURL.path) {
+           Self.hasNonEmptyFile(at: cleanedMicrophoneAudioURL, fileManager: fileManager) {
             return cleanedMicrophoneAudioURL
         }
         return microphoneAudioURL
+    }
+
+    private static func hasNonEmptyFile(at url: URL, fileManager: FileManager) -> Bool {
+        guard fileManager.fileExists(atPath: url.path),
+              let size = try? fileManager.attributesOfItem(atPath: url.path)[.size] as? NSNumber else {
+            return false
+        }
+        return size.int64Value > 0
     }
 
     public static func loadArchived(

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingOutput.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingOutput.swift
@@ -90,7 +90,11 @@ public struct MeetingRecordingOutput: Sendable, Equatable {
         let systemAudioURL = folderURL.appendingPathComponent("system.m4a")
         let cleanedURL = folderURL.appendingPathComponent(
             MeetingCleanedMicRenderer.cleanedMicrophoneFileName)
-        let cleanedMicrophoneAudioURL = isViableCleanedMicrophoneFile(at: cleanedURL)
+        // Keep archive loading cheap; this is called from UI list/reopen paths.
+        // The decodability probe stays in `microphoneTranscriptionURL`, which is
+        // the actual STT routing gate and falls back to raw if the artifact is
+        // corrupt or partial.
+        let cleanedMicrophoneAudioURL = hasNonEmptyFile(at: cleanedURL)
             ? cleanedURL
             : nil
 
@@ -117,5 +121,16 @@ public struct MeetingRecordingOutput: Sendable, Equatable {
             speechEngine: metadata.speechEngine,
             speechEngineWasCaptured: metadata.speechEngineWasCaptured
         )
+    }
+
+    private static func hasNonEmptyFile(
+        at url: URL,
+        fileManager: FileManager = .default
+    ) -> Bool {
+        guard fileManager.fileExists(atPath: url.path),
+              let size = try? fileManager.attributesOfItem(atPath: url.path)[.size] as? NSNumber else {
+            return false
+        }
+        return size.int64Value > 0
     }
 }

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingOutput.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingOutput.swift
@@ -7,6 +7,12 @@ public struct MeetingRecordingOutput: Sendable, Equatable {
     public let mixedAudioURL: URL
     public let microphoneAudioURL: URL
     public let systemAudioURL: URL
+    /// Echo-cancelled microphone derived from the raw mic + system reference
+    /// after stop (plan #605 U3). `nil` for single-source meetings or when no
+    /// AEC assets are bundled. The raw `microphoneAudioURL` always stays the
+    /// source of truth; this is a derived artifact preferred for the local
+    /// ("Me") transcript via `microphoneTranscriptionURL(fileManager:)`.
+    public let cleanedMicrophoneAudioURL: URL?
     public let durationSeconds: TimeInterval
     public let sourceAlignment: MeetingSourceAlignment
     public let speechEngine: SpeechEngineSelection
@@ -24,6 +30,7 @@ public struct MeetingRecordingOutput: Sendable, Equatable {
         mixedAudioURL: URL,
         microphoneAudioURL: URL,
         systemAudioURL: URL,
+        cleanedMicrophoneAudioURL: URL? = nil,
         durationSeconds: TimeInterval,
         sourceAlignment: MeetingSourceAlignment,
         speechEngine: SpeechEngineSelection = SpeechEngineSelection(engine: .parakeet),
@@ -36,11 +43,24 @@ public struct MeetingRecordingOutput: Sendable, Equatable {
         self.mixedAudioURL = mixedAudioURL
         self.microphoneAudioURL = microphoneAudioURL
         self.systemAudioURL = systemAudioURL
+        self.cleanedMicrophoneAudioURL = cleanedMicrophoneAudioURL
         self.durationSeconds = durationSeconds
         self.sourceAlignment = sourceAlignment
         self.speechEngine = speechEngine
         self.speechEngineWasCaptured = speechEngineWasCaptured
         self.userNotes = userNotes
+    }
+
+    /// The microphone audio to transcribe for the local ("Me") track: the
+    /// echo-cancelled artifact when it was derived and still exists on disk,
+    /// otherwise the raw mic. Centralizes the #605 cleaned-mic preference so
+    /// finalize-time transcription and recovery agree on one rule.
+    public func microphoneTranscriptionURL(fileManager: FileManager = .default) -> URL {
+        if let cleanedMicrophoneAudioURL,
+           fileManager.fileExists(atPath: cleanedMicrophoneAudioURL.path) {
+            return cleanedMicrophoneAudioURL
+        }
+        return microphoneAudioURL
     }
 
     public static func loadArchived(
@@ -52,6 +72,11 @@ public struct MeetingRecordingOutput: Sendable, Equatable {
         let metadata = try MeetingRecordingMetadataStore.load(from: folderURL)
         let microphoneAudioURL = folderURL.appendingPathComponent("microphone.m4a")
         let systemAudioURL = folderURL.appendingPathComponent("system.m4a")
+        let cleanedURL = folderURL.appendingPathComponent(
+            MeetingCleanedMicRenderer.cleanedMicrophoneFileName)
+        let cleanedMicrophoneAudioURL = FileManager.default.fileExists(atPath: cleanedURL.path)
+            ? cleanedURL
+            : nil
 
         if metadata.sourceAlignment.microphone != nil,
            !FileManager.default.fileExists(atPath: microphoneAudioURL.path) {
@@ -70,6 +95,7 @@ public struct MeetingRecordingOutput: Sendable, Equatable {
             mixedAudioURL: mixedAudioURL,
             microphoneAudioURL: microphoneAudioURL,
             systemAudioURL: systemAudioURL,
+            cleanedMicrophoneAudioURL: cleanedMicrophoneAudioURL,
             durationSeconds: durationSeconds,
             sourceAlignment: metadata.sourceAlignment,
             speechEngine: metadata.speechEngine,

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingOutput.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingOutput.swift
@@ -80,11 +80,7 @@ public struct MeetingRecordingOutput: Sendable, Equatable {
         at url: URL,
         fileManager: FileManager = .default
     ) -> Bool {
-        guard fileManager.fileExists(atPath: url.path),
-              let size = try? fileManager.attributesOfItem(atPath: url.path)[.size] as? NSNumber else {
-            return false
-        }
-        guard size.int64Value > 0,
+        guard hasNonEmptyFile(at: url, fileManager: fileManager),
               let file = try? AVAudioFile(forReading: url) else {
             return false
         }
@@ -112,12 +108,12 @@ public struct MeetingRecordingOutput: Sendable, Equatable {
             : nil
 
         if metadata.sourceAlignment.microphone != nil,
-           !fileManager.fileExists(atPath: microphoneAudioURL.path) {
+           !hasFile(at: microphoneAudioURL, fileManager: fileManager) {
             throw MeetingAudioError.storageFailed("Missing archived meeting source file: microphone.m4a")
         }
 
         if metadata.sourceAlignment.system != nil,
-           !fileManager.fileExists(atPath: systemAudioURL.path) {
+           !hasFile(at: systemAudioURL, fileManager: fileManager) {
             throw MeetingAudioError.storageFailed("Missing archived meeting source file: system.m4a")
         }
 
@@ -140,10 +136,17 @@ public struct MeetingRecordingOutput: Sendable, Equatable {
         at url: URL,
         fileManager: FileManager = .default
     ) -> Bool {
-        guard fileManager.fileExists(atPath: url.path),
+        guard hasFile(at: url, fileManager: fileManager),
               let size = try? fileManager.attributesOfItem(atPath: url.path)[.size] as? NSNumber else {
             return false
         }
         return size.int64Value > 0
+    }
+
+    private static func hasFile(
+        at url: URL,
+        fileManager: FileManager = .default
+    ) -> Bool {
+        fileManager.fileExists(atPath: url.path)
     }
 }

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingOutput.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingOutput.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import Foundation
 
 public struct MeetingRecordingOutput: Sendable, Equatable {
@@ -52,23 +53,30 @@ public struct MeetingRecordingOutput: Sendable, Equatable {
     }
 
     /// The microphone audio to transcribe for the local ("Me") track: the
-    /// echo-cancelled artifact when it was derived and still exists on disk,
+    /// echo-cancelled artifact when it was derived and remains decodable,
     /// otherwise the raw mic. Centralizes the #605 cleaned-mic preference so
     /// finalize-time transcription and recovery agree on one rule.
     public func microphoneTranscriptionURL(fileManager: FileManager = .default) -> URL {
         if let cleanedMicrophoneAudioURL,
-           Self.hasNonEmptyFile(at: cleanedMicrophoneAudioURL, fileManager: fileManager) {
+           Self.isViableCleanedMicrophoneFile(at: cleanedMicrophoneAudioURL, fileManager: fileManager) {
             return cleanedMicrophoneAudioURL
         }
         return microphoneAudioURL
     }
 
-    private static func hasNonEmptyFile(at url: URL, fileManager: FileManager) -> Bool {
+    private static func isViableCleanedMicrophoneFile(
+        at url: URL,
+        fileManager: FileManager = .default
+    ) -> Bool {
         guard fileManager.fileExists(atPath: url.path),
               let size = try? fileManager.attributesOfItem(atPath: url.path)[.size] as? NSNumber else {
             return false
         }
-        return size.int64Value > 0
+        guard size.int64Value > 0,
+              let file = try? AVAudioFile(forReading: url) else {
+            return false
+        }
+        return file.length > 0
     }
 
     public static func loadArchived(
@@ -82,7 +90,7 @@ public struct MeetingRecordingOutput: Sendable, Equatable {
         let systemAudioURL = folderURL.appendingPathComponent("system.m4a")
         let cleanedURL = folderURL.appendingPathComponent(
             MeetingCleanedMicRenderer.cleanedMicrophoneFileName)
-        let cleanedMicrophoneAudioURL = FileManager.default.fileExists(atPath: cleanedURL.path)
+        let cleanedMicrophoneAudioURL = isViableCleanedMicrophoneFile(at: cleanedURL)
             ? cleanedURL
             : nil
 

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingOutput.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingOutput.swift
@@ -56,6 +56,7 @@ public struct MeetingRecordingOutput: Sendable, Equatable {
     /// echo-cancelled artifact when it was derived and is non-empty, otherwise
     /// the raw mic. This public helper is intentionally cheap for UI/list paths;
     /// STT routing uses `validatedMicrophoneTranscriptionURL(fileManager:)`.
+    /// Performs synchronous filesystem stat calls, so avoid hot main-actor loops.
     public func microphoneTranscriptionURL(fileManager: FileManager = .default) -> URL {
         if let cleanedMicrophoneAudioURL,
            Self.hasNonEmptyFile(at: cleanedMicrophoneAudioURL, fileManager: fileManager) {

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingOutput.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingOutput.swift
@@ -93,7 +93,8 @@ public struct MeetingRecordingOutput: Sendable, Equatable {
     public static func loadArchived(
         displayName: String,
         mixedAudioURL: URL,
-        durationSeconds: TimeInterval
+        durationSeconds: TimeInterval,
+        fileManager: FileManager = .default
     ) throws -> MeetingRecordingOutput {
         let folderURL = mixedAudioURL.deletingLastPathComponent()
         let metadata = try MeetingRecordingMetadataStore.load(from: folderURL)
@@ -105,17 +106,17 @@ public struct MeetingRecordingOutput: Sendable, Equatable {
         // The decodability probe stays in `microphoneTranscriptionURL`, which is
         // the actual STT routing gate and falls back to raw if the artifact is
         // corrupt or partial.
-        let cleanedMicrophoneAudioURL = hasNonEmptyFile(at: cleanedURL)
+        let cleanedMicrophoneAudioURL = hasNonEmptyFile(at: cleanedURL, fileManager: fileManager)
             ? cleanedURL
             : nil
 
         if metadata.sourceAlignment.microphone != nil,
-           !FileManager.default.fileExists(atPath: microphoneAudioURL.path) {
+           !fileManager.fileExists(atPath: microphoneAudioURL.path) {
             throw MeetingAudioError.storageFailed("Missing archived meeting source file: microphone.m4a")
         }
 
         if metadata.sourceAlignment.system != nil,
-           !FileManager.default.fileExists(atPath: systemAudioURL.path) {
+           !fileManager.fileExists(atPath: systemAudioURL.path) {
             throw MeetingAudioError.storageFailed("Missing archived meeting source file: system.m4a")
         }
 

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingOutput.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingOutput.swift
@@ -103,9 +103,9 @@ public struct MeetingRecordingOutput: Sendable, Equatable {
         let cleanedURL = folderURL.appendingPathComponent(
             MeetingCleanedMicRenderer.cleanedMicrophoneFileName)
         // Keep archive loading cheap; this is called from UI list/reopen paths.
-        // The decodability probe stays in `microphoneTranscriptionURL`, which is
-        // the actual STT routing gate and falls back to raw if the artifact is
-        // corrupt or partial.
+        // The decodability probe stays in `validatedMicrophoneTranscriptionURL`,
+        // which is the actual STT routing gate and falls back to raw if the
+        // artifact is corrupt or partial.
         let cleanedMicrophoneAudioURL = hasNonEmptyFile(at: cleanedURL, fileManager: fileManager)
             ? cleanedURL
             : nil

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingRecoveryService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingRecoveryService.swift
@@ -217,7 +217,7 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
 
         let recoveredBySource = Dictionary(
             recoveredSources.map { ($0.source, $0.url) }, uniquingKeysWith: { first, _ in first })
-        let cleanedMicrophoneAudioURL = await renderCleanedMicrophone(
+        let cleanedMicrophoneAudioURL = try await renderCleanedMicrophone(
             folderURL: folderURL,
             microphoneURL: recoveredBySource[.microphone],
             systemURL: recoveredBySource[.system],
@@ -290,7 +290,7 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
         systemURL: URL?,
         sourceAlignment: MeetingSourceAlignment,
         sessionID: UUID
-    ) async -> URL? {
+    ) async throws -> URL? {
         let outputURL = folderURL.appendingPathComponent(
             MeetingCleanedMicRenderer.cleanedMicrophoneFileName)
         guard let microphoneURL, let systemURL else {
@@ -309,14 +309,33 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
         let conditionerFactory = micConditionerFactory
         let rendererFileManager = UncheckedSendableBox(fileManager)
 
-        let outcome = await Task.detached(priority: .utility) {
-            await MeetingCleanedMicRenderer(fileManager: rendererFileManager.value).render(
+        let task = Task.detached(priority: .utility) {
+            try await MeetingCleanedMicRenderer(fileManager: rendererFileManager.value).render(
                 microphoneURL: microphoneURL,
                 systemURL: systemURL,
                 sourceAlignment: sourceAlignment,
                 outputURL: outputURL,
                 conditioner: conditionerFactory())
-        }.value
+        }
+
+        let outcome: MeetingCleanedMicRenderer.Outcome
+        do {
+            outcome = try await withTaskCancellationHandler {
+                try await task.value
+            } onCancel: {
+                task.cancel()
+            }
+        } catch is CancellationError {
+            discardCleanedMicrophoneArtifact(
+                at: outputURL, sessionID: sessionID, reason: "renderer_cancelled")
+            logger.info("meeting_recovery_cleaned_mic session=\(sessionID.uuidString, privacy: .public) outcome=cancelled")
+            throw CancellationError()
+        } catch {
+            discardCleanedMicrophoneArtifact(
+                at: outputURL, sessionID: sessionID, reason: "renderer_threw")
+            logger.info("meeting_recovery_cleaned_mic session=\(sessionID.uuidString, privacy: .public) outcome=skipped reason=renderer_threw")
+            return nil
+        }
 
         switch outcome {
         case .rendered(let result):

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingRecoveryService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingRecoveryService.swift
@@ -45,6 +45,12 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
     private let transcriptionRepo: TranscriptionRepositoryProtocol
     private let audioConverter: AudioFileConverting
     private let fileManager: FileManager
+    /// Builds the echo suppressor used to re-derive `microphone-cleaned.m4a`
+    /// during recovery, mirroring the live recording path (plan #605 U3). Set
+    /// from the injected `echoSuppressionConfiguration` so recovered dual-source
+    /// meetings get the same cleaned-mic treatment as ones finalized in-process.
+    /// Resolves to passthrough (→ no cleaned file) without bundled AEC assets.
+    private let micConditionerFactory: @Sendable () -> any MicConditioning
 
     public init(
         meetingsRoot: URL = URL(fileURLWithPath: AppPaths.meetingRecordingsDir, isDirectory: true),
@@ -52,7 +58,8 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
         transcriptionService: TranscriptionServiceProtocol,
         transcriptionRepo: TranscriptionRepositoryProtocol,
         audioConverter: AudioFileConverting = AudioFileConverter(),
-        fileManager: FileManager = .default
+        fileManager: FileManager = .default,
+        echoSuppressionConfiguration: MeetingEchoSuppressionConfiguration = .fromEnvironment()
     ) {
         self.meetingsRoot = meetingsRoot
         self.lockFileStore = lockFileStore
@@ -60,6 +67,10 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
         self.transcriptionRepo = transcriptionRepo
         self.audioConverter = audioConverter
         self.fileManager = fileManager
+        self.micConditionerFactory = {
+            MeetingEchoSuppressionFactory.makeConditioner(
+                configuration: echoSuppressionConfiguration)
+        }
     }
 
     /// Minimum size (bytes) for either `microphone.m4a` or `system.m4a` to
@@ -185,6 +196,16 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
             logger.error("meeting_recovery_mix_failed_nonfatal session=\(lock.sessionId.uuidString, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
         }
 
+        let recoveredBySource = Dictionary(
+            recoveredSources.map { ($0.source, $0.url) }, uniquingKeysWith: { first, _ in first })
+        let cleanedMicrophoneAudioURL = await renderCleanedMicrophone(
+            folderURL: folderURL,
+            microphoneURL: recoveredBySource[.microphone],
+            systemURL: recoveredBySource[.system],
+            sourceAlignment: sourceAlignment,
+            sessionID: lock.sessionId
+        )
+
         // Clamp the wall-clock fallback to non-negative. If the user's clock
         // skewed (NTP correction backwards, manual time change) between when
         // the lock file was written and when recovery runs, `startedAt` can
@@ -200,6 +221,7 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
             mixedAudioURL: mixedURL,
             microphoneAudioURL: microphoneURL,
             systemAudioURL: systemURL,
+            cleanedMicrophoneAudioURL: cleanedMicrophoneAudioURL,
             durationSeconds: duration,
             sourceAlignment: sourceAlignment,
             speechEngine: lock.speechEngine,
@@ -234,6 +256,41 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
                 return
             }
             try fileManager.removeItem(at: folderURL)
+        }
+    }
+
+    /// Re-derive `microphone-cleaned.m4a` from the recovered mic + system audio
+    /// (plan #605 U3). Mirrors `MeetingRecordingService`; returns `nil` for
+    /// single-source recoveries, without AEC assets, or on render failure so the
+    /// raw mic stays the truth. Never throws into the recovery path.
+    private func renderCleanedMicrophone(
+        folderURL: URL,
+        microphoneURL: URL?,
+        systemURL: URL?,
+        sourceAlignment: MeetingSourceAlignment,
+        sessionID: UUID
+    ) async -> URL? {
+        guard let microphoneURL, let systemURL else { return nil }
+        let outputURL = folderURL.appendingPathComponent(
+            MeetingCleanedMicRenderer.cleanedMicrophoneFileName)
+        let conditionerFactory = micConditionerFactory
+
+        let outcome = await Task.detached(priority: .utility) {
+            MeetingCleanedMicRenderer().render(
+                microphoneURL: microphoneURL,
+                systemURL: systemURL,
+                sourceAlignment: sourceAlignment,
+                outputURL: outputURL,
+                conditioner: conditionerFactory())
+        }.value
+
+        switch outcome {
+        case .rendered(let result):
+            logger.info("meeting_recovery_cleaned_mic session=\(sessionID.uuidString, privacy: .public) outcome=rendered failures=\(result.processingFailures, privacy: .public)")
+            return result.outputURL
+        case .skipped(let reason):
+            logger.info("meeting_recovery_cleaned_mic session=\(sessionID.uuidString, privacy: .public) outcome=skipped reason=\(String(describing: reason), privacy: .public)")
+            return nil
         }
     }
 

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingRecoveryService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingRecoveryService.swift
@@ -342,11 +342,10 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
             try fileManager.removeItem(at: outputURL)
         } catch {
             let removeError = error
-            do {
-                try Data().write(to: outputURL, options: .atomic)
+            if fileManager.createFile(atPath: outputURL.path, contents: Data(), attributes: nil) {
                 logger.warning("meeting_recovery_cleaned_mic_cleanup session=\(sessionID.uuidString, privacy: .public) outcome=truncated reason=\(reason, privacy: .public) remove_error=\(removeError.localizedDescription, privacy: .private)")
-            } catch {
-                logger.error("meeting_recovery_cleaned_mic_cleanup session=\(sessionID.uuidString, privacy: .public) outcome=failed reason=\(reason, privacy: .public) remove_error=\(removeError.localizedDescription, privacy: .private) truncate_error=\(error.localizedDescription, privacy: .private)")
+            } else {
+                logger.error("meeting_recovery_cleaned_mic_cleanup session=\(sessionID.uuidString, privacy: .public) outcome=failed reason=\(reason, privacy: .public) remove_error=\(removeError.localizedDescription, privacy: .private) truncate_error=createFile returned false")
             }
         }
     }

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingRecoveryService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingRecoveryService.swift
@@ -305,9 +305,10 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
             return nil
         }
         let conditionerFactory = micConditionerFactory
+        let rendererFileManager = fileManager
 
         let outcome = await Task.detached(priority: .utility) {
-            await MeetingCleanedMicRenderer().render(
+            await MeetingCleanedMicRenderer(fileManager: rendererFileManager).render(
                 microphoneURL: microphoneURL,
                 systemURL: systemURL,
                 sourceAlignment: sourceAlignment,
@@ -320,6 +321,7 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
             logger.info("meeting_recovery_cleaned_mic session=\(sessionID.uuidString, privacy: .public) outcome=rendered failures=\(result.processingFailures, privacy: .public)")
             return result.outputURL
         case .skipped(let reason):
+            try? fileManager.removeItem(at: outputURL)
             logger.info("meeting_recovery_cleaned_mic session=\(sessionID.uuidString, privacy: .public) outcome=skipped reason=\(String(describing: reason), privacy: .public)")
             return nil
         }

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingRecoveryService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingRecoveryService.swift
@@ -46,13 +46,12 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
     private let audioConverter: AudioFileConverting
     private let fileManager: FileManager
     /// Builds the echo suppressor used to re-derive `microphone-cleaned.m4a`
-    /// during recovery, mirroring the live recording path (plan #605 U3). Set
-    /// from the injected `echoSuppressionConfiguration` so recovered dual-source
-    /// meetings get the same cleaned-mic treatment as ones finalized in-process.
-    /// Resolves to passthrough (→ no cleaned file) without bundled AEC assets.
+    /// during recovery when trustworthy source alignment is available. Set from
+    /// the injected `echoSuppressionConfiguration`; resolves to passthrough
+    /// (→ no cleaned file) without bundled AEC assets.
     private let micConditionerFactory: @Sendable () -> any MicConditioning
 
-    public init(
+    public convenience init(
         meetingsRoot: URL = URL(fileURLWithPath: AppPaths.meetingRecordingsDir, isDirectory: true),
         lockFileStore: MeetingRecordingLockFileStoring = MeetingRecordingLockFileStore(),
         transcriptionService: TranscriptionServiceProtocol,
@@ -61,16 +60,36 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
         fileManager: FileManager = .default,
         echoSuppressionConfiguration: MeetingEchoSuppressionConfiguration = .fromEnvironment()
     ) {
+        self.init(
+            meetingsRoot: meetingsRoot,
+            lockFileStore: lockFileStore,
+            transcriptionService: transcriptionService,
+            transcriptionRepo: transcriptionRepo,
+            audioConverter: audioConverter,
+            fileManager: fileManager,
+            micConditionerFactory: {
+                MeetingEchoSuppressionFactory.makeConditioner(
+                    configuration: echoSuppressionConfiguration)
+            }
+        )
+    }
+
+    init(
+        meetingsRoot: URL = URL(fileURLWithPath: AppPaths.meetingRecordingsDir, isDirectory: true),
+        lockFileStore: MeetingRecordingLockFileStoring = MeetingRecordingLockFileStore(),
+        transcriptionService: TranscriptionServiceProtocol,
+        transcriptionRepo: TranscriptionRepositoryProtocol,
+        audioConverter: AudioFileConverting = AudioFileConverter(),
+        fileManager: FileManager = .default,
+        micConditionerFactory: @escaping @Sendable () -> any MicConditioning
+    ) {
         self.meetingsRoot = meetingsRoot
         self.lockFileStore = lockFileStore
         self.transcriptionService = transcriptionService
         self.transcriptionRepo = transcriptionRepo
         self.audioConverter = audioConverter
         self.fileManager = fileManager
-        self.micConditionerFactory = {
-            MeetingEchoSuppressionFactory.makeConditioner(
-                configuration: echoSuppressionConfiguration)
-        }
+        self.micConditionerFactory = micConditionerFactory
     }
 
     /// Minimum size (bytes) for either `microphone.m4a` or `system.m4a` to
@@ -260,9 +279,11 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
     }
 
     /// Re-derive `microphone-cleaned.m4a` from the recovered mic + system audio
-    /// (plan #605 U3). Mirrors `MeetingRecordingService`; returns `nil` for
-    /// single-source recoveries, without AEC assets, or on render failure so the
-    /// raw mic stays the truth. Never throws into the recovery path.
+    /// (plan #605 U3) only when source alignment is trustworthy. Interrupted
+    /// sessions currently synthesize zero start offsets because lock files do not
+    /// persist per-source host times; in that case, return `nil` so final STT
+    /// falls back to raw mic instead of preferring a possibly misaligned cleaned
+    /// artifact. Never throws into the recovery path.
     private func renderCleanedMicrophone(
         folderURL: URL,
         microphoneURL: URL?,
@@ -271,6 +292,12 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
         sessionID: UUID
     ) async -> URL? {
         guard let microphoneURL, let systemURL else { return nil }
+        guard sourceAlignment.meetingOriginHostTime != nil,
+              sourceAlignment.microphone?.firstHostTime != nil,
+              sourceAlignment.system?.firstHostTime != nil else {
+            logger.info("meeting_recovery_cleaned_mic session=\(sessionID.uuidString, privacy: .public) outcome=skipped reason=synthetic_alignment")
+            return nil
+        }
         let outputURL = folderURL.appendingPathComponent(
             MeetingCleanedMicRenderer.cleanedMicrophoneFileName)
         let conditionerFactory = micConditionerFactory

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingRecoveryService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingRecoveryService.swift
@@ -291,9 +291,12 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
         sourceAlignment: MeetingSourceAlignment,
         sessionID: UUID
     ) async -> URL? {
-        guard let microphoneURL, let systemURL else { return nil }
         let outputURL = folderURL.appendingPathComponent(
             MeetingCleanedMicRenderer.cleanedMicrophoneFileName)
+        guard let microphoneURL, let systemURL else {
+            try? fileManager.removeItem(at: outputURL)
+            return nil
+        }
         guard sourceAlignment.meetingOriginHostTime != nil,
               sourceAlignment.microphone?.firstHostTime != nil,
               sourceAlignment.system?.firstHostTime != nil else {

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingRecoveryService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingRecoveryService.swift
@@ -217,7 +217,7 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
 
         let recoveredBySource = Dictionary(
             recoveredSources.map { ($0.source, $0.url) }, uniquingKeysWith: { first, _ in first })
-        let cleanedMicrophoneAudioURL = try await renderCleanedMicrophone(
+        let cleanedMicrophoneAudioURL = await renderCleanedMicrophone(
             folderURL: folderURL,
             microphoneURL: recoveredBySource[.microphone],
             systemURL: recoveredBySource[.system],
@@ -283,14 +283,15 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
     /// sessions currently synthesize zero start offsets because lock files do not
     /// persist per-source host times; in that case, return `nil` so final STT
     /// falls back to raw mic instead of preferring a possibly misaligned cleaned
-    /// artifact. Never throws into the recovery path.
+    /// artifact. Render failures/cancellation fall back to raw mic and never
+    /// throw into the recovery path.
     private func renderCleanedMicrophone(
         folderURL: URL,
         microphoneURL: URL?,
         systemURL: URL?,
         sourceAlignment: MeetingSourceAlignment,
         sessionID: UUID
-    ) async throws -> URL? {
+    ) async -> URL? {
         let outputURL = folderURL.appendingPathComponent(
             MeetingCleanedMicRenderer.cleanedMicrophoneFileName)
         guard let microphoneURL, let systemURL else {
@@ -329,7 +330,7 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
             discardCleanedMicrophoneArtifact(
                 at: outputURL, sessionID: sessionID, reason: "renderer_cancelled")
             logger.info("meeting_recovery_cleaned_mic session=\(sessionID.uuidString, privacy: .public) outcome=cancelled")
-            throw CancellationError()
+            return nil
         } catch {
             discardCleanedMicrophoneArtifact(
                 at: outputURL, sessionID: sessionID, reason: "renderer_threw")

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingRecoveryService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingRecoveryService.swift
@@ -294,13 +294,15 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
         let outputURL = folderURL.appendingPathComponent(
             MeetingCleanedMicRenderer.cleanedMicrophoneFileName)
         guard let microphoneURL, let systemURL else {
-            try? fileManager.removeItem(at: outputURL)
+            discardCleanedMicrophoneArtifact(
+                at: outputURL, sessionID: sessionID, reason: "missing_source")
             return nil
         }
         guard sourceAlignment.meetingOriginHostTime != nil,
               sourceAlignment.microphone?.firstHostTime != nil,
               sourceAlignment.system?.firstHostTime != nil else {
-            try? fileManager.removeItem(at: outputURL)
+            discardCleanedMicrophoneArtifact(
+                at: outputURL, sessionID: sessionID, reason: "synthetic_alignment")
             logger.info("meeting_recovery_cleaned_mic session=\(sessionID.uuidString, privacy: .public) outcome=skipped reason=synthetic_alignment")
             return nil
         }
@@ -321,9 +323,31 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
             logger.info("meeting_recovery_cleaned_mic session=\(sessionID.uuidString, privacy: .public) outcome=rendered failures=\(result.processingFailures, privacy: .public)")
             return result.outputURL
         case .skipped(let reason):
-            try? fileManager.removeItem(at: outputURL)
+            discardCleanedMicrophoneArtifact(
+                at: outputURL,
+                sessionID: sessionID,
+                reason: "renderer_skipped_\(String(describing: reason))")
             logger.info("meeting_recovery_cleaned_mic session=\(sessionID.uuidString, privacy: .public) outcome=skipped reason=\(String(describing: reason), privacy: .public)")
             return nil
+        }
+    }
+
+    private func discardCleanedMicrophoneArtifact(
+        at outputURL: URL,
+        sessionID: UUID,
+        reason: String
+    ) {
+        guard fileManager.fileExists(atPath: outputURL.path) else { return }
+        do {
+            try fileManager.removeItem(at: outputURL)
+        } catch {
+            let removeError = error
+            do {
+                try Data().write(to: outputURL, options: .atomic)
+                logger.warning("meeting_recovery_cleaned_mic_cleanup session=\(sessionID.uuidString, privacy: .public) outcome=truncated reason=\(reason, privacy: .public) remove_error=\(removeError.localizedDescription, privacy: .private)")
+            } catch {
+                logger.error("meeting_recovery_cleaned_mic_cleanup session=\(sessionID.uuidString, privacy: .public) outcome=failed reason=\(reason, privacy: .public) remove_error=\(removeError.localizedDescription, privacy: .private) truncate_error=\(error.localizedDescription, privacy: .private)")
+            }
         }
     }
 

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingRecoveryService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingRecoveryService.swift
@@ -292,18 +292,19 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
         sessionID: UUID
     ) async -> URL? {
         guard let microphoneURL, let systemURL else { return nil }
+        let outputURL = folderURL.appendingPathComponent(
+            MeetingCleanedMicRenderer.cleanedMicrophoneFileName)
         guard sourceAlignment.meetingOriginHostTime != nil,
               sourceAlignment.microphone?.firstHostTime != nil,
               sourceAlignment.system?.firstHostTime != nil else {
+            try? fileManager.removeItem(at: outputURL)
             logger.info("meeting_recovery_cleaned_mic session=\(sessionID.uuidString, privacy: .public) outcome=skipped reason=synthetic_alignment")
             return nil
         }
-        let outputURL = folderURL.appendingPathComponent(
-            MeetingCleanedMicRenderer.cleanedMicrophoneFileName)
         let conditionerFactory = micConditionerFactory
 
         let outcome = await Task.detached(priority: .utility) {
-            MeetingCleanedMicRenderer().render(
+            await MeetingCleanedMicRenderer().render(
                 microphoneURL: microphoneURL,
                 systemURL: systemURL,
                 sourceAlignment: sourceAlignment,

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingRecoveryService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingRecoveryService.swift
@@ -307,10 +307,10 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
             return nil
         }
         let conditionerFactory = micConditionerFactory
-        let rendererFileManager = fileManager
+        let rendererFileManager = UncheckedSendableBox(fileManager)
 
         let outcome = await Task.detached(priority: .utility) {
-            await MeetingCleanedMicRenderer(fileManager: rendererFileManager).render(
+            await MeetingCleanedMicRenderer(fileManager: rendererFileManager.value).render(
                 microphoneURL: microphoneURL,
                 systemURL: systemURL,
                 sourceAlignment: sourceAlignment,

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
@@ -593,7 +593,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
             preservePlayableMeetingAudioFallback(inputURLs: inputURLs, outputURL: session.mixedAudioURL)
         }
 
-        let cleanedMicrophoneAudioURL = await renderCleanedMicrophone(
+        let cleanedMicrophoneAudioURL = try await renderCleanedMicrophone(
             session: session,
             availableSources: availableSources,
             sourceAlignment: sourceAlignment
@@ -1255,7 +1255,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         session: Session,
         availableSources: Set<AudioSource>,
         sourceAlignment: MeetingSourceAlignment
-    ) async -> URL? {
+    ) async throws -> URL? {
         let outputURL = session.folderURL.appendingPathComponent(
             MeetingCleanedMicRenderer.cleanedMicrophoneFileName)
         // A cleaned mic needs a system reference to cancel against; single-source
@@ -1276,14 +1276,35 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         // dylib load) is built inside the detached task so it never blocks
         // recording state. A fresh suppressor starts from clean filter state
         // rather than inheriting the live preview's adapted taps.
-        let outcome = await Task.detached(priority: .utility) {
-            await MeetingCleanedMicRenderer(fileManager: rendererFileManager.value).render(
+        let task = Task.detached(priority: .utility) {
+            try await MeetingCleanedMicRenderer(fileManager: rendererFileManager.value).render(
                 microphoneURL: microphoneURL,
                 systemURL: systemURL,
                 sourceAlignment: sourceAlignment,
                 outputURL: outputURL,
                 conditioner: conditionerFactory())
-        }.value
+        }
+
+        let outcome: MeetingCleanedMicRenderer.Outcome
+        do {
+            outcome = try await withTaskCancellationHandler {
+                try await task.value
+            } onCancel: {
+                task.cancel()
+            }
+        } catch is CancellationError {
+            discardCleanedMicrophoneArtifact(
+                at: outputURL, sessionID: session.id, reason: "renderer_cancelled")
+            AudioCaptureDiagnostics.append(
+                "meeting_cleaned_mic session=\(session.id.uuidString) outcome=cancelled")
+            throw CancellationError()
+        } catch {
+            discardCleanedMicrophoneArtifact(
+                at: outputURL, sessionID: session.id, reason: "renderer_threw")
+            AudioCaptureDiagnostics.append(
+                "meeting_cleaned_mic session=\(session.id.uuidString) outcome=skipped reason=renderer_threw_\(error.localizedDescription)")
+            return nil
+        }
 
         switch outcome {
         case .rendered(let result):

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
@@ -1274,7 +1274,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         // recording state. A fresh suppressor starts from clean filter state
         // rather than inheriting the live preview's adapted taps.
         let outcome = await Task.detached(priority: .utility) {
-            MeetingCleanedMicRenderer().render(
+            await MeetingCleanedMicRenderer().render(
                 microphoneURL: microphoneURL,
                 systemURL: systemURL,
                 sourceAlignment: sourceAlignment,

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
@@ -1313,13 +1313,12 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
             try fileManager.removeItem(at: outputURL)
         } catch {
             let removeError = error
-            do {
-                try Data().write(to: outputURL, options: .atomic)
+            if fileManager.createFile(atPath: outputURL.path, contents: Data(), attributes: nil) {
                 AudioCaptureDiagnostics.append(
                     "meeting_cleaned_mic_cleanup session=\(sessionID.uuidString) outcome=truncated reason=\(reason) remove_error=\(removeError.localizedDescription)")
-            } catch {
+            } else {
                 AudioCaptureDiagnostics.append(
-                    "meeting_cleaned_mic_cleanup session=\(sessionID.uuidString) outcome=failed reason=\(reason) remove_error=\(removeError.localizedDescription) truncate_error=\(error.localizedDescription)")
+                    "meeting_cleaned_mic_cleanup session=\(sessionID.uuidString) outcome=failed reason=\(reason) remove_error=\(removeError.localizedDescription) truncate_error=createFile returned false")
             }
         }
     }

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
@@ -593,7 +593,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
             preservePlayableMeetingAudioFallback(inputURLs: inputURLs, outputURL: session.mixedAudioURL)
         }
 
-        let cleanedMicrophoneAudioURL = try await renderCleanedMicrophone(
+        let cleanedMicrophoneAudioURL = await renderCleanedMicrophone(
             session: session,
             availableSources: availableSources,
             sourceAlignment: sourceAlignment
@@ -1250,12 +1250,12 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
     /// freshly built echo suppressor (plan #605 U3). Returns the cleaned file URL
     /// when a real suppressor is loaded and both sources exist; `nil` (raw mic
     /// stays the truth) for single-source meetings, when no AEC assets are
-    /// bundled, or on any render failure. Never throws into finalize.
+    /// bundled, or on any render failure/cancellation. Never throws into finalize.
     private func renderCleanedMicrophone(
         session: Session,
         availableSources: Set<AudioSource>,
         sourceAlignment: MeetingSourceAlignment
-    ) async throws -> URL? {
+    ) async -> URL? {
         let outputURL = session.folderURL.appendingPathComponent(
             MeetingCleanedMicRenderer.cleanedMicrophoneFileName)
         // A cleaned mic needs a system reference to cancel against; single-source
@@ -1297,7 +1297,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
                 at: outputURL, sessionID: session.id, reason: "renderer_cancelled")
             AudioCaptureDiagnostics.append(
                 "meeting_cleaned_mic session=\(session.id.uuidString) outcome=cancelled")
-            throw CancellationError()
+            return nil
         } catch {
             discardCleanedMicrophoneArtifact(
                 at: outputURL, sessionID: session.id, reason: "renderer_threw")

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
@@ -560,8 +560,9 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
             throw MeetingAudioError.noAudioCaptured
         }
 
+        let availableSources = Set(inputURLs.map(source(for:)))
         let sourceAlignment = buildSourceAlignment(
-            availableSources: Set(inputURLs.map(source(for:))),
+            availableSources: availableSources,
             writerMetrics: writerMetrics
         )
         do {
@@ -591,6 +592,12 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
             )
             preservePlayableMeetingAudioFallback(inputURLs: inputURLs, outputURL: session.mixedAudioURL)
         }
+
+        let cleanedMicrophoneAudioURL = await renderCleanedMicrophone(
+            session: session,
+            availableSources: availableSources,
+            sourceAlignment: sourceAlignment
+        )
 
         let finalNotes = currentNotes
         let notesFileManager = MeetingNotesFile.SendableFileManager(fileManager)
@@ -644,6 +651,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
             mixedAudioURL: session.mixedAudioURL,
             microphoneAudioURL: session.microphoneAudioURL,
             systemAudioURL: session.systemAudioURL,
+            cleanedMicrophoneAudioURL: cleanedMicrophoneAudioURL,
             durationSeconds: durationSeconds,
             sourceAlignment: sourceAlignment,
             speechEngine: session.speechEngine,
@@ -1236,6 +1244,56 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
             assertionFailure("Unexpected URL passed to source(for:): \(url.path)")
         }
         return .system
+    }
+
+    /// Derive `microphone-cleaned.m4a` from the raw mic + system sources using a
+    /// freshly built echo suppressor (plan #605 U3). Returns the cleaned file URL
+    /// when a real suppressor is loaded and both sources exist; `nil` (raw mic
+    /// stays the truth) for single-source meetings, when no AEC assets are
+    /// bundled, or on any render failure. Never throws into finalize.
+    private func renderCleanedMicrophone(
+        session: Session,
+        availableSources: Set<AudioSource>,
+        sourceAlignment: MeetingSourceAlignment
+    ) async -> URL? {
+        // A cleaned mic needs a system reference to cancel against; single-source
+        // meetings have nothing to subtract.
+        guard availableSources.contains(.microphone),
+              availableSources.contains(.system) else {
+            return nil
+        }
+
+        let microphoneURL = session.microphoneAudioURL
+        let systemURL = session.systemAudioURL
+        let outputURL = session.folderURL.appendingPathComponent(
+            MeetingCleanedMicRenderer.cleanedMicrophoneFileName)
+        let conditionerFactory = micConditionerFactory
+
+        // Heavy decode/DSP/encode runs off the actor; the suppressor (and its
+        // dylib load) is built inside the detached task so it never blocks
+        // recording state. A fresh suppressor starts from clean filter state
+        // rather than inheriting the live preview's adapted taps.
+        let outcome = await Task.detached(priority: .utility) {
+            MeetingCleanedMicRenderer().render(
+                microphoneURL: microphoneURL,
+                systemURL: systemURL,
+                sourceAlignment: sourceAlignment,
+                outputURL: outputURL,
+                conditioner: conditionerFactory())
+        }.value
+
+        switch outcome {
+        case .rendered(let result):
+            AudioCaptureDiagnostics.append(
+                "meeting_cleaned_mic session=\(session.id.uuidString) outcome=rendered duration_s=\(String(format: "%.3f", result.durationSeconds)) processed_frames=\(result.processedFrames) raw_fallback_frames=\(result.rawFallbackFrames) failures=\(result.processingFailures) rms_ratio=\(String(format: "%.2f", result.outputToRawRmsRatio))"
+            )
+            return result.outputURL
+        case .skipped(let reason):
+            AudioCaptureDiagnostics.append(
+                "meeting_cleaned_mic session=\(session.id.uuidString) outcome=skipped reason=\(String(describing: reason))"
+            )
+            return nil
+        }
     }
 
     private func buildSourceAlignment(

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
@@ -1262,7 +1262,8 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         // meetings have nothing to subtract.
         guard availableSources.contains(.microphone),
               availableSources.contains(.system) else {
-            try? fileManager.removeItem(at: outputURL)
+            discardCleanedMicrophoneArtifact(
+                at: outputURL, sessionID: session.id, reason: "missing_source")
             return nil
         }
 
@@ -1291,11 +1292,35 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
             )
             return result.outputURL
         case .skipped(let reason):
-            try? fileManager.removeItem(at: outputURL)
+            discardCleanedMicrophoneArtifact(
+                at: outputURL,
+                sessionID: session.id,
+                reason: "renderer_skipped_\(String(describing: reason))")
             AudioCaptureDiagnostics.append(
                 "meeting_cleaned_mic session=\(session.id.uuidString) outcome=skipped reason=\(String(describing: reason))"
             )
             return nil
+        }
+    }
+
+    private func discardCleanedMicrophoneArtifact(
+        at outputURL: URL,
+        sessionID: UUID,
+        reason: String
+    ) {
+        guard fileManager.fileExists(atPath: outputURL.path) else { return }
+        do {
+            try fileManager.removeItem(at: outputURL)
+        } catch {
+            let removeError = error
+            do {
+                try Data().write(to: outputURL, options: .atomic)
+                AudioCaptureDiagnostics.append(
+                    "meeting_cleaned_mic_cleanup session=\(sessionID.uuidString) outcome=truncated reason=\(reason) remove_error=\(removeError.localizedDescription)")
+            } catch {
+                AudioCaptureDiagnostics.append(
+                    "meeting_cleaned_mic_cleanup session=\(sessionID.uuidString) outcome=failed reason=\(reason) remove_error=\(removeError.localizedDescription) truncate_error=\(error.localizedDescription)")
+            }
         }
     }
 

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
@@ -1256,25 +1256,27 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         availableSources: Set<AudioSource>,
         sourceAlignment: MeetingSourceAlignment
     ) async -> URL? {
+        let outputURL = session.folderURL.appendingPathComponent(
+            MeetingCleanedMicRenderer.cleanedMicrophoneFileName)
         // A cleaned mic needs a system reference to cancel against; single-source
         // meetings have nothing to subtract.
         guard availableSources.contains(.microphone),
               availableSources.contains(.system) else {
+            try? fileManager.removeItem(at: outputURL)
             return nil
         }
 
         let microphoneURL = session.microphoneAudioURL
         let systemURL = session.systemAudioURL
-        let outputURL = session.folderURL.appendingPathComponent(
-            MeetingCleanedMicRenderer.cleanedMicrophoneFileName)
         let conditionerFactory = micConditionerFactory
+        let rendererFileManager = fileManager
 
         // Heavy decode/DSP/encode runs off the actor; the suppressor (and its
         // dylib load) is built inside the detached task so it never blocks
         // recording state. A fresh suppressor starts from clean filter state
         // rather than inheriting the live preview's adapted taps.
         let outcome = await Task.detached(priority: .utility) {
-            await MeetingCleanedMicRenderer().render(
+            await MeetingCleanedMicRenderer(fileManager: rendererFileManager).render(
                 microphoneURL: microphoneURL,
                 systemURL: systemURL,
                 sourceAlignment: sourceAlignment,
@@ -1289,6 +1291,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
             )
             return result.outputURL
         case .skipped(let reason):
+            try? fileManager.removeItem(at: outputURL)
             AudioCaptureDiagnostics.append(
                 "meeting_cleaned_mic session=\(session.id.uuidString) outcome=skipped reason=\(String(describing: reason))"
             )

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
@@ -1270,14 +1270,14 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         let microphoneURL = session.microphoneAudioURL
         let systemURL = session.systemAudioURL
         let conditionerFactory = micConditionerFactory
-        let rendererFileManager = fileManager
+        let rendererFileManager = UncheckedSendableBox(fileManager)
 
         // Heavy decode/DSP/encode runs off the actor; the suppressor (and its
         // dylib load) is built inside the detached task so it never blocks
         // recording state. A fresh suppressor starts from clean filter state
         // rather than inheriting the live preview's adapted taps.
         let outcome = await Task.detached(priority: .utility) {
-            await MeetingCleanedMicRenderer(fileManager: rendererFileManager).render(
+            await MeetingCleanedMicRenderer(fileManager: rendererFileManager.value).render(
                 microphoneURL: microphoneURL,
                 systemURL: systemURL,
                 sourceAlignment: sourceAlignment,

--- a/Sources/MacParakeetCore/Services/TranscriptionService.swift
+++ b/Sources/MacParakeetCore/Services/TranscriptionService.swift
@@ -1330,7 +1330,7 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
             // Transcribe the echo-cancelled mic when it was derived (plan #605
             // U3/U4) so remote speaker bleed does not surface as false "Me"
             // text; falls back to the raw mic when no cleaned artifact exists.
-            return recording.microphoneTranscriptionURL()
+            return recording.validatedMicrophoneTranscriptionURL()
         case .system:
             return recording.systemAudioURL
         }

--- a/Sources/MacParakeetCore/Services/TranscriptionService.swift
+++ b/Sources/MacParakeetCore/Services/TranscriptionService.swift
@@ -1327,7 +1327,10 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
     private func meetingAudioURL(for source: AudioSource, recording: MeetingRecordingOutput) -> URL {
         switch source {
         case .microphone:
-            return recording.microphoneAudioURL
+            // Transcribe the echo-cancelled mic when it was derived (plan #605
+            // U3/U4) so remote speaker bleed does not surface as false "Me"
+            // text; falls back to the raw mic when no cleaned artifact exists.
+            return recording.microphoneTranscriptionURL()
         case .system:
             return recording.systemAudioURL
         }

--- a/Sources/MacParakeetCore/Utilities/TranscriptionAssetCleanup.swift
+++ b/Sources/MacParakeetCore/Utilities/TranscriptionAssetCleanup.swift
@@ -33,6 +33,10 @@ public enum TranscriptionAssetCleanup {
         "meeting.m4a",
         "microphone.m4a",
         "system.m4a",
+        // Derived echo-cancelled mic (plan #605 U3). Listed so the targeted
+        // "Remove Audio Only" detach path deletes it alongside the raw sources
+        // instead of orphaning it.
+        MeetingCleanedMicRenderer.cleanedMicrophoneFileName,
     ]
     private static let managedMeetingAudioExtensions: Set<String> = [
         "aac",

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingCleanedMicRendererTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingCleanedMicRendererTests.swift
@@ -110,7 +110,8 @@ final class MeetingCleanedMicRendererTests: XCTestCase {
         XCTAssertGreaterThan(result.processedFrames, 0)
         XCTAssertEqual(result.processingFailures, 0)
 
-        let decoded = try MeetingCleanedMicRenderer.decodeMonoFloat(url: outURL, sampleRate: 16_000)
+        let decoded = try await MeetingCleanedMicRenderer.decodeMonoFloat(
+            url: outURL, sampleRate: 16_000)
         let expected = Double(scenario.mic.count) / 16_000.0
         let actual = Double(decoded.count) / 16_000.0
         XCTAssertEqual(actual, expected, accuracy: 0.3, "cleaned duration ~ raw mic duration")

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingCleanedMicRendererTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingCleanedMicRendererTests.swift
@@ -42,6 +42,11 @@ final class MeetingCleanedMicRendererTests: XCTestCase {
         XCTAssertGreaterThan(erle, 8, "an aligned reference cancels the synthetic echo (ERLE \(erle) dB)")
         XCTAssertGreaterThan(result.processedFrames, 0)
         XCTAssertEqual(result.processingFailures, 0)
+        // The frame-carrying suppressor (unlike passthrough) can hold a partial
+        // final frame; the renderer clamps the flushed tail so the cleaned output
+        // still aligns 1:1 with the raw mic.
+        XCTAssertEqual(result.output.count, scenario.mic.count,
+            "cleaned output stays aligned 1:1 with the raw mic after flush")
     }
 
     func testAlignAndConditionAppliesRecordedStartOffset() {

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingCleanedMicRendererTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingCleanedMicRendererTests.swift
@@ -1,0 +1,171 @@
+import AVFoundation
+import XCTest
+@testable import MacParakeetCore
+
+/// Unit coverage for the post-stop cleaned-mic renderer (plan #605 U3). The DSP
+/// core (`alignAndCondition`) is exercised with the measurement-harness
+/// conditioners so echo cancellation and start-offset alignment are checked on
+/// ground-truth fixtures; the I/O path is round-tripped through real AAC `.m4a`
+/// files (lossy, so only structure/duration is asserted).
+final class MeetingCleanedMicRendererTests: XCTestCase {
+    private let echoPath = MeetingAecEchoPath(taps: [(delay: 120, gain: 0.6)])
+
+    // MARK: DSP core
+
+    func testAlignAndConditionOutputMatchesMicrophoneLength() {
+        let mic = [Float](repeating: 0.1, count: 5_000)
+        let system = [Float](repeating: 0.2, count: 3_000)
+        for (micOff, sysOff) in [(0, 0), (0, 500), (500, 0)] {
+            let result = MeetingCleanedMicRenderer.alignAndCondition(
+                microphone: mic, system: system,
+                microphoneStartOffsetMs: micOff, systemStartOffsetMs: sysOff,
+                sampleRate: 16_000,
+                conditioner: PassthroughMicConditioner())
+            XCTAssertEqual(result.output.count, mic.count,
+                "cleaned output must align 1:1 with the raw mic (offsets \(micOff)/\(sysOff))")
+        }
+    }
+
+    func testAlignAndConditionCancelsEchoWhenAligned() {
+        let scenario = MeetingAecScenarioFactory.make(
+            name: "far-end-only", nearEndActive: false, farEndActive: true,
+            echoPath: echoPath, noiseLevel: 0.0001)
+        let suppressor = StreamingMeetingEchoSuppressor(
+            processor: MeetingAecNLMSProcessor(), referenceDelaySamples: 120)
+        let result = MeetingCleanedMicRenderer.alignAndCondition(
+            microphone: scenario.mic, system: scenario.farEnd,
+            microphoneStartOffsetMs: 0, systemStartOffsetMs: 0,
+            sampleRate: 16_000, conditioner: suppressor)
+
+        let erle = MeetingAecMetrics.erleDB(
+            mic: scenario.mic, output: result.output, over: scenario.steadyStateWindow)
+        XCTAssertGreaterThan(erle, 8, "an aligned reference cancels the synthetic echo (ERLE \(erle) dB)")
+        XCTAssertGreaterThan(result.processedFrames, 0)
+        XCTAssertEqual(result.processingFailures, 0)
+    }
+
+    func testAlignAndConditionAppliesRecordedStartOffset() {
+        // The system stream started 500 ms (8000 samples at 16 kHz) after the
+        // mic, so the mic's echo only begins 8000 samples in. Only applying the
+        // recorded offset realigns the reference; ignoring it leaves the echo
+        // 8000 samples out of phase, far beyond the NLMS filter's reach.
+        let leadSamples = 8_000
+        let leadMs = 500
+        let far = MeetingAecSignal.voiceLike(
+            sampleCount: 24_000, sampleRate: 16_000,
+            formants: MeetingAecScenarioFactory.farFormants, seed: 0x0B0B)
+        let echoFull = echoPath.apply(to: far)
+        let mic = [Float](repeating: 0, count: leadSamples) + echoFull
+        let window = (mic.count / 2)..<(mic.count - 256)
+
+        func erle(systemOffsetMs: Int) -> Double {
+            let suppressor = StreamingMeetingEchoSuppressor(
+                processor: MeetingAecNLMSProcessor(), referenceDelaySamples: 120)
+            let out = MeetingCleanedMicRenderer.alignAndCondition(
+                microphone: mic, system: far,
+                microphoneStartOffsetMs: 0, systemStartOffsetMs: systemOffsetMs,
+                sampleRate: 16_000, conditioner: suppressor)
+            return MeetingAecMetrics.erleDB(mic: mic, output: out.output, over: window)
+        }
+
+        let aligned = erle(systemOffsetMs: leadMs)
+        let misaligned = erle(systemOffsetMs: 0)
+        XCTAssertGreaterThan(aligned, misaligned + 6,
+            "the recorded start offset realigns the reference and restores cancellation "
+            + "(aligned \(aligned) dB vs ignoring-offset \(misaligned) dB)")
+    }
+
+    // MARK: I/O round-trip
+
+    func testRenderProducesDecodableCleanedFile() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let scenario = MeetingAecScenarioFactory.make(
+            name: "double-talk", nearEndActive: true, farEndActive: true, echoPath: echoPath)
+        let micURL = dir.appendingPathComponent("microphone.m4a")
+        let sysURL = dir.appendingPathComponent("system.m4a")
+        try MeetingCleanedMicRenderer.encodeMonoFloat(
+            scenario.mic, sampleRate: 16_000, to: micURL, fileManager: .default)
+        try MeetingCleanedMicRenderer.encodeMonoFloat(
+            scenario.farEnd, sampleRate: 16_000, to: sysURL, fileManager: .default)
+
+        let outURL = dir.appendingPathComponent(MeetingCleanedMicRenderer.cleanedMicrophoneFileName)
+        let outcome = MeetingCleanedMicRenderer().render(
+            microphoneURL: micURL, systemURL: sysURL,
+            sourceAlignment: equalAlignment(),
+            outputURL: outURL,
+            conditioner: StreamingMeetingEchoSuppressor(
+                processor: MeetingAecNLMSProcessor(), referenceDelaySamples: 120))
+
+        guard case .rendered(let result) = outcome else {
+            return XCTFail("expected .rendered, got \(outcome)")
+        }
+        XCTAssertTrue(FileManager.default.fileExists(atPath: outURL.path))
+        XCTAssertGreaterThan(result.processedFrames, 0)
+        XCTAssertEqual(result.processingFailures, 0)
+
+        let decoded = try MeetingCleanedMicRenderer.decodeMonoFloat(url: outURL, sampleRate: 16_000)
+        let expected = Double(scenario.mic.count) / 16_000.0
+        let actual = Double(decoded.count) / 16_000.0
+        XCTAssertEqual(actual, expected, accuracy: 0.3, "cleaned duration ~ raw mic duration")
+    }
+
+    func testRenderSkipsWhenConditionerIsPassthrough() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let (micURL, sysURL) = try writeSourcePair(in: dir)
+
+        let outcome = MeetingCleanedMicRenderer().render(
+            microphoneURL: micURL, systemURL: sysURL,
+            sourceAlignment: equalAlignment(),
+            outputURL: dir.appendingPathComponent(MeetingCleanedMicRenderer.cleanedMicrophoneFileName),
+            conditioner: PassthroughMicConditioner())
+
+        XCTAssertEqual(outcome, .skipped(.conditionerUnavailable))
+    }
+
+    func testRenderSkipsWhenSystemReferenceMissing() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let (micURL, _) = try writeSourcePair(in: dir, includeSystem: false)
+
+        let outcome = MeetingCleanedMicRenderer().render(
+            microphoneURL: micURL,
+            systemURL: dir.appendingPathComponent("system.m4a"),
+            sourceAlignment: equalAlignment(),
+            outputURL: dir.appendingPathComponent(MeetingCleanedMicRenderer.cleanedMicrophoneFileName),
+            conditioner: StreamingMeetingEchoSuppressor(
+                processor: MeetingAecNLMSProcessor(), referenceDelaySamples: 120))
+
+        XCTAssertEqual(outcome, .skipped(.missingSystemReference))
+    }
+
+    // MARK: Helpers
+
+    private func makeTempDir() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private func equalAlignment() -> MeetingSourceAlignment {
+        MeetingSourceAlignment(meetingOriginHostTime: nil, microphone: nil, system: nil)
+    }
+
+    @discardableResult
+    private func writeSourcePair(in dir: URL, includeSystem: Bool = true) throws -> (URL, URL) {
+        let scenario = MeetingAecScenarioFactory.make(
+            name: "far-end-only", nearEndActive: true, farEndActive: true, echoPath: echoPath)
+        let micURL = dir.appendingPathComponent("microphone.m4a")
+        let sysURL = dir.appendingPathComponent("system.m4a")
+        try MeetingCleanedMicRenderer.encodeMonoFloat(
+            scenario.mic, sampleRate: 16_000, to: micURL, fileManager: .default)
+        if includeSystem {
+            try MeetingCleanedMicRenderer.encodeMonoFloat(
+                scenario.farEnd, sampleRate: 16_000, to: sysURL, fileManager: .default)
+        }
+        return (micURL, sysURL)
+    }
+}

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingCleanedMicRendererTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingCleanedMicRendererTests.swift
@@ -82,7 +82,7 @@ final class MeetingCleanedMicRendererTests: XCTestCase {
 
     // MARK: I/O round-trip
 
-    func testRenderProducesDecodableCleanedFile() throws {
+    func testRenderProducesDecodableCleanedFile() async throws {
         let dir = try makeTempDir()
         defer { try? FileManager.default.removeItem(at: dir) }
 
@@ -90,13 +90,13 @@ final class MeetingCleanedMicRendererTests: XCTestCase {
             name: "double-talk", nearEndActive: true, farEndActive: true, echoPath: echoPath)
         let micURL = dir.appendingPathComponent("microphone.m4a")
         let sysURL = dir.appendingPathComponent("system.m4a")
-        try MeetingCleanedMicRenderer.encodeMonoFloat(
+        try await MeetingCleanedMicRenderer.encodeMonoFloat(
             scenario.mic, sampleRate: 16_000, to: micURL, fileManager: .default)
-        try MeetingCleanedMicRenderer.encodeMonoFloat(
+        try await MeetingCleanedMicRenderer.encodeMonoFloat(
             scenario.farEnd, sampleRate: 16_000, to: sysURL, fileManager: .default)
 
         let outURL = dir.appendingPathComponent(MeetingCleanedMicRenderer.cleanedMicrophoneFileName)
-        let outcome = MeetingCleanedMicRenderer().render(
+        let outcome = await MeetingCleanedMicRenderer().render(
             microphoneURL: micURL, systemURL: sysURL,
             sourceAlignment: equalAlignment(),
             outputURL: outURL,
@@ -116,12 +116,12 @@ final class MeetingCleanedMicRendererTests: XCTestCase {
         XCTAssertEqual(actual, expected, accuracy: 0.3, "cleaned duration ~ raw mic duration")
     }
 
-    func testRenderSkipsWhenConditionerIsPassthrough() throws {
+    func testRenderSkipsWhenConditionerIsPassthrough() async throws {
         let dir = try makeTempDir()
         defer { try? FileManager.default.removeItem(at: dir) }
-        let (micURL, sysURL) = try writeSourcePair(in: dir)
+        let (micURL, sysURL) = try await writeSourcePair(in: dir)
 
-        let outcome = MeetingCleanedMicRenderer().render(
+        let outcome = await MeetingCleanedMicRenderer().render(
             microphoneURL: micURL, systemURL: sysURL,
             sourceAlignment: equalAlignment(),
             outputURL: dir.appendingPathComponent(MeetingCleanedMicRenderer.cleanedMicrophoneFileName),
@@ -130,12 +130,12 @@ final class MeetingCleanedMicRendererTests: XCTestCase {
         XCTAssertEqual(outcome, .skipped(.conditionerUnavailable))
     }
 
-    func testRenderSkipsWhenSystemReferenceMissing() throws {
+    func testRenderSkipsWhenSystemReferenceMissing() async throws {
         let dir = try makeTempDir()
         defer { try? FileManager.default.removeItem(at: dir) }
-        let (micURL, _) = try writeSourcePair(in: dir, includeSystem: false)
+        let (micURL, _) = try await writeSourcePair(in: dir, includeSystem: false)
 
-        let outcome = MeetingCleanedMicRenderer().render(
+        let outcome = await MeetingCleanedMicRenderer().render(
             microphoneURL: micURL,
             systemURL: dir.appendingPathComponent("system.m4a"),
             sourceAlignment: equalAlignment(),
@@ -160,15 +160,15 @@ final class MeetingCleanedMicRendererTests: XCTestCase {
     }
 
     @discardableResult
-    private func writeSourcePair(in dir: URL, includeSystem: Bool = true) throws -> (URL, URL) {
+    private func writeSourcePair(in dir: URL, includeSystem: Bool = true) async throws -> (URL, URL) {
         let scenario = MeetingAecScenarioFactory.make(
             name: "far-end-only", nearEndActive: true, farEndActive: true, echoPath: echoPath)
         let micURL = dir.appendingPathComponent("microphone.m4a")
         let sysURL = dir.appendingPathComponent("system.m4a")
-        try MeetingCleanedMicRenderer.encodeMonoFloat(
+        try await MeetingCleanedMicRenderer.encodeMonoFloat(
             scenario.mic, sampleRate: 16_000, to: micURL, fileManager: .default)
         if includeSystem {
-            try MeetingCleanedMicRenderer.encodeMonoFloat(
+            try await MeetingCleanedMicRenderer.encodeMonoFloat(
                 scenario.farEnd, sampleRate: 16_000, to: sysURL, fileManager: .default)
         }
         return (micURL, sysURL)

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingCleanedMicRendererTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingCleanedMicRendererTests.swift
@@ -12,11 +12,11 @@ final class MeetingCleanedMicRendererTests: XCTestCase {
 
     // MARK: DSP core
 
-    func testAlignAndConditionOutputMatchesMicrophoneLength() {
+    func testAlignAndConditionOutputMatchesMicrophoneLength() throws {
         let mic = [Float](repeating: 0.1, count: 5_000)
         let system = [Float](repeating: 0.2, count: 3_000)
         for (micOff, sysOff) in [(0, 0), (0, 500), (500, 0)] {
-            let result = MeetingCleanedMicRenderer.alignAndCondition(
+            let result = try MeetingCleanedMicRenderer.alignAndCondition(
                 microphone: mic, system: system,
                 microphoneStartOffsetMs: micOff, systemStartOffsetMs: sysOff,
                 sampleRate: 16_000,
@@ -26,13 +26,13 @@ final class MeetingCleanedMicRendererTests: XCTestCase {
         }
     }
 
-    func testAlignAndConditionCancelsEchoWhenAligned() {
+    func testAlignAndConditionCancelsEchoWhenAligned() throws {
         let scenario = MeetingAecScenarioFactory.make(
             name: "far-end-only", nearEndActive: false, farEndActive: true,
             echoPath: echoPath, noiseLevel: 0.0001)
         let suppressor = StreamingMeetingEchoSuppressor(
             processor: MeetingAecNLMSProcessor(), referenceDelaySamples: 120)
-        let result = MeetingCleanedMicRenderer.alignAndCondition(
+        let result = try MeetingCleanedMicRenderer.alignAndCondition(
             microphone: scenario.mic, system: scenario.farEnd,
             microphoneStartOffsetMs: 0, systemStartOffsetMs: 0,
             sampleRate: 16_000, conditioner: suppressor)
@@ -49,7 +49,7 @@ final class MeetingCleanedMicRendererTests: XCTestCase {
             "cleaned output stays aligned 1:1 with the raw mic after flush")
     }
 
-    func testAlignAndConditionAppliesRecordedStartOffset() {
+    func testAlignAndConditionAppliesRecordedStartOffset() throws {
         // The system stream started 500 ms (8000 samples at 16 kHz) after the
         // mic, so the mic's echo only begins 8000 samples in. Only applying the
         // recorded offset realigns the reference; ignoring it leaves the echo
@@ -63,18 +63,18 @@ final class MeetingCleanedMicRendererTests: XCTestCase {
         let mic = [Float](repeating: 0, count: leadSamples) + echoFull
         let window = (mic.count / 2)..<(mic.count - 256)
 
-        func erle(systemOffsetMs: Int) -> Double {
+        func erle(systemOffsetMs: Int) throws -> Double {
             let suppressor = StreamingMeetingEchoSuppressor(
                 processor: MeetingAecNLMSProcessor(), referenceDelaySamples: 120)
-            let out = MeetingCleanedMicRenderer.alignAndCondition(
+            let out = try MeetingCleanedMicRenderer.alignAndCondition(
                 microphone: mic, system: far,
                 microphoneStartOffsetMs: 0, systemStartOffsetMs: systemOffsetMs,
                 sampleRate: 16_000, conditioner: suppressor)
             return MeetingAecMetrics.erleDB(mic: mic, output: out.output, over: window)
         }
 
-        let aligned = erle(systemOffsetMs: leadMs)
-        let misaligned = erle(systemOffsetMs: 0)
+        let aligned = try erle(systemOffsetMs: leadMs)
+        let misaligned = try erle(systemOffsetMs: 0)
         XCTAssertGreaterThan(aligned, misaligned + 6,
             "the recorded start offset realigns the reference and restores cancellation "
             + "(aligned \(aligned) dB vs ignoring-offset \(misaligned) dB)")

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingCleanedMicRendererTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingCleanedMicRendererTests.swift
@@ -96,7 +96,7 @@ final class MeetingCleanedMicRendererTests: XCTestCase {
             scenario.farEnd, sampleRate: 16_000, to: sysURL, fileManager: .default)
 
         let outURL = dir.appendingPathComponent(MeetingCleanedMicRenderer.cleanedMicrophoneFileName)
-        let outcome = await MeetingCleanedMicRenderer().render(
+        let outcome = try await MeetingCleanedMicRenderer().render(
             microphoneURL: micURL, systemURL: sysURL,
             sourceAlignment: equalAlignment(),
             outputURL: outURL,
@@ -121,7 +121,7 @@ final class MeetingCleanedMicRendererTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: dir) }
         let (micURL, sysURL) = try await writeSourcePair(in: dir)
 
-        let outcome = await MeetingCleanedMicRenderer().render(
+        let outcome = try await MeetingCleanedMicRenderer().render(
             microphoneURL: micURL, systemURL: sysURL,
             sourceAlignment: equalAlignment(),
             outputURL: dir.appendingPathComponent(MeetingCleanedMicRenderer.cleanedMicrophoneFileName),
@@ -135,7 +135,7 @@ final class MeetingCleanedMicRendererTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: dir) }
         let (micURL, _) = try await writeSourcePair(in: dir, includeSystem: false)
 
-        let outcome = await MeetingCleanedMicRenderer().render(
+        let outcome = try await MeetingCleanedMicRenderer().render(
             microphoneURL: micURL,
             systemURL: dir.appendingPathComponent("system.m4a"),
             sourceAlignment: equalAlignment(),

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingOutputTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingOutputTests.swift
@@ -30,6 +30,18 @@ final class MeetingRecordingOutputTests: XCTestCase {
         XCTAssertEqual(output.microphoneTranscriptionURL(), rawURL)
     }
 
+    func testMicrophoneTranscriptionURLFallsBackToRawWhenCleanedIsEmpty() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let rawURL = dir.appendingPathComponent("microphone.m4a")
+        let cleanedURL = dir.appendingPathComponent("microphone-cleaned.m4a")
+        try Data([0x00]).write(to: rawURL)
+        FileManager.default.createFile(atPath: cleanedURL.path, contents: Data())
+
+        let output = makeOutput(folderURL: dir, microphoneAudioURL: rawURL, cleanedMicrophoneAudioURL: cleanedURL)
+        XCTAssertEqual(output.microphoneTranscriptionURL(), rawURL)
+    }
+
     func testMicrophoneTranscriptionURLFallsBackToRawWhenNoCleanedURL() throws {
         let dir = try makeTempDir()
         defer { try? FileManager.default.removeItem(at: dir) }

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingOutputTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingOutputTests.swift
@@ -4,8 +4,9 @@ import XCTest
 @testable import MacParakeetCore
 
 /// Coverage for the #605 cleaned-mic surface on `MeetingRecordingOutput`: the
-/// `microphoneTranscriptionURL` preference policy (U4) and the `loadArchived`
-/// disk probe that re-surfaces a derived cleaned mic on re-open.
+/// `microphoneTranscriptionURL` preference policy, the validated STT routing
+/// gate (U4), and the `loadArchived` disk probe that re-surfaces a derived
+/// cleaned mic on re-open.
 final class MeetingRecordingOutputTests: XCTestCase {
     func testMicrophoneTranscriptionURLPrefersExistingCleanedMic() throws {
         let dir = try makeTempDir()
@@ -31,7 +32,7 @@ final class MeetingRecordingOutputTests: XCTestCase {
         XCTAssertEqual(output.microphoneTranscriptionURL(), rawURL)
     }
 
-    func testMicrophoneTranscriptionURLFallsBackToRawWhenCleanedIsCorrupt() throws {
+    func testMicrophoneTranscriptionURLIsCheapAndDoesNotDecodeCorruptCleanedMic() throws {
         let dir = try makeTempDir()
         defer { try? FileManager.default.removeItem(at: dir) }
         let rawURL = dir.appendingPathComponent("microphone.m4a")
@@ -40,7 +41,19 @@ final class MeetingRecordingOutputTests: XCTestCase {
         try Data("partial m4a fragment".utf8).write(to: cleanedURL)
 
         let output = makeOutput(folderURL: dir, microphoneAudioURL: rawURL, cleanedMicrophoneAudioURL: cleanedURL)
-        XCTAssertEqual(output.microphoneTranscriptionURL(), rawURL)
+        XCTAssertEqual(output.microphoneTranscriptionURL(), cleanedURL)
+    }
+
+    func testValidatedMicrophoneTranscriptionURLFallsBackToRawWhenCleanedIsCorrupt() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let rawURL = dir.appendingPathComponent("microphone.m4a")
+        let cleanedURL = dir.appendingPathComponent("microphone-cleaned.m4a")
+        try Data([0x00]).write(to: rawURL)
+        try Data("partial m4a fragment".utf8).write(to: cleanedURL)
+
+        let output = makeOutput(folderURL: dir, microphoneAudioURL: rawURL, cleanedMicrophoneAudioURL: cleanedURL)
+        XCTAssertEqual(output.validatedMicrophoneTranscriptionURL(), rawURL)
     }
 
     func testMicrophoneTranscriptionURLFallsBackToRawWhenCleanedIsEmpty() throws {
@@ -90,7 +103,7 @@ final class MeetingRecordingOutputTests: XCTestCase {
         let output = try MeetingRecordingOutput.loadArchived(
             displayName: "Archived", mixedAudioURL: mixedURL, durationSeconds: 12)
         XCTAssertEqual(output.cleanedMicrophoneAudioURL, cleanedURL)
-        XCTAssertEqual(output.microphoneTranscriptionURL(), output.microphoneAudioURL)
+        XCTAssertEqual(output.validatedMicrophoneTranscriptionURL(), output.microphoneAudioURL)
     }
 
     func testLoadArchivedHasNoCleanedMicWhenAbsent() throws {

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingOutputTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingOutputTests.swift
@@ -131,6 +131,19 @@ final class MeetingRecordingOutputTests: XCTestCase {
         XCTAssertNil(output.cleanedMicrophoneAudioURL)
     }
 
+    func testMetadataLoadDoesNotTreatFailedContentsProbeAsMissingFile() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try saveAlignmentMetadata(in: dir)
+
+        let metadata = try MeetingRecordingMetadataStore.load(
+            from: dir,
+            fileManager: ContentsProbeFailingFileManager())
+
+        XCTAssertNil(metadata.sourceAlignment.microphone)
+        XCTAssertNil(metadata.sourceAlignment.system)
+    }
+
     // MARK: Helpers
 
     private func makeTempDir() throws -> URL {
@@ -198,5 +211,15 @@ final class MeetingRecordingOutputTests: XCTestCase {
             sourceAlignment: MeetingSourceAlignment(
                 meetingOriginHostTime: nil, microphone: nil, system: nil)
         )
+    }
+}
+
+private final class ContentsProbeFailingFileManager: FileManager {
+    override func fileExists(atPath path: String) -> Bool {
+        true
+    }
+
+    override func contents(atPath path: String) -> Data? {
+        nil
     }
 }

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingOutputTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingOutputTests.swift
@@ -131,17 +131,18 @@ final class MeetingRecordingOutputTests: XCTestCase {
         XCTAssertNil(output.cleanedMicrophoneAudioURL)
     }
 
-    func testMetadataLoadDoesNotTreatFailedContentsProbeAsMissingFile() throws {
+    func testMetadataLoadReportsFailedContentsProbeAsUnreadableNotMissing() throws {
         let dir = try makeTempDir()
         defer { try? FileManager.default.removeItem(at: dir) }
         try saveAlignmentMetadata(in: dir)
 
-        let metadata = try MeetingRecordingMetadataStore.load(
+        XCTAssertThrowsError(try MeetingRecordingMetadataStore.load(
             from: dir,
-            fileManager: ContentsProbeFailingFileManager())
-
-        XCTAssertNil(metadata.sourceAlignment.microphone)
-        XCTAssertNil(metadata.sourceAlignment.system)
+            fileManager: ContentsProbeFailingFileManager())) { error in
+                XCTAssertTrue(
+                    error.localizedDescription.contains("Unable to read archived meeting metadata"),
+                    "Unexpected error: \(error)")
+        }
     }
 
     // MARK: Helpers

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingOutputTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingOutputTests.swift
@@ -79,16 +79,18 @@ final class MeetingRecordingOutputTests: XCTestCase {
             dir.appendingPathComponent("microphone-cleaned.m4a"))
     }
 
-    func testLoadArchivedIgnoresCorruptCleanedMic() throws {
+    func testLoadArchivedSurfacesNonEmptyCleanedMicForDeferredValidation() throws {
         let dir = try makeTempDir()
         defer { try? FileManager.default.removeItem(at: dir) }
         try saveAlignmentMetadata(in: dir)
         let mixedURL = dir.appendingPathComponent("meeting.m4a")
-        try Data("partial m4a fragment".utf8).write(to: dir.appendingPathComponent("microphone-cleaned.m4a"))
+        let cleanedURL = dir.appendingPathComponent("microphone-cleaned.m4a")
+        try Data("partial m4a fragment".utf8).write(to: cleanedURL)
 
         let output = try MeetingRecordingOutput.loadArchived(
             displayName: "Archived", mixedAudioURL: mixedURL, durationSeconds: 12)
-        XCTAssertNil(output.cleanedMicrophoneAudioURL)
+        XCTAssertEqual(output.cleanedMicrophoneAudioURL, cleanedURL)
+        XCTAssertEqual(output.microphoneTranscriptionURL(), output.microphoneAudioURL)
     }
 
     func testLoadArchivedHasNoCleanedMicWhenAbsent() throws {
@@ -96,6 +98,20 @@ final class MeetingRecordingOutputTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: dir) }
         try saveAlignmentMetadata(in: dir)
         let mixedURL = dir.appendingPathComponent("meeting.m4a")
+
+        let output = try MeetingRecordingOutput.loadArchived(
+            displayName: "Archived", mixedAudioURL: mixedURL, durationSeconds: 12)
+        XCTAssertNil(output.cleanedMicrophoneAudioURL)
+    }
+
+    func testLoadArchivedHasNoCleanedMicWhenEmpty() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try saveAlignmentMetadata(in: dir)
+        let mixedURL = dir.appendingPathComponent("meeting.m4a")
+        FileManager.default.createFile(
+            atPath: dir.appendingPathComponent("microphone-cleaned.m4a").path,
+            contents: Data())
 
         let output = try MeetingRecordingOutput.loadArchived(
             displayName: "Archived", mixedAudioURL: mixedURL, durationSeconds: 12)

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingOutputTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingOutputTests.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import Foundation
 import XCTest
 @testable import MacParakeetCore
@@ -12,7 +13,7 @@ final class MeetingRecordingOutputTests: XCTestCase {
         let rawURL = dir.appendingPathComponent("microphone.m4a")
         let cleanedURL = dir.appendingPathComponent("microphone-cleaned.m4a")
         try Data([0x00]).write(to: rawURL)
-        try Data([0x00]).write(to: cleanedURL)
+        try writeM4A(to: cleanedURL)
 
         let output = makeOutput(folderURL: dir, microphoneAudioURL: rawURL, cleanedMicrophoneAudioURL: cleanedURL)
         XCTAssertEqual(output.microphoneTranscriptionURL(), cleanedURL)
@@ -25,6 +26,18 @@ final class MeetingRecordingOutputTests: XCTestCase {
         try Data([0x00]).write(to: rawURL)
         // URL is set but the file was never written / was deleted by retention.
         let cleanedURL = dir.appendingPathComponent("microphone-cleaned.m4a")
+
+        let output = makeOutput(folderURL: dir, microphoneAudioURL: rawURL, cleanedMicrophoneAudioURL: cleanedURL)
+        XCTAssertEqual(output.microphoneTranscriptionURL(), rawURL)
+    }
+
+    func testMicrophoneTranscriptionURLFallsBackToRawWhenCleanedIsCorrupt() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let rawURL = dir.appendingPathComponent("microphone.m4a")
+        let cleanedURL = dir.appendingPathComponent("microphone-cleaned.m4a")
+        try Data([0x00]).write(to: rawURL)
+        try Data("partial m4a fragment".utf8).write(to: cleanedURL)
 
         let output = makeOutput(folderURL: dir, microphoneAudioURL: rawURL, cleanedMicrophoneAudioURL: cleanedURL)
         XCTAssertEqual(output.microphoneTranscriptionURL(), rawURL)
@@ -57,13 +70,25 @@ final class MeetingRecordingOutputTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: dir) }
         try saveAlignmentMetadata(in: dir)
         let mixedURL = dir.appendingPathComponent("meeting.m4a")
-        try Data([0x00]).write(to: dir.appendingPathComponent("microphone-cleaned.m4a"))
+        try writeM4A(to: dir.appendingPathComponent("microphone-cleaned.m4a"))
 
         let output = try MeetingRecordingOutput.loadArchived(
             displayName: "Archived", mixedAudioURL: mixedURL, durationSeconds: 12)
         XCTAssertEqual(
             output.cleanedMicrophoneAudioURL,
             dir.appendingPathComponent("microphone-cleaned.m4a"))
+    }
+
+    func testLoadArchivedIgnoresCorruptCleanedMic() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try saveAlignmentMetadata(in: dir)
+        let mixedURL = dir.appendingPathComponent("meeting.m4a")
+        try Data("partial m4a fragment".utf8).write(to: dir.appendingPathComponent("microphone-cleaned.m4a"))
+
+        let output = try MeetingRecordingOutput.loadArchived(
+            displayName: "Archived", mixedAudioURL: mixedURL, durationSeconds: 12)
+        XCTAssertNil(output.cleanedMicrophoneAudioURL)
     }
 
     func testLoadArchivedHasNoCleanedMicWhenAbsent() throws {
@@ -98,6 +123,33 @@ final class MeetingRecordingOutputTests: XCTestCase {
             ),
             folderURL: dir
         )
+    }
+
+    private func writeM4A(to url: URL, sampleRate: Double = 16_000) throws {
+        let frameCount = Int(sampleRate / 10)
+        let format = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: sampleRate,
+            channels: 1,
+            interleaved: false
+        )!
+        let file = try AVAudioFile(
+            forWriting: url,
+            settings: [
+                AVFormatIDKey: kAudioFormatMPEG4AAC,
+                AVSampleRateKey: sampleRate,
+                AVNumberOfChannelsKey: 1,
+            ],
+            commonFormat: .pcmFormatFloat32,
+            interleaved: false
+        )
+        let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: AVAudioFrameCount(frameCount))!
+        buffer.frameLength = AVAudioFrameCount(frameCount)
+        let samples = buffer.floatChannelData![0]
+        for index in 0..<frameCount {
+            samples[index] = 0.1
+        }
+        try file.write(from: buffer)
     }
 
     private func makeOutput(

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingOutputTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingOutputTests.swift
@@ -1,0 +1,109 @@
+import Foundation
+import XCTest
+@testable import MacParakeetCore
+
+/// Coverage for the #605 cleaned-mic surface on `MeetingRecordingOutput`: the
+/// `microphoneTranscriptionURL` preference policy (U4) and the `loadArchived`
+/// disk probe that re-surfaces a derived cleaned mic on re-open.
+final class MeetingRecordingOutputTests: XCTestCase {
+    func testMicrophoneTranscriptionURLPrefersExistingCleanedMic() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let rawURL = dir.appendingPathComponent("microphone.m4a")
+        let cleanedURL = dir.appendingPathComponent("microphone-cleaned.m4a")
+        try Data([0x00]).write(to: rawURL)
+        try Data([0x00]).write(to: cleanedURL)
+
+        let output = makeOutput(folderURL: dir, microphoneAudioURL: rawURL, cleanedMicrophoneAudioURL: cleanedURL)
+        XCTAssertEqual(output.microphoneTranscriptionURL(), cleanedURL)
+    }
+
+    func testMicrophoneTranscriptionURLFallsBackToRawWhenCleanedMissingOnDisk() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let rawURL = dir.appendingPathComponent("microphone.m4a")
+        try Data([0x00]).write(to: rawURL)
+        // URL is set but the file was never written / was deleted by retention.
+        let cleanedURL = dir.appendingPathComponent("microphone-cleaned.m4a")
+
+        let output = makeOutput(folderURL: dir, microphoneAudioURL: rawURL, cleanedMicrophoneAudioURL: cleanedURL)
+        XCTAssertEqual(output.microphoneTranscriptionURL(), rawURL)
+    }
+
+    func testMicrophoneTranscriptionURLFallsBackToRawWhenNoCleanedURL() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let rawURL = dir.appendingPathComponent("microphone.m4a")
+        try Data([0x00]).write(to: rawURL)
+
+        let output = makeOutput(folderURL: dir, microphoneAudioURL: rawURL, cleanedMicrophoneAudioURL: nil)
+        XCTAssertEqual(output.microphoneTranscriptionURL(), rawURL)
+    }
+
+    func testLoadArchivedSurfacesCleanedMicWhenPresent() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try saveAlignmentMetadata(in: dir)
+        let mixedURL = dir.appendingPathComponent("meeting.m4a")
+        try Data([0x00]).write(to: dir.appendingPathComponent("microphone-cleaned.m4a"))
+
+        let output = try MeetingRecordingOutput.loadArchived(
+            displayName: "Archived", mixedAudioURL: mixedURL, durationSeconds: 12)
+        XCTAssertEqual(
+            output.cleanedMicrophoneAudioURL,
+            dir.appendingPathComponent("microphone-cleaned.m4a"))
+    }
+
+    func testLoadArchivedHasNoCleanedMicWhenAbsent() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try saveAlignmentMetadata(in: dir)
+        let mixedURL = dir.appendingPathComponent("meeting.m4a")
+
+        let output = try MeetingRecordingOutput.loadArchived(
+            displayName: "Archived", mixedAudioURL: mixedURL, durationSeconds: 12)
+        XCTAssertNil(output.cleanedMicrophoneAudioURL)
+    }
+
+    // MARK: Helpers
+
+    private func makeTempDir() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    /// Metadata with nil source tracks so `loadArchived` does not require the
+    /// raw `microphone.m4a`/`system.m4a` files — keeping these tests focused on
+    /// the cleaned-mic probe.
+    private func saveAlignmentMetadata(in dir: URL) throws {
+        try MeetingRecordingMetadataStore.save(
+            MeetingRecordingMetadata(
+                sourceAlignment: MeetingSourceAlignment(
+                    meetingOriginHostTime: nil, microphone: nil, system: nil),
+                speechEngine: SpeechEngineSelection(engine: .parakeet)
+            ),
+            folderURL: dir
+        )
+    }
+
+    private func makeOutput(
+        folderURL: URL,
+        microphoneAudioURL: URL,
+        cleanedMicrophoneAudioURL: URL?
+    ) -> MeetingRecordingOutput {
+        MeetingRecordingOutput(
+            sessionID: UUID(),
+            displayName: "Test",
+            folderURL: folderURL,
+            mixedAudioURL: folderURL.appendingPathComponent("meeting.m4a"),
+            microphoneAudioURL: microphoneAudioURL,
+            systemAudioURL: folderURL.appendingPathComponent("system.m4a"),
+            cleanedMicrophoneAudioURL: cleanedMicrophoneAudioURL,
+            durationSeconds: 1,
+            sourceAlignment: MeetingSourceAlignment(
+                meetingOriginHostTime: nil, microphone: nil, system: nil)
+        )
+    }
+}

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingRecoveryServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingRecoveryServiceTests.swift
@@ -282,6 +282,18 @@ final class MeetingRecordingRecoveryServiceTests: XCTestCase {
             "synthetic recovery alignment must remove stale cleaned artifacts so reopened sessions use raw mic")
     }
 
+    func testRecoverDeletesStaleCleanedMicWhenSourceMissing() async throws {
+        let fixture = try makeRecoverableSession(systemAudio: .corrupt)
+        let staleCleanedURL = fixture.folderURL.appendingPathComponent("microphone-cleaned.m4a")
+        try Data("partial m4a fragment".utf8).write(to: staleCleanedURL)
+
+        _ = try await recoveryService.recover(fixture.lock)
+
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: staleCleanedURL.path),
+            "missing recovered sources must remove stale cleaned artifacts so reopened sessions use raw mic")
+    }
+
     private enum SourceFixture {
         case valid
         case corrupt

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingRecoveryServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingRecoveryServiceTests.swift
@@ -571,7 +571,16 @@ private final class RecoveryMicConditionerFactoryProbe: @unchecked Sendable {
 
 private final class RecoveryLoadedMicConditioner: MicConditioning, @unchecked Sendable {
     var diagnostics: MeetingEchoSuppressionDiagnostics {
-        .passthrough(processorName: "test-loaded-cleaner", loaded: true)
+        MeetingEchoSuppressionDiagnostics(
+            processorName: "test-loaded-cleaner",
+            loaded: true,
+            micFrames: 0,
+            processedFrames: 0,
+            rawFallbackFrames: 0,
+            fullReferenceFrames: 0,
+            partialReferenceFrames: 0,
+            missingReferenceFrames: 0,
+            processingFailures: 0)
     }
 
     func condition(microphone: [Float], speaker: [Float], hasSpeakerReference: Bool) -> [Float] {

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingRecoveryServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingRecoveryServiceTests.swift
@@ -244,6 +244,32 @@ final class MeetingRecordingRecoveryServiceTests: XCTestCase {
         XCTAssertTrue(rows.first?.recoveredFromCrash == true)
     }
 
+    func testRecoverSkipsCleanedMicWhenRecoveredAlignmentIsSynthetic() async throws {
+        let fixture = try makeRecoverableSession()
+        let conditionerProbe = RecoveryMicConditionerFactoryProbe()
+        recoveryService = MeetingRecordingRecoveryService(
+            meetingsRoot: tempRoot,
+            lockFileStore: lockStore,
+            transcriptionService: transcriptionService,
+            transcriptionRepo: transcriptionRepo,
+            audioConverter: audioConverter,
+            micConditionerFactory: { @Sendable in conditionerProbe.make() }
+        )
+
+        _ = try await recoveryService.recover(fixture.lock)
+
+        let recording = try XCTUnwrap(transcriptionService.recordings.first)
+        XCTAssertNil(
+            recording.cleanedMicrophoneAudioURL,
+            "recovery synthesizes zero source offsets, so it must not prefer a derived cleaned mic")
+        XCTAssertFalse(FileManager.default.fileExists(
+            atPath: fixture.folderURL.appendingPathComponent("microphone-cleaned.m4a").path))
+        XCTAssertEqual(
+            conditionerProbe.buildCount,
+            0,
+            "synthetic alignment should skip before building or running the cleaner")
+    }
+
     private enum SourceFixture {
         case valid
         case corrupt
@@ -501,6 +527,34 @@ private enum RecoveryTestError: Error {
     case transcriptionFailed
     case lockDeleteFailed
     case mixFailed
+}
+
+private final class RecoveryMicConditionerFactoryProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+
+    var buildCount: Int {
+        lock.withLock { count }
+    }
+
+    func make() -> any MicConditioning {
+        lock.withLock {
+            count += 1
+        }
+        return RecoveryLoadedMicConditioner()
+    }
+}
+
+private final class RecoveryLoadedMicConditioner: MicConditioning, @unchecked Sendable {
+    var diagnostics: MeetingEchoSuppressionDiagnostics {
+        .passthrough(processorName: "test-loaded-cleaner", loaded: true)
+    }
+
+    func condition(microphone: [Float], speaker: [Float], hasSpeakerReference: Bool) -> [Float] {
+        microphone
+    }
+
+    func reset() {}
 }
 
 private struct RecoveryProcessChecker: ProcessAliveChecking {

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingRecoveryServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingRecoveryServiceTests.swift
@@ -270,6 +270,18 @@ final class MeetingRecordingRecoveryServiceTests: XCTestCase {
             "synthetic alignment should skip before building or running the cleaner")
     }
 
+    func testRecoverDeletesStaleCleanedMicWhenRecoveredAlignmentIsSynthetic() async throws {
+        let fixture = try makeRecoverableSession()
+        let staleCleanedURL = fixture.folderURL.appendingPathComponent("microphone-cleaned.m4a")
+        try Data("partial m4a fragment".utf8).write(to: staleCleanedURL)
+
+        _ = try await recoveryService.recover(fixture.lock)
+
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: staleCleanedURL.path),
+            "synthetic recovery alignment must remove stale cleaned artifacts so reopened sessions use raw mic")
+    }
+
     private enum SourceFixture {
         case valid
         case corrupt

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingServiceTests.swift
@@ -1335,6 +1335,103 @@ final class MeetingRecordingServiceTests: XCTestCase {
         }
     }
 
+    // MARK: - #605 U3 — cleaned-mic finalize hook
+
+    func testStopRecordingRendersCleanedMicForDualSourceWhenSuppressorLoaded() async throws {
+        let captureService = MockMeetingAudioCaptureService()
+        // A loaded, non-passthrough suppressor (NLMS over the real streaming
+        // wrapper) stands in for the bundled echo model so the render path runs
+        // without the proprietary dylib.
+        let service = MeetingRecordingService(
+            audioCaptureService: captureService,
+            audioConverter: MockMeetingAudioFileConverter(),
+            sttTranscriber: CountingMeetingSTTClient(),
+            micConditionerFactory: {
+                StreamingMeetingEchoSuppressor(
+                    processor: MeetingAecNLMSProcessor(), referenceDelaySamples: 120)
+            }
+        )
+
+        try await service.startRecording()
+        for offset in 0..<5 {
+            let microphoneBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 16_000, sampleValue: 0.25))
+            let systemBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 16_000, sampleValue: 0.25))
+            let time = AVAudioTime(hostTime: AVAudioTime.hostTime(forSeconds: 100.0 + Double(offset)))
+            await captureService.yield(.microphoneBuffer(microphoneBuffer, time))
+            await captureService.yield(.systemBuffer(systemBuffer, time))
+        }
+
+        let output = try await service.stopRecording()
+        defer { try? FileManager.default.removeItem(at: output.folderURL) }
+
+        let cleanedURL = try XCTUnwrap(
+            output.cleanedMicrophoneAudioURL,
+            "a loaded suppressor on a dual-source meeting derives a cleaned mic")
+        XCTAssertEqual(cleanedURL.lastPathComponent, "microphone-cleaned.m4a")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: cleanedURL.path))
+        // The cleaned mic is derived; the raw sources stay the source of truth.
+        XCTAssertTrue(FileManager.default.fileExists(atPath: output.microphoneAudioURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: output.systemAudioURL.path))
+        // The U4 routing policy prefers the cleaned artifact for the "Me" track.
+        XCTAssertEqual(output.microphoneTranscriptionURL(), cleanedURL)
+    }
+
+    func testStopRecordingSkipsCleanedMicForSingleSource() async throws {
+        let captureService = MockMeetingAudioCaptureService()
+        let service = MeetingRecordingService(
+            audioCaptureService: captureService,
+            audioConverter: MockMeetingAudioFileConverter(),
+            sttTranscriber: CountingMeetingSTTClient(),
+            micConditionerFactory: {
+                StreamingMeetingEchoSuppressor(
+                    processor: MeetingAecNLMSProcessor(), referenceDelaySamples: 120)
+            }
+        )
+
+        try await service.startRecording()
+        let microphoneBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 80_000, sampleValue: 0.25))
+        await captureService.yield(.microphoneBuffer(
+            microphoneBuffer,
+            AVAudioTime(hostTime: AVAudioTime.hostTime(forSeconds: 100.0))
+        ))
+
+        let output = try await service.stopRecording()
+        defer { try? FileManager.default.removeItem(at: output.folderURL) }
+
+        XCTAssertNil(
+            output.cleanedMicrophoneAudioURL,
+            "a mic-only meeting has no system reference to cancel against")
+        XCTAssertFalse(FileManager.default.fileExists(
+            atPath: output.folderURL.appendingPathComponent("microphone-cleaned.m4a").path))
+        // Routing falls back to the raw mic when no cleaned artifact exists.
+        XCTAssertEqual(output.microphoneTranscriptionURL(), output.microphoneAudioURL)
+    }
+
+    func testStopRecordingSkipsCleanedMicWhenSuppressorIsPassthrough() async throws {
+        // Default factory (no AEC env config) resolves to passthrough → nothing
+        // to derive, so a dual-source meeting still yields no cleaned mic.
+        let captureService = MockMeetingAudioCaptureService()
+        let service = MeetingRecordingService(
+            audioCaptureService: captureService,
+            audioConverter: MockMeetingAudioFileConverter(),
+            sttTranscriber: CountingMeetingSTTClient()
+        )
+
+        try await service.startRecording()
+        for offset in 0..<3 {
+            let microphoneBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 16_000, sampleValue: 0.25))
+            let systemBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 16_000, sampleValue: 0.25))
+            let time = AVAudioTime(hostTime: AVAudioTime.hostTime(forSeconds: 100.0 + Double(offset)))
+            await captureService.yield(.microphoneBuffer(microphoneBuffer, time))
+            await captureService.yield(.systemBuffer(systemBuffer, time))
+        }
+
+        let output = try await service.stopRecording()
+        defer { try? FileManager.default.removeItem(at: output.folderURL) }
+
+        XCTAssertNil(output.cleanedMicrophoneAudioURL)
+    }
+
     private func makeMonoFloatBuffer(frameCount: Int, sampleValue: Float) -> AVAudioPCMBuffer? {
         guard let format = AVAudioFormat(
             commonFormat: .pcmFormatFloat32,

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingServiceTests.swift
@@ -1372,8 +1372,8 @@ final class MeetingRecordingServiceTests: XCTestCase {
         // The cleaned mic is derived; the raw sources stay the source of truth.
         XCTAssertTrue(FileManager.default.fileExists(atPath: output.microphoneAudioURL.path))
         XCTAssertTrue(FileManager.default.fileExists(atPath: output.systemAudioURL.path))
-        // The U4 routing policy prefers the cleaned artifact for the "Me" track.
-        XCTAssertEqual(output.microphoneTranscriptionURL(), cleanedURL)
+        // The U4 routing policy prefers the cleaned artifact for the "Me" STT track.
+        XCTAssertEqual(output.validatedMicrophoneTranscriptionURL(), cleanedURL)
     }
 
     func testStopRecordingSkipsCleanedMicForSingleSource() async throws {
@@ -1403,8 +1403,8 @@ final class MeetingRecordingServiceTests: XCTestCase {
             "a mic-only meeting has no system reference to cancel against")
         XCTAssertFalse(FileManager.default.fileExists(
             atPath: output.folderURL.appendingPathComponent("microphone-cleaned.m4a").path))
-        // Routing falls back to the raw mic when no cleaned artifact exists.
-        XCTAssertEqual(output.microphoneTranscriptionURL(), output.microphoneAudioURL)
+        // STT routing falls back to the raw mic when no cleaned artifact exists.
+        XCTAssertEqual(output.validatedMicrophoneTranscriptionURL(), output.microphoneAudioURL)
     }
 
     func testStopRecordingSkipsCleanedMicWhenSuppressorIsPassthrough() async throws {

--- a/Tests/MacParakeetTests/Services/MeetingRecording/TranscriptionAssetCleanupCleanedMicTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/TranscriptionAssetCleanupCleanedMicTests.swift
@@ -1,0 +1,44 @@
+import Foundation
+import XCTest
+@testable import MacParakeetCore
+
+/// Ensures the derived `microphone-cleaned.m4a` (plan #605 U3) is treated as a
+/// standard managed meeting artifact so retention/detach removes it alongside
+/// the raw sources instead of orphaning it.
+final class TranscriptionAssetCleanupCleanedMicTests: XCTestCase {
+    func testCleanedMicIsAStandardMeetingAudioFileName() {
+        XCTAssertTrue(
+            TranscriptionAssetCleanup.isStandardMeetingAudioFileName("microphone-cleaned.m4a"),
+            "the targeted Remove-Audio-Only detach path keys off this set")
+        XCTAssertEqual(
+            "microphone-cleaned.m4a",
+            MeetingCleanedMicRenderer.cleanedMicrophoneFileName,
+            "retention must track the same filename the renderer writes")
+    }
+
+    func testRemoveManagedMeetingAudioSweepsCleanedMic() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let session = root.appendingPathComponent("session", isDirectory: true)
+        try FileManager.default.createDirectory(at: session, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let audioFiles = ["meeting.m4a", "microphone.m4a", "system.m4a", "microphone-cleaned.m4a"]
+        for name in audioFiles {
+            try Data([0x00]).write(to: session.appendingPathComponent(name))
+        }
+        let notesURL = session.appendingPathComponent("notes.txt")
+        try Data([0x00]).write(to: notesURL)
+
+        try TranscriptionAssetCleanup.removeManagedMeetingAudioFiles(under: root.path)
+
+        for name in audioFiles {
+            XCTAssertFalse(
+                FileManager.default.fileExists(atPath: session.appendingPathComponent(name).path),
+                "\(name) should be removed by the managed-audio sweep")
+        }
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: notesURL.path),
+            "non-audio sidecars are preserved")
+    }
+}

--- a/Tests/MacParakeetTests/Services/TranscriptionServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/TranscriptionServiceTests.swift
@@ -1317,6 +1317,66 @@ final class TranscriptionServiceTests: XCTestCase {
         XCTAssertFalse(diarizationApplied)
     }
 
+    func testTranscribeMeetingUsesValidatedCleanedMicForMicrophoneSource() async throws {
+        let recordingFolder = URL(fileURLWithPath: AppPaths.tempDir)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: recordingFolder, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: recordingFolder) }
+
+        let mixedURL = recordingFolder.appendingPathComponent("meeting.m4a")
+        let microphoneURL = recordingFolder.appendingPathComponent("microphone.m4a")
+        let systemURL = recordingFolder.appendingPathComponent("system.m4a")
+        let cleanedURL = recordingFolder.appendingPathComponent("microphone-cleaned.m4a")
+        XCTAssertTrue(FileManager.default.createFile(atPath: mixedURL.path, contents: Data("mixed".utf8)))
+        XCTAssertTrue(FileManager.default.createFile(atPath: microphoneURL.path, contents: Data("microphone".utf8)))
+        XCTAssertTrue(FileManager.default.createFile(atPath: systemURL.path, contents: Data("system".utf8)))
+        try await MeetingCleanedMicRenderer.encodeMonoFloat(
+            [Float](repeating: 0.05, count: 1_600),
+            sampleRate: 16_000,
+            to: cleanedURL,
+            fileManager: .default)
+
+        await mockSTT.configureSequence(results: [
+            STTResult(text: "local words", words: [
+                TimestampedWord(word: "local", startMs: 0, endMs: 200, confidence: 0.9),
+            ]),
+            STTResult(text: "remote words", words: [
+                TimestampedWord(word: "remote", startMs: 0, endMs: 200, confidence: 0.9),
+            ]),
+        ])
+
+        let recording = MeetingRecordingOutput(
+            sessionID: UUID(),
+            displayName: "Cleaned Mic Meeting",
+            folderURL: recordingFolder,
+            mixedAudioURL: mixedURL,
+            microphoneAudioURL: microphoneURL,
+            systemAudioURL: systemURL,
+            cleanedMicrophoneAudioURL: cleanedURL,
+            durationSeconds: 1.0,
+            sourceAlignment: MeetingSourceAlignment(
+                meetingOriginHostTime: nil,
+                microphone: .init(
+                    firstHostTime: nil,
+                    lastHostTime: nil,
+                    startOffsetMs: 0,
+                    writtenFrameCount: 16_000,
+                    sampleRate: 16_000),
+                system: .init(
+                    firstHostTime: nil,
+                    lastHostTime: nil,
+                    startOffsetMs: 0,
+                    writtenFrameCount: 16_000,
+                    sampleRate: 16_000)
+            )
+        )
+
+        _ = try await service.transcribeMeeting(recording: recording)
+
+        let convertURLs = await mockAudio.convertURLs
+        XCTAssertEqual(convertURLs, [cleanedURL, systemURL])
+    }
+
     func testPrepareMeetingTranscriptionCreatesProcessingStubBeforeSTT() async throws {
         let recording = try makeOneSourceMeetingRecording(displayName: "Queued Meeting")
         defer { try? FileManager.default.removeItem(at: recording.folderURL) }

--- a/plans/active/2026-06-28-meeting-aec-full-close.md
+++ b/plans/active/2026-06-28-meeting-aec-full-close.md
@@ -31,15 +31,39 @@ assets or hardware that cannot be produced in a sandbox.
 - **U7 — diagnostics: PARTIAL.** Delay, last-adopted confidence, adopted-count,
   and rejected-count added to `MeetingEchoSuppressionDiagnostics` (metadata
   only) and the existing `meeting_echo_suppression_summary` log. Feedback-surface
-  wiring remains.
-- **U8 — docs: PARTIAL.** `spec/05-audio-pipeline.md` updated. Contract/CLI
-  updates wait on the cleaned-mic artifact (U3).
-- **U3/U4/U5/U6/U9 — DEFERRED.** These are blocked on bundling and
-  signing/notarizing the proprietary LocalVQE dylib + model (U5) and on real
-  no-headphones speaker-mode QA (U9). Until a canceller is bundled, production
-  resolves to `PassthroughMicConditioner`, so an offline cleaned-mic renderer
-  (U3) and cleaned-mic final-STT routing (U4) would be inert; landing them now
-  would ship no-op scaffolding. They follow once U5's assets exist.
+  wiring remains. The cleaned-mic render emits a `meeting_cleaned_mic` capture
+  diagnostics line (outcome, processed/raw-fallback frames, failures, RMS ratio).
+- **U3 — cleaned mic artifact rendering after stop: DONE** (branch
+  `feat/meeting-aec-cleaned-mic`). `MeetingCleanedMicRenderer` (decode → align by
+  recorded start offsets → condition through a freshly built suppressor → AAC
+  encode) is wired into `MeetingRecordingService.stopRecording` (off-actor,
+  dual-source only) and `MeetingRecordingRecoveryService`. `MeetingRecordingOutput`
+  carries `cleanedMicrophoneAudioURL` and re-surfaces it via `loadArchived`.
+  Retention deletes `microphone-cleaned.m4a` with the other managed audio.
+- **U4 — prefer cleaned mic for final meeting STT: DONE.**
+  `transcribeMeetingSources` resolves the `.microphone` source through
+  `MeetingRecordingOutput.microphoneTranscriptionURL`, which prefers the cleaned
+  file when present and falls back to raw otherwise. The "health gate" is
+  presence + on-disk existence: the renderer guarantees every output frame is
+  either echo-cancelled or raw-fallback (never worse than raw per frame), so no
+  separate numeric runtime gate is applied. A global RMS/energy gate was
+  deliberately NOT used — on a real meeting it cannot distinguish good echo
+  removal (mic that was mostly bleed → correctly quiet) from a model that mutes
+  near-end voice; that near-end-fidelity risk is owned by model selection
+  (U5 chose echo-only v1.4) and real QA (U9), not a runtime heuristic.
+- **U8 — docs: UPDATED.** `spec/05-audio-pipeline.md` and
+  `spec/contracts/meeting-artifacts-v1.md` describe the derived artifact + STT
+  routing. CLI artifact output intentionally omits the cleaned mic: it is an
+  internal STT input, not a user-facing export the user opens.
+- **U3/U4 are inert in shipped builds until U5 bundles assets** — production
+  resolves to `PassthroughMicConditioner`, so `renderCleanedMicrophone` skips and
+  final STT reads raw `microphone.m4a` exactly as today. Landing the wiring now is
+  safe (no behavior change without assets), fully tested, and is the prerequisite
+  for U9; it is no longer deferred.
+- **U5/U6/U9 — REMAINING.** U5: bundle + sign/notarize the proprietary LocalVQE
+  dylib + chosen v1.4 model (model decision recorded below). U6: optional WebRTC
+  AEC3 benchmark or skip-decision record. U9: real no-headphones speaker-mode QA
+  closes #605.
 
 ## Goal Capsule
 

--- a/spec/05-audio-pipeline.md
+++ b/spec/05-audio-pipeline.md
@@ -217,6 +217,17 @@ Mic Input    → SharedMicrophoneStream (+ Voice Processing I/O when active)┘ 
   speaker bleed, not a complete AEC substitute. When VPIO is explicitly
   requested and engages, macOS applies AEC/noise suppression/AGC before buffers
   reach `MeetingRecordingService`.
+- Live suppression is **preview only**: `microphone.m4a` is always the raw mic.
+  After stop, when a suppressor is loaded and both source streams exist,
+  `MeetingCleanedMicRenderer` derives `microphone-cleaned.m4a` offline — it
+  re-decodes the raw mic + system to 16 kHz mono, re-aligns the reference by the
+  recorded `MeetingSourceAlignment` start offsets, and streams the pair through a
+  freshly built suppressor (clean filter state, not the live preview's adapted
+  taps). Every output frame is either echo-cancelled or raw-fallback, so the
+  cleaned mic is never worse than raw per frame. Single-source meetings and
+  bundles without AEC assets produce no cleaned file, and rendering never throws
+  into finalize (failures resolve to "no cleaned file"). The same derivation runs
+  in `MeetingRecordingRecoveryService` so recovered meetings get equal treatment.
 - Audio is stored as separate M4A files (AAC 64kbps, 48kHz mono) per source
 - Source audio is written as fragmented M4A with 1-second movie fragments so kill-9 recovery can keep playable audio through the last committed fragment.
 - After recording stops, the captured source M4As are finalized and merged into
@@ -227,9 +238,13 @@ Mic Input    → SharedMicrophoneStream (+ Voice Processing I/O when active)┘ 
 - Final meeting STT does **not** transcribe `meeting.m4a`. A background queue
   transcribes the captured source files separately with the engine captured at
   recording start, then merges those fresh results by persisted
-  `MeetingSourceAlignment`. `meeting.m4a` is kept as the playback/export
-  artifact. See `docs/research/meeting-dual-stream-transcription-pipeline.md`
-  for the full pipeline and tradeoffs.
+  `MeetingSourceAlignment`. The local (`Me`) microphone track prefers
+  `microphone-cleaned.m4a` when it exists (echo-cancelled; resolved through
+  `MeetingRecordingOutput.microphoneTranscriptionURL`) and otherwise falls back
+  to the raw `microphone.m4a`; the system track is unchanged. `meeting.m4a` is
+  kept as the playback/export artifact. See
+  `docs/research/meeting-dual-stream-transcription-pipeline.md` for the full
+  pipeline and tradeoffs.
 - Recovery locks and retention safety are a tested boundary contract. See [`spec/contracts/meeting-recovery-retention.md`](contracts/meeting-recovery-retention.md) before changing lock-file predicates or automatic meeting-audio deletion.
 - Live chunk enqueue keeps a conservative guard: when recent system energy strongly dominates processed mic energy for a short freshness window, mic chunks are skipped for live transcription only. Mic audio is still written to disk and included in final mix/output.
 - Joiner queue overflow, long-session sync lag, and runtime capture failures are emitted as diagnostics for observability (`MeetingAudioCaptureEvent.error` where available).
@@ -244,6 +259,7 @@ Mic Input    → SharedMicrophoneStream (+ Voice Processing I/O when active)┘ 
 | `MeetingAudioCaptureService` | Actor combining the selected source stream(s) into `AsyncStream<MeetingAudioCaptureEvent>` with unbounded buffering and runtime error emission where available |
 | `CaptureOrchestrator` | Owns ingest/join/offset/chunk flow for live preview |
 | `MicConditioner` | Meeting-side seam for mic samples; passthrough is the default, and an optional `StreamingMeetingEchoSuppressor` can use paired system reference samples when the runtime/model are available |
+| `MeetingCleanedMicRenderer` | Post-stop offline derivation of `microphone-cleaned.m4a` from the raw mic + system sources through a freshly built suppressor; skips when passthrough/single-source and never throws into finalize |
 | `LiveChunkTranscriber` | Owns live chunk queueing, cancellation, ordering, STT invocation |
 | `MeetingAudioStorageWriter` | Writes separate M4A files per selected source (mic and/or system) |
 | `MeetingRecordingMetadataStore` | Persists `MeetingSourceAlignment` for post-stop merge correctness |
@@ -295,8 +311,9 @@ the stopped meeting waits for that job to finish; once the slot is free,
 
 ```text
 ~/Library/Application Support/MacParakeet/meeting-recordings/{uuid}/
-    ├── microphone.m4a    # Mic audio when captured (AAC, 48kHz mono)
+    ├── microphone.m4a    # Raw mic audio when captured (AAC, 48kHz mono) — source of truth
     ├── system.m4a        # System audio when captured (AAC, 48kHz mono)
+    ├── microphone-cleaned.m4a  # Optional derived echo-cancelled mic (16kHz mono); STT input for the "Me" track when a suppressor is loaded
     ├── meeting.m4a       # Final playback/export artifact (stereo dual-source when both tracks exist; legacy fallback for downstream tools)
     ├── meeting-recording-metadata.json  # Persisted source timing/alignment + speech engine for post-stop merge
     ├── recording.lock     # Recording/awaiting-transcription recovery state, including notes and speech engine

--- a/spec/contracts/meeting-artifacts-v1.md
+++ b/spec/contracts/meeting-artifacts-v1.md
@@ -45,6 +45,12 @@ The v1 folder can contain these stable filenames:
   `transcriptions.filePath` while retained.
 - `microphone.m4a`: optional source mic audio.
 - `system.m4a`: optional source system audio.
+- `microphone-cleaned.m4a`: optional derived echo-cancelled mic (16 kHz mono),
+  produced after stop from `microphone.m4a` + `system.m4a` when a meeting echo
+  suppressor is loaded (plan #605 U3). Internal STT input for the local ("Me")
+  track, not a user-facing export; the raw `microphone.m4a` remains the source
+  of truth. Absent for single-source meetings and when no AEC assets are
+  bundled. Removed with the other managed audio by retention/detach.
 - `meeting-recording-metadata.json`: optional source-alignment and engine
   sidecar.
 - `manifest.json`: folder manifest.


### PR DESCRIPTION
## Summary

Completes #605 U3/U4 for meeting AEC: after a dual-source meeting stops, MacParakeet derives `microphone-cleaned.m4a` from the raw microphone plus system-audio reference, then routes the local ("Me") STT track through that cleaned mic artifact when it is valid.

The user-visible goal is straightforward: remote speaker audio that bleeds into the microphone should stop showing up as duplicate false "Me" transcript text.

## What changed

- Finalize derives a cleaned microphone artifact for dual-source meetings only, off the main actor, using a fresh echo suppressor state.
- STT routing now uses `validatedMicrophoneTranscriptionURL()` for the local microphone track: cleaned mic if present, non-empty, and decodable; otherwise raw mic.
- Public `microphoneTranscriptionURL()` stays lightweight for UI/list paths and does not synchronously open audio files.
- Crash recovery re-derives the cleaned mic only when recovered source alignment is trustworthy; synthetic or incomplete recovery falls back to raw mic.
- Stale or partial `microphone-cleaned.m4a` artifacts are removed or truncated on every skip/failure path so reopened meetings do not accidentally prefer old cleaned audio.
- Retention/delete flows treat `microphone-cleaned.m4a` as managed derived meeting audio.
- Docs/contracts were updated for the new internal cleaned-mic artifact.

## Safety model

- Raw `microphone.m4a` and `system.m4a` remain the source of truth.
- The cleaned mic is derived data used for STT routing, not a replacement for retained raw sources.
- Without bundled AEC assets, the suppressor resolves to passthrough and the render skips, so production behavior stays raw-mic fallback until U5 assets are bundled.
- Renderer failures never fail meeting finalization or recovery; they return `.skipped` and route STT to raw mic.
- Cooperative cancellation is preserved: cancelling stop/recovery cancels the detached render worker, cleans any partial derived artifact, and falls back to raw mic so the finalization/recovery tail can continue.

## Reviewer-driven hardening

- Avoided full-length aligned-reference allocation by generating speaker reference chunks on demand.
- Replaced blocking writer waits with cooperative `Task.sleep`, yielded during chunked decode work, checked cancellation during DSP/flush chunks, and preserved 1:1 mic tail length on under-flush.
- Required `AVAssetWriter` final status to be `.completed`.
- Cancelled started `AVAssetWriter`s on encode failure/cancellation to avoid abandoned writer state.
- Handled decoder `.endOfStream` explicitly.
- Rejected implausible source sample rates before output-buffer sizing and made decode flush failures explicit.
- Added a decoded-frame cap for the in-memory U3 renderer so very long sessions skip to raw mic instead of risking unbounded RAM.
- Split cheap public URL preference from validated STT-only decodability probing, with archive metadata/file checks routed through injected file-manager seams.
- Threaded `FileManager` through archive/routing paths and detached renderer creation.
- Propagated renderer cancellation through retained detached task handles in finalize and recovery while preserving raw-mic fallback.

## Validation

Local validation on the latest branch head:

```bash
git diff --check
MACPARAKEET_SKIP_WHISPERKIT=1 swift build --build-path .build-swift6-no-whisper -Xswiftc -swift-version -Xswiftc 6
swift test --filter 'MeetingCleanedMicRendererTests|MeetingRecordingOutputTests|MeetingRecordingRecoveryServiceTests|MeetingRecordingServiceTests|TranscriptionServiceTests'
```

Focused tests covered 159 tests with 0 failures.

## Remaining for #605

- U5: bundle/sign/notarize the chosen proprietary LocalVQE dylib and model assets.
- U9: real no-headphones speaker-mode QA before closing #605 fully.
