### PR TITLE
Harden meeting echo asset preparation

### DIFF
--- a/scripts/dist/build_app_bundle.sh
+++ b/scripts/dist/build_app_bundle.sh
@@ -44,6 +44,8 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 DIST_DIR="$ROOT_DIR/dist"
 
+. "$ROOT_DIR/scripts/dist/meeting_echo_asset_defaults.sh"
+
 APP_NAME="${APP_NAME:-MacParakeet}"
 BUNDLE_ID="${BUNDLE_ID:-com.macparakeet.MacParakeet}"
 VERSION="${VERSION:-0.0.0}"
@@ -64,8 +66,6 @@ RESOURCES_DIR="$CONTENTS_DIR/Resources"
 FRAMEWORKS_DIR="$CONTENTS_DIR/Frameworks"
 LEGAL_DIR="$RESOURCES_DIR/Legal"
 
-DEFAULT_MEETING_ECHO_MODEL_NAME="localvqe-v1.4-aec-200K-f32.gguf"
-DEFAULT_MEETING_ECHO_MODEL_SHA256="b6e43138588a83bfe903ab5e143b4020b91c1e1629f5a575ac5855ff0003c731"
 DEFAULT_MEETING_ECHO_ASSETS_DIR="$ROOT_DIR/.build/meeting-echo-assets"
 
 rm -rf "$APP_DIR"

--- a/scripts/dist/meeting_echo_asset_defaults.sh
+++ b/scripts/dist/meeting_echo_asset_defaults.sh
@@ -1,0 +1,5 @@
+# Shared release defaults for bundled meeting echo-suppression assets.
+# Sourced by build_app_bundle.sh and prepare_meeting_echo_assets.sh; not executed directly.
+
+DEFAULT_MEETING_ECHO_MODEL_NAME="localvqe-v1.4-aec-200K-f32.gguf"
+DEFAULT_MEETING_ECHO_MODEL_SHA256="b6e43138588a83bfe903ab5e143b4020b91c1e1629f5a575ac5855ff0003c731"

--- a/scripts/dist/prepare_meeting_echo_assets.sh
+++ b/scripts/dist/prepare_meeting_echo_assets.sh
@@ -7,21 +7,25 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
+. "$ROOT_DIR/scripts/dist/meeting_echo_asset_defaults.sh"
+
 DEFAULT_LOCALVQE_REPO_URL="https://github.com/localai-org/LocalVQE.git"
 DEFAULT_LOCALVQE_REF="35b116d5eb059d552fa46fac3ce2963ed13ce153"
-DEFAULT_MODEL_NAME="localvqe-v1.4-aec-200K-f32.gguf"
-DEFAULT_MODEL_URL="https://huggingface.co/LocalAI-io/LocalVQE/resolve/main/${DEFAULT_MODEL_NAME}"
-DEFAULT_MODEL_SHA256="b6e43138588a83bfe903ab5e143b4020b91c1e1629f5a575ac5855ff0003c731"
+DEFAULT_LOCALVQE_FETCH_REF="refs/heads/main"
+DEFAULT_MODEL_URL="https://huggingface.co/LocalAI-io/LocalVQE/resolve/main/${DEFAULT_MEETING_ECHO_MODEL_NAME}"
 
 ASSETS_DIR="${MACPARAKEET_MEETING_ECHO_ASSETS_DIR:-$ROOT_DIR/.build/meeting-echo-assets}"
 SOURCE_DIR="${LOCALVQE_SOURCE_DIR:-$ROOT_DIR/.build/localvqe-src}"
 BUILD_DIR="${LOCALVQE_BUILD_DIR:-$ASSETS_DIR/build}"
 LIB_DIR="$ASSETS_DIR/lib"
 MODEL_DIR="$ASSETS_DIR/model"
+RUNTIME_STAMP="$LIB_DIR/.localvqe-runtime.stamp"
+RUNTIME_MANIFEST="$LIB_DIR/.localvqe-runtime.dylibs"
 
 LOCALVQE_REPO_URL="${LOCALVQE_REPO_URL:-$DEFAULT_LOCALVQE_REPO_URL}"
 LOCALVQE_REF="${LOCALVQE_REF:-$DEFAULT_LOCALVQE_REF}"
