### PR TITLE
Redact user paths/filenames from diagnostic logs

### DIFF
--- a/Sources/MacParakeetCore/Services/AutoSaveService.swift
+++ b/Sources/MacParakeetCore/Services/AutoSaveService.swift
@@ -104,7 +104,7 @@ public final class AutoSaveService {
             case .json: try exportService.exportToJSON(transcription: transcription, url: fileURL)
             }
 
-            logger.info("Auto-saved \(scope.rawValue) transcript to \(fileURL.lastPathComponent)")
+            logger.info("auto_save_completed scope=\(scope.rawValue, privacy: .public) format=\(format.rawValue, privacy: .public) outcome=success")
             sendAutoSaveOperation(
                 operationContext: operationContext,
                 scope: scope,
@@ -112,13 +112,14 @@ public final class AutoSaveService {
                 outcome: .success
             )
         } catch {
-            logger.error("Auto-save failed for \(scope.rawValue): \(error.localizedDescription)")
+            let errorType = Observability.errorType(for: error)
+            logger.error("auto_save_failed scope=\(scope.rawValue, privacy: .public) format=\(format.rawValue, privacy: .public) outcome=failure error_type=\(errorType, privacy: .public)")
             sendAutoSaveOperation(
                 operationContext: operationContext,
                 scope: scope,
                 format: format,
                 outcome: .failure,
-                errorType: Observability.errorType(for: error)
+                errorType: errorType
             )
         }
     }

--- a/Sources/MacParakeetViewModels/MediaPlayerViewModel.swift
+++ b/Sources/MacParakeetViewModels/MediaPlayerViewModel.swift
@@ -259,7 +259,7 @@ public final class MediaPlayerViewModel {
         playerState = .loading
         loadingElapsed = 0
         startLoadingTimer()
-        logger.info("Loading media: mode=\(String(describing: mode), privacy: .public), source=\(transcription.sourceURL ?? transcription.filePath ?? "none", privacy: .private)")
+        logger.info("Loading media: mode=\(String(describing: mode), privacy: .public), sourceType=\(transcription.sourceType.rawValue, privacy: .public)")
 
         let task = Task { @MainActor [weak self] in
             guard let self else { return }
@@ -371,7 +371,7 @@ public final class MediaPlayerViewModel {
 
         let start = ContinuousClock.now
         do {
-            logger.info("Extracting stream URL via yt-dlp for source=\(sourceURL, privacy: .private)")
+            logger.info("Extracting stream URL via yt-dlp")
             let streamURL = try await videoStreamService.streamURL(for: sourceURL)
             let extractionTime = ContinuousClock.now - start
             logger.info("Stream URL extracted in \(extractionTime)")

--- a/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
@@ -984,7 +984,7 @@ public final class TranscriptionViewModel {
             // A failed file never aborts the batch — it bumps the failure count
             // (surfaced in the status line + completion banner) and advances.
             batchFailedCount += 1
-            logger.error("Batch file transcription failed error=\(error.localizedDescription, privacy: .public)")
+            logger.error("Batch file transcription failed error_type=\(TelemetryErrorClassifier.classify(error), privacy: .public)")
             loadTranscriptions()
             advanceBatch()
         } else {

--- a/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
@@ -272,7 +272,7 @@ public final class TranscriptionViewModel {
         do {
             transcriptions = try repo.fetchAll(limit: 50)
         } catch {
-            logger.error("Failed to load transcriptions: \(error.localizedDescription, privacy: .public)")
+            logger.error("Failed to load transcriptions error_type=\(TelemetryErrorClassifier.classify(error), privacy: .public)")
             transcriptions = []
         }
     }
@@ -641,7 +641,7 @@ public final class TranscriptionViewModel {
                     // Skip auto-run prompts on retranscribe — they would duplicate the existing tabs.
                     completeSuccessfulTranscription(taskID: taskID, result: updatedResult, runAutoPrompts: false)
                 } catch {
-                    logger.error("Failed to save transcription result error=\(error.localizedDescription, privacy: .public)")
+                    logger.error("Failed to save transcription result error_type=\(TelemetryErrorClassifier.classify(error), privacy: .public)")
                     completeFailedTranscription(taskID: taskID, error: error)
                 }
             } catch is CancellationError {
@@ -1204,7 +1204,7 @@ public final class TranscriptionViewModel {
             }
             return true
         } catch {
-            logger.error("Failed to persist transcript edit error=\(error.localizedDescription, privacy: .public)")
+            logger.error("Failed to persist transcript edit error_type=\(TelemetryErrorClassifier.classify(error), privacy: .public)")
             return false
         }
     }
@@ -1231,7 +1231,7 @@ public final class TranscriptionViewModel {
             }
             return true
         } catch {
-            logger.error("Failed to persist transcript revert error=\(error.localizedDescription, privacy: .public)")
+            logger.error("Failed to persist transcript revert error_type=\(TelemetryErrorClassifier.classify(error), privacy: .public)")
             return false
         }
     }
@@ -1250,7 +1250,7 @@ public final class TranscriptionViewModel {
         do {
             try transcriptionRepo?.updateSpeakers(id: transcription.id, speakers: speakers)
         } catch {
-            logger.error("Failed to persist speaker rename error=\(error.localizedDescription, privacy: .public)")
+            logger.error("Failed to persist speaker rename error_type=\(TelemetryErrorClassifier.classify(error), privacy: .public)")
         }
     }
 
@@ -1269,7 +1269,7 @@ public final class TranscriptionViewModel {
                 transcriptions[index].derivedTitle = trimmed
             }
         } catch {
-            logger.error("Failed to persist transcription rename error=\(error.localizedDescription, privacy: .public)")
+            logger.error("Failed to persist transcription rename error_type=\(TelemetryErrorClassifier.classify(error), privacy: .public)")
         }
     }
 
