### PR TITLE
Document release demo smoke gate

### DIFF
--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -227,6 +227,11 @@ spctl --assess --type execute --verbose=4 dist/MacParakeet.app
 
 dist/MacParakeet.app/Contents/Resources/yt-dlp --version
 # Expected: prints a yt-dlp version, not a [PYI:ERROR] Python shared library failure
+
+scripts/dev/release_demo_smoke.sh \
+  --cli dist/MacParakeet.app/Contents/MacOS/macparakeet-cli \
+  --output-dir ".codex/release-demo-smoke/release-X.Y.Z"
+# Expected: local health, transcription, and export smoke passes with evidence
 ```
 
 ### Step 3: Upload DMG to R2


### PR DESCRIPTION
## Summary
- Add the existing release demo smoke script to the distribution verification checklist before upload.
- Points release builders at the signed app-bundled CLI and a versioned evidence directory.

## Verification
- scripts/dev/release_demo_smoke.sh --help
- scripts/dev/release_demo_smoke.sh --output-dir .codex/release-demo-smoke/dys-1871-doc-verify

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the release demo smoke gate to the distribution verification checklist to block DMG uploads until the smoke passes. Aligns with Linear DYS-1871 by instructing builders to run `scripts/dev/release_demo_smoke.sh` with the signed app‑bundled CLI and a versioned evidence directory (verifies local health, transcription, and export).

<sup>Written for commit acf54148a8ec7006be87259282b4cb82f0bd1fcf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/658?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

