### PR TITLE
Add ASR benchmark suite contract

### DIFF
--- a/benchmarks/asr/.gitignore
+++ b/benchmarks/asr/.gitignore
@@ -1,3 +1,4 @@
 # Full-set per-file hypotheses are large (~13 MB) and regenerable via
 # run_macparakeet.py (no --limit). Commit the summary instead.
 results/full/*.jsonl
+venv/

--- a/benchmarks/asr/README.md
+++ b/benchmarks/asr/README.md
@@ -138,7 +138,7 @@ harness conventions.
 | `score.py` | English scorer — canonical normalizer + jiwer → corpus WER, macro-avg, p90, failure-rate, RTFx. `--ci N` adds a bootstrap 95% CI; `--simple` fallback. |
 | `score_multi.py` | Multilingual scorer — WER (en/EU) or CER (ko/ja/zh) via `BasicTextNormalizer`; `--ci N`. |
 | `paired_delta.py` | Paired bootstrap CI on the WER/CER *difference* between two engines (the significance test). |
-| `speed_bench.py` | Speed/memory — steady RTFx, cold-start, peak RSS, one engine at a time. |
+| `speed_bench.py` | Speed/memory — steady RTFx, cold-start, peak RSS, one engine at a time. Uses `macparakeet-cli` for shipping engines, including Cohere; `cohere-fa-reference` is legacy-only. |
 | `test_scorers.py` | Scorer correctness tests (run: `python3 test_scorers.py`). |
 | `manifest.json` | Benchmark contract — engines, datasets, metrics, tasks, product surfaces, and quality gates. |
 | `manifest_tool.py` / `test_manifest.py` | Repo-only contract validation and summary rendering. |
@@ -214,9 +214,10 @@ a larger set before shipping per-language engine routing.
 
 **Method note:** the committed Cohere speed/memory row is still the older
 FluidAudio CLI reference measurement; the other six rows use `macparakeet-cli`.
-MacParakeet now has a Cohere CLI path, so rerun Cohere through `macparakeet-cli`
-before making in-app cold-start or memory claims. Treat the current RAM floor as
-a lower bound.
+`speed_bench.py --engine cohere` now measures MacParakeet's shipping Cohere CLI
+path; use `cohere-fa-reference` only to compare the old FluidAudio reference row.
+Rerun Cohere through `macparakeet-cli` before making in-app cold-start or memory
+claims. Treat the current RAM floor as a lower bound.
 
 The Cohere peak RSS is **constant at 2 / 8 / 12 files** → it's the model's
 resident working set, not harness accumulation (an autoregressive 2B transformer
@@ -290,10 +291,9 @@ macOS 15.
   by up to ~1.5 pt vs the full set and can reorder mid-pack engines — hence the
   full-set English run. `results/{*.jsonl, stride200/}` keep the first-200 +
   stride-200 evidence that motivated it.
-- **Cohere speed/memory** in the committed results is measured via the FluidAudio
-  CLI reference harness, not yet through MacParakeet's current Cohere runtime —
-  treat the figures as a lower bound and confirm in-app before making release or
-  Settings claims.
+- **Cohere speed/memory** in the committed results is measured via the legacy
+  FluidAudio CLI reference harness. The runner now supports MacParakeet's Cohere
+  CLI runtime, so confirm that path before making release or Settings claims.
 - **Not benchmarked:** Qwen3-ASR and Moonshine (need an MLX runtime — deferred).
   Changing defaults or automatic engine routing is a separate ADR/spec-gated
   product change, even when the benchmark evidence is favorable.

--- a/benchmarks/asr/README.md
+++ b/benchmarks/asr/README.md
@@ -7,15 +7,61 @@ Open ASR Leaderboard standard), so cross-engine numbers are directly comparable 
 the single most important property a multi-model benchmark must have. It measures
 three axes: **accuracy** (English + multilingual), **speed**, and **memory**.
 
-Engines are the four families MacParakeet ships or is evaluating: **Parakeet**
+Engines are the four families MacParakeet ships and evaluates: **Parakeet**
 (v2 / v3 / unified), **Nemotron** (English / multilingual, Beta), **WhisperKit**
 (large-v3-turbo), and **Cohere** Transcribe (`cohere-transcribe-03-2026`, q8) —
-the model flagged after #520 / #552 / #554 and confirmed runnable on-device via
-the FluidAudio CoreML SDK MacParakeet already ships.
+the model flagged after #520 / #552 / #554 and now available as a batch-only
+MacParakeet engine through the same FluidAudio CoreML SDK.
 
 > Supersedes the LibriSpeech-`test-clean`-only `benchmarks/parakeet-unified/`
 > evidence. English numbers below are the **full** test sets; multilingual is a
 > capped FLEURS pass (see "Status & limitations").
+
+## Benchmark contract
+
+This directory is the source of truth for ASR evidence. It is intentionally
+small: a manifest, deterministic scorers, runners for the shipping CLI path, and
+committed result fixtures that can be re-scored without downloading models.
+
+| Industry practice | MacParakeet implementation |
+|-------------------|----------------------------|
+| Open ASR Leaderboard-style normalization: one text-normalization path before WER/CER | `score.py` and `score_multi.py` apply the same Whisper normalizers to every engine. |
+| NIST/SCTK-style explicit scoring contract | JSONL records carry stable utterance IDs, references, hypotheses, dataset, engine, language, and optional timing. |
+| ESPnet/Kaldi-style reproducible recipe | `run_all.sh` separates repo-only verification from heavy `speed` and `transcribe` regeneration. |
+| Statistical claims need uncertainty | Marginal bootstrap CIs are reported, and engine-vs-engine claims use paired bootstrap deltas. |
+| Accuracy alone is not a product decision | `manifest.json` records product surfaces, speed, memory, live-preview support, and evidence gates. |
+| Public benchmarks are not enough for product UX | Public datasets are kept separate from planned private consented dictation/meeting fixtures. |
+
+## Suite matrix
+
+| Tier | Dataset / fixture | Current status | Purpose | Publishability |
+|------|-------------------|----------------|---------|----------------|
+| English full-set | LibriSpeech `test-clean` + `test-other` | Committed full results | Clean/noisy English model ranking | Final-grade for read-English claims. |
+| Multilingual directional | FLEURS en/ko/ja/zh | Committed capped results, 150/language | Language coverage and failure discovery | Ranking-grade; expand before routing defaults. |
+| Performance | Local speed/memory micro-bench | Committed reference results | Cold start, steady RTFx, peak RSS | Hardware-specific; rerun for release claims. |
+| Meeting public | AMI Meeting Corpus | Planned | Multi-speaker meeting final transcript quality | Needed before meeting-specific engine claims. |
+| Accented/wild English | Earnings-22 | Planned | Real-world accents, long-form speech | Needed before broad noisy/accented claims. |
+| Product regression | Consented MacParakeet fixtures | Planned private | Dictation, meeting, file/media edge cases | Internal gate; do not commit private audio/transcripts. |
+
+`manifest.json` is validated by `manifest_tool.py` and `test_manifest.py` during
+`./run_all.sh verify`. Treat the manifest as the benchmark API: adding a dataset,
+engine, metric, or product decision gate should update it in the same PR.
+
+## Research basis
+
+The suite follows the public evaluation patterns used by the
+[HuggingFace Open ASR Leaderboard](https://github.com/huggingface/open_asr_leaderboard)
+(shared normalization, WER + RTFx), [NIST SCTK/SCLITE](https://github.com/usnistgov/SCTK)
+(explicit reference-vs-hypothesis scoring),
+[ESPnet recipes](https://espnet.github.io/espnet/espnet2_tutorial.html)
+(reproducible data/eval scripts), and meeting-eval work such as
+[MeetEval](https://github.com/fgnt/meeteval) (meeting transcription needs its
+own metric surface). Dataset choices are intentionally layered:
+[LibriSpeech](https://www.openslr.org/12) for saturated English read speech,
+[FLEURS](https://arxiv.org/abs/2205.12446) for multilingual coverage,
+[AMI](https://groups.inf.ed.ac.uk/ami/corpus/) for meetings,
+[Earnings-22](https://arxiv.org/abs/2203.15591) for accented long-form English,
+and a private MacParakeet fixture tier for product regressions.
 
 ## TL;DR (what the evidence says)
 
@@ -24,8 +70,8 @@ the FluidAudio CoreML SDK MacParakeet already ships.
   ANE compile, and runs **~11× realtime** (vs ~70× for Parakeet). Its accuracy
   lead is *statistically real* only on noisy English (`test-other`) and Japanese;
   on clean English, Korean, and Chinese it ties the best alternative within 95%
-  CIs. → **Add Cohere as an opt-in accuracy / noisy-audio / Japanese engine for
-  16 GB+ Macs, not a default.**
+  CIs. → **Keep Cohere as an opt-in accuracy / noisy-audio / Japanese engine for
+  16 GB+ Macs, not the default.**
 - **Parakeet stays the right default** for fast dictation (best speed, ~120 MB
   RAM, English WER within noise of Cohere on clean speech). **Unified slightly
   beats v2** on clean speech (paired Δ −0.22 pt, CI [−0.34, −0.11]) and ties on
@@ -94,9 +140,11 @@ harness conventions.
 | `paired_delta.py` | Paired bootstrap CI on the WER/CER *difference* between two engines (the significance test). |
 | `speed_bench.py` | Speed/memory — steady RTFx, cold-start, peak RSS, one engine at a time. |
 | `test_scorers.py` | Scorer correctness tests (run: `python3 test_scorers.py`). |
+| `manifest.json` | Benchmark contract — engines, datasets, metrics, tasks, product surfaces, and quality gates. |
+| `manifest_tool.py` / `test_manifest.py` | Repo-only contract validation and summary rendering. |
 | `run_macparakeet.py` | Drives `macparakeet-cli transcribe` for integrated engines on LibriSpeech (the real shipping path). |
 | `run_macparakeet_fleurs.py` | Same, over a FLEURS language subset (multilingual). |
-| `fa_json_to_jsonl.py` | Converts a FluidAudio CLI benchmark JSON → the same JSONL, so non-integrated engines (Cohere) score through the same scorer. |
+| `fa_json_to_jsonl.py` | Converts a FluidAudio CLI benchmark JSON → the same JSONL for legacy/reference imports. |
 | `run_all.sh` | Driver: `verify` (repo-only: tests + re-score committed evidence with CIs), `speed`, `transcribe`. |
 | `requirements.txt` | Pinned scorer dependencies. |
 | `results/` | Committed evidence (see "Verification & reproducibility"). |
@@ -164,10 +212,11 @@ a larger set before shipping per-language engine routing.
 | whisper-large-v3-turbo | 2.29 s | ~14× | 274 MB |
 | **cohere-transcribe-03-2026** | **73 s** | **~11×** | **~11.6 GB** |
 
-**Method note:** Cohere is measured via the FluidAudio CLI (the same SDK
-MacParakeet would integrate); the other six via `macparakeet-cli`. So Cohere's
-figures are a *reference-harness* proxy, not yet an in-app measurement — treat the
-RAM floor as a lower bound.
+**Method note:** the committed Cohere speed/memory row is still the older
+FluidAudio CLI reference measurement; the other six rows use `macparakeet-cli`.
+MacParakeet now has a Cohere CLI path, so rerun Cohere through `macparakeet-cli`
+before making in-app cold-start or memory claims. Treat the current RAM floor as
+a lower bound.
 
 The Cohere peak RSS is **constant at 2 / 8 / 12 files** → it's the model's
 resident working set, not harness accumulation (an autoregressive 2B transformer
@@ -193,10 +242,10 @@ punctuation/capitalization. So unified is the better English Parakeet build.
 
 **Recommendation (evidence-based):**
 1. Keep **Parakeet** the default (speed + memory + clean-English parity).
-2. Add **Cohere** as an **opt-in** engine surfaced for noisy audio, Japanese, and
-   accuracy-critical work, gated to **16 GB+ RAM** (reference-harness ~11 GB;
-   confirm the in-app figure before shipping) with a clear cold-start/size
-   warning. Reuses the existing FluidAudio SDK — no new runtime.
+2. Keep **Cohere** as an **opt-in** engine surfaced for noisy audio, Japanese,
+   and accuracy-critical work, gated to **16 GB+ RAM** until an in-app rerun
+   proves otherwise. Its Settings copy should be explicit about cold start,
+   memory, no auto-detect, no live preview, and no word timestamps.
 3. Keep **WhisperKit** as the pragmatic multilingual engine (light, competitive
    Korean/Chinese); it remains the better default for CJK on memory grounds.
    Per-language routing (Japanese→Cohere) is provisional on n=150 — validate on a
@@ -206,10 +255,11 @@ punctuation/capitalization. So unified is the better English Parakeet build.
 ## Verification & reproducibility
 
 - **Scorer/CI determinism.** `./run_all.sh verify` (repo-only, no datasets or
-  models) runs the scorer tests and re-scores the committed (frozen) hypotheses
-  with CIs, reproducing the headline macro WER (2.07 / 2.38 / 2.57 / 3.00 / 3.22 /
-  3.70 / 5.17). This proves the *scorer* is deterministic — it re-scores fixed
-  text, it does not re-transcribe.
+  models) validates the benchmark manifest, runs manifest/scorer tests, and
+  re-scores the committed (frozen) hypotheses with CIs, reproducing the headline
+  macro WER (2.07 / 2.38 / 2.57 / 3.00 / 3.22 / 3.70 / 5.17). This proves the
+  *contract and scorer* are deterministic — it re-scores fixed text, it does not
+  re-transcribe.
 - **Spot pipeline reproduction.** Separately, re-transcribing through a clean
   `macparakeet-cli` and scoring on *identical utterance IDs* gives **Δ = 0.00 pt**
   vs the committed data on a stride-60 `test-clean` subset (six integrated
@@ -226,7 +276,7 @@ punctuation/capitalization. So unified is the better English Parakeet build.
 - **Determinism:** the scorers are deterministic; the bootstrap uses a fixed seed
   (1234). Same inputs → same numbers.
 
-**Provenance.** macparakeet-cli **2.9.0**; FluidAudio **v0.15.4**; CPython
+**Provenance.** macparakeet-cli **2.11.0**; FluidAudio **v0.15.4**; CPython
 **3.14.5** with pinned deps; LibriSpeech test-clean/test-other (OpenSLR SLR12);
 FLEURS via `FluidInference/fleurs-full` (HF); Cohere model
 `FluidInference/cohere-transcribe-03-2026-coreml` (q8); Apple M4 Pro / 48 GB /
@@ -240,10 +290,10 @@ macOS 15.
   by up to ~1.5 pt vs the full set and can reorder mid-pack engines — hence the
   full-set English run. `results/{*.jsonl, stride200/}` keep the first-200 +
   stride-200 evidence that motivated it.
-- **Cohere speed/memory** is measured via the FluidAudio CLI (the same SDK
-  MacParakeet would integrate), not yet through MacParakeet's own runtime (Cohere
-  isn't an integrated engine) — treat the figures as a lower bound and confirm
-  in-app before shipping.
+- **Cohere speed/memory** in the committed results is measured via the FluidAudio
+  CLI reference harness, not yet through MacParakeet's current Cohere runtime —
+  treat the figures as a lower bound and confirm in-app before making release or
+  Settings claims.
 - **Not benchmarked:** Qwen3-ASR and Moonshine (need an MLX runtime — deferred).
-  Integrating any winner (e.g. Cohere as an opt-in FluidAudio engine) is a
-  separate ADR-gated change.
+  Changing defaults or automatic engine routing is a separate ADR/spec-gated
+  product change, even when the benchmark evidence is favorable.

--- a/benchmarks/asr/manifest.json
+++ b/benchmarks/asr/manifest.json
@@ -237,7 +237,7 @@
       "license": "Derived metrics only.",
       "language": "en",
       "domain": "cold start, steady RTFx, peak RSS",
-      "expected_size": "24 LibriSpeech files for integrated engines; Cohere reference evidence currently from FluidAudio CLI."
+      "expected_size": "24 LibriSpeech files for integrated engines; Cohere reference evidence currently from FluidAudio CLI, but new runs should use macparakeet-cli."
     }
   ],
   "metrics": [
@@ -449,7 +449,7 @@
         "peak_rss_mb"
       ],
       "status": "current_reference_evidence",
-      "runner": "speed_bench.py",
+      "runner": "speed_bench.py; use cohere-fa-reference only for legacy FluidAudio comparisons.",
       "publication_rule": "Report hardware, macOS version, model path, runtime path, contention assumptions, and whether Cohere was measured through macparakeet-cli or FluidAudio reference CLI."
     }
   ],

--- a/benchmarks/asr/manifest.json
+++ b/benchmarks/asr/manifest.json
@@ -1,0 +1,494 @@
+{
+  "schema_version": 1,
+  "suite": {
+    "name": "MacParakeet ASR Benchmark Suite",
+    "owner": "MacParakeet",
+    "source_of_truth": "benchmarks/asr/README.md",
+    "purpose": "A product-owned, reproducible benchmark contract for choosing local ASR engines on Apple Silicon across accuracy, latency, memory, language coverage, and MacParakeet product surfaces.",
+    "principles": [
+      "Score every hypothesis through the same normalizer and metric implementation.",
+      "Keep public research datasets separate from private product fixtures.",
+      "Report uncertainty and use paired tests for engine-vs-engine claims.",
+      "Measure accuracy, speed, memory, and product-surface support separately.",
+      "Publish enough provenance for another MacParakeet checkout to reproduce the numbers."
+    ]
+  },
+  "engines": [
+    {
+      "id": "parakeet-v3",
+      "name": "Parakeet TDT 0.6B v3",
+      "runtime": "FluidAudio CoreML/ANE via macparakeet-cli",
+      "status": "shipping_default",
+      "language_scope": "multilingual",
+      "product_surfaces": [
+        "dictation_final",
+        "dictation_live_preview",
+        "meeting_final",
+        "meeting_live_preview",
+        "file_media",
+        "performance"
+      ],
+      "cli_flags": [
+        "--engine",
+        "parakeet",
+        "--parakeet-model",
+        "v3"
+      ],
+      "caveat": "Fast default, but current FLEURS evidence shows CJK/Korean failures."
+    },
+    {
+      "id": "parakeet-v2",
+      "name": "Parakeet TDT 0.6B v2",
+      "runtime": "FluidAudio CoreML/ANE via macparakeet-cli",
+      "status": "shipping_opt_in",
+      "language_scope": "English",
+      "product_surfaces": [
+        "dictation_final",
+        "dictation_live_preview",
+        "meeting_final",
+        "meeting_live_preview",
+        "file_media",
+        "performance"
+      ],
+      "cli_flags": [
+        "--engine",
+        "parakeet",
+        "--parakeet-model",
+        "v2"
+      ],
+      "caveat": "English-only no-punctuation TDT build."
+    },
+    {
+      "id": "parakeet-unified",
+      "name": "Parakeet Unified",
+      "runtime": "FluidAudio CoreML/ANE via macparakeet-cli",
+      "status": "shipping_opt_in",
+      "language_scope": "English",
+      "product_surfaces": [
+        "dictation_final",
+        "dictation_live_preview",
+        "meeting_final",
+        "meeting_live_preview",
+        "file_media",
+        "performance"
+      ],
+      "cli_flags": [
+        "--engine",
+        "parakeet",
+        "--parakeet-model",
+        "unified"
+      ],
+      "caveat": "English-only build with punctuation/capitalization."
+    },
+    {
+      "id": "nemotron-en",
+      "name": "Nemotron English 1120ms Beta",
+      "runtime": "FluidAudio CoreML/ANE via macparakeet-cli",
+      "status": "shipping_beta",
+      "language_scope": "English",
+      "product_surfaces": [
+        "dictation_final",
+        "dictation_live_preview",
+        "meeting_final",
+        "meeting_live_preview",
+        "file_media",
+        "performance"
+      ],
+      "cli_flags": [
+        "--engine",
+        "nemotron",
+        "--nemotron-model",
+        "english-1120ms"
+      ],
+      "caveat": "Beta engine; benchmarked as dominated by Parakeet on current English evidence."
+    },
+    {
+      "id": "nemotron-multi",
+      "name": "Nemotron Multilingual 1120ms Beta",
+      "runtime": "FluidAudio CoreML/ANE via macparakeet-cli",
+      "status": "shipping_beta",
+      "language_scope": "multilingual",
+      "product_surfaces": [
+        "dictation_final",
+        "dictation_live_preview",
+        "meeting_final",
+        "meeting_live_preview",
+        "file_media",
+        "performance"
+      ],
+      "cli_flags": [
+        "--engine",
+        "nemotron",
+        "--nemotron-model",
+        "multilingual-1120ms"
+      ],
+      "caveat": "Beta engine; keep benchmarked but do not promote without new evidence."
+    },
+    {
+      "id": "whisper",
+      "name": "WhisperKit large-v3-turbo",
+      "runtime": "WhisperKit via macparakeet-cli",
+      "status": "shipping_opt_in",
+      "language_scope": "multilingual",
+      "product_surfaces": [
+        "dictation_final",
+        "meeting_final",
+        "file_media",
+        "performance"
+      ],
+      "cli_flags": [
+        "--engine",
+        "whisper"
+      ],
+      "caveat": "Light multilingual fallback; live preview remains default-off pending latency evidence."
+    },
+    {
+      "id": "cohere",
+      "name": "Cohere Transcribe 03-2026 q8",
+      "runtime": "FluidAudio CoreML/ANE via macparakeet-cli",
+      "status": "shipping_opt_in",
+      "language_scope": "selected_languages",
+      "product_surfaces": [
+        "dictation_final",
+        "meeting_final",
+        "file_media",
+        "performance"
+      ],
+      "cli_flags": [
+        "--engine",
+        "cohere",
+        "--language",
+        "en"
+      ],
+      "caveat": "Batch-only, no live preview, no word timestamps, no auto language detection, and should stay 16 GB+ gated unless new memory evidence says otherwise."
+    }
+  ],
+  "datasets": [
+    {
+      "id": "librispeech-test-clean",
+      "name": "LibriSpeech test-clean",
+      "tier": "public_research",
+      "status": "committed_full_results",
+      "license": "Public-domain-derived audiobook corpus; see OpenSLR SLR12.",
+      "source_url": "https://www.openslr.org/12",
+      "language": "en",
+      "domain": "clean read speech",
+      "expected_size": "2620 utterances"
+    },
+    {
+      "id": "librispeech-test-other",
+      "name": "LibriSpeech test-other",
+      "tier": "public_research",
+      "status": "committed_full_results",
+      "license": "Public-domain-derived audiobook corpus; see OpenSLR SLR12.",
+      "source_url": "https://www.openslr.org/12",
+      "language": "en",
+      "domain": "noisier read speech",
+      "expected_size": "2939 utterances"
+    },
+    {
+      "id": "fleurs-en-ko-ja-zh",
+      "name": "FLEURS en/ko/ja/zh",
+      "tier": "public_research",
+      "status": "committed_capped_results",
+      "license": "See FLEURS dataset terms.",
+      "source_url": "https://arxiv.org/abs/2205.12446",
+      "language": "en, ko, ja, zh",
+      "domain": "parallel multilingual read speech",
+      "expected_size": "150 utterances per language in committed evidence; expand before publishing language-routing absolutes."
+    },
+    {
+      "id": "ami-meetings",
+      "name": "AMI Meeting Corpus",
+      "tier": "planned_public_meeting",
+      "status": "planned",
+      "license": "See AMI corpus terms.",
+      "source_url": "https://groups.inf.ed.ac.uk/ami/corpus/",
+      "language": "en",
+      "domain": "multi-speaker meetings",
+      "expected_size": "Use a fixed, documented subset before promoting meeting-engine decisions."
+    },
+    {
+      "id": "earnings22-accented",
+      "name": "Earnings-22",
+      "tier": "planned_public_wild",
+      "status": "planned",
+      "license": "Free-to-use benchmark; see dataset paper/card.",
+      "source_url": "https://arxiv.org/abs/2203.15591",
+      "language": "en",
+      "domain": "accented, long-form earnings calls",
+      "expected_size": "125 files / about 119 hours."
+    },
+    {
+      "id": "macparakeet-private-product-fixtures",
+      "name": "MacParakeet private product fixtures",
+      "tier": "private_product",
+      "status": "planned_private",
+      "license": "Do not commit audio or transcripts without explicit consent.",
+      "language": "mixed",
+      "domain": "real dictation, meeting, file, and media workflows",
+      "expected_size": "Small consented regression set plus rotating internal challenge set."
+    },
+    {
+      "id": "speed-memory-local",
+      "name": "Local speed and memory micro-benchmark",
+      "tier": "local_performance",
+      "status": "committed_reference_results",
+      "license": "Derived metrics only.",
+      "language": "en",
+      "domain": "cold start, steady RTFx, peak RSS",
+      "expected_size": "24 LibriSpeech files for integrated engines; Cohere reference evidence currently from FluidAudio CLI."
+    }
+  ],
+  "metrics": [
+    {
+      "id": "wer",
+      "name": "Word error rate",
+      "kind": "accuracy",
+      "implementation": "score.py / score_multi.py",
+      "notes": "Corpus WER after canonical normalization."
+    },
+    {
+      "id": "cer",
+      "name": "Character error rate",
+      "kind": "accuracy",
+      "implementation": "score_multi.py",
+      "notes": "Used for Korean, Japanese, Chinese, Thai, and related no-space languages."
+    },
+    {
+      "id": "paired_delta_ci",
+      "name": "Paired bootstrap delta CI",
+      "kind": "significance",
+      "implementation": "paired_delta.py",
+      "notes": "Required for engine-vs-engine claims on shared utterance sets."
+    },
+    {
+      "id": "bootstrap_ci",
+      "name": "Bootstrap confidence interval",
+      "kind": "uncertainty",
+      "implementation": "score.py / score_multi.py",
+      "notes": "95% CI by resampling utterances with a fixed seed."
+    },
+    {
+      "id": "rtfx",
+      "name": "Realtime factor throughput",
+      "kind": "performance",
+      "implementation": "score.py / speed_bench.py",
+      "notes": "audio_seconds / wall_seconds; higher is faster."
+    },
+    {
+      "id": "cold_start_s",
+      "name": "Cold start seconds",
+      "kind": "performance",
+      "implementation": "speed_bench.py",
+      "notes": "Fresh-process time to first transcript."
+    },
+    {
+      "id": "peak_rss_mb",
+      "name": "Peak RSS MB",
+      "kind": "memory",
+      "implementation": "speed_bench.py",
+      "notes": "Maximum resident set size from /usr/bin/time -l."
+    },
+    {
+      "id": "surface_support",
+      "name": "Product surface support",
+      "kind": "product_fit",
+      "implementation": "manifest.json",
+      "notes": "Explicitly records whether an engine can serve live preview, final transcription, meeting, file/media, and performance tasks."
+    }
+  ],
+  "tasks": [
+    {
+      "id": "english_accuracy_full",
+      "name": "English full-set accuracy",
+      "surface": "file_media",
+      "datasets": [
+        "librispeech-test-clean",
+        "librispeech-test-other"
+      ],
+      "engines": [
+        "parakeet-v2",
+        "parakeet-v3",
+        "parakeet-unified",
+        "nemotron-en",
+        "nemotron-multi",
+        "whisper",
+        "cohere"
+      ],
+      "primary_metric": "wer",
+      "metrics": [
+        "wer",
+        "bootstrap_ci",
+        "paired_delta_ci",
+        "rtfx"
+      ],
+      "status": "current_committed_evidence",
+      "runner": "run_macparakeet.py for shipping engines; fa_json_to_jsonl.py only for legacy FluidAudio reference imports.",
+      "publication_rule": "Use full test-clean and test-other for English claims; do not cite first-N subsets as final."
+    },
+    {
+      "id": "multilingual_accuracy_capped",
+      "name": "Multilingual directional accuracy",
+      "surface": "file_media",
+      "datasets": [
+        "fleurs-en-ko-ja-zh"
+      ],
+      "engines": [
+        "parakeet-v3",
+        "nemotron-multi",
+        "whisper",
+        "cohere"
+      ],
+      "primary_metric": "cer",
+      "metrics": [
+        "wer",
+        "cer",
+        "bootstrap_ci",
+        "paired_delta_ci"
+      ],
+      "status": "current_capped_evidence",
+      "runner": "run_macparakeet_fleurs.py for shipping engines; fa_json_to_jsonl.py only for legacy FluidAudio reference imports.",
+      "publication_rule": "Treat n=150/language as ranking-grade; expand before shipping automatic language routing."
+    },
+    {
+      "id": "meeting_accuracy_planned",
+      "name": "Meeting transcription accuracy",
+      "surface": "meeting_final",
+      "datasets": [
+        "ami-meetings",
+        "macparakeet-private-product-fixtures"
+      ],
+      "engines": [
+        "parakeet-v3",
+        "parakeet-unified",
+        "nemotron-multi",
+        "whisper",
+        "cohere"
+      ],
+      "primary_metric": "wer",
+      "metrics": [
+        "wer",
+        "bootstrap_ci",
+        "paired_delta_ci",
+        "surface_support"
+      ],
+      "status": "planned",
+      "runner": "future meeting fixture runner",
+      "publication_rule": "Separate final transcript quality from live-preview behavior and speaker-label quality."
+    },
+    {
+      "id": "live_preview_support",
+      "name": "Live preview suitability",
+      "surface": "dictation_live_preview",
+      "datasets": [
+        "macparakeet-private-product-fixtures"
+      ],
+      "engines": [
+        "parakeet-v2",
+        "parakeet-v3",
+        "parakeet-unified",
+        "nemotron-en",
+        "nemotron-multi"
+      ],
+      "primary_metric": "surface_support",
+      "metrics": [
+        "surface_support",
+        "rtfx"
+      ],
+      "status": "planned_private",
+      "runner": "future live-preview latency/stability harness",
+      "publication_rule": "Do not infer live-preview quality from batch WER alone; Cohere and Whisper are excluded until product support changes."
+    },
+    {
+      "id": "accent_wild_planned",
+      "name": "Accented real-world English",
+      "surface": "research",
+      "datasets": [
+        "earnings22-accented"
+      ],
+      "engines": [
+        "parakeet-v2",
+        "parakeet-v3",
+        "parakeet-unified",
+        "nemotron-en",
+        "nemotron-multi",
+        "whisper",
+        "cohere"
+      ],
+      "primary_metric": "wer",
+      "metrics": [
+        "wer",
+        "bootstrap_ci",
+        "paired_delta_ci"
+      ],
+      "status": "planned",
+      "runner": "future long-form runner",
+      "publication_rule": "Use when evaluating noisy/accented claims; LibriSpeech alone is not enough."
+    },
+    {
+      "id": "speed_memory_local",
+      "name": "Speed and memory",
+      "surface": "performance",
+      "datasets": [
+        "speed-memory-local"
+      ],
+      "engines": [
+        "parakeet-v2",
+        "parakeet-v3",
+        "parakeet-unified",
+        "nemotron-en",
+        "nemotron-multi",
+        "whisper",
+        "cohere"
+      ],
+      "primary_metric": "rtfx",
+      "metrics": [
+        "rtfx",
+        "cold_start_s",
+        "peak_rss_mb"
+      ],
+      "status": "current_reference_evidence",
+      "runner": "speed_bench.py",
+      "publication_rule": "Report hardware, macOS version, model path, runtime path, contention assumptions, and whether Cohere was measured through macparakeet-cli or FluidAudio reference CLI."
+    }
+  ],
+  "quality_gates": [
+    {
+      "id": "repo_verify",
+      "name": "Repo-only verifier",
+      "scope": "pull_request",
+      "required_evidence": [
+        "./run_all.sh verify passes",
+        "manifest_tool.py validate manifest.json passes",
+        "scorer tests pass",
+        "committed JSONL evidence re-scores deterministically"
+      ]
+    },
+    {
+      "id": "product_default_change",
+      "name": "Speech-engine default or routing change",
+      "scope": "product_decision",
+      "required_evidence": [
+        "Full English LibriSpeech test-clean and test-other results",
+        "Relevant multilingual or domain dataset results",
+        "Paired bootstrap deltas for claimed wins",
+        "Speed, cold-start, and peak-RSS measurements on supported hardware",
+        "Explicit product-surface support check for dictation, meeting, file/media, and live preview"
+      ]
+    },
+    {
+      "id": "published_result_refresh",
+      "name": "Published benchmark refresh",
+      "scope": "research_release",
+      "required_evidence": [
+        "Pinned MacParakeet commit and CLI version",
+        "Pinned model/runtime versions",
+        "Dataset source, split, utterance count, and selection policy",
+        "Normalizer and scorer version",
+        "Hardware and macOS version",
+        "Raw hypotheses or compressed artifact available when license-safe"
+      ]
+    }
+  ]
+}

--- a/benchmarks/asr/manifest_tool.py
+++ b/benchmarks/asr/manifest_tool.py
@@ -42,9 +42,16 @@ ALLOWED_SURFACES = {
 }
 
 
-def load_manifest(path: Path) -> dict[str, Any]:
-    with path.open(encoding="utf-8") as fh:
-        return json.load(fh)
+def load_manifest(path: Path) -> Any:
+    try:
+        with path.open(encoding="utf-8") as fh:
+            return json.load(fh)
+    except FileNotFoundError:
+        print(f"manifest error: file not found: {path}", file=sys.stderr)
+        raise SystemExit(1)
+    except json.JSONDecodeError as exc:
+        print(f"manifest error: invalid JSON in {path}: {exc}", file=sys.stderr)
+        raise SystemExit(1)
 
 
 def _ids(rows: list[Any], kind: str, errors: list[str]) -> set[str]:
@@ -83,8 +90,10 @@ def _require_fields(rows: list[Any], kind: str, errors: list[str]) -> None:
                 errors.append(f"engines.{item_id}.product_surfaces must be a non-empty list")
 
 
-def validate_manifest(data: dict[str, Any]) -> list[str]:
+def validate_manifest(data: Any) -> list[str]:
     errors: list[str] = []
+    if not isinstance(data, dict):
+        return ["manifest root must be a JSON object"]
 
     for field in REQUIRED_TOP_LEVEL:
         if field not in data:
@@ -94,6 +103,17 @@ def validate_manifest(data: dict[str, Any]) -> list[str]:
 
     if data.get("schema_version") != 1:
         errors.append("schema_version must be 1")
+
+    suite = data.get("suite")
+    if not isinstance(suite, dict):
+        errors.append("top-level field 'suite' must be an object")
+    else:
+        name = suite.get("name")
+        purpose = suite.get("purpose")
+        if not isinstance(name, str) or not name.strip():
+            errors.append("suite.name must be a non-empty string")
+        if purpose is not None and not isinstance(purpose, str):
+            errors.append("suite.purpose must be a string")
 
     for kind in ("engines", "datasets", "tasks", "metrics", "quality_gates"):
         if not isinstance(data.get(kind), list):
@@ -148,11 +168,15 @@ def validate_manifest(data: dict[str, Any]) -> list[str]:
     return errors
 
 
+def _md_cell(value: Any) -> str:
+    return str(value).replace("\n", " ").replace("|", "\\|")
+
+
 def markdown_summary(data: dict[str, Any]) -> str:
     lines = [
-        f"# {data['suite']['name']}",
+        f"# {_md_cell(data['suite']['name'])}",
         "",
-        data["suite"].get("purpose", "").strip(),
+        _md_cell(data["suite"].get("purpose", "").strip()),
         "",
         "## Tasks",
         "",
@@ -162,12 +186,12 @@ def markdown_summary(data: dict[str, Any]) -> str:
     for task in data["tasks"]:
         lines.append(
             "| {name} | `{surface}` | {status} | {datasets} | {engines} | `{metric}` |".format(
-                name=task["name"],
-                surface=task["surface"],
-                status=task["status"],
+                name=_md_cell(task["name"]),
+                surface=_md_cell(task["surface"]),
+                status=_md_cell(task["status"]),
                 datasets=", ".join(f"`{d}`" for d in task["datasets"]),
                 engines=", ".join(f"`{e}`" for e in task["engines"]),
-                metric=task["primary_metric"],
+                metric=_md_cell(task["primary_metric"]),
             )
         )
 
@@ -181,10 +205,10 @@ def markdown_summary(data: dict[str, Any]) -> str:
     for engine in data["engines"]:
         lines.append(
             "| {name} | {runtime} | {surfaces} | {caveat} |".format(
-                name=engine["name"],
-                runtime=engine["runtime"],
+                name=_md_cell(engine["name"]),
+                runtime=_md_cell(engine["runtime"]),
                 surfaces=", ".join(f"`{s}`" for s in engine["product_surfaces"]),
-                caveat=engine.get("caveat", ""),
+                caveat=_md_cell(engine.get("caveat", "")),
             )
         )
     return "\n".join(lines) + "\n"

--- a/benchmarks/asr/manifest_tool.py
+++ b/benchmarks/asr/manifest_tool.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Validate and summarize the MacParakeet ASR benchmark manifest.
+
+The manifest is the suite contract: engines, datasets, tasks, metrics, and
+decision gates. This tool deliberately stays dependency-free so `run_all.sh
+verify` can check the contract without downloading models or benchmark data.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+REQUIRED_TOP_LEVEL = (
+    "schema_version",
+    "suite",
+    "engines",
+    "datasets",
+    "tasks",
+    "metrics",
+    "quality_gates",
+)
+
+REQUIRED_LIST_FIELDS = {
+    "engines": ("id", "name", "runtime", "product_surfaces"),
+    "datasets": ("id", "name", "tier", "status", "license"),
+    "tasks": ("id", "name", "surface", "datasets", "engines", "primary_metric", "metrics", "status"),
+    "metrics": ("id", "name", "kind"),
+    "quality_gates": ("id", "name", "scope", "required_evidence"),
+}
+
+ALLOWED_SURFACES = {
+    "dictation_final",
+    "dictation_live_preview",
+    "meeting_final",
+    "meeting_live_preview",
+    "file_media",
+    "performance",
+    "research",
+}
+
+
+def load_manifest(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _ids(rows: list[dict[str, Any]], kind: str, errors: list[str]) -> set[str]:
+    seen: set[str] = set()
+    for idx, row in enumerate(rows):
+        item_id = row.get("id")
+        if not isinstance(item_id, str) or not item_id.strip():
+            errors.append(f"{kind}[{idx}] is missing a non-empty id")
+            continue
+        if item_id in seen:
+            errors.append(f"{kind} has duplicate id '{item_id}'")
+        seen.add(item_id)
+    return seen
+
+
+def _require_fields(rows: list[dict[str, Any]], kind: str, errors: list[str]) -> None:
+    required = REQUIRED_LIST_FIELDS[kind]
+    for row in rows:
+        item_id = row.get("id", "<missing>")
+        for field in required:
+            if field not in row:
+                errors.append(f"{kind}.{item_id} missing required field '{field}'")
+        if kind == "tasks":
+            for field in ("datasets", "engines", "metrics"):
+                value = row.get(field)
+                if not isinstance(value, list) or not value:
+                    errors.append(f"tasks.{item_id}.{field} must be a non-empty list")
+        if kind == "engines":
+            surfaces = row.get("product_surfaces")
+            if not isinstance(surfaces, list) or not surfaces:
+                errors.append(f"engines.{item_id}.product_surfaces must be a non-empty list")
+
+
+def validate_manifest(data: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+
+    for field in REQUIRED_TOP_LEVEL:
+        if field not in data:
+            errors.append(f"top-level field '{field}' is required")
+    if errors:
+        return errors
+
+    if data.get("schema_version") != 1:
+        errors.append("schema_version must be 1")
+
+    for kind in ("engines", "datasets", "tasks", "metrics", "quality_gates"):
+        if not isinstance(data.get(kind), list):
+            errors.append(f"top-level field '{kind}' must be a list")
+    if errors:
+        return errors
+
+    for kind in ("engines", "datasets", "tasks", "metrics", "quality_gates"):
+        _require_fields(data[kind], kind, errors)
+
+    engine_ids = _ids(data["engines"], "engines", errors)
+    dataset_ids = _ids(data["datasets"], "datasets", errors)
+    metric_ids = _ids(data["metrics"], "metrics", errors)
+    _ids(data["tasks"], "tasks", errors)
+    _ids(data["quality_gates"], "quality_gates", errors)
+
+    for engine in data["engines"]:
+        for surface in engine.get("product_surfaces", []):
+            if surface not in ALLOWED_SURFACES:
+                errors.append(f"engines.{engine.get('id')}.product_surfaces has unknown surface '{surface}'")
+
+    for task in data["tasks"]:
+        task_id = task.get("id")
+        surface = task.get("surface")
+        if surface not in ALLOWED_SURFACES:
+            errors.append(f"tasks.{task_id}.surface has unknown surface '{surface}'")
+        for dataset in task.get("datasets", []):
+            if dataset not in dataset_ids:
+                errors.append(f"tasks.{task_id}.datasets references unknown dataset '{dataset}'")
+        for engine in task.get("engines", []):
+            if engine not in engine_ids:
+                errors.append(f"tasks.{task_id}.engines references unknown engine '{engine}'")
+        primary = task.get("primary_metric")
+        if primary not in metric_ids:
+            errors.append(f"tasks.{task_id}.primary_metric references unknown metric '{primary}'")
+        if primary not in task.get("metrics", []):
+            errors.append(f"tasks.{task_id}.primary_metric '{primary}' must also be listed in metrics")
+        for metric in task.get("metrics", []):
+            if metric not in metric_ids:
+                errors.append(f"tasks.{task_id}.metrics references unknown metric '{metric}'")
+
+    return errors
+
+
+def markdown_summary(data: dict[str, Any]) -> str:
+    lines = [
+        f"# {data['suite']['name']}",
+        "",
+        data["suite"].get("purpose", "").strip(),
+        "",
+        "## Tasks",
+        "",
+        "| Task | Surface | Status | Datasets | Engines | Primary metric |",
+        "|------|---------|--------|----------|---------|----------------|",
+    ]
+    for task in data["tasks"]:
+        lines.append(
+            "| {name} | `{surface}` | {status} | {datasets} | {engines} | `{metric}` |".format(
+                name=task["name"],
+                surface=task["surface"],
+                status=task["status"],
+                datasets=", ".join(f"`{d}`" for d in task["datasets"]),
+                engines=", ".join(f"`{e}`" for e in task["engines"]),
+                metric=task["primary_metric"],
+            )
+        )
+
+    lines.extend([
+        "",
+        "## Engines",
+        "",
+        "| Engine | Runtime | Surfaces | Caveat |",
+        "|--------|---------|----------|--------|",
+    ])
+    for engine in data["engines"]:
+        lines.append(
+            "| {name} | {runtime} | {surfaces} | {caveat} |".format(
+                name=engine["name"],
+                runtime=engine["runtime"],
+                surfaces=", ".join(f"`{s}`" for s in engine["product_surfaces"]),
+                caveat=engine.get("caveat", ""),
+            )
+        )
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("command", choices=["validate", "summary"])
+    ap.add_argument("manifest", nargs="?", type=Path, default=Path("manifest.json"))
+    args = ap.parse_args()
+
+    manifest = load_manifest(args.manifest)
+    errors = validate_manifest(manifest)
+    if errors:
+        for error in errors:
+            print(f"manifest error: {error}", file=sys.stderr)
+        return 1
+
+    if args.command == "validate":
+        print(f"manifest ok: {args.manifest}")
+    else:
+        print(markdown_summary(manifest), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/asr/manifest_tool.py
+++ b/benchmarks/asr/manifest_tool.py
@@ -47,9 +47,11 @@ def load_manifest(path: Path) -> dict[str, Any]:
         return json.load(fh)
 
 
-def _ids(rows: list[dict[str, Any]], kind: str, errors: list[str]) -> set[str]:
+def _ids(rows: list[Any], kind: str, errors: list[str]) -> set[str]:
     seen: set[str] = set()
     for idx, row in enumerate(rows):
+        if not isinstance(row, dict):
+            continue
         item_id = row.get("id")
         if not isinstance(item_id, str) or not item_id.strip():
             errors.append(f"{kind}[{idx}] is missing a non-empty id")
@@ -60,9 +62,12 @@ def _ids(rows: list[dict[str, Any]], kind: str, errors: list[str]) -> set[str]:
     return seen
 
 
-def _require_fields(rows: list[dict[str, Any]], kind: str, errors: list[str]) -> None:
+def _require_fields(rows: list[Any], kind: str, errors: list[str]) -> None:
     required = REQUIRED_LIST_FIELDS[kind]
-    for row in rows:
+    for idx, row in enumerate(rows):
+        if not isinstance(row, dict):
+            errors.append(f"{kind}[{idx}] must be an object")
+            continue
         item_id = row.get("id", "<missing>")
         for field in required:
             if field not in row:
@@ -106,27 +111,37 @@ def validate_manifest(data: dict[str, Any]) -> list[str]:
     _ids(data["quality_gates"], "quality_gates", errors)
 
     for engine in data["engines"]:
-        for surface in engine.get("product_surfaces", []):
+        if not isinstance(engine, dict):
+            continue
+        surfaces = engine.get("product_surfaces")
+        if not isinstance(surfaces, list):
+            continue
+        for surface in surfaces:
             if surface not in ALLOWED_SURFACES:
                 errors.append(f"engines.{engine.get('id')}.product_surfaces has unknown surface '{surface}'")
 
     for task in data["tasks"]:
+        if not isinstance(task, dict):
+            continue
         task_id = task.get("id")
         surface = task.get("surface")
         if surface not in ALLOWED_SURFACES:
             errors.append(f"tasks.{task_id}.surface has unknown surface '{surface}'")
-        for dataset in task.get("datasets", []):
+        datasets = task.get("datasets") if isinstance(task.get("datasets"), list) else []
+        engines = task.get("engines") if isinstance(task.get("engines"), list) else []
+        metrics = task.get("metrics") if isinstance(task.get("metrics"), list) else []
+        for dataset in datasets:
             if dataset not in dataset_ids:
                 errors.append(f"tasks.{task_id}.datasets references unknown dataset '{dataset}'")
-        for engine in task.get("engines", []):
+        for engine in engines:
             if engine not in engine_ids:
                 errors.append(f"tasks.{task_id}.engines references unknown engine '{engine}'")
         primary = task.get("primary_metric")
         if primary not in metric_ids:
             errors.append(f"tasks.{task_id}.primary_metric references unknown metric '{primary}'")
-        if primary not in task.get("metrics", []):
+        if metrics and primary not in metrics:
             errors.append(f"tasks.{task_id}.primary_metric '{primary}' must also be listed in metrics")
-        for metric in task.get("metrics", []):
+        for metric in metrics:
             if metric not in metric_ids:
                 errors.append(f"tasks.{task_id}.metrics references unknown metric '{metric}'")
 

--- a/benchmarks/asr/manifest_tool.py
+++ b/benchmarks/asr/manifest_tool.py
@@ -81,11 +81,15 @@ def _require_fields(rows: list[Any], kind: str, errors: list[str]) -> None:
                 errors.append(f"{kind}.{item_id} missing required field '{field}'")
         if kind == "tasks":
             for field in ("datasets", "engines", "metrics"):
-                value = row.get(field)
+                if field not in row:
+                    continue
+                value = row[field]
                 if not isinstance(value, list) or not value:
                     errors.append(f"tasks.{item_id}.{field} must be a non-empty list")
         if kind == "engines":
-            surfaces = row.get("product_surfaces")
+            if "product_surfaces" not in row:
+                continue
+            surfaces = row["product_surfaces"]
             if not isinstance(surfaces, list) or not surfaces:
                 errors.append(f"engines.{item_id}.product_surfaces must be a non-empty list")
 

--- a/benchmarks/asr/manifest_tool.py
+++ b/benchmarks/asr/manifest_tool.py
@@ -148,9 +148,10 @@ def validate_manifest(data: Any) -> list[str]:
         if not isinstance(task, dict):
             continue
         task_id = task.get("id")
-        surface = task.get("surface")
-        if surface not in ALLOWED_SURFACES:
-            errors.append(f"tasks.{task_id}.surface has unknown surface '{surface}'")
+        if "surface" in task:
+            surface = task["surface"]
+            if surface not in ALLOWED_SURFACES:
+                errors.append(f"tasks.{task_id}.surface has unknown surface '{surface}'")
         datasets = task.get("datasets") if isinstance(task.get("datasets"), list) else []
         engines = task.get("engines") if isinstance(task.get("engines"), list) else []
         metrics = task.get("metrics") if isinstance(task.get("metrics"), list) else []
@@ -160,10 +161,10 @@ def validate_manifest(data: Any) -> list[str]:
         for engine in engines:
             if engine not in engine_ids:
                 errors.append(f"tasks.{task_id}.engines references unknown engine '{engine}'")
-        primary = task.get("primary_metric")
-        if primary not in metric_ids:
+        primary = task.get("primary_metric") if "primary_metric" in task else None
+        if primary is not None and primary not in metric_ids:
             errors.append(f"tasks.{task_id}.primary_metric references unknown metric '{primary}'")
-        if metrics and primary not in metrics:
+        if primary is not None and metrics and primary not in metrics:
             errors.append(f"tasks.{task_id}.primary_metric '{primary}' must also be listed in metrics")
         for metric in metrics:
             if metric not in metric_ids:

--- a/benchmarks/asr/run_all.sh
+++ b/benchmarks/asr/run_all.sh
@@ -11,8 +11,9 @@
 set -euo pipefail
 cd "$(dirname "$0")"
 
-PY="${PY:-python3}"                       # set PY=venv/bin/python3 to use the venv
+PY="${PY:-python3}"                         # set PY=venv/bin/python3 to use the venv
 BOOT="${BOOT:-2000}"; SEED="${SEED:-1234}"  # bootstrap resamples / RNG seed
+COHERE_SPEED_N="${COHERE_SPEED_N:-12}"      # Cohere is memory/cold-start heavy
 # Heavy-path assets (override as needed):
 MP_CLI="${MP_CLI:-$HOME/code/macparakeet/.build/release/macparakeet-cli}"
 FA_CLI="${FA_CLI:-$HOME/asr-bench/FluidAudio-0154/.build/release/fluidaudiocli}"
@@ -46,7 +47,11 @@ speed() {
   for e in parakeet-v2 parakeet-v3 parakeet-unified nemotron-en nemotron-multi whisper; do
     "$PY" speed_bench.py --engine "$e" --cli "$MP_CLI" --dataset-dir "$LS_CLEAN" --n 24 --out "$out"
   done
-  "$PY" speed_bench.py --engine cohere --fa "$FA_CLI" --cohere-model "$COHERE_MODEL" --n 12 --out "$out"
+  "$PY" speed_bench.py --engine cohere --cli "$MP_CLI" --dataset-dir "$LS_CLEAN" \
+    --n "$COHERE_SPEED_N" --out "$out"
+  echo "Legacy Cohere FluidAudio reference speed import, if needed for comparison:"
+  echo "  $PY speed_bench.py --engine cohere-fa-reference --fa \$FA_CLI \\"
+  echo "    --cohere-model \$COHERE_MODEL --n \$COHERE_SPEED_N --out $out"
 }
 
 transcribe() {

--- a/benchmarks/asr/run_all.sh
+++ b/benchmarks/asr/run_all.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Reproduce the ASR benchmark. Two tiers:
 #
-#   ./run_all.sh verify     # cheap, repo-only: scorer tests + re-score committed
-#                           # evidence with 95% CIs (no datasets/models needed)
+#   ./run_all.sh verify     # cheap, repo-only: manifest + scorer tests + re-score
+#                           # committed evidence with 95% CIs (no datasets/models)
 #   ./run_all.sh speed      # heavy: speed/memory micro-benchmark (needs assets)
 #   ./run_all.sh transcribe # heavy: regenerate hypotheses from audio (needs assets)
 #
@@ -20,6 +20,10 @@ COHERE_MODEL="${COHERE_MODEL:-$HOME/asr-bench/cohere-coreml/q8}"
 LS_CLEAN="${LS_CLEAN:-$HOME/asr-bench/LibriSpeech/test-clean}"
 
 verify() {
+  echo "== manifest contract =="
+  "$PY" manifest_tool.py validate manifest.json
+  "$PY" test_manifest.py
+  echo
   echo "== scorer unit tests =="
   "$PY" test_scorers.py
   echo; echo "== re-score committed multilingual (with 95% CI) =="
@@ -48,13 +52,14 @@ speed() {
 transcribe() {
   echo "== regenerate English hypotheses via macparakeet-cli (full sets) =="
   for sub in test-clean test-other; do
-    for e in parakeet-v2 parakeet-v3 parakeet-unified nemotron-en nemotron-multi whisper; do
+    for e in parakeet-v2 parakeet-v3 parakeet-unified nemotron-en nemotron-multi whisper cohere; do
       "$PY" run_macparakeet.py --cli "$MP_CLI" \
         --dataset-dir "$HOME/asr-bench/LibriSpeech/$sub" --dataset-name "$sub" \
         --engine "$e" --records "results/full/${e}__${sub}.jsonl"
     done
   done
-  echo "Cohere via FluidAudio: fluidaudiocli cohere-benchmark --dataset librispeech \\"
+  echo "Legacy Cohere FluidAudio reference import, if needed for result comparison:"
+  echo "  fluidaudiocli cohere-benchmark --dataset librispeech \\"
   echo "  --subset test-clean --model-dir \$COHERE_MODEL --output cohere.json"
   echo "then: python3 fa_json_to_jsonl.py cohere.json --engine cohere --dataset test-clean --out ..."
 }

--- a/benchmarks/asr/run_macparakeet.py
+++ b/benchmarks/asr/run_macparakeet.py
@@ -11,9 +11,10 @@ scored by the same canonical scorer (`score.py`). Pair the emitted JSONL with:
 
 Engines (`--engine` value -> macparakeet-cli flags):
     parakeet-v2 / v3 / unified   -> --engine parakeet --parakeet-model {v2,v3,unified}
-    nemotron-en                  -> --engine nemotron --nemotron-model nemotron-english-1120ms
-    nemotron-multi               -> --engine nemotron --nemotron-model nemotron-multilingual-1120ms
+    nemotron-en                  -> --engine nemotron --nemotron-model english-1120ms
+    nemotron-multi               -> --engine nemotron --nemotron-model multilingual-1120ms
     whisper                      -> --engine whisper
+    cohere                       -> --engine cohere --language en
 
 RTFx note: proc_s is the batch wall-clock (incl. one-time model load) amortized
 across files proportional to audio length, so the scorer's RTFx column reflects
@@ -38,6 +39,7 @@ ENGINES = {
     "nemotron-en": ["--engine", "nemotron", "--nemotron-model", "english-1120ms"],
     "nemotron-multi": ["--engine", "nemotron", "--nemotron-model", "multilingual-1120ms"],
     "whisper": ["--engine", "whisper"],
+    "cohere": ["--engine", "cohere", "--language", "en"],
 }
 
 

--- a/benchmarks/asr/run_macparakeet_fleurs.py
+++ b/benchmarks/asr/run_macparakeet_fleurs.py
@@ -11,6 +11,7 @@ Engines (`--engine` -> macparakeet-cli flags); --language hint set from the FLEU
     whisper          -> --engine whisper --language <hint>
     nemotron-multi   -> --engine nemotron --nemotron-model multilingual-1120ms --language <hint>
     parakeet-v3      -> --engine parakeet --parakeet-model v3 --language <hint>   (EU+en; not CJK)
+    cohere           -> --engine cohere --language <hint>
 
 Score with score_multi.py (WER for en, CER for ko/ja/zh).
 """
@@ -32,6 +33,7 @@ ENGINES = {
     "whisper": lambda hint: ["--engine", "whisper", "--language", hint],
     "nemotron-multi": lambda hint: ["--engine", "nemotron", "--nemotron-model", "multilingual-1120ms", "--language", hint],
     "parakeet-v3": lambda hint: ["--engine", "parakeet", "--parakeet-model", "v3", "--language", hint],
+    "cohere": lambda hint: ["--engine", "cohere", "--language", hint],
 }
 
 

--- a/benchmarks/asr/run_macparakeet_fleurs.py
+++ b/benchmarks/asr/run_macparakeet_fleurs.py
@@ -21,6 +21,7 @@ import argparse
 import json
 import shutil
 import subprocess
+import sys
 import tempfile
 import time
 from pathlib import Path
@@ -84,6 +85,7 @@ def main() -> int:
         for p in wavs:
             tx = out_dir / f"{p.stem}.txt"
             if not tx.exists():
+                print(f"  WARN missing transcript: {tx.name}", file=sys.stderr)
                 continue
             rec = {"id": p.stem, "ref": refs[p.stem], "hyp": tx.read_text(encoding="utf-8").strip(),
                    "lang": args.lang, "engine": args.engine}

--- a/benchmarks/asr/speed_bench.py
+++ b/benchmarks/asr/speed_bench.py
@@ -167,15 +167,13 @@ def main() -> int:
             print(f">>> measuring {eng} ...", flush=True)
             rec = measure_cohere_reference(args.fa.expanduser().resolve(),
                                            args.cohere_model.expanduser().resolve(), args.n)
-        elif eng in MP_ENGINES:
+        else:
             if not args.cli:
                 raise SystemExit("--cli required for macparakeet-cli engines")
             if not files:
                 raise SystemExit("--dataset-dir required for macparakeet-cli engines")
             print(f">>> measuring {eng} ...", flush=True)
             rec = measure_macparakeet(eng, args.cli.expanduser().resolve(), files, args.n)
-        else:
-            raise SystemExit(f"unknown engine {eng!r}; expected one of {ALL_ENGINES}")
         print("   " + json.dumps(rec))
         out_records.append(rec)
         if args.out:

--- a/benchmarks/asr/speed_bench.py
+++ b/benchmarks/asr/speed_bench.py
@@ -12,12 +12,15 @@ speed/memory profile, **one engine at a time, nothing else running**:
     For macparakeet-cli engines we run the same prefix at two sizes (1 file vs
     N files) in fresh processes; the difference cancels the fixed load:
         steady = (audio_N - audio_1) / (wall_N - wall_1)
-    For Cohere (FluidAudio CLI) we read its per-file rtfx and drop file 0.
+    For the current committed Cohere reference result (FluidAudio CLI) we read
+    its per-file rtfx and drop file 0.
   - **peak RSS** = `/usr/bin/time -l` "maximum resident set size" of the
     isolated child process (the whole CLI: Swift runtime + the loaded model).
 
 Backends: macparakeet-cli (parakeet-v2/v3/unified, nemotron-en/multi, whisper)
-and the FluidAudio CLI cohere-benchmark (cohere — not an integrated engine).
+and the FluidAudio CLI cohere-benchmark for the existing Cohere reference
+measurement. Rerun Cohere through macparakeet-cli before making in-app memory or
+cold-start claims.
 
 Usage:
     speed_bench.py --engine parakeet-v3 --cli /path/to/macparakeet-cli \

--- a/benchmarks/asr/speed_bench.py
+++ b/benchmarks/asr/speed_bench.py
@@ -12,20 +12,21 @@ speed/memory profile, **one engine at a time, nothing else running**:
     For macparakeet-cli engines we run the same prefix at two sizes (1 file vs
     N files) in fresh processes; the difference cancels the fixed load:
         steady = (audio_N - audio_1) / (wall_N - wall_1)
-    For the current committed Cohere reference result (FluidAudio CLI) we read
-    its per-file rtfx and drop file 0.
+    For the legacy Cohere reference result (FluidAudio CLI) we read its per-file
+    rtfx and drop file 0.
   - **peak RSS** = `/usr/bin/time -l` "maximum resident set size" of the
     isolated child process (the whole CLI: Swift runtime + the loaded model).
 
-Backends: macparakeet-cli (parakeet-v2/v3/unified, nemotron-en/multi, whisper)
-and the FluidAudio CLI cohere-benchmark for the existing Cohere reference
-measurement. Rerun Cohere through macparakeet-cli before making in-app memory or
-cold-start claims.
+Backends: macparakeet-cli (parakeet-v2/v3/unified, nemotron-en/multi, whisper,
+cohere) and an explicit FluidAudio CLI reference mode
+(`cohere-fa-reference`) for legacy comparisons.
 
 Usage:
     speed_bench.py --engine parakeet-v3 --cli /path/to/macparakeet-cli \
         --dataset-dir ~/asr-bench/LibriSpeech/test-clean --n 24 --out speed.jsonl
-    speed_bench.py --engine cohere --fa /path/to/fluidaudiocli \
+    speed_bench.py --engine cohere --cli /path/to/macparakeet-cli \
+        --dataset-dir ~/asr-bench/LibriSpeech/test-clean --n 12 --out speed.jsonl
+    speed_bench.py --engine cohere-fa-reference --fa /path/to/fluidaudiocli \
         --cohere-model ~/asr-bench/cohere-coreml/q8 --n 12 --out speed.jsonl
 """
 from __future__ import annotations
@@ -47,7 +48,10 @@ MP_ENGINES = {
     "nemotron-en": ["--engine", "nemotron", "--nemotron-model", "english-1120ms"],
     "nemotron-multi": ["--engine", "nemotron", "--nemotron-model", "multilingual-1120ms"],
     "whisper": ["--engine", "whisper"],
+    "cohere": ["--engine", "cohere", "--language", "en"],
 }
+REFERENCE_ENGINES = ("cohere-fa-reference",)
+ALL_ENGINES = (*MP_ENGINES, *REFERENCE_ENGINES, "all")
 _RSS_RE = re.compile(r"^\s*(\d+)\s+maximum resident set size", re.MULTILINE)
 
 
@@ -108,8 +112,8 @@ def measure_macparakeet(engine: str, cli: Path, files: list[Path], n: int) -> di
         shutil.rmtree(work, ignore_errors=True)
 
 
-def measure_cohere(fa: Path, model_dir: Path, n: int) -> dict:
-    work = Path(tempfile.mkdtemp(prefix="speed-cohere-"))
+def measure_cohere_reference(fa: Path, model_dir: Path, n: int) -> dict:
+    work = Path(tempfile.mkdtemp(prefix="speed-cohere-fa-reference-"))
     out = work / "cohere.json"
     try:
         # --dataset librispeech matters: it defaults to fleurs, which would
@@ -125,22 +129,27 @@ def measure_cohere(fa: Path, model_dir: Path, n: int) -> dict:
         cold = results[0].get("processingTime") if results else None
         steady = statistics.median(rtfx[1:]) if len(rtfx) > 1 else None
         rss = peak_rss_mb(stderr)
-        return dict(engine="cohere", method="fluidaudio per-file (drop file0)", n_files=len(results),
-                    cold_start_s=round(cold, 2) if cold else None,
-                    steady_rtfx=round(steady, 1) if steady else None,
-                    peak_rss_mb=round(rss) if rss else None,
-                    total_wall_s=round(wall, 1))
+        return dict(
+            engine="cohere-fa-reference",
+            method="fluidaudio reference per-file (drop file0)",
+            n_files=len(results),
+            cold_start_s=round(cold, 2) if cold else None,
+            steady_rtfx=round(steady, 1) if steady else None,
+            peak_rss_mb=round(rss) if rss else None,
+            total_wall_s=round(wall, 1),
+        )
     finally:
         shutil.rmtree(work, ignore_errors=True)
 
 
 def main() -> int:
     ap = argparse.ArgumentParser()
-    ap.add_argument("--engine", required=True, help="one of %s, cohere, or 'all'" % list(MP_ENGINES))
+    ap.add_argument("--engine", required=True, choices=ALL_ENGINES,
+                    help="engine to measure; 'all' runs shipping macparakeet-cli engines")
     ap.add_argument("--cli", type=Path, help="macparakeet-cli (for integrated engines)")
-    ap.add_argument("--fa", type=Path, help="fluidaudiocli (for cohere)")
-    ap.add_argument("--cohere-model", type=Path, help="cohere q8 model dir")
-    ap.add_argument("--dataset-dir", type=Path, help="LibriSpeech test-clean dir (mp engines)")
+    ap.add_argument("--fa", type=Path, help="fluidaudiocli (for cohere-fa-reference)")
+    ap.add_argument("--cohere-model", type=Path, help="cohere q8 model dir (reference mode)")
+    ap.add_argument("--dataset-dir", type=Path, help="LibriSpeech test-clean dir (macparakeet-cli engines)")
     ap.add_argument("--n", type=int, default=24, help="warm-batch size")
     ap.add_argument("--out", type=Path, help="append the result JSON line here")
     args = ap.parse_args()
@@ -149,17 +158,24 @@ def main() -> int:
     if args.dataset_dir:
         files = sorted(args.dataset_dir.expanduser().resolve().glob("*/*/*.flac"))
 
-    engines = list(MP_ENGINES) + ["cohere"] if args.engine == "all" else [args.engine]
+    engines = list(MP_ENGINES) if args.engine == "all" else [args.engine]
     out_records = []
     for eng in engines:
-        print(f">>> measuring {eng} ...", flush=True)
-        if eng == "cohere":
-            rec = measure_cohere(args.fa.expanduser().resolve(),
-                                 args.cohere_model.expanduser().resolve(), args.n)
-        else:
+        if eng in REFERENCE_ENGINES:
+            if not args.fa or not args.cohere_model:
+                raise SystemExit("--fa and --cohere-model required for cohere-fa-reference")
+            print(f">>> measuring {eng} ...", flush=True)
+            rec = measure_cohere_reference(args.fa.expanduser().resolve(),
+                                           args.cohere_model.expanduser().resolve(), args.n)
+        elif eng in MP_ENGINES:
+            if not args.cli:
+                raise SystemExit("--cli required for macparakeet-cli engines")
             if not files:
                 raise SystemExit("--dataset-dir required for macparakeet-cli engines")
+            print(f">>> measuring {eng} ...", flush=True)
             rec = measure_macparakeet(eng, args.cli.expanduser().resolve(), files, args.n)
+        else:
+            raise SystemExit(f"unknown engine {eng!r}; expected one of {ALL_ENGINES}")
         print("   " + json.dumps(rec))
         out_records.append(rec)
         if args.out:

--- a/benchmarks/asr/test_manifest.py
+++ b/benchmarks/asr/test_manifest.py
@@ -44,9 +44,12 @@ def test_manifest_covers_shipping_engines() -> None:
         "cohere",
     }
     check("all shipping/evaluated engines listed", expected <= engine_ids, str(expected - engine_ids))
-    cohere = next(engine for engine in data["engines"] if engine["id"] == "cohere")
-    check("cohere excluded from live preview", "dictation_live_preview" not in cohere["product_surfaces"])
-    check("cohere caveat records no auto-detect", "no auto language detection" in cohere["caveat"])
+    cohere = next((engine for engine in data["engines"] if engine["id"] == "cohere"), None)
+    if cohere is None:
+        check("cohere engine exists in manifest", False, "cohere engine not found")
+        return
+    check("cohere excluded from live preview", "dictation_live_preview" not in cohere.get("product_surfaces", []))
+    check("cohere caveat records no auto-detect", "no auto language detection" in cohere.get("caveat", ""))
 
 
 def test_summary_mentions_gates() -> None:
@@ -56,6 +59,11 @@ def test_summary_mentions_gates() -> None:
     check("summary includes full English task", "English full-set accuracy" in summary)
     check("summary includes Cohere engine", "Cohere Transcribe" in summary)
     check("summary includes product surface code", "`file_media`" in summary)
+
+    escaped = copy.deepcopy(data)
+    escaped["engines"][0]["caveat"] = "left | right"
+    escaped_summary = manifest_tool.markdown_summary(escaped)
+    check("summary escapes markdown pipes", "left \\| right" in escaped_summary)
 
 
 def test_unknown_references_fail() -> None:
@@ -85,6 +93,14 @@ def test_malformed_manifest_reports_errors() -> None:
     broken_task["tasks"][0]["datasets"] = "not-a-list"
     errors = manifest_tool.validate_manifest(broken_task)
     check("task reference fields must be lists", any("tasks.english_accuracy_full.datasets" in e for e in errors), str(errors))
+
+    errors = manifest_tool.validate_manifest([])
+    check("non-object root rejected", errors == ["manifest root must be a JSON object"], str(errors))
+
+    broken_suite = copy.deepcopy(data)
+    broken_suite["suite"] = {"name": ""}
+    errors = manifest_tool.validate_manifest(broken_suite)
+    check("suite name validated", any("suite.name must be a non-empty string" in e for e in errors), str(errors))
 
 
 def main() -> int:

--- a/benchmarks/asr/test_manifest.py
+++ b/benchmarks/asr/test_manifest.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Tests for the ASR benchmark manifest contract."""
+from __future__ import annotations
+
+import copy
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import manifest_tool
+
+_fails: list[str] = []
+_HERE = Path(__file__).resolve().parent
+
+
+def check(name: str, condition: bool, detail: str = "") -> None:
+    if condition:
+        print(f"  ok   {name}")
+    else:
+        _fails.append(name)
+        suffix = f": {detail}" if detail else ""
+        print(f"  FAIL {name}{suffix}")
+
+
+def test_manifest_validates() -> None:
+    print("manifest validation:")
+    data = manifest_tool.load_manifest(_HERE / "manifest.json")
+    errors = manifest_tool.validate_manifest(data)
+    check("manifest has no validation errors", errors == [], "; ".join(errors))
+
+
+def test_manifest_covers_shipping_engines() -> None:
+    print("shipping engine coverage:")
+    data = manifest_tool.load_manifest(_HERE / "manifest.json")
+    engine_ids = {engine["id"] for engine in data["engines"]}
+    expected = {
+        "parakeet-v2",
+        "parakeet-v3",
+        "parakeet-unified",
+        "nemotron-en",
+        "nemotron-multi",
+        "whisper",
+        "cohere",
+    }
+    check("all shipping/evaluated engines listed", expected <= engine_ids, str(expected - engine_ids))
+    cohere = next(engine for engine in data["engines"] if engine["id"] == "cohere")
+    check("cohere excluded from live preview", "dictation_live_preview" not in cohere["product_surfaces"])
+    check("cohere caveat records no auto-detect", "no auto language detection" in cohere["caveat"])
+
+
+def test_summary_mentions_gates() -> None:
+    print("summary rendering:")
+    data = manifest_tool.load_manifest(_HERE / "manifest.json")
+    summary = manifest_tool.markdown_summary(data)
+    check("summary includes full English task", "English full-set accuracy" in summary)
+    check("summary includes Cohere engine", "Cohere Transcribe" in summary)
+    check("summary includes product surface code", "`file_media`" in summary)
+
+
+def test_unknown_references_fail() -> None:
+    print("negative validation:")
+    data = manifest_tool.load_manifest(_HERE / "manifest.json")
+    broken = copy.deepcopy(data)
+    broken["tasks"][0]["engines"].append("missing-engine")
+    errors = manifest_tool.validate_manifest(broken)
+    check("unknown engine rejected", any("missing-engine" in error for error in errors), str(errors))
+
+
+def main() -> int:
+    for test in (
+        test_manifest_validates,
+        test_manifest_covers_shipping_engines,
+        test_summary_mentions_gates,
+        test_unknown_references_fail,
+    ):
+        test()
+    print()
+    if _fails:
+        print(f"FAILED {len(_fails)}: {', '.join(_fails)}")
+        return 1
+    print("all manifest tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/asr/test_manifest.py
+++ b/benchmarks/asr/test_manifest.py
@@ -67,12 +67,33 @@ def test_unknown_references_fail() -> None:
     check("unknown engine rejected", any("missing-engine" in error for error in errors), str(errors))
 
 
+def test_malformed_manifest_reports_errors() -> None:
+    print("malformed manifest handling:")
+    data = manifest_tool.load_manifest(_HERE / "manifest.json")
+
+    broken_top = copy.deepcopy(data)
+    broken_top["engines"] = {"id": "not-a-list"}
+    errors = manifest_tool.validate_manifest(broken_top)
+    check("non-list top-level section rejected", any("'engines' must be a list" in e for e in errors), str(errors))
+
+    broken_entry = copy.deepcopy(data)
+    broken_entry["engines"][0] = "not-an-object"
+    errors = manifest_tool.validate_manifest(broken_entry)
+    check("non-object list entry rejected", any("engines[0] must be an object" in e for e in errors), str(errors))
+
+    broken_task = copy.deepcopy(data)
+    broken_task["tasks"][0]["datasets"] = "not-a-list"
+    errors = manifest_tool.validate_manifest(broken_task)
+    check("task reference fields must be lists", any("tasks.english_accuracy_full.datasets" in e for e in errors), str(errors))
+
+
 def main() -> int:
     for test in (
         test_manifest_validates,
         test_manifest_covers_shipping_engines,
         test_summary_mentions_gates,
         test_unknown_references_fail,
+        test_malformed_manifest_reports_errors,
     ):
         test()
     print()

--- a/benchmarks/asr/test_manifest.py
+++ b/benchmarks/asr/test_manifest.py
@@ -94,6 +94,26 @@ def test_malformed_manifest_reports_errors() -> None:
     errors = manifest_tool.validate_manifest(broken_task)
     check("task reference fields must be lists", any("tasks.english_accuracy_full.datasets" in e for e in errors), str(errors))
 
+    missing_task_field = copy.deepcopy(data)
+    del missing_task_field["tasks"][0]["datasets"]
+    errors = manifest_tool.validate_manifest(missing_task_field)
+    check(
+        "missing task list field avoids duplicate type error",
+        any("missing required field 'datasets'" in e for e in errors)
+        and not any(".datasets must be a non-empty list" in e for e in errors),
+        str(errors),
+    )
+
+    missing_engine_field = copy.deepcopy(data)
+    del missing_engine_field["engines"][0]["product_surfaces"]
+    errors = manifest_tool.validate_manifest(missing_engine_field)
+    check(
+        "missing engine surface field avoids duplicate type error",
+        any("missing required field 'product_surfaces'" in e for e in errors)
+        and not any(".product_surfaces must be a non-empty list" in e for e in errors),
+        str(errors),
+    )
+
     errors = manifest_tool.validate_manifest([])
     check("non-object root rejected", errors == ["manifest root must be a JSON object"], str(errors))
 

--- a/benchmarks/asr/test_manifest.py
+++ b/benchmarks/asr/test_manifest.py
@@ -104,6 +104,27 @@ def test_malformed_manifest_reports_errors() -> None:
         str(errors),
     )
 
+    missing_task_surface = copy.deepcopy(data)
+    del missing_task_surface["tasks"][0]["surface"]
+    errors = manifest_tool.validate_manifest(missing_task_surface)
+    check(
+        "missing task surface avoids duplicate unknown-surface error",
+        any("missing required field 'surface'" in e for e in errors)
+        and not any(".surface has unknown surface" in e for e in errors),
+        str(errors),
+    )
+
+    missing_task_primary = copy.deepcopy(data)
+    del missing_task_primary["tasks"][0]["primary_metric"]
+    errors = manifest_tool.validate_manifest(missing_task_primary)
+    check(
+        "missing task primary metric avoids duplicate reference error",
+        any("missing required field 'primary_metric'" in e for e in errors)
+        and not any(".primary_metric references unknown metric" in e for e in errors)
+        and not any(".primary_metric 'None'" in e for e in errors),
+        str(errors),
+    )
+
     missing_engine_field = copy.deepcopy(data)
     del missing_engine_field["engines"][0]["product_surfaces"]
     errors = manifest_tool.validate_manifest(missing_engine_field)


### PR DESCRIPTION
## Summary

This PR turns the existing ASR benchmark work into a **MacParakeet-owned benchmark suite contract**: reproducible enough for research review, explicit enough for product decisions, and still small enough to maintain.

It builds on the ASR model landscape research in #660. That PR explains the model tradeoffs; this PR makes the benchmark suite itself auditable and repeatable.

## What changed

| Area | Change |
|------|--------|
| Suite contract | Added `benchmarks/asr/manifest.json` as the source of truth for engines, datasets, tasks, metrics, product surfaces, and decision gates. |
| Validation | Added dependency-free `manifest_tool.py` plus `test_manifest.py`; `./run_all.sh verify` now checks the benchmark contract before scorer tests. |
| Documentation | Upgraded `benchmarks/asr/README.md` into a distilled benchmark source of truth with research basis, suite matrix, current findings, caveats, and publishability tiers. |
| Shipping-path runners | Added Cohere to the `macparakeet-cli` LibriSpeech and FLEURS runners with explicit language hints, so future regenerations exercise the current product path. |
| Cohere caveat cleanup | Updated stale wording: Cohere is now a shipping batch/final transcription engine, but committed speed/memory figures are still FluidAudio-reference measurements until rerun through `macparakeet-cli`. |
| Hygiene | Added `benchmarks/asr/venv/` to `.gitignore` because the README already recommends that local env path. |

## Benchmark design

| Tier | Dataset / fixture | Current status | Purpose | Publishability |
|------|-------------------|----------------|---------|----------------|
| English full-set | LibriSpeech `test-clean` + `test-other` | Committed full results | Clean/noisy English model ranking | Final-grade for read-English claims. |
| Multilingual directional | FLEURS en/ko/ja/zh | Committed capped results, 150/language | Language coverage and failure discovery | Ranking-grade; expand before routing defaults. |
| Performance | Local speed/memory micro-bench | Committed reference results | Cold start, steady RTFx, peak RSS | Hardware-specific; rerun for release claims. |
| Meeting public | AMI Meeting Corpus | Planned | Multi-speaker meeting final transcript quality | Needed before meeting-specific engine claims. |
| Accented/wild English | Earnings-22 | Planned | Real-world accents, long-form speech | Needed before broad noisy/accented claims. |
| Product regression | Consented MacParakeet fixtures | Planned private | Dictation, meeting, file/media edge cases | Internal gate; do not commit private audio/transcripts. |

The goal is not a giant framework. The suite stays lean: deterministic scorers, shipping-path runners, a manifest contract, and committed result fixtures that can be re-scored without downloading models.

## Research basis captured in the README

The suite explicitly follows public ASR evaluation patterns from:

| Source | Practice we adopt |
|--------|-------------------|
| HuggingFace Open ASR Leaderboard | Shared normalization, WER, RTFx, reproducible comparison framing. |
| NIST SCTK / SCLITE | Explicit reference-vs-hypothesis scoring contract. |
| ESPnet recipes | Reproducible data/eval recipe separation. |
| MeetEval | Meeting transcription needs its own metric/product surface, not just batch WER. |
| LibriSpeech / FLEURS / AMI / Earnings-22 | Layered public datasets covering clean/noisy English, multilingual speech, meetings, and accented long-form audio. |

## Current product implications preserved

| Finding | Product stance encoded by this PR |
|---------|----------------------------------|
| Parakeet remains the right default | Fast, tiny memory footprint, clean-English parity with Cohere within CI. |
| Cohere is strongest for noisy English/Japanese but expensive | Keep opt-in, 16 GB+ gated, batch/final only; Settings copy should be explicit about cold start, memory, no auto-detect, no live preview, and no word timestamps. |
| Parakeet-v3 fails CJK/Korean in current FLEURS evidence | Do not rely on Parakeet-v3 for CJK/Korean despite it being the multilingual default. |
| Nemotron remains dominated in current evidence | Keep benchmarked as Beta; no promotion without new evidence. |
| Capped FLEURS is directional | Do not ship automatic per-language routing from n=150/language alone. |

## Verification

Ran from `benchmarks/asr` with the pinned local venv:

```bash
python3 -m venv venv
venv/bin/pip install -r requirements.txt
PY=venv/bin/python3 ./run_all.sh verify
git diff --check
```

Results:

| Check | Result |
|-------|--------|
| `manifest_tool.py validate manifest.json` | Pass |
| `test_manifest.py` | Pass |
| `test_scorers.py` | Pass |
| Multilingual committed evidence re-score | Pass |
| Full English committed evidence re-score | Pass, reproduces macro WER: Cohere 2.07, Parakeet Unified 2.38, Parakeet v2 2.57, Whisper 3.00, Parakeet v3 3.22, Nemotron EN 3.70, Nemotron Multi 5.17 |
| `git diff --check` | Pass |

## Notes

- No benchmark audio or private fixtures are added in this PR.
- Heavy regeneration still lives behind `./run_all.sh speed` and `./run_all.sh transcribe`.
- The committed Cohere speed/memory row remains a FluidAudio CLI reference result; the runners now support current `macparakeet-cli --engine cohere` so the next heavy refresh can replace that with app-path evidence.
