### PR TITLE
Meeting AEC: add double-talk SIR sweep metric to measurement harness

### DIFF
--- a/Tests/MacParakeetTests/Services/Capture/MeetingAecMeasurementHarness.swift
+++ b/Tests/MacParakeetTests/Services/Capture/MeetingAecMeasurementHarness.swift
@@ -297,16 +297,23 @@ enum MeetingAecScenarioFactory {
         var scale = Float(sqrt(targetEchoPower / baseEchoPower))
         var far = MeetingAecSignal.scaled(baseFar, by: scale)
         var echo = echoPath.apply(to: far)
+        let convergenceTolerance = 0.0005
         for _ in 0..<6 {
             let echoPower = MeetingAecMetrics.power(echo, over: window)
             guard echoPower > 0 else { break }
             let correction = sqrt(targetEchoPower / echoPower)
             guard correction.isFinite else { break }
-            if abs(correction - 1) < 0.0005 { break }
+            if abs(correction - 1) < convergenceTolerance { break }
             scale *= Float(correction)
             far = MeetingAecSignal.scaled(baseFar, by: scale)
             echo = echoPath.apply(to: far)
         }
+        let finalEchoPower = MeetingAecMetrics.power(echo, over: window)
+        let finalCorrection = sqrt(targetEchoPower / finalEchoPower)
+        precondition(
+            finalCorrection.isFinite && abs(finalCorrection - 1) < convergenceTolerance,
+            String(format: "AEC double-talk calibration failed to converge: correction %.6f", finalCorrection)
+        )
         return (far, echo)
     }
 }

--- a/Tests/MacParakeetTests/Services/Capture/MeetingAecMeasurementHarness.swift
+++ b/Tests/MacParakeetTests/Services/Capture/MeetingAecMeasurementHarness.swift
@@ -355,11 +355,7 @@ enum MeetingAecMetrics {
         guard let window = boundedWindow(window, counts: mic.count, output.count) else { return 0 }
         let micPower = power(mic, over: window)
         let outPower = power(output, over: window)
-        if micPower < powerFloor, outPower < powerFloor {
-            guard outPower > micPower else { return 0 }
-            return 10 * log10(max(micPower, Double.leastNonzeroMagnitude) / outPower)
-        }
-        return 10 * log10(max(micPower, Double.leastNonzeroMagnitude) / max(outPower, powerFloor))
+        return 10 * log10(max(micPower, powerFloor) / max(outPower, powerFloor))
     }
 
     /// Near-end error (dB relative to near-end power): how far the output drifts

--- a/Tests/MacParakeetTests/Services/Capture/MeetingAecMeasurementHarness.swift
+++ b/Tests/MacParakeetTests/Services/Capture/MeetingAecMeasurementHarness.swift
@@ -300,7 +300,10 @@ enum MeetingAecScenarioFactory {
         let convergenceTolerance = 0.0005
         for _ in 0..<6 {
             let echoPower = MeetingAecMetrics.power(echo, over: window)
-            guard echoPower > 0 else { break }
+            precondition(
+                echoPower > 0,
+                "AEC double-talk calibration underflowed: scaled far-end produced zero echo power"
+            )
             let correction = sqrt(targetEchoPower / echoPower)
             guard correction.isFinite else { break }
             if abs(correction - 1) < convergenceTolerance { break }
@@ -309,6 +312,10 @@ enum MeetingAecScenarioFactory {
             echo = echoPath.apply(to: far)
         }
         let finalEchoPower = MeetingAecMetrics.power(echo, over: window)
+        precondition(
+            finalEchoPower > 0,
+            "AEC double-talk calibration underflowed: scaled far-end produced zero echo power"
+        )
         let finalCorrection = sqrt(targetEchoPower / finalEchoPower)
         precondition(
             finalCorrection.isFinite && abs(finalCorrection - 1) < convergenceTolerance,

--- a/Tests/MacParakeetTests/Services/Capture/MeetingAecMeasurementHarness.swift
+++ b/Tests/MacParakeetTests/Services/Capture/MeetingAecMeasurementHarness.swift
@@ -83,6 +83,11 @@ enum MeetingAecSignal {
         return out
     }
 
+    static func scaled(_ signal: [Float], by scale: Float) -> [Float] {
+        guard scale != 1 else { return signal }
+        return signal.map { $0 * scale }
+    }
+
     static func silence(sampleCount: Int) -> [Float] {
         [Float](repeating: 0, count: sampleCount)
     }
@@ -156,17 +161,19 @@ enum MeetingAecScenarioFactory {
         farEndActive: Bool,
         echoPath: MeetingAecEchoPath,
         sampleCount: Int = 24_000,
-        noiseLevel: Float = 0.001
+        noiseLevel: Float = 0.001,
+        nearAmplitude: Float = 0.3,
+        farAmplitude: Float = 0.3
     ) -> MeetingAecScenario {
         let near = nearEndActive
             ? MeetingAecSignal.voiceLike(
                 sampleCount: sampleCount, sampleRate: sampleRate,
-                formants: nearFormants, seed: nearSeed)
+                formants: nearFormants, seed: nearSeed, amplitude: nearAmplitude)
             : MeetingAecSignal.silence(sampleCount: sampleCount)
         let far = farEndActive
             ? MeetingAecSignal.voiceLike(
                 sampleCount: sampleCount, sampleRate: sampleRate,
-                formants: farFormants, seed: farSeed)
+                formants: farFormants, seed: farSeed, amplitude: farAmplitude)
             : MeetingAecSignal.silence(sampleCount: sampleCount)
         let echo = echoPath.apply(to: far)
 
@@ -178,6 +185,98 @@ enum MeetingAecScenarioFactory {
         return MeetingAecScenario(
             name: name, sampleRate: sampleRate,
             nearEnd: near, farEnd: far, echo: echo, mic: mic)
+    }
+
+    /// Double-talk fixture with a controlled signal-to-interference ratio (SIR):
+    /// local-user speech power vs reference bleed power in the steady-state
+    /// scoring window. The whole steady-state window is overlap by construction,
+    /// so metrics computed there are specifically double-talk metrics.
+    static func makeDoubleTalk(
+        name: String,
+        echoPath: MeetingAecEchoPath,
+        signalToInterferenceDB: Double,
+        sampleCount: Int = 24_000,
+        noiseLevel: Float = 0.001
+    ) -> MeetingAecScenario {
+        makeOverlapScenario(
+            name: name,
+            nearEndActive: true,
+            echoPath: echoPath,
+            signalToInterferenceDB: signalToInterferenceDB,
+            sampleCount: sampleCount,
+            noiseLevel: noiseLevel
+        )
+    }
+
+    /// Echo-only companion for `makeDoubleTalk`: same reference-bleed level as
+    /// the requested SIR, but with no local-user speech. This exposes the other
+    /// failure direction: residual echo should approach silence/empty transcript.
+    static func makeEchoOnlyAtDoubleTalkLevel(
+        name: String,
+        echoPath: MeetingAecEchoPath,
+        signalToInterferenceDB: Double,
+        sampleCount: Int = 24_000,
+        noiseLevel: Float = 0.001
+    ) -> MeetingAecScenario {
+        makeOverlapScenario(
+            name: name,
+            nearEndActive: false,
+            echoPath: echoPath,
+            signalToInterferenceDB: signalToInterferenceDB,
+            sampleCount: sampleCount,
+            noiseLevel: noiseLevel
+        )
+    }
+
+    private static func makeOverlapScenario(
+        name: String,
+        nearEndActive: Bool,
+        echoPath: MeetingAecEchoPath,
+        signalToInterferenceDB: Double,
+        sampleCount: Int,
+        noiseLevel: Float
+    ) -> MeetingAecScenario {
+        let canonicalNear = MeetingAecSignal.voiceLike(
+            sampleCount: sampleCount,
+            sampleRate: sampleRate,
+            formants: nearFormants,
+            seed: nearSeed
+        )
+        let near = nearEndActive ? canonicalNear : MeetingAecSignal.silence(sampleCount: sampleCount)
+        let baseFar = MeetingAecSignal.voiceLike(
+            sampleCount: sampleCount,
+            sampleRate: sampleRate,
+            formants: farFormants,
+            seed: farSeed
+        )
+        let baseEcho = echoPath.apply(to: baseFar)
+        let window = steadyStateWindow(sampleCount: sampleCount)
+        let nearPower = MeetingAecMetrics.power(canonicalNear, over: window)
+        let echoPower = MeetingAecMetrics.power(baseEcho, over: window)
+        let targetEchoPower = nearPower / pow(10, signalToInterferenceDB / 10)
+        let scale = Float(sqrt(targetEchoPower / max(echoPower, 1e-12)))
+        let far = MeetingAecSignal.scaled(baseFar, by: scale)
+        let echo = MeetingAecSignal.scaled(baseEcho, by: scale)
+
+        var noise = MeetingAecRandom(seed: noiseSeed)
+        var mic = [Float](repeating: 0, count: sampleCount)
+        for i in 0..<sampleCount {
+            mic[i] = near[i] + echo[i] + noiseLevel * noise.nextSymmetric()
+        }
+        return MeetingAecScenario(
+            name: name,
+            sampleRate: sampleRate,
+            nearEnd: near,
+            farEnd: far,
+            echo: echo,
+            mic: mic
+        )
+    }
+
+    private static func steadyStateWindow(sampleCount: Int) -> Range<Int> {
+        let lower = sampleCount / 2
+        let upper = max(lower, sampleCount - MeetingAecScenario.maxFrameSize)
+        return lower..<upper
     }
 }
 
@@ -218,6 +317,24 @@ enum MeetingAecMetrics {
         let errPower = errAcc / Double(window.count)
         let nearPower = power(nearEnd, over: window)
         return 10 * log10(errPower / max(nearPower, 1e-12))
+    }
+
+    /// Signal power relative to a reference signal, in dB. Used for echo-only
+    /// rows where the ideal transcript is empty: lower residual power relative
+    /// to a nominal local voice means less speech-like echo left to transcribe.
+    static func relativePowerDB(signal: [Float], reference: [Float], over window: Range<Int>) -> Double {
+        let signalPower = power(signal, over: window)
+        let referencePower = power(reference, over: window)
+        return 10 * log10(signalPower / max(referencePower, 1e-12))
+    }
+
+    /// RMS ratio of a candidate output to an expected reference. ~1 means energy
+    /// was preserved, <1 means suppression, >1 usually means residual echo/noise.
+    static func rmsRatio(_ output: [Float], reference: [Float], over window: Range<Int>) -> Float {
+        let outputPower = power(output, over: window)
+        let referencePower = power(reference, over: window)
+        guard referencePower > 0 else { return 0 }
+        return Float((outputPower / referencePower).squareRoot())
     }
 
     /// Largest absolute sample deviation from a reference signal. Used to assert

--- a/Tests/MacParakeetTests/Services/Capture/MeetingAecMeasurementHarness.swift
+++ b/Tests/MacParakeetTests/Services/Capture/MeetingAecMeasurementHarness.swift
@@ -395,7 +395,7 @@ enum MeetingAecMetrics {
         guard let window = boundedWindow(window, counts: output.count, reference.count) else { return 0 }
         let outputPower = power(output, over: window)
         let referencePower = power(reference, over: window)
-        guard referencePower > 0 else { return 0 }
+        precondition(referencePower > 0, "AEC RMS ratio reference power is zero")
         return Float((outputPower / referencePower).squareRoot())
     }
 
@@ -422,6 +422,25 @@ enum MeetingAecRunner {
         chunkSizes: [Int] = [320, 256, 160, 512, 128]
     ) -> [Float] {
         conditioner.reset()
+        return stream(conditioner, scenario: scenario, chunkSizes: chunkSizes)
+    }
+
+    static func runWithDiagnostics(
+        _ conditioner: any MicConditioning,
+        scenario: MeetingAecScenario,
+        chunkSizes: [Int] = [320, 256, 160, 512, 128]
+    ) -> (output: [Float], diagnostics: MeetingEchoSuppressionDiagnostics) {
+        conditioner.reset()
+        let baseline = conditioner.diagnostics
+        let output = stream(conditioner, scenario: scenario, chunkSizes: chunkSizes)
+        return (output, conditioner.diagnostics.subtracting(baseline))
+    }
+
+    private static func stream(
+        _ conditioner: any MicConditioning,
+        scenario: MeetingAecScenario,
+        chunkSizes: [Int]
+    ) -> [Float] {
         var output: [Float] = []
         output.reserveCapacity(scenario.sampleCount)
         var cursor = 0
@@ -438,6 +457,26 @@ enum MeetingAecRunner {
         }
         output += conditioner.flush()
         return output
+    }
+}
+
+private extension MeetingEchoSuppressionDiagnostics {
+    func subtracting(_ baseline: MeetingEchoSuppressionDiagnostics) -> MeetingEchoSuppressionDiagnostics {
+        MeetingEchoSuppressionDiagnostics(
+            processorName: processorName,
+            loaded: loaded,
+            micFrames: max(0, micFrames - baseline.micFrames),
+            processedFrames: max(0, processedFrames - baseline.processedFrames),
+            rawFallbackFrames: max(0, rawFallbackFrames - baseline.rawFallbackFrames),
+            fullReferenceFrames: max(0, fullReferenceFrames - baseline.fullReferenceFrames),
+            partialReferenceFrames: max(0, partialReferenceFrames - baseline.partialReferenceFrames),
+            missingReferenceFrames: max(0, missingReferenceFrames - baseline.missingReferenceFrames),
+            processingFailures: max(0, processingFailures - baseline.processingFailures),
+            currentDelaySamples: currentDelaySamples,
+            delayConfidence: delayConfidence,
+            delayEstimateCount: max(0, delayEstimateCount - baseline.delayEstimateCount),
+            rejectedDelayEstimates: max(0, rejectedDelayEstimates - baseline.rejectedDelayEstimates)
+        )
     }
 }
 