-MODEL_NAME="${MACPARAKEET_MEETING_ECHO_MODEL_NAME:-$DEFAULT_MODEL_NAME}"
+LOCALVQE_FETCH_REF="${LOCALVQE_FETCH_REF:-$DEFAULT_LOCALVQE_FETCH_REF}"
+MODEL_NAME="${MACPARAKEET_MEETING_ECHO_MODEL_NAME:-$DEFAULT_MEETING_ECHO_MODEL_NAME}"
 MODEL_URL="${MACPARAKEET_MEETING_ECHO_MODEL_URL:-$DEFAULT_MODEL_URL}"
 MODEL_SHA256="${MACPARAKEET_MEETING_ECHO_MODEL_SHA256:-}"
 UNIVERSAL="${MACPARAKEET_MEETING_ECHO_UNIVERSAL:-${UNIVERSAL:-0}}"
@@ -45,8 +49,8 @@ if [[ "$MODEL_NAME" == */* || "$(printf '%s' "$MODEL_NAME" | tr '[:upper:]' '[:l
   exit 1
 fi
 
-if [[ "$MODEL_NAME" == "$DEFAULT_MODEL_NAME" ]]; then
-  MODEL_SHA256="${MODEL_SHA256:-$DEFAULT_MODEL_SHA256}"
+if [[ "$MODEL_NAME" == "$DEFAULT_MEETING_ECHO_MODEL_NAME" ]]; then
+  MODEL_SHA256="${MODEL_SHA256:-$DEFAULT_MEETING_ECHO_MODEL_SHA256}"
 else
   if [[ -z "${MACPARAKEET_MEETING_ECHO_MODEL_URL:-}" ]]; then
     echo "Error: custom MACPARAKEET_MEETING_ECHO_MODEL_NAME requires MACPARAKEET_MEETING_ECHO_MODEL_URL." >&2
@@ -72,10 +76,46 @@ ensure_localvqe_source() {
     git clone --filter=blob:none "$LOCALVQE_REPO_URL" "$SOURCE_DIR"
   fi
 
-  git -C "$SOURCE_DIR" fetch --depth 1 origin "$LOCALVQE_REF"
-  git -C "$SOURCE_DIR" checkout --detach FETCH_HEAD
+  # Fetch an advertised ref for portability, then checkout the exact pinned
+  # commit. Avoid a depth-limited fetch so the pin survives future branch moves.
+  local fetch_args=()
+  if [[ "$(git -C "$SOURCE_DIR" rev-parse --is-shallow-repository)" == "true" ]]; then
+    fetch_args+=(--unshallow)
+  else
+    fetch_args+=(--filter=blob:none)
+  fi
+  git -C "$SOURCE_DIR" fetch "${fetch_args[@]}" origin "$LOCALVQE_FETCH_REF"
+  local checkout_output
+  if ! checkout_output="$(git -C "$SOURCE_DIR" checkout --detach "$LOCALVQE_REF" 2>&1)"; then
+    echo "Error: failed to checkout pinned LocalVQE commit '$LOCALVQE_REF'." >&2
+    if [[ -n "$checkout_output" ]]; then
+      echo "$checkout_output" >&2
+    fi
+    echo "If the commit is not reachable from '$LOCALVQE_FETCH_REF', set LOCALVQE_FETCH_REF to an advertised branch or tag that contains LOCALVQE_REF." >&2
+    exit 1
+  fi
   git -C "$SOURCE_DIR" submodule sync --recursive
   git -C "$SOURCE_DIR" submodule update --init --depth 1 ggml/vendor/ggml
+}
+
+localvqe_source_is_current() {
+  [[ -d "$SOURCE_DIR/.git" ]] || return 1
+
+  local source_remote
+  source_remote="$(git -C "$SOURCE_DIR" remote get-url origin 2>/dev/null)" || return 1
+  [[ "$source_remote" == "$LOCALVQE_REPO_URL" ]] || return 1
+
+  local source_head
+  source_head="$(git -C "$SOURCE_DIR" rev-parse --verify HEAD 2>/dev/null)" || return 1
+  [[ "$source_head" == "$LOCALVQE_REF" ]] || return 1
+
+  local submodule_status
+  submodule_status="$(git -C "$SOURCE_DIR" submodule status --recursive ggml/vendor/ggml 2>/dev/null)" || return 1
+  [[ -n "$submodule_status" ]] || return 1
+  if grep -qvE '^[[:space:]]' <<< "$submodule_status"; then
+    return 1
+  fi
+  return 0
 }
 
 actual_sha256() {
@@ -119,10 +159,16 @@ ensure_model() {
 
 build_localvqe_runtime() {
   echo "Building LocalVQE runtime from ${LOCALVQE_REF}"
+  local cmake_build_type_upper
+  cmake_build_type_upper="$(printf '%s' "$CMAKE_BUILD_TYPE" | tr '[:lower:]' '[:upper:]')"
   local cmake_args=(
     -S "$SOURCE_DIR/ggml"
     -B "$BUILD_DIR"
     -DCMAKE_BUILD_TYPE="$CMAKE_BUILD_TYPE"
+    -DCMAKE_LIBRARY_OUTPUT_DIRECTORY="$BUILD_DIR"
+    -DCMAKE_RUNTIME_OUTPUT_DIRECTORY="$BUILD_DIR"
+    "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_${cmake_build_type_upper}=$BUILD_DIR"
+    "-DCMAKE_RUNTIME_OUTPUT_DIRECTORY_${cmake_build_type_upper}=$BUILD_DIR"
     -DLOCALVQE_BUILD_SHARED=ON
     -DLOCALVQE_VULKAN=OFF
     -DLOCALVQE_CUDA=OFF
@@ -139,9 +185,53 @@ build_localvqe_runtime() {
   cmake --build "$BUILD_DIR" --target localvqe_shared -j"$jobs"
 }
 
+runtime_stamp_value() {
+  printf 'repo=%s\n' "$LOCALVQE_REPO_URL"
+  printf 'ref=%s\n' "$LOCALVQE_REF"
+  printf 'build_type=%s\n' "$CMAKE_BUILD_TYPE"
+  printf 'universal=%s\n' "$UNIVERSAL"
+}
+
+runtime_dylib_manifest_value() {
+  find "$LIB_DIR" -maxdepth 1 -type f -name '*.dylib' -exec basename {} \; | sort
+}
+
+runtime_cache_is_current() {
+  [[ -f "$LIB_DIR/liblocalvqe.dylib" && -f "$RUNTIME_STAMP" && -f "$RUNTIME_MANIFEST" ]] &&
+    cmp -s "$RUNTIME_STAMP" <(runtime_stamp_value) &&
+    cmp -s "$RUNTIME_MANIFEST" <(runtime_dylib_manifest_value)
+}
+
+reset_build_dir() {
+  if [[ -z "$BUILD_DIR" || "$BUILD_DIR" == "/" ]]; then
+    echo "Error: refusing to remove unsafe LOCALVQE_BUILD_DIR: '$BUILD_DIR'." >&2
+    exit 1
+  fi
+  rm -rf "$BUILD_DIR"
+}
+
+ensure_localvqe_runtime() {
+  if runtime_cache_is_current; then
+    echo "Meeting echo runtime already present: $LIB_DIR/liblocalvqe.dylib"
+    return 0
+  fi
+
+  rm -f "$RUNTIME_STAMP" "$RUNTIME_MANIFEST"
+  reset_build_dir
+  if localvqe_source_is_current; then
+    echo "LocalVQE source already pinned: $SOURCE_DIR"
+  else
+    ensure_localvqe_source
+  fi
+  build_localvqe_runtime
+  copy_runtime_outputs
+  runtime_dylib_manifest_value > "$RUNTIME_MANIFEST"
+  runtime_stamp_value > "$RUNTIME_STAMP"
+}
+
 copy_runtime_outputs() {
   local runtime_src
-  runtime_src="$(find "$BUILD_DIR" -type f -name 'liblocalvqe*.dylib' | sort | head -n 1)"
+  runtime_src="$(find "$BUILD_DIR" -maxdepth 1 -type f -name 'liblocalvqe*.dylib' | sort | head -n 1)"
   if [[ -z "${runtime_src:-}" || ! -f "$runtime_src" ]]; then
     echo "Error: LocalVQE build did not produce liblocalvqe*.dylib under $BUILD_DIR" >&2
     exit 1
@@ -157,9 +247,29 @@ copy_runtime_outputs() {
       continue
     fi
     install -m 0755 "$dylib" "$LIB_DIR/$base"
-  done < <(find "$BUILD_DIR" -type f -name '*.dylib' -print0)
+  done < <(find "$BUILD_DIR" -maxdepth 1 -type f -name '*.dylib' -print0)
 
   normalize_dylibs
+}
+
+rewrite_dependency() {
+  local old_path="$1"
+  local new_path="$2"
+  local target="$3"
+  if [[ "$old_path" == "$new_path" ]]; then
+    return 0
+  fi
+
+  local output
+  if ! output="$(install_name_tool -change "$old_path" "$new_path" "$target" 2>&1)"; then
+    echo "Error: failed to rewrite LocalVQE dylib dependency." >&2
+    echo "  Target: $target" >&2
+    echo "  Change: $old_path -> $new_path" >&2
+    if [[ -n "$output" ]]; then
+      echo "$output" >&2
+    fi
+    exit 1
+  fi
 }
 
 normalize_dylibs() {
@@ -186,23 +296,23 @@ normalize_dylibs() {
 
   for dylib in "$LIB_DIR"/*.dylib; do
     [[ -f "$dylib" ]] || continue
+    local dylib_id
+    dylib_id="$(otool -D "$dylib" | tail -n 1)"
     while IFS= read -r dep; do
+      [[ "$dep" == "$dylib_id" ]] && continue
       local dep_base
       dep_base="$(basename "$dep")"
-      if [[ -f "$LIB_DIR/$dep_base" ]]; then
-        install_name_tool -change "$dep" "@loader_path/$dep_base" "$dylib" || true
-      fi
       if [[ "$dep_base" == liblocalvqe*.dylib ]]; then
-        install_name_tool -change "$dep" "@loader_path/liblocalvqe.dylib" "$dylib" || true
+        rewrite_dependency "$dep" "@loader_path/liblocalvqe.dylib" "$dylib"
+      elif [[ -f "$LIB_DIR/$dep_base" ]]; then
+        rewrite_dependency "$dep" "@loader_path/$dep_base" "$dylib"
       fi
-    done < <(otool -L "$dylib" | awk '/^[[:space:]]/ {print $1}')
+    done < <(otool -L "$dylib" | sed -E -n 's/^[[:space:]]+(.*) \(compatibility.*/\1/p' | sort -u)
   done
 }
 
-ensure_localvqe_source
 ensure_model
-build_localvqe_runtime
-copy_runtime_outputs
+ensure_localvqe_runtime
 
 echo "Prepared meeting echo runtime: $LIB_DIR/liblocalvqe.dylib"
 echo "Prepared meeting echo model: $MODEL_DIR/$MODEL_NAME"


### PR DESCRIPTION
## Summary

- harden LocalVQE asset preparation after #654 merged
- fetch advertised LocalVQE refs, pin CMake output directories, and fail loudly on install-name rewrite errors
- add a runtime stamp cache and shared meeting-echo model defaults so cached runs avoid unnecessary network fetches and checksum bumps stay single-sourced

## Validation

- `bash -n scripts/dist/meeting_echo_asset_defaults.sh`
- `bash -n scripts/dist/prepare_meeting_echo_assets.sh`
- `bash -n scripts/dist/build_app_bundle.sh`
- `bash -n scripts/dist/verify_meeting_echo_assets.sh`
- `git diff --check origin/main..HEAD`
- `scripts/dist/prepare_meeting_echo_assets.sh` cached path: no LocalVQE fetch, runtime/model already present
- stale runtime stamp smoke: forced rebuild produced `liblocalvqe.dylib` and rewrote dependencies
- custom model guard exits before download without `MACPARAKEET_MEETING_ECHO_MODEL_SHA256`
- `VERSION=0.0.0 BUILD_SYSTEM=swiftpm BUNDLE_YTDLP=0 BUNDLE_NODE=0 FFMPEG_PATH=/bin/echo REQUIRE_MEETING_ECHO_ASSETS=1 scripts/dist/build_app_bundle.sh`

Follow-up to #654 because that PR was merged before this hardening commit could attach to it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened meeting echo asset preparation to make LocalVQE builds reproducible, cached, and fail-fast. Shared model defaults are now single-sourced via `scripts/dist/meeting_echo_asset_defaults.sh`.

- **Bug Fixes**
  - Fetch via `LOCALVQE_FETCH_REF` (default `refs/heads/main`), unshallow if needed, and hard-checkout the pinned `LOCALVQE_REF` with a clear error if unreachable.
  - Pin all CMake library/runtime outputs (including config-specific) to `$BUILD_DIR` and only copy `.dylib` files from the top level.
  - Make install-name rewrites strict: skip self IDs, limit to top-level outputs, and fail on any `install_name_tool` error.

- **Refactors**
  - Add a runtime stamp and dylib manifest cache (`.localvqe-runtime.stamp`, `.localvqe-runtime.dylibs`) plus a source pin check to skip LocalVQE rebuilds and network fetches when unchanged.
  - Move default model name and SHA256 to `scripts/dist/meeting_echo_asset_defaults.sh`; sourced by `build_app_bundle.sh` and `prepare_meeting_echo_assets.sh`.

<sup>Written for commit cc268a64f44e2b40840d3489862e6e1563e5c774. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/656?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

