### PR TITLE
docs(aec): align cleaned mic readiness docs

### DIFF
--- a/plans/active/2026-06-28-meeting-aec-full-close.md
+++ b/plans/active/2026-06-28-meeting-aec-full-close.md
@@ -42,34 +42,40 @@ assets or hardware that cannot be produced in a sandbox.
   Retention deletes `microphone-cleaned.m4a` with the other managed audio.
 - **U4 — prefer cleaned mic for final meeting STT: DONE.**
   `transcribeMeetingSources` resolves the `.microphone` source through
-  `MeetingRecordingOutput.microphoneTranscriptionURL`, which prefers the cleaned
-  file when present and falls back to raw otherwise. The "health gate" is
-  presence + on-disk existence: the renderer guarantees every output frame is
-  either echo-cancelled or raw-fallback (never worse than raw per frame), so no
-  separate numeric runtime gate is applied. A global RMS/energy gate was
-  deliberately NOT used — on a real meeting it cannot distinguish good echo
-  removal (mic that was mostly bleed → correctly quiet) from a model that mutes
+  `MeetingRecordingOutput.resolvedMicrophoneTranscriptionSource`. The stop path
+  schedules a background render to a hidden candidate file, while final STT waits
+  on a bounded `MeetingCleanedMicrophoneReadiness` handle. It publishes and uses
+  `microphone-cleaned.m4a` only when the render completes before the deadline and
+  the artifact is non-empty and decodable; timeout, invalid output, missing
+  reference, missing assets, render failure, or untrusted recovered alignment
+  select raw `microphone.m4a` with a diagnostic reason. A global RMS/energy gate
+  is deliberately NOT used — on a real meeting it cannot distinguish good echo
+  removal (mic that was mostly bleed -> correctly quiet) from a model that mutes
   near-end voice; that near-end-fidelity risk is owned by model selection
   (U5 chose echo-only v1.4) and real QA (U9), not a runtime heuristic.
