### PR TITLE
fix: keep exported PDF/DOCX text legible in Dark Mode

### DIFF
--- a/Sources/MacParakeetCore/Services/ExportService.swift
+++ b/Sources/MacParakeetCore/Services/ExportService.swift
@@ -495,7 +495,32 @@ public final class ExportService: ExportServiceProtocol, Sendable {
 
     // MARK: - Rich Text (AppKit)
 
-    @MainActor private func buildRichTranscript(transcription: Transcription) throws -> NSAttributedString {
+    /// Concrete text colors for exported PDF/DOCX documents.
+    ///
+    /// Exported files are standalone artifacts rendered on a white page, so they
+    /// must not follow the app's live appearance. Dynamic label colors
+    /// (`NSColor.labelColor` and friends) resolve to near-white in Dark Mode,
+    /// which bakes invisible text into the exported document. Resolve the
+    /// semantic colors against a fixed light (aqua) appearance once so exports
+    /// stay legible regardless of the running app's theme.
+    private enum ExportTextColor {
+        @MainActor static let primary = resolveAgainstLightAppearance(.labelColor)
+        @MainActor static let secondary = resolveAgainstLightAppearance(.secondaryLabelColor)
+        @MainActor static let tertiary = resolveAgainstLightAppearance(.tertiaryLabelColor)
+
+        @MainActor private static func resolveAgainstLightAppearance(_ color: NSColor) -> NSColor {
+            guard let light = NSAppearance(named: .aqua) else {
+                return color.usingColorSpace(.sRGB) ?? color
+            }
+            var resolved = color
+            light.performAsCurrentDrawingAppearance {
+                resolved = color.usingColorSpace(.sRGB) ?? color
+            }
+            return resolved
+        }
+    }
+
+    @MainActor func buildRichTranscript(transcription: Transcription) throws -> NSAttributedString {
         let result = NSMutableAttributedString()
 
         let titleFont = NSFont.boldSystemFont(ofSize: 24)
@@ -503,8 +528,18 @@ public final class ExportService: ExportServiceProtocol, Sendable {
         let bodyFont = NSFont.systemFont(ofSize: 12)
         let timestampFont = NSFont.monospacedSystemFont(ofSize: 11, weight: .medium)
 
+        // Every run gets an explicit, appearance-independent color: an unset
+        // foreground color would fall back to the dynamic default text color and
+        // render near-white (invisible) on the white page in Dark Mode.
+        let primaryColor = ExportTextColor.primary
+        let secondaryColor = ExportTextColor.secondary
+        let tertiaryColor = ExportTextColor.tertiary
+
         // Title
-        result.append(NSAttributedString(string: transcription.fileName + "\n\n", attributes: [.font: titleFont]))
+        result.append(
+            NSAttributedString(
+                string: transcription.fileName + "\n\n",
+                attributes: [.font: titleFont, .foregroundColor: primaryColor]))
 
         // Metadata
         var metaLines: [String] = []
@@ -518,39 +553,57 @@ public final class ExportService: ExportServiceProtocol, Sendable {
         formatter.dateStyle = .medium
         formatter.timeStyle = .short
         metaLines.append("Transcribed: \(formatter.string(from: transcription.createdAt))")
-        
+
         if !metaLines.isEmpty {
             let metaText = metaLines.joined(separator: "\n") + "\n\n"
-            result.append(NSAttributedString(string: metaText, attributes: [.font: headerFont, .foregroundColor: NSColor.secondaryLabelColor]))
+            result.append(
+                NSAttributedString(
+                    string: metaText,
+                    attributes: [.font: headerFont, .foregroundColor: secondaryColor]))
         }
 
         // Horizontal line equivalent
-        result.append(NSAttributedString(string: "----------------------------------------------------------\n\n", attributes: [.foregroundColor: NSColor.tertiaryLabelColor]))
+        result.append(
+            NSAttributedString(
+                string: "----------------------------------------------------------\n\n",
+                attributes: [.foregroundColor: tertiaryColor]))
 
         // Content
         if let text = editedTranscriptText(transcription: transcription) {
-            result.append(NSAttributedString(string: text, attributes: [.font: bodyFont]))
+            result.append(
+                NSAttributedString(
+                    string: text,
+                    attributes: [.font: bodyFont, .foregroundColor: primaryColor]))
         } else if let timestamps = transcription.wordTimestamps, !timestamps.isEmpty {
             let cues = buildSubtitleCues(from: timestamps)
             var lastSpeakerId: String? = nil
             for cue in cues {
                 if let label = speakerLabel(for: cue.speakerId, in: transcription.speakers),
                    cue.speakerId != lastSpeakerId {
-                    let speakerAttr = NSAttributedString(string: "\(label)\n", attributes: [.font: headerFont, .foregroundColor: NSColor.labelColor])
+                    let speakerAttr = NSAttributedString(
+                        string: "\(label)\n",
+                        attributes: [.font: headerFont, .foregroundColor: primaryColor])
                     result.append(speakerAttr)
                 }
                 lastSpeakerId = cue.speakerId
 
                 let ts = "[" + formatReadableTimestamp(ms: cue.startMs) + "] "
-                let attrTs = NSAttributedString(string: ts, attributes: [.font: timestampFont, .foregroundColor: NSColor.secondaryLabelColor])
+                let attrTs = NSAttributedString(
+                    string: ts,
+                    attributes: [.font: timestampFont, .foregroundColor: secondaryColor])
                 result.append(attrTs)
 
-                let attrText = NSAttributedString(string: cue.text + "\n\n", attributes: [.font: bodyFont])
+                let attrText = NSAttributedString(
+                    string: cue.text + "\n\n",
+                    attributes: [.font: bodyFont, .foregroundColor: primaryColor])
                 result.append(attrText)
             }
         } else {
             let text = preferredText(transcription: transcription)
-            result.append(NSAttributedString(string: text, attributes: [.font: bodyFont]))
+            result.append(
+                NSAttributedString(
+                    string: text,
+                    attributes: [.font: bodyFont, .foregroundColor: primaryColor]))
         }
 
         return result

--- a/Sources/MacParakeetCore/Services/ExportService.swift
+++ b/Sources/MacParakeetCore/Services/ExportService.swift
@@ -509,8 +509,12 @@ public final class ExportService: ExportServiceProtocol, Sendable {
         @MainActor static let tertiary = resolveAgainstLightAppearance(.tertiaryLabelColor)
 
         @MainActor private static func resolveAgainstLightAppearance(_ color: NSColor) -> NSColor {
+            // `.aqua` is effectively always available. If it somehow isn't, fall
+            // back to a fixed dark color rather than resolving the dynamic color
+            // against a possibly-dark ambient appearance (which would defeat the
+            // whole point and could bake near-white text into the export).
             guard let light = NSAppearance(named: .aqua) else {
-                return color.usingColorSpace(.sRGB) ?? color
+                return .black
             }
             var resolved = color
             light.performAsCurrentDrawingAppearance {

--- a/Sources/MacParakeetCore/Services/ExportService.swift
+++ b/Sources/MacParakeetCore/Services/ExportService.swift
@@ -516,9 +516,9 @@ public final class ExportService: ExportServiceProtocol, Sendable {
             guard let light = NSAppearance(named: .aqua) else {
                 return .black
             }
-            var resolved = color
+            var resolved = NSColor.black
             light.performAsCurrentDrawingAppearance {
-                resolved = color.usingColorSpace(.sRGB) ?? color
+                resolved = color.usingColorSpace(.sRGB) ?? .black
             }
             return resolved
         }

--- a/Tests/MacParakeetTests/Services/ExportServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/ExportServiceTests.swift
@@ -719,13 +719,24 @@ final class ExportServiceTests: XCTestCase {
 
     // MARK: - Export Color Legibility
 
-    /// Every run in an exported PDF/DOCX must carry an explicit, appearance-
-    /// independent dark color. A missing color falls back to the dynamic default
-    /// text color, and a dynamic label color resolves to near-white in Dark Mode
-    /// — both make the exported document invisible on its white page.
+    /// Every run in an exported PDF/DOCX — across all content branches — must
+    /// carry an explicit, appearance-independent dark color. A missing color
+    /// falls back to the dynamic default text color, and a dynamic label color
+    /// resolves to near-white in Dark Mode; both make the export invisible on
+    /// its white page.
     func testBuildRichTranscriptUsesAppearanceIndependentDarkColors() throws {
-        let transcription = Transcription(
-            fileName: "colors.mp3",
+        // Precondition: the resolver must actually distinguish appearances,
+        // otherwise the per-run checks below would be vacuous. A dynamic label
+        // color resolves dark under Light and near-white under Dark.
+        let dynamicLight = concreteColor(.labelColor, appearance: .aqua)
+        let dynamicDark = concreteColor(.labelColor, appearance: .darkAqua)
+        XCTAssertNotEqual(dynamicLight, dynamicDark, "Precondition: resolver must distinguish light vs dark")
+        XCTAssertGreaterThan(brightness(of: dynamicDark), 0.6, "Precondition: labelColor near-white in Dark Mode")
+
+        // Cover every content branch of buildRichTranscript: word-timestamp
+        // speaker cues, an edited-transcript override, and the plain fallback.
+        let timestampedWithSpeakers = Transcription(
+            fileName: "meeting.mp3",
             durationMs: 5000,
             wordTimestamps: [
                 WordTimestamp(word: "Hello.", startMs: 0, endMs: 500, confidence: 0.99, speakerId: "S1"),
@@ -737,34 +748,48 @@ final class ExportServiceTests: XCTestCase {
             ],
             status: .completed
         )
+        let editedOverride = Transcription(
+            fileName: "edited.mp3",
+            durationMs: 5000,
+            rawTranscript: "Original text",
+            cleanTranscript: "Edited transcript body",
+            wordTimestamps: [
+                WordTimestamp(word: "Original", startMs: 0, endMs: 500, confidence: 0.99)
+            ],
+            status: .completed,
+            isTranscriptEdited: true
+        )
+        let plainText = Transcription(
+            fileName: "note.mp3",
+            durationMs: 3000,
+            rawTranscript: "Just a plain transcript.",
+            status: .completed
+        )
 
-        // Precondition: the resolver must actually distinguish appearances,
-        // otherwise the per-run checks below would be vacuous. A dynamic label
-        // color resolves dark under Light and near-white under Dark.
-        let dynamicLight = concreteColor(.labelColor, appearance: .aqua)
-        let dynamicDark = concreteColor(.labelColor, appearance: .darkAqua)
-        XCTAssertNotEqual(dynamicLight, dynamicDark, "Precondition: resolver must distinguish light vs dark")
-        XCTAssertGreaterThan(dynamicDark.brightnessComponent, 0.6, "Precondition: labelColor near-white in Dark Mode")
+        for transcription in [timestampedWithSpeakers, editedOverride, plainText] {
+            let name = transcription.fileName
+            let attributed = try exportService.buildRichTranscript(transcription: transcription)
+            XCTAssertGreaterThan(attributed.length, 0, "\(name): empty export")
+            let fullRange = NSRange(location: 0, length: attributed.length)
 
-        let attributed = try exportService.buildRichTranscript(transcription: transcription)
-        XCTAssertGreaterThan(attributed.length, 0)
-        let fullRange = NSRange(location: 0, length: attributed.length)
-
-        var inspectedRuns = 0
-        attributed.enumerateAttribute(.foregroundColor, in: fullRange) { value, range, _ in
-            inspectedRuns += 1
-            guard let color = value as? NSColor else {
-                XCTFail("Run \(range) has no explicit foreground color; it would vanish on a white page in Dark Mode")
-                return
+            var inspectedRuns = 0
+            attributed.enumerateAttribute(.foregroundColor, in: fullRange) { value, range, _ in
+                inspectedRuns += 1
+                guard let color = value as? NSColor else {
+                    XCTFail("\(name) run \(range): no explicit foreground color; would vanish on white in Dark Mode")
+                    return
+                }
+                let light = concreteColor(color, appearance: .aqua)
+                let dark = concreteColor(color, appearance: .darkAqua)
+                XCTAssertEqual(light, dark, "\(name): exported color must be appearance-independent")
+                XCTAssertLessThan(brightness(of: color), 0.6, "\(name): exported text must be dark on white")
             }
-            let light = concreteColor(color, appearance: .aqua)
-            let dark = concreteColor(color, appearance: .darkAqua)
-            XCTAssertEqual(light, dark, "Exported color must not change with app appearance (was it left dynamic?)")
-            XCTAssertLessThan(light.brightnessComponent, 0.6, "Exported text must be dark to read on white")
+            XCTAssertGreaterThan(inspectedRuns, 0, "\(name): no runs inspected")
         }
-        XCTAssertGreaterThan(inspectedRuns, 0)
     }
 
+    /// Resolve a (possibly dynamic) color to a concrete sRGB value under a fixed
+    /// appearance, for comparing how it renders in Light vs Dark.
     private func concreteColor(_ color: NSColor, appearance name: NSAppearance.Name) -> NSColor {
         guard let appearance = NSAppearance(named: name) else {
             return color.usingColorSpace(.sRGB) ?? color
@@ -774,6 +799,15 @@ final class ExportServiceTests: XCTestCase {
             resolved = color.usingColorSpace(.sRGB) ?? color
         }
         return resolved
+    }
+
+    /// HSB brightness read from a guaranteed-sRGB copy, so it never raises on a
+    /// non-RGB color space (`brightnessComponent` would).
+    private func brightness(of color: NSColor) -> CGFloat {
+        guard let rgb = color.usingColorSpace(.sRGB) else { return 0 }
+        var red: CGFloat = 0, green: CGFloat = 0, blue: CGFloat = 0, alpha: CGFloat = 0
+        rgb.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+        return max(red, green, blue)
     }
 
     private func firstPageContentStream(from url: URL) throws -> String {

--- a/Tests/MacParakeetTests/Services/ExportServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/ExportServiceTests.swift
@@ -717,6 +717,65 @@ final class ExportServiceTests: XCTestCase {
         XCTAssertEqual(exportService.formatReadableTimestamp(ms: 3661000), "1:01:01")
     }
 
+    // MARK: - Export Color Legibility
+
+    /// Every run in an exported PDF/DOCX must carry an explicit, appearance-
+    /// independent dark color. A missing color falls back to the dynamic default
+    /// text color, and a dynamic label color resolves to near-white in Dark Mode
+    /// — both make the exported document invisible on its white page.
+    func testBuildRichTranscriptUsesAppearanceIndependentDarkColors() throws {
+        let transcription = Transcription(
+            fileName: "colors.mp3",
+            durationMs: 5000,
+            wordTimestamps: [
+                WordTimestamp(word: "Hello.", startMs: 0, endMs: 500, confidence: 0.99, speakerId: "S1"),
+                WordTimestamp(word: "Hi.", startMs: 600, endMs: 1000, confidence: 0.98, speakerId: "S2"),
+            ],
+            speakers: [
+                SpeakerInfo(id: "S1", label: "Alice"),
+                SpeakerInfo(id: "S2", label: "Bob"),
+            ],
+            status: .completed
+        )
+
+        // Precondition: the resolver must actually distinguish appearances,
+        // otherwise the per-run checks below would be vacuous. A dynamic label
+        // color resolves dark under Light and near-white under Dark.
+        let dynamicLight = concreteColor(.labelColor, appearance: .aqua)
+        let dynamicDark = concreteColor(.labelColor, appearance: .darkAqua)
+        XCTAssertNotEqual(dynamicLight, dynamicDark, "Precondition: resolver must distinguish light vs dark")
+        XCTAssertGreaterThan(dynamicDark.brightnessComponent, 0.6, "Precondition: labelColor near-white in Dark Mode")
+
+        let attributed = try exportService.buildRichTranscript(transcription: transcription)
+        XCTAssertGreaterThan(attributed.length, 0)
+        let fullRange = NSRange(location: 0, length: attributed.length)
+
+        var inspectedRuns = 0
+        attributed.enumerateAttribute(.foregroundColor, in: fullRange) { value, range, _ in
+            inspectedRuns += 1
+            guard let color = value as? NSColor else {
+                XCTFail("Run \(range) has no explicit foreground color; it would vanish on a white page in Dark Mode")
+                return
+            }
+            let light = concreteColor(color, appearance: .aqua)
+            let dark = concreteColor(color, appearance: .darkAqua)
+            XCTAssertEqual(light, dark, "Exported color must not change with app appearance (was it left dynamic?)")
+            XCTAssertLessThan(light.brightnessComponent, 0.6, "Exported text must be dark to read on white")
+        }
+        XCTAssertGreaterThan(inspectedRuns, 0)
+    }
+
+    private func concreteColor(_ color: NSColor, appearance name: NSAppearance.Name) -> NSColor {
+        guard let appearance = NSAppearance(named: name) else {
+            return color.usingColorSpace(.sRGB) ?? color
+        }
+        var resolved = color
+        appearance.performAsCurrentDrawingAppearance {
+            resolved = color.usingColorSpace(.sRGB) ?? color
+        }
+        return resolved
+    }
+
     private func firstPageContentStream(from url: URL) throws -> String {
         guard let document = CGPDFDocument(url as CFURL),
               let page = document.page(at: 1),


### PR DESCRIPTION
## Summary
- Exported **PDF/DOCX** documents render on a white page but drew text with the app's **dynamic** label colors (`NSColor.labelColor`, `secondaryLabelColor`, `tertiaryLabelColor`), and the **title/body runs had no explicit color at all** (falling back to the dynamic default text color). In **Dark Mode** these all resolve to near-white, so the entire exported transcript was **invisible on the white page**.
- `buildRichTranscript` now bakes every run's color against a fixed **light (aqua)** appearance and gives the previously color-less title/body runs an explicit color. Exports are legible regardless of the running app's theme; **light-mode output is unchanged**.
- The fix lives in the shared serializer, so it covers **both single-item export and the new library bulk export** (#661).

## Why this surfaced
Flagged during the independent review of #661 (bulk export). It is a **pre-existing** bug in single-item PDF/DOCX export — not introduced by bulk export — so it's fixed here as a focused follow-up.

## Testing
- New self-validating regression test `testBuildRichTranscriptUsesAppearanceIndependentDarkColors`: asserts every run carries an **explicit, appearance-independent, dark** foreground color, with a **precondition** that proves the appearance resolver actually distinguishes light vs dark (so the assertions aren't vacuous).
- `swift test` — full suite green (0 failures)
- Swift 6 language-mode gate — clean
- `swift-format lint --strict` — clean on the added lines

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes invisible text in exported PDF/DOCX in Dark Mode by resolving dynamic label colors against a fixed light appearance and giving every text run an explicit dark color. Exports are readable on a white page for both single-item and library bulk export; light-mode output is unchanged.

- **Bug Fixes**
  - Resolve `NSColor.labelColor`, `secondaryLabelColor`, and `tertiaryLabelColor` against `.aqua` and convert to sRGB once for exports; fall back to a fixed dark color if `.aqua` or sRGB conversion is unavailable to avoid storing dynamic colors.
  - Apply an appearance-independent `.foregroundColor` to every run in `buildRichTranscript` (title, metadata, separators, timestamps, body, speaker headers).
  - Harden tests: cover all content branches and assert explicit, appearance-independent dark colors; compute brightness from sRGB; add a precondition proving Light vs Dark resolution differs.

<sup>Written for commit fff1f6ca6949322b3199988795f1707103904acd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/667?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