@@ -1282,7 +1282,7 @@ public final class TranscriptionViewModel {
         do {
             hasPromptResultTabs = try promptResultRepo?.hasPromptResults(transcriptionId: transcriptionID) ?? false
         } catch {
-            logger.error("Failed to query prompt results error=\(error.localizedDescription, privacy: .public)")
+            logger.error("Failed to query prompt results error_type=\(TelemetryErrorClassifier.classify(error), privacy: .public)")
             hasPromptResultTabs = false
         }
     }


### PR DESCRIPTION
## Summary
- Diagnostic OSLog calls in the auto-save, batch file transcription, and media playback paths were emitting user filenames, raw `error.localizedDescription` (which frequently embeds output paths / FFmpeg stderr with input filenames), and full media source URLs — some marked `.private`, but OSLog-private payloads can still surface via sysdiagnose/support modes. Users sometimes paste local diagnostic logs into public GitHub issues, so these needed redaction.
- `AutoSaveService.swift`: success log drops the generated export filename in favor of `scope`/`format`/`outcome=success`; failure log replaces raw `error.localizedDescription` with the existing `Observability.errorType(for:)` classification (already computed a few lines below for telemetry).
- `TranscriptionViewModel.swift`: batch file transcription failure log replaces raw `error.localizedDescription` (previously marked OSLog `.public`, the worst case) with `TelemetryErrorClassifier.classify(error)`.
- `MediaPlayerViewModel.swift`: media-load log replaces the raw source URL/path with `transcription.sourceType.rawValue`; yt-dlp stream-extraction log drops the raw source URL entirely.
- No behavior changes — only log content. No new telemetry events or network-bound fields.
- Reused existing sanitization/classification helpers (`TelemetryErrorClassifier`, `Observability.errorType`) rather than adding a new one, since both already existed and are already unit-tested.

Explicitly out of scope: `MeetingRecordingRecoveryService.swift` (owned by an in-flight PR) and any wide-event/structured-diagnostic-schema infrastructure — both flagged separately in `journal/2026-07-03-diagnostics-audit.md` but deliberately not touched here to keep this PR narrow.

## Test plan
- [x] `swift build` — green
- [x] `swift test` — full suite green (see CI)
- [x] Manual diff review confirming no filename/path/URL is passed into any touched log call

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts user filenames, paths, and source URLs from diagnostic logs across auto-save, transcription (including persistence flows), and media playback. Replaces raw error strings with classifications and removes source identifiers; no behavior or telemetry changes.

- **Bug Fixes**
  - AutoSaveService: success log now emits scope/format/outcome; failure log uses `Observability.errorType` instead of `error.localizedDescription`.
  - TranscriptionViewModel: replaces `error.localizedDescription` with `TelemetryErrorClassifier.classify(error)` for load/save/edit/revert/rename/prompt-query failures and batch errors.
  - MediaPlayerViewModel: media-load log reports `sourceType` instead of a URL/path; yt-dlp extraction log drops the source URL.

<sup>Written for commit eb628c3fdd1ad0f3a5199211db5b5582a4265abc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/670?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