--- a/Tests/MacParakeetTests/Services/Capture/MeetingAecMeasurementHarness.swift
+++ b/Tests/MacParakeetTests/Services/Capture/MeetingAecMeasurementHarness.swift
@@ -355,7 +355,7 @@ enum MeetingAecMetrics {
         guard let window = boundedWindow(window, counts: mic.count, output.count) else { return 0 }
         let micPower = power(mic, over: window)
         let outPower = power(output, over: window)
-        return 10 * log10(max(micPower, powerFloor) / max(outPower, powerFloor))
+        return 10 * log10(max(micPower, Double.leastNonzeroMagnitude) / max(outPower, powerFloor))
     }
 
     /// Near-end error (dB relative to near-end power): how far the output drifts

--- a/Tests/MacParakeetTests/Services/Capture/MeetingAecMeasurementHarness.swift
+++ b/Tests/MacParakeetTests/Services/Capture/MeetingAecMeasurementHarness.swift
@@ -333,7 +333,7 @@ enum MeetingAecMetrics {
     private static func boundedWindow(_ window: Range<Int>, counts: Int...) -> Range<Int>? {
         guard !counts.isEmpty else { return nil }
         let lower = max(0, window.lowerBound)
-        let upper = min(window.upperBound, counts.min() ?? 0)
+        let upper = min(window.upperBound, counts.min()!)
         guard lower < upper else { return nil }
         return lower..<upper
     }
@@ -355,6 +355,10 @@ enum MeetingAecMetrics {
         guard let window = boundedWindow(window, counts: mic.count, output.count) else { return 0 }
         let micPower = power(mic, over: window)
         let outPower = power(output, over: window)
+        if micPower < powerFloor, outPower < powerFloor {
+            guard outPower > micPower else { return 0 }
+            return 10 * log10(max(micPower, Double.leastNonzeroMagnitude) / outPower)
+        }
         return 10 * log10(max(micPower, Double.leastNonzeroMagnitude) / max(outPower, powerFloor))
     }
 

--- a/Tests/MacParakeetTests/Services/Capture/MeetingAecMeasurementHarness.swift
+++ b/Tests/MacParakeetTests/Services/Capture/MeetingAecMeasurementHarness.swift
@@ -84,7 +84,6 @@ enum MeetingAecSignal {
     }
 
     static func scaled(_ signal: [Float], by scale: Float) -> [Float] {
-        guard scale != 1 else { return signal }
         return signal.map { $0 * scale }
     }
 
@@ -143,7 +142,13 @@ struct MeetingAecScenario {
     /// samples keeps that uncancelled tail out of the measurement. (256 is the
     /// LocalVQE hop and every processor's frame size here.)
     static let maxFrameSize = 256
-    var steadyStateWindow: Range<Int> { (sampleCount / 2)..<(sampleCount - Self.maxFrameSize) }
+    var steadyStateWindow: Range<Int> { Self.steadyStateWindow(sampleCount: sampleCount) }
+
+    static func steadyStateWindow(sampleCount: Int) -> Range<Int> {
+        let lower = sampleCount / 2
+        let upper = max(lower, sampleCount - maxFrameSize)
+        return lower..<upper
+    }
 }
 
 enum MeetingAecScenarioFactory {
@@ -249,14 +254,17 @@ enum MeetingAecScenarioFactory {
             formants: farFormants,
             seed: farSeed
         )
-        let baseEcho = echoPath.apply(to: baseFar)
-        let window = steadyStateWindow(sampleCount: sampleCount)
+        let window = MeetingAecScenario.steadyStateWindow(sampleCount: sampleCount)
         let nearPower = MeetingAecMetrics.power(canonicalNear, over: window)
-        let echoPower = MeetingAecMetrics.power(baseEcho, over: window)
         let targetEchoPower = nearPower / pow(10, signalToInterferenceDB / 10)
-        let scale = Float(sqrt(targetEchoPower / max(echoPower, 1e-12)))
-        let far = MeetingAecSignal.scaled(baseFar, by: scale)
-        let echo = MeetingAecSignal.scaled(baseEcho, by: scale)
+        let calibrated = calibrateFarEnd(
+            baseFar,
+            echoPath: echoPath,
+            targetEchoPower: targetEchoPower,
+            over: window
+        )
+        let far = calibrated.far
+        let echo = calibrated.echo
 
         var noise = MeetingAecRandom(seed: noiseSeed)
         var mic = [Float](repeating: 0, count: sampleCount)
@@ -273,18 +281,51 @@ enum MeetingAecScenarioFactory {
         )
     }
 
-    private static func steadyStateWindow(sampleCount: Int) -> Range<Int> {
-        let lower = sampleCount / 2
-        let upper = max(lower, sampleCount - MeetingAecScenario.maxFrameSize)
-        return lower..<upper
+    private static func calibrateFarEnd(
+        _ baseFar: [Float],
+        echoPath: MeetingAecEchoPath,
+        targetEchoPower: Double,
+        over window: Range<Int>
+    ) -> (far: [Float], echo: [Float]) {
+        let baseEcho = echoPath.apply(to: baseFar)
+        let baseEchoPower = MeetingAecMetrics.power(baseEcho, over: window)
+        guard targetEchoPower > 0, baseEchoPower > 0 else {
+            let silence = MeetingAecSignal.silence(sampleCount: baseFar.count)
+            return (silence, silence)
+        }
+
+        var scale = Float(sqrt(targetEchoPower / baseEchoPower))
+        var far = MeetingAecSignal.scaled(baseFar, by: scale)
+        var echo = echoPath.apply(to: far)
+        for _ in 0..<6 {
+            let echoPower = MeetingAecMetrics.power(echo, over: window)
+            guard echoPower > 0 else { break }
+            let correction = sqrt(targetEchoPower / echoPower)
+            guard correction.isFinite else { break }
+            if abs(correction - 1) < 0.0005 { break }
+            scale *= Float(correction)
+            far = MeetingAecSignal.scaled(baseFar, by: scale)
+            echo = echoPath.apply(to: far)
+        }
+        return (far, echo)
     }
 }
 
 // MARK: Metrics
 
 enum MeetingAecMetrics {
+    private static let powerFloor = 1e-12
+
+    private static func boundedWindow(_ window: Range<Int>, counts: Int...) -> Range<Int>? {
+        guard !counts.isEmpty else { return nil }
+        let lower = max(0, window.lowerBound)
+        let upper = min(window.upperBound, counts.min() ?? 0)
+        guard lower < upper else { return nil }
+        return lower..<upper
+    }
+
     static func power(_ signal: [Float], over window: Range<Int>) -> Double {
-        guard !window.isEmpty else { return 0 }
+        guard let window = boundedWindow(window, counts: signal.count) else { return 0 }
         var acc = 0.0
         for i in window {
             let v = Double(signal[i])
@@ -297,9 +338,10 @@ enum MeetingAecMetrics {
     /// unprocessed mic. Higher = more echo removed. Meaningful for far-end-only
     /// fixtures, where any mic energy is echo by construction.
     static func erleDB(mic: [Float], output: [Float], over window: Range<Int>) -> Double {
+        guard let window = boundedWindow(window, counts: mic.count, output.count) else { return 0 }
         let micPower = power(mic, over: window)
         let outPower = power(output, over: window)
-        return 10 * log10(micPower / max(outPower, 1e-12))
+        return 10 * log10(max(micPower, powerFloor) / max(outPower, powerFloor))
     }
 
     /// Near-end error (dB relative to near-end power): how far the output drifts
@@ -308,7 +350,7 @@ enum MeetingAecMetrics {
     /// Lower (more negative) is better; 0 dB means the error is as loud as the
     /// voice we wanted to keep.
     static func nearEndErrorDB(output: [Float], nearEnd: [Float], over window: Range<Int>) -> Double {
-        guard !window.isEmpty else { return 0 }
+        guard let window = boundedWindow(window, counts: output.count, nearEnd.count) else { return 0 }
         var errAcc = 0.0
         for i in window {
             let d = Double(output[i]) - Double(nearEnd[i])
@@ -316,21 +358,23 @@ enum MeetingAecMetrics {
         }
         let errPower = errAcc / Double(window.count)
         let nearPower = power(nearEnd, over: window)
-        return 10 * log10(errPower / max(nearPower, 1e-12))
+        return 10 * log10(max(errPower, powerFloor) / max(nearPower, powerFloor))
     }
 
     /// Signal power relative to a reference signal, in dB. Used for echo-only
     /// rows where the ideal transcript is empty: lower residual power relative
     /// to a nominal local voice means less speech-like echo left to transcribe.
     static func relativePowerDB(signal: [Float], reference: [Float], over window: Range<Int>) -> Double {
+        guard let window = boundedWindow(window, counts: signal.count, reference.count) else { return 0 }
         let signalPower = power(signal, over: window)
         let referencePower = power(reference, over: window)
-        return 10 * log10(signalPower / max(referencePower, 1e-12))
+        return 10 * log10(max(signalPower, powerFloor) / max(referencePower, powerFloor))
     }
 
     /// RMS ratio of a candidate output to an expected reference. ~1 means energy
     /// was preserved, <1 means suppression, >1 usually means residual echo/noise.
     static func rmsRatio(_ output: [Float], reference: [Float], over window: Range<Int>) -> Float {
+        guard let window = boundedWindow(window, counts: output.count, reference.count) else { return 0 }
         let outputPower = power(output, over: window)
         let referencePower = power(reference, over: window)
         guard referencePower > 0 else { return 0 }

--- a/Tests/MacParakeetTests/Services/Capture/MeetingAecMeasurementTests.swift
+++ b/Tests/MacParakeetTests/Services/Capture/MeetingAecMeasurementTests.swift
@@ -261,16 +261,18 @@ final class MeetingAecMeasurementTests: XCTestCase {
 
         XCTAssertTrue(scenario.steadyStateWindow.isEmpty)
         XCTAssertEqual(MeetingAecMetrics.power(scenario.mic, over: scenario.steadyStateWindow), 0)
+        let output = MeetingAecRunner.run(PassthroughMicConditioner(), scenario: scenario)
+        XCTAssertEqual(output.count, scenario.sampleCount)
         XCTAssertEqual(
             MeetingAecMetrics.relativePowerDB(
-                signal: [],
+                signal: output,
                 reference: scenario.nearEnd,
                 over: scenario.steadyStateWindow
             ),
             0
         )
         XCTAssertEqual(
-            MeetingAecMetrics.rmsRatio([], reference: scenario.nearEnd, over: scenario.steadyStateWindow),
+            MeetingAecMetrics.rmsRatio(output, reference: scenario.nearEnd, over: scenario.steadyStateWindow),
             0
         )
     }

--- a/Tests/MacParakeetTests/Services/Capture/MeetingAecMeasurementTests.swift
+++ b/Tests/MacParakeetTests/Services/Capture/MeetingAecMeasurementTests.swift
@@ -229,6 +229,52 @@ final class MeetingAecMeasurementTests: XCTestCase {
         }
     }
 
+    func testDoubleTalkScenarioKeepsEchoPathConsistentWhenPathIsNonlinear() {
+        let targetSIR = 6.0
+        let nonlinearEcho = MeetingAecEchoPath(
+            taps: [(delay: 120, gain: 0.6), (delay: 180, gain: 0.25)],
+            nonlinearity: 0.4
+        )
+        let scenario = MeetingAecScenarioFactory.makeDoubleTalk(
+            name: "nonlinear-double-talk",
+            echoPath: nonlinearEcho,
+            signalToInterferenceDB: targetSIR
+        )
+
+        let recomputedEcho = nonlinearEcho.apply(to: scenario.farEnd)
+        let worstDrift = MeetingAecMetrics.maxAbsDifference(recomputedEcho, scenario.echo)
+        XCTAssertLessThan(worstDrift, 1e-6, "scenario echo must remain the echo path applied to farEnd")
+
+        let nearPower = MeetingAecMetrics.power(scenario.nearEnd, over: scenario.steadyStateWindow)
+        let echoPower = MeetingAecMetrics.power(scenario.echo, over: scenario.steadyStateWindow)
+        let measuredSIR = 10 * log10(nearPower / max(echoPower, 1e-12))
+        XCTAssertEqual(measuredSIR, targetSIR, accuracy: 0.05)
+    }
+
+    func testShortScenarioSteadyStateWindowAndMetricsStayFinite() {
+        let scenario = MeetingAecScenarioFactory.makeDoubleTalk(
+            name: "short-double-talk",
+            echoPath: singleTapEcho,
+            signalToInterferenceDB: 0,
+            sampleCount: 300
+        )
+
+        XCTAssertTrue(scenario.steadyStateWindow.isEmpty)
+        XCTAssertEqual(MeetingAecMetrics.power(scenario.mic, over: scenario.steadyStateWindow), 0)
+        XCTAssertEqual(
+            MeetingAecMetrics.relativePowerDB(
+                signal: [],
+                reference: scenario.nearEnd,
+                over: scenario.steadyStateWindow
+            ),
+            0
+        )
+        XCTAssertEqual(
+            MeetingAecMetrics.rmsRatio([], reference: scenario.nearEnd, over: scenario.steadyStateWindow),
+            0
+        )
+    }
+
     // MARK: Formatting helpers
 
     private func fmt(_ value: Double) -> String {

--- a/Tests/MacParakeetTests/Services/Capture/MeetingAecMeasurementTests.swift
+++ b/Tests/MacParakeetTests/Services/Capture/MeetingAecMeasurementTests.swift
@@ -15,6 +15,7 @@ final class MeetingAecMeasurementTests: XCTestCase {
         taps: [(delay: 120, gain: 0.6), (delay: 180, gain: 0.25), (delay: 240, gain: 0.12)]
     )
     private let trueDelay = 120
+    private let doubleTalkSIRs = [0.0, 6.0, 12.0]
 
     // MARK: Harness sanity — pass-through changes nothing, so ERLE is ~0 dB.
 
@@ -150,6 +151,82 @@ final class MeetingAecMeasurementTests: XCTestCase {
             "naive NLMS (no double-talk detector) does not meaningfully reduce error under continuous double-talk")
         XCTAssertGreaterThan(singleTalkERLE - improvement, 10.0,
             "double-talk extracts a large penalty vs the no-near-end case (the local voice perturbs adaptation)")
+    }
+
+    func testNLMSDoubleTalkSIRSweepReportsOverlapAccuracyAndEchoOnlyResidual() {
+        print("[AEC] NLMS double-talk SIR sweep (nearErr lower is better; echoResid should approach silence):")
+        print("        SIR    dtRaw   dtNLMS  dtImpr  echoRaw echoNLMS    ERLE")
+        for sir in doubleTalkSIRs {
+            let doubleTalk = MeetingAecScenarioFactory.makeDoubleTalk(
+                name: "double-talk-\(Int(sir))db",
+                echoPath: multiTapEcho,
+                signalToInterferenceDB: sir
+            )
+            let window = doubleTalk.steadyStateWindow
+            let suppressor = StreamingMeetingEchoSuppressor(
+                processor: MeetingAecNLMSProcessor(),
+                referenceDelaySamples: trueDelay
+            )
+            let processed = MeetingAecRunner.run(suppressor, scenario: doubleTalk)
+            let passthrough = MeetingAecRunner.run(PassthroughMicConditioner(), scenario: doubleTalk)
+            let processedError = MeetingAecMetrics.nearEndErrorDB(
+                output: processed,
+                nearEnd: doubleTalk.nearEnd,
+                over: window
+            )
+            let rawError = MeetingAecMetrics.nearEndErrorDB(
+                output: passthrough,
+                nearEnd: doubleTalk.nearEnd,
+                over: window
+            )
+
+            let echoOnly = MeetingAecScenarioFactory.makeEchoOnlyAtDoubleTalkLevel(
+                name: "echo-only-\(Int(sir))db",
+                echoPath: multiTapEcho,
+                signalToInterferenceDB: sir
+            )
+            let echoWindow = echoOnly.steadyStateWindow
+            let echoSuppressor = StreamingMeetingEchoSuppressor(
+                processor: MeetingAecNLMSProcessor(),
+                referenceDelaySamples: trueDelay
+            )
+            let echoProcessed = MeetingAecRunner.run(echoSuppressor, scenario: echoOnly)
+            let echoRaw = MeetingAecRunner.run(PassthroughMicConditioner(), scenario: echoOnly)
+            let echoProcessedResidual = MeetingAecMetrics.relativePowerDB(
+                signal: echoProcessed,
+                reference: doubleTalk.nearEnd,
+                over: echoWindow
+            )
+            let echoRawResidual = MeetingAecMetrics.relativePowerDB(
+                signal: echoRaw,
+                reference: doubleTalk.nearEnd,
+                over: echoWindow
+            )
+            let echoERLE = MeetingAecMetrics.erleDB(
+                mic: echoOnly.mic,
+                output: echoProcessed,
+                over: echoWindow
+            )
+            let improvement = rawError - processedError
+
+            print(String(
+                format: "      %+4.0f %8.1f %8.1f %7.1f %8.1f %8.1f %7.1f",
+                sir,
+                rawError,
+                processedError,
+                improvement,
+                echoRawResidual,
+                echoProcessedResidual,
+                echoERLE
+            ))
+
+            XCTAssertTrue(processedError.isFinite)
+            XCTAssertTrue(rawError.isFinite)
+            XCTAssertLessThan(
+                echoProcessedResidual,
+                echoRawResidual,
+                "echo-only residual should drop at SIR \(sir) dB")
+        }
     }
 
     // MARK: Formatting helpers

--- a/Tests/MacParakeetTests/Services/Capture/MeetingAecMeasurementTests.swift
+++ b/Tests/MacParakeetTests/Services/Capture/MeetingAecMeasurementTests.swift
@@ -277,9 +277,15 @@ final class MeetingAecMeasurementTests: XCTestCase {
         )
 
         let quietMic = [Float](repeating: Float(sqrt(0.5e-12)), count: 4)
-        let louderOutput = [Float](repeating: Float(sqrt(0.8e-12)), count: 4)
+        let subFloorOutput = [Float](repeating: Float(sqrt(0.8e-12)), count: 4)
+        XCTAssertEqual(
+            MeetingAecMetrics.erleDB(mic: quietMic, output: subFloorOutput, over: 0..<4),
+            0,
+            accuracy: 0.0001
+        )
+        let aboveFloorOutput = [Float](repeating: Float(sqrt(2.0e-12)), count: 4)
         XCTAssertLessThan(
-            MeetingAecMetrics.erleDB(mic: quietMic, output: louderOutput, over: 0..<4),
+            MeetingAecMetrics.erleDB(mic: quietMic, output: aboveFloorOutput, over: 0..<4),
             0
         )
         XCTAssertEqual(

--- a/Tests/MacParakeetTests/Services/Capture/MeetingAecMeasurementTests.swift
+++ b/Tests/MacParakeetTests/Services/Capture/MeetingAecMeasurementTests.swift
@@ -275,6 +275,17 @@ final class MeetingAecMeasurementTests: XCTestCase {
             MeetingAecMetrics.rmsRatio(output, reference: scenario.nearEnd, over: scenario.steadyStateWindow),
             0
         )
+
+        let quietMic = [Float](repeating: Float(sqrt(0.5e-12)), count: 4)
+        let louderOutput = [Float](repeating: Float(sqrt(0.8e-12)), count: 4)
+        XCTAssertLessThan(
+            MeetingAecMetrics.erleDB(mic: quietMic, output: louderOutput, over: 0..<4),
+            0
+        )
+        XCTAssertEqual(
+            MeetingAecMetrics.erleDB(mic: [0], output: [0], over: 0..<1),
+            0
+        )
     }
 
     // MARK: Formatting helpers

--- a/Tests/MacParakeetTests/Services/Capture/MeetingAecModelScoringTests.swift
+++ b/Tests/MacParakeetTests/Services/Capture/MeetingAecModelScoringTests.swift
@@ -429,7 +429,7 @@ final class MeetingAecModelScoringTests: XCTestCase {
         print("[AEC-SCORE] SIR is local-user speech vs reference bleed. echoResid is echo-only output"
             + " power relative to nominal local speech; lower should approach silence.")
         print(String(
-            format: "  %-34@ %-11@ %5@ %9@ %9@ %8@ %8@ %8@ %10@ %10@ %8@",
+            format: "  %-34@ %-11@ %4@ %8@ %9@ %8@ %8@ %8@ %9@ %10@ %8@",
             "model" as CVarArg, "echo" as CVarArg, "SIR" as CVarArg,
             "dtRaw" as CVarArg, "dtClean" as CVarArg, "dtImpr" as CVarArg,
             "rawRet" as CVarArg, "clnRet" as CVarArg,

--- a/Tests/MacParakeetTests/Services/Capture/MeetingAecModelScoringTests.swift
+++ b/Tests/MacParakeetTests/Services/Capture/MeetingAecModelScoringTests.swift
@@ -166,11 +166,12 @@ final class MeetingAecModelScoringTests: XCTestCase {
                 continue
             }
             for (echoLabel, echoPath) in echoPaths {
+                let conditioner = makeConditioner(libraryURL: libraryURL, modelURL: modelURL)
                 scores.append(scoreModel(
                     label: modelURL.lastPathComponent,
                     modelKey: modelURL.path,
                     echoLabel: echoLabel,
-                    conditioner: preflight,
+                    conditioner: conditioner,
                     echoPath: echoPath))
             }
         }
@@ -372,12 +373,12 @@ final class MeetingAecModelScoringTests: XCTestCase {
             let retentions = group.map { $0.nearEndRetentionRatio }
             return ModelAggregate(
                 label: group.first?.label ?? "?",
-                meanFarERLE: group.reduce(0) { $0 + $1.farEndERLE } / n,
-                meanDoubleTalkError: group.reduce(0) { $0 + $1.doubleTalkErrorDB } / n,
-                meanDoubleTalkImprovement: group.reduce(0) { $0 + $1.doubleTalkImprovement } / n,
+                meanFarERLE: group.reduce(0.0) { $0 + $1.farEndERLE } / n,
+                meanDoubleTalkError: group.reduce(0.0) { $0 + $1.doubleTalkErrorDB } / n,
+                meanDoubleTalkImprovement: group.reduce(0.0) { $0 + $1.doubleTalkImprovement } / n,
                 minRetention: retentions.min() ?? 0,
                 maxRetention: retentions.max() ?? 0,
-                meanNearError: group.reduce(0) { $0 + $1.nearEndErrorDB } / n,
+                meanNearError: group.reduce(0.0) { $0 + $1.nearEndErrorDB } / n,
                 totalProcessingFailures: group.reduce(0) { $0 + $1.processingFailures })
         }
     }
@@ -465,17 +466,20 @@ final class MeetingAecModelScoringTests: XCTestCase {
             if l?.score.label != r?.score.label {
                 return (l?.score.label ?? "") < (r?.score.label ?? "")
             }
+            if l?.score.modelKey != r?.score.modelKey {
+                return (l?.score.modelKey ?? "") < (r?.score.modelKey ?? "")
+            }
             return (l?.row.signalToInterferenceDB ?? 0) < (r?.row.signalToInterferenceDB ?? 0)
         }) {
             guard let first = group.first else { continue }
             let n = Double(group.count)
-            let cleanError = group.reduce(0) { $0 + $1.row.cleanErrorDB } / n
-            let rawError = group.reduce(0) { $0 + $1.row.rawErrorDB } / n
-            let improvement = group.reduce(0) { $0 + $1.row.improvementDB } / n
-            let echoClean = group.reduce(0) { $0 + $1.row.echoOnlyCleanResidualDB } / n
-            let echoRaw = group.reduce(0) { $0 + $1.row.echoOnlyRawResidualDB } / n
-            let echoERLE = group.reduce(0) { $0 + $1.row.echoOnlyERLE } / n
-            let cleanRetention = group.reduce(0) { $0 + Double($1.row.cleanRetentionRatio) } / n
+            let cleanError = group.reduce(0.0) { $0 + $1.row.cleanErrorDB } / n
+            let rawError = group.reduce(0.0) { $0 + $1.row.rawErrorDB } / n
+            let improvement = group.reduce(0.0) { $0 + $1.row.improvementDB } / n
+            let echoClean = group.reduce(0.0) { $0 + $1.row.echoOnlyCleanResidualDB } / n
+            let echoRaw = group.reduce(0.0) { $0 + $1.row.echoOnlyRawResidualDB } / n
+            let echoERLE = group.reduce(0.0) { $0 + $1.row.echoOnlyERLE } / n
+            let cleanRetention = group.reduce(0.0) { $0 + Double($1.row.cleanRetentionRatio) } / n
             print(String(
                 format: "  %-34@ SIR %+4.0f  dtRaw %6.1f  dtClean %6.1f  dtImpr %6.1f  clnRet %.2f  echoRaw %6.1f  echoClean %6.1f  echoERLE %6.1f",
                 first.score.label as CVarArg,

--- a/Tests/MacParakeetTests/Services/Capture/MeetingAecModelScoringTests.swift
+++ b/Tests/MacParakeetTests/Services/Capture/MeetingAecModelScoringTests.swift
@@ -486,14 +486,16 @@ final class MeetingAecModelScoringTests: XCTestCase {
             let echoClean = group.reduce(0.0) { $0 + $1.row.echoOnlyCleanResidualDB } / n
             let echoRaw = group.reduce(0.0) { $0 + $1.row.echoOnlyRawResidualDB } / n
             let echoERLE = group.reduce(0.0) { $0 + $1.row.echoOnlyERLE } / n
+            let rawRetention = group.reduce(0.0) { $0 + Double($1.row.rawRetentionRatio) } / n
             let cleanRetention = group.reduce(0.0) { $0 + Double($1.row.cleanRetentionRatio) } / n
             print(String(
-                format: "  %-34@ SIR %+4.0f  dtRaw %6.1f  dtClean %6.1f  dtImpr %6.1f  clnRet %.2f  echoRaw %6.1f  echoClean %6.1f  echoERLE %6.1f",
+                format: "  %-34@ SIR %+4.0f  dtRaw %6.1f  dtClean %6.1f  dtImpr %6.1f  rawRet %.2f  clnRet %.2f  echoRaw %6.1f  echoClean %6.1f  echoERLE %6.1f",
                 first.score.label as CVarArg,
                 first.row.signalToInterferenceDB,
                 rawError,
                 cleanError,
                 improvement,
+                rawRetention,
                 cleanRetention,
                 echoRaw,
                 echoClean,

--- a/Tests/MacParakeetTests/Services/Capture/MeetingAecModelScoringTests.swift
+++ b/Tests/MacParakeetTests/Services/Capture/MeetingAecModelScoringTests.swift
@@ -20,14 +20,18 @@ import XCTest
 /// **What the harness can and cannot prove.** The near-end is decorrelated,
 /// voiced-like *tones*, not speech. So the gate asserts only on the axes the
 /// fixture measures reliably — far-end echo removal (ERLE) and near-end *energy*
-/// retention — and merely *reports* the waveform-fidelity numbers (near-end
-/// error, double-talk improvement), because a neural model trained on real speech
-/// reshapes synthetic tones in ways that penalize exact-waveform error whether or
-/// not it would damage real speech. Real speaker-mode QA (plan unit U9) owns
-/// fidelity and remains the binding gate before any default-on.
+/// retention — and reports overlap-segment accuracy using the harness's existing
+/// near-end error metric at 0/+6/+12 dB SIR. This is the synthetic equivalent of
+/// double-talk WER: it is computed only where local speech overlaps reference
+/// playback. It is still not a substitute for real-speech WER, because a neural
+/// model trained on real speech reshapes synthetic tones in ways that penalize
+/// exact-waveform error whether or not it would damage real speech. Real
+/// speaker-mode QA (plan unit U9) owns fidelity and remains the binding gate
+/// before any default-on.
 final class MeetingAecModelScoringTests: XCTestCase {
     private static let libraryKey = "MACPARAKEET_TEST_LOCALVQE_LIBRARY"
     private static let modelsKey = "MACPARAKEET_TEST_LOCALVQE_MODELS"
+    private static let doubleTalkSignalToInterferenceDBs = [0.0, 6.0, 12.0]
 
     // Robust-axis gates (calibrated with margin to the chosen v1.4 candidate:
     // ERLE 35.6 dB, retain 1.02). A shippable model must remove strong echo and
@@ -42,6 +46,31 @@ final class MeetingAecModelScoringTests: XCTestCase {
     private let multiTapEcho = MeetingAecEchoPath(
         taps: [(delay: 120, gain: 0.6), (delay: 180, gain: 0.25), (delay: 240, gain: 0.12)]
     )
+
+    private struct DoubleTalkSegmentScore {
+        let signalToInterferenceDB: Double
+        /// Overlap-segment near-end error. Lower is better; this is the harness's
+        /// synthetic accuracy proxy for WER on local speech during double-talk.
+        let cleanErrorDB: Double
+        let rawErrorDB: Double
+        /// Double-talk RMS ratio vs the expected local voice. Low values can
+        /// expose over-suppression of the user; high values usually mean residual
+        /// echo remains in the cleaned mic.
+        let cleanRetentionRatio: Float
+        let rawRetentionRatio: Float
+        /// Echo-only output power relative to the nominal local voice. Lower is
+        /// better, and should move toward silence / empty transcript.
+        let echoOnlyCleanResidualDB: Double
+        let echoOnlyRawResidualDB: Double
+        let echoOnlyERLE: Double
+
+        var improvementDB: Double { rawErrorDB - cleanErrorDB }
+    }
+
+    private struct OverlapSweepResult {
+        let scores: [DoubleTalkSegmentScore]
+        let diagnostics: [MeetingEchoSuppressionDiagnostics]
+    }
 
     private struct ModelScore {
         let label: String      // display name (filename)
@@ -59,6 +88,9 @@ final class MeetingAecModelScoringTests: XCTestCase {
         /// same fixture. Reported, not gated (see fidelity caveat).
         let doubleTalkErrorDB: Double
         let doubleTalkPassthroughErrorDB: Double
+        /// SIR-controlled overlap rows: the new double-talk segment metric and
+        /// the matching echo-only residual metric.
+        let doubleTalkSegmentScores: [DoubleTalkSegmentScore]
         /// Total frames successfully processed across far-end, near-end, and
         /// double-talk runs.
         let processedFrames: Int
@@ -147,6 +179,8 @@ final class MeetingAecModelScoringTests: XCTestCase {
         printScoreTable(scores)
         let aggregates = aggregate(scores)
         printAggregates(aggregates)
+        printDoubleTalkSegmentTable(scores)
+        printDoubleTalkSegmentAggregates(scores)
 
         // No silent contamination: a loaded processor that throws on frames falls
         // back to raw mic, which inflates retention and pollutes ERLE/near-end. And
@@ -205,7 +239,11 @@ final class MeetingAecModelScoringTests: XCTestCase {
         let nearWindow = nearScenario.steadyStateWindow
         let nearErr = MeetingAecMetrics.nearEndErrorDB(
             output: nearOut, nearEnd: nearScenario.nearEnd, over: nearWindow)
-        let retention = rmsRatio(nearOut, scenario: nearScenario, over: nearWindow)
+        let retention = MeetingAecMetrics.rmsRatio(
+            nearOut,
+            reference: nearScenario.mic,
+            over: nearWindow
+        )
 
         // Double-talk → near-end error vs passthrough (reported, not gated).
         let dtScenario = MeetingAecScenarioFactory.make(
@@ -218,7 +256,8 @@ final class MeetingAecModelScoringTests: XCTestCase {
         let dtPass = MeetingAecRunner.run(PassthroughMicConditioner(), scenario: dtScenario)
         let dtPassErr = MeetingAecMetrics.nearEndErrorDB(
             output: dtPass, nearEnd: dtScenario.nearEnd, over: dtWindow)
-        let diagnostics = [farDiagnostics, nearDiagnostics, dtDiagnostics]
+        let overlapSweep = scoreDoubleTalkSegments(conditioner: conditioner, echoPath: echoPath)
+        let diagnostics = [farDiagnostics, nearDiagnostics, dtDiagnostics] + overlapSweep.diagnostics
 
         return ModelScore(
             label: label, modelKey: modelKey, echoLabel: echoLabel,
@@ -226,9 +265,86 @@ final class MeetingAecModelScoringTests: XCTestCase {
             nearEndErrorDB: nearErr,
             nearEndRetentionRatio: retention,
             doubleTalkErrorDB: dtErr, doubleTalkPassthroughErrorDB: dtPassErr,
+            doubleTalkSegmentScores: overlapSweep.scores,
             processedFrames: diagnostics.reduce(0) { $0 + $1.processedFrames },
             processingFailures: diagnostics.reduce(0) { $0 + $1.processingFailures },
             delaySamples: dtDiagnostics.currentDelaySamples)
+    }
+
+    private func scoreDoubleTalkSegments(
+        conditioner: any MicConditioning,
+        echoPath: MeetingAecEchoPath
+    ) -> OverlapSweepResult {
+        var rows: [DoubleTalkSegmentScore] = []
+        var diagnostics: [MeetingEchoSuppressionDiagnostics] = []
+        for sir in Self.doubleTalkSignalToInterferenceDBs {
+            let doubleTalk = MeetingAecScenarioFactory.makeDoubleTalk(
+                name: "double-talk-\(Int(sir))db",
+                echoPath: echoPath,
+                signalToInterferenceDB: sir
+            )
+            let window = doubleTalk.steadyStateWindow
+            let cleaned = MeetingAecRunner.run(conditioner, scenario: doubleTalk)
+            diagnostics.append(conditioner.diagnostics)
+            let raw = MeetingAecRunner.run(PassthroughMicConditioner(), scenario: doubleTalk)
+            let cleanError = MeetingAecMetrics.nearEndErrorDB(
+                output: cleaned,
+                nearEnd: doubleTalk.nearEnd,
+                over: window
+            )
+            let rawError = MeetingAecMetrics.nearEndErrorDB(
+                output: raw,
+                nearEnd: doubleTalk.nearEnd,
+                over: window
+            )
+            let cleanRetention = MeetingAecMetrics.rmsRatio(
+                cleaned,
+                reference: doubleTalk.nearEnd,
+                over: window
+            )
+            let rawRetention = MeetingAecMetrics.rmsRatio(
+                raw,
+                reference: doubleTalk.nearEnd,
+                over: window
+            )
+
+            let echoOnly = MeetingAecScenarioFactory.makeEchoOnlyAtDoubleTalkLevel(
+                name: "echo-only-\(Int(sir))db",
+                echoPath: echoPath,
+                signalToInterferenceDB: sir
+            )
+            let echoWindow = echoOnly.steadyStateWindow
+            let echoCleaned = MeetingAecRunner.run(conditioner, scenario: echoOnly)
+            diagnostics.append(conditioner.diagnostics)
+            let echoRaw = MeetingAecRunner.run(PassthroughMicConditioner(), scenario: echoOnly)
+            let echoCleanResidual = MeetingAecMetrics.relativePowerDB(
+                signal: echoCleaned,
+                reference: doubleTalk.nearEnd,
+                over: echoWindow
+            )
+            let echoRawResidual = MeetingAecMetrics.relativePowerDB(
+                signal: echoRaw,
+                reference: doubleTalk.nearEnd,
+                over: echoWindow
+            )
+            let echoERLE = MeetingAecMetrics.erleDB(
+                mic: echoOnly.mic,
+                output: echoCleaned,
+                over: echoWindow
+            )
+
+            rows.append(DoubleTalkSegmentScore(
+                signalToInterferenceDB: sir,
+                cleanErrorDB: cleanError,
+                rawErrorDB: rawError,
+                cleanRetentionRatio: cleanRetention,
+                rawRetentionRatio: rawRetention,
+                echoOnlyCleanResidualDB: echoCleanResidual,
+                echoOnlyRawResidualDB: echoRawResidual,
+                echoOnlyERLE: echoERLE
+            ))
+        }
+        return OverlapSweepResult(scores: rows, diagnostics: diagnostics)
     }
 
     private func makeConditioner(libraryURL: URL, modelURL: URL) -> any MicConditioning {
@@ -240,16 +356,12 @@ final class MeetingAecModelScoringTests: XCTestCase {
             bundle: Bundle(for: Self.self))
     }
 
-    private func rmsRatio(
-        _ output: [Float], scenario: MeetingAecScenario, over window: Range<Int>
-    ) -> Float {
-        let outPower = MeetingAecMetrics.power(output, over: window)
-        let micPower = MeetingAecMetrics.power(scenario.mic, over: window)
-        guard micPower > 0 else { return 0 }
-        return Float((outPower / micPower).squareRoot())
-    }
-
     // MARK: Aggregation + reporting
+
+    private struct SegmentAggregateKey: Hashable {
+        let modelKey: String
+        let signalToInterferenceDB: Double
+    }
 
     private func aggregate(_ scores: [ModelScore]) -> [ModelAggregate] {
         // Group by full path, not filename, so a rebuilt model with the same
@@ -302,6 +414,81 @@ final class MeetingAecModelScoringTests: XCTestCase {
         }
         print("[AEC-SCORE] (dtImpr = passthrough dtErr − model dtErr; positive = model helped"
             + " under double-talk. fail = frames that fell back to raw mic.)")
+    }
+
+    private func printDoubleTalkSegmentTable(_ scores: [ModelScore]) {
+        print("[AEC-SCORE] double-talk segment sweep (existing harness accuracy metric, not real-speech WER)")
+        print("[AEC-SCORE] SIR is local-user speech vs reference bleed. echoResid is echo-only output"
+            + " power relative to nominal local speech; lower should approach silence.")
+        print(String(
+            format: "  %-34@ %-11@ %5@ %9@ %9@ %8@ %8@ %8@ %10@ %10@ %8@",
+            "model" as CVarArg, "echo" as CVarArg, "SIR" as CVarArg,
+            "dtRaw" as CVarArg, "dtClean" as CVarArg, "dtImpr" as CVarArg,
+            "rawRet" as CVarArg, "clnRet" as CVarArg,
+            "echoRaw" as CVarArg, "echoClean" as CVarArg, "echoERLE" as CVarArg))
+        for s in scores {
+            for row in s.doubleTalkSegmentScores {
+                print(String(
+                    format: "  %-34@ %-11@ %+4.0f %8.1f %9.1f %8.1f %8.2f %8.2f %9.1f %10.1f %8.1f",
+                    s.label as CVarArg,
+                    s.echoLabel as CVarArg,
+                    row.signalToInterferenceDB,
+                    row.rawErrorDB,
+                    row.cleanErrorDB,
+                    row.improvementDB,
+                    Double(row.rawRetentionRatio),
+                    Double(row.cleanRetentionRatio),
+                    row.echoOnlyRawResidualDB,
+                    row.echoOnlyCleanResidualDB,
+                    row.echoOnlyERLE
+                ))
+            }
+        }
+    }
+
+    private func printDoubleTalkSegmentAggregates(_ scores: [ModelScore]) {
+        let flattened = scores.flatMap { score in
+            score.doubleTalkSegmentScores.map { row in
+                (score: score, row: row)
+            }
+        }
+        let grouped = Dictionary(grouping: flattened) { item in
+            SegmentAggregateKey(
+                modelKey: item.score.modelKey,
+                signalToInterferenceDB: item.row.signalToInterferenceDB
+            )
+        }
+        print("[AEC-SCORE] per-model double-talk aggregate by SIR (mean across echo paths):")
+        for group in grouped.values.sorted(by: { lhs, rhs in
+            let l = lhs.first
+            let r = rhs.first
+            if l?.score.label != r?.score.label {
+                return (l?.score.label ?? "") < (r?.score.label ?? "")
+            }
+            return (l?.row.signalToInterferenceDB ?? 0) < (r?.row.signalToInterferenceDB ?? 0)
+        }) {
+            guard let first = group.first else { continue }
+            let n = Double(group.count)
+            let cleanError = group.reduce(0) { $0 + $1.row.cleanErrorDB } / n
+            let rawError = group.reduce(0) { $0 + $1.row.rawErrorDB } / n
+            let improvement = group.reduce(0) { $0 + $1.row.improvementDB } / n
+            let echoClean = group.reduce(0) { $0 + $1.row.echoOnlyCleanResidualDB } / n
+            let echoRaw = group.reduce(0) { $0 + $1.row.echoOnlyRawResidualDB } / n
+            let echoERLE = group.reduce(0) { $0 + $1.row.echoOnlyERLE } / n
+            let cleanRetention = group.reduce(0) { $0 + Double($1.row.cleanRetentionRatio) } / n
+            print(String(
+                format: "  %-34@ SIR %+4.0f  dtRaw %6.1f  dtClean %6.1f  dtImpr %6.1f  clnRet %.2f  echoRaw %6.1f  echoClean %6.1f  echoERLE %6.1f",
+                first.score.label as CVarArg,
+                first.row.signalToInterferenceDB,
+                rawError,
+                cleanError,
+                improvement,
+                cleanRetention,
+                echoRaw,
+                echoClean,
+                echoERLE
+            ))
+        }
     }
 
     private func printAggregates(_ aggregates: [ModelAggregate]) {

--- a/Tests/MacParakeetTests/Services/Capture/MeetingAecModelScoringTests.swift
+++ b/Tests/MacParakeetTests/Services/Capture/MeetingAecModelScoringTests.swift
@@ -169,11 +169,12 @@ final class MeetingAecModelScoringTests: XCTestCase {
                 continue
             }
             for (echoLabel, echoPath) in echoPaths {
+                let conditioner = makeCandidateConditioner()
                 scores.append(scoreModel(
                     label: modelURL.lastPathComponent,
                     modelKey: modelURL.path,
                     echoLabel: echoLabel,
-                    makeConditioner: makeCandidateConditioner,
+                    conditioner: conditioner,
                     echoPath: echoPath))
             }
         }
@@ -223,24 +224,24 @@ final class MeetingAecModelScoringTests: XCTestCase {
         label: String,
         modelKey: String,
         echoLabel: String,
-        makeConditioner: () -> any MicConditioning,
+        conditioner: any MicConditioning,
         echoPath: MeetingAecEchoPath
     ) -> ModelScore {
         // Far-end-only → ERLE (any mic energy is echo by construction).
         let farScenario = MeetingAecScenarioFactory.make(
             name: "far-end-only", nearEndActive: false, farEndActive: true, echoPath: echoPath)
-        let farConditioner = makeConditioner()
-        let farOut = MeetingAecRunner.run(farConditioner, scenario: farScenario)
-        let farDiagnostics = farConditioner.diagnostics
+        let farRun = MeetingAecRunner.runWithDiagnostics(conditioner, scenario: farScenario)
+        let farOut = farRun.output
+        let farDiagnostics = farRun.diagnostics
         let farERLE = MeetingAecMetrics.erleDB(
             mic: farScenario.mic, output: farOut, over: farScenario.steadyStateWindow)
 
         // Near-end-only → must preserve the local voice's energy and not go silent.
         let nearScenario = MeetingAecScenarioFactory.make(
             name: "near-end-only", nearEndActive: true, farEndActive: false, echoPath: echoPath)
-        let nearConditioner = makeConditioner()
-        let nearOut = MeetingAecRunner.run(nearConditioner, scenario: nearScenario)
-        let nearDiagnostics = nearConditioner.diagnostics
+        let nearRun = MeetingAecRunner.runWithDiagnostics(conditioner, scenario: nearScenario)
+        let nearOut = nearRun.output
+        let nearDiagnostics = nearRun.diagnostics
         let nearWindow = nearScenario.steadyStateWindow
         let nearErr = MeetingAecMetrics.nearEndErrorDB(
             output: nearOut, nearEnd: nearScenario.nearEnd, over: nearWindow)
@@ -253,16 +254,16 @@ final class MeetingAecModelScoringTests: XCTestCase {
         // Double-talk → near-end error vs passthrough (reported, not gated).
         let dtScenario = MeetingAecScenarioFactory.make(
             name: "double-talk", nearEndActive: true, farEndActive: true, echoPath: echoPath)
-        let dtConditioner = makeConditioner()
-        let dtOut = MeetingAecRunner.run(dtConditioner, scenario: dtScenario)
-        let dtDiagnostics = dtConditioner.diagnostics
+        let dtRun = MeetingAecRunner.runWithDiagnostics(conditioner, scenario: dtScenario)
+        let dtOut = dtRun.output
+        let dtDiagnostics = dtRun.diagnostics
         let dtWindow = dtScenario.steadyStateWindow
         let dtErr = MeetingAecMetrics.nearEndErrorDB(
             output: dtOut, nearEnd: dtScenario.nearEnd, over: dtWindow)
         let dtPass = MeetingAecRunner.run(PassthroughMicConditioner(), scenario: dtScenario)
         let dtPassErr = MeetingAecMetrics.nearEndErrorDB(
             output: dtPass, nearEnd: dtScenario.nearEnd, over: dtWindow)
-        let overlapSweep = scoreDoubleTalkSegments(makeConditioner: makeConditioner, echoPath: echoPath)
+        let overlapSweep = scoreDoubleTalkSegments(conditioner: conditioner, echoPath: echoPath)
         let diagnostics = [farDiagnostics, nearDiagnostics, dtDiagnostics] + overlapSweep.diagnostics
 
         return ModelScore(
@@ -278,7 +279,7 @@ final class MeetingAecModelScoringTests: XCTestCase {
     }
 
     private func scoreDoubleTalkSegments(
-        makeConditioner: () -> any MicConditioning,
+        conditioner: any MicConditioning,
         echoPath: MeetingAecEchoPath
     ) -> OverlapSweepResult {
         var rows: [DoubleTalkSegmentScore] = []
@@ -290,9 +291,9 @@ final class MeetingAecModelScoringTests: XCTestCase {
                 signalToInterferenceDB: sir
             )
             let window = doubleTalk.steadyStateWindow
-            let doubleTalkConditioner = makeConditioner()
-            let cleaned = MeetingAecRunner.run(doubleTalkConditioner, scenario: doubleTalk)
-            diagnostics.append(doubleTalkConditioner.diagnostics)
+            let doubleTalkRun = MeetingAecRunner.runWithDiagnostics(conditioner, scenario: doubleTalk)
+            let cleaned = doubleTalkRun.output
+            diagnostics.append(doubleTalkRun.diagnostics)
             let raw = MeetingAecRunner.run(PassthroughMicConditioner(), scenario: doubleTalk)
             let cleanError = MeetingAecMetrics.nearEndErrorDB(
                 output: cleaned,
@@ -321,9 +322,9 @@ final class MeetingAecModelScoringTests: XCTestCase {
                 signalToInterferenceDB: sir
             )
             let echoWindow = echoOnly.steadyStateWindow
-            let echoOnlyConditioner = makeConditioner()
-            let echoCleaned = MeetingAecRunner.run(echoOnlyConditioner, scenario: echoOnly)
-            diagnostics.append(echoOnlyConditioner.diagnostics)
+            let echoOnlyRun = MeetingAecRunner.runWithDiagnostics(conditioner, scenario: echoOnly)
+            let echoCleaned = echoOnlyRun.output
+            diagnostics.append(echoOnlyRun.diagnostics)
             let echoRaw = MeetingAecRunner.run(PassthroughMicConditioner(), scenario: echoOnly)
             let echoCleanResidual = MeetingAecMetrics.relativePowerDB(
                 signal: echoCleaned,

--- a/Tests/MacParakeetTests/Services/Capture/MeetingAecModelScoringTests.swift
+++ b/Tests/MacParakeetTests/Services/Capture/MeetingAecModelScoringTests.swift
@@ -155,10 +155,13 @@ final class MeetingAecModelScoringTests: XCTestCase {
 
         var scores: [ModelScore] = []
         for modelURL in modelURLs {
+            let makeCandidateConditioner = {
+                self.makeConditioner(libraryURL: libraryURL, modelURL: modelURL)
+            }
             // Preflight: the factory falls back to an unavailable passthrough
             // (loaded == false) when the dylib/model can't instantiate. Fail with
             // one crisp message rather than scoring a bogus passthrough as the model.
-            let preflight = makeConditioner(libraryURL: libraryURL, modelURL: modelURL)
+            let preflight = makeCandidateConditioner()
             guard preflight.diagnostics.loaded,
                   preflight.diagnostics.processorName == MeetingEchoSuppressionFactory.processorName else {
                 XCTFail("\(modelURL.lastPathComponent): not a loadable LocalVQE model — the runtime "
@@ -166,12 +169,11 @@ final class MeetingAecModelScoringTests: XCTestCase {
                 continue
             }
             for (echoLabel, echoPath) in echoPaths {
-                let conditioner = makeConditioner(libraryURL: libraryURL, modelURL: modelURL)
                 scores.append(scoreModel(
                     label: modelURL.lastPathComponent,
                     modelKey: modelURL.path,
                     echoLabel: echoLabel,
-                    conditioner: conditioner,
+                    makeConditioner: makeCandidateConditioner,
                     echoPath: echoPath))
             }
         }
@@ -221,22 +223,24 @@ final class MeetingAecModelScoringTests: XCTestCase {
         label: String,
         modelKey: String,
         echoLabel: String,
-        conditioner: any MicConditioning,
+        makeConditioner: () -> any MicConditioning,
         echoPath: MeetingAecEchoPath
     ) -> ModelScore {
         // Far-end-only → ERLE (any mic energy is echo by construction).
         let farScenario = MeetingAecScenarioFactory.make(
             name: "far-end-only", nearEndActive: false, farEndActive: true, echoPath: echoPath)
-        let farOut = MeetingAecRunner.run(conditioner, scenario: farScenario)
-        let farDiagnostics = conditioner.diagnostics
+        let farConditioner = makeConditioner()
+        let farOut = MeetingAecRunner.run(farConditioner, scenario: farScenario)
+        let farDiagnostics = farConditioner.diagnostics
         let farERLE = MeetingAecMetrics.erleDB(
             mic: farScenario.mic, output: farOut, over: farScenario.steadyStateWindow)
 
         // Near-end-only → must preserve the local voice's energy and not go silent.
         let nearScenario = MeetingAecScenarioFactory.make(
             name: "near-end-only", nearEndActive: true, farEndActive: false, echoPath: echoPath)
-        let nearOut = MeetingAecRunner.run(conditioner, scenario: nearScenario)
-        let nearDiagnostics = conditioner.diagnostics
+        let nearConditioner = makeConditioner()
+        let nearOut = MeetingAecRunner.run(nearConditioner, scenario: nearScenario)
+        let nearDiagnostics = nearConditioner.diagnostics
         let nearWindow = nearScenario.steadyStateWindow
         let nearErr = MeetingAecMetrics.nearEndErrorDB(
             output: nearOut, nearEnd: nearScenario.nearEnd, over: nearWindow)
@@ -249,15 +253,16 @@ final class MeetingAecModelScoringTests: XCTestCase {
         // Double-talk → near-end error vs passthrough (reported, not gated).
         let dtScenario = MeetingAecScenarioFactory.make(
             name: "double-talk", nearEndActive: true, farEndActive: true, echoPath: echoPath)
-        let dtOut = MeetingAecRunner.run(conditioner, scenario: dtScenario)
-        let dtDiagnostics = conditioner.diagnostics
+        let dtConditioner = makeConditioner()
+        let dtOut = MeetingAecRunner.run(dtConditioner, scenario: dtScenario)
+        let dtDiagnostics = dtConditioner.diagnostics
         let dtWindow = dtScenario.steadyStateWindow
         let dtErr = MeetingAecMetrics.nearEndErrorDB(
             output: dtOut, nearEnd: dtScenario.nearEnd, over: dtWindow)
         let dtPass = MeetingAecRunner.run(PassthroughMicConditioner(), scenario: dtScenario)
         let dtPassErr = MeetingAecMetrics.nearEndErrorDB(
             output: dtPass, nearEnd: dtScenario.nearEnd, over: dtWindow)
-        let overlapSweep = scoreDoubleTalkSegments(conditioner: conditioner, echoPath: echoPath)
+        let overlapSweep = scoreDoubleTalkSegments(makeConditioner: makeConditioner, echoPath: echoPath)
         let diagnostics = [farDiagnostics, nearDiagnostics, dtDiagnostics] + overlapSweep.diagnostics
 
         return ModelScore(
@@ -273,7 +278,7 @@ final class MeetingAecModelScoringTests: XCTestCase {
     }
 
     private func scoreDoubleTalkSegments(
-        conditioner: any MicConditioning,
+        makeConditioner: () -> any MicConditioning,
         echoPath: MeetingAecEchoPath
     ) -> OverlapSweepResult {
         var rows: [DoubleTalkSegmentScore] = []
@@ -285,8 +290,9 @@ final class MeetingAecModelScoringTests: XCTestCase {
                 signalToInterferenceDB: sir
             )
             let window = doubleTalk.steadyStateWindow
-            let cleaned = MeetingAecRunner.run(conditioner, scenario: doubleTalk)
-            diagnostics.append(conditioner.diagnostics)
+            let doubleTalkConditioner = makeConditioner()
+            let cleaned = MeetingAecRunner.run(doubleTalkConditioner, scenario: doubleTalk)
+            diagnostics.append(doubleTalkConditioner.diagnostics)
             let raw = MeetingAecRunner.run(PassthroughMicConditioner(), scenario: doubleTalk)
             let cleanError = MeetingAecMetrics.nearEndErrorDB(
                 output: cleaned,
@@ -315,8 +321,9 @@ final class MeetingAecModelScoringTests: XCTestCase {
                 signalToInterferenceDB: sir
             )
             let echoWindow = echoOnly.steadyStateWindow
-            let echoCleaned = MeetingAecRunner.run(conditioner, scenario: echoOnly)
-            diagnostics.append(conditioner.diagnostics)
+            let echoOnlyConditioner = makeConditioner()
+            let echoCleaned = MeetingAecRunner.run(echoOnlyConditioner, scenario: echoOnly)
+            diagnostics.append(echoOnlyConditioner.diagnostics)
             let echoRaw = MeetingAecRunner.run(PassthroughMicConditioner(), scenario: echoOnly)
             let echoCleanResidual = MeetingAecMetrics.relativePowerDB(
                 signal: echoCleaned,


### PR DESCRIPTION
## Summary
- Extends the meeting-AEC measurement harness (used to score LocalVQE candidates and pick the v1.4 echo-only default in #605/#650) with an explicit double-talk failure-mode metric.
- Before: the harness measured far-end-only ERLE, near-end-only retention, reference-delay sensitivity, and a single continuous double-talk near-end-error value. No SIR sweep, no explicit echo-only ("should approach silence") reporting.
- Now: adds SIR-controlled double-talk fixtures at 0, +6, +12 dB (mixing synthetic ground-truth "user" speech with synthetic reference bleed), reports the harness's existing near-end-error accuracy proxy specifically on overlap segments, and reports matching echo-only residual power/ERLE so both failure directions are visible. Wired into both the standalone characterization test and the env-gated LocalVQE model-scoring gate.
- This remains the harness's existing synthetic tone-based accuracy proxy, not real-speech WER — the repo has no speech-audio/STT fixture path in this test tree. That gap is called out explicitly rather than silently assumed away.

## v1.4 default model — real-asset run (mean, single/multi tap)
```
SIR   dtRaw   dtClean  dtImpr  clnRet  echoRaw  echoClean  echoERLE
+0     -0.0      2.1    -2.1    0.52     -0.0     -37.6      37.6
+6     -6.0      3.2    -9.2    0.74     -6.0     -39.8      33.8
+12   -12.0      4.0   -16.0    0.90    -12.0     -40.5      28.5
```
Echo-only segments behave as intended (residual drops hard, ERLE 28–38 dB). Double-talk overlap accuracy is *worse than raw* at every SIR tested, worst at 0/+6 dB — v1.4 echo-only was tuned for the echo-only case and currently costs near-end intelligibility under double talk. This is a measurement/tooling change only; it does not alter the shipping default or any product code path.

## Test plan
- [x] `swift test --filter MeetingAecMeasurementTests` (synthetic SIR sweep, passes)
- [x] `swift test --filter MeetingAecModelScoringTests` skips cleanly without local assets
- [x] Real v1.4 run against local `.build/meeting-echo-assets` (dylib + `localvqe-v1.4-aec-200K-f32.gguf`)
- [x] `git diff --check`
- [ ] Greptile review loop (in progress)

Diff is confined to `Tests/MacParakeetTests/Services/Capture/{MeetingAecMeasurementHarness,MeetingAecMeasurementTests,MeetingAecModelScoringTests}.swift` — harness/dev-tooling only, no product code touched.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds SIR-controlled double-talk metrics to the Meeting AEC harness and model-scoring tests, with per-SIR reporting and echo-only companions. Improves visibility into overlap accuracy, retention, and residual echo at 0/+6/+12 dB SIR; enforces calibration convergence, reuses model instances while keeping diagnostics correct, and applies a shared ERLE power floor with clear behavior. No product code touched.

- New Features
  - Double-talk fixtures at 0, +6, +12 dB SIR and matching echo-only companions.
  - Reports overlap-segment near-end error, retention (RMS ratio), echo-only residual power (vs nominal near-end), and ERLE.
  - Model scoring prints per-SIR segment tables and per-model SIR aggregates; deterministic aggregation.

- Bug Fixes
  - Far-end scaling calibrated to hit target SIR with nonlinear echo paths; asserts convergence and separates zero-echo underflow.
  - Bounded metric windows and a shared power floor; metrics stay finite on short/empty windows; ERLE clamps below-floor cases to 0 dB and allows negative when output exceeds mic.
  - Reuse one conditioner per model+echo path; per-run diagnostics are deltas after reset, preventing repeated model loads while keeping counts isolated.
  - Aligned per-SIR table headers; aggregates include raw retention.

<sup>Written for commit 0175a8e09dcfdb6ced5213fb5b922f66b66fb696. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/669?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

