### PR TITLE
Fix no-Whisper Swift test gate

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,21 +13,28 @@ let packageDependencies: [Package.Dependency] = [
     // ArgumentParser for CLI
     .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
     // Sparkle for auto-updates (non-App Store distribution)
-    .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.9.0")
-] + (skipWhisperKit ? [] : [
+    .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.9.0"),
+    // FluidAudio's Swift module exposes yyjson under current Xcode/Swift.
+    .package(url: "https://github.com/ibireme/yyjson.git", exact: "0.12.0"),
     // WhisperKit for multilingual STT fallback (Korean + 95 other languages).
     // Argmax is not Swift 6 language-mode clean yet, so CI can omit this package
-    // only for the first-party Swift 6 syntax/concurrency compile check.
+    // as a target dependency for the first-party Swift 6 syntax/concurrency
+    // compile check without removing its lockfile pins.
     .package(url: "https://github.com/argmaxinc/argmax-oss-swift", exact: "0.18.0")
-])
+]
 
 let coreDependencies: [Target.Dependency] = [
     .product(name: "GRDB", package: "GRDB.swift"),
     .product(name: "FluidAudio", package: "FluidAudio"),
+    .product(name: "yyjson", package: "yyjson"),
     "MacParakeetObjCShims"
 ] + (skipWhisperKit ? [] : [
     .product(name: "WhisperKit", package: "argmax-oss-swift")
 ])
