### PR TITLE
Meeting AEC: bundle default LocalVQE assets (#605 U5)

### DIFF
--- a/Sources/MacParakeetCore/Services/Capture/MeetingEchoSuppressionRuntime.swift
+++ b/Sources/MacParakeetCore/Services/Capture/MeetingEchoSuppressionRuntime.swift
@@ -143,10 +143,11 @@ enum MeetingEchoSuppressionFactory {
     static let processorName = "localvqe"
     static let defaultLibraryName = "liblocalvqe.dylib"
     static let defaultModelDirectoryName = "MeetingEchoSuppression"
-    static let defaultModelName = "localvqe-v1.2-1.3M-f32.gguf"
+    static let defaultModelName = "localvqe-v1.4-aec-200K-f32.gguf"
+    static let legacyJointModelName = "localvqe-v1.2-1.3M-f32.gguf"
     static let bundledModelNames = [
-        "localvqe-v1.4-aec-200K-f32.gguf",
         defaultModelName,
+        legacyJointModelName,
         "localvqe-v1.3-4.8M-f32.gguf",
         "localvqe-v1.4-aec-200K-bf16.gguf",
         "localvqe-v1.4-aec-2.7K-f32.gguf",

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -23,6 +23,19 @@ This project bundles or downloads third-party software components. The following
 - Source: <https://nodejs.org/>
 - Used for: Bundled runtime for yt-dlp JavaScript extractors
 
+## LocalVQE
+
+- License: Apache License 2.0
+- Source: <https://github.com/localai-org/LocalVQE>
+- Model source: <https://huggingface.co/LocalAI-io/LocalVQE>
+- Used for: Optional bundled meeting echo suppression runtime and GGUF model
+
+## ggml
+
+- License: MIT License
+- Source: <https://github.com/ggml-org/ggml>
+- Used for: LocalVQE runtime backend linked into the meeting echo suppression runtime
+
 ## Swift Package Dependencies
 
 ### GRDB.swift

--- a/Tests/MacParakeetTests/Services/Capture/MeetingEchoSuppressionRuntimeTests.swift
+++ b/Tests/MacParakeetTests/Services/Capture/MeetingEchoSuppressionRuntimeTests.swift
@@ -83,6 +83,13 @@ final class MeetingEchoSuppressionRuntimeTests: XCTestCase {
         XCTAssertEqual(configuration.frameSize, 256)
     }
 
+    func testDefaultModelNameUsesSelectedV14EchoOnlyModel() {
+        XCTAssertEqual(
+            MeetingEchoSuppressionFactory.defaultModelName,
+            "localvqe-v1.4-aec-200K-f32.gguf"
+        )
+    }
+
     func testConfigurationParsesUnescapedFileURLWithSpaces() {
         let configuration = MeetingEchoSuppressionConfiguration.fromEnvironment([
             MeetingEchoSuppressionConfiguration.modelPathEnvironmentKey:
@@ -189,13 +196,15 @@ final class MeetingEchoSuppressionRuntimeTests: XCTestCase {
             atomically: true,
             encoding: .utf8
         )
-        try Data("v12".utf8).write(
+        try Data("v14".utf8).write(
             to: modelDirectory.appendingPathComponent(
                 MeetingEchoSuppressionFactory.defaultModelName
             )
         )
-        try Data("v14".utf8).write(
-            to: modelDirectory.appendingPathComponent("localvqe-v1.4-aec-200K-f32.gguf")
+        try Data("v12".utf8).write(
+            to: modelDirectory.appendingPathComponent(
+                MeetingEchoSuppressionFactory.legacyJointModelName
+            )
         )
         try Data("custom".utf8).write(
             to: modelDirectory.appendingPathComponent("custom-localvqe-test.gguf")
@@ -217,8 +226,8 @@ final class MeetingEchoSuppressionRuntimeTests: XCTestCase {
 
         let firstCandidate = try XCTUnwrap(candidateURLs.first)
         XCTAssertNil(firstCandidate)
-        XCTAssertEqual(candidates[0], "localvqe-v1.4-aec-200K-f32.gguf")
-        XCTAssertTrue(candidates.contains(MeetingEchoSuppressionFactory.defaultModelName))
+        XCTAssertEqual(candidates[0], MeetingEchoSuppressionFactory.defaultModelName)
+        XCTAssertTrue(candidates.contains(MeetingEchoSuppressionFactory.legacyJointModelName))
         XCTAssertEqual(candidates.last, "custom-localvqe-test.gguf")
         XCTAssertFalse(candidates.contains("linked-localvqe-test.gguf"))
     }
@@ -356,7 +365,7 @@ final class MeetingEchoSuppressionRuntimeTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: appURL.deletingLastPathComponent()) }
         let secondModelURL = appURL.appendingPathComponent(
             "Contents/Resources/MeetingEchoSuppression/" +
-                MeetingEchoSuppressionFactory.defaultModelName
+                MeetingEchoSuppressionFactory.legacyJointModelName
         )
         try Data("second model".utf8).write(to: secondModelURL)
 

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -33,9 +33,27 @@ transcription so future helper updates never mutate the signed app bundle. To
 use a pre-fetched helper in release builds, set `YTDLP_PATH`; set
 `BUNDLE_YTDLP=0` only for diagnostic builds.
 
-Meeting echo suppression assets are optional for local/dev bundles, but any
-build that claims speaker-mode AEC readiness must bundle and verify both native
-assets:
+Meeting echo suppression assets are optional for local/dev bundles, but
+AEC-ready release builds should require them. With
+`REQUIRE_MEETING_ECHO_ASSETS=1`, the bundle script builds the pinned LocalVQE
+runtime from source and downloads the selected v1.4 echo-only GGUF into
+`.build/meeting-echo-assets/` when explicit asset paths are not supplied:
+
+```bash
+export REQUIRE_MEETING_ECHO_ASSETS=1
+VERSION=X.Y.Z scripts/dist/build_app_bundle.sh
+```
+
+The default model is `localvqe-v1.4-aec-200K-f32.gguf`
+(`SHA256=b6e43138588a83bfe903ab5e143b4020b91c1e1629f5a575ac5855ff0003c731`).
+It is roughly 2.9 MB before compression. The source-built runtime is copied to
+`Contents/Frameworks/liblocalvqe.dylib`, and the selected model is copied under
+`Contents/Resources/MeetingEchoSuppression/`. Release bundles must contain
+exactly one GGUF model so asset verification and runtime model resolution cannot
+drift.
+
+To use prebuilt assets instead of the pinned auto-prep path, set both source
+paths explicitly:
 
 ```bash
 export MACPARAKEET_MEETING_ECHO_LIBRARY=/absolute/path/to/liblocalvqe.dylib
@@ -47,11 +65,9 @@ VERSION=X.Y.Z scripts/dist/build_app_bundle.sh
 
 `build_app_bundle.sh` preserves the source GGUF filename by default; override
 with `MACPARAKEET_MEETING_ECHO_MODEL_NAME=<filename>.gguf` only when the source
-path is not the intended bundled name. The bundled runtime is copied to
-`Contents/Frameworks/liblocalvqe.dylib`; the selected model is copied under
-`Contents/Resources/MeetingEchoSuppression/`. Release bundles must contain
-exactly one GGUF model so asset verification and runtime model resolution cannot
-drift.
+path is not the intended bundled name. Set
+`MACPARAKEET_MEETING_ECHO_AUTO_PREPARE=0` to force explicit prebuilt paths and
+fail if they are absent.
 
 `scripts/dist/verify_meeting_echo_assets.sh dist/MacParakeet.app` is the release
 gate. With `REQUIRE_MEETING_ECHO_ASSETS=1`, it fails if either asset is missing,

--- a/scripts/dist/build_app_bundle.sh
+++ b/scripts/dist/build_app_bundle.sh
@@ -31,8 +31,10 @@ set -euo pipefail
 #   YTDLP_PATH         (default: auto-download latest) source yt-dlp binary to bundle
 #   BUNDLE_NODE        (default: 1) bundle Node runtime for yt-dlp
 #   NODE_VERSION       (default: 24.13.1) Node version used when downloading
-#   BUNDLE_MEETING_ECHO_ASSETS (default: 1 when echo library+model paths are set, else 0)
+#   BUNDLE_MEETING_ECHO_ASSETS (default: 1 when required or echo library/model paths are set, else 0)
 #   REQUIRE_MEETING_ECHO_ASSETS (default: 0) fail if echo assets are not bundled
+#   MACPARAKEET_MEETING_ECHO_AUTO_PREPARE (default: 1) build/download pinned default echo assets when paths are unset
+#   MACPARAKEET_MEETING_ECHO_ASSETS_DIR (default: .build/meeting-echo-assets) prepared asset output/cache
 #   MACPARAKEET_MEETING_ECHO_LIBRARY source dylib for meeting echo suppression
 #   MACPARAKEET_MEETING_ECHO_DYLIB_DIR optional directory of dependent dylibs to copy into Frameworks
 #   MACPARAKEET_MEETING_ECHO_MODEL source GGUF model for meeting echo suppression
@@ -61,6 +63,10 @@ MACOS_DIR="$CONTENTS_DIR/MacOS"
 RESOURCES_DIR="$CONTENTS_DIR/Resources"
 FRAMEWORKS_DIR="$CONTENTS_DIR/Frameworks"
 LEGAL_DIR="$RESOURCES_DIR/Legal"
+
+DEFAULT_MEETING_ECHO_MODEL_NAME="localvqe-v1.4-aec-200K-f32.gguf"
+DEFAULT_MEETING_ECHO_MODEL_SHA256="b6e43138588a83bfe903ab5e143b4020b91c1e1629f5a575ac5855ff0003c731"
+DEFAULT_MEETING_ECHO_ASSETS_DIR="$ROOT_DIR/.build/meeting-echo-assets"
 
 rm -rf "$APP_DIR"
 mkdir -p "$MACOS_DIR" "$RESOURCES_DIR" "$FRAMEWORKS_DIR" "$LEGAL_DIR"
@@ -409,7 +415,9 @@ fi
 bundle_meeting_echo_assets() {
   local should_bundle="${BUNDLE_MEETING_ECHO_ASSETS:-}"
   if [[ -z "$should_bundle" ]]; then
-    if [[ -n "${MACPARAKEET_MEETING_ECHO_LIBRARY:-}" && -n "${MACPARAKEET_MEETING_ECHO_MODEL:-}" ]]; then
+    if [[ "${REQUIRE_MEETING_ECHO_ASSETS:-0}" == "1" ||
+          -n "${MACPARAKEET_MEETING_ECHO_LIBRARY:-}" ||
+          -n "${MACPARAKEET_MEETING_ECHO_MODEL:-}" ]]; then
       should_bundle="1"
     else
       should_bundle="0"
@@ -418,7 +426,7 @@ bundle_meeting_echo_assets() {
 
   if [[ "$should_bundle" != "1" ]]; then
     if [[ "${REQUIRE_MEETING_ECHO_ASSETS:-0}" == "1" ]]; then
-      echo "Error: REQUIRE_MEETING_ECHO_ASSETS=1 but BUNDLE_MEETING_ECHO_ASSETS is not enabled." >&2
+      echo "Error: REQUIRE_MEETING_ECHO_ASSETS=1 but BUNDLE_MEETING_ECHO_ASSETS=0." >&2
       exit 1
     fi
     echo "Skipping meeting echo-suppression assets (BUNDLE_MEETING_ECHO_ASSETS=0)"
@@ -427,6 +435,42 @@ bundle_meeting_echo_assets() {
 
   local library_src="${MACPARAKEET_MEETING_ECHO_LIBRARY:-}"
   local model_src="${MACPARAKEET_MEETING_ECHO_MODEL:-}"
+  local model_name="${MACPARAKEET_MEETING_ECHO_MODEL_NAME:-}"
+  local expected_model_sha="${MACPARAKEET_MEETING_ECHO_MODEL_SHA256:-}"
+  local dependent_dylib_dir="${MACPARAKEET_MEETING_ECHO_DYLIB_DIR:-}"
+
+  if [[ -z "$library_src" && -z "$model_src" ]]; then
+    if [[ "${MACPARAKEET_MEETING_ECHO_AUTO_PREPARE:-1}" != "1" ]]; then
+      echo "Error: meeting echo asset paths are unset and MACPARAKEET_MEETING_ECHO_AUTO_PREPARE=0." >&2
+      exit 1
+    fi
+
+    local prepared_assets_dir="${MACPARAKEET_MEETING_ECHO_ASSETS_DIR:-$DEFAULT_MEETING_ECHO_ASSETS_DIR}"
+    local prepared_model_name="${model_name:-$DEFAULT_MEETING_ECHO_MODEL_NAME}"
+    local prepared_model_sha="$expected_model_sha"
+    if [[ "$prepared_model_name" == "$DEFAULT_MEETING_ECHO_MODEL_NAME" ]]; then
+      prepared_model_sha="${prepared_model_sha:-$DEFAULT_MEETING_ECHO_MODEL_SHA256}"
+    elif [[ -z "$prepared_model_sha" ]]; then
+      echo "Error: custom auto-prepared meeting echo models require MACPARAKEET_MEETING_ECHO_MODEL_SHA256." >&2
+      exit 1
+    fi
+    echo "Preparing bundled meeting echo assets in $prepared_assets_dir"
+    MACPARAKEET_MEETING_ECHO_ASSETS_DIR="$prepared_assets_dir" \
+      MACPARAKEET_MEETING_ECHO_MODEL_NAME="$prepared_model_name" \
+      MACPARAKEET_MEETING_ECHO_MODEL_SHA256="$prepared_model_sha" \
+      MACPARAKEET_MEETING_ECHO_UNIVERSAL="${MACPARAKEET_MEETING_ECHO_UNIVERSAL:-$UNIVERSAL}" \
+      "$ROOT_DIR/scripts/dist/prepare_meeting_echo_assets.sh"
+
+    library_src="$prepared_assets_dir/lib/liblocalvqe.dylib"
+    model_src="$prepared_assets_dir/model/$prepared_model_name"
+    model_name="$prepared_model_name"
+    expected_model_sha="$prepared_model_sha"
+    dependent_dylib_dir="${dependent_dylib_dir:-$prepared_assets_dir/lib}"
+  elif [[ -z "$library_src" || -z "$model_src" ]]; then
+    echo "Error: MACPARAKEET_MEETING_ECHO_LIBRARY and MACPARAKEET_MEETING_ECHO_MODEL must be set together." >&2
+    exit 1
+  fi
+
   if [[ -z "$library_src" || ! -f "$library_src" ]]; then
     echo "Error: MACPARAKEET_MEETING_ECHO_LIBRARY must point to a dylib when bundling echo assets." >&2
     exit 1
@@ -436,36 +480,43 @@ bundle_meeting_echo_assets() {
     exit 1
   fi
 
-  local model_name="${MACPARAKEET_MEETING_ECHO_MODEL_NAME:-$(basename "$model_src")}"
+  model_name="${model_name:-$(basename "$model_src")}"
   local model_name_lc
   model_name_lc="$(printf '%s' "$model_name" | tr '[:upper:]' '[:lower:]')"
   if [[ -z "$model_name" || "$model_name" == */* || "$model_name_lc" != *.gguf ]]; then
     echo "Error: MACPARAKEET_MEETING_ECHO_MODEL_NAME must be a GGUF filename, not a path." >&2
     exit 1
   fi
+  if [[ -z "$expected_model_sha" && "$model_name" == "$DEFAULT_MEETING_ECHO_MODEL_NAME" ]]; then
+    expected_model_sha="$DEFAULT_MEETING_ECHO_MODEL_SHA256"
+  fi
+  if [[ "${REQUIRE_MEETING_ECHO_ASSETS:-0}" == "1" && -z "$expected_model_sha" ]]; then
+    echo "Error: REQUIRE_MEETING_ECHO_ASSETS=1 requires MACPARAKEET_MEETING_ECHO_MODEL_SHA256." >&2
+    exit 1
+  fi
 
-  if [[ -n "${MACPARAKEET_MEETING_ECHO_MODEL_SHA256:-}" ]]; then
+  if [[ -n "$expected_model_sha" ]]; then
     local actual_sha
     local expected_sha_lc
     actual_sha="$(shasum -a 256 "$model_src" | awk '{print $1}')"
-    expected_sha_lc="$(printf '%s' "$MACPARAKEET_MEETING_ECHO_MODEL_SHA256" | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')"
+    expected_sha_lc="$(printf '%s' "$expected_model_sha" | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')"
     if [[ "$actual_sha" != "$expected_sha_lc" ]]; then
       echo "Error: meeting echo model SHA256 verification failed." >&2
-      echo "  Expected: $MACPARAKEET_MEETING_ECHO_MODEL_SHA256" >&2
+      echo "  Expected: $expected_model_sha" >&2
       echo "  Actual:   $actual_sha" >&2
       exit 1
     fi
     echo "Meeting echo model SHA256 verified: $actual_sha"
   fi
 
-  if [[ -n "${MACPARAKEET_MEETING_ECHO_DYLIB_DIR:-}" ]]; then
-    if [[ ! -d "$MACPARAKEET_MEETING_ECHO_DYLIB_DIR" ]]; then
-      echo "Error: MACPARAKEET_MEETING_ECHO_DYLIB_DIR is not a directory: $MACPARAKEET_MEETING_ECHO_DYLIB_DIR" >&2
+  if [[ -n "$dependent_dylib_dir" ]]; then
+    if [[ ! -d "$dependent_dylib_dir" ]]; then
+      echo "Error: MACPARAKEET_MEETING_ECHO_DYLIB_DIR is not a directory: $dependent_dylib_dir" >&2
       exit 1
     fi
     while IFS= read -r -d '' dylib; do
       install -m 0755 "$dylib" "$FRAMEWORKS_DIR/$(basename "$dylib")"
-    done < <(find "$MACPARAKEET_MEETING_ECHO_DYLIB_DIR" -maxdepth 1 -type f -name '*.dylib' -print0)
+    done < <(find "$dependent_dylib_dir" -maxdepth 1 -type f -name '*.dylib' -print0)
   fi
 
   install -m 0755 "$library_src" "$FRAMEWORKS_DIR/liblocalvqe.dylib"
@@ -479,7 +530,9 @@ bundle_meeting_echo_assets() {
   echo "Bundled meeting echo runtime: $FRAMEWORKS_DIR/liblocalvqe.dylib"
   echo "Bundled meeting echo model: $RESOURCES_DIR/MeetingEchoSuppression/$model_name"
 
-  MACPARAKEET_MEETING_ECHO_MODEL_NAME="$model_name" "$ROOT_DIR/scripts/dist/verify_meeting_echo_assets.sh" "$APP_DIR"
+  MACPARAKEET_MEETING_ECHO_MODEL_NAME="$model_name" \
+    MACPARAKEET_MEETING_ECHO_MODEL_SHA256="$expected_model_sha" \
+    "$ROOT_DIR/scripts/dist/verify_meeting_echo_assets.sh" "$APP_DIR"
 }
 
 bundle_meeting_echo_assets

--- a/scripts/dist/prepare_meeting_echo_assets.sh
+++ b/scripts/dist/prepare_meeting_echo_assets.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Prepare the native meeting echo-suppression assets expected by
+# scripts/dist/build_app_bundle.sh. Outputs are deterministic and live under
+# .build by default so the assets are not committed into the repository.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+DEFAULT_LOCALVQE_REPO_URL="https://github.com/localai-org/LocalVQE.git"
+DEFAULT_LOCALVQE_REF="35b116d5eb059d552fa46fac3ce2963ed13ce153"
+DEFAULT_MODEL_NAME="localvqe-v1.4-aec-200K-f32.gguf"
+DEFAULT_MODEL_URL="https://huggingface.co/LocalAI-io/LocalVQE/resolve/main/${DEFAULT_MODEL_NAME}"
+DEFAULT_MODEL_SHA256="b6e43138588a83bfe903ab5e143b4020b91c1e1629f5a575ac5855ff0003c731"
+
+ASSETS_DIR="${MACPARAKEET_MEETING_ECHO_ASSETS_DIR:-$ROOT_DIR/.build/meeting-echo-assets}"
+SOURCE_DIR="${LOCALVQE_SOURCE_DIR:-$ROOT_DIR/.build/localvqe-src}"
+BUILD_DIR="${LOCALVQE_BUILD_DIR:-$ASSETS_DIR/build}"
+LIB_DIR="$ASSETS_DIR/lib"
+MODEL_DIR="$ASSETS_DIR/model"
+
+LOCALVQE_REPO_URL="${LOCALVQE_REPO_URL:-$DEFAULT_LOCALVQE_REPO_URL}"
+LOCALVQE_REF="${LOCALVQE_REF:-$DEFAULT_LOCALVQE_REF}"
+MODEL_NAME="${MACPARAKEET_MEETING_ECHO_MODEL_NAME:-$DEFAULT_MODEL_NAME}"
+MODEL_URL="${MACPARAKEET_MEETING_ECHO_MODEL_URL:-$DEFAULT_MODEL_URL}"
+MODEL_SHA256="${MACPARAKEET_MEETING_ECHO_MODEL_SHA256:-}"
+UNIVERSAL="${MACPARAKEET_MEETING_ECHO_UNIVERSAL:-${UNIVERSAL:-0}}"
+CMAKE_BUILD_TYPE="${LOCALVQE_CMAKE_BUILD_TYPE:-Release}"
+
+require_tool() {
+  local tool="$1"
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    echo "Error: '${tool}' is required to prepare meeting echo assets." >&2
+    exit 1
+  fi
+}
+
+require_tool git
+require_tool cmake
+require_tool curl
+require_tool shasum
+
+if [[ "$MODEL_NAME" == */* || "$(printf '%s' "$MODEL_NAME" | tr '[:upper:]' '[:lower:]')" != *.gguf ]]; then
+  echo "Error: MACPARAKEET_MEETING_ECHO_MODEL_NAME must be a GGUF filename, not a path." >&2
+  exit 1
+fi
+
+if [[ "$MODEL_NAME" == "$DEFAULT_MODEL_NAME" ]]; then
+  MODEL_SHA256="${MODEL_SHA256:-$DEFAULT_MODEL_SHA256}"
+else
+  if [[ -z "${MACPARAKEET_MEETING_ECHO_MODEL_URL:-}" ]]; then
+    echo "Error: custom MACPARAKEET_MEETING_ECHO_MODEL_NAME requires MACPARAKEET_MEETING_ECHO_MODEL_URL." >&2
+    exit 1
+  fi
+  if [[ -z "$MODEL_SHA256" ]]; then
+    echo "Error: custom MACPARAKEET_MEETING_ECHO_MODEL_NAME requires MACPARAKEET_MEETING_ECHO_MODEL_SHA256." >&2
+    exit 1
+  fi
+fi
+
+mkdir -p "$ASSETS_DIR" "$LIB_DIR" "$MODEL_DIR"
+
+ensure_localvqe_source() {
+  if [[ -d "$SOURCE_DIR/.git" ]]; then
+    echo "Updating LocalVQE source at $SOURCE_DIR"
+    git -C "$SOURCE_DIR" remote set-url origin "$LOCALVQE_REPO_URL"
+  elif [[ -e "$SOURCE_DIR" ]]; then
+    echo "Error: LOCALVQE_SOURCE_DIR exists but is not a git repository: $SOURCE_DIR" >&2
+    exit 1
+  else
+    echo "Cloning LocalVQE source into $SOURCE_DIR"
+    git clone --filter=blob:none "$LOCALVQE_REPO_URL" "$SOURCE_DIR"
+  fi
+
+  git -C "$SOURCE_DIR" fetch --depth 1 origin "$LOCALVQE_REF"
+  git -C "$SOURCE_DIR" checkout --detach FETCH_HEAD
+  git -C "$SOURCE_DIR" submodule sync --recursive
+  git -C "$SOURCE_DIR" submodule update --init --depth 1 ggml/vendor/ggml
+}
+
+actual_sha256() {
+  shasum -a 256 "$1" | awk '{print $1}'
+}
+
+ensure_model() {
+  local model_path="$MODEL_DIR/$MODEL_NAME"
+  local expected_sha_lc
+  expected_sha_lc="$(printf '%s' "$MODEL_SHA256" | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')"
+
+  if [[ -f "$model_path" ]]; then
+    local existing_sha
+    existing_sha="$(actual_sha256 "$model_path")"
+    if [[ "$existing_sha" == "$expected_sha_lc" ]]; then
+      echo "Meeting echo model already present: $model_path"
+      return 0
+    fi
+    echo "Existing meeting echo model checksum mismatch; re-downloading $MODEL_NAME" >&2
+    rm -f "$model_path"
+  fi
+
+  echo "Downloading meeting echo model: $MODEL_NAME"
+  local tmp_path="$model_path.tmp"
+  rm -f "$tmp_path"
+  curl --fail --location --show-error --silent "$MODEL_URL" --output "$tmp_path"
+
+  local actual_sha
+  actual_sha="$(actual_sha256 "$tmp_path")"
+  if [[ "$actual_sha" != "$expected_sha_lc" ]]; then
+    rm -f "$tmp_path"
+    echo "Error: downloaded meeting echo model SHA256 verification failed." >&2
+    echo "  Expected: $MODEL_SHA256" >&2
+    echo "  Actual:   $actual_sha" >&2
+    exit 1
+  fi
+  mv "$tmp_path" "$model_path"
+  chmod 0644 "$model_path"
+  echo "Meeting echo model SHA256 verified: $actual_sha"
+}
+
+build_localvqe_runtime() {
+  echo "Building LocalVQE runtime from ${LOCALVQE_REF}"
+  local cmake_args=(
+    -S "$SOURCE_DIR/ggml"
+    -B "$BUILD_DIR"
+    -DCMAKE_BUILD_TYPE="$CMAKE_BUILD_TYPE"
+    -DLOCALVQE_BUILD_SHARED=ON
+    -DLOCALVQE_VULKAN=OFF
+    -DLOCALVQE_CUDA=OFF
+    -DGGML_METAL=OFF
+  )
+  if [[ "$UNIVERSAL" == "1" ]]; then
+    cmake_args+=("-DCMAKE_OSX_ARCHITECTURES=arm64;x86_64")
+  fi
+
+  cmake "${cmake_args[@]}"
+
+  local jobs
+  jobs="$(sysctl -n hw.ncpu 2>/dev/null || echo 4)"
+  cmake --build "$BUILD_DIR" --target localvqe_shared -j"$jobs"
+}
+
+copy_runtime_outputs() {
+  local runtime_src
+  runtime_src="$(find "$BUILD_DIR" -type f -name 'liblocalvqe*.dylib' | sort | head -n 1)"
+  if [[ -z "${runtime_src:-}" || ! -f "$runtime_src" ]]; then
+    echo "Error: LocalVQE build did not produce liblocalvqe*.dylib under $BUILD_DIR" >&2
+    exit 1
+  fi
+
+  find "$LIB_DIR" -maxdepth 1 -type f -name '*.dylib' -delete
+  install -m 0755 "$runtime_src" "$LIB_DIR/liblocalvqe.dylib"
+
+  while IFS= read -r -d '' dylib; do
+    local base
+    base="$(basename "$dylib")"
+    if [[ "$base" == liblocalvqe* ]]; then
+      continue
+    fi
+    install -m 0755 "$dylib" "$LIB_DIR/$base"
+  done < <(find "$BUILD_DIR" -type f -name '*.dylib' -print0)
+
+  normalize_dylibs
+}
+
+normalize_dylibs() {
+  if ! command -v install_name_tool >/dev/null 2>&1; then
+    echo "Warning: install_name_tool is not available; leaving LocalVQE install names unchanged." >&2
+    return 0
+  fi
+
+  local dylib
+  for dylib in "$LIB_DIR"/*.dylib; do
+    [[ -f "$dylib" ]] || continue
+    local base
+    base="$(basename "$dylib")"
+    if [[ "$base" == "liblocalvqe.dylib" ]]; then
+      install_name_tool -id "@rpath/liblocalvqe.dylib" "$dylib"
+    else
+      install_name_tool -id "@rpath/$base" "$dylib"
+    fi
+  done
+
+  if ! command -v otool >/dev/null 2>&1; then
+    return 0
+  fi
+
+  for dylib in "$LIB_DIR"/*.dylib; do
+    [[ -f "$dylib" ]] || continue
+    while IFS= read -r dep; do
+      local dep_base
+      dep_base="$(basename "$dep")"
+      if [[ -f "$LIB_DIR/$dep_base" ]]; then
+        install_name_tool -change "$dep" "@loader_path/$dep_base" "$dylib" || true
+      fi
+      if [[ "$dep_base" == liblocalvqe*.dylib ]]; then
+        install_name_tool -change "$dep" "@loader_path/liblocalvqe.dylib" "$dylib" || true
+      fi
+    done < <(otool -L "$dylib" | awk '/^[[:space:]]/ {print $1}')
+  done
+}
+
+ensure_localvqe_source
+ensure_model
+build_localvqe_runtime
+copy_runtime_outputs
+
+echo "Prepared meeting echo runtime: $LIB_DIR/liblocalvqe.dylib"
+echo "Prepared meeting echo model: $MODEL_DIR/$MODEL_NAME"
+echo "Meeting echo model SHA256: $MODEL_SHA256"

--- a/spec/05-audio-pipeline.md
+++ b/spec/05-audio-pipeline.md
@@ -194,15 +194,17 @@ Mic Input    → SharedMicrophoneStream (+ Voice Processing I/O when active)┘ 
   live-preview chunk boundaries via `MeetingAudioPairJoiner` plus per-source
   `MeetingLiveAudioChunking` strategies. Single-source sessions skip the
   unselected stream and produce a mono `meeting.m4a`.
-- Mic conditioning is pass-through by default. Raw capture applies no platform
-  AEC/noise suppression/AGC. The optional `StreamingMeetingEchoSuppressor`
-  can transform paired mic/system samples when a LocalVQE-compatible runtime
-  and model are available; otherwise it falls back to raw mic samples with
-  diagnostics. Release bundles that claim meeting AEC readiness must include
+- Raw capture applies no platform AEC/noise suppression/AGC. Meeting mic
+  conditioning starts in automatic mode: release bundles with LocalVQE assets
+  run `StreamingMeetingEchoSuppressor` over paired mic/system samples, while
+  local/dev bundles without those assets fall back to raw mic samples with
+  diagnostics. AEC-ready release bundles must include
   `Contents/Frameworks/liblocalvqe.dylib` plus exactly one selected GGUF under
   `Contents/Resources/MeetingEchoSuppression/`; distribution verification
   checks the model checksum, required LocalVQE C symbols, executable bit, and
-  portable dylib references before the app can claim that path. When the
+  portable dylib references before the app can claim that path. The selected
+  bundled default is the v1.4 echo-only model
+  (`localvqe-v1.4-aec-200K-f32.gguf`). When the
   suppressor runs it aligns the system reference to the
   microphone using a runtime delay recovered from the audio by
   `MeetingEchoDelayEstimator` (normalized cross-correlation, confidence-gated),


### PR DESCRIPTION
## Summary

AEC-ready release builds can now produce the native LocalVQE assets themselves. Setting `REQUIRE_MEETING_ECHO_ASSETS=1` makes `build_app_bundle.sh` build the pinned LocalVQE runtime, download the selected v1.4 echo-only GGUF, verify the model checksum and dylib shape, and bundle both assets into the app.

The shipped runtime default now matches that release asset: `localvqe-v1.4-aec-200K-f32.gguf`. Local/dev bundles without required assets still fall back to raw mic passthrough, while release builds that claim meeting AEC readiness fail fast if the assets are missing or unverifiable.

## Notes

- The prepared assets live under `.build/meeting-echo-assets/` and are not committed.
- The selected model SHA is pinned to `b6e43138588a83bfe903ab5e143b4020b91c1e1629f5a575ac5855ff0003c731`.
- The generated runtime is copied to `Contents/Frameworks/liblocalvqe.dylib`; the model is copied to `Contents/Resources/MeetingEchoSuppression/`.
- Custom auto-prepared models must provide their own URL and SHA, so they cannot accidentally inherit the default model checksum.
- Distribution docs, audio-pipeline docs, and third-party attributions now describe the bundled LocalVQE/ggml path.

## Validation

- `bash -n scripts/dist/prepare_meeting_echo_assets.sh`
- `bash -n scripts/dist/build_app_bundle.sh`
- `bash -n scripts/dist/verify_meeting_echo_assets.sh`
- custom model guard: `MACPARAKEET_MEETING_ECHO_MODEL_NAME=custom-localvqe-test.gguf MACPARAKEET_MEETING_ECHO_MODEL_URL=https://example.invalid/custom.gguf scripts/dist/prepare_meeting_echo_assets.sh` exits before download and requires `MACPARAKEET_MEETING_ECHO_MODEL_SHA256`
- `git diff --check`
- `scripts/dist/prepare_meeting_echo_assets.sh`
- strict verifier smoke using the prepared `liblocalvqe.dylib` and `localvqe-v1.4-aec-200K-f32.gguf`
- `swift test --filter MeetingEchoSuppressionRuntimeTests`
- `MACPARAKEET_TEST_LOCALVQE_LIBRARY=.build/meeting-echo-assets/lib/liblocalvqe.dylib MACPARAKEET_TEST_LOCALVQE_MODEL=.build/meeting-echo-assets/model/localvqe-v1.4-aec-200K-f32.gguf MACPARAKEET_TEST_LOCALVQE_MODEL_SHA256=b6e43138588a83bfe903ab5e143b4020b91c1e1629f5a575ac5855ff0003c731 swift test --filter MeetingEchoSuppressionRuntimeTests/testRealLocalVQERuntimeLoadsWhenTestAssetsAreProvided`
- `MACPARAKEET_SKIP_WHISPERKIT=1 swift build --build-path .build-swift6-no-whisper -Xswiftc -swift-version -Xswiftc 6`
- `swift test` — 4,317 XCTest tests plus 17 Swift Testing tests, 0 failures
- `VERSION=0.0.0 BUILD_SYSTEM=swiftpm BUNDLE_YTDLP=0 BUNDLE_NODE=0 FFMPEG_PATH=/bin/echo REQUIRE_MEETING_ECHO_ASSETS=1 scripts/dist/build_app_bundle.sh` — produced `dist/MacParakeet.app` and `Meeting echo assets verified: localvqe-v1.4-aec-200K-f32.gguf`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
