### PR TITLE
feat: add Omi Med STT v1 as a local-install-only Parakeet build

### DIFF
--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -91,6 +91,13 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
 
 ### Added
 
+- New Parakeet build `omi-med-v1` (Omi Med STT v1, an English medical
+  fine-tune of Parakeet TDT 0.6B v2): accepted by `config set parakeet-model`,
+  `transcribe --parakeet-model`, `retranscribe --parakeet-model`, and the
+  `models` commands as `parakeet-omi-med-v1` (aliases `parakeet-omi-med`,
+  `parakeet-medical`). The build is local-install-only — `models download`
+  and `models select` fail with install guidance when the converted CoreML
+  bundle is not present (see `Sources/MacParakeetCore/STT/README.md`).
 - Added `retranscribe <record> --update` to rerun STT against retained source
   audio for an existing saved dictation, transcription, or meeting in place.
   Records resolve by UUID/prefix, with exact transcription/meeting title

--- a/Sources/CLI/Commands/ConfigCommand.swift
+++ b/Sources/CLI/Commands/ConfigCommand.swift
@@ -31,9 +31,10 @@ struct ConfigCommand: ParsableCommand {
           telemetry                 on|off                         default: on
           processing-mode           raw|clean                       default: raw
           speech-engine             parakeet|nemotron|whisper|cohere default: parakeet
-          parakeet-model            v3|v2|unified                   default: v3
+          parakeet-model            v3|v2|unified|omi-med-v1        default: v3
                                     (v3=supported languages, v2=English
-                                    timestamps, unified=English no timestamps)
+                                    timestamps, unified=English no timestamps,
+                                    omi-med-v1=English medical, local install)
           nemotron-model            multilingual-1120ms|            default: multilingual-1120ms
                                     english-1120ms (Beta streaming)
           nemotron-language         auto|<Nemotron language code>   default: auto
@@ -548,8 +549,10 @@ struct ConfigCommand: ParsableCommand {
             return .v2
         case "unified", "english-unified", "unified-offline":
             return .unified
+        case "omi-med-v1", "omi-med", "medical", "med":
+            return .omiMedV1
         default:
-            throw ValidationError("Invalid value for parakeet-model: '\(value)'. Use v3 (multilingual), v2 (English-only), or unified (English-only with punctuation/capitalization).")
+            throw ValidationError("Invalid value for parakeet-model: '\(value)'. Use v3 (multilingual), v2 (English-only), unified (English-only with punctuation/capitalization), or omi-med-v1 (English medical, requires local install).")
         }
     }
 

--- a/Sources/CLI/Commands/ModelsCommand.swift
+++ b/Sources/CLI/Commands/ModelsCommand.swift
@@ -133,7 +133,7 @@ extension ModelsCommand {
             abstract: "Download a local speech model without starting a transcription."
         )
 
