### PR TITLE
Commit guide: seed-prompt intent altitude + Author's Notes section

### DIFF
--- a/docs/commit-guidelines.md
+++ b/docs/commit-guidelines.md
@@ -55,15 +55,31 @@ bug, a demo blocker, a perf number, an audit finding). Enough that
 someone reading in 2027 with no project context understands the
 motivation.
 
-## Prompt That Would Produce This Diff
-Self-contained enough that an agent with repo access could replay
-this work. Reference specific file paths, design docs, and ADRs by
-name. Include the constraints (don't break X, match Y's pattern).
+## Seed Prompt
+The highest-level intent from which the whole change could be
+reconstructed — the architect's brief, not a stepwise recipe. State
+the goal, the constraints (don't break X, match Y's pattern), and the
+design decisions that were settled before the work began. Reference
+design docs and ADRs by name. Name specific files only when the
+location is itself part of the intent — an agent replaying this
+should be able to rediscover the right files from the intent alone
+(case by case; a surgical fix may warrant them, a feature usually
+doesn't). This section was formerly titled "Prompt That Would Produce
+This Diff"; older commits use that heading.
 
 ## ADRs Applied (if any)
 Links to architectural decisions that informed the change. If none,
 say "None — this is X polish, not architecture" so the reader knows
 it's a deliberate omission rather than oversight.
+
+## Author's Notes (optional, encouraged for agent authors)
+Honest first-person reflections from whoever wrote the diff: what
+surprised you, what you are least confident about, where you
+disagreed with the brief and what you did about it, debt knowingly
+left behind, anything the reviewer should probe. Candor beats polish
+— a doubt recorded here is a gift to the next debugger, and
+disagreement with the brief is signal for the architect, not
+insubordination.
 
 ## Files Changed
 Per-file rationale with line counts. For comprehensive changes, the
@@ -178,17 +194,20 @@ Users need visual feedback when dictating — they need to know the app
 is recording, see their voice levels, and have a clear way to cancel.
 The pill overlay appears over all apps without stealing focus.
 
-## Prompt That Would Produce This Diff
-Implement a dictation overlay for MacParakeet. Create a compact dark
-pill that:
-1. Appears as a borderless NSPanel over all windows
-2. Shows recording state with a pulsing indicator
-3. Displays real-time waveform from AVAudioEngine audio levels
-4. Has a cancel button (Escape key also cancels)
-5. Does NOT steal focus from the active app (non-activating panel)
+## Seed Prompt
+Give MacParakeet dictation visual feedback: a compact dark pill
+overlay, visible over all apps, that shows recording state and live
+voice levels and offers cancel (button + Escape). Hard constraints:
+must never steal focus from the active app (non-activating panel),
+and the audio-level source must come from the existing capture path
+rather than a second tap. Expose whatever publisher the view needs
+from `DictationService`.
 
-Add `audioLevelPublisher` to `DictationService` so the view can
-subscribe to audio levels.
+## Author's Notes
+The 100ms level-smoothing constant is eyeballed, not measured — if
+the waveform ever feels laggy, start there. I considered driving the
+waveform from the STT engine's VAD signal instead of raw levels and
+rejected it: it would couple UI cadence to engine choice.
 
 ## ADRs Applied
 - ADR-001 + ADR-007: Parakeet TDT model with FluidAudio CoreML runtime
@@ -260,9 +279,9 @@ README change needed.
 1. **Git history becomes the project's long-term memory** — rich
    context lives in version control rather than disappearing into
    chat transcripts and PR comments that nobody re-reads.
-2. **Reproducible changes** — the prompt section is a recipe that
-   could regenerate the diff if needed, and a record of the
-   constraints the author was working within.
+2. **Reconstructable changes** — the seed prompt preserves the
+   intent and constraints from which the work could be regenerated,
+   which outlives any particular file layout.
 3. **Onboarding via archaeology** — new devs and agents understand
    decisions by reading commits, not by scheduling explanations.
 4. **Auditable reasoning** — the "why" is preserved alongside the

--- a/docs/commit-guidelines.md
+++ b/docs/commit-guidelines.md
@@ -61,7 +61,7 @@ reconstructed — the architect's brief, not a stepwise recipe. State
 the goal, the constraints (don't break X, match Y's pattern), and the
 design decisions that were settled before the work began. Reference
 design docs and ADRs by name. Name specific files only when the
-location is itself part of the intent — an agent replaying this
+location is itself part of the intent — an agent reconstructing this
 should be able to rediscover the right files from the intent alone
 (case by case; a surgical fix may warrant them, a feature usually
 doesn't). This section was formerly titled "Prompt That Would Produce


### PR DESCRIPTION
Refines docs/commit-guidelines.md per today's workflow decision (orchestrator + codex-exec pipeline, PR as the universal artifact):

1. **"Prompt That Would Produce This Diff" → "Seed Prompt"** — redefined one altitude up: the architect-level goal, constraints, and settled decisions from which the change can be reconstructed. Specific file paths become case-by-case rather than expected; an agent replaying the work should rediscover the files from the intent. Old heading documented as an alias so history stays legible.

2. **New optional "Author's Notes" section** — a sanctioned home for the diff author's honest first-person signal: uncertainties, surprises, disagreement with the brief, debt knowingly left. Candor over polish; disagreement framed as signal for the architect.

3. Inline comprehensive example updated to demonstrate both; "Why this matters" reworded from replay-recipe to intent-reconstruction.

Doc-only change; no code, no behavior. no-mistakes gate skipped per AGENTS.md scale-to-risk (docs-only), noted here as that section requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the commit guidelines to an intent-first “Seed Prompt” and add an optional “Author’s Notes” section for candid context. Clarifies case-by-case file path guidance and keeps the old heading for history; docs-only change.

- **Refactors**
  - Rename “Prompt That Would Produce This Diff” to “Seed Prompt”; define at architect level (goal, constraints, settled decisions) with file paths case-by-case and rediscoverable; document the old heading for older commits.
  - Reword “Why this matters” to stress reconstructable intent over stepwise recipes.

- **New Features**
  - Add optional “Author’s Notes” (encouraged for agent authors) for uncertainties, brief disagreements, and known debt.
  - Update the inline example to demonstrate the new sections and constraints.

<sup>Written for commit 5e3a967426445a02c5695dab9722934240529f06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/672?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

