### PR TITLE
Guard release signing version metadata

### DIFF
--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -218,7 +218,7 @@ The script will `exit 1` if Sparkle is missing or required echo assets fail veri
 scripts/dist/sign_notarize.sh
 ```
 
-The script defaults `NOTARYTOOL_PROFILE` to `AC_PASSWORD`. Both app and DMG are signed, notarized, and stapled. The script submits and polls for completion — **never use `notarytool submit --wait`** (it crashes with a bus error; see gotcha #1 below).
+The script defaults `NOTARYTOOL_PROFILE` to `AC_PASSWORD`. It first refuses dev/sentinel bundle versions such as `0.0.0`, `dev`, or `*pdx*`; rebuild with `VERSION=X.Y.Z` before signing. Both app and DMG are signed, notarized, and stapled. The script submits and polls for completion — **never use `notarytool submit --wait`** (it crashes with a bus error; see gotcha #1 below).
 
 Verify:
 ```bash

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -218,7 +218,7 @@ The script will `exit 1` if Sparkle is missing or required echo assets fail veri
 scripts/dist/sign_notarize.sh
 ```
 
-The script defaults `NOTARYTOOL_PROFILE` to `AC_PASSWORD`. It first refuses dev/sentinel bundle versions such as `0.0.0`, `dev`, or `*pdx*`; rebuild with `VERSION=X.Y.Z` before signing. Both app and DMG are signed, notarized, and stapled. The script submits and polls for completion — **never use `notarytool submit --wait`** (it crashes with a bus error; see gotcha #1 below).
+The script defaults `NOTARYTOOL_PROFILE` to `AC_PASSWORD`. It first refuses dev/sentinel bundle versions such as `0.0.0`, `dev`, or `*pdx*`; rebuild with `VERSION=X.Y.Z` before signing. For explicit local diagnostic signing only, set `MACPARAKEET_ALLOW_DEV_VERSION_SIGNING=1`. Both app and DMG are signed, notarized, and stapled. The script submits and polls for completion — **never use `notarytool submit --wait`** (it crashes with a bus error; see gotcha #1 below).
 
 Verify:
 ```bash

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -227,6 +227,11 @@ spctl --assess --type execute --verbose=4 dist/MacParakeet.app
 
 dist/MacParakeet.app/Contents/Resources/yt-dlp --version
 # Expected: prints a yt-dlp version, not a [PYI:ERROR] Python shared library failure