-        @Argument(help: "Model identifier from `models list`, e.g. parakeet-v2, parakeet-v3, parakeet-unified, nemotron-multilingual-1120ms, nemotron-english-1120ms, cohere-transcribe, or whisper-large-v3-v20240930-turbo-632MB.")
+        @Argument(help: "Model identifier from `models list`, e.g. parakeet-v2, parakeet-v3, parakeet-unified, parakeet-omi-med-v1, nemotron-multilingual-1120ms, nemotron-english-1120ms, cohere-transcribe, or whisper-large-v3-v20240930-turbo-632MB.")
         var variant: String
 
         func run() async throws {
@@ -282,7 +282,7 @@ extension ModelsCommand {
                 """
         )
 
-        @Argument(help: "Model identifier from `models list`, e.g. parakeet-v2, parakeet-v3, parakeet-unified, nemotron-multilingual-1120ms, nemotron-english-1120ms, cohere-transcribe, or whisper-large-v3-v20240930-turbo-632MB.")
+        @Argument(help: "Model identifier from `models list`, e.g. parakeet-v2, parakeet-v3, parakeet-unified, parakeet-omi-med-v1, nemotron-multilingual-1120ms, nemotron-english-1120ms, cohere-transcribe, or whisper-large-v3-v20240930-turbo-632MB.")
         var id: String
 
         @Flag(name: .long, help: "Delete even the model currently in use (it will re-download on next use).")
@@ -380,6 +380,9 @@ func parakeetDownloadVariant(
 /// build to ``ParakeetUnifiedEngine`` (it has no `AsrModelVersion`); the TDT
 /// builds use the shared `AsrManager` cache.
 func isParakeetVariantCached(_ variant: ParakeetModelVariant) -> Bool {
+    if variant.usesLocalInstallOnly {
+        return OmiMedParakeetModel.isInstalled()
+    }
     if variant.usesUnifiedEngine {
         return ParakeetUnifiedEngine.isModelCached()
     }
@@ -387,9 +390,13 @@ func isParakeetVariantCached(_ variant: ParakeetModelVariant) -> Bool {
     return STTClient.isModelCached(version: version)
 }
 
-/// Deletes the on-disk model for `variant`, dispatching Unified to its own engine.
+/// Deletes the on-disk model for `variant`, dispatching Unified and the
+/// local-install-only Omi Med build to their own stores.
 @discardableResult
 func deleteParakeetVariant(_ variant: ParakeetModelVariant) -> Bool {
+    if variant.usesLocalInstallOnly {
+        return STTRuntime.deleteOmiMedParakeetModel()
+    }
     if variant.usesUnifiedEngine {
         return ParakeetUnifiedEngine.deleteModel()
     }
@@ -397,11 +404,24 @@ func deleteParakeetVariant(_ variant: ParakeetModelVariant) -> Bool {
     return STTRuntime.deleteParakeetModel(version: version)
 }
 
-/// Downloads the on-disk model for `variant`, dispatching Unified to its own engine.
+/// Downloads the on-disk model for `variant`, dispatching Unified to its own
+/// engine. Local-install-only builds (Omi Med) have no download repo — fail
+/// with install guidance instead of silently fetching the wrong weights.
 func downloadParakeetVariant(
     _ variant: ParakeetModelVariant,
     onProgress: @escaping @Sendable (String) -> Void
 ) async throws {
+    if variant.usesLocalInstallOnly {
+        if OmiMedParakeetModel.isInstalled() {
+            onProgress("\(variant.modelName) is already installed.")
+            return
+        }
+        throw ValidationError(
+            "\(variant.modelName) has no in-app download. Convert the model offline and install "
+                + "the CoreML bundle at \(OmiMedParakeetModel.modelDirectory().path) "
+                + "(see Sources/MacParakeetCore/STT/README.md)."
+        )
+    }
     if variant.usesUnifiedEngine {
         _ = try await ParakeetUnifiedEngine.downloadModel(onProgress: onProgress)
         return
@@ -437,7 +457,7 @@ func resolveWhisperDownloadModel(_ variant: String) throws -> String {
         throw ValidationError("Model variant cannot be empty.")
     }
     guard normalizedInput.hasPrefix("whisper-") else {
-        throw ValidationError("Unsupported model identifier '\(variant)'. Use a parakeet-v2, parakeet-v3, parakeet-unified, nemotron-multilingual-1120ms, nemotron-english-1120ms, cohere-transcribe, or whisper-* id from `models list`.")
+        throw ValidationError("Unsupported model identifier '\(variant)'. Use a parakeet-v2, parakeet-v3, parakeet-unified, parakeet-omi-med-v1, nemotron-multilingual-1120ms, nemotron-english-1120ms, cohere-transcribe, or whisper-* id from `models list`.")
     }
     return WhisperEngine.normalizeModelVariant(normalizedInput)
 }
@@ -786,6 +806,20 @@ func validateSelectableSpeechModelDownload(
     isWhisperModelDownloaded: ((String) -> Bool)? = nil,
     isCohereModelDownloaded: (() -> Bool)? = nil
 ) throws {
+    // Stock Parakeet builds download on first use, so selection is never
+    // gated on presence. Local-install-only builds (Omi Med) cannot be
+    // fetched later — selecting one without its bundle would strand the STT
+    // stack, so require the install up front.
+    if let parakeetVariant = selection.parakeetVariant,
+        parakeetVariant.usesLocalInstallOnly,
+        !isParakeetVariantCached(parakeetVariant) {
+        throw ValidationError(
+            "\(parakeetVariant.modelName) is not installed. Install the converted CoreML bundle at "
+                + "\(OmiMedParakeetModel.modelDirectory().path) first "
+                + "(see Sources/MacParakeetCore/STT/README.md)."
+        )
+    }
+
     if let nemotronVariant = selection.nemotronVariant {
         let language = SpeechEnginePreference.nemotronDefaultLanguage(defaults: defaults)
         let downloaded = (isNemotronModelDownloaded ?? { variant, language in
@@ -923,6 +957,8 @@ private func parseParakeetSelectionVariant(_ lowered: String) -> ParakeetModelVa
         return .v2
     case "unified", "english-unified", "unified-offline":
         return .unified
+    case "omi-med-v1", "omi-med", "medical", "med":
+        return .omiMedV1
     default:
         return nil
     }

--- a/Sources/CLI/Commands/RetranscribeCommand.swift
+++ b/Sources/CLI/Commands/RetranscribeCommand.swift
@@ -147,7 +147,7 @@ struct RetranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding 
     @Option(help: "Language hint for Nemotron, Whisper, or Cohere, such as ko, en, or en-US. Cohere requires a supported language; Parakeet and the English-only Nemotron build ignore this flag.")
     var language: String?
 
-    @Option(name: .long, help: "Parakeet build: app-default, v3 (English + supported European languages), v2 (English word timestamps), unified (readable English, no word timestamps). Ignored for Nemotron, Cohere, and Whisper.")
+    @Option(name: .long, help: "Parakeet build: app-default, v3 (English + supported European languages), v2 (English word timestamps), unified (readable English, no word timestamps), omi-med-v1 (English medical, requires local install). Ignored for Nemotron, Cohere, and Whisper.")
     var parakeetModel: TranscribeParakeetModel = .appDefault
 
     @Option(name: .long, help: "Nemotron Beta build: app-default, multilingual-1120ms, english-1120ms. Ignored for Parakeet, Cohere, and Whisper.")

--- a/Sources/CLI/Commands/TranscribeCommand.swift
+++ b/Sources/CLI/Commands/TranscribeCommand.swift
@@ -42,6 +42,7 @@ enum TranscribeParakeetModel: String, ExpressibleByArgument, CaseIterable, Senda
     case v3
     case v2
     case unified
+    case omiMedV1 = "omi-med-v1"
 }
 
 enum TranscribeNemotronModel: String, ExpressibleByArgument, CaseIterable, Sendable {
@@ -98,7 +99,7 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
     @Option(help: "Language hint for Nemotron, Whisper, or Cohere, such as ko, en, or en-US. Cohere requires a supported language; Parakeet and the English-only Nemotron build ignore this flag.")
     var language: String?
 
-    @Option(name: .long, help: "Parakeet build: app-default, v3 (English + supported European languages), v2 (English word timestamps), unified (readable English, no word timestamps). app-default follows the saved preference; ignored for Nemotron, Cohere, and Whisper.")
+    @Option(name: .long, help: "Parakeet build: app-default, v3 (English + supported European languages), v2 (English word timestamps), unified (readable English, no word timestamps), omi-med-v1 (English medical, requires local install). app-default follows the saved preference; ignored for Nemotron, Cohere, and Whisper.")
     var parakeetModel: TranscribeParakeetModel = .appDefault
 
     @Option(name: .long, help: "Nemotron Beta build: app-default, multilingual-1120ms, english-1120ms. app-default follows the saved preference; ignored for Parakeet, Cohere, and Whisper. The English build ignores --language.")
@@ -270,6 +271,8 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
             return .v2
         case .unified:
             return .unified
+        case .omiMedV1:
+            return .omiMedV1
         }
     }
 

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -537,6 +537,9 @@ struct SettingsView: View {
     private func modelDeletionMessage(for deletion: PendingModelDeletion) -> String {
         switch deletion {
         case .parakeet(let variant):
+            if variant.usesLocalInstallOnly {
+                return "This frees \(variant.approximateDownloadSize). \(variant.modelName) has no in-app download — reinstalling requires converting the model again."
+            }
             return "This frees \(variant.approximateDownloadSize). You can download \(variant.modelName) again at any time."
         case .nemotron(let variant):
             return "This frees \(variant.approximateDownloadSize). You can download \(variant.modelName) again at any time."
@@ -2344,6 +2347,17 @@ struct SettingsView: View {
                     parakeetModelOptionRow(.v2)
                     Divider()
                     parakeetModelOptionRow(.unified)
+                    // Omi Med has no in-app download (its CoreML bundle is
+                    // converted offline and installed locally), so the row —
+                    // whose empty state promises "downloads on first use" —
+                    // only appears once the bundle is actually installed. It
+                    // stays visible while selected so the active build is
+                    // never hidden, even if its files were removed externally.
+                    if viewModel.engine.downloadedParakeetVariants.contains(.omiMedV1)
+                        || viewModel.engine.parakeetModelVariant == .omiMedV1 {
+                        Divider()
+                        parakeetModelOptionRow(.omiMedV1)
+                    }
                 }
             }
             .transition(.opacity)

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
@@ -3566,6 +3566,7 @@ private struct EngineOptionCard: View {
             case .v3: "Fast local default • word timestamps"
             case .v2: "English stability • word timestamps"
             case .unified: "Readable English • no word timestamps"
+            case .omiMedV1: "English medical • word timestamps"
             }
         case .nemotron:
             nemotronVariant.isEnglishOnly

--- a/Sources/MacParakeetCore/STT/OmiMedParakeetModel.swift
+++ b/Sources/MacParakeetCore/STT/OmiMedParakeetModel.swift
@@ -1,0 +1,163 @@
+@preconcurrency import CoreML
+import FluidAudio
+import Foundation
+
+/// Loader for the Omi Med STT v1 CoreML bundle — an English medical
+/// fine-tune of NVIDIA Parakeet TDT 0.6B v2 (`omi-health/omi-med-stt-v1`).
+///
+/// The bundle is architecturally identical to FluidAudio's stock v2 build
+/// (same tokenizer, blank id 1024, same component I/O contract), so the
+/// loaded models drive the shared TDT `AsrManager` as `AsrModelVersion.v2`.
+/// Unlike the stock builds there is no FluidAudio HuggingFace repo to fetch
+/// from: the compiled CoreML artifacts are produced offline from the upstream
+/// `.nemo` checkpoint (FluidInference `mobius` parakeet-tdt-v2 conversion,
+/// FP16 MLProgram, single-step JointDecision) and installed into
+/// ``modelDirectory()``.
+///
+/// Loading is strictly local and never calls FluidAudio's download-or-load
+/// helpers. That is deliberate: `DownloadUtils` recovers from missing or
+/// corrupt files by re-downloading the *stock* v2 weights, which would
+/// silently replace the medical fine-tune. A missing install throws
+/// ``STTError/modelNotInstalled(_:)`` instead.
+public enum OmiMedParakeetModel {
+
+    /// Leaf directory under FluidAudio's models base holding the compiled
+    /// bundle. Sibling of the stock `parakeet-tdt-0.6b-v2` cache so `models
+    /// clear`-style maintenance sees every speech model in one place.
+    public static let folderName = "omi-med-stt-v1-coreml"
+
+    /// Compiled component bundles, mirroring FluidAudio's v2 layout
+    /// (`ModelNames.ASR`): split preprocessor/encoder frontend, RNNT
+    /// prediction network, and the fused single-step joint+decision head.
+    static let requiredModelFiles: [String] = [
+        "Preprocessor.mlmodelc",
+        "Encoder.mlmodelc",
+        "Decoder.mlmodelc",
+        "JointDecision.mlmodelc",
+    ]
+
+    /// Token-id → sentencepiece piece map in FluidAudio's dict format.
+    static let vocabularyFileName = "parakeet_vocab.json"
+
+    /// `<Application Support>/FluidAudio/Models/omi-med-stt-v1-coreml`.
+    public nonisolated static func modelDirectory() -> URL {
+        let appSupport = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first ?? FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library", isDirectory: true)
+            .appendingPathComponent("Application Support", isDirectory: true)
+        return appSupport
+            .appendingPathComponent("FluidAudio", isDirectory: true)
+            .appendingPathComponent("Models", isDirectory: true)
+            .appendingPathComponent(folderName, isDirectory: true)
+    }
+
+    public nonisolated static func isInstalled() -> Bool {
+        isInstalled(at: modelDirectory())
+    }
+
+    /// Directory-parameterized core of ``isInstalled()`` so tests can exercise
+    /// the required-file check against a temp dir.
+    nonisolated static func isInstalled(at directory: URL) -> Bool {
+        let fileManager = FileManager.default
+        let allModelsPresent = requiredModelFiles.allSatisfy {
+            fileManager.fileExists(atPath: directory.appendingPathComponent($0).path)
+        }
+        let vocabPresent = fileManager.fileExists(
+            atPath: directory.appendingPathComponent(vocabularyFileName).path)
+        return allModelsPresent && vocabPresent
+    }
+
+    /// Removes the installed bundle. Returns `true` only when the directory
+    /// existed and is gone afterward; a no-op `false` when nothing was
+    /// installed. Reinstalling requires re-running the offline conversion (or
+    /// restoring a saved copy) — there is no in-app download.
+    @discardableResult
+    public nonisolated static func deleteModel() -> Bool {
+        let fileManager = FileManager.default
+        let directory = modelDirectory()
+        guard fileManager.fileExists(atPath: directory.path) else { return false }
+        do {
+            try fileManager.removeItem(at: directory)
+        } catch {
+            return false
+        }
+        return !fileManager.fileExists(atPath: directory.path)
+    }
+
+    /// Loads the installed bundle into a FluidAudio `AsrModels` value the
+    /// shared TDT `AsrManager` accepts. Compute-unit placement mirrors
+    /// `AsrModels.load` for v2: preprocessor pinned to CPU (its ops map to CPU
+    /// anyway), everything else on CPU+ANE.
+    static func load() async throws -> AsrModels {
+        let directory = modelDirectory()
+        guard isInstalled(at: directory) else {
+            throw STTError.modelNotInstalled(
+                "Omi Med STT v1 is not installed. Install the converted CoreML bundle at "
+                    + "\(directory.path) (see Sources/MacParakeetCore/STT/README.md)."
+            )
+        }
+
+        let neuralEngineConfig = AsrModels.defaultConfiguration()
+        let cpuOnlyConfig = MLModelConfiguration()
+        cpuOnlyConfig.computeUnits = .cpuOnly
+
+        do {
+            let preprocessor = try await MLModel.load(
+                contentsOf: directory.appendingPathComponent("Preprocessor.mlmodelc"),
+                configuration: cpuOnlyConfig
+            )
+            let encoder = try await MLModel.load(
+                contentsOf: directory.appendingPathComponent("Encoder.mlmodelc"),
+                configuration: neuralEngineConfig
+            )
+            let decoder = try await MLModel.load(
+                contentsOf: directory.appendingPathComponent("Decoder.mlmodelc"),
+                configuration: neuralEngineConfig
+            )
+            let joint = try await MLModel.load(
+                contentsOf: directory.appendingPathComponent("JointDecision.mlmodelc"),
+                configuration: neuralEngineConfig
+            )
+            let vocabulary = try loadVocabulary(
+                from: directory.appendingPathComponent(vocabularyFileName))
+
+            return AsrModels(
+                encoder: encoder,
+                preprocessor: preprocessor,
+                decoder: decoder,
+                joint: joint,
+                configuration: neuralEngineConfig,
+                vocabulary: vocabulary,
+                version: .v2
+            )
+        } catch let error as STTError {
+            throw error
+        } catch {
+            throw STTError.engineStartFailed(
+                "Failed to load Omi Med STT v1 from \(directory.path): \(error.localizedDescription)"
+            )
+        }
+    }
+
+    /// Parses FluidAudio's dict-format vocabulary (`{"<token_id>": "<piece>"}`).
+    nonisolated static func loadVocabulary(from url: URL) throws -> [Int: String] {
+        let data = try Data(contentsOf: url)
+        guard let entries = try JSONSerialization.jsonObject(with: data) as? [String: String] else {
+            throw STTError.engineStartFailed(
+                "Omi Med vocabulary at \(url.path) is not a {\"id\": \"token\"} JSON dictionary."
+            )
+        }
+        var vocabulary: [Int: String] = [:]
+        vocabulary.reserveCapacity(entries.count)
+        for (key, value) in entries {
+            guard let tokenId = Int(key) else { continue }
+            vocabulary[tokenId] = value
+        }
+        guard !vocabulary.isEmpty else {
+            throw STTError.engineStartFailed("Omi Med vocabulary at \(url.path) is empty.")
+        }
+        return vocabulary
+    }
+}

--- a/Sources/MacParakeetCore/STT/ParakeetModelVariant+ASR.swift
+++ b/Sources/MacParakeetCore/STT/ParakeetModelVariant+ASR.swift
@@ -14,6 +14,11 @@ extension ParakeetModelVariant {
         case .v3: .v3
         case .v2: .v2
         case .unified: nil
+        // Omi Med is a v2 fine-tune with the identical component contract, so
+        // the shared TDT runtime treats it as `.v2` — only the weights (loaded
+        // from `OmiMedParakeetModel`'s local directory, never the stock v2
+        // download cache) differ.
+        case .omiMedV1: .v2
         }
     }
 
@@ -21,6 +26,8 @@ extension ParakeetModelVariant {
     /// Any non-`v2` version collapses to `.v3` — MacParakeet only exposes the
     /// v2/v3 pair, so the specialized CJK builds (if ever loaded) read as the
     /// multilingual default rather than crashing an exhaustive switch.
+    /// `.v2` is ambiguous here (Omi Med also runs as `.v2`); callers that can
+    /// know the active user-facing variant should prefer it over this mapping.
     public init(asrModelVersion: AsrModelVersion) {
         switch asrModelVersion {
         case .v2: self = .v2

--- a/Sources/MacParakeetCore/STT/README.md
+++ b/Sources/MacParakeetCore/STT/README.md
@@ -82,7 +82,16 @@ to one `STTRuntime`; callers do not own model lifecycles directly.
   **local-install-only**: there is no FluidAudio HuggingFace repo, so nothing
   in the app or CLI downloads it, and the loader never touches FluidAudio's
   download-or-load path (whose corrupt-cache recovery would silently replace
-  the fine-tune with stock v2 weights). Installing the bundle:
+  the fine-tune with stock v2 weights). Installing the bundle — the easy path
+  is the pre-converted CoreML release at
+  [`cmsha/omi-med-stt-v1-coreml`](https://huggingface.co/cmsha/omi-med-stt-v1-coreml):
+
+  ```bash
+  hf download cmsha/omi-med-stt-v1-coreml \
+    --local-dir ~/Library/Application\ Support/FluidAudio/Models/omi-med-stt-v1-coreml
+  ```
+
+  To reproduce the conversion from the source checkpoint instead:
   1. Download `omimedstt-v1.nemo` from `huggingface.co/omi-health/omi-med-stt-v1`.
   2. Run the FluidInference `mobius` parakeet-tdt-v2 CoreML export against it
      (`models/stt/parakeet-tdt-v2-0.6b/coreml/convert-parakeet.py --nemo-path …`),

--- a/Sources/MacParakeetCore/STT/README.md
+++ b/Sources/MacParakeetCore/STT/README.md
@@ -2,8 +2,9 @@
 
 > One process-wide speech-to-text control plane. Parakeet (FluidAudio /
 > CoreML) is default, with v3 multilingual as the default build, v2
-> English-only and Parakeet Unified (English-only, punctuated offline output
-> plus native live dictation partials)
+> English-only, Parakeet Unified (English-only, punctuated offline output
+> plus native live dictation partials), and Omi Med STT v1 (English medical
+> v2 fine-tune, local-install-only)
 > as opt-in Parakeet variants; Nemotron is an opt-in Beta
 > engine with two builds — multilingual (Nemotron 3.5, default) and an
 > English-only streaming build (Nemotron Speech Streaming EN 0.6B);
@@ -73,6 +74,31 @@ to one `STTRuntime`; callers do not own model lifecycles directly.
 - `NativeLiveDictating.swift` — internal protocol the native streaming engines
   conform to so `STTRuntime` can route a live dictation session to the active
   Nemotron or Parakeet Unified build without knowing the concrete engine type.
+- `OmiMedParakeetModel.swift` — loader for the Omi Med STT v1 bundle
+  (`omi-health/omi-med-stt-v1`), an English medical fine-tune of Parakeet TDT
+  0.6B v2 selected via `ParakeetModelVariant.omiMedV1`. Identical architecture,
+  tokenizer, and CoreML component contract to stock v2, so it drives the shared
+  TDT `AsrManager` as `AsrModelVersion.v2` — only the weights differ. It is
+  **local-install-only**: there is no FluidAudio HuggingFace repo, so nothing
+  in the app or CLI downloads it, and the loader never touches FluidAudio's
+  download-or-load path (whose corrupt-cache recovery would silently replace
+  the fine-tune with stock v2 weights). Installing the bundle:
+  1. Download `omimedstt-v1.nemo` from `huggingface.co/omi-health/omi-med-stt-v1`.
+  2. Run the FluidInference `mobius` parakeet-tdt-v2 CoreML export against it
+     (`models/stt/parakeet-tdt-v2-0.6b/coreml/convert-parakeet.py --nemo-path …`),
+     which emits FP16 MLProgram `.mlpackage`s with the v2 I/O contract.
+  3. Compile with `xcrun coremlcompiler compile` and rename:
+     `parakeet_preprocessor→Preprocessor.mlmodelc`,
+     `parakeet_encoder→Encoder.mlmodelc`, `parakeet_decoder→Decoder.mlmodelc`,
+     `parakeet_joint_decision_single_step→JointDecision.mlmodelc` (FluidAudio's
+     v2 joint is the fused *single-step* decision head).
+  4. Export the tokenizer as dict-format `parakeet_vocab.json`
+     (`{"<token_id>": "<piece>"}`, 1024 tokens, blank id 1024).
+  5. Place all five artifacts (~1.1 GB) in
+     `~/Library/Application Support/FluidAudio/Models/omi-med-stt-v1-coreml/`.
+  Settings shows the build only while installed (or selected); the CLI accepts
+  `parakeet-omi-med-v1` and fails selection/download with this guidance when
+  the bundle is missing.
 
 **Hotkey state (lives here for testability)**
 - `FnKeyStateMachine.swift` — pure state machine for legacy combined
@@ -204,9 +230,9 @@ directly **must** wrap it the same way — calling the manager bare reopens the
 crash for whichever lane runs unguarded.
 
 **Engine routing is per-job.** Parakeet stays default. The selected Parakeet
-build is `v3` unless the user opts into `v2` through Settings or the CLI
-(`config set parakeet-model`, `models select parakeet-v2`, or
-`transcribe --parakeet-model v2`). A subscriber can request Nemotron or
+build is `v3` unless the user opts into `v2`, `unified`, or `omi-med-v1`
+through Settings or the CLI (`config set parakeet-model`,
+`models select parakeet-v2`, or `transcribe --parakeet-model v2`). A subscriber can request Nemotron or
 WhisperKit or Cohere globally (Settings / `models select`) or per call (CLI
 `--engine nemotron --language ko`, `--engine cohere --language ja`,
 `--engine whisper --language ko`). When set globally, dictation also routes

--- a/Sources/MacParakeetCore/STT/STTClientProtocol.swift
+++ b/Sources/MacParakeetCore/STT/STTClientProtocol.swift
@@ -152,6 +152,9 @@ public enum STTError: Error, LocalizedError {
     case timeout
     case modelNotLoaded
     case modelDownloadFailed
+    /// A local-install-only model (no in-app download) is selected but its
+    /// files are missing. The payload says where the bundle must be installed.
+    case modelNotInstalled(String)
     case outOfMemory
     case invalidResponse
     case engineBusy
@@ -164,6 +167,7 @@ public enum STTError: Error, LocalizedError {
         case .timeout: return "STT request timed out"
         case .modelNotLoaded: return "STT model not loaded"
         case .modelDownloadFailed: return "Speech model isn't downloaded yet — check your internet connection and try again."
+        case .modelNotInstalled(let reason): return reason
         case .outOfMemory: return "Out of memory during transcription"
         case .invalidResponse: return "Invalid response from speech engine"
         case .engineBusy: return "Speech engine is busy. Try again after the current transcription finishes."

--- a/Sources/MacParakeetCore/STT/STTRuntime.swift
+++ b/Sources/MacParakeetCore/STT/STTRuntime.swift
@@ -509,7 +509,7 @@ public actor STTRuntime: STTRuntimeProtocol {
                         words: STTWordTimingBuilder.words(from: result.tokenTimings),
                         language: "en",
                         engine: .parakeet,
-                        engineVariant: ParakeetModelVariant(asrModelVersion: modelVersion).rawValue
+                        engineVariant: currentParakeetVariant.rawValue
                     )
                 } catch {
                     throw try Self.mapTranscriptionError(error)
@@ -566,7 +566,7 @@ public actor STTRuntime: STTRuntimeProtocol {
                 words: words,
                 language: "en",
                 engine: .parakeet,
-                engineVariant: ParakeetModelVariant(asrModelVersion: modelVersion).rawValue
+                engineVariant: currentParakeetVariant.rawValue
             )
         } catch {
             throw try Self.mapTranscriptionError(error)
@@ -692,7 +692,7 @@ public actor STTRuntime: STTRuntimeProtocol {
                 // Mirrors batch Parakeet attribution: the build variant carries v2/v3.
                 language: "en",
                 engine: .parakeet,
-                engineVariant: ParakeetModelVariant(asrModelVersion: modelVersion).rawValue
+                engineVariant: currentParakeetVariant.rawValue
             )
         } catch {
             throw try Self.mapTranscriptionError(error)
@@ -1104,7 +1104,16 @@ public actor STTRuntime: STTRuntimeProtocol {
             onProgress?("Preparing \(variant.modelName)...")
             // Download the target build first so the current model keeps serving
             // until the fetch completes. Unified and TDT live in different repos.
-            if variant.usesUnifiedEngine {
+            // Local-install-only builds (Omi Med) have nothing to download —
+            // fail fast with install guidance so the current model keeps serving.
+            if variant.usesLocalInstallOnly {
+                guard OmiMedParakeetModel.isInstalled() else {
+                    throw STTError.modelNotInstalled(
+                        "\(variant.modelName) is not installed. Install the converted CoreML bundle at "
+                            + "\(OmiMedParakeetModel.modelDirectory().path)."
+                    )
+                }
+            } else if variant.usesUnifiedEngine {
                 try await ParakeetUnifiedEngine.downloadModel(onProgress: onProgress)
             } else if let targetVersion = variant.asrModelVersion {
                 try await downloadParakeetModels(version: targetVersion, onProgress: onProgress)
@@ -1276,6 +1285,46 @@ public actor STTRuntime: STTRuntimeProtocol {
     public nonisolated static func isModelCached(version: AsrModelVersion = .v3) -> Bool {
         let cacheDir = AsrModels.defaultCacheDirectory(for: version)
         return AsrModels.modelsExist(at: cacheDir, version: version)
+    }
+
+    /// Variant-keyed on-disk presence check. Dispatches the Unified build to
+    /// ``ParakeetUnifiedEngine`` and the local-install-only Omi Med build to
+    /// ``OmiMedParakeetModel``; the stock TDT builds use the version-keyed
+    /// FluidAudio cache. Prefer this over `isModelCached(version:)` whenever a
+    /// `ParakeetModelVariant` is in hand — the version-keyed check cannot
+    /// distinguish Omi Med from stock v2.
+    public nonisolated static func isParakeetModelCached(variant: ParakeetModelVariant) -> Bool {
+        if variant.usesLocalInstallOnly {
+            return OmiMedParakeetModel.isInstalled()
+        }
+        if variant.usesUnifiedEngine {
+            return ParakeetUnifiedEngine.isModelCached()
+        }
+        guard let version = variant.asrModelVersion else { return false }
+        return isModelCached(version: version)
+    }
+
+    /// Deletes the local-install-only Omi Med bundle, mirroring
+    /// ``deleteParakeetModel(version:)``'s telemetry so model deletions report
+    /// through the same `model_operation` channel. Pure file work — callers
+    /// must not delete the build currently loaded by the active engine.
+    @discardableResult
+    public nonisolated static func deleteOmiMedParakeetModel() -> Bool {
+        let operationContext = Observability.childOperationContext()
+        let removed = OmiMedParakeetModel.deleteModel()
+        Telemetry.send(.modelOperation(
+            operationID: operationContext.operationID,
+            operationContext: operationContext,
+            action: .deleteModel,
+            outcome: removed ? .success : .failure,
+            stage: .delete,
+            modelKind: .parakeetSTT,
+            speechEngine: .parakeet,
+            engineVariant: ParakeetModelVariant.omiMedV1.rawValue,
+            durationSeconds: Observability.durationSeconds(since: operationContext.startedAt),
+            errorType: nil
+        ))
+        return removed
     }
 
     public nonisolated static func isNemotronModelCached(
@@ -1664,16 +1713,26 @@ public actor STTRuntime: STTRuntimeProtocol {
 
         let generation = nextInitializationGeneration()
         let version = modelVersion
+        let variant = currentParakeetVariant
         let warmUpProgressHandler = self.warmUpProgressHandler
         let task = Task {
             var interactiveManager: AsrManager?
             var backgroundManager: AsrManager?
             let progressHandler = Self.makeDownloadProgressHandler(warmUpProgressHandler)
 
-            let downloadedModels = try await AsrModels.downloadAndLoad(
-                version: version,
-                progressHandler: progressHandler
-            )
+            let downloadedModels: AsrModels
+            if variant.usesLocalInstallOnly {
+                // Local-install-only builds (Omi Med) never touch FluidAudio's
+                // download-or-load path: its corrupt-cache recovery re-downloads
+                // the *stock* weights, which would silently drop the fine-tune.
+                warmUpProgressHandler?("Loading \(variant.modelName) with Core ML...")
+                downloadedModels = try await OmiMedParakeetModel.load()
+            } else {
+                downloadedModels = try await AsrModels.downloadAndLoad(
+                    version: version,
+                    progressHandler: progressHandler
+                )
+            }
             do {
                 // FluidAudio progress is manager-scoped, so each slot keeps its
                 // own manager while the read-only model bundle stays shared.

--- a/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
+++ b/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
@@ -1699,6 +1699,7 @@ extension TelemetryEventSpec {
             ParakeetModelVariant.v2.rawValue,
             ParakeetModelVariant.v3.rawValue,
             ParakeetModelVariant.unified.rawValue,
+            ParakeetModelVariant.omiMedV1.rawValue,
             NemotronModelVariant.multilingual1120.rawValue,
             NemotronModelVariant.english1120.rawValue,
             CohereTranscribeEngine.ComputePolicy.ane.rawValue,

--- a/Sources/MacParakeetCore/SpeechEnginePreference.swift
+++ b/Sources/MacParakeetCore/SpeechEnginePreference.swift
@@ -358,6 +358,14 @@ public enum ParakeetModelVariant: String, CaseIterable, Codable, Sendable {
     /// of the shared `AsrManager`. The offline batch path is competitive with
     /// v2 on English and adds punctuation/capitalization (issue #520).
     case unified
+    /// Omi Med STT v1 (`omi-health/omi-med-stt-v1`): an English medical
+    /// fine-tune of Parakeet TDT 0.6B v2 for clinical dialogue. Same
+    /// architecture, tokenizer, and CoreML component contract as `v2`, so it
+    /// runs on the shared TDT `AsrManager` as `AsrModelVersion.v2` — only the
+    /// weights differ. Unlike the stock builds it has no FluidAudio download
+    /// repo: the CoreML bundle is converted offline and installed locally
+    /// (see ``usesLocalInstallOnly`` and `OmiMedParakeetModel`).
+    case omiMedV1 = "omi-med-v1"
 
     /// Short label for the variant's language posture.
     public var displayName: String {
@@ -365,6 +373,7 @@ public enum ParakeetModelVariant: String, CaseIterable, Codable, Sendable {
         case .v3: "Multilingual"
         case .v2: "English only"
         case .unified: "English (Unified)"
+        case .omiMedV1: "English (Medical)"
         }
     }
 
@@ -374,6 +383,7 @@ public enum ParakeetModelVariant: String, CaseIterable, Codable, Sendable {
         case .v3: "Parakeet TDT 0.6B v3"
         case .v2: "Parakeet TDT 0.6B v2"
         case .unified: "Parakeet Unified 0.6B"
+        case .omiMedV1: "Omi Med STT v1"
         }
     }
 
@@ -386,21 +396,24 @@ public enum ParakeetModelVariant: String, CaseIterable, Codable, Sendable {
             "English-only option for stable meetings and exports. Includes word timestamps."
         case .unified:
             "Readable English with live preview. No word timestamps for exports."
+        case .omiMedV1:
+            "English medical fine-tune of Parakeet v2 for clinical dialogue. Includes word timestamps."
         }
     }
 
     /// Approximate on-disk download footprint. The TDT builds land near ~465 MB
     /// (v3 int8 encoder ≈ 461 MB measured; v2 ≈ 465 MB); Unified's int8 offline
-    /// bundle is ~565 MB. Kept deliberately rounded so the copy doesn't read as
-    /// falsely precise.
+    /// bundle is ~565 MB; Omi Med's FP16 encoder bundle is ~1.1 GB measured.
+    /// Kept deliberately rounded so the copy doesn't read as falsely precise.
     public var approximateDownloadSize: String {
         switch self {
         case .v3, .v2: "~465 MB"
         case .unified: "~565 MB"
+        case .omiMedV1: "~1.1 GB"
         }
     }
 
-    public var isEnglishOnly: Bool { self == .v2 || self == .unified }
+    public var isEnglishOnly: Bool { self == .v2 || self == .unified || self == .omiMedV1 }
 
     /// Whether this variant is served by ``ParakeetUnifiedEngine`` (its own
     /// FluidAudio runtime) rather than the shared TDT `AsrManager`. The STT
@@ -408,11 +421,18 @@ public enum ParakeetModelVariant: String, CaseIterable, Codable, Sendable {
     /// path; it is the single predicate every TDT-only site guards on.
     public var usesUnifiedEngine: Bool { self == .unified }
 
+    /// Whether this variant's CoreML bundle is installed locally rather than
+    /// downloaded from a FluidAudio HuggingFace repo. Download and auto-fetch
+    /// paths must skip these variants — falling back to a stock download would
+    /// silently swap in the wrong weights.
+    public var usesLocalInstallOnly: Bool { self == .omiMedV1 }
+
     public var alternative: ParakeetModelVariant {
         switch self {
         case .v3: .v2
         case .v2: .v3
         case .unified: .v2
+        case .omiMedV1: .v2
         }
     }
 }

--- a/Sources/MacParakeetViewModels/EngineSettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/EngineSettingsViewModel.swift
@@ -181,9 +181,7 @@ public final class EngineSettingsViewModel {
     public init(
         defaults: UserDefaults = .standard,
         parakeetModelVariantCached: @escaping @Sendable (ParakeetModelVariant) -> Bool = {
-            if $0.usesUnifiedEngine { return ParakeetUnifiedEngine.isModelCached() }
-            guard let version = $0.asrModelVersion else { return false }
-            return STTRuntime.isModelCached(version: version)
+            STTRuntime.isParakeetModelCached(variant: $0)
         },
         nemotronModelVariantCached: @escaping @Sendable (NemotronModelVariant, String?) -> Bool = {
             STTRuntime.isNemotronModelCached(modelVariant: $0, language: $1)
@@ -195,6 +193,7 @@ public final class EngineSettingsViewModel {
             CohereTranscribeEngine.hasModelCacheDirectory()
         },
         deleteParakeetModelOnDisk: @escaping @Sendable (ParakeetModelVariant) -> Bool = {
+            if $0.usesLocalInstallOnly { return STTRuntime.deleteOmiMedParakeetModel() }
             if $0.usesUnifiedEngine { return ParakeetUnifiedEngine.deleteModel() }
             guard let version = $0.asrModelVersion else { return false }
             return STTRuntime.deleteParakeetModel(version: version)
@@ -1303,7 +1302,7 @@ public final class EngineSettingsViewModel {
         switch sttError {
         case .engineBusy:
             return .engineBusy
-        case .modelDownloadFailed, .modelNotLoaded:
+        case .modelDownloadFailed, .modelNotLoaded, .modelNotInstalled:
             return .modelNotDownloaded
         case .engineNotRunning,
              .engineStartFailed,

--- a/Sources/MacParakeetViewModels/OnboardingViewModel.swift
+++ b/Sources/MacParakeetViewModels/OnboardingViewModel.swift
@@ -820,7 +820,7 @@ public final class OnboardingViewModel {
         switch sttError {
         case .engineBusy:
             return .engineBusy
-        case .modelDownloadFailed, .modelNotLoaded:
+        case .modelDownloadFailed, .modelNotLoaded, .modelNotInstalled:
             return .modelNotDownloaded
         case .engineNotRunning,
              .engineStartFailed,

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -611,11 +611,7 @@ public final class SettingsViewModel {
         youtubeDownloadsDirPath: @escaping @Sendable () -> String = { AppPaths.youtubeDownloadsDir },
         meetingRecordingsDirPath: @escaping @Sendable () -> String = { AppPaths.meetingRecordingsDir },
         parakeetModelVariantCached: @escaping @Sendable (ParakeetModelVariant) -> Bool = {
-            // Unified is a separate FluidAudio runtime with no `AsrModelVersion`;
-            // dispatch it to its own engine's cache check.
-            if $0.usesUnifiedEngine { return ParakeetUnifiedEngine.isModelCached() }
-            guard let version = $0.asrModelVersion else { return false }
-            return STTRuntime.isModelCached(version: version)
+            STTRuntime.isParakeetModelCached(variant: $0)
         },
         nemotronModelVariantCached: @escaping @Sendable (NemotronModelVariant, String?) -> Bool = {
             STTRuntime.isNemotronModelCached(modelVariant: $0, language: $1)
@@ -624,6 +620,7 @@ public final class SettingsViewModel {
             CohereTranscribeEngine.isModelCached()
         },
         deleteParakeetModelOnDisk: @escaping @Sendable (ParakeetModelVariant) -> Bool = {
+            if $0.usesLocalInstallOnly { return STTRuntime.deleteOmiMedParakeetModel() }
             if $0.usesUnifiedEngine { return ParakeetUnifiedEngine.deleteModel() }
             guard let version = $0.asrModelVersion else { return false }
             return STTRuntime.deleteParakeetModel(version: version)

--- a/Tests/CLITests/ModelLifecycleCommandTests.swift
+++ b/Tests/CLITests/ModelLifecycleCommandTests.swift
@@ -312,6 +312,11 @@ final class ModelLifecycleCommandTests: XCTestCase {
         XCTAssertEqual(parakeetDownloadVariant(from: "parakeet-unified", defaults: defaults), .unified)
         XCTAssertEqual(parakeetDownloadVariant(from: "parakeet:unified", defaults: defaults), .unified)
         XCTAssertEqual(parakeetModelID(for: .unified), "parakeet-unified")
+        // Omi Med (local-install-only) resolves from its id and aliases.
+        XCTAssertEqual(parakeetDownloadVariant(from: "parakeet-omi-med-v1", defaults: defaults), .omiMedV1)
+        XCTAssertEqual(parakeetDownloadVariant(from: "parakeet:omi-med", defaults: defaults), .omiMedV1)
+        XCTAssertEqual(parakeetDownloadVariant(from: "parakeet-medical", defaults: defaults), .omiMedV1)
+        XCTAssertEqual(parakeetModelID(for: .omiMedV1), "parakeet-omi-med-v1")
         // Bare "parakeet" resolves to the persisted build.
         SpeechEnginePreference.saveParakeetModelVariant(.v2, defaults: defaults)
         XCTAssertEqual(parakeetDownloadVariant(from: "parakeet", defaults: defaults), .v2)

--- a/Tests/CLITests/TranscribeCommandTests.swift
+++ b/Tests/CLITests/TranscribeCommandTests.swift
@@ -49,6 +49,11 @@ final class TranscribeCommandTests: XCTestCase {
             TranscribeCommand.resolveParakeetModelVariant(.unified, storedVariant: .v3),
             .unified
         )
+        // Omi Med is selectable per-call via --parakeet-model omi-med-v1.
+        XCTAssertEqual(
+            TranscribeCommand.resolveParakeetModelVariant(.omiMedV1, storedVariant: .v3),
+            .omiMedV1
+        )
     }
 
     func testResolveNemotronModelVariantFollowsStoredForAppDefault() {

--- a/Tests/MacParakeetTests/STT/OmiMedParakeetModelTests.swift
+++ b/Tests/MacParakeetTests/STT/OmiMedParakeetModelTests.swift
@@ -1,0 +1,89 @@
+import Foundation
+import XCTest
+
+@testable import MacParakeetCore
+
+/// File-layout and vocabulary-parsing coverage for the local-install-only
+/// Omi Med Parakeet bundle. Model loading itself needs the real ~1.1 GB
+/// CoreML artifacts, so it is exercised via the CLI/dev-app, not unit tests.
+final class OmiMedParakeetModelTests: XCTestCase {
+
+    private var tempDir: URL!
+
+    override func setUpWithError() throws {
+        tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("omi-med-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: tempDir)
+    }
+
+    private func installFixtureBundle(omitting omitted: Set<String> = []) throws {
+        // The check only requires presence; compiled-model *content* is the
+        // CoreML runtime's concern at load time.
+        for name in OmiMedParakeetModel.requiredModelFiles where !omitted.contains(name) {
+            try FileManager.default.createDirectory(
+                at: tempDir.appendingPathComponent(name), withIntermediateDirectories: true)
+        }
+        if !omitted.contains(OmiMedParakeetModel.vocabularyFileName) {
+            try Data(#"{"0": "\#u{2581}the"}"#.utf8).write(
+                to: tempDir.appendingPathComponent(OmiMedParakeetModel.vocabularyFileName))
+        }
+    }
+
+    func testIsInstalledRequiresEveryComponentAndVocabulary() throws {
+        XCTAssertFalse(OmiMedParakeetModel.isInstalled(at: tempDir))
+
+        try installFixtureBundle()
+        XCTAssertTrue(OmiMedParakeetModel.isInstalled(at: tempDir))
+    }
+
+    func testIsInstalledFailsWhenAnyComponentIsMissing() throws {
+        for missing in OmiMedParakeetModel.requiredModelFiles + [OmiMedParakeetModel.vocabularyFileName] {
+            let caseDir = tempDir.appendingPathComponent(missing, isDirectory: true)
+                .appendingPathExtension("case")
+            try FileManager.default.createDirectory(at: caseDir, withIntermediateDirectories: true)
+            defer { try? FileManager.default.removeItem(at: caseDir) }
+
+            for name in OmiMedParakeetModel.requiredModelFiles where name != missing {
+                try FileManager.default.createDirectory(
+                    at: caseDir.appendingPathComponent(name), withIntermediateDirectories: true)
+            }
+            if missing != OmiMedParakeetModel.vocabularyFileName {
+                try Data("{}".utf8).write(
+                    to: caseDir.appendingPathComponent(OmiMedParakeetModel.vocabularyFileName))
+            }
+            XCTAssertFalse(
+                OmiMedParakeetModel.isInstalled(at: caseDir),
+                "bundle missing \(missing) must not report installed"
+            )
+        }
+    }
+
+    func testLoadVocabularyParsesDictFormat() throws {
+        let vocabURL = tempDir.appendingPathComponent("vocab.json")
+        try Data(#"{"0": "\#u{2581}the", "1023": "z", "not-a-number": "x"}"#.utf8).write(to: vocabURL)
+
+        let vocabulary = try OmiMedParakeetModel.loadVocabulary(from: vocabURL)
+        XCTAssertEqual(vocabulary[0], "\u{2581}the")
+        XCTAssertEqual(vocabulary[1023], "z")
+        XCTAssertEqual(vocabulary.count, 2, "non-integer keys are dropped")
+    }
+
+    func testLoadVocabularyRejectsNonDictAndEmptyFiles() throws {
+        let arrayURL = tempDir.appendingPathComponent("array.json")
+        try Data(#"["a", "b"]"#.utf8).write(to: arrayURL)
+        XCTAssertThrowsError(try OmiMedParakeetModel.loadVocabulary(from: arrayURL))
+
+        let emptyURL = tempDir.appendingPathComponent("empty.json")
+        try Data("{}".utf8).write(to: emptyURL)
+        XCTAssertThrowsError(try OmiMedParakeetModel.loadVocabulary(from: emptyURL))
+    }
+
+    func testModelDirectoryLivesUnderFluidAudioModels() {
+        let path = OmiMedParakeetModel.modelDirectory().path
+        XCTAssertTrue(path.hasSuffix("FluidAudio/Models/\(OmiMedParakeetModel.folderName)"))
+    }
+}

--- a/Tests/MacParakeetTests/STT/SpeechEnginePreferenceTests.swift
+++ b/Tests/MacParakeetTests/STT/SpeechEnginePreferenceTests.swift
@@ -206,6 +206,41 @@ final class SpeechEnginePreferenceTests: XCTestCase {
         XCTAssertEqual(ParakeetModelVariant.unified.modelName, "Parakeet Unified 0.6B")
     }
 
+    // MARK: - Omi Med variant (local-install-only Parakeet v2 fine-tune)
+
+    func testOmiMedVariantRoundTrips() {
+        let (defaults, suite) = makeIsolatedDefaults()
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        SpeechEnginePreference.saveParakeetModelVariant(.omiMedV1, defaults: defaults)
+        XCTAssertEqual(SpeechEnginePreference.parakeetModelVariant(defaults: defaults), .omiMedV1)
+        XCTAssertEqual(ParakeetModelVariant(rawValue: "omi-med-v1"), .omiMedV1)
+    }
+
+    func testOmiMedRunsAsV2OnTheSharedTdtRuntime() {
+        // Omi Med is a v2 fine-tune with the identical component contract, so
+        // it must key the shared TDT `AsrManager` as `.v2`, not the Unified
+        // engine.
+        XCTAssertEqual(ParakeetModelVariant.omiMedV1.asrModelVersion, .v2)
+        XCTAssertFalse(ParakeetModelVariant.omiMedV1.usesUnifiedEngine)
+    }
+
+    func testOmiMedIsLocalInstallOnly() {
+        // Download/auto-fetch paths must skip Omi Med: falling back to a stock
+        // v2 download would silently swap in the wrong weights.
+        XCTAssertTrue(ParakeetModelVariant.omiMedV1.usesLocalInstallOnly)
+        XCTAssertFalse(ParakeetModelVariant.v2.usesLocalInstallOnly)
+        XCTAssertFalse(ParakeetModelVariant.v3.usesLocalInstallOnly)
+        XCTAssertFalse(ParakeetModelVariant.unified.usesLocalInstallOnly)
+    }
+
+    func testOmiMedIsEnglishOnlyAndListed() {
+        XCTAssertTrue(ParakeetModelVariant.omiMedV1.isEnglishOnly)
+        XCTAssertTrue(ParakeetModelVariant.allCases.contains(.omiMedV1))
+        XCTAssertEqual(ParakeetModelVariant.omiMedV1.modelName, "Omi Med STT v1")
+        XCTAssertEqual(ParakeetModelVariant.omiMedV1.alternative, .v2)
+    }
+
     func testSpeechModelVariantSummariesStayUserFacing() {
         XCTAssertEqual(
             ParakeetModelVariant.v3.coverageSummary,
@@ -218,6 +253,10 @@ final class SpeechEnginePreferenceTests: XCTestCase {
         XCTAssertEqual(
             ParakeetModelVariant.unified.coverageSummary,
             "Readable English with live preview. No word timestamps for exports."
+        )
+        XCTAssertEqual(
+            ParakeetModelVariant.omiMedV1.coverageSummary,
+            "English medical fine-tune of Parakeet v2 for clinical dialogue. Includes word timestamps."
         )
         XCTAssertEqual(
             NemotronModelVariant.multilingual1120.coverageSummary,

--- a/Tests/MacParakeetTests/TelemetryServiceTests.swift
+++ b/Tests/MacParakeetTests/TelemetryServiceTests.swift
@@ -662,6 +662,7 @@ final class TelemetryServiceTests: XCTestCase {
             (ParakeetModelVariant.v2.rawValue, "v2"),
             (ParakeetModelVariant.v3.rawValue, "v3"),
             (ParakeetModelVariant.unified.rawValue, "unified"),
+            (ParakeetModelVariant.omiMedV1.rawValue, "omi-med-v1"),
             (NemotronModelVariant.multilingual1120.rawValue, "multilingual-1120ms"),
             (NemotronModelVariant.english1120.rawValue, "english-1120ms"),
             (CohereTranscribeEngine.ComputePolicy.ane.rawValue, "ane"),


### PR DESCRIPTION
## Summary

Adds **Omi Med STT v1** ([omi-health/omi-med-stt-v1](https://huggingface.co/omi-health/omi-med-stt-v1)) — an English medical fine-tune of Parakeet TDT 0.6B v2 for clinical dialogue — as a selectable Parakeet build (`ParakeetModelVariant.omiMedV1`, raw value `omi-med-v1`).

- **Same runtime, different weights.** The fine-tune is architecturally identical to stock v2 (tokenizer, blank id 1024, CoreML component I/O contract), so it runs on the shared TDT `AsrManager` as `AsrModelVersion.v2` with word timestamps, dictation preview, and meeting jobs unchanged.
- **Local-install-only.** There is no FluidAudio HF repo for this build. A new `usesLocalInstallOnly` predicate keeps it out of every download path, and the new `OmiMedParakeetModel` loader constructs `AsrModels` directly from `<Application Support>/FluidAudio/Models/omi-med-stt-v1-coreml/` — deliberately bypassing `AsrModels.downloadAndLoad`, whose corrupt-cache recovery would silently replace the fine-tune with stock v2 weights. Missing installs throw the new `STTError.modelNotInstalled` with install guidance. Conversion/install steps are documented in `Sources/MacParakeetCore/STT/README.md`; a ready-made CoreML bundle is published at [cmsha/omi-med-stt-v1-coreml](https://huggingface.co/cmsha/omi-med-stt-v1-coreml).
- **Variant-keyed dispatch.** `STTRuntime.isParakeetModelCached(variant:)` / `deleteOmiMedParakeetModel()` replace the `asrModelVersion`-derived checks in the view models and CLI (version-keyed checks can't distinguish Omi Med from stock v2), and TDT result attribution now reads `currentParakeetVariant`. Telemetry allowlists `omi-med-v1` verbatim.
- **Surfaces.** Settings shows the build only while installed (or selected) with honest delete copy; the CLI accepts `parakeet-omi-med-v1` / `omi-med-v1` across `models list|select|download|delete`, `config set parakeet-model`, and `transcribe`/`retranscribe --parakeet-model`; `models select`/`download` fail with install guidance when the bundle is missing. CLI CHANGELOG updated (additive, minor).

## Testing

- `swift build` and full `swift test` pass.
- New `OmiMedParakeetModelTests` (install-detection, vocab parsing) plus extended SpeechEnginePreference/CLI/telemetry tests.
- End-to-end validated on-device: converted the upstream `.nemo` with the FluidInference mobius parakeet-tdt-v2 CoreML export, installed the bundle, and ran `macparakeet-cli transcribe --parakeet-model omi-med-v1` — correct clinical transcription (amoxicillin, metoprolol, atorvastatin, lisinopril, hydrochlorothiazide) with word timings, in the GUI and CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Omi Med STT v1 as a selectable Parakeet build that runs on the v2 runtime and loads strictly from a local CoreML bundle. Updates CLI, settings, telemetry, and docs (now pointing to a one-command install of a pre-converted bundle).

- **New Features**
  - New `ParakeetModelVariant.omiMedV1` (`omi-med-v1`) for English medical dictation with word timestamps; maps to v2 runtime.
  - Local loader `OmiMedParakeetModel` reads from `~/Library/Application Support/FluidAudio/Models/omi-med-stt-v1-coreml/` and throws `STTError.modelNotInstalled`; never calls the stock download path.
  - CLI accepts `parakeet-omi-med-v1` / `omi-med-v1` (aliases `omi-med`, `medical`) across `config set`, `transcribe`, `retranscribe`, and `models`; `models select|download` return install guidance instead of fetching.
  - Settings shows the option only when installed (or selected) and updates delete copy; deletion uses `deleteOmiMedParakeetModel`.
  - Variant-keyed cache checks (`STTRuntime.isParakeetModelCached(variant:)`) and result attribution use the current variant; telemetry allowlists `omi-med-v1`.

- **Migration**
  - No auto-download. Recommended: `hf download cmsha/omi-med-stt-v1-coreml --local-dir "~/Library/Application Support/FluidAudio/Models/omi-med-stt-v1-coreml"` (~1.1 GB).
  - Or convert `omi-health/omi-med-stt-v1` via the FluidInference `mobius` parakeet-tdt-v2 export and compile; install `Preprocessor.mlmodelc`, `Encoder.mlmodelc`, `Decoder.mlmodelc`, `JointDecision.mlmodelc`, and `parakeet_vocab.json` in the directory above.
  - Select with Settings or `--parakeet-model omi-med-v1`; selection fails with path guidance if not installed.
  - See `Sources/MacParakeetCore/STT/README.md` for details.

<sup>Written for commit 952e3b790d688f824b828536626f8672ebda756d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/668?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