-- **U5 — release verification + model decision gate: IN PROGRESS.** The
-  packaging/verification half landed in PR #646
-  (`scripts/dist/verify_meeting_echo_assets.sh`, runtime asset gates). The model
-  decision gate was scored on the synthetic harness (PR #650,
-  `MeetingAecModelScoringTests`): **echo-only `localvqe-v1.4-aec-200K-f32` is the
-  chosen release default candidate** because the joint `v1.2` model zeroes the
-  near-end voice (retain 0.00) while v1.4 preserves it (retain ~1.0) at 35.6 dB
-  ERLE — see "Model decision gate — result (2026-06-28)" under U5. Remaining U5:
-  build/sign/notarize the proprietary universal `liblocalvqe.dylib` + bundle the
-  chosen model, then flip `defaultModelName`.
+- **U5 — release verification + model decision gate: DONE for the repo gate,
+  still pending product QA.** The packaging/verification path landed in PRs
+  #646/#654/#656 (`scripts/dist/prepare_meeting_echo_assets.sh`,
+  `scripts/dist/verify_meeting_echo_assets.sh`, runtime asset gates, checksum
+  defaults, and bundle auto-prepare). The model decision gate was scored on the
+  synthetic harness (PR #650, `MeetingAecModelScoringTests`): **echo-only
+  `localvqe-v1.4-aec-200K-f32` is the chosen release default** because the joint
+  `v1.2` model zeroes the near-end voice (retain 0.00) while v1.4 preserves it
+  (retain ~1.0) at 35.6 dB ERLE — see "Model decision gate — result
+  (2026-06-28)" under U5. `MeetingEchoSuppressionFactory.defaultModelName` and
+  `scripts/dist/meeting_echo_asset_defaults.sh` now both point at the v1.4
+  default. Remaining release risk belongs to U9 real speaker-mode QA, signing/
+  notarization evidence for the final app bundle, and any WebRTC skip/benchmark
+  decision under U6.
 - **U8 — docs: UPDATED.** `spec/05-audio-pipeline.md` and
   `spec/contracts/meeting-artifacts-v1.md` describe the derived artifact + STT
   routing. CLI artifact output intentionally omits the cleaned mic: it is an
   internal STT input, not a user-facing export the user opens.
-- **U3/U4 are inert in shipped builds until U5 bundles assets** — production
-  resolves to `PassthroughMicConditioner`, so `renderCleanedMicrophone` skips and
-  final STT reads raw `microphone.m4a` exactly as today. Landing the wiring now is
-  safe (no behavior change without assets), fully tested, and is the prerequisite
-  for U9; it is no longer deferred.
+- **U3/U4 are inert when shipped builds lack AEC assets** — production resolves
+  to `PassthroughMicConditioner`, so the scheduled cleaned-mic render reports
+  `rawNoAECAssets`, removes any stale candidate/stable cleaned file, and final
+  STT reads raw `microphone.m4a`. With release assets present, final STT can wait
+  for and use the cleaned artifact through the readiness gate above.
 - **U6/U9 — REMAINING.** U6: optional WebRTC AEC3 benchmark or skip-decision
   record. U9: real no-headphones speaker-mode QA closes #605.
 
@@ -115,7 +121,8 @@ The shipped measurement harness proved that reference alignment is load-bearing:
 
 **Artifacts and transcription**
 
-- R9. Prefer the cleaned mic path for the final `Me` stream only after health gates pass.
+- R9. Prefer the cleaned mic path for the final `Me` stream only after readiness
+  and decodability gates pass.
 - R10. Retain any `microphone-cleaned.m4a` derived artifact under the same retention and deletion rules as other meeting source audio.
 - R11. Keep `meeting.m4a` as playback/export output and avoid treating it as the final STT input.
 
@@ -201,7 +208,8 @@ flowchart TB
 1. Make delay estimation and metrics production-ready before changing product behavior.
 2. Integrate adaptive delay into `MicConditioning` and prove synthetic improvement.
 3. Add post-stop cleaned mic artifact rendering while raw files remain untouched.
-4. Teach final meeting STT to prefer the cleaned mic only when health gates pass.
+4. Teach final meeting STT to prefer the cleaned mic only when readiness and
+   decodability gates pass.
 5. Package and verify LocalVQE assets for release builds.
 6. Run benchmark and real-meeting QA, then update specs and close issue #605.
 
@@ -276,7 +284,7 @@ flowchart TB
   - `Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingServiceTests.swift`
   - `Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingRecoveryServiceTests.swift`
   - `Tests/MacParakeetTests/Services/MeetingRecording/MeetingArtifactStoreTests.swift`
-- **Approach:** Derive cleaned mic from finalized raw source files rather than adding a third real-time writer first. This keeps capture-risk low and lets the renderer reuse `MeetingSourceAlignment`, the selected echo runtime, and health gates before final STT. Persist enough metadata for recovery and later inspection.
+- **Approach:** Derive cleaned mic from finalized raw source files rather than adding a third real-time writer first. This keeps capture-risk low and lets the renderer reuse `MeetingSourceAlignment`, the selected echo runtime, and readiness/decodability gates before final STT. Persist enough metadata for recovery and later inspection.
 - **Patterns to follow:** `MeetingAudioStorageWriter` source-file naming, `MeetingRecordingOutput` source URL conventions, recovery lock handling in `MeetingRecordingRecoveryService`.
 - **Test scenarios:**
   - Dual-source meeting with available cleaner writes `microphone-cleaned.m4a` and records metadata pointing to it.
@@ -287,7 +295,7 @@ flowchart TB
   - Meeting audio retention/deletion removes `microphone-cleaned.m4a` together with other retained meeting source audio.
 - **Verification:** Meeting recording, recovery, artifact-store, and retention tests prove cleaned artifact lifecycle without regressing raw artifact preservation.
 
-### U4. Prefer cleaned mic for final meeting STT with health gates
+### U4. Prefer cleaned mic for final meeting STT with readiness gates
 
 - **Goal:** Route final `Me` transcription through the cleaned mic artifact only when it is present, decodable, duration-aligned, and healthy.
 - **Requirements:** R2, R5, R6, R7, R8, R9, R11, AE1, AE2, AE3, AE4, AE5
@@ -299,8 +307,12 @@ flowchart TB
   - `Tests/MacParakeetTests/Services/TranscriptionServiceTests.swift`
   - `Tests/MacParakeetTests/Services/MeetingRecording/MeetingTranscriptSourceReconcilerTests.swift`
   - `Tests/MacParakeetTests/Services/MeetingRecording/MeetingTranscriptFinalizerTests.swift`
-- **Approach:** Update `transcribeMeetingSources` so `AudioSource.microphone` resolves to the cleaned mic candidate when health gates pass and raw mic otherwise. Keep system STT on `system.m4a`. Keep `MeetingTranscriptSourceReconciler` as a safety net for residual overlap, not the primary AEC mechanism.
-- **Health gates:** cleaned file exists, decodes, duration is within tolerance of raw mic/source alignment, processor diagnostics show nonzero processed frames, failure/fallback ratio is below threshold, and near-end-only/silent-reference checks do not indicate destructive suppression.
+- **Approach:** Update `transcribeMeetingSources` so `AudioSource.microphone` resolves to the cleaned mic candidate when readiness/decodability gates pass and raw mic otherwise. Keep system STT on `system.m4a`. Keep `MeetingTranscriptSourceReconciler` as a safety net for residual overlap, not the primary AEC mechanism.
+- **Health gates:** the cleaned render completes before the bounded deadline,
+  the candidate output can be atomically published, and the published file is
+  non-empty and decodable. Processor diagnostics and RMS ratio are emitted for
+  QA, but not used as runtime routing gates; near-end/silent-reference safety is
+  owned by model selection plus real speaker-mode QA.
 - **Patterns to follow:** Existing source alignment offsets and vocabulary application in `TranscriptionService`; source reconciliation in `MeetingTranscriptFinalizer`.
 - **Test scenarios:**
   - When cleaned mic is healthy, final microphone STT receives the cleaned file path.
@@ -323,8 +335,15 @@ flowchart TB
   - `scripts/dist/verify_meeting_echo_assets.sh`
   - `docs/distribution.md`
   - `spec/05-audio-pipeline.md`
-- **Approach:** Continue using `liblocalvqe.dylib` plus `MeetingEchoSuppression/localvqe-v1.2-1.3M-f32.gguf` or the selected v1.4 AEC model, but make release builds fail when required assets are missing. Keep dev builds able to run passthrough. Verify checksum, executable bit, dependency paths, and code signature where available.
-- **Model decision gate:** Score v1.4 AEC and v1.2 joint models on the harness before choosing the release default. Prefer echo-only v1.4 if it preserves near-end better, even if v1.2 removes more noise.
+- **Approach:** Use `liblocalvqe.dylib` plus
+  `MeetingEchoSuppression/localvqe-v1.4-aec-200K-f32.gguf` as the selected
+  default model, and make release builds fail when required assets are missing.
+  Keep dev builds able to run passthrough. Verify checksum, executable bit,
+  dependency paths, and code signature where available.
+- **Model decision gate:** Score v1.4 AEC and v1.2 joint models on the harness
+  before choosing the release default. Prefer echo-only v1.4 if it preserves
+  near-end better, even if v1.2 removes more noise. This gate has selected v1.4;
+  rerun it when changing the default model or LocalVQE runtime pin.
 - **Patterns to follow:** Existing `BUNDLE_MEETING_ECHO_ASSETS`, `REQUIRE_MEETING_ECHO_ASSETS`, and `MACPARAKEET_MEETING_ECHO_MODEL_SHA256` handling.
 - **Test scenarios:**
   - Automatic mode with no bundled assets returns passthrough and logs unavailable state.
@@ -382,12 +401,12 @@ stays intelligible and undistorted and (b) far-end echo does not appear in the `
 transcript. If v1.4's double-talk near-end is still damaged on real speech, the
 echo-only-vs-joint choice — or LocalVQE itself (WebRTC AEC3, plan U6) — must be revisited.
 
-**Follow-up (its own reviewed change, not done in the scoring branch).** When a
-canceller is bundled, set `MeetingEchoSuppressionFactory.defaultModelName` to
-`localvqe-v1.4-aec-200K-f32.gguf` (currently `localvqe-v1.2-1.3M-f32.gguf`) and bundle
-that file via `MACPARAKEET_MEETING_ECHO_MODEL_SRC`/`_NAME`. The runtime resolves
-`Resources/MeetingEchoSuppression/<defaultModelName>`, so the constant and the bundled
-basename must match.
+**Follow-up completed in later reviewed changes.** The runtime default and
+bundle defaults now both point at `localvqe-v1.4-aec-200K-f32.gguf`, with the
+pinned default checksum `b6e43138...3c731`. Release builds can auto-prepare the
+runtime/model through `scripts/dist/prepare_meeting_echo_assets.sh`, then
+`scripts/dist/build_app_bundle.sh` verifies the bundled assets before the app can
+claim meeting AEC readiness.
 
 **Reproduce:**
 
@@ -440,7 +459,7 @@ test skips when the env vars are unset, so CI stays green without the private as
 - **Test scenarios:**
   - Successful cleaned path logs processor loaded, delay confidence, processed frame count, cleaned artifact URL basename, and final-STT source choice.
   - Missing assets logs passthrough/fallback reason.
-  - Failed health gate logs fallback reason without exposing transcript text or audio samples.
+  - Failed readiness gate logs fallback reason without exposing transcript text or audio samples.
   - Feedback diagnostic scope includes AEC summary lines within existing size/time caps.
 - **Verification:** Uploaded diagnostic logs can distinguish "AEC worked", "AEC skipped by configuration", "AEC tried and fell back", and "final STT used raw".
 
@@ -458,7 +477,7 @@ test skips when the env vars are unset, so CI stays green without the private as
   - `Tests/CLITests/MeetingsCommandTests.swift`
   - `docs/human-qa-guide.md`
   - `docs/distribution.md`
-- **Approach:** Document that raw source files remain truth, cleaned mic is a derived artifact, final meeting STT may prefer cleaned mic after health gates, and retention applies to cleaned audio. Expose cleaned artifact presence in any existing meeting artifact listing without making users manage it separately.
+- **Approach:** Document that raw source files remain truth, cleaned mic is a derived artifact, final meeting STT may prefer cleaned mic after the readiness/decodability gates, and retention applies to cleaned audio. Expose cleaned artifact presence in any existing meeting artifact listing without making users manage it separately.
 - **Patterns to follow:** Existing meeting artifact folder/CLI conventions and boundary contract docs.
 - **Test scenarios:**
   - CLI meeting artifact output includes cleaned mic when present and omits it cleanly when absent.
@@ -495,7 +514,7 @@ test skips when the env vars are unset, so CI stays green without the private as
 | `swift test --filter MeetingAecMeasurementTests` | U1, U2, U5, U6 | Harness reports aligned cancellation, misalignment failure, LocalVQE/WebRTC or documented benchmark decision, and double-talk retention. |
 | `swift test --filter MeetingEchoSuppressorTests` | U2 | Frame carry, adaptive delay, partial/missing reference, reset, and flush behavior hold. |
 | `swift test --filter MeetingRecordingServiceTests` | U3, U7 | Cleaned artifact lifecycle and diagnostics are covered. |
-| `swift test --filter TranscriptionServiceTests` | U4 | Final meeting STT prefers cleaned mic only after health gates. |
+| `swift test --filter TranscriptionServiceTests` | U4 | Final meeting STT prefers cleaned mic only after the readiness/decodability gates. |
 | `swift test --filter MeetingRecordingRecoveryServiceTests` | U3 | Recovery tolerates absent cleaned artifact and preserves raw sources. |
 | `swift test --filter MeetingsCommandTests` | U8 | CLI/artifact listing reflects cleaned mic presence. |
 | `scripts/dist/verify_meeting_echo_assets.sh <app>` | U5 | Release bundle contains valid echo assets when AEC is claimed. |
@@ -549,7 +568,7 @@ test skips when the env vars are unset, so CI stays green without the private as
 
 - U1-U8 are implemented with focused tests and full `swift test` passing.
 - Release bundle verification proves echo assets are present and valid when the build claims AEC support.
-- Final meeting STT uses cleaned mic for the `Me` stream when health gates pass and raw mic when they fail.
+- Final meeting STT uses cleaned mic for the `Me` stream when readiness/decodability gates pass and raw mic when they fail.
 - Raw `microphone.m4a` and `system.m4a` remain preserved and recoverable.
 - `microphone-cleaned.m4a` or the equivalent derived cleaned input follows meeting audio retention/deletion rules.
 - Diagnostic logs distinguish loaded, skipped, failed, and fallback AEC states.

--- a/plans/active/2026-06-28-meeting-aec-full-close.md
+++ b/plans/active/2026-06-28-meeting-aec-full-close.md
@@ -69,8 +69,9 @@ assets or hardware that cannot be produced in a sandbox.
   decision under U6.
 - **U8 — docs: UPDATED.** `spec/05-audio-pipeline.md` and
   `spec/contracts/meeting-artifacts-v1.md` describe the derived artifact + STT
-  routing. CLI artifact output intentionally omits the cleaned mic: it is an
-  internal STT input, not a user-facing export the user opens.
+  routing. Human-facing CLI artifact listings intentionally omit the cleaned mic
+  as a user-openable export; manifest/JSON consumers still see
+  `cleanedMicrophoneAudioPath` when the derived file is viable.
 - **U3/U4 are inert when shipped builds lack AEC assets** — production resolves
   to `PassthroughMicConditioner`, so the scheduled cleaned-mic render reports
   `rawNoAECAssets`, removes any stale candidate/stable cleaned file, and final
@@ -477,10 +478,13 @@ test skips when the env vars are unset, so CI stays green without the private as
   - `Tests/CLITests/MeetingsCommandTests.swift`
   - `docs/human-qa-guide.md`
   - `docs/distribution.md`
-- **Approach:** Document that raw source files remain truth, cleaned mic is a derived artifact, final meeting STT may prefer cleaned mic after the readiness/decodability gates, and retention applies to cleaned audio. Expose cleaned artifact presence in any existing meeting artifact listing without making users manage it separately.
+- **Approach:** Document that raw source files remain truth, cleaned mic is a derived artifact, final meeting STT may prefer cleaned mic after the readiness/decodability gates, and retention applies to cleaned audio. Expose cleaned artifact presence through manifest/JSON artifact surfaces without making users manage it as a separate opened export.
 - **Patterns to follow:** Existing meeting artifact folder/CLI conventions and boundary contract docs.
 - **Test scenarios:**
-  - CLI meeting artifact output includes cleaned mic when present and omits it cleanly when absent.
+  - Manifest/JSON meeting artifact output includes `cleanedMicrophoneAudioPath`
+    when the cleaned mic is viable and omits it cleanly when absent.
+  - Human-facing CLI artifact listings omit the cleaned mic as a separate
+    user-openable export.
   - Contract tests cover retention/deletion of cleaned mic alongside raw source audio.
   - Spec text no longer implies passthrough is the only production AEC state once assets are shipped.
 - **Verification:** Specs/contracts/CLI agree on artifact names, lifecycle, and final STT source preference.

--- a/spec/05-audio-pipeline.md
+++ b/spec/05-audio-pipeline.md
@@ -220,16 +220,17 @@ Mic Input    → SharedMicrophoneStream (+ Voice Processing I/O when active)┘ 
   requested and engages, macOS applies AEC/noise suppression/AGC before buffers
   reach `MeetingRecordingService`.
 - Live suppression is **preview only**: `microphone.m4a` is always the raw mic.
-  After stop, when a suppressor is loaded and both source streams exist,
-  `MeetingCleanedMicRenderer` derives `microphone-cleaned.m4a` offline — it
+  After stop, when both source streams and trusted source-alignment metadata
+  exist, `MeetingCleanedMicRenderer` derives `microphone-cleaned.m4a` offline. It
   re-decodes the raw mic + system to 16 kHz mono, re-aligns the reference by the
   recorded `MeetingSourceAlignment` start offsets, and streams the pair through a
   freshly built suppressor (clean filter state, not the live preview's adapted
-  taps). Every output frame is either echo-cancelled or raw-fallback, so the
-  cleaned mic is never worse than raw per frame. Single-source meetings and
-  bundles without AEC assets produce no cleaned file, and rendering never throws
-  into finalize (failures resolve to "no cleaned file"). The same derivation runs
-  in `MeetingRecordingRecoveryService` so recovered meetings get equal treatment.
+  taps). Output frames are either processor output or raw fallback for processor
+  failures; near-end fidelity is not inferred from a runtime energy heuristic,
+  and remains owned by model choice plus real speaker-mode QA. Single-source
+  meetings, missing AEC assets, render failures, and recovered recordings with
+  only synthetic alignment fall back to raw mic. Rendering never throws into
+  recorder finalize.
 - Audio is stored as separate M4A files (AAC 64kbps, 48kHz mono) per source
 - Source audio is written as fragmented M4A with 1-second movie fragments so kill-9 recovery can keep playable audio through the last committed fragment.
 - After recording stops, the captured source M4As are finalized and merged into
@@ -240,11 +241,16 @@ Mic Input    → SharedMicrophoneStream (+ Voice Processing I/O when active)┘ 
 - Final meeting STT does **not** transcribe `meeting.m4a`. A background queue
   transcribes the captured source files separately with the engine captured at
   recording start, then merges those fresh results by persisted
-  `MeetingSourceAlignment`. The local (`Me`) microphone track prefers
-  `microphone-cleaned.m4a` when it exists (echo-cancelled; resolved through
-  `MeetingRecordingOutput.microphoneTranscriptionURL`) and otherwise falls back
-  to the raw `microphone.m4a`; the system track is unchanged. `meeting.m4a` is
-  kept as the playback/export artifact. See
+  `MeetingSourceAlignment`. For the local (`Me`) microphone track,
+  `TranscriptionService` waits on the bounded
+  `MeetingCleanedMicrophoneReadiness` handle produced by stop/recovery. It uses
+  `microphone-cleaned.m4a` only after the render completes before its deadline
+  and the file is non-empty and decodable; timeout, invalid output, missing
+  reference, missing assets, render failure, or untrusted alignment select raw
+  `microphone.m4a` with a diagnostic reason. The system track is unchanged.
+  `MeetingRecordingOutput.microphoneTranscriptionURL` remains a cheap UI/list
+  helper, not the final-STT gate. `meeting.m4a` is kept as the playback/export
+  artifact. See
   `docs/research/meeting-dual-stream-transcription-pipeline.md` for the full
   pipeline and tradeoffs.
 - Recovery locks and retention safety are a tested boundary contract. See [`spec/contracts/meeting-recovery-retention.md`](contracts/meeting-recovery-retention.md) before changing lock-file predicates or automatic meeting-audio deletion.
@@ -315,7 +321,7 @@ the stopped meeting waits for that job to finish; once the slot is free,
 ~/Library/Application Support/MacParakeet/meeting-recordings/{uuid}/
     ├── microphone.m4a    # Raw mic audio when captured (AAC, 48kHz mono) — source of truth
     ├── system.m4a        # System audio when captured (AAC, 48kHz mono)
-    ├── microphone-cleaned.m4a  # Optional derived echo-cancelled mic (16kHz mono); STT input for the "Me" track when a suppressor is loaded
+    ├── microphone-cleaned.m4a  # Optional derived echo-cancelled mic (16kHz mono); STT input for the "Me" track only after readiness/decodability gates pass
     ├── meeting.m4a       # Final playback/export artifact (stereo dual-source when both tracks exist; legacy fallback for downstream tools)
     ├── meeting-recording-metadata.json  # Persisted source timing/alignment + speech engine for post-stop merge
     ├── recording.lock     # Recording/awaiting-transcription recovery state, including notes and speech engine

--- a/spec/contracts/meeting-artifacts-v1.md
+++ b/spec/contracts/meeting-artifacts-v1.md
@@ -47,10 +47,13 @@ The v1 folder can contain these stable filenames:
 - `system.m4a`: optional source system audio.
 - `microphone-cleaned.m4a`: optional derived echo-cancelled mic (16 kHz mono),
   produced after stop from `microphone.m4a` + `system.m4a` when a meeting echo
-  suppressor is loaded (plan #605 U3). Internal STT input for the local ("Me")
-  track, not a user-facing export; the raw `microphone.m4a` remains the source
-  of truth. Absent for single-source meetings and when no AEC assets are
-  bundled. Removed with the other managed audio by retention/detach.
+  suppressor is loaded and trusted source-alignment metadata exists (plan #605
+  U3). Internal STT input for the local ("Me") track only after final-STT
+  readiness/decodability gates pass, not a user-facing export; the raw
+  `microphone.m4a` remains the source of truth. Absent for single-source
+  meetings, missing/unloaded AEC assets, render failures, and recovered meetings
+  with only synthetic alignment. Removed with the other managed audio by
+  retention/detach.
 - `meeting-recording-metadata.json`: optional source-alignment and engine
   sidecar.
 - `manifest.json`: folder manifest.


### PR DESCRIPTION
## Summary

The AEC docs now match the current cleaned-mic behavior: final meeting STT waits on the bounded readiness handle, publishes `microphone-cleaned.m4a` only after the candidate is complete and decodable, and falls back to raw mic on timeout, invalid output, missing assets/reference, render failure, or untrusted recovered alignment.

This also removes stale wording that implied the cleaned artifact is always "never worse" than raw audio or that recovered synthetic-alignment meetings get the same cleaned-mic treatment. The active plan now separates the repo-level v1.4 default/model gate from the remaining real speaker-mode QA and release bundle evidence.

Related: #605

## Validation

- `swift test --filter MeetingRecordingOutputTests`
- `swift test --filter MeetingCleanedMicRendererTests`
- `swift test --filter MeetingRecordingServiceTests`
- `swift test --filter TranscriptionServiceTests`
- `swift test --filter MeetingRecordingRecoveryServiceTests`
- `swift test --filter MeetingArtifactStoreTests`
- `swift test --filter TranscriptionAssetCleanupCleanedMicTests`
- `swift test --filter MeetingEchoSuppressionRuntimeTests`
- `swift test --filter MeetingEchoSuppressorTests`
- `swift test --filter MeetingEchoDelayEstimatorTests`
- `swift test --filter MeetingAecMeasurementTests`
- LocalVQE runtime load with `localvqe-v1.4-aec-200K-f32.gguf`
- LocalVQE throughput: 60s render at 12.37x realtime, 0 failures
- LocalVQE model scoring gate with the v1.4 model
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5_Codex-000000)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align AEC docs with the cleaned‑mic readiness flow: final STT waits on `MeetingCleanedMicrophoneReadiness`, uses `microphone-cleaned.m4a` only when published and decodable, and falls back to raw on timeout, invalid output, missing reference/assets, render failure, or untrusted recovered alignment (plan #605).
Clarifies the artifact surface and defaults: the cleaned mic is internal STT input (not an export); manifest/JSON can include `cleanedMicrophoneAudioPath` while human CLI listings omit it; `MeetingRecordingOutput.microphoneTranscriptionURL` is a UI helper, not the final‑STT gate; documents repo‑level v1.4 default `localvqe-v1.4-aec-200K-f32.gguf`, prepare/verify scripts, and passthrough when assets are absent.

<sup>Written for commit c0d06d6259fde9589f4eb391eb8c1de85ac02867. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/674?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

