### PR TITLE
feat: add library bulk transcript export

### DIFF
--- a/Sources/CLI/Commands/ExportCommand.swift
+++ b/Sources/CLI/Commands/ExportCommand.swift
@@ -91,7 +91,7 @@ struct ExportCommand: AsyncParsableCommand {
             encoder.dateEncodingStrategy = .iso8601
             let data = try encoder.encode(transcription)
             guard let string = String(data: data, encoding: .utf8) else {
-                throw CocoaError(.fileWriteUnknown)
+                throw CocoaError(.fileReadInapplicableStringEncoding)
             }
             return string
         }

--- a/Sources/CLI/Commands/ExportCommand.swift
+++ b/Sources/CLI/Commands/ExportCommand.swift
@@ -90,7 +90,10 @@ struct ExportCommand: AsyncParsableCommand {
             encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
             encoder.dateEncodingStrategy = .iso8601
             let data = try encoder.encode(transcription)
-            return String(data: data, encoding: .utf8) ?? "{}"
+            guard let string = String(data: data, encoding: .utf8) else {
+                throw CocoaError(.fileWriteUnknown)
+            }
+            return string
         }
     }
 

--- a/Sources/CLI/Commands/ExportCommand.swift
+++ b/Sources/CLI/Commands/ExportCommand.swift
@@ -43,16 +43,16 @@ struct ExportCommand: AsyncParsableCommand {
     var database: String?
 
     func run() async throws {
-        try await emitJSONOrRethrow(json: stdout && format == .json) {
+        try emitJSONOrRethrow(json: stdout && format == .json) {
             try AppPaths.ensureDirectories()
             let dbManager = try DatabaseManager(path: resolvedDatabasePath(database))
             let repo = TranscriptionRepository(dbQueue: dbManager.dbQueue)
 
             let transcription = try findTranscription(id: id, repo: repo)
-            let exportService = await ExportService()
+            let exportService = ExportService()
 
             if stdout {
-                let content = await formatContent(transcription: transcription, exportService: exportService)
+                let content = try formatContent(transcription: transcription, exportService: exportService)
                 print(content)
             } else {
                 let outputURL = resolveOutputURL(transcription: transcription)
@@ -60,7 +60,7 @@ struct ExportCommand: AsyncParsableCommand {
                     at: outputURL.deletingLastPathComponent(),
                     withIntermediateDirectories: true
                 )
-                try await writeExport(transcription: transcription, exportService: exportService, url: outputURL)
+                try writeExport(transcription: transcription, exportService: exportService, url: outputURL)
                 print("Exported to \(outputURL.path)")
             }
         }
@@ -75,40 +75,37 @@ struct ExportCommand: AsyncParsableCommand {
         return URL(fileURLWithPath: FileManager.default.currentDirectoryPath).appendingPathComponent(fileName)
     }
 
-    private func formatContent(transcription: Transcription, exportService: ExportService) async -> String {
+    private func formatContent(transcription: Transcription, exportService: ExportService) throws -> String {
         switch format {
         case .txt:
-            return await exportService.formatForClipboard(transcription: transcription)
+            return exportService.formatForClipboard(transcription: transcription)
         case .markdown:
-            return await exportService.formatMarkdown(transcription: transcription)
+            return exportService.formatMarkdown(transcription: transcription)
         case .srt:
-            return await exportService.formatSRT(transcription: transcription)
+            return exportService.formatSRT(transcription: transcription)
         case .vtt:
-            return await exportService.formatVTT(transcription: transcription)
+            return exportService.formatVTT(transcription: transcription)
         case .json:
             let encoder = JSONEncoder()
             encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
             encoder.dateEncodingStrategy = .iso8601
-            if let data = try? encoder.encode(transcription),
-               let str = String(data: data, encoding: .utf8) {
-                return str
-            }
-            return "{}"
+            let data = try encoder.encode(transcription)
+            return String(data: data, encoding: .utf8) ?? "{}"
         }
     }
 
-    private func writeExport(transcription: Transcription, exportService: ExportService, url: URL) async throws {
+    private func writeExport(transcription: Transcription, exportService: ExportService, url: URL) throws {
         switch format {
         case .txt:
-            try await exportService.exportToTxt(transcription: transcription, url: url)
+            try exportService.exportToTxt(transcription: transcription, url: url)
         case .markdown:
-            try await exportService.exportToMarkdown(transcription: transcription, url: url)
+            try exportService.exportToMarkdown(transcription: transcription, url: url)
         case .srt:
-            try await exportService.exportToSRT(transcription: transcription, url: url)
+            try exportService.exportToSRT(transcription: transcription, url: url)
         case .vtt:
-            try await exportService.exportToVTT(transcription: transcription, url: url)
+            try exportService.exportToVTT(transcription: transcription, url: url)
         case .json:
-            try await exportService.exportToJSON(transcription: transcription, url: url)
+            try exportService.exportToJSON(transcription: transcription, url: url)
         }
     }
 }

--- a/Sources/CLI/Commands/MeetingsCommand.swift
+++ b/Sources/CLI/Commands/MeetingsCommand.swift
@@ -939,7 +939,10 @@ private func exportContent(
             transcription,
             promptResultCount: promptResultCount
         ))
-        return String(data: data, encoding: .utf8) ?? "{}"
+        guard let string = String(data: data, encoding: .utf8) else {
+            throw CocoaError(.fileReadInapplicableStringEncoding)
+        }
+        return string
     }
 }
 

--- a/Sources/CLI/Commands/MeetingsCommand.swift
+++ b/Sources/CLI/Commands/MeetingsCommand.swift
@@ -143,10 +143,10 @@ struct MeetingsCommand: AsyncParsableCommand {
         var database: String?
 
         func run() async throws {
-            try await emitJSONOrRethrow(json: format == .json) {
+            try emitJSONOrRethrow(json: format == .json) {
                 let repo = try makeTranscriptionRepository(database: database)
                 let transcription = try findMeeting(idOrName: meeting, repo: repo)
-                let exportService = await ExportService()
+                let exportService = ExportService()
 
                 switch format {
                 case .text:
@@ -154,9 +154,9 @@ struct MeetingsCommand: AsyncParsableCommand {
                 case .json:
                     try printJSON(MeetingTranscriptRecord(transcription))
                 case .srt:
-                    print(await exportService.formatSRT(transcription: transcription))
+                    print(exportService.formatSRT(transcription: transcription))
                 case .vtt:
-                    print(await exportService.formatVTT(transcription: transcription))
+                    print(exportService.formatVTT(transcription: transcription))
                 }
             }
         }

--- a/Sources/MacParakeet/Views/Transcription/BulkTranscriptionSelectionBar.swift
+++ b/Sources/MacParakeet/Views/Transcription/BulkTranscriptionSelectionBar.swift
@@ -7,6 +7,7 @@ struct BulkTranscriptionSelectionBar: View {
     let areAllVisibleSelected: Bool
     let isPerformingOperation: Bool
     var operationLabel = "Deleting..."
+    var isExportDisabled = false
     let onSelectVisible: () -> Void
     let onClear: () -> Void
     let onCancel: () -> Void
@@ -187,7 +188,7 @@ struct BulkTranscriptionSelectionBar: View {
                 title: "Export...",
                 systemImage: "arrow.down.doc",
                 tone: .utility,
-                isDisabled: selectedCount == 0 || isPerformingOperation,
+                isDisabled: isExportDisabled || selectedCount == 0 || isPerformingOperation,
                 action: onExport
             )
         }

--- a/Sources/MacParakeet/Views/Transcription/BulkTranscriptionSelectionBar.swift
+++ b/Sources/MacParakeet/Views/Transcription/BulkTranscriptionSelectionBar.swift
@@ -269,7 +269,6 @@ private struct SelectionBarActionButton: View {
     let action: () -> Void
 
     @State private var isHovered = false
-    @State private var didPushCursor = false
 
     var body: some View {
         Group {
@@ -309,37 +308,14 @@ private struct SelectionBarActionButton: View {
         .opacity(isDisabled ? 0.48 : 1)
         .onHover { hovering in
             isHovered = hovering && !isDisabled
-            updateCursor(isHovering: hovering)
         }
         .onChange(of: isDisabled) { _, _ in
             if isDisabled {
                 isHovered = false
             }
-            updateCursor(isHovering: isHovered)
         }
-        .onDisappear {
-            releaseCursorIfNeeded()
-        }
+        .pointingHandCursor(isActive: isHovered && !isDisabled)
         .animation(DesignSystem.Animation.hoverTransition, value: isHovered)
         .animation(DesignSystem.Animation.hoverTransition, value: isDisabled)
-    }
-
-    private func updateCursor(isHovering: Bool) {
-        let shouldShowPointer = isHovering && !isDisabled
-        if shouldShowPointer, !didPushCursor {
-            NSCursor.pointingHand.push()
-            didPushCursor = true
-            return
-        }
-        if !shouldShowPointer, didPushCursor {
-            releaseCursorIfNeeded()
-        }
-    }
-
-    private func releaseCursorIfNeeded() {
-        if didPushCursor {
-            NSCursor.pop()
-            didPushCursor = false
-        }
     }
 }

--- a/Sources/MacParakeet/Views/Transcription/BulkTranscriptionSelectionBar.swift
+++ b/Sources/MacParakeet/Views/Transcription/BulkTranscriptionSelectionBar.swift
@@ -6,9 +6,11 @@ struct BulkTranscriptionSelectionBar: View {
     let isMeetingContext: Bool
     let areAllVisibleSelected: Bool
     let isPerformingOperation: Bool
+    var operationLabel = "Deleting..."
     let onSelectVisible: () -> Void
     let onClear: () -> Void
     let onCancel: () -> Void
+    var onExport: (() -> Void)?
     let onDeleteAudioOnly: () -> Void
     let onDeleteItems: () -> Void
 
@@ -45,7 +47,7 @@ struct BulkTranscriptionSelectionBar: View {
                 .opacity(0.55)
         }
         .accessibilityElement(children: .contain)
-        .accessibilityLabel(isPerformingOperation ? "Deleting selected items" : "\(selectedCount) selected")
+        .accessibilityLabel(isPerformingOperation ? operationLabel : "\(selectedCount) selected")
         // Resolve the bar's internal layout as one unit so the enclosing
         // selection-mode animation moves it as a cohesive block. Without this,
         // the container animation interpolates the inner `Spacer` from
@@ -84,7 +86,7 @@ struct BulkTranscriptionSelectionBar: View {
                     .foregroundStyle(DesignSystem.Colors.accent)
             }
 
-            Text(isPerformingOperation ? "Deleting..." : "\(selectedCount) selected")
+            Text(isPerformingOperation ? operationLabel : "\(selectedCount) selected")
                 .font(DesignSystem.Typography.bodySmall.weight(.semibold))
                 .foregroundStyle(DesignSystem.Colors.textPrimary)
         }
@@ -116,6 +118,7 @@ struct BulkTranscriptionSelectionBar: View {
             cancelAction
             selectVisibleAction
             clearAction
+            exportAction
         }
     }
 
@@ -133,6 +136,7 @@ struct BulkTranscriptionSelectionBar: View {
             cancelAction
             selectVisibleAction
             clearAction
+            exportAction
             if showsAudioAction {
                 deleteAudioAction
             }
@@ -174,6 +178,19 @@ struct BulkTranscriptionSelectionBar: View {
             isDisabled: selectedCount == 0 || isPerformingOperation,
             action: onClear
         )
+    }
+
+    @ViewBuilder
+    private var exportAction: some View {
+        if let onExport {
+            SelectionBarActionButton(
+                title: "Export...",
+                systemImage: "arrow.down.doc",
+                tone: .utility,
+                isDisabled: selectedCount == 0 || isPerformingOperation,
+                action: onExport
+            )
+        }
     }
 
     private var deleteAudioAction: some View {

--- a/Sources/MacParakeet/Views/Transcription/BulkTranscriptionSelectionBar.swift
+++ b/Sources/MacParakeet/Views/Transcription/BulkTranscriptionSelectionBar.swift
@@ -188,7 +188,7 @@ struct BulkTranscriptionSelectionBar: View {
                 title: "Export...",
                 systemImage: "arrow.down.doc",
                 tone: .utility,
-                isDisabled: isExportDisabled || selectedCount == 0 || isPerformingOperation,
+                isDisabled: isExportDisabled,
                 action: onExport
             )
         }

--- a/Sources/MacParakeet/Views/Transcription/PointingHandCursorModifier.swift
+++ b/Sources/MacParakeet/Views/Transcription/PointingHandCursorModifier.swift
@@ -14,6 +14,9 @@ private struct PointingHandCursorModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         content
+            .onAppear {
+                updateCursor(isActive: isActive)
+            }
             .onChange(of: isActive) { _, isActive in
                 updateCursor(isActive: isActive)
             }

--- a/Sources/MacParakeet/Views/Transcription/PointingHandCursorModifier.swift
+++ b/Sources/MacParakeet/Views/Transcription/PointingHandCursorModifier.swift
@@ -1,0 +1,43 @@
+import AppKit
+import SwiftUI
+
+extension View {
+    func pointingHandCursor(isActive: Bool) -> some View {
+        modifier(PointingHandCursorModifier(isActive: isActive))
+    }
+}
+
+private struct PointingHandCursorModifier: ViewModifier {
+    let isActive: Bool
+
+    @State private var didPushCursor = false
+
+    func body(content: Content) -> some View {
+        content
+            .onChange(of: isActive) { _, isActive in
+                updateCursor(isActive: isActive)
+            }
+            .onDisappear {
+                releaseCursorIfNeeded()
+            }
+    }
+
+    private func updateCursor(isActive: Bool) {
+        if isActive, !didPushCursor {
+            NSCursor.pointingHand.push()
+            didPushCursor = true
+            return
+        }
+
+        if !isActive {
+            releaseCursorIfNeeded()
+        }
+    }
+
+    private func releaseCursorIfNeeded() {
+        if didPushCursor {
+            NSCursor.pop()
+            didPushCursor = false
+        }
+    }
+}

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultActions.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultActions.swift
@@ -100,11 +100,12 @@ enum TranscriptResultActions {
             Telemetry.send(.exportUsed(format: format.rawValue))
             return fileURL
         } catch {
-            Telemetry.send(.exportFailed(
-                format: format.rawValue,
-                errorType: TelemetryErrorClassifier.classify(error),
-                errorDetail: TelemetryErrorClassifier.errorDetail(error)
-            ))
+            Telemetry.send(
+                .exportFailed(
+                    format: format.rawValue,
+                    errorType: TelemetryErrorClassifier.classify(error),
+                    errorDetail: TelemetryErrorClassifier.errorDetail(error)
+                ))
             throw error
         }
     }
@@ -123,11 +124,12 @@ enum TranscriptResultActions {
             Telemetry.send(.exportUsed(format: format.rawValue))
             return fileURL
         } catch {
-            Telemetry.send(.exportFailed(
-                format: format.rawValue,
-                errorType: TelemetryErrorClassifier.classify(error),
-                errorDetail: TelemetryErrorClassifier.errorDetail(error)
-            ))
+            Telemetry.send(
+                .exportFailed(
+                    format: format.rawValue,
+                    errorType: TelemetryErrorClassifier.classify(error),
+                    errorDetail: TelemetryErrorClassifier.errorDetail(error)
+                ))
             throw error
         }
     }
@@ -151,11 +153,11 @@ enum TranscriptResultActions {
         let directoryExisted = FileManager.default.fileExists(atPath: directory.path)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
 
-        var exportedURLs: [URL] = []
+        var exportedFiles: [CreatedExportFile] = []
         var failedCount = 0
         var firstErrorDescription: String?
         defer {
-            if exportedURLs.isEmpty, !directoryExisted {
+            if exportedFiles.isEmpty, !directoryExisted {
                 removeEmptyDirectoryIfPresent(at: directory)
             }
         }
@@ -182,7 +184,7 @@ enum TranscriptResultActions {
                         to: fileURL,
                         using: exportService
                     )
-                    exportedURLs.append(fileURL)
+                    exportedFiles.append(CreatedExportFile(url: fileURL))
                     if let onFileExported {
                         await onFileExported(fileURL)
                     }
@@ -198,22 +200,24 @@ enum TranscriptResultActions {
                 }
             }
         } catch is CancellationError {
-            removeFilesIfPresent(exportedURLs)
+            removeCreatedFilesIfPresent(exportedFiles)
             if !directoryExisted {
                 removeEmptyDirectoryIfPresent(at: directory)
             }
             throw CancellationError()
         }
 
+        let exportedURLs = exportedFiles.map(\.url)
         if !exportedURLs.isEmpty {
             Telemetry.send(.exportUsed(format: format.rawValue))
         }
         if failedCount > 0 {
-            Telemetry.send(.exportFailed(
-                format: format.rawValue,
-                errorType: exportedURLs.isEmpty ? "bulk_total_failure" : "bulk_partial_failure",
-                errorDetail: firstErrorDescription
-            ))
+            Telemetry.send(
+                .exportFailed(
+                    format: format.rawValue,
+                    errorType: exportedURLs.isEmpty ? "bulk_total_failure" : "bulk_partial_failure",
+                    errorDetail: firstErrorDescription
+                ))
         }
 
         return BulkTranscriptExportResult(
@@ -334,9 +338,48 @@ enum TranscriptResultActions {
         try? FileManager.default.removeItem(at: directory)
     }
 
-    nonisolated private static func removeFilesIfPresent(_ urls: [URL]) {
-        for url in urls {
-            try? FileManager.default.removeItem(at: url)
+    private struct CreatedExportFile: Sendable {
+        let url: URL
+        let cleanupIdentity: ExportedFileCleanupIdentity?
+
+        init(url: URL) {
+            self.url = url
+            cleanupIdentity = Self.identity(for: url)
+        }
+
+        func isStillSameFile() -> Bool {
+            guard let cleanupIdentity else { return false }
+            return Self.identity(for: url) == cleanupIdentity
+        }
+
+        private static func identity(for url: URL) -> ExportedFileCleanupIdentity? {
+            guard let attributes = try? FileManager.default.attributesOfItem(atPath: url.path) else {
+                return nil
+            }
+            let identity = ExportedFileCleanupIdentity(
+                systemNumber: (attributes[.systemNumber] as? NSNumber)?.uint64Value,
+                fileNumber: (attributes[.systemFileNumber] as? NSNumber)?.uint64Value,
+                size: (attributes[.size] as? NSNumber)?.uint64Value,
+                modificationTime: (attributes[.modificationDate] as? Date)?.timeIntervalSinceReferenceDate
+            )
+            return identity.hasAnyValue ? identity : nil
+        }
+    }
+
+    private struct ExportedFileCleanupIdentity: Equatable, Sendable {
+        let systemNumber: UInt64?
+        let fileNumber: UInt64?
+        let size: UInt64?
+        let modificationTime: TimeInterval?
+
+        var hasAnyValue: Bool {
+            systemNumber != nil || fileNumber != nil || size != nil || modificationTime != nil
+        }
+    }
+
+    nonisolated private static func removeCreatedFilesIfPresent(_ files: [CreatedExportFile]) {
+        for file in files where file.isStillSameFile() {
+            try? FileManager.default.removeItem(at: file.url)
         }
     }
 

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultActions.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultActions.swift
@@ -138,6 +138,8 @@ enum TranscriptResultActions {
         options: TranscriptExportOptions = .default,
         directory: URL
     ) async throws -> BulkTranscriptExportResult {
+        try Task.checkCancellation()
+
         let accessedSecurityScope = directory.startAccessingSecurityScopedResource()
         defer {
             if accessedSecurityScope {

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultActions.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultActions.swift
@@ -2,7 +2,7 @@ import AppKit
 import Foundation
 import MacParakeetCore
 
-enum TranscriptExportFormat: String, CaseIterable, Identifiable {
+enum TranscriptExportFormat: String, CaseIterable, Identifiable, Sendable {
     case txt, md, srt, vtt, docx, pdf, json
 
     var id: String { rawValue }
@@ -45,6 +45,24 @@ enum TranscriptExportFormat: String, CaseIterable, Identifiable {
 
     var supportsTranscriptOptions: Bool {
         self == .txt || self == .md
+    }
+}
+
+struct BulkTranscriptExportResult: Identifiable, Sendable {
+    let id = UUID()
+    let directory: URL
+    let format: TranscriptExportFormat
+    let requestedCount: Int
+    let exportedURLs: [URL]
+    let failedCount: Int
+    let firstErrorDescription: String?
+
+    var exportedCount: Int {
+        exportedURLs.count
+    }
+
+    var isCompleteSuccess: Bool {
+        requestedCount > 0 && failedCount == 0
     }
 }
 
@@ -96,17 +114,7 @@ enum TranscriptResultActions {
             let stem = TranscriptSegmenter.sanitizedExportStem(from: transcription.fileName)
             let downloadsURL = try downloadsDirectory()
             let fileURL = nextAvailableURL(in: downloadsURL, stem: stem, format: format)
-            let exportService = ExportService()
-
-            switch format {
-            case .txt: try exportService.exportToTxt(transcription: transcription, url: fileURL, options: options)
-            case .md: try exportService.exportToMarkdown(transcription: transcription, url: fileURL, options: options)
-            case .srt: try exportService.exportToSRT(transcription: transcription, url: fileURL)
-            case .vtt: try exportService.exportToVTT(transcription: transcription, url: fileURL)
-            case .docx: try exportService.exportToDocx(transcription: transcription, url: fileURL)
-            case .pdf: try exportService.exportToPDF(transcription: transcription, url: fileURL)
-            case .json: try exportService.exportToJSON(transcription: transcription, url: fileURL)
-            }
+            try exportTranscript(transcription: transcription, format: format, options: options, to: fileURL)
 
             Telemetry.send(.exportUsed(format: format.rawValue))
             return fileURL
@@ -120,6 +128,71 @@ enum TranscriptResultActions {
         }
     }
 
+    nonisolated static func exportTranscriptsToDirectory(
+        transcriptions: [Transcription],
+        format: TranscriptExportFormat,
+        options: TranscriptExportOptions = .default,
+        directory: URL
+    ) async throws -> BulkTranscriptExportResult {
+        let directoryExisted = FileManager.default.fileExists(atPath: directory.path)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        var exportedURLs: [URL] = []
+        var failedCount = 0
+        var firstErrorDescription: String?
+        defer {
+            if exportedURLs.isEmpty, !directoryExisted {
+                removeEmptyDirectoryIfPresent(at: directory)
+            }
+        }
+
+        for transcription in transcriptions {
+            try Task.checkCancellation()
+            let stem = TranscriptSegmenter.sanitizedExportStem(from: transcription.fileName)
+            let fileURL = nextAvailableURL(in: directory, stem: stem, format: format)
+            let resolvedOptions = resolvedOptions(
+                for: transcription,
+                format: format,
+                preferredOptions: options
+            )
+
+            do {
+                try await exportTranscriptForBulk(
+                    transcription: transcription,
+                    format: format,
+                    options: resolvedOptions,
+                    to: fileURL
+                )
+                exportedURLs.append(fileURL)
+            } catch {
+                failedCount += 1
+                if firstErrorDescription == nil {
+                    firstErrorDescription = error.localizedDescription
+                }
+            }
+        }
+
+        if !exportedURLs.isEmpty {
+            Telemetry.send(.exportUsed(format: format.rawValue))
+        }
+        if failedCount > 0 {
+            Telemetry.send(.exportFailed(
+                format: format.rawValue,
+                errorType: exportedURLs.isEmpty ? "bulk_total_failure" : "bulk_partial_failure",
+                errorDetail: firstErrorDescription
+            ))
+        }
+
+        return BulkTranscriptExportResult(
+            directory: directory,
+            format: format,
+            requestedCount: transcriptions.count,
+            exportedURLs: exportedURLs,
+            failedCount: failedCount,
+            firstErrorDescription: firstErrorDescription
+        )
+    }
+
     private static func downloadsDirectory() throws -> URL {
         guard let url = FileManager.default.urls(for: .downloadsDirectory, in: .userDomainMask).first else {
             throw CocoaError(.fileNoSuchFile)
@@ -127,7 +200,79 @@ enum TranscriptResultActions {
         return url
     }
 
-    private static func nextAvailableURL(
+    private static func exportTranscript(
+        transcription: Transcription,
+        format: TranscriptExportFormat,
+        options: TranscriptExportOptions,
+        to fileURL: URL
+    ) throws {
+        let exportService = ExportService()
+
+        switch format {
+        case .txt: try exportService.exportToTxt(transcription: transcription, url: fileURL, options: options)
+        case .md: try exportService.exportToMarkdown(transcription: transcription, url: fileURL, options: options)
+        case .srt: try exportService.exportToSRT(transcription: transcription, url: fileURL)
+        case .vtt: try exportService.exportToVTT(transcription: transcription, url: fileURL)
+        case .docx: try exportService.exportToDocx(transcription: transcription, url: fileURL)
+        case .pdf: try exportService.exportToPDF(transcription: transcription, url: fileURL)
+        case .json: try exportService.exportToJSON(transcription: transcription, url: fileURL)
+        }
+    }
+
+    nonisolated private static func exportTranscriptForBulk(
+        transcription: Transcription,
+        format: TranscriptExportFormat,
+        options: TranscriptExportOptions,
+        to fileURL: URL
+    ) async throws {
+        let exportService = ExportService()
+
+        switch format {
+        case .txt: try exportService.exportToTxt(transcription: transcription, url: fileURL, options: options)
+        case .md: try exportService.exportToMarkdown(transcription: transcription, url: fileURL, options: options)
+        case .srt: try exportService.exportToSRT(transcription: transcription, url: fileURL)
+        case .vtt: try exportService.exportToVTT(transcription: transcription, url: fileURL)
+        case .json: try exportService.exportToJSON(transcription: transcription, url: fileURL)
+        case .docx:
+            try await MainActor.run {
+                try exportService.exportToDocx(transcription: transcription, url: fileURL)
+            }
+        case .pdf:
+            try await MainActor.run {
+                try exportService.exportToPDF(transcription: transcription, url: fileURL)
+            }
+        }
+    }
+
+    nonisolated private static func removeEmptyDirectoryIfPresent(at directory: URL) {
+        guard
+            let contents = try? FileManager.default.contentsOfDirectory(
+                at: directory,
+                includingPropertiesForKeys: nil
+            ),
+            contents.isEmpty
+        else {
+            return
+        }
+
+        try? FileManager.default.removeItem(at: directory)
+    }
+
+    nonisolated private static func resolvedOptions(
+        for transcription: Transcription,
+        format: TranscriptExportFormat,
+        preferredOptions: TranscriptExportOptions
+    ) -> TranscriptExportOptions {
+        guard format.supportsTranscriptOptions else { return .default }
+        let hasAlignedTimestamps = transcription.hasWordTimestamps && !transcription.isTranscriptEdited
+        let hasSpeakerLabels = transcription.hasSpeakerLabeledWords && !transcription.isTranscriptEdited
+        return preferredOptions.resolved(
+            canIncludeTimestamps: hasAlignedTimestamps,
+            canIncludeSpeakerLabels: hasSpeakerLabels
+        )
+    }
+
+    nonisolated private static func nextAvailableURL(
         in directory: URL,
         stem: String,
         format: TranscriptExportFormat

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultActions.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultActions.swift
@@ -193,8 +193,6 @@ enum TranscriptResultActions {
                     }
                 }
             }
-
-            try Task.checkCancellation()
         } catch is CancellationError {
             removeFilesIfPresent(exportedURLs)
             if !directoryExisted {

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultActions.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultActions.swift
@@ -159,41 +159,49 @@ enum TranscriptResultActions {
             }
         }
 
-        let exportService = ExportService()
-        for transcription in transcriptions {
-            try Task.checkCancellation()
-            await Task.yield()
+        do {
+            let exportService = ExportService()
+            for transcription in transcriptions {
+                try Task.checkCancellation()
+                await Task.yield()
 
-            let stem = TranscriptSegmenter.sanitizedExportStem(from: transcription.fileName)
-            let fileURL = nextAvailableURL(in: directory, stem: stem, format: format)
-            let resolvedOptions = resolvedOptions(
-                for: transcription,
-                format: format,
-                preferredOptions: options
-            )
-
-            do {
-                try await exportTranscriptForBulk(
-                    transcription: transcription,
+                let stem = TranscriptSegmenter.sanitizedExportStem(from: transcription.fileName)
+                let fileURL = nextAvailableURL(in: directory, stem: stem, format: format)
+                let resolvedOptions = resolvedOptions(
+                    for: transcription,
                     format: format,
-                    options: resolvedOptions,
-                    to: fileURL,
-                    using: exportService
+                    preferredOptions: options
                 )
-                exportedURLs.append(fileURL)
-            } catch is CancellationError {
-                // Cancellation is not a per-item file failure — let it
-                // propagate out of the batch so the caller can stop cleanly.
-                throw CancellationError()
-            } catch {
-                failedCount += 1
-                if firstErrorDescription == nil {
-                    firstErrorDescription = error.localizedDescription
+
+                do {
+                    try await exportTranscriptForBulk(
+                        transcription: transcription,
+                        format: format,
+                        options: resolvedOptions,
+                        to: fileURL,
+                        using: exportService
+                    )
+                    exportedURLs.append(fileURL)
+                } catch is CancellationError {
+                    // Cancellation is not a per-item file failure — let it
+                    // propagate out of the batch so the caller can stop cleanly.
+                    throw CancellationError()
+                } catch {
+                    failedCount += 1
+                    if firstErrorDescription == nil {
+                        firstErrorDescription = error.localizedDescription
+                    }
                 }
             }
-        }
 
-        try Task.checkCancellation()
+            try Task.checkCancellation()
+        } catch is CancellationError {
+            removeFilesIfPresent(exportedURLs)
+            if !directoryExisted {
+                removeEmptyDirectoryIfPresent(at: directory)
+            }
+            throw CancellationError()
+        }
 
         if !exportedURLs.isEmpty {
             Telemetry.send(.exportUsed(format: format.rawValue))
@@ -322,6 +330,12 @@ enum TranscriptResultActions {
         }
 
         try? FileManager.default.removeItem(at: directory)
+    }
+
+    nonisolated private static func removeFilesIfPresent(_ urls: [URL]) {
+        for url in urls {
+            try? FileManager.default.removeItem(at: url)
+        }
     }
 
     nonisolated private static func resolvedOptions(

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultActions.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultActions.swift
@@ -254,6 +254,8 @@ enum TranscriptResultActions {
             return
         }
 
+        // PDF/DOCX rendering uses AppKit. Hop per file instead of wrapping the
+        // whole batch so cancellation and UI work can interleave between files.
         try await MainActor.run {
             try exportTranscriptOnMainActor(
                 transcription: transcription,
@@ -300,10 +302,8 @@ enum TranscriptResultActions {
         case .vtt: try exportService.exportToVTT(transcription: transcription, url: fileURL)
         case .json: try exportService.exportToJSON(transcription: transcription, url: fileURL)
         case .docx, .pdf:
-            throw NSError(
-                domain: "MacParakeetError",
-                code: 1,
-                userInfo: [NSLocalizedDescriptionKey: "\(format.shortName) export must run on the main actor."]
+            preconditionFailure(
+                "\(format.shortName) export must run on the main actor; this path should never be reached."
             )
         }
     }

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultActions.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultActions.swift
@@ -134,6 +134,13 @@ enum TranscriptResultActions {
         options: TranscriptExportOptions = .default,
         directory: URL
     ) async throws -> BulkTranscriptExportResult {
+        let accessedSecurityScope = directory.startAccessingSecurityScopedResource()
+        defer {
+            if accessedSecurityScope {
+                directory.stopAccessingSecurityScopedResource()
+            }
+        }
+
         let directoryExisted = FileManager.default.fileExists(atPath: directory.path)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
 
@@ -177,6 +184,8 @@ enum TranscriptResultActions {
                 }
             }
         }
+
+        try Task.checkCancellation()
 
         if !exportedURLs.isEmpty {
             Telemetry.send(.exportUsed(format: format.rawValue))

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultActions.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultActions.swift
@@ -185,7 +185,6 @@ enum TranscriptResultActions {
                     exportedURLs.append(fileURL)
                     if let onFileExported {
                         await onFileExported(fileURL)
-                        try Task.checkCancellation()
                     }
                 } catch is CancellationError {
                     // Cancellation is not a per-item file failure — let it

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultActions.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultActions.swift
@@ -136,7 +136,8 @@ enum TranscriptResultActions {
         transcriptions: [Transcription],
         format: TranscriptExportFormat,
         options: TranscriptExportOptions = .default,
-        directory: URL
+        directory: URL,
+        onFileExported: (@Sendable (URL) async -> Void)? = nil
     ) async throws -> BulkTranscriptExportResult {
         try Task.checkCancellation()
 
@@ -182,6 +183,10 @@ enum TranscriptResultActions {
                         using: exportService
                     )
                     exportedURLs.append(fileURL)
+                    if let onFileExported {
+                        await onFileExported(fileURL)
+                        try Task.checkCancellation()
+                    }
                 } catch is CancellationError {
                     // Cancellation is not a per-item file failure — let it
                     // propagate out of the batch so the caller can stop cleanly.

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultActions.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultActions.swift
@@ -46,6 +46,10 @@ enum TranscriptExportFormat: String, CaseIterable, Identifiable, Sendable {
     var supportsTranscriptOptions: Bool {
         self == .txt || self == .md
     }
+
+    var usesAppKitRenderer: Bool {
+        self == .docx || self == .pdf
+    }
 }
 
 struct BulkTranscriptExportResult: Identifiable, Sendable {
@@ -221,17 +225,13 @@ enum TranscriptResultActions {
         options: TranscriptExportOptions,
         to fileURL: URL
     ) throws {
-        let exportService = ExportService()
-
-        switch format {
-        case .txt: try exportService.exportToTxt(transcription: transcription, url: fileURL, options: options)
-        case .md: try exportService.exportToMarkdown(transcription: transcription, url: fileURL, options: options)
-        case .srt: try exportService.exportToSRT(transcription: transcription, url: fileURL)
-        case .vtt: try exportService.exportToVTT(transcription: transcription, url: fileURL)
-        case .docx: try exportService.exportToDocx(transcription: transcription, url: fileURL)
-        case .pdf: try exportService.exportToPDF(transcription: transcription, url: fileURL)
-        case .json: try exportService.exportToJSON(transcription: transcription, url: fileURL)
-        }
+        try exportTranscriptOnMainActor(
+            transcription: transcription,
+            format: format,
+            options: options,
+            to: fileURL,
+            using: ExportService()
+        )
     }
 
     nonisolated private static func exportTranscriptForBulk(
@@ -241,20 +241,68 @@ enum TranscriptResultActions {
         to fileURL: URL,
         using exportService: ExportService
     ) async throws {
+        guard format.usesAppKitRenderer else {
+            try exportNonAppKitTranscript(
+                transcription: transcription,
+                format: format,
+                options: options,
+                to: fileURL,
+                using: exportService
+            )
+            return
+        }
+
+        try await MainActor.run {
+            try exportTranscriptOnMainActor(
+                transcription: transcription,
+                format: format,
+                options: options,
+                to: fileURL,
+                using: exportService
+            )
+        }
+    }
+
+    @MainActor private static func exportTranscriptOnMainActor(
+        transcription: Transcription,
+        format: TranscriptExportFormat,
+        options: TranscriptExportOptions,
+        to fileURL: URL,
+        using exportService: ExportService
+    ) throws {
+        switch format {
+        case .docx: try exportService.exportToDocx(transcription: transcription, url: fileURL)
+        case .pdf: try exportService.exportToPDF(transcription: transcription, url: fileURL)
+        default:
+            try exportNonAppKitTranscript(
+                transcription: transcription,
+                format: format,
+                options: options,
+                to: fileURL,
+                using: exportService
+            )
+        }
+    }
+
+    nonisolated private static func exportNonAppKitTranscript(
+        transcription: Transcription,
+        format: TranscriptExportFormat,
+        options: TranscriptExportOptions,
+        to fileURL: URL,
+        using exportService: ExportService
+    ) throws {
         switch format {
         case .txt: try exportService.exportToTxt(transcription: transcription, url: fileURL, options: options)
         case .md: try exportService.exportToMarkdown(transcription: transcription, url: fileURL, options: options)
         case .srt: try exportService.exportToSRT(transcription: transcription, url: fileURL)
         case .vtt: try exportService.exportToVTT(transcription: transcription, url: fileURL)
         case .json: try exportService.exportToJSON(transcription: transcription, url: fileURL)
-        case .docx:
-            try await MainActor.run {
-                try exportService.exportToDocx(transcription: transcription, url: fileURL)
-            }
-        case .pdf:
-            try await MainActor.run {
-                try exportService.exportToPDF(transcription: transcription, url: fileURL)
-            }
+        case .docx, .pdf:
+            throw NSError(
+                domain: "MacParakeetError",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "\(format.shortName) export must run on the main actor."]
+            )
         }
     }
 

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultActions.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultActions.swift
@@ -66,7 +66,7 @@ struct BulkTranscriptExportResult: Identifiable, Sendable {
     }
 
     var isCompleteSuccess: Bool {
-        requestedCount > 0 && failedCount == 0
+        requestedCount > 0 && failedCount == 0 && exportedCount == requestedCount
     }
 }
 

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultActions.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultActions.swift
@@ -162,6 +162,8 @@ enum TranscriptResultActions {
         let exportService = ExportService()
         for transcription in transcriptions {
             try Task.checkCancellation()
+            await Task.yield()
+
             let stem = TranscriptSegmenter.sanitizedExportStem(from: transcription.fileName)
             let fileURL = nextAvailableURL(in: directory, stem: stem, format: format)
             let resolvedOptions = resolvedOptions(

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultActions.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultActions.swift
@@ -146,6 +146,7 @@ enum TranscriptResultActions {
             }
         }
 
+        let exportService = ExportService()
         for transcription in transcriptions {
             try Task.checkCancellation()
             let stem = TranscriptSegmenter.sanitizedExportStem(from: transcription.fileName)
@@ -161,9 +162,14 @@ enum TranscriptResultActions {
                     transcription: transcription,
                     format: format,
                     options: resolvedOptions,
-                    to: fileURL
+                    to: fileURL,
+                    using: exportService
                 )
                 exportedURLs.append(fileURL)
+            } catch is CancellationError {
+                // Cancellation is not a per-item file failure — let it
+                // propagate out of the batch so the caller can stop cleanly.
+                throw CancellationError()
             } catch {
                 failedCount += 1
                 if firstErrorDescription == nil {
@@ -223,10 +229,9 @@ enum TranscriptResultActions {
         transcription: Transcription,
         format: TranscriptExportFormat,
         options: TranscriptExportOptions,
-        to fileURL: URL
+        to fileURL: URL,
+        using exportService: ExportService
     ) async throws {
-        let exportService = ExportService()
-
         switch format {
         case .txt: try exportService.exportToTxt(transcription: transcription, url: fileURL, options: options)
         case .md: try exportService.exportToMarkdown(transcription: transcription, url: fileURL, options: options)

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
@@ -922,6 +922,7 @@ private struct LibraryFilterChip: View {
     let onTap: () -> Void
 
     @State private var isHovered = false
+    @State private var didPushCursor = false
 
     private var foreground: Color {
         if isSelected { return DesignSystem.Colors.accent }
@@ -949,7 +950,28 @@ private struct LibraryFilterChip: View {
         .buttonStyle(.plain)
         .onHover { hovering in
             isHovered = hovering
-            if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+            updateCursor(isHovering: hovering)
+        }
+        .onDisappear {
+            releaseCursorIfNeeded()
+        }
+    }
+
+    private func updateCursor(isHovering: Bool) {
+        if isHovering, !didPushCursor {
+            NSCursor.pointingHand.push()
+            didPushCursor = true
+            return
+        }
+        if !isHovering {
+            releaseCursorIfNeeded()
+        }
+    }
+
+    private func releaseCursorIfNeeded() {
+        if didPushCursor {
+            NSCursor.pop()
+            didPushCursor = false
         }
     }
 }

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
@@ -572,7 +572,11 @@ struct TranscriptionLibraryView: View {
                 }
                 .parakeetAction(.primaryProminent)
                 .keyboardShortcut(.defaultAction)
-                .disabled(viewModel.selectedTranscriptionCount == 0 || bulkExportInProgress)
+                .disabled(
+                    viewModel.selectedTranscriptionCount == 0 ||
+                        bulkExportInProgress ||
+                        viewModel.isBulkOperationInProgress
+                )
             }
         }
         .padding(DesignSystem.Spacing.md)

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
@@ -399,7 +399,7 @@ struct TranscriptionLibraryView: View {
 
     private var selectionActionsBar: some View {
         BulkTranscriptionSelectionBar(
-            selectedCount: viewModel.selectedTranscriptionCount,
+            selectedCount: selectedBulkExportTargets.count,
             selectedMeetingAudioCount: viewModel.selectedMeetingAudioCount,
             isMeetingContext: isMeetingListMode,
             areAllVisibleSelected: viewModel.areAllLoadedVisibleTranscriptionsSelected,

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
@@ -640,8 +640,7 @@ struct TranscriptionLibraryView: View {
         if result.exportedCount > 0 {
             return "Exported \(result.exportedCount) of \(result.requestedCount)"
         }
-        assertionFailure("Bulk export result popover should only be shown after at least one file exports")
-        return "Exported 0 of \(result.requestedCount)"
+        preconditionFailure("Bulk export result popover should only be shown after at least one file exports")
     }
 
     private func runBulkExport() {

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
@@ -473,6 +473,12 @@ struct TranscriptionLibraryView: View {
         )
     }
 
+    private var isBulkExportActionDisabled: Bool {
+        viewModel.selectedTranscriptionCount == 0 ||
+            bulkExportInProgress ||
+            viewModel.isBulkOperationInProgress
+    }
+
     private var bulkExportOptionsPopover: some View {
         VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
             HStack(spacing: DesignSystem.Spacing.sm) {
@@ -572,11 +578,7 @@ struct TranscriptionLibraryView: View {
                 }
                 .parakeetAction(.primaryProminent)
                 .keyboardShortcut(.defaultAction)
-                .disabled(
-                    viewModel.selectedTranscriptionCount == 0 ||
-                        bulkExportInProgress ||
-                        viewModel.isBulkOperationInProgress
-                )
+                .disabled(isBulkExportActionDisabled)
             }
         }
         .padding(DesignSystem.Spacing.md)
@@ -646,7 +648,7 @@ struct TranscriptionLibraryView: View {
     private func runBulkExport() {
         let targets = viewModel.selectedLoadedTranscriptionsForExport
         guard !targets.isEmpty else { return }
-        guard !viewModel.isBulkOperationInProgress, !bulkExportInProgress else { return }
+        guard !isBulkExportActionDisabled else { return }
 
         cancelBulkExport()
         let outcome = runBulkExportFolderPanel()
@@ -663,11 +665,7 @@ struct TranscriptionLibraryView: View {
 
         bulkExportCoordinatorTask = Task { @MainActor in
             defer {
-                if bulkExportRunID == runID {
-                    bulkExportInProgress = false
-                    bulkExportCoordinatorTask = nil
-                    bulkExportWorkerTask = nil
-                }
+                finishBulkExportRun(runID)
             }
 
             do {
@@ -707,6 +705,14 @@ struct TranscriptionLibraryView: View {
                 SoundManager.shared.play(.errorSoft)
             }
         }
+    }
+
+    @MainActor
+    private func finishBulkExportRun(_ runID: UUID) {
+        guard bulkExportRunID == runID else { return }
+        bulkExportInProgress = false
+        bulkExportCoordinatorTask = nil
+        bulkExportWorkerTask = nil
     }
 
     @MainActor

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
@@ -867,7 +867,11 @@ struct TranscriptionLibraryView: View {
     }
 
     private func handleSelectionKeyPress(_ press: KeyPress) -> KeyPress.Result {
-        guard viewModel.isBulkSelectionModeEnabled, !viewModel.isBulkOperationInProgress else { return .ignored }
+        guard
+            viewModel.isBulkSelectionModeEnabled,
+            !viewModel.isBulkOperationInProgress,
+            !bulkExportInProgress
+        else { return .ignored }
         if press.key == .delete || press.key == .deleteForward {
             guard viewModel.hasSelectedTranscriptions else { return .ignored }
             viewModel.requestDeleteSelectedItems()

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
@@ -20,7 +20,6 @@ struct TranscriptionLibraryView: View {
     @State private var selectedBulkExportFormat: TranscriptExportFormat = .txt
     @State private var bulkExportOptions = TranscriptExportOptions.default
     @State private var bulkExportInProgress = false
-    @State private var bulkExportPanelShowing = false
     @State private var bulkExportResult: BulkTranscriptExportResult?
     @State private var bulkExportErrorMessage: String?
     @State private var bulkExportCoordinatorTask: Task<Void, Never>?
@@ -235,7 +234,7 @@ struct TranscriptionLibraryView: View {
                             isSelected: viewModel.isTranscriptionSelected(transcription),
                             showsSelectionControls: viewModel.isBulkSelectionModeEnabled
                         ) {
-                            if viewModel.isBulkOperationInProgress {
+                            if viewModel.isBulkOperationInProgress || bulkExportInProgress {
                                 return
                             }
                             if viewModel.isBulkSelectionModeEnabled {
@@ -271,7 +270,7 @@ struct TranscriptionLibraryView: View {
                             isSelected: viewModel.isTranscriptionSelected(transcription),
                             showsSelectionControls: viewModel.isBulkSelectionModeEnabled,
                             onTap: {
-                                if viewModel.isBulkOperationInProgress {
+                                if viewModel.isBulkOperationInProgress || bulkExportInProgress {
                                     return
                                 }
                                 if viewModel.isBulkSelectionModeEnabled {
@@ -397,8 +396,8 @@ struct TranscriptionLibraryView: View {
             selectedMeetingAudioCount: viewModel.selectedMeetingAudioCount,
             isMeetingContext: isMeetingListMode,
             areAllVisibleSelected: viewModel.areAllLoadedVisibleTranscriptionsSelected,
-            isPerformingOperation: viewModel.isBulkOperationInProgress || bulkExportPanelShowing || bulkExportInProgress,
-            operationLabel: bulkExportPanelShowing ? "Choosing folder..." : (bulkExportInProgress ? "Exporting..." : "Deleting..."),
+            isPerformingOperation: viewModel.isBulkOperationInProgress || bulkExportInProgress,
+            operationLabel: bulkExportInProgress ? "Exporting..." : "Deleting...",
             onSelectVisible: { viewModel.selectLoadedVisibleTranscriptions() },
             onClear: { viewModel.clearSelection() },
             onCancel: { viewModel.exitBulkSelection() },
@@ -437,7 +436,10 @@ struct TranscriptionLibraryView: View {
         }
     }
 
-    private var bulkExportFormatOrder: [TranscriptExportFormat] {
+    // Static so the completeness assertion runs once at first use rather than
+    // allocating two Sets on every body re-render (the popover re-renders on
+    // each format selection).
+    private static let bulkExportFormatOrder: [TranscriptExportFormat] = {
         let preferredOrder: [TranscriptExportFormat] = [.txt, .md, .srt, .vtt, .json, .pdf, .docx]
         assert(
             preferredOrder.count == TranscriptExportFormat.allCases.count &&
@@ -445,7 +447,7 @@ struct TranscriptionLibraryView: View {
             "Bulk export format order must include every TranscriptExportFormat case"
         )
         return preferredOrder
-    }
+    }()
 
     private var bulkExportOptionsPopover: some View {
         VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
@@ -482,7 +484,7 @@ struct TranscriptionLibraryView: View {
                     alignment: .leading,
                     spacing: 8
                 ) {
-                    ForEach(bulkExportFormatOrder) { format in
+                    ForEach(Self.bulkExportFormatOrder) { format in
                         Button {
                             selectedBulkExportFormat = format
                         } label: {
@@ -546,7 +548,7 @@ struct TranscriptionLibraryView: View {
                 }
                 .parakeetAction(.primaryProminent)
                 .keyboardShortcut(.defaultAction)
-                .disabled(viewModel.selectedTranscriptionCount == 0 || bulkExportPanelShowing || bulkExportInProgress)
+                .disabled(viewModel.selectedTranscriptionCount == 0 || bulkExportInProgress)
             }
         }
         .padding(DesignSystem.Spacing.md)
@@ -625,9 +627,7 @@ struct TranscriptionLibraryView: View {
                 bulkExportWorkerTask = nil
             }
 
-            bulkExportPanelShowing = true
-            let outcome = await runBulkExportFolderPanel()
-            bulkExportPanelShowing = false
+            let outcome = runBulkExportFolderPanel()
             guard !Task.isCancelled, case .selected(let directory) = outcome else { return }
 
             do {
@@ -679,8 +679,8 @@ struct TranscriptionLibraryView: View {
         bulkExportCoordinatorTask = nil
         bulkExportWorkerTask?.cancel()
         bulkExportWorkerTask = nil
-        bulkExportPanelShowing = false
         bulkExportInProgress = false
+        bulkExportResult = nil
     }
 
     private enum BulkExportFolderOutcome: Sendable {
@@ -688,8 +688,12 @@ struct TranscriptionLibraryView: View {
         case cancelled
     }
 
+    // Synchronous app-modal panel, matching MeetingAudioActions.runSaveAudioPanel
+    // and DictationHistoryViewModel. Modal blocks app interaction while open, so
+    // the coordinator task can't be cancelled mid-panel and there's no dangling
+    // continuation to leak.
     @MainActor
-    private func runBulkExportFolderPanel() async -> BulkExportFolderOutcome {
+    private func runBulkExportFolderPanel() -> BulkExportFolderOutcome {
         let panel = NSOpenPanel()
         panel.title = "Choose Export Folder"
         panel.prompt = "Export"
@@ -702,16 +706,8 @@ struct TranscriptionLibraryView: View {
             panel.directoryURL = downloads
         }
 
-        return await withCheckedContinuation { continuation in
-            panel.begin { response in
-                guard response == .OK, let directory = panel.url else {
-                    continuation.resume(returning: .cancelled)
-                    return
-                }
-
-                continuation.resume(returning: .selected(directory))
-            }
-        }
+        guard panel.runModal() == .OK, let directory = panel.url else { return .cancelled }
+        return .selected(directory)
     }
 
     private var emptyState: some View {

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
@@ -405,6 +405,7 @@ struct TranscriptionLibraryView: View {
             areAllVisibleSelected: viewModel.areAllLoadedVisibleTranscriptionsSelected,
             isPerformingOperation: viewModel.isBulkOperationInProgress || bulkExportInProgress,
             operationLabel: bulkExportInProgress ? "Exporting..." : "Deleting...",
+            isExportDisabled: isBulkExportActionDisabled,
             onSelectVisible: { viewModel.selectLoadedVisibleTranscriptions() },
             onClear: { viewModel.clearSelection() },
             onCancel: { viewModel.exitBulkSelection() },

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
@@ -964,6 +964,7 @@ private struct LibraryPrimaryActionButton: View {
     let action: () -> Void
 
     @State private var isHovered = false
+    @State private var didPushCursor = false
 
     var body: some View {
         Button(action: action) {
@@ -989,10 +990,31 @@ private struct LibraryPrimaryActionButton: View {
         .buttonStyle(.plain)
         .onHover { hovering in
             isHovered = hovering
-            if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+            updateCursor(isHovering: hovering)
+        }
+        .onDisappear {
+            releaseCursorIfNeeded()
         }
         .accessibilityLabel(title)
         .accessibilityHint("Starts a new transcription")
+    }
+
+    private func updateCursor(isHovering: Bool) {
+        if isHovering, !didPushCursor {
+            NSCursor.pointingHand.push()
+            didPushCursor = true
+            return
+        }
+        if !isHovering {
+            releaseCursorIfNeeded()
+        }
+    }
+
+    private func releaseCursorIfNeeded() {
+        if didPushCursor {
+            NSCursor.pop()
+            didPushCursor = false
+        }
     }
 }
 

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
@@ -24,6 +24,7 @@ struct TranscriptionLibraryView: View {
     @State private var bulkExportErrorMessage: String?
     @State private var bulkExportCoordinatorTask: Task<Void, Never>?
     @State private var bulkExportWorkerTask: Task<BulkTranscriptExportResult, Error>?
+    @State private var bulkExportRunID = UUID()
     @FocusState private var selectionKeyboardFocused: Bool
 
     private var visibleLibraryFilters: [LibraryFilter] {
@@ -621,20 +622,25 @@ struct TranscriptionLibraryView: View {
         guard !targets.isEmpty else { return }
 
         cancelBulkExport()
+        let runID = UUID()
+        bulkExportRunID = runID
         bulkExportCoordinatorTask = Task { @MainActor in
             defer {
-                bulkExportCoordinatorTask = nil
-                bulkExportWorkerTask = nil
+                if bulkExportRunID == runID {
+                    bulkExportCoordinatorTask = nil
+                    bulkExportWorkerTask = nil
+                }
             }
 
             let outcome = runBulkExportFolderPanel()
-            guard !Task.isCancelled, case .selected(let directory) = outcome else { return }
+            guard bulkExportRunID == runID, !Task.isCancelled, case .selected(let directory) = outcome else { return }
 
             do {
                 bulkExportInProgress = true
                 bulkExportErrorMessage = nil
                 bulkExportResult = nil
                 await Task.yield()
+                guard bulkExportRunID == runID, !Task.isCancelled else { return }
 
                 let format = selectedBulkExportFormat
                 let options = bulkExportOptions
@@ -652,6 +658,7 @@ struct TranscriptionLibraryView: View {
                 } onCancel: {
                     exportTask.cancel()
                 }
+                guard bulkExportRunID == runID else { return }
                 bulkExportWorkerTask = nil
                 bulkExportInProgress = false
 
@@ -664,8 +671,10 @@ struct TranscriptionLibraryView: View {
                 SoundManager.shared.play(result.isCompleteSuccess ? .transcriptionComplete : .errorSoft)
                 bulkExportResult = result
             } catch is CancellationError {
+                guard bulkExportRunID == runID else { return }
                 bulkExportInProgress = false
             } catch {
+                guard bulkExportRunID == runID else { return }
                 bulkExportInProgress = false
                 bulkExportErrorMessage = error.localizedDescription
                 SoundManager.shared.play(.errorSoft)
@@ -681,6 +690,8 @@ struct TranscriptionLibraryView: View {
         bulkExportWorkerTask = nil
         bulkExportInProgress = false
         bulkExportResult = nil
+        bulkExportErrorMessage = nil
+        bulkExportRunID = UUID()
     }
 
     private enum BulkExportFolderOutcome: Sendable {

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
@@ -17,7 +17,8 @@ struct TranscriptionLibraryView: View {
     @State private var pendingDeleteAudio: Transcription?
     @State private var audioSaveErrorMessage: String?
     @State private var showingBulkExportOptions = false
-    @State private var selectedBulkExportFormat: TranscriptExportFormat = .txt
+    @AppStorage("com.macparakeet.libraryBulkExportFormat")
+    private var selectedBulkExportFormatRawValue = TranscriptExportFormat.txt.rawValue
     @State private var bulkExportOptions = TranscriptExportOptions.default
     @State private var bulkExportInProgress = false
     @State private var bulkExportResult: BulkTranscriptExportResult?
@@ -449,6 +450,15 @@ struct TranscriptionLibraryView: View {
         )
         return preferredOrder
     }()
+
+    private var selectedBulkExportFormat: TranscriptExportFormat {
+        get {
+            TranscriptExportFormat(rawValue: selectedBulkExportFormatRawValue) ?? .txt
+        }
+        nonmutating set {
+            selectedBulkExportFormatRawValue = newValue.rawValue
+        }
+    }
 
     private var bulkExportOptionsPopover: some View {
         VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
@@ -647,7 +647,7 @@ struct TranscriptionLibraryView: View {
         if result.exportedCount > 0 {
             return "Exported \(result.exportedCount) of \(result.requestedCount)"
         }
-        preconditionFailure("Bulk export result popover should only be shown after at least one file exports")
+        return "No files exported"
     }
 
     private func runBulkExport() {

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
@@ -503,7 +503,7 @@ struct TranscriptionLibraryView: View {
             }
 
             Text(
-                "\(viewModel.selectedTranscriptionCount) \(viewModel.selectedTranscriptionCount == 1 ? "item" : "items")"
+                "\(selectedBulkExportTargets.count) \(selectedBulkExportTargets.count == 1 ? "item" : "items")"
             )
             .font(DesignSystem.Typography.caption.weight(.medium))
             .foregroundStyle(DesignSystem.Colors.textSecondary)

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
@@ -647,6 +647,7 @@ struct TranscriptionLibraryView: View {
         bulkExportCoordinatorTask = Task { @MainActor in
             defer {
                 if bulkExportRunID == runID {
+                    bulkExportInProgress = false
                     bulkExportCoordinatorTask = nil
                     bulkExportWorkerTask = nil
                 }
@@ -672,7 +673,6 @@ struct TranscriptionLibraryView: View {
                 }
                 guard bulkExportRunID == runID else { return }
                 bulkExportWorkerTask = nil
-                bulkExportInProgress = false
 
                 guard result.exportedCount > 0 else {
                     bulkExportErrorMessage = result.firstErrorDescription ?? "No files were exported."
@@ -684,10 +684,8 @@ struct TranscriptionLibraryView: View {
                 bulkExportResult = result
             } catch is CancellationError {
                 guard bulkExportRunID == runID else { return }
-                bulkExportInProgress = false
             } catch {
                 guard bulkExportRunID == runID else { return }
-                bulkExportInProgress = false
                 bulkExportErrorMessage = error.localizedDescription
                 SoundManager.shared.play(.errorSoft)
             }

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
@@ -19,7 +19,12 @@ struct TranscriptionLibraryView: View {
     @State private var showingBulkExportOptions = false
     @AppStorage("com.macparakeet.libraryBulkExportFormat")
     private var selectedBulkExportFormatRawValue = TranscriptExportFormat.txt.rawValue
-    @State private var bulkExportOptions = TranscriptExportOptions.default
+    @AppStorage("com.macparakeet.libraryBulkExportIncludeTimestamps")
+    private var bulkExportIncludeTimestamps = true
+    @AppStorage("com.macparakeet.libraryBulkExportIncludeSpeakerLabels")
+    private var bulkExportIncludeSpeakerLabels = true
+    @AppStorage("com.macparakeet.libraryBulkExportIncludeMetadata")
+    private var bulkExportIncludeMetadata = true
     @State private var bulkExportInProgress = false
     @State private var bulkExportResult: BulkTranscriptExportResult?
     @State private var bulkExportErrorMessage: String?
@@ -460,6 +465,14 @@ struct TranscriptionLibraryView: View {
         }
     }
 
+    private var bulkExportOptions: TranscriptExportOptions {
+        TranscriptExportOptions(
+            includeTimestamps: bulkExportIncludeTimestamps,
+            includeSpeakerLabels: bulkExportIncludeSpeakerLabels,
+            includeMetadata: bulkExportIncludeMetadata
+        )
+    }
+
     private var bulkExportOptionsPopover: some View {
         VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
             HStack(spacing: DesignSystem.Spacing.sm) {
@@ -541,9 +554,9 @@ struct TranscriptionLibraryView: View {
                         .font(DesignSystem.Typography.caption.weight(.medium))
                         .foregroundStyle(DesignSystem.Colors.textSecondary)
 
-                    Toggle("Include timestamps when available", isOn: $bulkExportOptions.includeTimestamps)
-                    Toggle("Include speaker labels when available", isOn: $bulkExportOptions.includeSpeakerLabels)
-                    Toggle("Include metadata", isOn: $bulkExportOptions.includeMetadata)
+                    Toggle("Include timestamps when available", isOn: $bulkExportIncludeTimestamps)
+                    Toggle("Include speaker labels when available", isOn: $bulkExportIncludeSpeakerLabels)
+                    Toggle("Include metadata", isOn: $bulkExportIncludeMetadata)
                 }
             }
 

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
@@ -443,12 +443,12 @@ struct TranscriptionLibraryView: View {
         }
     }
 
-    // Static so the completeness assertion runs once at first use rather than
+    // Static so the completeness check runs once at first use rather than
     // allocating two Sets on every body re-render (the popover re-renders on
     // each format selection).
     private static let bulkExportFormatOrder: [TranscriptExportFormat] = {
         let preferredOrder: [TranscriptExportFormat] = [.txt, .md, .srt, .vtt, .json, .pdf, .docx]
-        assert(
+        precondition(
             preferredOrder.count == TranscriptExportFormat.allCases.count &&
                 Set(preferredOrder) == Set(TranscriptExportFormat.allCases),
             "Bulk export format order must include every TranscriptExportFormat case"

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
@@ -646,6 +646,7 @@ struct TranscriptionLibraryView: View {
     private func runBulkExport() {
         let targets = viewModel.selectedLoadedTranscriptionsForExport
         guard !targets.isEmpty else { return }
+        guard !viewModel.isBulkOperationInProgress, !bulkExportInProgress else { return }
 
         cancelBulkExport()
         let outcome = runBulkExportFolderPanel()

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
@@ -926,7 +926,6 @@ private struct LibraryFilterChip: View {
     let onTap: () -> Void
 
     @State private var isHovered = false
-    @State private var didPushCursor = false
 
     private var foreground: Color {
         if isSelected { return DesignSystem.Colors.accent }
@@ -954,29 +953,8 @@ private struct LibraryFilterChip: View {
         .buttonStyle(.plain)
         .onHover { hovering in
             isHovered = hovering
-            updateCursor(isHovering: hovering)
         }
-        .onDisappear {
-            releaseCursorIfNeeded()
-        }
-    }
-
-    private func updateCursor(isHovering: Bool) {
-        if isHovering, !didPushCursor {
-            NSCursor.pointingHand.push()
-            didPushCursor = true
-            return
-        }
-        if !isHovering {
-            releaseCursorIfNeeded()
-        }
-    }
-
-    private func releaseCursorIfNeeded() {
-        if didPushCursor {
-            NSCursor.pop()
-            didPushCursor = false
-        }
+        .pointingHandCursor(isActive: isHovered)
     }
 }
 
@@ -990,7 +968,6 @@ private struct LibraryPrimaryActionButton: View {
     let action: () -> Void
 
     @State private var isHovered = false
-    @State private var didPushCursor = false
 
     var body: some View {
         Button(action: action) {
@@ -1016,31 +993,10 @@ private struct LibraryPrimaryActionButton: View {
         .buttonStyle(.plain)
         .onHover { hovering in
             isHovered = hovering
-            updateCursor(isHovering: hovering)
         }
-        .onDisappear {
-            releaseCursorIfNeeded()
-        }
+        .pointingHandCursor(isActive: isHovered)
         .accessibilityLabel(title)
         .accessibilityHint("Starts a new transcription")
-    }
-
-    private func updateCursor(isHovering: Bool) {
-        if isHovering, !didPushCursor {
-            NSCursor.pointingHand.push()
-            didPushCursor = true
-            return
-        }
-        if !isHovering {
-            releaseCursorIfNeeded()
-        }
-    }
-
-    private func releaseCursorIfNeeded() {
-        if didPushCursor {
-            NSCursor.pop()
-            didPushCursor = false
-        }
     }
 }
 

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
@@ -473,8 +473,12 @@ struct TranscriptionLibraryView: View {
         )
     }
 
+    private var selectedBulkExportTargets: [Transcription] {
+        viewModel.selectedLoadedTranscriptionsForExport
+    }
+
     private var isBulkExportActionDisabled: Bool {
-        viewModel.selectedTranscriptionCount == 0 ||
+        selectedBulkExportTargets.isEmpty ||
             bulkExportInProgress ||
             viewModel.isBulkOperationInProgress
     }
@@ -646,9 +650,8 @@ struct TranscriptionLibraryView: View {
     }
 
     private func runBulkExport() {
-        let targets = viewModel.selectedLoadedTranscriptionsForExport
-        guard !targets.isEmpty else { return }
         guard !isBulkExportActionDisabled else { return }
+        let targets = selectedBulkExportTargets
 
         cancelBulkExport()
         let outcome = runBulkExportFolderPanel()

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
@@ -632,8 +632,18 @@ struct TranscriptionLibraryView: View {
         guard !targets.isEmpty else { return }
 
         cancelBulkExport()
+        let outcome = runBulkExportFolderPanel()
+        guard case .selected(let directory) = outcome else { return }
+
         let runID = UUID()
+        let format = selectedBulkExportFormat
+        let options = bulkExportOptions
+
         bulkExportRunID = runID
+        bulkExportInProgress = true
+        bulkExportErrorMessage = nil
+        bulkExportResult = nil
+
         bulkExportCoordinatorTask = Task { @MainActor in
             defer {
                 if bulkExportRunID == runID {
@@ -642,18 +652,10 @@ struct TranscriptionLibraryView: View {
                 }
             }
 
-            let outcome = runBulkExportFolderPanel()
-            guard bulkExportRunID == runID, !Task.isCancelled, case .selected(let directory) = outcome else { return }
-
             do {
-                bulkExportInProgress = true
-                bulkExportErrorMessage = nil
-                bulkExportResult = nil
                 await Task.yield()
                 guard bulkExportRunID == runID, !Task.isCancelled else { return }
 
-                let format = selectedBulkExportFormat
-                let options = bulkExportOptions
                 let exportTask = Task.detached(priority: .userInitiated) {
                     try await TranscriptResultActions.exportTranscriptsToDirectory(
                         transcriptions: targets,
@@ -710,9 +712,8 @@ struct TranscriptionLibraryView: View {
     }
 
     // Synchronous app-modal panel, matching MeetingAudioActions.runSaveAudioPanel
-    // and DictationHistoryViewModel. Modal blocks app interaction while open, so
-    // the coordinator task can't be cancelled mid-panel and there's no dangling
-    // continuation to leak.
+    // and DictationHistoryViewModel. It runs before the async export coordinator
+    // starts, so no Task is suspended inside the modal interaction.
     @MainActor
     private func runBulkExportFolderPanel() -> BulkExportFolderOutcome {
         let panel = NSOpenPanel()

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 import MacParakeetCore
 import MacParakeetViewModels
@@ -15,6 +16,15 @@ struct TranscriptionLibraryView: View {
     @State private var pendingDelete: Transcription?
     @State private var pendingDeleteAudio: Transcription?
     @State private var audioSaveErrorMessage: String?
+    @State private var showingBulkExportOptions = false
+    @State private var selectedBulkExportFormat: TranscriptExportFormat = .txt
+    @State private var bulkExportOptions = TranscriptExportOptions.default
+    @State private var bulkExportInProgress = false
+    @State private var bulkExportPanelShowing = false
+    @State private var bulkExportResult: BulkTranscriptExportResult?
+    @State private var bulkExportErrorMessage: String?
+    @State private var bulkExportCoordinatorTask: Task<Void, Never>?
+    @State private var bulkExportWorkerTask: Task<BulkTranscriptExportResult, Error>?
     @FocusState private var selectionKeyboardFocused: Bool
 
     private var visibleLibraryFilters: [LibraryFilter] {
@@ -189,6 +199,25 @@ struct TranscriptionLibraryView: View {
             }
         } message: {
             Text(audioSaveErrorMessage ?? "Unable to save meeting audio.")
+        }
+        .alert(
+            "Export Failed",
+            isPresented: Binding(
+                get: { bulkExportErrorMessage != nil },
+                set: { if !$0 { bulkExportErrorMessage = nil } }
+            )
+        ) {
+            Button("OK", role: .cancel) {
+                bulkExportErrorMessage = nil
+            }
+        } message: {
+            Text(bulkExportErrorMessage ?? "Unable to export selected transcripts.")
+        }
+        .popover(item: $bulkExportResult, arrowEdge: .top) { result in
+            bulkExportConfirmationPopover(result)
+        }
+        .onDisappear {
+            cancelBulkExport()
         }
     }
 
@@ -368,13 +397,18 @@ struct TranscriptionLibraryView: View {
             selectedMeetingAudioCount: viewModel.selectedMeetingAudioCount,
             isMeetingContext: isMeetingListMode,
             areAllVisibleSelected: viewModel.areAllLoadedVisibleTranscriptionsSelected,
-            isPerformingOperation: viewModel.isBulkOperationInProgress,
+            isPerformingOperation: viewModel.isBulkOperationInProgress || bulkExportPanelShowing || bulkExportInProgress,
+            operationLabel: bulkExportPanelShowing ? "Choosing folder..." : (bulkExportInProgress ? "Exporting..." : "Deleting..."),
             onSelectVisible: { viewModel.selectLoadedVisibleTranscriptions() },
             onClear: { viewModel.clearSelection() },
             onCancel: { viewModel.exitBulkSelection() },
+            onExport: { showingBulkExportOptions = true },
             onDeleteAudioOnly: { viewModel.requestDeleteSelectedMeetingAudio() },
             onDeleteItems: { viewModel.requestDeleteSelectedItems() }
         )
+        .popover(isPresented: $showingBulkExportOptions, arrowEdge: .top) {
+            bulkExportOptionsPopover
+        }
     }
 
     private var showsSelectManyButton: Bool {
@@ -399,6 +433,283 @@ struct TranscriptionLibraryView: View {
                 }
             } catch {
                 audioSaveErrorMessage = error.localizedDescription
+            }
+        }
+    }
+
+    private var bulkExportFormatOrder: [TranscriptExportFormat] {
+        let preferredOrder: [TranscriptExportFormat] = [.txt, .md, .srt, .vtt, .json, .pdf, .docx]
+        assert(
+            preferredOrder.count == TranscriptExportFormat.allCases.count &&
+                Set(preferredOrder) == Set(TranscriptExportFormat.allCases),
+            "Bulk export format order must include every TranscriptExportFormat case"
+        )
+        return preferredOrder
+    }
+
+    private var bulkExportOptionsPopover: some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
+            HStack(spacing: DesignSystem.Spacing.sm) {
+                Label("Export Selected", systemImage: "arrow.down.doc")
+                    .font(DesignSystem.Typography.body.bold())
+
+                Spacer()
+
+                Button {
+                    showingBulkExportOptions = false
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(.tertiary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Close export options")
+            }
+
+            Text(
+                "\(viewModel.selectedTranscriptionCount) \(viewModel.selectedTranscriptionCount == 1 ? "item" : "items")"
+            )
+            .font(DesignSystem.Typography.caption.weight(.medium))
+            .foregroundStyle(DesignSystem.Colors.textSecondary)
+
+            VStack(alignment: .leading, spacing: DesignSystem.Spacing.xs) {
+                Text("Format")
+                    .font(DesignSystem.Typography.caption.weight(.medium))
+                    .foregroundStyle(DesignSystem.Colors.textSecondary)
+
+                LazyVGrid(
+                    columns: [GridItem(.adaptive(minimum: 104), spacing: 8)],
+                    alignment: .leading,
+                    spacing: 8
+                ) {
+                    ForEach(bulkExportFormatOrder) { format in
+                        Button {
+                            selectedBulkExportFormat = format
+                        } label: {
+                            HStack(spacing: 6) {
+                                Image(systemName: format.iconName)
+                                    .frame(width: 16)
+                                Text(format.shortName)
+                                    .lineLimit(1)
+                                    .minimumScaleFactor(0.85)
+                                Spacer(minLength: 0)
+                            }
+                            .font(DesignSystem.Typography.caption)
+                            .padding(.horizontal, 9)
+                            .padding(.vertical, 7)
+                            .frame(maxWidth: .infinity)
+                            .background(
+                                RoundedRectangle(cornerRadius: 6)
+                                    .fill(
+                                        selectedBulkExportFormat == format
+                                            ? DesignSystem.Colors.accent.opacity(0.14)
+                                            : DesignSystem.Colors.surface)
+                            )
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 6)
+                                    .strokeBorder(
+                                        selectedBulkExportFormat == format
+                                            ? DesignSystem.Colors.accent.opacity(0.7)
+                                            : DesignSystem.Colors.border.opacity(0.7),
+                                        lineWidth: 1
+                                    )
+                            )
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel(format.displayName)
+                        .accessibilityValue(selectedBulkExportFormat == format ? "Selected" : "")
+                    }
+                }
+            }
+
+            if selectedBulkExportFormat.supportsTranscriptOptions {
+                VStack(alignment: .leading, spacing: DesignSystem.Spacing.xs) {
+                    Text("Options")
+                        .font(DesignSystem.Typography.caption.weight(.medium))
+                        .foregroundStyle(DesignSystem.Colors.textSecondary)
+
+                    Toggle("Include timestamps when available", isOn: $bulkExportOptions.includeTimestamps)
+                    Toggle("Include speaker labels when available", isOn: $bulkExportOptions.includeSpeakerLabels)
+                    Toggle("Include metadata", isOn: $bulkExportOptions.includeMetadata)
+                }
+            }
+
+            Divider()
+
+            HStack {
+                Spacer()
+                Button {
+                    showingBulkExportOptions = false
+                    runBulkExport()
+                } label: {
+                    Label("Choose Folder...", systemImage: "folder")
+                }
+                .parakeetAction(.primaryProminent)
+                .keyboardShortcut(.defaultAction)
+                .disabled(viewModel.selectedTranscriptionCount == 0 || bulkExportPanelShowing || bulkExportInProgress)
+            }
+        }
+        .padding(DesignSystem.Spacing.md)
+        .frame(width: 390)
+    }
+
+    @ViewBuilder
+    private func bulkExportConfirmationPopover(_ result: BulkTranscriptExportResult) -> some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+            HStack(alignment: .top, spacing: 8) {
+                Image(systemName: result.isCompleteSuccess ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
+                    .font(.system(size: 18))
+                    .foregroundStyle(
+                        result.isCompleteSuccess ? DesignSystem.Colors.successGreen : DesignSystem.Colors.warningAmber)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(bulkExportResultTitle(result))
+                        .font(DesignSystem.Typography.body.bold())
+                    Text(result.directory.lastPathComponent)
+                        .font(DesignSystem.Typography.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                    if result.failedCount > 0 {
+                        Text("\(result.failedCount) \(result.failedCount == 1 ? "file" : "files") failed.")
+                            .font(DesignSystem.Typography.caption)
+                            .foregroundStyle(DesignSystem.Colors.warningAmber)
+                    }
+                }
+
+                Spacer(minLength: 4)
+
+                Button {
+                    bulkExportResult = nil
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(.tertiary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Close export confirmation")
+            }
+
+            Button {
+                NSWorkspace.shared.activateFileViewerSelecting(result.exportedURLs)
+                bulkExportResult = nil
+            } label: {
+                Label("Show in Finder", systemImage: "folder")
+                    .font(DesignSystem.Typography.caption)
+            }
+            .parakeetAction(.secondary)
+        }
+        .padding(DesignSystem.Spacing.md)
+        .frame(minWidth: 240)
+    }
+
+    private func bulkExportResultTitle(_ result: BulkTranscriptExportResult) -> String {
+        if result.isCompleteSuccess {
+            return
+                "Exported \(result.exportedCount) \(result.format.shortName) \(result.exportedCount == 1 ? "file" : "files")"
+        }
+        if result.exportedCount > 0 {
+            return "Exported \(result.exportedCount) of \(result.requestedCount)"
+        }
+        assertionFailure("Bulk export result popover should only be shown after at least one file exports")
+        return "Exported 0 of \(result.requestedCount)"
+    }
+
+    private func runBulkExport() {
+        let targets = viewModel.selectedLoadedTranscriptionsForExport
+        guard !targets.isEmpty else { return }
+
+        cancelBulkExport()
+        bulkExportCoordinatorTask = Task { @MainActor in
+            defer {
+                bulkExportCoordinatorTask = nil
+                bulkExportWorkerTask = nil
+            }
+
+            bulkExportPanelShowing = true
+            let outcome = await runBulkExportFolderPanel()
+            bulkExportPanelShowing = false
+            guard !Task.isCancelled, case .selected(let directory) = outcome else { return }
+
+            do {
+                bulkExportInProgress = true
+                bulkExportErrorMessage = nil
+                bulkExportResult = nil
+                await Task.yield()
+
+                let format = selectedBulkExportFormat
+                let options = bulkExportOptions
+                let exportTask = Task.detached(priority: .userInitiated) {
+                    try await TranscriptResultActions.exportTranscriptsToDirectory(
+                        transcriptions: targets,
+                        format: format,
+                        options: options,
+                        directory: directory
+                    )
+                }
+                bulkExportWorkerTask = exportTask
+                let result = try await withTaskCancellationHandler {
+                    try await exportTask.value
+                } onCancel: {
+                    exportTask.cancel()
+                }
+                bulkExportWorkerTask = nil
+                bulkExportInProgress = false
+
+                guard result.exportedCount > 0 else {
+                    bulkExportErrorMessage = result.firstErrorDescription ?? "No files were exported."
+                    SoundManager.shared.play(.errorSoft)
+                    return
+                }
+
+                SoundManager.shared.play(result.isCompleteSuccess ? .transcriptionComplete : .errorSoft)
+                bulkExportResult = result
+            } catch is CancellationError {
+                bulkExportInProgress = false
+            } catch {
+                bulkExportInProgress = false
+                bulkExportErrorMessage = error.localizedDescription
+                SoundManager.shared.play(.errorSoft)
+            }
+        }
+    }
+
+    @MainActor
+    private func cancelBulkExport() {
+        bulkExportCoordinatorTask?.cancel()
+        bulkExportCoordinatorTask = nil
+        bulkExportWorkerTask?.cancel()
+        bulkExportWorkerTask = nil
+        bulkExportPanelShowing = false
+        bulkExportInProgress = false
+    }
+
+    private enum BulkExportFolderOutcome: Sendable {
+        case selected(URL)
+        case cancelled
+    }
+
+    @MainActor
+    private func runBulkExportFolderPanel() async -> BulkExportFolderOutcome {
+        let panel = NSOpenPanel()
+        panel.title = "Choose Export Folder"
+        panel.prompt = "Export"
+        panel.message = "Choose a folder for the selected transcript files."
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.canCreateDirectories = true
+        panel.allowsMultipleSelection = false
+        if let downloads = FileManager.default.urls(for: .downloadsDirectory, in: .userDomainMask).first {
+            panel.directoryURL = downloads
+        }
+
+        return await withCheckedContinuation { continuation in
+            panel.begin { response in
+                guard response == .OK, let directory = panel.url else {
+                    continuation.resume(returning: .cancelled)
+                    return
+                }
+
+                continuation.resume(returning: .selected(directory))
             }
         }
     }

--- a/Sources/MacParakeetCore/Services/ExportService.swift
+++ b/Sources/MacParakeetCore/Services/ExportService.swift
@@ -1,7 +1,6 @@
-import Foundation
 import AppKit
+import Foundation
 
-@MainActor
 public protocol ExportServiceProtocol: Sendable {
     func exportToTxt(transcription: Transcription, url: URL) throws
     func exportToSRT(transcription: Transcription, url: URL) throws
@@ -52,8 +51,8 @@ public struct TranscriptExportOptions: Sendable, Equatable {
 }
 
 /// Handles exporting transcriptions to files and clipboard.
-/// @MainActor because PDF/DOCX paths use NSTextStorage/NSLayoutManager (AppKit, not thread-safe).
-@MainActor
+/// PDF/DOCX paths stay on MainActor because they use NSTextStorage/NSLayoutManager
+/// (AppKit, not thread-safe). Text, subtitle, and JSON exports are safe off-main.
 public final class ExportService: ExportServiceProtocol, Sendable {
     public init() {}
 

--- a/Sources/MacParakeetCore/Services/ExportService.swift
+++ b/Sources/MacParakeetCore/Services/ExportService.swift
@@ -191,6 +191,7 @@ public final class ExportService: ExportServiceProtocol, Sendable {
             // Save graphics state, set up coordinate system for this page.
             // We flip the CGContext so y goes top-down (needed for pagination math)
             // and tell NSGraphicsContext it's flipped so AppKit draws glyphs upright.
+            context.saveGState()
             let nsContext = NSGraphicsContext(cgContext: context, flipped: true)
             NSGraphicsContext.saveGraphicsState()
             NSGraphicsContext.current = nsContext
@@ -204,6 +205,7 @@ public final class ExportService: ExportServiceProtocol, Sendable {
             layoutManager.drawGlyphs(forGlyphRange: glyphRange, at: drawOrigin)
 
             NSGraphicsContext.restoreGraphicsState()
+            context.restoreGState()
             context.endPage()
 
             yOffset += textHeight

--- a/Sources/MacParakeetCore/Services/ExportService.swift
+++ b/Sources/MacParakeetCore/Services/ExportService.swift
@@ -135,7 +135,7 @@ public final class ExportService: ExportServiceProtocol, Sendable {
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         encoder.dateEncodingStrategy = .iso8601
         let data = try encoder.encode(transcription)
-        try data.write(to: url)
+        try data.write(to: url, options: .atomic)
     }
 
     /// Export transcription as PDF file using Core Graphics PDF context.
@@ -219,7 +219,7 @@ public final class ExportService: ExportServiceProtocol, Sendable {
             from: range,
             documentAttributes: [.documentType: NSAttributedString.DocumentType.officeOpenXML]
         )
-        try data.write(to: url)
+        try data.write(to: url, options: .atomic)
     }
 
     /// Format word timestamps as SRT subtitle string

--- a/Sources/MacParakeetViewModels/TranscriptionLibraryViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionLibraryViewModel.swift
@@ -160,6 +160,10 @@ public final class TranscriptionLibraryViewModel {
         selectedLoadedTranscriptions.filter(Self.hasAvailableMeetingAudio).count
     }
 
+    public var selectedLoadedTranscriptionsForExport: [Transcription] {
+        selectedLoadedTranscriptions
+    }
+
     private func groupByDate(_ items: [Transcription]) -> [(group: TranscriptionDateGroup, items: [Transcription])] {
         guard !items.isEmpty else { return [] }
         let now = nowProvider()

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionLibraryViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionLibraryViewModelTests.swift
@@ -315,6 +315,21 @@ final class TranscriptionLibraryViewModelTests: XCTestCase {
         XCTAssertEqual(vm.selectedTranscriptionIDs, [matching.id])
     }
 
+    func testSelectedLoadedTranscriptionsForExportFollowsVisibleOrder() async throws {
+        let first = Transcription(createdAt: Date(timeIntervalSince1970: 2), fileName: "first.mp3", status: .completed)
+        let second = Transcription(createdAt: Date(timeIntervalSince1970: 1), fileName: "second.mp3", status: .completed)
+        try repo.save(second)
+        try repo.save(first)
+
+        await load()
+
+        vm.beginBulkSelection()
+        vm.selectLoadedVisibleTranscriptions()
+
+        XCTAssertEqual(vm.filteredTranscriptions.map(\.id), [first.id, second.id])
+        XCTAssertEqual(vm.selectedLoadedTranscriptionsForExport.map(\.id), [first.id, second.id])
+    }
+
     func testAllLoadedVisibleTranscriptionsSelectedWhenSearchHasNoMatches() async throws {
         let matching = Transcription(fileName: "Swift Tutorial", status: .completed)
         try repo.save(matching)

--- a/Tests/MacParakeetTests/Views/TranscriptResultActionsTests.swift
+++ b/Tests/MacParakeetTests/Views/TranscriptResultActionsTests.swift
@@ -155,6 +155,48 @@ final class TranscriptResultActionsTests: XCTestCase {
         }
     }
 
+    func testBulkExportCancellationDoesNotDeleteReplacementFile() async throws {
+        let outputDir = tempDir.appendingPathComponent("replacement-export", isDirectory: true)
+        let first = Transcription(
+            fileName: "first.m4a",
+            rawTranscript: "First export will be replaced",
+            status: .completed
+        )
+        let second = Transcription(
+            fileName: "second.m4a",
+            rawTranscript: "Second export should never start",
+            status: .completed
+        )
+        let replacementText = "Replacement content from another writer"
+        let cancellationProbe = MidExportCancellationProbe()
+
+        let task = Task.detached {
+            return try await TranscriptResultActions.exportTranscriptsToDirectory(
+                transcriptions: [first, second],
+                format: .txt,
+                directory: outputDir,
+                onFileExported: { url in
+                    try? replacementText.write(to: url, atomically: true, encoding: .utf8)
+                    await cancellationProbe.recordAndCancel(url)
+                }
+            )
+        }
+        await cancellationProbe.setTask(task)
+
+        do {
+            _ = try await task.value
+            XCTFail("Expected cancellation to propagate out of bulk export")
+        } catch is CancellationError {
+            let exportedURLs = await cancellationProbe.exportedURLs
+            XCTAssertEqual(exportedURLs.map(\.lastPathComponent), ["first.txt"])
+            let replacementURL = try XCTUnwrap(exportedURLs.first)
+            XCTAssertEqual(
+                try String(contentsOf: replacementURL, encoding: .utf8),
+                replacementText
+            )
+        }
+    }
+
     func testBulkExportCancellationAfterFinalFileKeepsCompletedExport() async throws {
         let outputDir = tempDir.appendingPathComponent("completed-export", isDirectory: true)
         let transcription = Transcription(

--- a/Tests/MacParakeetTests/Views/TranscriptResultActionsTests.swift
+++ b/Tests/MacParakeetTests/Views/TranscriptResultActionsTests.swift
@@ -50,6 +50,7 @@ final class TranscriptResultActionsTests: XCTestCase {
         XCTAssertEqual(result.requestedCount, 2)
         XCTAssertEqual(result.exportedCount, 2)
         XCTAssertEqual(result.failedCount, 0)
+        XCTAssertTrue(result.isCompleteSuccess)
         XCTAssertEqual(result.exportedURLs.map(\.lastPathComponent), ["call (1).txt", "call (2).txt"])
         XCTAssertEqual(
             try String(contentsOf: tempDir.appendingPathComponent("call (1).txt"), encoding: .utf8),
@@ -63,6 +64,19 @@ final class TranscriptResultActionsTests: XCTestCase {
             try String(contentsOf: tempDir.appendingPathComponent("call.txt"), encoding: .utf8),
             "Existing"
         )
+    }
+
+    func testBulkExportCompleteSuccessRequiresEveryRequestedFile() {
+        let result = BulkTranscriptExportResult(
+            directory: tempDir,
+            format: .txt,
+            requestedCount: 2,
+            exportedURLs: [tempDir.appendingPathComponent("one.txt")],
+            failedCount: 0,
+            firstErrorDescription: nil
+        )
+
+        XCTAssertFalse(result.isCompleteSuccess)
     }
 
     func testBulkExportResolvesOptionsPerTranscript() async throws {

--- a/Tests/MacParakeetTests/Views/TranscriptResultActionsTests.swift
+++ b/Tests/MacParakeetTests/Views/TranscriptResultActionsTests.swift
@@ -105,49 +105,73 @@ final class TranscriptResultActionsTests: XCTestCase {
         XCTAssertFalse(editedContent.contains("**[0:00]**"))
     }
 
-    func testBulkExportPropagatesCancellationAndCleansEmptyCreatedDirectory() async throws {
+    func testBulkExportCancellationRemovesPartialFilesAndCreatedDirectory() async throws {
         let outputDir = tempDir.appendingPathComponent("cancelled-export", isDirectory: true)
-        let transcription = Transcription(
-            fileName: "cancel-me.m4a",
-            rawTranscript: "Should not export",
+        let first = Transcription(
+            fileName: "first.m4a",
+            rawTranscript: "First export should be removed",
             status: .completed
         )
-        let gate = CancellationStartGate()
+        let second = Transcription(
+            fileName: "second.m4a",
+            rawTranscript: "Second export should never start",
+            status: .completed
+        )
+        let cancellationProbe = MidExportCancellationProbe()
 
         let task = Task.detached {
-            await gate.wait()
             return try await TranscriptResultActions.exportTranscriptsToDirectory(
-                transcriptions: [transcription],
+                transcriptions: [first, second],
                 format: .txt,
-                directory: outputDir
+                directory: outputDir,
+                onFileExported: { url in
+                    await cancellationProbe.recordAndCancel(url)
+                }
             )
         }
-        task.cancel()
-        await gate.open()
+        await cancellationProbe.setTask(task)
 
         do {
             _ = try await task.value
             XCTFail("Expected cancellation to propagate out of bulk export")
         } catch is CancellationError {
+            let exportedURLs = await cancellationProbe.exportedURLs
+            XCTAssertEqual(exportedURLs.map(\.lastPathComponent), ["first.txt"])
             XCTAssertFalse(FileManager.default.fileExists(atPath: outputDir.path))
         }
     }
 }
 
-private actor CancellationStartGate {
-    private var isOpen = false
-    private var continuation: CheckedContinuation<Void, Never>?
+private actor MidExportCancellationProbe {
+    private var task: Task<BulkTranscriptExportResult, Error>?
+    private var taskWaiters: [CheckedContinuation<Task<BulkTranscriptExportResult, Error>, Never>] = []
+    private var recordedURLs: [URL] = []
 
-    func wait() async {
-        if isOpen { return }
-        await withCheckedContinuation { continuation in
-            self.continuation = continuation
+    var exportedURLs: [URL] {
+        recordedURLs
+    }
+
+    func setTask(_ task: Task<BulkTranscriptExportResult, Error>) {
+        self.task = task
+        let waiters = taskWaiters
+        taskWaiters.removeAll()
+        for waiter in waiters {
+            waiter.resume(returning: task)
         }
     }
 
-    func open() {
-        isOpen = true
-        continuation?.resume()
-        continuation = nil
+    func recordAndCancel(_ url: URL) async {
+        recordedURLs.append(url)
+        let task = await taskHandle()
+        task.cancel()
+    }
+
+    private func taskHandle() async -> Task<BulkTranscriptExportResult, Error> {
+        if let task {
+            return task
+        }
+        return await withCheckedContinuation { continuation in
+            taskWaiters.append(continuation)
+        }
     }
 }

--- a/Tests/MacParakeetTests/Views/TranscriptResultActionsTests.swift
+++ b/Tests/MacParakeetTests/Views/TranscriptResultActionsTests.swift
@@ -104,4 +104,50 @@ final class TranscriptResultActionsTests: XCTestCase {
         XCTAssertEqual(editedContent.trimmingCharacters(in: .whitespacesAndNewlines), "Edited transcript")
         XCTAssertFalse(editedContent.contains("**[0:00]**"))
     }
+
+    func testBulkExportPropagatesCancellationAndCleansEmptyCreatedDirectory() async throws {
+        let outputDir = tempDir.appendingPathComponent("cancelled-export", isDirectory: true)
+        let transcription = Transcription(
+            fileName: "cancel-me.m4a",
+            rawTranscript: "Should not export",
+            status: .completed
+        )
+        let gate = CancellationStartGate()
+
+        let task = Task.detached {
+            await gate.wait()
+            return try await TranscriptResultActions.exportTranscriptsToDirectory(
+                transcriptions: [transcription],
+                format: .txt,
+                directory: outputDir
+            )
+        }
+        task.cancel()
+        await gate.open()
+
+        do {
+            _ = try await task.value
+            XCTFail("Expected cancellation to propagate out of bulk export")
+        } catch is CancellationError {
+            XCTAssertFalse(FileManager.default.fileExists(atPath: outputDir.path))
+        }
+    }
+}
+
+private actor CancellationStartGate {
+    private var isOpen = false
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    func wait() async {
+        if isOpen { return }
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    func open() {
+        isOpen = true
+        continuation?.resume()
+        continuation = nil
+    }
 }

--- a/Tests/MacParakeetTests/Views/TranscriptResultActionsTests.swift
+++ b/Tests/MacParakeetTests/Views/TranscriptResultActionsTests.swift
@@ -140,6 +140,35 @@ final class TranscriptResultActionsTests: XCTestCase {
             XCTAssertFalse(FileManager.default.fileExists(atPath: outputDir.path))
         }
     }
+
+    func testBulkExportCancellationAfterFinalFileKeepsCompletedExport() async throws {
+        let outputDir = tempDir.appendingPathComponent("completed-export", isDirectory: true)
+        let transcription = Transcription(
+            fileName: "final.m4a",
+            rawTranscript: "Final export should remain",
+            status: .completed
+        )
+        let cancellationProbe = MidExportCancellationProbe()
+
+        let task = Task.detached {
+            return try await TranscriptResultActions.exportTranscriptsToDirectory(
+                transcriptions: [transcription],
+                format: .txt,
+                directory: outputDir,
+                onFileExported: { url in
+                    await cancellationProbe.recordAndCancel(url)
+                }
+            )
+        }
+        await cancellationProbe.setTask(task)
+
+        let result = try await task.value
+        let exportedURLs = await cancellationProbe.exportedURLs
+        XCTAssertEqual(result.exportedCount, 1)
+        XCTAssertEqual(result.failedCount, 0)
+        XCTAssertEqual(exportedURLs.map(\.lastPathComponent), ["final.txt"])
+        XCTAssertTrue(FileManager.default.fileExists(atPath: outputDir.appendingPathComponent("final.txt").path))
+    }
 }
 
 private actor MidExportCancellationProbe {

--- a/Tests/MacParakeetTests/Views/TranscriptResultActionsTests.swift
+++ b/Tests/MacParakeetTests/Views/TranscriptResultActionsTests.swift
@@ -1,0 +1,107 @@
+import XCTest
+@testable import MacParakeet
+@testable import MacParakeetCore
+
+@MainActor
+final class TranscriptResultActionsTests: XCTestCase {
+    private var tempDir: URL!
+
+    override func setUpWithError() throws {
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("bulk-export-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        if let tempDir {
+            try? FileManager.default.removeItem(at: tempDir)
+        }
+        tempDir = nil
+    }
+
+    func testBulkExportWritesCollisionSafeFiles() async throws {
+        let first = Transcription(
+            fileName: "call.m4a",
+            rawTranscript: "First transcript",
+            status: .completed
+        )
+        let second = Transcription(
+            fileName: "call.mp3",
+            rawTranscript: "Second transcript",
+            status: .completed
+        )
+        try "Existing".write(
+            to: tempDir.appendingPathComponent("call.txt"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let result = try await TranscriptResultActions.exportTranscriptsToDirectory(
+            transcriptions: [first, second],
+            format: .txt,
+            options: TranscriptExportOptions(
+                includeTimestamps: false,
+                includeSpeakerLabels: false,
+                includeMetadata: false
+            ),
+            directory: tempDir
+        )
+
+        XCTAssertEqual(result.requestedCount, 2)
+        XCTAssertEqual(result.exportedCount, 2)
+        XCTAssertEqual(result.failedCount, 0)
+        XCTAssertEqual(result.exportedURLs.map(\.lastPathComponent), ["call (1).txt", "call (2).txt"])
+        XCTAssertEqual(
+            try String(contentsOf: tempDir.appendingPathComponent("call (1).txt"), encoding: .utf8),
+            "First transcript"
+        )
+        XCTAssertEqual(
+            try String(contentsOf: tempDir.appendingPathComponent("call (2).txt"), encoding: .utf8),
+            "Second transcript"
+        )
+        XCTAssertEqual(
+            try String(contentsOf: tempDir.appendingPathComponent("call.txt"), encoding: .utf8),
+            "Existing"
+        )
+    }
+
+    func testBulkExportResolvesOptionsPerTranscript() async throws {
+        let timed = Transcription(
+            fileName: "timed.m4a",
+            rawTranscript: "Hello world.",
+            wordTimestamps: [
+                WordTimestamp(word: "Hello", startMs: 0, endMs: 500, confidence: 0.9),
+                WordTimestamp(word: "world.", startMs: 500, endMs: 1000, confidence: 0.9),
+            ],
+            status: .completed
+        )
+        let edited = Transcription(
+            fileName: "edited.m4a",
+            rawTranscript: "Original",
+            cleanTranscript: "Edited transcript",
+            wordTimestamps: [
+                WordTimestamp(word: "Original", startMs: 0, endMs: 500, confidence: 0.9)
+            ],
+            status: .completed,
+            isTranscriptEdited: true
+        )
+
+        _ = try await TranscriptResultActions.exportTranscriptsToDirectory(
+            transcriptions: [timed, edited],
+            format: .md,
+            options: TranscriptExportOptions(
+                includeTimestamps: true,
+                includeSpeakerLabels: true,
+                includeMetadata: false
+            ),
+            directory: tempDir
+        )
+
+        let timedContent = try String(contentsOf: tempDir.appendingPathComponent("timed.md"), encoding: .utf8)
+        let editedContent = try String(contentsOf: tempDir.appendingPathComponent("edited.md"), encoding: .utf8)
+
+        XCTAssertTrue(timedContent.contains("**[0:00]** Hello world."))
+        XCTAssertEqual(editedContent.trimmingCharacters(in: .whitespacesAndNewlines), "Edited transcript")
+        XCTAssertFalse(editedContent.contains("**[0:00]**"))
+    }
+}


### PR DESCRIPTION
## Summary
- Adds an Export action to Library multi-select with a compact format/options popover and folder picker.
- Exports selected transcriptions to a chosen folder in TXT, Markdown, SRT, VTT, JSON, PDF, or DOCX with collision-safe filenames, partial-success reporting, Finder reveal, and cancellation on view teardown.
- Moves text/subtitle/JSON export paths off the main actor while keeping PDF/DOCX on the AppKit-required main actor, and updates CLI callers for the narrower actor isolation.

Closes #657.

## Testing
- `swift test --filter TranscriptResultActionsTests`
- `swift test --filter TranscriptionLibraryViewModelTests`
- `swift test --filter ExportCommandTests`
- `swift test --filter MeetingsCommandTests`
- `swift test` (4323 XCTest tests, 13 skipped, 0 failures; 17 Swift Testing tests passed)
- `scripts/dev/check.sh TranscriptResultActionsTests`
- `MACPARAKEET_SKIP_WHISPERKIT=1 swift build --build-path .build-swift6-no-whisper -Xswiftc -swift-version -Xswiftc 6`
- `git diff --check origin/main`
- `scripts/dev/greptile_review.sh origin/main` (review `2edbb7e0-a563-49a8-9c84-8644d01decd2`, confidence 4/5, safe to merge, no comments)

## Post-Deploy Monitoring & Validation
No production/server monitoring required; this is a local macOS Library export flow. Manual validation should select multiple Library rows, export at least TXT and Markdown to a temporary folder, confirm collision-safe file names, and verify Finder reveal. PDF/DOCX still use the AppKit document renderer and may briefly occupy the main actor per file.

---
[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5 Codex](https://img.shields.io/badge/GPT--5_Codex-000000)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds bulk export to the Library multi-select so users can export selected transcripts to a chosen folder in TXT, Markdown, SRT, VTT, JSON, PDF, or DOCX with safe filenames, persisted options, and clear success/partial-failure feedback. Strengthens the flow with an app‑modal folder picker, UI blocking while exporting, and cancellation cleanup that only removes files created by the export.

- **New Features**
  - Export button in the selection bar with a compact format/options popover (timestamps, speaker labels, metadata); remembers last used selections; shows “Exporting...”; disables row taps and delete shortcuts; Export button state tracks selection and in‑progress status.
  - App‑modal folder picker; collision‑safe filenames and per‑file option resolution based on transcript capabilities; confirmation popover with exported/failed counts and “Show in Finder”; result persists until dismissed and is cleared on view teardown; success/error sounds.

- **Refactors**
  - Text/subtitle/JSON exports run off‑main; PDF/DOCX run on MainActor; reuse one ExportService per batch; atomic writes for JSON/DOCX; security‑scoped folder access; rethrow CancellationError; cleanup deletes only files created by this export and empties dirs on cancel/total failure; preserve completed exports if cancelled after the final file; enforce a static export format order; CLI exports are synchronous/throwing with accurate JSON string‑encoding errors.
  - Centralized pointing cursor handling via a shared `pointingHandCursor` modifier with safe push/pop; hardened PDF pagination with save/restore graphics state.

<sup>Written for commit 26d9b1f13950bb2beb76a19db293ae00aee1f724. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/661?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