+
+scripts/dev/release_demo_smoke.sh \
+  --cli dist/MacParakeet.app/Contents/MacOS/macparakeet-cli \
+  --output-dir ".codex/release-demo-smoke/release-X.Y.Z"
+# Expected: local health, transcription, and export smoke passes with evidence
 ```
 
 ### Step 3: Upload DMG to R2

--- a/scripts/dist/sign_notarize.sh
+++ b/scripts/dist/sign_notarize.sh
@@ -16,6 +16,7 @@ set -euo pipefail
 #   CREATE_DMG            (default: 1)
 #   NOTARY_TIMEOUT_SECONDS       (default: 1800)
 #   NOTARY_POLL_INTERVAL_SECONDS (default: 15)
+#   MACPARAKEET_ALLOW_DEV_VERSION_SIGNING (default: 0; set 1 only for diagnostic signing)
 #
 # Outputs:
 #   dist/MacParakeet.app (signed + stapled)

--- a/scripts/dist/sign_notarize.sh
+++ b/scripts/dist/sign_notarize.sh
@@ -85,6 +85,8 @@ if [[ ! -d "$APP_PATH" ]]; then
   exit 1
 fi
 
+"$ROOT_DIR/scripts/dist/verify_release_version.sh" "$APP_PATH"
+
 echo "[1/8] Clearing extended attributes…"
 xattr -cr "$APP_PATH" || true
 

--- a/scripts/dist/test_verify_release_version.sh
+++ b/scripts/dist/test_verify_release_version.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+VERIFY_SCRIPT="$ROOT_DIR/scripts/dist/verify_release_version.sh"
+TMP_DIR="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+make_app() {
+  local name="$1"
+  local short_version="${2-}"
+  local build_number="${3-42}"
+  local include_short_version="${4-1}"
+  local app_path="$TMP_DIR/${name}.app"
+  local plist_path="$app_path/Contents/Info.plist"
+
+  mkdir -p "$app_path/Contents"
+  /usr/libexec/PlistBuddy -c 'Clear dict' "$plist_path" >/dev/null 2>&1 || true
+  /usr/libexec/PlistBuddy -c 'Add :CFBundleIdentifier string com.macparakeet.fixture' "$plist_path"
+  /usr/libexec/PlistBuddy -c "Add :CFBundleVersion string $build_number" "$plist_path"
+  if [[ "$include_short_version" == "1" ]]; then
+    /usr/libexec/PlistBuddy -c "Add :CFBundleShortVersionString string $short_version" "$plist_path"
+  fi
+
+  printf '%s\n' "$app_path"
+}
+
+assert_pass() {
+  local label="$1"
+  local app_path="$2"
+  local output
+
+  if ! output="$("$VERIFY_SCRIPT" "$app_path" 2>&1)"; then
+    printf 'FAIL: %s should pass\n%s\n' "$label" "$output" >&2
+    exit 1
+  fi
+
+  if [[ "$output" != *"Verified release version:"* ]]; then
+    printf 'FAIL: %s did not print success output\n%s\n' "$label" "$output" >&2
+    exit 1
+  fi
+}
+
+assert_fail_contains() {
+  local label="$1"
+  local app_path="$2"
+  local expected="$3"
+  local output
+
+  if output="$("$VERIFY_SCRIPT" "$app_path" 2>&1)"; then
+    printf 'FAIL: %s should fail\n%s\n' "$label" "$output" >&2
+    exit 1
+  fi
+
+  if [[ "$output" != *"$expected"* ]]; then
+    printf 'FAIL: %s expected error containing %q\n%s\n' "$label" "$expected" "$output" >&2
+    exit 1
+  fi
+}
+
+assert_pass "valid semver" "$(make_app valid '1.2.3')"
+assert_pass "valid semver with surrounding whitespace" "$(make_app valid-spaced $' \t1.2.3  ')"
+
+assert_fail_contains "sentinel 0.0.0" "$(make_app zero '0.0.0')" "Refusing to sign dev/sentinel app version"
+assert_fail_contains "dev version" "$(make_app dev 'dev')" "Refusing to sign dev/sentinel app version"
+assert_fail_contains "pdx version" "$(make_app pdx '0.6.0-pdx')" "Refusing to sign dev/sentinel app version"
+assert_fail_contains "missing short version" "$(make_app missing '' '42' '0')" "CFBundleShortVersionString is missing or empty"
+assert_fail_contains "empty short version" "$(make_app empty '')" "CFBundleShortVersionString is missing or empty"
+assert_fail_contains "malformed semver" "$(make_app malformed '1.2')" "CFBundleShortVersionString must be X.Y.Z"
+assert_fail_contains "quoted malformed version" "$(make_app quoted '\"1.2.3')" "CFBundleShortVersionString must be X.Y.Z"
+assert_fail_contains "backslash malformed version" "$(make_app backslash '1.2.\\')" "CFBundleShortVersionString must be X.Y.Z"
+
+echo "verify_release_version fixture tests passed"

--- a/scripts/dist/verify_release_version.sh
+++ b/scripts/dist/verify_release_version.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_PATH="${1:-dist/MacParakeet.app}"
+
+fail() {
+  echo "error: $*" >&2
+  exit 1
+}
+
+if [[ ! -d "$APP_PATH" ]]; then
+  fail "Missing app bundle: $APP_PATH"
+fi
+
+INFO_PLIST="$APP_PATH/Contents/Info.plist"
+if [[ ! -f "$INFO_PLIST" ]]; then
+  fail "Missing Info.plist: $INFO_PLIST"
+fi
+
+short_version="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$INFO_PLIST" 2>/dev/null || true)"
+build_number="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$INFO_PLIST" 2>/dev/null || true)"
+
+normalized="$(printf '%s' "$short_version" | tr '[:upper:]' '[:lower:]' | xargs)"
+if [[ -z "$normalized" ]]; then
+  fail "CFBundleShortVersionString is missing or empty; rebuild with VERSION=X.Y.Z before signing."
+fi
+
+if [[ "$normalized" == "0.0.0" || "$normalized" == "dev" || "$normalized" == *"pdx"* ]]; then
+  fail "Refusing to sign dev/sentinel app version '$short_version'; rebuild with VERSION=X.Y.Z."
+fi
+
+if ! [[ "$normalized" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  fail "CFBundleShortVersionString must be X.Y.Z for release signing; got '$short_version'."
+fi
+
+if [[ -z "$build_number" ]]; then
+  fail "CFBundleVersion is missing or empty; rebuild before signing."
+fi
+
+echo "Verified release version: $short_version ($build_number)"

--- a/scripts/dist/verify_release_version.sh
+++ b/scripts/dist/verify_release_version.sh
@@ -31,7 +31,7 @@ if [[ "$ALLOW_DEV_VERSION_SIGNING" == "1" ]]; then
   exit 0
 fi
 
-normalized="$(printf '%s' "$short_version" | tr '[:upper:]' '[:lower:]' | xargs)"
+normalized="$(printf '%s' "$short_version" | tr '[:upper:]' '[:lower:]' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
 if [[ -z "$normalized" ]]; then
   fail "CFBundleShortVersionString is missing or empty; rebuild with VERSION=X.Y.Z before signing."
 fi

--- a/scripts/dist/verify_release_version.sh
+++ b/scripts/dist/verify_release_version.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 APP_PATH="${1:-dist/MacParakeet.app}"
+ALLOW_DEV_VERSION_SIGNING="${MACPARAKEET_ALLOW_DEV_VERSION_SIGNING:-0}"
 
 fail() {
   echo "error: $*" >&2
@@ -20,6 +21,16 @@ fi
 short_version="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$INFO_PLIST" 2>/dev/null || true)"
 build_number="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$INFO_PLIST" 2>/dev/null || true)"
 
+if [[ -z "$build_number" ]]; then
+  fail "CFBundleVersion is missing or empty; rebuild before signing."
+fi
+
+if [[ "$ALLOW_DEV_VERSION_SIGNING" == "1" ]]; then
+  echo "Warning: MACPARAKEET_ALLOW_DEV_VERSION_SIGNING=1; allowing diagnostic signing for version '$short_version'." >&2
+  echo "Verified diagnostic signing version override: $short_version ($build_number)"
+  exit 0
+fi
+
 normalized="$(printf '%s' "$short_version" | tr '[:upper:]' '[:lower:]' | xargs)"
 if [[ -z "$normalized" ]]; then
   fail "CFBundleShortVersionString is missing or empty; rebuild with VERSION=X.Y.Z before signing."
@@ -31,10 +42,6 @@ fi
 
 if ! [[ "$normalized" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
   fail "CFBundleShortVersionString must be X.Y.Z for release signing; got '$short_version'."
-fi
-
-if [[ -z "$build_number" ]]; then
-  fail "CFBundleVersion is missing or empty; rebuild before signing."
 fi
 
 echo "Verified release version: $short_version ($build_number)"


### PR DESCRIPTION
## Summary
- add a release metadata verifier for app bundles
- call it before signing/notarization so dev/sentinel versions fail before codesign work
- document the early signing failure in the distribution guide

## Verification
- bash -n scripts/dist/verify_release_version.sh scripts/dist/sign_notarize.sh
- fake 0.0.0 app bundle fails through scripts/dist/sign_notarize.sh before signing
- fake 0.6.21 app bundle passes scripts/dist/verify_release_version.sh

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a release version guard for macOS app bundles, verifying Info.plist before codesign/notarization. Dev/sentinel versions fail fast with an explicit override, and docs now include a release demo smoke gate. Addresses Linear DYS-1946.

- New Features
  - Added `scripts/dist/verify_release_version.sh` to enforce `CFBundleShortVersionString` as X.Y.Z (rejects `0.0.0`, `dev`, or `*pdx*`), require `CFBundleVersion`, and trim/normalize the version; added `scripts/dist/test_verify_release_version.sh` to cover edge cases.
  - `scripts/dist/sign_notarize.sh` runs this check first and supports `MACPARAKEET_ALLOW_DEV_VERSION_SIGNING=1` for local diagnostics; docs updated to note refusal/override and the `scripts/dev/release_demo_smoke.sh` smoke gate.

<sup>Written for commit 0fe3b0a4db32294cc5c8ac42cc418360960f933f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/659?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