+
+let whisperKitSwiftSettings: [SwiftSetting] = skipWhisperKit ? [] : [
+    .define("MACPARAKEET_HAS_WHISPERKIT")
+]
 
 let package = Package(
     name: "MacParakeet",
@@ -89,7 +96,8 @@ let package = Package(
                 "Services/System/README.md",
                 "STT/README.md",
                 "TextProcessing/README.md",
-            ]
+            ],
+            swiftSettings: whisperKitSwiftSettings
         ),
         // ViewModels library (testable, depends on Core + AppKit/SwiftUI)
         .target(
@@ -101,7 +109,8 @@ let package = Package(
         .testTarget(
             name: "MacParakeetTests",
             dependencies: ["MacParakeet", "MacParakeetCore", "MacParakeetViewModels", "MacParakeetObjCShims"],
-            path: "Tests/MacParakeetTests"
+            path: "Tests/MacParakeetTests",
+            swiftSettings: whisperKitSwiftSettings
         ),
         .testTarget(
             name: "CLITests",

--- a/Sources/MacParakeetCore/STT/WhisperEngine.swift
+++ b/Sources/MacParakeetCore/STT/WhisperEngine.swift
@@ -1,7 +1,7 @@
 import Foundation
 import OSLog
 
-#if canImport(WhisperKit)
+#if MACPARAKEET_HAS_WHISPERKIT
 import WhisperKit
 #endif
 
@@ -19,7 +19,7 @@ public actor WhisperEngine: STTTranscribing {
     private let defaults: UserDefaults
     private let transcriptionPermit = AsyncPermit()
 
-    #if canImport(WhisperKit)
+    #if MACPARAKEET_HAS_WHISPERKIT
     private var whisperKit: WhisperKit?
     private var isLoaded = false
     #endif
@@ -168,7 +168,7 @@ public actor WhisperEngine: STTTranscribing {
         language: String?,
         onProgress: (@Sendable (Int, Int) -> Void)? = nil
     ) async throws -> STTResult {
-        #if canImport(WhisperKit)
+        #if MACPARAKEET_HAS_WHISPERKIT
         do {
             try await prepareLocked(onProgress: nil)
             guard let whisperKit else {
@@ -204,7 +204,7 @@ public actor WhisperEngine: STTTranscribing {
         language: String?,
         onProgress: (@Sendable (Int, Int) -> Void)? = nil
     ) async throws -> STTResult {
-        #if canImport(WhisperKit)
+        #if MACPARAKEET_HAS_WHISPERKIT
         do {
             try await prepareLocked(onProgress: nil)
             guard let whisperKit else {
@@ -243,7 +243,7 @@ public actor WhisperEngine: STTTranscribing {
     }
 
     private func prepareLocked(onProgress: (@Sendable (String) -> Void)? = nil) async throws {
-        #if canImport(WhisperKit)
+        #if MACPARAKEET_HAS_WHISPERKIT
         if isLoaded, whisperKit != nil { return }
         guard let modelFolder = Self.localModelFolder(model: modelVariant, downloadBase: downloadBase) else {
             throw STTError.engineStartFailed(
@@ -313,7 +313,7 @@ public actor WhisperEngine: STTTranscribing {
         defer { transcriptionPermit.signal() }
         guard !Task.isCancelled else { return }
 
-        #if canImport(WhisperKit)
+        #if MACPARAKEET_HAS_WHISPERKIT
         await whisperKit?.unloadModels()
         whisperKit = nil
         isLoaded = false
@@ -321,7 +321,7 @@ public actor WhisperEngine: STTTranscribing {
     }
 
     public func isReady() -> Bool {
-        #if canImport(WhisperKit)
+        #if MACPARAKEET_HAS_WHISPERKIT
         isLoaded && whisperKit != nil
         #else
         false
@@ -333,7 +333,7 @@ public actor WhisperEngine: STTTranscribing {
         downloadBase: URL = WhisperEngine.defaultDownloadBase,
         onProgress: (@Sendable (Int, Int) -> Void)? = nil
     ) async throws -> URL {
-        #if canImport(WhisperKit)
+        #if MACPARAKEET_HAS_WHISPERKIT
         try AppPaths.ensureDirectories()
         return try await WhisperKit.download(
             variant: normalizeModelVariant(model),
@@ -365,7 +365,7 @@ public actor WhisperEngine: STTTranscribing {
         )
     }
 
-    #if canImport(WhisperKit)
+    #if MACPARAKEET_HAS_WHISPERKIT
     static func makeDecodingOptions(language: String?) -> DecodingOptions {
         let resolvedLanguage = SpeechEnginePreference.normalizeLanguage(language)
         return DecodingOptions(

--- a/Tests/MacParakeetTests/STT/STTClientTests.swift
+++ b/Tests/MacParakeetTests/STT/STTClientTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 @testable import MacParakeetCore
-#if canImport(WhisperKit)
+#if MACPARAKEET_HAS_WHISPERKIT
 import WhisperKit
 #endif
 
@@ -83,7 +83,7 @@ final class STTClientTests: XCTestCase {
     }
 
     func testWhisperDecodeOptionsForForcedLanguageUsesPrefillPrompt() {
-        #if canImport(WhisperKit)
+        #if MACPARAKEET_HAS_WHISPERKIT
         let options = WhisperEngine.makeDecodingOptions(language: "KO_kr")
 
         XCTAssertEqual(options.language, "ko")
@@ -94,7 +94,7 @@ final class STTClientTests: XCTestCase {
     }
 
     func testWhisperDecodeOptionsForAutoLanguageDetectsWithoutPrefillPrompt() {
-        #if canImport(WhisperKit)
+        #if MACPARAKEET_HAS_WHISPERKIT
         let options = WhisperEngine.makeDecodingOptions(language: "auto")
 
         XCTAssertNil(options.language)
@@ -105,7 +105,7 @@ final class STTClientTests: XCTestCase {
     }
 
     func testWhisperForcedLanguageFallbackOnlyRetriesEmptyResults() {
-        #if canImport(WhisperKit)
+        #if MACPARAKEET_HAS_WHISPERKIT
         let empty = TranscriptionResult(text: "  \n", segments: [], language: "ko", timings: TranscriptionTimings())
         XCTAssertTrue(WhisperEngine.shouldRetryWithoutForcedLanguage(empty))
 


### PR DESCRIPTION
## Summary
- Repacked the no-Whisper Swift test gate fix onto fresh `origin/main`.
- Keeps the diff scoped to `Package.swift`, `WhisperEngine.swift`, and `STTClientTests.swift`.

## Verification
- `MACPARAKEET_SKIP_WHISPERKIT=1 swift test`
  - 4317 XCTest, 13 skipped, 0 failures
  - 17 Swift Testing tests, 0 failures
- `git diff --check origin/main...HEAD`
- `git diff --name-only origin/main...HEAD` => only the three intended files

Paperclip: DYS-1654


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the no-Whisper Swift test gate by switching `WhisperKit` checks to a compile-time flag so CI can build and test with `MACPARAKEET_SKIP_WHISPERKIT=1`. Also adds `yyjson` to satisfy a `FluidAudio`-exposed dependency. Addresses Linear DYS-1654.

- **Bug Fixes**
  - Replace `#if canImport(WhisperKit)` with `#if MACPARAKEET_HAS_WHISPERKIT` in `WhisperEngine.swift` and tests.
  - Define `MACPARAKEET_HAS_WHISPERKIT` via `swiftSettings` when `WhisperKit` is enabled (applied to core and tests).
  - Keep `argmax-oss-swift` pinned but omit it as a target dependency for the Swift 6 compile-check path.

- **Dependencies**
  - Add `yyjson` (exact `0.12.0`) and link its product to `MacParakeetCore` to match `FluidAudio`’s exposure.

<sup>Written for commit 66bc8b7feee92388712794a73cea7c595975cd35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/655?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

