### PR TITLE
fix: gate cleaned mic readiness for meetings

### DIFF
--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingArtifactStore.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingArtifactStore.swift
@@ -301,7 +301,10 @@ private struct MeetingArtifactFiles: Codable {
         let metadataURL = MeetingRecordingMetadataStore.metadataURL(for: folderURL)
         let fileManager = FileManager.default
         microphoneAudioPath = fileManager.fileExists(atPath: microphoneURL.path) ? microphoneURL.path : nil
-        cleanedMicrophoneAudioPath = fileManager.fileExists(atPath: cleanedMicrophoneURL.path)
+        cleanedMicrophoneAudioPath = MeetingRecordingOutput.isViableCleanedMicrophoneFile(
+            at: cleanedMicrophoneURL,
+            fileManager: fileManager
+        )
             ? cleanedMicrophoneURL.path
             : nil
         systemAudioPath = fileManager.fileExists(atPath: systemURL.path) ? systemURL.path : nil

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingArtifactStore.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingArtifactStore.swift
@@ -281,6 +281,7 @@ private struct MeetingArtifactFiles: Codable {
     let folderPath: String
     let mixedAudioPath: String?
     let microphoneAudioPath: String?
+    let cleanedMicrophoneAudioPath: String?
     let systemAudioPath: String?
     let metadataPath: String?
     let manifestPath: String
@@ -294,10 +295,15 @@ private struct MeetingArtifactFiles: Codable {
         mixedAudioPath = transcription.filePath
         let folderURL = URL(fileURLWithPath: snapshot.folderPath, isDirectory: true)
         let microphoneURL = folderURL.appendingPathComponent("microphone.m4a")
+        let cleanedMicrophoneURL = folderURL.appendingPathComponent(
+            MeetingCleanedMicRenderer.cleanedMicrophoneFileName)
         let systemURL = folderURL.appendingPathComponent("system.m4a")
         let metadataURL = MeetingRecordingMetadataStore.metadataURL(for: folderURL)
         let fileManager = FileManager.default
         microphoneAudioPath = fileManager.fileExists(atPath: microphoneURL.path) ? microphoneURL.path : nil
+        cleanedMicrophoneAudioPath = fileManager.fileExists(atPath: cleanedMicrophoneURL.path)
+            ? cleanedMicrophoneURL.path
+            : nil
         systemAudioPath = fileManager.fileExists(atPath: systemURL.path) ? systemURL.path : nil
         metadataPath = fileManager.fileExists(atPath: metadataURL.path) ? metadataURL.path : nil
         manifestPath = snapshot.manifestPath

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingCleanedMicrophoneReadiness.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingCleanedMicrophoneReadiness.swift
@@ -63,48 +63,126 @@ enum MeetingCleanedMicrophoneRenderCompletion: Sendable, Equatable {
 
 struct MeetingCleanedMicrophoneReadiness: Sendable {
     let outputURL: URL?
+    private let candidateOutputURL: URL?
     private let task: Task<MeetingCleanedMicrophoneRenderCompletion, Never>?
+    private let fileManager: UncheckedSendableBox<FileManager>?
     private let notScheduledReason: MeetingCleanedMicrophoneRoutingReason?
+
+    private init(
+        outputURL: URL?,
+        candidateOutputURL: URL?,
+        task: Task<MeetingCleanedMicrophoneRenderCompletion, Never>?,
+        fileManager: FileManager?,
+        notScheduledReason: MeetingCleanedMicrophoneRoutingReason?
+    ) {
+        self.outputURL = outputURL
+        self.candidateOutputURL = candidateOutputURL
+        self.task = task
+        self.fileManager = fileManager.map(UncheckedSendableBox.init)
+        self.notScheduledReason = notScheduledReason
+    }
 
     static func notScheduled(
         reason: MeetingCleanedMicrophoneRoutingReason
     ) -> MeetingCleanedMicrophoneReadiness {
         MeetingCleanedMicrophoneReadiness(
             outputURL: nil,
+            candidateOutputURL: nil,
             task: nil,
+            fileManager: nil,
             notScheduledReason: reason
         )
     }
 
     static func scheduled(
         outputURL: URL,
-        task: Task<MeetingCleanedMicrophoneRenderCompletion, Never>
+        task: Task<MeetingCleanedMicrophoneRenderCompletion, Never>,
+        candidateOutputURL: URL? = nil,
+        fileManager: FileManager = .default
     ) -> MeetingCleanedMicrophoneReadiness {
         MeetingCleanedMicrophoneReadiness(
             outputURL: outputURL,
+            candidateOutputURL: candidateOutputURL,
             task: task,
+            fileManager: fileManager,
             notScheduledReason: nil
         )
     }
 
-    func awaitCompletion(timeoutSeconds: TimeInterval) async -> MeetingCleanedMicrophoneRenderCompletion? {
+    func awaitCompletion(timeoutSeconds: TimeInterval) async throws -> MeetingCleanedMicrophoneRenderCompletion? {
         if let notScheduledReason {
             return .fallback(notScheduledReason)
         }
         guard let task else { return nil }
 
-        return await withCheckedContinuation { continuation in
-            let race = MeetingCleanedMicrophoneReadinessRace(continuation: continuation)
-            let renderWaiter = Task {
-                let completion = await task.value
-                race.resume(completion, cancelRenderWaiter: false, cancelTimeout: true)
+        let race = MeetingCleanedMicrophoneReadinessRace()
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                race.start(continuation)
+                let renderWaiter = Task {
+                    let completion = await task.value
+                    race.resumeFromRender(
+                        resolveCompletedRender(completion),
+                        onLose: discardCandidateOutputs
+                    )
+                }
+                race.setRenderWaiter(renderWaiter)
+                let timeoutWaiter = Task {
+                    do {
+                        try await Task.sleep(nanoseconds: Self.nanoseconds(for: timeoutSeconds))
+                    } catch {
+                        return
+                    }
+                    _ = race.resume(
+                        nil,
+                        cancelRenderWaiter: true,
+                        cancelTimeout: false,
+                        beforeResume: {
+                            task.cancel()
+                            discardCandidateOutputs()
+                        }
+                    )
+                }
+                race.setTimeoutWaiter(timeoutWaiter)
             }
-            race.setRenderWaiter(renderWaiter)
-            let timeoutWaiter = Task {
-                try? await Task.sleep(nanoseconds: Self.nanoseconds(for: timeoutSeconds))
-                race.resume(nil, cancelRenderWaiter: true, cancelTimeout: false)
+        } onCancel: {
+            _ = race.cancel {
+                task.cancel()
+                discardCandidateOutputs()
             }
-            race.setTimeoutWaiter(timeoutWaiter)
+        }
+    }
+
+    private func resolveCompletedRender(
+        _ completion: MeetingCleanedMicrophoneRenderCompletion
+    ) -> MeetingCleanedMicrophoneRenderCompletion {
+        guard case .rendered(let renderedURL) = completion,
+              let outputURL,
+              let candidateOutputURL else {
+            return completion
+        }
+
+        let fileManager = fileManager?.value ?? .default
+        do {
+            try? fileManager.removeItem(at: outputURL)
+            try fileManager.moveItem(at: renderedURL, to: outputURL)
+            if renderedURL != candidateOutputURL {
+                try? fileManager.removeItem(at: candidateOutputURL)
+            }
+            return .rendered(outputURL)
+        } catch {
+            discardCandidateOutputs()
+            return .fallback(.rawRenderFailed)
+        }
+    }
+
+    private func discardCandidateOutputs() {
+        let fileManager = fileManager?.value ?? .default
+        if let candidateOutputURL {
+            try? fileManager.removeItem(at: candidateOutputURL)
+        }
+        if let outputURL {
+            try? fileManager.removeItem(at: outputURL)
         }
     }
 
@@ -121,12 +199,22 @@ private final class MeetingCleanedMicrophoneReadinessRace: @unchecked Sendable {
     private var didResume = false
     private var renderWaiter: Task<Void, Never>?
     private var timeoutWaiter: Task<Void, Never>?
-    private let continuation: CheckedContinuation<MeetingCleanedMicrophoneRenderCompletion?, Never>
+    private var continuation: CheckedContinuation<MeetingCleanedMicrophoneRenderCompletion?, Error>?
+    private var pendingCancellation = false
 
-    init(
-        continuation: CheckedContinuation<MeetingCleanedMicrophoneRenderCompletion?, Never>
+    func start(
+        _ continuation: CheckedContinuation<MeetingCleanedMicrophoneRenderCompletion?, Error>
     ) {
-        self.continuation = continuation
+        let shouldCancel = lock.withLock {
+            self.continuation = continuation
+            guard pendingCancellation, !didResume else { return false }
+            didResume = true
+            self.continuation = nil
+            return true
+        }
+        if shouldCancel {
+            continuation.resume(throwing: CancellationError())
+        }
     }
 
     func setRenderWaiter(_ task: Task<Void, Never>) {
@@ -149,27 +237,89 @@ private final class MeetingCleanedMicrophoneReadinessRace: @unchecked Sendable {
         }
     }
 
+    func resumeFromRender(
+        _ value: @autoclosure () -> MeetingCleanedMicrophoneRenderCompletion,
+        onLose: () -> Void
+    ) {
+        let resumeState: (
+            continuation: CheckedContinuation<MeetingCleanedMicrophoneRenderCompletion?, Error>?,
+            timeoutWaiter: Task<Void, Never>?,
+            lost: Bool
+        ) = lock.withLock {
+            guard !didResume else { return (nil, nil, true) }
+            didResume = true
+            let continuation = self.continuation
+            self.continuation = nil
+            return (continuation, timeoutWaiter, false)
+        }
+
+        if resumeState.lost {
+            onLose()
+            return
+        }
+        guard let continuation = resumeState.continuation else {
+            return
+        }
+        resumeState.timeoutWaiter?.cancel()
+        continuation.resume(returning: value())
+    }
+
     func resume(
         _ value: MeetingCleanedMicrophoneRenderCompletion?,
         cancelRenderWaiter: Bool,
-        cancelTimeout: Bool
-    ) {
-        let resumeState: (shouldResume: Bool, tasksToCancel: [Task<Void, Never>]) = lock.withLock {
-            guard !didResume else { return (false, []) }
+        cancelTimeout: Bool,
+        beforeResume: (() -> Void)? = nil
+    ) -> Bool {
+        let resumeState: (
+            continuation: CheckedContinuation<MeetingCleanedMicrophoneRenderCompletion?, Error>?,
+            tasksToCancel: [Task<Void, Never>]
+        ) = lock.withLock {
+            guard !didResume else { return (nil, []) }
             didResume = true
+            let continuation = self.continuation
+            self.continuation = nil
             let tasks = [
                 cancelRenderWaiter ? renderWaiter : nil,
                 cancelTimeout ? timeoutWaiter : nil,
             ].compactMap { $0 }
-            return (true, tasks)
+            return (continuation, tasks)
         }
-        guard resumeState.shouldResume else {
-            return
+        guard let continuation = resumeState.continuation else {
+            return false
         }
-        continuation.resume(returning: value)
+        beforeResume?()
         for task in resumeState.tasksToCancel {
             task.cancel()
         }
+        continuation.resume(returning: value)
+        return true
+    }
+
+    func cancel(beforeResume: () -> Void) -> Bool {
+        let resumeState: (
+            continuation: CheckedContinuation<MeetingCleanedMicrophoneRenderCompletion?, Error>?,
+            tasksToCancel: [Task<Void, Never>],
+            shouldCancelRender: Bool
+        ) = lock.withLock {
+            guard !didResume else { return (nil, [], false) }
+            let tasks = [renderWaiter, timeoutWaiter].compactMap { $0 }
+            guard let continuation else {
+                pendingCancellation = true
+                return (nil, tasks, true)
+            }
+            didResume = true
+            self.continuation = nil
+            return (continuation, tasks, true)
+        }
+        guard resumeState.shouldCancelRender else {
+            return false
+        }
+        beforeResume()
+        for task in resumeState.tasksToCancel {
+            task.cancel()
+        }
+        resumeState.continuation?.resume(throwing: CancellationError())
+        return true
     }
 }
 
@@ -216,8 +366,22 @@ enum MeetingCleanedMicrophoneRenderScheduler {
             )
             return .notScheduled(reason: .rawMissingSystemReference)
         }
-
         let rendererFileManager = UncheckedSendableBox(fileManager)
+        let candidateOutputURL = candidateOutputURL(for: outputURL, sessionID: sessionID)
+        discardArtifact(
+            at: outputURL,
+            sessionID: sessionID,
+            reason: "prepare_candidate_render",
+            fileManager: fileManager,
+            eventName: eventName
+        )
+        discardArtifact(
+            at: candidateOutputURL,
+            sessionID: sessionID,
+            reason: "prepare_candidate_render",
+            fileManager: fileManager,
+            eventName: eventName
+        )
         let task = Task.detached(priority: .utility) {
             do {
                 let outcome = try await MeetingCleanedMicRenderer(
@@ -226,19 +390,19 @@ enum MeetingCleanedMicrophoneRenderScheduler {
                     microphoneURL: microphoneURL,
                     systemURL: systemURL,
                     sourceAlignment: sourceAlignment,
-                    outputURL: outputURL,
+                    outputURL: candidateOutputURL,
                     conditioner: conditionerFactory()
                 )
                 return handleOutcome(
                     outcome,
-                    outputURL: outputURL,
+                    outputURL: candidateOutputURL,
                     sessionID: sessionID,
                     fileManager: rendererFileManager.value,
                     eventName: eventName
                 )
             } catch is CancellationError {
                 discardArtifact(
-                    at: outputURL,
+                    at: candidateOutputURL,
                     sessionID: sessionID,
                     reason: "renderer_cancelled",
                     fileManager: rendererFileManager.value,
@@ -253,7 +417,7 @@ enum MeetingCleanedMicrophoneRenderScheduler {
                 return .fallback(.rawRenderFailed)
             } catch {
                 discardArtifact(
-                    at: outputURL,
+                    at: candidateOutputURL,
                     sessionID: sessionID,
                     reason: "renderer_threw",
                     fileManager: rendererFileManager.value,
@@ -272,7 +436,21 @@ enum MeetingCleanedMicrophoneRenderScheduler {
 
         AudioCaptureDiagnostics.append(
             "\(eventName) session=\(sessionID.uuidString) outcome=scheduled")
-        return .scheduled(outputURL: outputURL, task: task)
+        return .scheduled(
+            outputURL: outputURL,
+            task: task,
+            candidateOutputURL: candidateOutputURL,
+            fileManager: fileManager
+        )
+    }
+
+    private static func candidateOutputURL(for outputURL: URL, sessionID: UUID) -> URL {
+        let basename = outputURL.deletingPathExtension().lastPathComponent
+        let pathExtension = outputURL.pathExtension.isEmpty ? "tmp" : outputURL.pathExtension
+        return outputURL
+            .deletingLastPathComponent()
+            .appendingPathComponent(".\(basename)-\(sessionID.uuidString).tmp")
+            .appendingPathExtension(pathExtension)
     }
 
     private static func handleOutcome(
@@ -360,10 +538,10 @@ extension MeetingRecordingOutput {
     func resolvedMicrophoneTranscriptionSource(
         policy: MeetingCleanedMicrophoneReadinessPolicy = .production,
         fileManager: FileManager = .default
-    ) async -> MeetingCleanedMicrophoneSourceDecision {
+    ) async throws -> MeetingCleanedMicrophoneSourceDecision {
+        let timeoutSeconds = policy.timeoutSeconds(for: durationSeconds)
         if let cleanedMicrophoneReadiness {
-            let timeoutSeconds = policy.timeoutSeconds(for: durationSeconds)
-            guard let completion = await cleanedMicrophoneReadiness.awaitCompletion(
+            guard let completion = try await cleanedMicrophoneReadiness.awaitCompletion(
                 timeoutSeconds: timeoutSeconds
             ) else {
                 return .init(url: microphoneAudioURL, reason: .rawTimeout)

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingCleanedMicrophoneReadiness.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingCleanedMicrophoneReadiness.swift
@@ -1,0 +1,397 @@
+import Foundation
+
+public enum MeetingCleanedMicrophoneRoutingReason: String, Sendable, Codable, CaseIterable {
+    case cleanedUsed
+    case rawTimeout
+    case rawInvalidArtifact
+    case rawRenderFailed
+    case rawMissingSystemReference
+    case rawNoAECAssets
+    case skippedNoEchoPath
+}
+
+public struct MeetingCleanedMicrophoneReadinessPolicy: Sendable, Equatable {
+    /// The v1.4 LocalVQE AEC model measured on this worktree at 16.33x realtime
+    /// for the conditioning core: 60.0 s synthetic meeting audio in 3.674 s on
+    /// an Apple M4 Pro via `MeetingAecRenderThroughputTests`. A 0.25x duration
+    /// budget assumes only 4x realtime, leaving roughly 3x margin for file
+    /// decode/encode and cold system load while still bounding final-STT delay.
+    public static let production = MeetingCleanedMicrophoneReadinessPolicy(
+        floorSeconds: 60,
+        durationMultiplier: 0.25,
+        capSeconds: 10 * 60
+    )
+
+    public let floorSeconds: TimeInterval
+    public let durationMultiplier: Double
+    public let capSeconds: TimeInterval
+
+    public init(
+        floorSeconds: TimeInterval,
+        durationMultiplier: Double,
+        capSeconds: TimeInterval
+    ) {
+        self.floorSeconds = max(0, floorSeconds)
+        self.durationMultiplier = max(0, durationMultiplier)
+        self.capSeconds = max(0, capSeconds)
+    }
+
+    public func timeoutSeconds(for recordingDuration: TimeInterval) -> TimeInterval {
+        let scaled: TimeInterval
+        if recordingDuration.isFinite {
+            scaled = max(0, recordingDuration) * durationMultiplier
+        } else {
+            scaled = capSeconds
+        }
+        return max(floorSeconds, min(scaled, capSeconds))
+    }
+}
+
+public struct MeetingCleanedMicrophoneSourceDecision: Sendable, Equatable {
+    public let url: URL
+    public let reason: MeetingCleanedMicrophoneRoutingReason
+
+    public var usesCleanedMicrophone: Bool {
+        reason == .cleanedUsed
+    }
+}
+
+enum MeetingCleanedMicrophoneRenderCompletion: Sendable, Equatable {
+    case rendered(URL)
+    case fallback(MeetingCleanedMicrophoneRoutingReason)
+}
+
+struct MeetingCleanedMicrophoneReadiness: Sendable {
+    let outputURL: URL?
+    private let task: Task<MeetingCleanedMicrophoneRenderCompletion, Never>?
+    private let notScheduledReason: MeetingCleanedMicrophoneRoutingReason?
+
+    static func notScheduled(
+        reason: MeetingCleanedMicrophoneRoutingReason
+    ) -> MeetingCleanedMicrophoneReadiness {
+        MeetingCleanedMicrophoneReadiness(
+            outputURL: nil,
+            task: nil,
+            notScheduledReason: reason
+        )
+    }
+
+    static func scheduled(
+        outputURL: URL,
+        task: Task<MeetingCleanedMicrophoneRenderCompletion, Never>
+    ) -> MeetingCleanedMicrophoneReadiness {
+        MeetingCleanedMicrophoneReadiness(
+            outputURL: outputURL,
+            task: task,
+            notScheduledReason: nil
+        )
+    }
+
+    func awaitCompletion(timeoutSeconds: TimeInterval) async -> MeetingCleanedMicrophoneRenderCompletion? {
+        if let notScheduledReason {
+            return .fallback(notScheduledReason)
+        }
+        guard let task else { return nil }
+
+        return await withCheckedContinuation { continuation in
+            let race = MeetingCleanedMicrophoneReadinessRace(continuation: continuation)
+            let renderWaiter = Task {
+                let completion = await task.value
+                race.resume(completion, cancelRenderWaiter: false, cancelTimeout: true)
+            }
+            race.setRenderWaiter(renderWaiter)
+            let timeoutWaiter = Task {
+                try? await Task.sleep(nanoseconds: Self.nanoseconds(for: timeoutSeconds))
+                race.resume(nil, cancelRenderWaiter: true, cancelTimeout: false)
+            }
+            race.setTimeoutWaiter(timeoutWaiter)
+        }
+    }
+
+    private static func nanoseconds(for seconds: TimeInterval) -> UInt64 {
+        let clamped = max(0, seconds)
+        let maxSeconds = Double(UInt64.max) / 1_000_000_000
+        guard clamped < maxSeconds else { return UInt64.max }
+        return UInt64((clamped * 1_000_000_000).rounded())
+    }
+}
+
+private final class MeetingCleanedMicrophoneReadinessRace: @unchecked Sendable {
+    private let lock = NSLock()
+    private var didResume = false
+    private var renderWaiter: Task<Void, Never>?
+    private var timeoutWaiter: Task<Void, Never>?
+    private let continuation: CheckedContinuation<MeetingCleanedMicrophoneRenderCompletion?, Never>
+
+    init(
+        continuation: CheckedContinuation<MeetingCleanedMicrophoneRenderCompletion?, Never>
+    ) {
+        self.continuation = continuation
+    }
+
+    func setRenderWaiter(_ task: Task<Void, Never>) {
+        let shouldCancel = lock.withLock {
+            renderWaiter = task
+            return didResume
+        }
+        if shouldCancel {
+            task.cancel()
+        }
+    }
+
+    func setTimeoutWaiter(_ task: Task<Void, Never>) {
+        let shouldCancel = lock.withLock {
+            timeoutWaiter = task
+            return didResume
+        }
+        if shouldCancel {
+            task.cancel()
+        }
+    }
+
+    func resume(
+        _ value: MeetingCleanedMicrophoneRenderCompletion?,
+        cancelRenderWaiter: Bool,
+        cancelTimeout: Bool
+    ) {
+        let resumeState: (shouldResume: Bool, tasksToCancel: [Task<Void, Never>]) = lock.withLock {
+            guard !didResume else { return (false, []) }
+            didResume = true
+            let tasks = [
+                cancelRenderWaiter ? renderWaiter : nil,
+                cancelTimeout ? timeoutWaiter : nil,
+            ].compactMap { $0 }
+            return (true, tasks)
+        }
+        guard resumeState.shouldResume else {
+            return
+        }
+        continuation.resume(returning: value)
+        for task in resumeState.tasksToCancel {
+            task.cancel()
+        }
+    }
+}
+
+enum MeetingCleanedMicrophoneRenderScheduler {
+    static func schedule(
+        outputURL: URL,
+        microphoneURL: URL?,
+        systemURL: URL?,
+        sourceAlignment: MeetingSourceAlignment,
+        sessionID: UUID,
+        conditionerFactory: @escaping @Sendable () -> any MicConditioning,
+        fileManager: FileManager,
+        eventName: String
+    ) -> MeetingCleanedMicrophoneReadiness {
+        guard let microphoneURL else {
+            discardArtifact(
+                at: outputURL,
+                sessionID: sessionID,
+                reason: "missing_microphone",
+                fileManager: fileManager,
+                eventName: eventName
+            )
+            appendDiagnostic(
+                eventName: eventName,
+                sessionID: sessionID,
+                outcome: "not_scheduled",
+                reason: .rawRenderFailed
+            )
+            return .notScheduled(reason: .rawRenderFailed)
+        }
+        guard let systemURL else {
+            discardArtifact(
+                at: outputURL,
+                sessionID: sessionID,
+                reason: "missing_system_reference",
+                fileManager: fileManager,
+                eventName: eventName
+            )
+            appendDiagnostic(
+                eventName: eventName,
+                sessionID: sessionID,
+                outcome: "not_scheduled",
+                reason: .rawMissingSystemReference
+            )
+            return .notScheduled(reason: .rawMissingSystemReference)
+        }
+
+        let rendererFileManager = UncheckedSendableBox(fileManager)
+        let task = Task.detached(priority: .utility) {
+            do {
+                let outcome = try await MeetingCleanedMicRenderer(
+                    fileManager: rendererFileManager.value
+                ).render(
+                    microphoneURL: microphoneURL,
+                    systemURL: systemURL,
+                    sourceAlignment: sourceAlignment,
+                    outputURL: outputURL,
+                    conditioner: conditionerFactory()
+                )
+                return handleOutcome(
+                    outcome,
+                    outputURL: outputURL,
+                    sessionID: sessionID,
+                    fileManager: rendererFileManager.value,
+                    eventName: eventName
+                )
+            } catch is CancellationError {
+                discardArtifact(
+                    at: outputURL,
+                    sessionID: sessionID,
+                    reason: "renderer_cancelled",
+                    fileManager: rendererFileManager.value,
+                    eventName: eventName
+                )
+                appendDiagnostic(
+                    eventName: eventName,
+                    sessionID: sessionID,
+                    outcome: "cancelled",
+                    reason: .rawRenderFailed
+                )
+                return .fallback(.rawRenderFailed)
+            } catch {
+                discardArtifact(
+                    at: outputURL,
+                    sessionID: sessionID,
+                    reason: "renderer_threw",
+                    fileManager: rendererFileManager.value,
+                    eventName: eventName
+                )
+                appendDiagnostic(
+                    eventName: eventName,
+                    sessionID: sessionID,
+                    outcome: "skipped",
+                    reason: .rawRenderFailed,
+                    detail: "error=\(AudioCaptureDiagnostics.errorType(error))"
+                )
+                return .fallback(.rawRenderFailed)
+            }
+        }
+
+        AudioCaptureDiagnostics.append(
+            "\(eventName) session=\(sessionID.uuidString) outcome=scheduled")
+        return .scheduled(outputURL: outputURL, task: task)
+    }
+
+    private static func handleOutcome(
+        _ outcome: MeetingCleanedMicRenderer.Outcome,
+        outputURL: URL,
+        sessionID: UUID,
+        fileManager: FileManager,
+        eventName: String
+    ) -> MeetingCleanedMicrophoneRenderCompletion {
+        switch outcome {
+        case .rendered(let result):
+            AudioCaptureDiagnostics.append(
+                "\(eventName) session=\(sessionID.uuidString) outcome=rendered duration_s=\(String(format: "%.3f", result.durationSeconds)) processed_frames=\(result.processedFrames) raw_fallback_frames=\(result.rawFallbackFrames) failures=\(result.processingFailures) rms_ratio=\(String(format: "%.2f", result.outputToRawRmsRatio))"
+            )
+            return .rendered(result.outputURL)
+        case .skipped(let reason):
+            let routingReason = routingReason(for: reason)
+            discardArtifact(
+                at: outputURL,
+                sessionID: sessionID,
+                reason: "renderer_skipped_\(String(describing: reason))",
+                fileManager: fileManager,
+                eventName: eventName
+            )
+            appendDiagnostic(
+                eventName: eventName,
+                sessionID: sessionID,
+                outcome: "skipped",
+                reason: routingReason,
+                detail: "renderer_reason=\(String(describing: reason))"
+            )
+            return .fallback(routingReason)
+        }
+    }
+
+    private static func routingReason(
+        for skipReason: MeetingCleanedMicRenderer.SkipReason
+    ) -> MeetingCleanedMicrophoneRoutingReason {
+        switch skipReason {
+        case .conditionerUnavailable:
+            return .rawNoAECAssets
+        case .missingSystemReference:
+            return .rawMissingSystemReference
+        case .missingMicrophoneSource, .emptyMicrophone, .inputTooLong, .decodeFailed, .renderFailed:
+            return .rawRenderFailed
+        }
+    }
+
+    private static func discardArtifact(
+        at outputURL: URL,
+        sessionID: UUID,
+        reason: String,
+        fileManager: FileManager,
+        eventName: String
+    ) {
+        guard fileManager.fileExists(atPath: outputURL.path) else { return }
+        do {
+            try fileManager.removeItem(at: outputURL)
+        } catch {
+            let removeError = error
+            if fileManager.createFile(atPath: outputURL.path, contents: Data(), attributes: nil) {
+                AudioCaptureDiagnostics.append(
+                    "\(eventName)_cleanup session=\(sessionID.uuidString) outcome=truncated reason=\(reason) remove_error=\(removeError.localizedDescription)")
+            } else {
+                AudioCaptureDiagnostics.append(
+                    "\(eventName)_cleanup session=\(sessionID.uuidString) outcome=failed reason=\(reason) remove_error=\(removeError.localizedDescription) truncate_error=createFile returned false")
+            }
+        }
+    }
+
+    private static func appendDiagnostic(
+        eventName: String,
+        sessionID: UUID,
+        outcome: String,
+        reason: MeetingCleanedMicrophoneRoutingReason,
+        detail: String? = nil
+    ) {
+        let suffix = detail.map { " \($0)" } ?? ""
+        AudioCaptureDiagnostics.append(
+            "\(eventName) session=\(sessionID.uuidString) outcome=\(outcome) reason=\(reason.rawValue)\(suffix)")
+    }
+}
+
+extension MeetingRecordingOutput {
+    func resolvedMicrophoneTranscriptionSource(
+        policy: MeetingCleanedMicrophoneReadinessPolicy = .production,
+        fileManager: FileManager = .default
+    ) async -> MeetingCleanedMicrophoneSourceDecision {
+        if let cleanedMicrophoneReadiness {
+            let timeoutSeconds = policy.timeoutSeconds(for: durationSeconds)
+            guard let completion = await cleanedMicrophoneReadiness.awaitCompletion(
+                timeoutSeconds: timeoutSeconds
+            ) else {
+                return .init(url: microphoneAudioURL, reason: .rawTimeout)
+            }
+            switch completion {
+            case .rendered(let url):
+                if Self.isViableCleanedMicrophoneFile(at: url, fileManager: fileManager) {
+                    return .init(url: url, reason: .cleanedUsed)
+                }
+                return .init(url: microphoneAudioURL, reason: .rawInvalidArtifact)
+            case .fallback(let reason):
+                return .init(url: microphoneAudioURL, reason: reason)
+            }
+        }
+
+        if let cleanedMicrophoneAudioURL {
+            if Self.isViableCleanedMicrophoneFile(
+                at: cleanedMicrophoneAudioURL,
+                fileManager: fileManager
+            ) {
+                return .init(url: cleanedMicrophoneAudioURL, reason: .cleanedUsed)
+            }
+            return .init(url: microphoneAudioURL, reason: .rawInvalidArtifact)
+        }
+
+        return .init(
+            url: microphoneAudioURL,
+            reason: sourceAlignment.system == nil ? .rawMissingSystemReference : .rawNoAECAssets
+        )
+    }
+}

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingCleanedMicrophoneReadiness.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingCleanedMicrophoneReadiness.swift
@@ -368,6 +368,30 @@ enum MeetingCleanedMicrophoneRenderScheduler {
         }
         let rendererFileManager = UncheckedSendableBox(fileManager)
         let candidateOutputURL = candidateOutputURL(for: outputURL, sessionID: sessionID)
+        guard hasTrustedEchoPathAlignment(sourceAlignment) else {
+            discardArtifact(
+                at: outputURL,
+                sessionID: sessionID,
+                reason: "untrusted_alignment",
+                fileManager: fileManager,
+                eventName: eventName
+            )
+            discardArtifact(
+                at: candidateOutputURL,
+                sessionID: sessionID,
+                reason: "untrusted_alignment",
+                fileManager: fileManager,
+                eventName: eventName
+            )
+            appendDiagnostic(
+                eventName: eventName,
+                sessionID: sessionID,
+                outcome: "not_scheduled",
+                reason: .skippedNoEchoPath,
+                detail: "alignment=untrusted"
+            )
+            return .notScheduled(reason: .skippedNoEchoPath)
+        }
         discardArtifact(
             at: outputURL,
             sessionID: sessionID,
@@ -451,6 +475,18 @@ enum MeetingCleanedMicrophoneRenderScheduler {
             .deletingLastPathComponent()
             .appendingPathComponent(".\(basename)-\(sessionID.uuidString).tmp")
             .appendingPathExtension(pathExtension)
+    }
+
+    private static func hasTrustedEchoPathAlignment(_ alignment: MeetingSourceAlignment) -> Bool {
+        guard let microphone = alignment.microphone,
+              let system = alignment.system else {
+            return false
+        }
+        return alignment.meetingOriginHostTime != nil
+            && microphone.firstHostTime != nil
+            && microphone.lastHostTime != nil
+            && system.firstHostTime != nil
+            && system.lastHostTime != nil
     }
 
     private static func handleOutcome(

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingOutput.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingOutput.swift
@@ -9,11 +9,12 @@ public struct MeetingRecordingOutput: Sendable, Equatable {
     public let microphoneAudioURL: URL
     public let systemAudioURL: URL
     /// Echo-cancelled microphone derived from the raw mic + system reference
-    /// after stop (plan #605 U3). `nil` for single-source meetings or when no
-    /// AEC assets are bundled. The raw `microphoneAudioURL` always stays the
-    /// source of truth; this is a derived artifact preferred for the local
-    /// ("Me") transcript via `microphoneTranscriptionURL(fileManager:)`.
+    /// after stop (plan #605 U3). For dual-source meetings this may be the
+    /// scheduled output path before the background render has completed. The raw
+    /// `microphoneAudioURL` always stays the source of truth; STT finalization
+    /// waits on `cleanedMicrophoneReadiness` before preferring this artifact.
     public let cleanedMicrophoneAudioURL: URL?
+    let cleanedMicrophoneReadiness: MeetingCleanedMicrophoneReadiness?
     public let durationSeconds: TimeInterval
     public let sourceAlignment: MeetingSourceAlignment
     public let speechEngine: SpeechEngineSelection
@@ -38,6 +39,38 @@ public struct MeetingRecordingOutput: Sendable, Equatable {
         speechEngineWasCaptured: Bool = true,
         userNotes: String? = nil
     ) {
+        self.init(
+            sessionID: sessionID,
+            displayName: displayName,
+            folderURL: folderURL,
+            mixedAudioURL: mixedAudioURL,
+            microphoneAudioURL: microphoneAudioURL,
+            systemAudioURL: systemAudioURL,
+            cleanedMicrophoneAudioURL: cleanedMicrophoneAudioURL,
+            cleanedMicrophoneReadiness: nil,
+            durationSeconds: durationSeconds,
+            sourceAlignment: sourceAlignment,
+            speechEngine: speechEngine,
+            speechEngineWasCaptured: speechEngineWasCaptured,
+            userNotes: userNotes
+        )
+    }
+
+    init(
+        sessionID: UUID,
+        displayName: String,
+        folderURL: URL,
+        mixedAudioURL: URL,
+        microphoneAudioURL: URL,
+        systemAudioURL: URL,
+        cleanedMicrophoneAudioURL: URL? = nil,
+        cleanedMicrophoneReadiness: MeetingCleanedMicrophoneReadiness?,
+        durationSeconds: TimeInterval,
+        sourceAlignment: MeetingSourceAlignment,
+        speechEngine: SpeechEngineSelection = SpeechEngineSelection(engine: .parakeet),
+        speechEngineWasCaptured: Bool = true,
+        userNotes: String? = nil
+    ) {
         self.sessionID = sessionID
         self.displayName = displayName
         self.folderURL = folderURL
@@ -45,6 +78,7 @@ public struct MeetingRecordingOutput: Sendable, Equatable {
         self.microphoneAudioURL = microphoneAudioURL
         self.systemAudioURL = systemAudioURL
         self.cleanedMicrophoneAudioURL = cleanedMicrophoneAudioURL
+        self.cleanedMicrophoneReadiness = cleanedMicrophoneReadiness
         self.durationSeconds = durationSeconds
         self.sourceAlignment = sourceAlignment
         self.speechEngine = speechEngine
@@ -76,7 +110,7 @@ public struct MeetingRecordingOutput: Sendable, Equatable {
         return microphoneAudioURL
     }
 
-    private static func isViableCleanedMicrophoneFile(
+    static func isViableCleanedMicrophoneFile(
         at url: URL,
         fileManager: FileManager = .default
     ) -> Bool {
@@ -150,5 +184,20 @@ public struct MeetingRecordingOutput: Sendable, Equatable {
         fileManager: FileManager = .default
     ) -> Bool {
         fileManager.fileExists(atPath: url.path)
+    }
+
+    public static func == (lhs: MeetingRecordingOutput, rhs: MeetingRecordingOutput) -> Bool {
+        lhs.sessionID == rhs.sessionID
+            && lhs.displayName == rhs.displayName
+            && lhs.folderURL == rhs.folderURL
+            && lhs.mixedAudioURL == rhs.mixedAudioURL
+            && lhs.microphoneAudioURL == rhs.microphoneAudioURL
+            && lhs.systemAudioURL == rhs.systemAudioURL
+            && lhs.cleanedMicrophoneAudioURL == rhs.cleanedMicrophoneAudioURL
+            && lhs.durationSeconds == rhs.durationSeconds
+            && lhs.sourceAlignment == rhs.sourceAlignment
+            && lhs.speechEngine == rhs.speechEngine
+            && lhs.speechEngineWasCaptured == rhs.speechEngineWasCaptured
+            && lhs.userNotes == rhs.userNotes
     }
 }

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingRecoveryService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingRecoveryService.swift
@@ -217,7 +217,7 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
 
         let recoveredBySource = Dictionary(
             recoveredSources.map { ($0.source, $0.url) }, uniquingKeysWith: { first, _ in first })
-        let cleanedMicrophoneAudioURL = await renderCleanedMicrophone(
+        let cleanedMicrophoneReadiness = scheduleCleanedMicrophoneRender(
             folderURL: folderURL,
             microphoneURL: recoveredBySource[.microphone],
             systemURL: recoveredBySource[.system],
@@ -240,7 +240,8 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
             mixedAudioURL: mixedURL,
             microphoneAudioURL: microphoneURL,
             systemAudioURL: systemURL,
-            cleanedMicrophoneAudioURL: cleanedMicrophoneAudioURL,
+            cleanedMicrophoneAudioURL: cleanedMicrophoneReadiness.outputURL,
+            cleanedMicrophoneReadiness: cleanedMicrophoneReadiness,
             durationSeconds: duration,
             sourceAlignment: sourceAlignment,
             speechEngine: lock.speechEngine,
@@ -278,96 +279,28 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
         }
     }
 
-    /// Re-derive `microphone-cleaned.m4a` from the recovered mic + system audio
-    /// (plan #605 U3) only when source alignment is trustworthy. Interrupted
-    /// sessions currently synthesize zero start offsets because lock files do not
-    /// persist per-source host times; in that case, return `nil` so final STT
-    /// falls back to raw mic instead of preferring a possibly misaligned cleaned
-    /// artifact. Render failures/cancellation fall back to raw mic and never
-    /// throw into the recovery path.
-    private func renderCleanedMicrophone(
+    /// Re-derive `microphone-cleaned.m4a` from recovered mic + system audio on
+    /// the same readiness gate as the normal stop path. Recovery does not block
+    /// here; final STT owns the bounded wait and observable raw fallback.
+    private func scheduleCleanedMicrophoneRender(
         folderURL: URL,
         microphoneURL: URL?,
         systemURL: URL?,
         sourceAlignment: MeetingSourceAlignment,
         sessionID: UUID
-    ) async -> URL? {
+    ) -> MeetingCleanedMicrophoneReadiness {
         let outputURL = folderURL.appendingPathComponent(
             MeetingCleanedMicRenderer.cleanedMicrophoneFileName)
-        guard let microphoneURL, let systemURL else {
-            discardCleanedMicrophoneArtifact(
-                at: outputURL, sessionID: sessionID, reason: "missing_source")
-            return nil
-        }
-        guard sourceAlignment.meetingOriginHostTime != nil,
-              sourceAlignment.microphone?.firstHostTime != nil,
-              sourceAlignment.system?.firstHostTime != nil else {
-            discardCleanedMicrophoneArtifact(
-                at: outputURL, sessionID: sessionID, reason: "synthetic_alignment")
-            logger.info("meeting_recovery_cleaned_mic session=\(sessionID.uuidString, privacy: .public) outcome=skipped reason=synthetic_alignment")
-            return nil
-        }
-        let conditionerFactory = micConditionerFactory
-        let rendererFileManager = UncheckedSendableBox(fileManager)
-
-        let task = Task.detached(priority: .utility) {
-            try await MeetingCleanedMicRenderer(fileManager: rendererFileManager.value).render(
-                microphoneURL: microphoneURL,
-                systemURL: systemURL,
-                sourceAlignment: sourceAlignment,
-                outputURL: outputURL,
-                conditioner: conditionerFactory())
-        }
-
-        let outcome: MeetingCleanedMicRenderer.Outcome
-        do {
-            outcome = try await withTaskCancellationHandler {
-                try await task.value
-            } onCancel: {
-                task.cancel()
-            }
-        } catch is CancellationError {
-            discardCleanedMicrophoneArtifact(
-                at: outputURL, sessionID: sessionID, reason: "renderer_cancelled")
-            logger.info("meeting_recovery_cleaned_mic session=\(sessionID.uuidString, privacy: .public) outcome=cancelled")
-            return nil
-        } catch {
-            discardCleanedMicrophoneArtifact(
-                at: outputURL, sessionID: sessionID, reason: "renderer_threw")
-            logger.info("meeting_recovery_cleaned_mic session=\(sessionID.uuidString, privacy: .public) outcome=skipped reason=renderer_threw")
-            return nil
-        }
-
-        switch outcome {
-        case .rendered(let result):
-            logger.info("meeting_recovery_cleaned_mic session=\(sessionID.uuidString, privacy: .public) outcome=rendered failures=\(result.processingFailures, privacy: .public)")
-            return result.outputURL
-        case .skipped(let reason):
-            discardCleanedMicrophoneArtifact(
-                at: outputURL,
-                sessionID: sessionID,
-                reason: "renderer_skipped_\(String(describing: reason))")
-            logger.info("meeting_recovery_cleaned_mic session=\(sessionID.uuidString, privacy: .public) outcome=skipped reason=\(String(describing: reason), privacy: .public)")
-            return nil
-        }
-    }
-
-    private func discardCleanedMicrophoneArtifact(
-        at outputURL: URL,
-        sessionID: UUID,
-        reason: String
-    ) {
-        guard fileManager.fileExists(atPath: outputURL.path) else { return }
-        do {
-            try fileManager.removeItem(at: outputURL)
-        } catch {
-            let removeError = error
-            if fileManager.createFile(atPath: outputURL.path, contents: Data(), attributes: nil) {
-                logger.warning("meeting_recovery_cleaned_mic_cleanup session=\(sessionID.uuidString, privacy: .public) outcome=truncated reason=\(reason, privacy: .public) remove_error=\(removeError.localizedDescription, privacy: .private)")
-            } else {
-                logger.error("meeting_recovery_cleaned_mic_cleanup session=\(sessionID.uuidString, privacy: .public) outcome=failed reason=\(reason, privacy: .public) remove_error=\(removeError.localizedDescription, privacy: .private) truncate_error=createFile returned false")
-            }
-        }
+        return MeetingCleanedMicrophoneRenderScheduler.schedule(
+            outputURL: outputURL,
+            microphoneURL: microphoneURL,
+            systemURL: systemURL,
+            sourceAlignment: sourceAlignment,
+            sessionID: sessionID,
+            conditionerFactory: micConditionerFactory,
+            fileManager: fileManager,
+            eventName: "meeting_recovery_cleaned_mic"
+        )
     }
 
     private func makeRecoveredAlignment(

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
@@ -596,12 +596,6 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
             preservePlayableMeetingAudioFallback(inputURLs: inputURLs, outputURL: session.mixedAudioURL)
         }
 
-        let cleanedMicrophoneReadiness = scheduleCleanedMicrophoneRender(
-            session: session,
-            availableSources: availableSources,
-            sourceAlignment: sourceAlignment
-        )
-
         let finalNotes = currentNotes
         let notesFileManager = MeetingNotesFile.SendableFileManager(fileManager)
         do {
@@ -636,6 +630,12 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
             throw MeetingAudioError.storageFailed(error.localizedDescription)
         }
         currentLockFile = awaitingLock
+
+        let cleanedMicrophoneReadiness = scheduleCleanedMicrophoneRender(
+            session: session,
+            availableSources: availableSources,
+            sourceAlignment: sourceAlignment
+        )
 
         // Stop while paused: settle the in-flight pause interval into the
         // accumulated total so the persisted duration only reflects time

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
@@ -86,6 +86,17 @@ public extension MeetingRecordingServiceProtocol {
     }
 }
 
+typealias MeetingCleanedMicrophoneReadinessScheduling = @Sendable (
+    _ outputURL: URL,
+    _ microphoneURL: URL?,
+    _ systemURL: URL?,
+    _ sourceAlignment: MeetingSourceAlignment,
+    _ sessionID: UUID,
+    _ conditionerFactory: @escaping @Sendable () -> any MicConditioning,
+    _ fileManager: FileManager,
+    _ eventName: String
+) -> MeetingCleanedMicrophoneReadiness
+
 public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
     private struct SourceCaptureMetrics: Sendable {
         var firstHostTime: UInt64?
@@ -172,6 +183,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
     private let speechEngineSessionManager: (any SpeechEngineSessionManaging)?
     private let micConditionerFactory: @Sendable () -> any MicConditioning
     private let cleanedMicConditionerFactory: @Sendable () -> any MicConditioning
+    private let cleanedMicrophoneReadinessScheduler: MeetingCleanedMicrophoneReadinessScheduling
 
     private var currentSession: Session?
     /// Buffer-discard flag for pause/resume. Reset in `cleanupState`.
@@ -281,7 +293,19 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         fileManager: FileManager = .default,
         isVadLiveChunkingEnabled: @escaping @Sendable () -> Bool = { false },
         micConditionerFactory: @escaping @Sendable () -> any MicConditioning,
-        cleanedMicConditionerFactory: (@Sendable () -> any MicConditioning)? = nil
+        cleanedMicConditionerFactory: (@Sendable () -> any MicConditioning)? = nil,
+        cleanedMicrophoneReadinessScheduler: @escaping MeetingCleanedMicrophoneReadinessScheduling = { outputURL, microphoneURL, systemURL, sourceAlignment, sessionID, conditionerFactory, fileManager, eventName in
+            MeetingCleanedMicrophoneRenderScheduler.schedule(
+                outputURL: outputURL,
+                microphoneURL: microphoneURL,
+                systemURL: systemURL,
+                sourceAlignment: sourceAlignment,
+                sessionID: sessionID,
+                conditionerFactory: conditionerFactory,
+                fileManager: fileManager,
+                eventName: eventName
+            )
+        }
     ) {
         self.requestedMicProcessingMode = micProcessingMode
         self.audioCaptureService = audioCaptureService
@@ -291,6 +315,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         self.isVadLiveChunkingEnabled = isVadLiveChunkingEnabled
         self.micConditionerFactory = micConditionerFactory
         self.cleanedMicConditionerFactory = cleanedMicConditionerFactory ?? micConditionerFactory
+        self.cleanedMicrophoneReadinessScheduler = cleanedMicrophoneReadinessScheduler
         self.liveChunkTranscriber = LiveChunkTranscriber(sttTranscriber: sttTranscriber)
         self.speechEngineSessionManager = sttTranscriber as? any SpeechEngineSessionManaging
     }
@@ -1260,15 +1285,15 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
     ) -> MeetingCleanedMicrophoneReadiness {
         let outputURL = session.folderURL.appendingPathComponent(
             MeetingCleanedMicRenderer.cleanedMicrophoneFileName)
-        return MeetingCleanedMicrophoneRenderScheduler.schedule(
-            outputURL: outputURL,
-            microphoneURL: availableSources.contains(.microphone) ? session.microphoneAudioURL : nil,
-            systemURL: availableSources.contains(.system) ? session.systemAudioURL : nil,
-            sourceAlignment: sourceAlignment,
-            sessionID: session.id,
-            conditionerFactory: cleanedMicConditionerFactory,
-            fileManager: fileManager,
-            eventName: "meeting_cleaned_mic"
+        return cleanedMicrophoneReadinessScheduler(
+            outputURL,
+            availableSources.contains(.microphone) ? session.microphoneAudioURL : nil,
+            availableSources.contains(.system) ? session.systemAudioURL : nil,
+            sourceAlignment,
+            session.id,
+            cleanedMicConditionerFactory,
+            fileManager,
+            "meeting_cleaned_mic"
         )
     }
 

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
@@ -171,6 +171,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
     private let lockFileStore: MeetingRecordingLockFileStoring
     private let speechEngineSessionManager: (any SpeechEngineSessionManaging)?
     private let micConditionerFactory: @Sendable () -> any MicConditioning
+    private let cleanedMicConditionerFactory: @Sendable () -> any MicConditioning
 
     private var currentSession: Session?
     /// Buffer-discard flag for pause/resume. Reset in `cleanupState`.
@@ -279,7 +280,8 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         lockFileStore: MeetingRecordingLockFileStoring = MeetingRecordingLockFileStore(),
         fileManager: FileManager = .default,
         isVadLiveChunkingEnabled: @escaping @Sendable () -> Bool = { false },
-        micConditionerFactory: @escaping @Sendable () -> any MicConditioning
+        micConditionerFactory: @escaping @Sendable () -> any MicConditioning,
+        cleanedMicConditionerFactory: (@Sendable () -> any MicConditioning)? = nil
     ) {
         self.requestedMicProcessingMode = micProcessingMode
         self.audioCaptureService = audioCaptureService
@@ -288,6 +290,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         self.fileManager = fileManager
         self.isVadLiveChunkingEnabled = isVadLiveChunkingEnabled
         self.micConditionerFactory = micConditionerFactory
+        self.cleanedMicConditionerFactory = cleanedMicConditionerFactory ?? micConditionerFactory
         self.liveChunkTranscriber = LiveChunkTranscriber(sttTranscriber: sttTranscriber)
         self.speechEngineSessionManager = sttTranscriber as? any SpeechEngineSessionManaging
     }
@@ -593,7 +596,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
             preservePlayableMeetingAudioFallback(inputURLs: inputURLs, outputURL: session.mixedAudioURL)
         }
 
-        let cleanedMicrophoneAudioURL = await renderCleanedMicrophone(
+        let cleanedMicrophoneReadiness = scheduleCleanedMicrophoneRender(
             session: session,
             availableSources: availableSources,
             sourceAlignment: sourceAlignment
@@ -651,7 +654,8 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
             mixedAudioURL: session.mixedAudioURL,
             microphoneAudioURL: session.microphoneAudioURL,
             systemAudioURL: session.systemAudioURL,
-            cleanedMicrophoneAudioURL: cleanedMicrophoneAudioURL,
+            cleanedMicrophoneAudioURL: cleanedMicrophoneReadiness.outputURL,
+            cleanedMicrophoneReadiness: cleanedMicrophoneReadiness,
             durationSeconds: durationSeconds,
             sourceAlignment: sourceAlignment,
             speechEngine: session.speechEngine,
@@ -1246,102 +1250,26 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         return .system
     }
 
-    /// Derive `microphone-cleaned.m4a` from the raw mic + system sources using a
-    /// freshly built echo suppressor (plan #605 U3). Returns the cleaned file URL
-    /// when a real suppressor is loaded and both sources exist; `nil` (raw mic
-    /// stays the truth) for single-source meetings, when no AEC assets are
-    /// bundled, or on any render failure/cancellation. Never throws into finalize.
-    private func renderCleanedMicrophone(
+    /// Schedule `microphone-cleaned.m4a` derivation from the raw mic + system
+    /// sources. The returned readiness handle is the final-STT gate; stop must
+    /// not wait for model-backed render work.
+    private func scheduleCleanedMicrophoneRender(
         session: Session,
         availableSources: Set<AudioSource>,
         sourceAlignment: MeetingSourceAlignment
-    ) async -> URL? {
+    ) -> MeetingCleanedMicrophoneReadiness {
         let outputURL = session.folderURL.appendingPathComponent(
             MeetingCleanedMicRenderer.cleanedMicrophoneFileName)
-        // A cleaned mic needs a system reference to cancel against; single-source
-        // meetings have nothing to subtract.
-        guard availableSources.contains(.microphone),
-              availableSources.contains(.system) else {
-            discardCleanedMicrophoneArtifact(
-                at: outputURL, sessionID: session.id, reason: "missing_source")
-            return nil
-        }
-
-        let microphoneURL = session.microphoneAudioURL
-        let systemURL = session.systemAudioURL
-        let conditionerFactory = micConditionerFactory
-        let rendererFileManager = UncheckedSendableBox(fileManager)
-
-        // Heavy decode/DSP/encode runs off the actor; the suppressor (and its
-        // dylib load) is built inside the detached task so it never blocks
-        // recording state. A fresh suppressor starts from clean filter state
-        // rather than inheriting the live preview's adapted taps.
-        let task = Task.detached(priority: .utility) {
-            try await MeetingCleanedMicRenderer(fileManager: rendererFileManager.value).render(
-                microphoneURL: microphoneURL,
-                systemURL: systemURL,
-                sourceAlignment: sourceAlignment,
-                outputURL: outputURL,
-                conditioner: conditionerFactory())
-        }
-
-        let outcome: MeetingCleanedMicRenderer.Outcome
-        do {
-            outcome = try await withTaskCancellationHandler {
-                try await task.value
-            } onCancel: {
-                task.cancel()
-            }
-        } catch is CancellationError {
-            discardCleanedMicrophoneArtifact(
-                at: outputURL, sessionID: session.id, reason: "renderer_cancelled")
-            AudioCaptureDiagnostics.append(
-                "meeting_cleaned_mic session=\(session.id.uuidString) outcome=cancelled")
-            return nil
-        } catch {
-            discardCleanedMicrophoneArtifact(
-                at: outputURL, sessionID: session.id, reason: "renderer_threw")
-            AudioCaptureDiagnostics.append(
-                "meeting_cleaned_mic session=\(session.id.uuidString) outcome=skipped reason=renderer_threw_\(error.localizedDescription)")
-            return nil
-        }
-
-        switch outcome {
-        case .rendered(let result):
-            AudioCaptureDiagnostics.append(
-                "meeting_cleaned_mic session=\(session.id.uuidString) outcome=rendered duration_s=\(String(format: "%.3f", result.durationSeconds)) processed_frames=\(result.processedFrames) raw_fallback_frames=\(result.rawFallbackFrames) failures=\(result.processingFailures) rms_ratio=\(String(format: "%.2f", result.outputToRawRmsRatio))"
-            )
-            return result.outputURL
-        case .skipped(let reason):
-            discardCleanedMicrophoneArtifact(
-                at: outputURL,
-                sessionID: session.id,
-                reason: "renderer_skipped_\(String(describing: reason))")
-            AudioCaptureDiagnostics.append(
-                "meeting_cleaned_mic session=\(session.id.uuidString) outcome=skipped reason=\(String(describing: reason))"
-            )
-            return nil
-        }
-    }
-
-    private func discardCleanedMicrophoneArtifact(
-        at outputURL: URL,
-        sessionID: UUID,
-        reason: String
-    ) {
-        guard fileManager.fileExists(atPath: outputURL.path) else { return }
-        do {
-            try fileManager.removeItem(at: outputURL)
-        } catch {
-            let removeError = error
-            if fileManager.createFile(atPath: outputURL.path, contents: Data(), attributes: nil) {
-                AudioCaptureDiagnostics.append(
-                    "meeting_cleaned_mic_cleanup session=\(sessionID.uuidString) outcome=truncated reason=\(reason) remove_error=\(removeError.localizedDescription)")
-            } else {
-                AudioCaptureDiagnostics.append(
-                    "meeting_cleaned_mic_cleanup session=\(sessionID.uuidString) outcome=failed reason=\(reason) remove_error=\(removeError.localizedDescription) truncate_error=createFile returned false")
-            }
-        }
+        return MeetingCleanedMicrophoneRenderScheduler.schedule(
+            outputURL: outputURL,
+            microphoneURL: availableSources.contains(.microphone) ? session.microphoneAudioURL : nil,
+            systemURL: availableSources.contains(.system) ? session.systemAudioURL : nil,
+            sourceAlignment: sourceAlignment,
+            sessionID: session.id,
+            conditionerFactory: cleanedMicConditionerFactory,
+            fileManager: fileManager,
+            eventName: "meeting_cleaned_mic"
+        )
     }
 
     private func buildSourceAlignment(

--- a/Sources/MacParakeetCore/Services/TranscriptionService.swift
+++ b/Sources/MacParakeetCore/Services/TranscriptionService.swift
@@ -1233,7 +1233,7 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
         let activeSources = [AudioSource.microphone, .system].filter { recording.sourceAlignment.track(for: $0) != nil }
         let speechEngine = speechEngineOverride ?? (recording.speechEngineWasCaptured ? recording.speechEngine : nil)
         let microphoneDecision = activeSources.contains(.microphone)
-            ? await resolveMeetingMicrophoneSource(for: recording)
+            ? try await resolveMeetingMicrophoneSource(for: recording)
             : nil
 
         for (index, source) in activeSources.enumerated() {
@@ -1336,14 +1336,14 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
 
     private func resolveMeetingMicrophoneSource(
         for recording: MeetingRecordingOutput
-    ) async -> MeetingCleanedMicrophoneSourceDecision {
-        let decision = await recording.resolvedMicrophoneTranscriptionSource(
-            policy: meetingCleanedMicrophoneReadinessPolicy
-        )
-        let selected = decision.usesCleanedMicrophone ? "cleaned" : "raw"
+    ) async throws -> MeetingCleanedMicrophoneSourceDecision {
         let timeoutSeconds = meetingCleanedMicrophoneReadinessPolicy.timeoutSeconds(
             for: recording.durationSeconds
         )
+        let decision = try await recording.resolvedMicrophoneTranscriptionSource(
+            policy: meetingCleanedMicrophoneReadinessPolicy
+        )
+        let selected = decision.usesCleanedMicrophone ? "cleaned" : "raw"
         logger.info(
             "meeting_cleaned_mic_source session=\(recording.sessionID.uuidString, privacy: .public) selected=\(selected, privacy: .public) reason=\(decision.reason.rawValue, privacy: .public) timeout_s=\(timeoutSeconds, format: .fixed(precision: 3), privacy: .public)"
         )

--- a/Sources/MacParakeetCore/Services/TranscriptionService.swift
+++ b/Sources/MacParakeetCore/Services/TranscriptionService.swift
@@ -240,6 +240,7 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
     private let playbackConverter: YouTubeAudioPlaybackConverting
     private let meetingArtifactStore: MeetingArtifactStoring?
     private let meetingAutomationHookRunner: MeetingAutomationHookRunning?
+    private let meetingCleanedMicrophoneReadinessPolicy: MeetingCleanedMicrophoneReadinessPolicy
 
     public init(
         audioProcessor: AudioProcessorProtocol,
@@ -266,7 +267,8 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
         thumbnailCache: ThumbnailCaching = ThumbnailCacheService.shared,
         playbackConverter: YouTubeAudioPlaybackConverting = YouTubeAudioPlaybackConverter(),
         meetingArtifactStore: MeetingArtifactStoring? = MeetingArtifactStore(),
-        meetingAutomationHookRunner: MeetingAutomationHookRunning? = MeetingAutomationHookRunner()
+        meetingAutomationHookRunner: MeetingAutomationHookRunning? = MeetingAutomationHookRunner(),
+        meetingCleanedMicrophoneReadinessPolicy: MeetingCleanedMicrophoneReadinessPolicy = .production
     ) {
         self.audioProcessor = audioProcessor
         self.sttTranscriber = sttTranscriber
@@ -294,6 +296,7 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
         self.playbackConverter = playbackConverter
         self.meetingArtifactStore = meetingArtifactStore
         self.meetingAutomationHookRunner = meetingAutomationHookRunner
+        self.meetingCleanedMicrophoneReadinessPolicy = meetingCleanedMicrophoneReadinessPolicy
     }
 
     public func transcribe(
@@ -1229,9 +1232,16 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
         var outputs: [MeetingTranscriptFinalizer.SourceTranscript] = []
         let activeSources = [AudioSource.microphone, .system].filter { recording.sourceAlignment.track(for: $0) != nil }
         let speechEngine = speechEngineOverride ?? (recording.speechEngineWasCaptured ? recording.speechEngine : nil)
+        let microphoneDecision = activeSources.contains(.microphone)
+            ? await resolveMeetingMicrophoneSource(for: recording)
+            : nil
 
         for (index, source) in activeSources.enumerated() {
-            let fileURL = meetingAudioURL(for: source, recording: recording)
+            let fileURL = meetingAudioURL(
+                for: source,
+                recording: recording,
+                microphoneDecision: microphoneDecision
+            )
             lifecycleStage = .audioConversion
             onProgress?(.converting)
             let wavURL = try await audioProcessor.convert(fileURL: fileURL)
@@ -1324,13 +1334,36 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
         }
     }
 
-    private func meetingAudioURL(for source: AudioSource, recording: MeetingRecordingOutput) -> URL {
+    private func resolveMeetingMicrophoneSource(
+        for recording: MeetingRecordingOutput
+    ) async -> MeetingCleanedMicrophoneSourceDecision {
+        let decision = await recording.resolvedMicrophoneTranscriptionSource(
+            policy: meetingCleanedMicrophoneReadinessPolicy
+        )
+        let selected = decision.usesCleanedMicrophone ? "cleaned" : "raw"
+        let timeoutSeconds = meetingCleanedMicrophoneReadinessPolicy.timeoutSeconds(
+            for: recording.durationSeconds
+        )
+        logger.info(
+            "meeting_cleaned_mic_source session=\(recording.sessionID.uuidString, privacy: .public) selected=\(selected, privacy: .public) reason=\(decision.reason.rawValue, privacy: .public) timeout_s=\(timeoutSeconds, format: .fixed(precision: 3), privacy: .public)"
+        )
+        AudioCaptureDiagnostics.append(
+            "meeting_cleaned_mic_source session=\(recording.sessionID.uuidString) selected=\(selected) reason=\(decision.reason.rawValue) timeout_s=\(String(format: "%.3f", timeoutSeconds))"
+        )
+        return decision
+    }
+
+    private func meetingAudioURL(
+        for source: AudioSource,
+        recording: MeetingRecordingOutput,
+        microphoneDecision: MeetingCleanedMicrophoneSourceDecision?
+    ) -> URL {
         switch source {
         case .microphone:
             // Transcribe the echo-cancelled mic when it was derived (plan #605
-            // U3/U4) so remote speaker bleed does not surface as false "Me"
-            // text; falls back to the raw mic when no cleaned artifact exists.
-            return recording.validatedMicrophoneTranscriptionURL()
+            // U3/U4) and ready before the bounded deadline so remote speaker
+            // bleed does not surface as false "Me" text.
+            return microphoneDecision?.url ?? recording.validatedMicrophoneTranscriptionURL()
         case .system:
             return recording.systemAudioURL
         }

--- a/Tests/MacParakeetTests/Services/Capture/MeetingAecRenderThroughputTests.swift
+++ b/Tests/MacParakeetTests/Services/Capture/MeetingAecRenderThroughputTests.swift
@@ -1,0 +1,76 @@
+import XCTest
+@testable import MacParakeetCore
+
+/// Env-gated timing probe for the production cleaned-mic conditioning core with
+/// real LocalVQE assets. This is intentionally skipped in normal CI; run locally with:
+///
+///   MACPARAKEET_TEST_LOCALVQE_LIBRARY=/path/to/liblocalvqe.dylib \
+///   MACPARAKEET_TEST_LOCALVQE_MODEL=/path/to/localvqe-v1.4-aec-200K-f32.gguf \
+///   swift test --filter MeetingAecRenderThroughputTests
+final class MeetingAecRenderThroughputTests: XCTestCase {
+    private static let libraryKey = "MACPARAKEET_TEST_LOCALVQE_LIBRARY"
+    private static let modelKey = "MACPARAKEET_TEST_LOCALVQE_MODEL"
+
+    func testLocalVQECleanedMicRenderThroughput() async throws {
+        let env = ProcessInfo.processInfo.environment
+        guard let libraryPath = env[Self.libraryKey]?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !libraryPath.isEmpty,
+              let modelPath = env[Self.modelKey]?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !modelPath.isEmpty else {
+            throw XCTSkip("Set \(Self.libraryKey) and \(Self.modelKey) to measure real LocalVQE render throughput.")
+        }
+
+        let libraryURL = URL(fileURLWithPath: libraryPath)
+        let modelURL = URL(fileURLWithPath: modelPath)
+        try XCTSkipUnless(FileManager.default.fileExists(atPath: libraryURL.path), "Missing LocalVQE library.")
+        try XCTSkipUnless(FileManager.default.fileExists(atPath: modelURL.path), "Missing LocalVQE model.")
+
+        let seconds = 60
+        let sampleRate = MeetingCleanedMicRenderer.renderSampleRate
+        let scenario = MeetingAecScenarioFactory.make(
+            name: "localvqe-render-throughput",
+            nearEndActive: true,
+            farEndActive: true,
+            echoPath: MeetingAecEchoPath(
+                taps: [(delay: 120, gain: 0.6), (delay: 180, gain: 0.25), (delay: 240, gain: 0.12)]
+            ),
+            sampleCount: seconds * sampleRate
+        )
+
+        let conditioner = MeetingEchoSuppressionFactory.makeConditioner(
+            configuration: MeetingEchoSuppressionConfiguration(
+                mode: .dynamicLibrary,
+                libraryURL: libraryURL,
+                modelURL: modelURL,
+                sampleRate: sampleRate,
+                frameSize: MeetingEchoSuppressionConfiguration.defaultFrameSize,
+                adaptiveReferenceDelay: false
+            )
+        )
+        try XCTSkipUnless(conditioner.diagnostics.loaded, "LocalVQE conditioner did not load.")
+
+        let started = ContinuousClock.now
+        let result = try MeetingCleanedMicRenderer.alignAndCondition(
+            microphone: scenario.mic,
+            system: scenario.farEnd,
+            microphoneStartOffsetMs: 0,
+            systemStartOffsetMs: 0,
+            sampleRate: sampleRate,
+            conditioner: conditioner
+        )
+        let elapsed = started.duration(to: .now)
+        let elapsedSeconds = Double(elapsed.components.seconds)
+            + Double(elapsed.components.attoseconds) / 1_000_000_000_000_000_000
+        let audioSeconds = Double(result.output.count) / Double(sampleRate)
+        let realtimeFactor = audioSeconds / elapsedSeconds
+        print(String(
+            format: "[AEC-THROUGHPUT] LocalVQE cleaned-mic conditioning: audio %.1fs elapsed %.3fs throughput %.2fx failures %ld",
+            audioSeconds,
+            elapsedSeconds,
+            realtimeFactor,
+            result.processingFailures
+        ))
+        XCTAssertEqual(result.output.count, scenario.sampleCount)
+        XCTAssertEqual(result.processingFailures, 0)
+    }
+}

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingArtifactStoreTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingArtifactStoreTests.swift
@@ -273,13 +273,9 @@ final class MeetingArtifactStoreTests: XCTestCase {
             let file = try AVAudioFile(
                 forWriting: url,
                 settings: [
-                    AVFormatIDKey: kAudioFormatLinearPCM,
+                    AVFormatIDKey: kAudioFormatAppleLossless,
                     AVSampleRateKey: sampleRate,
                     AVNumberOfChannelsKey: 1,
-                    AVLinearPCMBitDepthKey: 32,
-                    AVLinearPCMIsFloatKey: true,
-                    AVLinearPCMIsBigEndianKey: false,
-                    AVLinearPCMIsNonInterleaved: true,
                 ],
                 commonFormat: .pcmFormatFloat32,
                 interleaved: false

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingArtifactStoreTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingArtifactStoreTests.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import Foundation
 import XCTest
 @testable import MacParakeetCore
@@ -108,7 +109,7 @@ final class MeetingArtifactStoreTests: XCTestCase {
 
     func testMaterializeIncludesCleanedMicrophoneAudioPathWhenArtifactExists() async throws {
         let cleanedURL = folderURL.appendingPathComponent("microphone-cleaned.m4a")
-        try Data("cleaned".utf8).write(to: cleanedURL)
+        try writeM4A(to: cleanedURL)
         let transcription = makeMeeting(notes: nil)
 
         let snapshot = try await MeetingArtifactStore().materialize(
@@ -119,6 +120,21 @@ final class MeetingArtifactStoreTests: XCTestCase {
         let manifest = try jsonObject(at: URL(fileURLWithPath: snapshot.manifestPath))
         let files = try XCTUnwrap(manifest["files"] as? [String: Any])
         XCTAssertEqual(files["cleanedMicrophoneAudioPath"] as? String, cleanedURL.path)
+    }
+
+    func testMaterializeOmitsInvalidCleanedMicrophoneAudioPath() async throws {
+        let cleanedURL = folderURL.appendingPathComponent("microphone-cleaned.m4a")
+        try Data("partial m4a fragment".utf8).write(to: cleanedURL)
+        let transcription = makeMeeting(notes: nil)
+
+        let snapshot = try await MeetingArtifactStore().materialize(
+            transcription: transcription,
+            promptResults: []
+        )
+
+        let manifest = try jsonObject(at: URL(fileURLWithPath: snapshot.manifestPath))
+        let files = try XCTUnwrap(manifest["files"] as? [String: Any])
+        XCTAssertNil(files["cleanedMicrophoneAudioPath"] as? String)
     }
 
     func testMaterializeRemovesStaleNotesAndPromptResultFiles() async throws {
@@ -224,6 +240,52 @@ final class MeetingArtifactStoreTests: XCTestCase {
             engine: "parakeet",
             engineVariant: "v3"
         )
+    }
+
+    private func writeM4A(to url: URL, sampleRate: Double = 16_000) throws {
+        let frameCount = Int(sampleRate / 10)
+        let format = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: sampleRate,
+            channels: 1,
+            interleaved: false
+        )!
+        let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: AVAudioFrameCount(frameCount))!
+        buffer.frameLength = AVAudioFrameCount(frameCount)
+        let samples = buffer.floatChannelData![0]
+        for index in 0..<frameCount {
+            samples[index] = 0.1
+        }
+
+        do {
+            let file = try AVAudioFile(
+                forWriting: url,
+                settings: [
+                    AVFormatIDKey: kAudioFormatMPEG4AAC,
+                    AVSampleRateKey: sampleRate,
+                    AVNumberOfChannelsKey: 1,
+                ],
+                commonFormat: .pcmFormatFloat32,
+                interleaved: false
+            )
+            try file.write(from: buffer)
+        } catch {
+            let file = try AVAudioFile(
+                forWriting: url,
+                settings: [
+                    AVFormatIDKey: kAudioFormatLinearPCM,
+                    AVSampleRateKey: sampleRate,
+                    AVNumberOfChannelsKey: 1,
+                    AVLinearPCMBitDepthKey: 32,
+                    AVLinearPCMIsFloatKey: true,
+                    AVLinearPCMIsBigEndianKey: false,
+                    AVLinearPCMIsNonInterleaved: true,
+                ],
+                commonFormat: .pcmFormatFloat32,
+                interleaved: false
+            )
+            try file.write(from: buffer)
+        }
     }
 
     private func jsonObject(at url: URL) throws -> [String: Any] {

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingArtifactStoreTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingArtifactStoreTests.swift
@@ -83,6 +83,7 @@ final class MeetingArtifactStoreTests: XCTestCase {
         XCTAssertEqual(files["mixedAudioPath"] as? String, transcription.filePath)
         XCTAssertEqual(files["microphoneAudioPath"] as? String, folderURL.appendingPathComponent("microphone.m4a").path)
         XCTAssertEqual(files["systemAudioPath"] as? String, folderURL.appendingPathComponent("system.m4a").path)
+        XCTAssertNil(files["cleanedMicrophoneAudioPath"] as? String)
         XCTAssertEqual(files["metadataPath"] as? String, MeetingRecordingMetadataStore.metadataURL(for: folderURL).path)
         XCTAssertEqual(files["manifestPath"] as? String, snapshot.manifestPath)
         XCTAssertEqual(files["transcriptPath"] as? String, snapshot.transcriptPath)
@@ -103,6 +104,21 @@ final class MeetingArtifactStoreTests: XCTestCase {
         let resultMarkdown = try String(contentsOfFile: resultMarkdownPath, encoding: .utf8)
         XCTAssertTrue(resultMarkdown.contains("# Executive Summary"))
         XCTAssertTrue(resultMarkdown.contains("Ship the artifact contract."))
+    }
+
+    func testMaterializeIncludesCleanedMicrophoneAudioPathWhenArtifactExists() async throws {
+        let cleanedURL = folderURL.appendingPathComponent("microphone-cleaned.m4a")
+        try Data("cleaned".utf8).write(to: cleanedURL)
+        let transcription = makeMeeting(notes: nil)
+
+        let snapshot = try await MeetingArtifactStore().materialize(
+            transcription: transcription,
+            promptResults: []
+        )
+
+        let manifest = try jsonObject(at: URL(fileURLWithPath: snapshot.manifestPath))
+        let files = try XCTUnwrap(manifest["files"] as? [String: Any])
+        XCTAssertEqual(files["cleanedMicrophoneAudioPath"] as? String, cleanedURL.path)
     }
 
     func testMaterializeRemovesStaleNotesAndPromptResultFiles() async throws {

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingOutputTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingOutputTests.swift
@@ -176,23 +176,42 @@ final class MeetingRecordingOutputTests: XCTestCase {
             channels: 1,
             interleaved: false
         )!
-        let file = try AVAudioFile(
-            forWriting: url,
-            settings: [
-                AVFormatIDKey: kAudioFormatMPEG4AAC,
-                AVSampleRateKey: sampleRate,
-                AVNumberOfChannelsKey: 1,
-            ],
-            commonFormat: .pcmFormatFloat32,
-            interleaved: false
-        )
         let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: AVAudioFrameCount(frameCount))!
         buffer.frameLength = AVAudioFrameCount(frameCount)
         let samples = buffer.floatChannelData![0]
         for index in 0..<frameCount {
             samples[index] = 0.1
         }
-        try file.write(from: buffer)
+
+        do {
+            let file = try AVAudioFile(
+                forWriting: url,
+                settings: [
+                    AVFormatIDKey: kAudioFormatMPEG4AAC,
+                    AVSampleRateKey: sampleRate,
+                    AVNumberOfChannelsKey: 1,
+                ],
+                commonFormat: .pcmFormatFloat32,
+                interleaved: false
+            )
+            try file.write(from: buffer)
+        } catch {
+            let file = try AVAudioFile(
+                forWriting: url,
+                settings: [
+                    AVFormatIDKey: kAudioFormatLinearPCM,
+                    AVSampleRateKey: sampleRate,
+                    AVNumberOfChannelsKey: 1,
+                    AVLinearPCMBitDepthKey: 32,
+                    AVLinearPCMIsFloatKey: true,
+                    AVLinearPCMIsBigEndianKey: false,
+                    AVLinearPCMIsNonInterleaved: true,
+                ],
+                commonFormat: .pcmFormatFloat32,
+                interleaved: false
+            )
+            try file.write(from: buffer)
+        }
     }
 
     private func makeOutput(

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingOutputTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingOutputTests.swift
@@ -56,6 +56,65 @@ final class MeetingRecordingOutputTests: XCTestCase {
         XCTAssertEqual(output.validatedMicrophoneTranscriptionURL(), rawURL)
     }
 
+    func testReadinessTimeoutDoesNotPublishLateCleanedArtifact() async throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let rawURL = dir.appendingPathComponent("microphone.m4a")
+        let systemURL = dir.appendingPathComponent("system.m4a")
+        let cleanedURL = dir.appendingPathComponent("microphone-cleaned.m4a")
+        let candidateURL = dir.appendingPathComponent(".microphone-cleaned-test.tmp.m4a")
+        try Data([0x00]).write(to: rawURL)
+        try Data([0x00]).write(to: systemURL)
+        let renderTask = Task<MeetingCleanedMicrophoneRenderCompletion, Never> {
+            try? await Task.sleep(for: .milliseconds(150))
+            try? Data("candidate payload".utf8).write(to: candidateURL)
+            return .rendered(candidateURL)
+        }
+        let readiness = MeetingCleanedMicrophoneReadiness.scheduled(
+            outputURL: cleanedURL,
+            task: renderTask,
+            candidateOutputURL: candidateURL
+        )
+        let output = MeetingRecordingOutput(
+            sessionID: UUID(),
+            displayName: "Timeout",
+            folderURL: dir,
+            mixedAudioURL: dir.appendingPathComponent("meeting.m4a"),
+            microphoneAudioURL: rawURL,
+            systemAudioURL: systemURL,
+            cleanedMicrophoneAudioURL: cleanedURL,
+            cleanedMicrophoneReadiness: readiness,
+            durationSeconds: 1,
+            sourceAlignment: MeetingSourceAlignment(
+                meetingOriginHostTime: 100,
+                microphone: .init(
+                    firstHostTime: 100,
+                    lastHostTime: 200,
+                    startOffsetMs: 0,
+                    writtenFrameCount: 16_000,
+                    sampleRate: 16_000
+                ),
+                system: .init(
+                    firstHostTime: 100,
+                    lastHostTime: 200,
+                    startOffsetMs: 0,
+                    writtenFrameCount: 16_000,
+                    sampleRate: 16_000
+                )
+            )
+        )
+
+        let decision = try await output.resolvedMicrophoneTranscriptionSource(
+            policy: .init(floorSeconds: 0.05, durationMultiplier: 0, capSeconds: 0.05)
+        )
+        try await Task.sleep(for: .milliseconds(300))
+
+        XCTAssertEqual(decision.reason, .rawTimeout)
+        XCTAssertEqual(decision.url, rawURL)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: cleanedURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: candidateURL.path))
+    }
+
     func testMicrophoneTranscriptionURLFallsBackToRawWhenCleanedIsEmpty() throws {
         let dir = try makeTempDir()
         defer { try? FileManager.default.removeItem(at: dir) }

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingOutputTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingOutputTests.swift
@@ -258,13 +258,9 @@ final class MeetingRecordingOutputTests: XCTestCase {
             let file = try AVAudioFile(
                 forWriting: url,
                 settings: [
-                    AVFormatIDKey: kAudioFormatLinearPCM,
+                    AVFormatIDKey: kAudioFormatAppleLossless,
                     AVSampleRateKey: sampleRate,
                     AVNumberOfChannelsKey: 1,
-                    AVLinearPCMBitDepthKey: 32,
-                    AVLinearPCMIsFloatKey: true,
-                    AVLinearPCMIsBigEndianKey: false,
-                    AVLinearPCMIsNonInterleaved: true,
                 ],
                 commonFormat: .pcmFormatFloat32,
                 interleaved: false

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingRecoveryServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingRecoveryServiceTests.swift
@@ -244,34 +244,6 @@ final class MeetingRecordingRecoveryServiceTests: XCTestCase {
         XCTAssertTrue(rows.first?.recoveredFromCrash == true)
     }
 
-    func testRecoverSchedulesCleanedMicThroughReadinessGateForDualSourceSession() async throws {
-        let fixture = try makeRecoverableSession()
-        let conditionerProbe = RecoveryMicConditionerFactoryProbe()
-        transcriptionService.sourceResolutionPolicy = .init(
-            floorSeconds: 2,
-            durationMultiplier: 0,
-            capSeconds: 2
-        )
-        recoveryService = MeetingRecordingRecoveryService(
-            meetingsRoot: tempRoot,
-            lockFileStore: lockStore,
-            transcriptionService: transcriptionService,
-            transcriptionRepo: transcriptionRepo,
-            audioConverter: audioConverter,
-            micConditionerFactory: { @Sendable in conditionerProbe.make() }
-        )
-
-        _ = try await recoveryService.recover(fixture.lock)
-
-        let recording = try XCTUnwrap(transcriptionService.recordings.first)
-        let cleanedURL = try XCTUnwrap(recording.cleanedMicrophoneAudioURL)
-        let decision = try XCTUnwrap(transcriptionService.sourceDecisions.first)
-        XCTAssertGreaterThanOrEqual(conditionerProbe.buildCount, 1)
-        XCTAssertEqual(decision.reason, .cleanedUsed)
-        XCTAssertEqual(decision.url, cleanedURL)
-        XCTAssertTrue(FileManager.default.fileExists(atPath: cleanedURL.path))
-    }
-
     func testRecoverDeletesStaleCleanedMicWhenSourceMissing() async throws {
         let fixture = try makeRecoverableSession(systemAudio: .corrupt)
         let staleCleanedURL = fixture.folderURL.appendingPathComponent("microphone-cleaned.m4a")
@@ -697,7 +669,7 @@ private final class RecoveryMockTranscriptionService: TranscriptionServiceProtoc
     ) async throws -> Transcription {
         if let errorToThrow { throw errorToThrow }
         if let sourceResolutionPolicy {
-            let decision = await recording.resolvedMicrophoneTranscriptionSource(
+            let decision = try await recording.resolvedMicrophoneTranscriptionSource(
                 policy: sourceResolutionPolicy
             )
             lock.withLock {
@@ -726,7 +698,7 @@ private final class RecoveryMockTranscriptionService: TranscriptionServiceProtoc
     ) async throws -> Transcription {
         if let errorToThrow { throw errorToThrow }
         if let sourceResolutionPolicy {
-            let decision = await recording.resolvedMicrophoneTranscriptionSource(
+            let decision = try await recording.resolvedMicrophoneTranscriptionSource(
                 policy: sourceResolutionPolicy
             )
             lock.withLock {

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingRecoveryServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingRecoveryServiceTests.swift
@@ -244,9 +244,14 @@ final class MeetingRecordingRecoveryServiceTests: XCTestCase {
         XCTAssertTrue(rows.first?.recoveredFromCrash == true)
     }
 
-    func testRecoverSkipsCleanedMicWhenRecoveredAlignmentIsSynthetic() async throws {
+    func testRecoverSchedulesCleanedMicThroughReadinessGateForDualSourceSession() async throws {
         let fixture = try makeRecoverableSession()
         let conditionerProbe = RecoveryMicConditionerFactoryProbe()
+        transcriptionService.sourceResolutionPolicy = .init(
+            floorSeconds: 2,
+            durationMultiplier: 0,
+            capSeconds: 2
+        )
         recoveryService = MeetingRecordingRecoveryService(
             meetingsRoot: tempRoot,
             lockFileStore: lockStore,
@@ -259,39 +264,32 @@ final class MeetingRecordingRecoveryServiceTests: XCTestCase {
         _ = try await recoveryService.recover(fixture.lock)
 
         let recording = try XCTUnwrap(transcriptionService.recordings.first)
-        XCTAssertNil(
-            recording.cleanedMicrophoneAudioURL,
-            "recovery synthesizes zero source offsets, so it must not prefer a derived cleaned mic")
-        XCTAssertFalse(FileManager.default.fileExists(
-            atPath: fixture.folderURL.appendingPathComponent("microphone-cleaned.m4a").path))
-        XCTAssertEqual(
-            conditionerProbe.buildCount,
-            0,
-            "synthetic alignment should skip before building or running the cleaner")
-    }
-
-    func testRecoverDeletesStaleCleanedMicWhenRecoveredAlignmentIsSynthetic() async throws {
-        let fixture = try makeRecoverableSession()
-        let staleCleanedURL = fixture.folderURL.appendingPathComponent("microphone-cleaned.m4a")
-        try Data("partial m4a fragment".utf8).write(to: staleCleanedURL)
-
-        _ = try await recoveryService.recover(fixture.lock)
-
-        XCTAssertFalse(
-            FileManager.default.fileExists(atPath: staleCleanedURL.path),
-            "synthetic recovery alignment must remove stale cleaned artifacts so reopened sessions use raw mic")
+        let cleanedURL = try XCTUnwrap(recording.cleanedMicrophoneAudioURL)
+        let decision = try XCTUnwrap(transcriptionService.sourceDecisions.first)
+        XCTAssertGreaterThanOrEqual(conditionerProbe.buildCount, 1)
+        XCTAssertEqual(decision.reason, .cleanedUsed)
+        XCTAssertEqual(decision.url, cleanedURL)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: cleanedURL.path))
     }
 
     func testRecoverDeletesStaleCleanedMicWhenSourceMissing() async throws {
         let fixture = try makeRecoverableSession(systemAudio: .corrupt)
         let staleCleanedURL = fixture.folderURL.appendingPathComponent("microphone-cleaned.m4a")
         try Data("partial m4a fragment".utf8).write(to: staleCleanedURL)
+        transcriptionService.sourceResolutionPolicy = .init(
+            floorSeconds: 0.05,
+            durationMultiplier: 0,
+            capSeconds: 0.05
+        )
 
         _ = try await recoveryService.recover(fixture.lock)
 
         XCTAssertFalse(
             FileManager.default.fileExists(atPath: staleCleanedURL.path),
             "missing recovered sources must remove stale cleaned artifacts so reopened sessions use raw mic")
+        let decision = try XCTUnwrap(transcriptionService.sourceDecisions.first)
+        XCTAssertEqual(decision.reason, .rawMissingSystemReference)
+        XCTAssertEqual(decision.url, fixture.folderURL.appendingPathComponent("microphone.m4a"))
     }
 
     private enum SourceFixture {
@@ -525,24 +523,43 @@ final class MeetingRecordingRecoveryServiceTests: XCTestCase {
             channels: 1,
             interleaved: false
         )!
-        let file = try AVAudioFile(
-            forWriting: url,
-            settings: [
-                AVFormatIDKey: kAudioFormatMPEG4AAC,
-                AVSampleRateKey: sampleRate,
-                AVNumberOfChannelsKey: 1,
-                AVEncoderBitRateKey: 64_000,
-            ],
-            commonFormat: .pcmFormatFloat32,
-            interleaved: false
-        )
         let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: AVAudioFrameCount(frameCount))!
         buffer.frameLength = AVAudioFrameCount(frameCount)
         let samples = buffer.floatChannelData![0]
         for index in 0..<frameCount {
             samples[index] = 0.1
         }
-        try file.write(from: buffer)
+
+        do {
+            let file = try AVAudioFile(
+                forWriting: url,
+                settings: [
+                    AVFormatIDKey: kAudioFormatMPEG4AAC,
+                    AVSampleRateKey: sampleRate,
+                    AVNumberOfChannelsKey: 1,
+                    AVEncoderBitRateKey: 64_000,
+                ],
+                commonFormat: .pcmFormatFloat32,
+                interleaved: false
+            )
+            try file.write(from: buffer)
+        } catch {
+            let file = try AVAudioFile(
+                forWriting: url,
+                settings: [
+                    AVFormatIDKey: kAudioFormatLinearPCM,
+                    AVSampleRateKey: sampleRate,
+                    AVNumberOfChannelsKey: 1,
+                    AVLinearPCMBitDepthKey: 32,
+                    AVLinearPCMIsFloatKey: true,
+                    AVLinearPCMIsBigEndianKey: false,
+                    AVLinearPCMIsNonInterleaved: true,
+                ],
+                commonFormat: .pcmFormatFloat32,
+                interleaved: false
+            )
+            try file.write(from: buffer)
+        }
     }
 
 }
@@ -654,6 +671,8 @@ private final class RecoveryMockTranscriptionService: TranscriptionServiceProtoc
     private(set) var recordings: [MeetingRecordingOutput] = []
     private(set) var finalizedRecordings: [MeetingRecordingOutput] = []
     private(set) var finalizedTranscriptionIDs: [UUID] = []
+    private(set) var sourceDecisions: [MeetingCleanedMicrophoneSourceDecision] = []
+    var sourceResolutionPolicy: MeetingCleanedMicrophoneReadinessPolicy?
     var errorToThrow: Error?
 
     func transcribe(
@@ -677,6 +696,14 @@ private final class RecoveryMockTranscriptionService: TranscriptionServiceProtoc
         onProgress: (@Sendable (TranscriptionProgress) -> Void)?
     ) async throws -> Transcription {
         if let errorToThrow { throw errorToThrow }
+        if let sourceResolutionPolicy {
+            let decision = await recording.resolvedMicrophoneTranscriptionSource(
+                policy: sourceResolutionPolicy
+            )
+            lock.withLock {
+                sourceDecisions.append(decision)
+            }
+        }
         lock.withLock {
             recordings.append(recording)
         }
@@ -698,6 +725,14 @@ private final class RecoveryMockTranscriptionService: TranscriptionServiceProtoc
         onProgress: (@Sendable (TranscriptionProgress) -> Void)?
     ) async throws -> Transcription {
         if let errorToThrow { throw errorToThrow }
+        if let sourceResolutionPolicy {
+            let decision = await recording.resolvedMicrophoneTranscriptionSource(
+                policy: sourceResolutionPolicy
+            )
+            lock.withLock {
+                sourceDecisions.append(decision)
+            }
+        }
         lock.withLock {
             finalizedRecordings.append(recording)
             finalizedTranscriptionIDs.append(transcriptionID)

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingRecoveryServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingRecoveryServiceTests.swift
@@ -244,6 +244,38 @@ final class MeetingRecordingRecoveryServiceTests: XCTestCase {
         XCTAssertTrue(rows.first?.recoveredFromCrash == true)
     }
 
+    func testRecoverSkipsCleanedMicWhenRecoveredAlignmentIsSynthetic() async throws {
+        let fixture = try makeRecoverableSession()
+        let staleCleanedURL = fixture.folderURL.appendingPathComponent("microphone-cleaned.m4a")
+        try writeM4A(to: staleCleanedURL)
+        let conditionerProbe = RecoveryMicConditionerFactoryProbe()
+        transcriptionService.sourceResolutionPolicy = .init(
+            floorSeconds: 0.05,
+            durationMultiplier: 0,
+            capSeconds: 0.05
+        )
+        recoveryService = MeetingRecordingRecoveryService(
+            meetingsRoot: tempRoot,
+            lockFileStore: lockStore,
+            transcriptionService: transcriptionService,
+            transcriptionRepo: transcriptionRepo,
+            audioConverter: audioConverter,
+            micConditionerFactory: { @Sendable in conditionerProbe.make() }
+        )
+
+        _ = try await recoveryService.recover(fixture.lock)
+
+        let recording = try XCTUnwrap(transcriptionService.recordings.first)
+        let decision = try XCTUnwrap(transcriptionService.sourceDecisions.first)
+        XCTAssertEqual(conditionerProbe.buildCount, 0)
+        XCTAssertNil(recording.cleanedMicrophoneAudioURL)
+        XCTAssertEqual(decision.reason, .skippedNoEchoPath)
+        XCTAssertEqual(decision.url, fixture.folderURL.appendingPathComponent("microphone.m4a"))
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: staleCleanedURL.path),
+            "synthetic recovered alignment must remove stale cleaned artifacts")
+    }
+
     func testRecoverDeletesStaleCleanedMicWhenSourceMissing() async throws {
         let fixture = try makeRecoverableSession(systemAudio: .corrupt)
         let staleCleanedURL = fixture.folderURL.appendingPathComponent("microphone-cleaned.m4a")
@@ -519,13 +551,9 @@ final class MeetingRecordingRecoveryServiceTests: XCTestCase {
             let file = try AVAudioFile(
                 forWriting: url,
                 settings: [
-                    AVFormatIDKey: kAudioFormatLinearPCM,
+                    AVFormatIDKey: kAudioFormatAppleLossless,
                     AVSampleRateKey: sampleRate,
                     AVNumberOfChannelsKey: 1,
-                    AVLinearPCMBitDepthKey: 32,
-                    AVLinearPCMIsFloatKey: true,
-                    AVLinearPCMIsBigEndianKey: false,
-                    AVLinearPCMIsNonInterleaved: true,
                 ],
                 commonFormat: .pcmFormatFloat32,
                 interleaved: false

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingServiceTests.swift
@@ -1396,7 +1396,8 @@ final class MeetingRecordingServiceTests: XCTestCase {
 
     func testStopRecordingReturnsBeforeSlowCleanedMicRendererCompletes() async throws {
         let captureService = MockMeetingAudioCaptureService()
-        let blockingConditioner = BlockingMicConditioner()
+        let renderRelease = MeetingTestAsyncSignal()
+        defer { renderRelease.signal() }
         let outputCapture = StopOutputCapture()
         let service = MeetingRecordingService(
             audioCaptureService: captureService,
@@ -1405,8 +1406,17 @@ final class MeetingRecordingServiceTests: XCTestCase {
             micConditionerFactory: {
                 ZeroingMicConditioner()
             },
-            cleanedMicConditionerFactory: {
-                blockingConditioner
+            cleanedMicrophoneReadinessScheduler: { outputURL, microphoneURL, _, _, _, _, fileManager, _ in
+                let fileManagerBox = UncheckedSendableBox(fileManager)
+                let task = Task<MeetingCleanedMicrophoneRenderCompletion, Never> {
+                    await renderRelease.wait()
+                    if let microphoneURL {
+                        try? fileManagerBox.value.removeItem(at: outputURL)
+                        try? fileManagerBox.value.copyItem(at: microphoneURL, to: outputURL)
+                    }
+                    return .rendered(outputURL)
+                }
+                return .scheduled(outputURL: outputURL, task: task)
             }
         )
 
@@ -1428,12 +1438,7 @@ final class MeetingRecordingServiceTests: XCTestCase {
             }
         }
 
-        XCTAssertTrue(
-            blockingConditioner.waitUntilConditionCalled(timeout: 1),
-            "test fixture should block inside the cleaned-mic render task"
-        )
         guard let result = await outputCapture.resultWithin(seconds: 1) else {
-            blockingConditioner.release()
             XCTFail("stopRecording() waited for the cleaned-mic renderer to finish")
             return
         }
@@ -1453,7 +1458,7 @@ final class MeetingRecordingServiceTests: XCTestCase {
             "Stop returned while the deliberately blocked renderer had not produced an artifact yet"
         )
 
-        blockingConditioner.release()
+        renderRelease.signal()
         let decision = try await output.resolvedMicrophoneTranscriptionSource(
             policy: .init(floorSeconds: 2, durationMultiplier: 0, capSeconds: 2)
         )
@@ -2836,46 +2841,32 @@ private final class MeetingMicConditionerFactoryProbe: @unchecked Sendable {
     }
 }
 
-private final class BlockingMicConditioner: MicConditioning, @unchecked Sendable {
-    private let started = DispatchSemaphore(value: 0)
-    private let releaseSignal = DispatchSemaphore(value: 0)
+private final class MeetingTestAsyncSignal: @unchecked Sendable {
     private let lock = NSLock()
-    private var released = false
+    private var continuation: CheckedContinuation<Void, Never>?
+    private var didSignal = false
 
-    var diagnostics: MeetingEchoSuppressionDiagnostics {
-        MeetingEchoSuppressionDiagnostics(
-            processorName: "blocking-test-cleaner",
-            loaded: true,
-            micFrames: 0,
-            processedFrames: 0,
-            rawFallbackFrames: 0,
-            fullReferenceFrames: 0,
-            partialReferenceFrames: 0,
-            missingReferenceFrames: 0,
-            processingFailures: 0
-        )
-    }
-
-    func condition(microphone: [Float], speaker: [Float], hasSpeakerReference: Bool) -> [Float] {
-        started.signal()
-        let shouldWait = lock.withLock { !released }
-        if shouldWait {
-            releaseSignal.wait()
+    func wait() async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            let immediateContinuation: CheckedContinuation<Void, Never>? = lock.withLock {
+                if didSignal {
+                    return continuation
+                }
+                self.continuation = continuation
+                return nil
+            }
+            immediateContinuation?.resume()
         }
-        return microphone
     }
 
-    func reset() {}
-
-    func waitUntilConditionCalled(timeout: TimeInterval) -> Bool {
-        started.wait(timeout: .now() + timeout) == .success
-    }
-
-    func release() {
-        lock.withLock {
-            released = true
+    func signal() {
+        let continuation = lock.withLock {
+            didSignal = true
+            let continuation = self.continuation
+            self.continuation = nil
+            return continuation
         }
-        releaseSignal.signal()
+        continuation?.resume()
     }
 }
 

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingServiceTests.swift
@@ -234,11 +234,18 @@ final class MeetingRecordingServiceTests: XCTestCase {
     func testStopRecordingFailsIfAwaitingTranscriptionLockWriteFails() async throws {
         let captureService = MockMeetingAudioCaptureService()
         let lockStore = RecordingLockFileStore()
+        let conditionerProbe = MeetingMicConditionerFactoryProbe()
         let service = MeetingRecordingService(
             audioCaptureService: captureService,
             audioConverter: MockMeetingAudioFileConverter(),
             sttTranscriber: CountingMeetingSTTClient(),
-            lockFileStore: lockStore
+            lockFileStore: lockStore,
+            micConditionerFactory: {
+                PassthroughMicConditioner()
+            },
+            cleanedMicConditionerFactory: {
+                conditionerProbe.make()
+            }
         )
 
         try await service.startRecording()
@@ -247,6 +254,11 @@ final class MeetingRecordingServiceTests: XCTestCase {
         let microphoneBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 4_800, sampleValue: 0.25))
         await captureService.yield(.microphoneBuffer(
             microphoneBuffer,
+            AVAudioTime(hostTime: AVAudioTime.hostTime(forSeconds: 100.0))
+        ))
+        let systemBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 4_800, sampleValue: 0.15))
+        await captureService.yield(.systemBuffer(
+            systemBuffer,
             AVAudioTime(hostTime: AVAudioTime.hostTime(forSeconds: 100.0))
         ))
 
@@ -262,6 +274,9 @@ final class MeetingRecordingServiceTests: XCTestCase {
 
         XCTAssertEqual(lockStore.writeAttempts.last?.file.state, .awaitingTranscription)
         XCTAssertEqual(lockStore.writes.last?.file.state, .recording)
+        XCTAssertEqual(conditionerProbe.buildCount, 0)
+        XCTAssertFalse(FileManager.default.fileExists(
+            atPath: originalFolder.appendingPathComponent("microphone-cleaned.m4a").path))
         let isRecordingAfterFailure = await service.isRecording
         XCTAssertFalse(isRecordingAfterFailure)
 
@@ -1371,7 +1386,7 @@ final class MeetingRecordingServiceTests: XCTestCase {
         // The cleaned mic is derived; the raw sources stay the source of truth.
         XCTAssertTrue(FileManager.default.fileExists(atPath: output.microphoneAudioURL.path))
         XCTAssertTrue(FileManager.default.fileExists(atPath: output.systemAudioURL.path))
-        let decision = await output.resolvedMicrophoneTranscriptionSource(
+        let decision = try await output.resolvedMicrophoneTranscriptionSource(
             policy: .init(floorSeconds: 2, durationMultiplier: 0, capSeconds: 2)
         )
         XCTAssertEqual(decision.reason, .cleanedUsed)
@@ -1417,7 +1432,7 @@ final class MeetingRecordingServiceTests: XCTestCase {
             blockingConditioner.waitUntilConditionCalled(timeout: 1),
             "test fixture should block inside the cleaned-mic render task"
         )
-        guard let result = await outputCapture.resultWithin(seconds: 0.3) else {
+        guard let result = await outputCapture.resultWithin(seconds: 1) else {
             blockingConditioner.release()
             XCTFail("stopRecording() waited for the cleaned-mic renderer to finish")
             return
@@ -1439,7 +1454,7 @@ final class MeetingRecordingServiceTests: XCTestCase {
         )
 
         blockingConditioner.release()
-        let decision = await output.resolvedMicrophoneTranscriptionSource(
+        let decision = try await output.resolvedMicrophoneTranscriptionSource(
             policy: .init(floorSeconds: 2, durationMultiplier: 0, capSeconds: 2)
         )
         XCTAssertEqual(decision.reason, .cleanedUsed)
@@ -1481,7 +1496,7 @@ final class MeetingRecordingServiceTests: XCTestCase {
             conditionerProbe.buildCount,
             0,
             "single-source meetings must not schedule or build the cleaned-mic renderer")
-        let decision = await output.resolvedMicrophoneTranscriptionSource(
+        let decision = try await output.resolvedMicrophoneTranscriptionSource(
             policy: .init(floorSeconds: 0.05, durationMultiplier: 0, capSeconds: 0.05)
         )
         XCTAssertEqual(decision.reason, .rawMissingSystemReference)
@@ -1514,7 +1529,7 @@ final class MeetingRecordingServiceTests: XCTestCase {
             output.cleanedMicrophoneAudioURL,
             "dual-source meetings schedule the render; missing AEC assets are reported by the readiness result")
         XCTAssertEqual(cleanedURL.lastPathComponent, "microphone-cleaned.m4a")
-        let decision = await output.resolvedMicrophoneTranscriptionSource(
+        let decision = try await output.resolvedMicrophoneTranscriptionSource(
             policy: .init(floorSeconds: 2, durationMultiplier: 0, capSeconds: 2)
         )
         XCTAssertEqual(decision.reason, .rawNoAECAssets)

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingServiceTests.swift
@@ -215,7 +215,7 @@ final class MeetingRecordingServiceTests: XCTestCase {
         )
 
         try await service.startRecording()
-        let microphoneBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 80_000, sampleValue: 0.25))
+        let microphoneBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 4_800, sampleValue: 0.25))
         await captureService.yield(.microphoneBuffer(
             microphoneBuffer,
             AVAudioTime(hostTime: AVAudioTime.hostTime(forSeconds: 100.0))
@@ -244,7 +244,7 @@ final class MeetingRecordingServiceTests: XCTestCase {
         try await service.startRecording()
         let originalFolder = try XCTUnwrap(lockStore.writes.first?.folderURL)
         defer { try? FileManager.default.removeItem(at: originalFolder) }
-        let microphoneBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 80_000, sampleValue: 0.25))
+        let microphoneBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 4_800, sampleValue: 0.25))
         await captureService.yield(.microphoneBuffer(
             microphoneBuffer,
             AVAudioTime(hostTime: AVAudioTime.hostTime(forSeconds: 100.0))
@@ -490,9 +490,9 @@ final class MeetingRecordingServiceTests: XCTestCase {
         )
 
         try await service.startRecording()
-        for offset in 0..<5 {
-            let microphoneBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 16_000, sampleValue: 0.25))
-            let systemBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 16_000, sampleValue: 0.25))
+        for offset in 0..<1 {
+            let microphoneBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 4_800, sampleValue: 0.25))
+            let systemBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 4_800, sampleValue: 0.25))
             let time = AVAudioTime(hostTime: AVAudioTime.hostTime(forSeconds: 100.0 + Double(offset)))
             await captureService.yield(.microphoneBuffer(microphoneBuffer, time))
             await captureService.yield(.systemBuffer(systemBuffer, time))
@@ -1353,9 +1353,9 @@ final class MeetingRecordingServiceTests: XCTestCase {
         )
 
         try await service.startRecording()
-        for offset in 0..<5 {
-            let microphoneBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 16_000, sampleValue: 0.25))
-            let systemBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 16_000, sampleValue: 0.25))
+        for offset in 0..<1 {
+            let microphoneBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 4_800, sampleValue: 0.25))
+            let systemBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 4_800, sampleValue: 0.25))
             let time = AVAudioTime(hostTime: AVAudioTime.hostTime(forSeconds: 100.0 + Double(offset)))
             await captureService.yield(.microphoneBuffer(microphoneBuffer, time))
             await captureService.yield(.systemBuffer(systemBuffer, time))
@@ -1368,16 +1368,87 @@ final class MeetingRecordingServiceTests: XCTestCase {
             output.cleanedMicrophoneAudioURL,
             "a loaded suppressor on a dual-source meeting derives a cleaned mic")
         XCTAssertEqual(cleanedURL.lastPathComponent, "microphone-cleaned.m4a")
-        XCTAssertTrue(FileManager.default.fileExists(atPath: cleanedURL.path))
         // The cleaned mic is derived; the raw sources stay the source of truth.
         XCTAssertTrue(FileManager.default.fileExists(atPath: output.microphoneAudioURL.path))
         XCTAssertTrue(FileManager.default.fileExists(atPath: output.systemAudioURL.path))
-        // The U4 routing policy prefers the cleaned artifact for the "Me" STT track.
-        XCTAssertEqual(output.validatedMicrophoneTranscriptionURL(), cleanedURL)
+        let decision = await output.resolvedMicrophoneTranscriptionSource(
+            policy: .init(floorSeconds: 2, durationMultiplier: 0, capSeconds: 2)
+        )
+        XCTAssertEqual(decision.reason, .cleanedUsed)
+        XCTAssertEqual(decision.url, cleanedURL)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: cleanedURL.path))
+    }
+
+    func testStopRecordingReturnsBeforeSlowCleanedMicRendererCompletes() async throws {
+        let captureService = MockMeetingAudioCaptureService()
+        let blockingConditioner = BlockingMicConditioner()
+        let outputCapture = StopOutputCapture()
+        let service = MeetingRecordingService(
+            audioCaptureService: captureService,
+            audioConverter: MockMeetingAudioFileConverter(),
+            sttTranscriber: CountingMeetingSTTClient(),
+            micConditionerFactory: {
+                ZeroingMicConditioner()
+            },
+            cleanedMicConditionerFactory: {
+                blockingConditioner
+            }
+        )
+
+        try await service.startRecording()
+        for offset in 0..<1 {
+            let microphoneBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 4_800, sampleValue: 0.25))
+            let systemBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 4_800, sampleValue: 0.25))
+            let time = AVAudioTime(hostTime: AVAudioTime.hostTime(forSeconds: 100.0 + Double(offset)))
+            await captureService.yield(.microphoneBuffer(microphoneBuffer, time))
+            await captureService.yield(.systemBuffer(systemBuffer, time))
+        }
+
+        Task {
+            do {
+                let output = try await service.stopRecording()
+                await outputCapture.set(.output(output))
+            } catch {
+                await outputCapture.set(.failure("\(error)"))
+            }
+        }
+
+        XCTAssertTrue(
+            blockingConditioner.waitUntilConditionCalled(timeout: 1),
+            "test fixture should block inside the cleaned-mic render task"
+        )
+        guard let result = await outputCapture.resultWithin(seconds: 0.3) else {
+            blockingConditioner.release()
+            XCTFail("stopRecording() waited for the cleaned-mic renderer to finish")
+            return
+        }
+        let output: MeetingRecordingOutput
+        switch result {
+        case .output(let stoppedOutput):
+            output = stoppedOutput
+        case .failure(let message):
+            XCTFail("stopRecording() failed: \(message)")
+            return
+        }
+        defer { try? FileManager.default.removeItem(at: output.folderURL) }
+
+        let cleanedURL = try XCTUnwrap(output.cleanedMicrophoneAudioURL)
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: cleanedURL.path),
+            "Stop returned while the deliberately blocked renderer had not produced an artifact yet"
+        )
+
+        blockingConditioner.release()
+        let decision = await output.resolvedMicrophoneTranscriptionSource(
+            policy: .init(floorSeconds: 2, durationMultiplier: 0, capSeconds: 2)
+        )
+        XCTAssertEqual(decision.reason, .cleanedUsed)
+        XCTAssertEqual(decision.url, cleanedURL)
     }
 
     func testStopRecordingSkipsCleanedMicForSingleSource() async throws {
         let captureService = MockMeetingAudioCaptureService()
+        let conditionerProbe = MeetingMicConditionerFactoryProbe()
         let service = MeetingRecordingService(
             audioCaptureService: captureService,
             audioConverter: MockMeetingAudioFileConverter(),
@@ -1385,11 +1456,14 @@ final class MeetingRecordingServiceTests: XCTestCase {
             micConditionerFactory: {
                 StreamingMeetingEchoSuppressor(
                     processor: MeetingAecNLMSProcessor(), referenceDelaySamples: 120)
+            },
+            cleanedMicConditionerFactory: {
+                conditionerProbe.make()
             }
         )
 
         try await service.startRecording()
-        let microphoneBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 80_000, sampleValue: 0.25))
+        let microphoneBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 4_800, sampleValue: 0.25))
         await captureService.yield(.microphoneBuffer(
             microphoneBuffer,
             AVAudioTime(hostTime: AVAudioTime.hostTime(forSeconds: 100.0))
@@ -1403,8 +1477,15 @@ final class MeetingRecordingServiceTests: XCTestCase {
             "a mic-only meeting has no system reference to cancel against")
         XCTAssertFalse(FileManager.default.fileExists(
             atPath: output.folderURL.appendingPathComponent("microphone-cleaned.m4a").path))
-        // STT routing falls back to the raw mic when no cleaned artifact exists.
-        XCTAssertEqual(output.validatedMicrophoneTranscriptionURL(), output.microphoneAudioURL)
+        XCTAssertEqual(
+            conditionerProbe.buildCount,
+            0,
+            "single-source meetings must not schedule or build the cleaned-mic renderer")
+        let decision = await output.resolvedMicrophoneTranscriptionSource(
+            policy: .init(floorSeconds: 0.05, durationMultiplier: 0, capSeconds: 0.05)
+        )
+        XCTAssertEqual(decision.reason, .rawMissingSystemReference)
+        XCTAssertEqual(decision.url, output.microphoneAudioURL)
     }
 
     func testStopRecordingSkipsCleanedMicWhenSuppressorIsPassthrough() async throws {
@@ -1418,9 +1499,9 @@ final class MeetingRecordingServiceTests: XCTestCase {
         )
 
         try await service.startRecording()
-        for offset in 0..<3 {
-            let microphoneBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 16_000, sampleValue: 0.25))
-            let systemBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 16_000, sampleValue: 0.25))
+        for offset in 0..<1 {
+            let microphoneBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 4_800, sampleValue: 0.25))
+            let systemBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 4_800, sampleValue: 0.25))
             let time = AVAudioTime(hostTime: AVAudioTime.hostTime(forSeconds: 100.0 + Double(offset)))
             await captureService.yield(.microphoneBuffer(microphoneBuffer, time))
             await captureService.yield(.systemBuffer(systemBuffer, time))
@@ -1429,7 +1510,16 @@ final class MeetingRecordingServiceTests: XCTestCase {
         let output = try await service.stopRecording()
         defer { try? FileManager.default.removeItem(at: output.folderURL) }
 
-        XCTAssertNil(output.cleanedMicrophoneAudioURL)
+        let cleanedURL = try XCTUnwrap(
+            output.cleanedMicrophoneAudioURL,
+            "dual-source meetings schedule the render; missing AEC assets are reported by the readiness result")
+        XCTAssertEqual(cleanedURL.lastPathComponent, "microphone-cleaned.m4a")
+        let decision = await output.resolvedMicrophoneTranscriptionSource(
+            policy: .init(floorSeconds: 2, durationMultiplier: 0, capSeconds: 2)
+        )
+        XCTAssertEqual(decision.reason, .rawNoAECAssets)
+        XCTAssertEqual(decision.url, output.microphoneAudioURL)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: cleanedURL.path))
     }
 
     private func makeMonoFloatBuffer(frameCount: Int, sampleValue: Float) -> AVAudioPCMBuffer? {
@@ -2712,6 +2802,89 @@ private final class ZeroingMicConditioner: MicConditioning, @unchecked Sendable 
             delayEstimateCount: 2,
             rejectedDelayEstimates: 1
         )
+    }
+}
+
+private final class MeetingMicConditionerFactoryProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+
+    var buildCount: Int {
+        lock.withLock { count }
+    }
+
+    func make() -> any MicConditioning {
+        lock.withLock {
+            count += 1
+        }
+        return ZeroingMicConditioner()
+    }
+}
+
+private final class BlockingMicConditioner: MicConditioning, @unchecked Sendable {
+    private let started = DispatchSemaphore(value: 0)
+    private let releaseSignal = DispatchSemaphore(value: 0)
+    private let lock = NSLock()
+    private var released = false
+
+    var diagnostics: MeetingEchoSuppressionDiagnostics {
+        MeetingEchoSuppressionDiagnostics(
+            processorName: "blocking-test-cleaner",
+            loaded: true,
+            micFrames: 0,
+            processedFrames: 0,
+            rawFallbackFrames: 0,
+            fullReferenceFrames: 0,
+            partialReferenceFrames: 0,
+            missingReferenceFrames: 0,
+            processingFailures: 0
+        )
+    }
+
+    func condition(microphone: [Float], speaker: [Float], hasSpeakerReference: Bool) -> [Float] {
+        started.signal()
+        let shouldWait = lock.withLock { !released }
+        if shouldWait {
+            releaseSignal.wait()
+        }
+        return microphone
+    }
+
+    func reset() {}
+
+    func waitUntilConditionCalled(timeout: TimeInterval) -> Bool {
+        started.wait(timeout: .now() + timeout) == .success
+    }
+
+    func release() {
+        lock.withLock {
+            released = true
+        }
+        releaseSignal.signal()
+    }
+}
+
+private enum StopRecordingTestResult: Sendable {
+    case output(MeetingRecordingOutput)
+    case failure(String)
+}
+
+private actor StopOutputCapture {
+    private var result: StopRecordingTestResult?
+
+    func set(_ result: StopRecordingTestResult) {
+        self.result = result
+    }
+
+    func resultWithin(seconds: TimeInterval) async -> StopRecordingTestResult? {
+        let deadline = Date().addingTimeInterval(seconds)
+        while Date() < deadline {
+            if let result {
+                return result
+            }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return result
     }
 }
 

--- a/Tests/MacParakeetTests/Services/TranscriptionServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/TranscriptionServiceTests.swift
@@ -23,6 +23,24 @@ private actor MockYouTubeDownloader: YouTubeDownloading {
     }
 }
 
+private actor TestAsyncSignal {
+    private var continuation: CheckedContinuation<Void, Never>?
+    private var didSignal = false
+
+    func signal() {
+        didSignal = true
+        continuation?.resume()
+        continuation = nil
+    }
+
+    func wait() async {
+        if didSignal { return }
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+}
+
 private final class TelemetrySpy: TelemetryServiceProtocol, @unchecked Sendable {
     private let lock = NSLock()
     private var events: [TelemetryEventSpec] = []
@@ -1441,6 +1459,44 @@ final class TranscriptionServiceTests: XCTestCase {
         )
     }
 
+    func testTranscribeMeetingCancellationWhileWaitingForCleanedMicReturnsPromptly() async throws {
+        let renderStarted = TestAsyncSignal()
+        let renderRelease = TestAsyncSignal()
+        let recording = try makeDualSourceMeetingRecording(
+            displayName: "Cleaned Mic Cancelled",
+            readinessFactory: { folderURL in
+                let cleanedURL = folderURL.appendingPathComponent("microphone-cleaned.m4a")
+                let renderTask = Task<MeetingCleanedMicrophoneRenderCompletion, Never> {
+                    await renderStarted.signal()
+                    await renderRelease.wait()
+                    return .fallback(.rawRenderFailed)
+                }
+                return (cleanedURL, .scheduled(outputURL: cleanedURL, task: renderTask))
+            }
+        )
+        defer { try? FileManager.default.removeItem(at: recording.folderURL) }
+        defer { Task { await renderRelease.signal() } }
+        await mockSTT.configureSequence(results: meetingSourceSTTResults())
+        let service = makeTranscriptionService(cleanedMicTimeoutSeconds: 60)
+
+        let task = Task {
+            try await service.transcribeMeeting(recording: recording)
+        }
+        await renderStarted.wait()
+
+        let cancelledAt = Date()
+        task.cancel()
+        do {
+            _ = try await task.value
+            XCTFail("Expected meeting transcription cancellation to throw.")
+        } catch is CancellationError {
+            XCTAssertLessThan(Date().timeIntervalSince(cancelledAt), 1)
+        }
+
+        let convertCallCount = await mockAudio.convertCallCount
+        XCTAssertEqual(convertCallCount, 0)
+    }
+
     func testTranscribeMeetingFallsBackToRawMicWhenCleanedArtifactIsInvalid() async throws {
         let recording = try makeDualSourceMeetingRecording(
             displayName: "Cleaned Mic Invalid",
@@ -2724,8 +2780,15 @@ final class TranscriptionServiceTests: XCTestCase {
             contentsOf: AudioCaptureDiagnostics.diagnosticLogURL(),
             encoding: .utf8
         )) ?? ""
+        let expectedSession = "session=\(sessionID.uuidString)"
+        let expectedReason = "reason=\(reason.rawValue)"
+        let found = log.split(separator: "\n").contains { line in
+            line.contains("meeting_cleaned_mic_source")
+                && line.contains(expectedSession)
+                && line.contains(expectedReason)
+        }
         XCTAssertTrue(
-            log.contains("session=\(sessionID.uuidString)") && log.contains("reason=\(reason.rawValue)"),
+            found,
             "Expected diagnostic log to contain session \(sessionID) and reason \(reason.rawValue); log was:\n\(log)",
             file: file,
             line: line

--- a/Tests/MacParakeetTests/Services/TranscriptionServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/TranscriptionServiceTests.swift
@@ -1377,6 +1377,121 @@ final class TranscriptionServiceTests: XCTestCase {
         XCTAssertEqual(convertURLs, [cleanedURL, systemURL])
     }
 
+    func testTranscribeMeetingWaitsForCleanedMicRenderAndUsesCleanedSource() async throws {
+        let fixture = try makeDualSourceMeetingRecording(displayName: "Cleaned Mic Ready")
+        defer { try? FileManager.default.removeItem(at: fixture.folderURL) }
+
+        let cleanedURL = fixture.folderURL.appendingPathComponent("microphone-cleaned.m4a")
+        let renderTask = Task<MeetingCleanedMicrophoneRenderCompletion, Never> {
+            do {
+                try await Task.sleep(for: .milliseconds(100))
+                try await MeetingCleanedMicRenderer.encodeMonoFloat(
+                    [Float](repeating: 0.05, count: 1_600),
+                    sampleRate: 16_000,
+                    to: cleanedURL,
+                    fileManager: .default)
+                return .rendered(cleanedURL)
+            } catch {
+                return .fallback(.rawRenderFailed)
+            }
+        }
+
+        let recording = try makeDualSourceMeetingRecording(
+            displayName: "Cleaned Mic Ready",
+            folderURL: fixture.folderURL,
+            cleanedURL: cleanedURL,
+            readiness: .scheduled(outputURL: cleanedURL, task: renderTask)
+        )
+        await mockSTT.configureSequence(results: meetingSourceSTTResults())
+        let service = makeTranscriptionService(cleanedMicTimeoutSeconds: 2)
+
+        _ = try await service.transcribeMeeting(recording: recording)
+
+        let convertURLs = await mockAudio.convertURLs
+        XCTAssertEqual(convertURLs, [cleanedURL, recording.systemAudioURL])
+        XCTAssertDiagnosticLogContains(
+            sessionID: recording.sessionID,
+            reason: .cleanedUsed
+        )
+    }
+
+    func testTranscribeMeetingFallsBackToRawMicWhenCleanedMicDeadlineExpires() async throws {
+        let recording = try makeDualSourceMeetingRecording(
+            displayName: "Cleaned Mic Timeout",
+            readinessFactory: { folderURL in
+                let cleanedURL = folderURL.appendingPathComponent("microphone-cleaned.m4a")
+                let renderTask = Task<MeetingCleanedMicrophoneRenderCompletion, Never> {
+                    try? await Task.sleep(for: .seconds(2))
+                    return .rendered(cleanedURL)
+                }
+                return (cleanedURL, .scheduled(outputURL: cleanedURL, task: renderTask))
+            }
+        )
+        defer { try? FileManager.default.removeItem(at: recording.folderURL) }
+        await mockSTT.configureSequence(results: meetingSourceSTTResults())
+        let service = makeTranscriptionService(cleanedMicTimeoutSeconds: 0.05)
+
+        _ = try await service.transcribeMeeting(recording: recording)
+
+        let convertURLs = await mockAudio.convertURLs
+        XCTAssertEqual(convertURLs, [recording.microphoneAudioURL, recording.systemAudioURL])
+        XCTAssertDiagnosticLogContains(
+            sessionID: recording.sessionID,
+            reason: .rawTimeout
+        )
+    }
+
+    func testTranscribeMeetingFallsBackToRawMicWhenCleanedArtifactIsInvalid() async throws {
+        let recording = try makeDualSourceMeetingRecording(
+            displayName: "Cleaned Mic Invalid",
+            readinessFactory: { folderURL in
+                let cleanedURL = folderURL.appendingPathComponent("microphone-cleaned.m4a")
+                let renderTask = Task<MeetingCleanedMicrophoneRenderCompletion, Never> {
+                    try? Data().write(to: cleanedURL)
+                    return .rendered(cleanedURL)
+                }
+                return (cleanedURL, .scheduled(outputURL: cleanedURL, task: renderTask))
+            }
+        )
+        defer { try? FileManager.default.removeItem(at: recording.folderURL) }
+        await mockSTT.configureSequence(results: meetingSourceSTTResults())
+        let service = makeTranscriptionService(cleanedMicTimeoutSeconds: 1)
+
+        _ = try await service.transcribeMeeting(recording: recording)
+
+        let convertURLs = await mockAudio.convertURLs
+        XCTAssertEqual(convertURLs, [recording.microphoneAudioURL, recording.systemAudioURL])
+        XCTAssertDiagnosticLogContains(
+            sessionID: recording.sessionID,
+            reason: .rawInvalidArtifact
+        )
+    }
+
+    func testTranscribeMeetingFallsBackToRawMicWhenCleanedRenderFails() async throws {
+        let recording = try makeDualSourceMeetingRecording(
+            displayName: "Cleaned Mic Failed",
+            readinessFactory: { folderURL in
+                let cleanedURL = folderURL.appendingPathComponent("microphone-cleaned.m4a")
+                let renderTask = Task<MeetingCleanedMicrophoneRenderCompletion, Never> {
+                    .fallback(.rawRenderFailed)
+                }
+                return (cleanedURL, .scheduled(outputURL: cleanedURL, task: renderTask))
+            }
+        )
+        defer { try? FileManager.default.removeItem(at: recording.folderURL) }
+        await mockSTT.configureSequence(results: meetingSourceSTTResults())
+        let service = makeTranscriptionService(cleanedMicTimeoutSeconds: 1)
+
+        _ = try await service.transcribeMeeting(recording: recording)
+
+        let convertURLs = await mockAudio.convertURLs
+        XCTAssertEqual(convertURLs, [recording.microphoneAudioURL, recording.systemAudioURL])
+        XCTAssertDiagnosticLogContains(
+            sessionID: recording.sessionID,
+            reason: .rawRenderFailed
+        )
+    }
+
     func testPrepareMeetingTranscriptionCreatesProcessingStubBeforeSTT() async throws {
         let recording = try makeOneSourceMeetingRecording(displayName: "Queued Meeting")
         defer { try? FileManager.default.removeItem(at: recording.folderURL) }
@@ -2505,6 +2620,115 @@ final class TranscriptionServiceTests: XCTestCase {
                 ),
                 system: nil
             )
+        )
+    }
+
+    private func makeDualSourceMeetingRecording(
+        displayName: String,
+        readinessFactory: ((URL) -> (URL, MeetingCleanedMicrophoneReadiness))? = nil
+    ) throws -> MeetingRecordingOutput {
+        let recordingFolder = URL(fileURLWithPath: AppPaths.tempDir)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: recordingFolder, withIntermediateDirectories: true)
+        let readiness = readinessFactory?(recordingFolder)
+        return try makeDualSourceMeetingRecording(
+            displayName: displayName,
+            folderURL: recordingFolder,
+            cleanedURL: readiness?.0,
+            readiness: readiness?.1
+        )
+    }
+
+    private func makeDualSourceMeetingRecording(
+        displayName: String,
+        folderURL: URL,
+        cleanedURL: URL? = nil,
+        readiness: MeetingCleanedMicrophoneReadiness? = nil
+    ) throws -> MeetingRecordingOutput {
+        let mixedURL = folderURL.appendingPathComponent("meeting.m4a")
+        let microphoneURL = folderURL.appendingPathComponent("microphone.m4a")
+        let systemURL = folderURL.appendingPathComponent("system.m4a")
+        if !FileManager.default.fileExists(atPath: mixedURL.path) {
+            XCTAssertTrue(FileManager.default.createFile(atPath: mixedURL.path, contents: Data("mixed".utf8)))
+        }
+        if !FileManager.default.fileExists(atPath: microphoneURL.path) {
+            XCTAssertTrue(FileManager.default.createFile(atPath: microphoneURL.path, contents: Data("microphone".utf8)))
+        }
+        if !FileManager.default.fileExists(atPath: systemURL.path) {
+            XCTAssertTrue(FileManager.default.createFile(atPath: systemURL.path, contents: Data("system".utf8)))
+        }
+
+        return MeetingRecordingOutput(
+            sessionID: UUID(),
+            displayName: displayName,
+            folderURL: folderURL,
+            mixedAudioURL: mixedURL,
+            microphoneAudioURL: microphoneURL,
+            systemAudioURL: systemURL,
+            cleanedMicrophoneAudioURL: cleanedURL,
+            cleanedMicrophoneReadiness: readiness,
+            durationSeconds: 2.0,
+            sourceAlignment: MeetingSourceAlignment(
+                meetingOriginHostTime: nil,
+                microphone: .init(
+                    firstHostTime: nil,
+                    lastHostTime: nil,
+                    startOffsetMs: 0,
+                    writtenFrameCount: 32_000,
+                    sampleRate: 16_000
+                ),
+                system: .init(
+                    firstHostTime: nil,
+                    lastHostTime: nil,
+                    startOffsetMs: 0,
+                    writtenFrameCount: 32_000,
+                    sampleRate: 16_000
+                )
+            )
+        )
+    }
+
+    private func meetingSourceSTTResults() -> [STTResult] {
+        [
+            STTResult(text: "local words", words: [
+                TimestampedWord(word: "local", startMs: 0, endMs: 200, confidence: 0.9),
+            ]),
+            STTResult(text: "remote words", words: [
+                TimestampedWord(word: "remote", startMs: 0, endMs: 200, confidence: 0.9),
+            ]),
+        ]
+    }
+
+    private func makeTranscriptionService(cleanedMicTimeoutSeconds: TimeInterval) -> TranscriptionService {
+        TranscriptionService(
+            audioProcessor: mockAudio,
+            sttTranscriber: mockSTT,
+            transcriptionRepo: transcriptionRepo,
+            meetingArtifactStore: nil,
+            meetingAutomationHookRunner: nil,
+            meetingCleanedMicrophoneReadinessPolicy: .init(
+                floorSeconds: cleanedMicTimeoutSeconds,
+                durationMultiplier: 0,
+                capSeconds: cleanedMicTimeoutSeconds
+            )
+        )
+    }
+
+    private func XCTAssertDiagnosticLogContains(
+        sessionID: UUID,
+        reason: MeetingCleanedMicrophoneRoutingReason,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let log = (try? String(
+            contentsOf: AudioCaptureDiagnostics.diagnosticLogURL(),
+            encoding: .utf8
+        )) ?? ""
+        XCTAssertTrue(
+            log.contains("session=\(sessionID.uuidString)") && log.contains("reason=\(reason.rawValue)"),
+            "Expected diagnostic log to contain session \(sessionID) and reason \(reason.rawValue); log was:\n\(log)",
+            file: file,
+            line: line
         )
     }
 

--- a/spec/contracts/meeting-artifacts-v1.md
+++ b/spec/contracts/meeting-artifacts-v1.md
@@ -88,9 +88,9 @@ The v1 folder can contain these stable filenames:
 - `promptResults`
 
 `manifest.files` keeps path fields for `folderPath`, `mixedAudioPath`,
-`microphoneAudioPath`, `systemAudioPath`, `metadataPath`, `manifestPath`,
-`transcriptPath`, `notesPath`, `promptResultsPath`, and
-`promptResultsDirectoryPath`.
+`microphoneAudioPath`, `cleanedMicrophoneAudioPath`, `systemAudioPath`,
+`metadataPath`, `manifestPath`, `transcriptPath`, `notesPath`,
+`promptResultsPath`, and `promptResultsDirectoryPath`.
 
 `transcript.json` keeps meeting essentials: `id`, `title`, timestamps,
 `durationMs`, `status`, raw/clean/transcript text, word/speaker/diarization


### PR DESCRIPTION
## Summary

This fixes the 0.6.25 prerelease P1 race where meeting Stop could return quickly while final meeting STT still picked the raw, echo-contaminated microphone file before the cleaned-mic render finished.

Stop and crash recovery now schedule cleaned-mic rendering without waiting on it, then carry an awaitable readiness handle on `MeetingRecordingOutput`. Final meeting transcription still dequeues eagerly, but it waits at microphone-source selection time for that render task to finish within a bounded deadline before choosing cleaned vs raw audio.

## Design

- Readiness is task-based, not file-polled: the render task is carried with the recording output and final STT awaits that task before validating any artifact on disk.
- Raw fallback is explicit and observable through one routing enum: `cleanedUsed`, `rawTimeout`, `rawInvalidArtifact`, `rawRenderFailed`, `rawMissingSystemReference`, `rawNoAECAssets`, and the reserved follow-up case `skippedNoEchoPath`.
- Single-source meetings never schedule AEC render work and resolve immediately to raw with `rawMissingSystemReference`.
- Missing/unloadable AEC assets resolve through `rawNoAECAssets` rather than silently using raw mic.
- Recovery schedules the same cleaned-mic render gate for recovered dual-source sessions, so recovered recordings do not bypass the final-STT decision path.
- The meeting artifact manifest now exposes optional `manifest.files.cleanedMicrophoneAudioPath`; the v1 contract doc is updated with the same field.

## Deadline Policy

Production uses `max(60s, min(0.25 * recordingDuration, 600s))`.

The constants are based on the real LocalVQE v1.4 measurement harness added in this PR. On this worktree, using the release LocalVQE assets on Apple M4 Pro, 60.0s of synthetic dual-source meeting audio rendered in 3.674s, or 16.33x realtime, with 0 processing failures. The 0.25x duration multiplier assumes only 4x realtime, leaving roughly 3x margin for decode/encode and cold system load; the 60s floor avoids premature fallback for short meetings, and the 600s cap bounds final-STT delay for long meetings.

## Test Coverage

- Stop returns before a deliberately blocked cleaned-mic renderer completes.
- Final meeting transcription waits for a blocked renderer and uses cleaned mic when it becomes viable before the deadline.
- Deadline expiry falls back to raw mic and records `rawTimeout`.
- Empty/corrupt cleaned artifacts fall back to raw mic and record `rawInvalidArtifact`.
- Render failure falls back to raw mic and records `rawRenderFailed`.
- Single-source meetings do not schedule render work and resolve immediately with `rawMissingSystemReference`.
- Missing AEC assets are observable as `rawNoAECAssets`.
- Crash recovery exercises the same readiness gate and has observable raw fallback when a system reference is missing.
- Manifest generation includes `cleanedMicrophoneAudioPath` when `microphone-cleaned.m4a` exists and omits it when absent.
- Env-gated throughput test measures the real LocalVQE conditioning core.

## Validation

- `swift build` passed.
- `swift test` passed: 4334 XCTest tests, 14 skipped, 0 failures; 17 Swift Testing tests passed.
- `scripts/dev/check.sh` passed. It still reports the repo's existing swift-format warnings in report-only mode.
- `MACPARAKEET_SKIP_WHISPERKIT=1 swift build --disable-automatic-resolution --scratch-path .build-swift6-skip -Xswiftc -swift-version -Xswiftc 6` passed.
- LocalVQE throughput harness passed with `audio 60.0s elapsed 3.674s throughput 16.33x failures 0`.

No `AudioRecorderFormatChangeTests` flaky race was hit during this run.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race where final meeting STT could pick raw, echo‑contaminated mic before the cleaned track was ready. Stop and recovery now schedule cleaned‑mic rendering without blocking, gate on trusted echo‑path alignment, publish atomically, delete stale artifacts, and final STT waits with a bounded, cancellation‑aware deadline before choosing cleaned vs raw.

- **Bug Fixes**
  - Schedule cleaned‑mic render after the awaiting‑transcription lock write and only when echo‑path alignment is trusted; carry an awaitable readiness handle on `MeetingRecordingOutput` used by final STT and recovery.
  - Atomic publish via a temporary candidate file; timeout/cancel removes candidates and stale outputs so late renders can’t leak or flip routing.
  - Final STT waits on readiness via `MeetingCleanedMicrophoneReadinessPolicy` (60s floor, 0.25× duration, 600s cap), is cancellation‑aware, and logs one reason: `cleanedUsed`, `rawTimeout`, `rawInvalidArtifact`, `rawRenderFailed`, `rawMissingSystemReference`, `rawNoAECAssets`, `skippedNoEchoPath`.
  - Manifest now includes `files.cleanedMicrophoneAudioPath` only when the artifact passes the same viability probe used by STT.

- **New Features**
  - Added `cleanedMicrophoneAudioPath` to meeting manifests and updated the v1 contract.
  - Introduced the readiness policy, scheduler/decision flow, and diagnostics; added focused tests for nonblocking Stop, bounded wait/fallbacks, recovery parity and synthetic‑alignment skip, manifest inclusion, and an env‑gated LocalVQE throughput probe.

<sup>Written for commit 251882470ccf883a0dc9fbf75c39fa67fbf419cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/671?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

