### PR TITLE
Add audio routing diagnostics

### DIFF
--- a/Sources/MacParakeetCore/Audio/AudioCaptureDiagnostics.swift
+++ b/Sources/MacParakeetCore/Audio/AudioCaptureDiagnostics.swift
@@ -4,6 +4,10 @@ import os
 
 public enum AudioCaptureDiagnostics {
     private static let lock = OSAllocatedUnfairLock(initialState: ())
+    private static let appendQueue = DispatchQueue(
+        label: "com.macparakeet.audio-capture-diagnostics.append",
+        qos: .utility
+    )
     private static let logPathOverrideEnvironmentKey = "MACPARAKEET_AUDIO_DIAGNOSTICS_LOG_PATH"
     /// On-disk cap for `dictation-audio.log`. Crossing it deletes the file
     /// (not append-rotate). Sized so a heavy user dictating 30–60 min/day
@@ -111,6 +115,12 @@ public enum AudioCaptureDiagnostics {
             } catch {
                 // Diagnostics must never affect audio capture.
             }
+        }
+    }
+
+    static func appendAsync(_ message: String) {
+        appendQueue.async {
+            append(message)
         }
     }
 

--- a/Sources/MacParakeetCore/Audio/MicrophoneCapture.swift
+++ b/Sources/MacParakeetCore/Audio/MicrophoneCapture.swift
@@ -140,11 +140,11 @@ public func meetingInputDeviceAttempts(
 
     func outputTransportLabel(_ outputIsBluetooth: Bool?) -> String {
         switch outputIsBluetooth {
-        case true:
+        case .some(true):
             return "bluetooth"
-        case false:
+        case .some(false):
             return "other"
-        case nil:
+        case .none:
             return "unresolved-nil"
         }
     }

--- a/Sources/MacParakeetCore/Audio/MicrophoneCapture.swift
+++ b/Sources/MacParakeetCore/Audio/MicrophoneCapture.swift
@@ -169,7 +169,7 @@ public func meetingInputDeviceAttempts(
                 policyReason = "explicit_selection_resolved"
             }
             policyOutcome = shouldAvoidDefaultOutput
-                ? (hasResolvedSelection ? "skipped" : "fired")
+                ? "fired"
                 : "skipped"
         }
 
@@ -218,7 +218,7 @@ public func meetingInputDeviceAttempts(
             }
         }
     }
-    AudioCaptureDiagnostics.append(
+    AudioCaptureDiagnostics.appendAsync(
         "mic_attempts_bluetooth_output_policy preference=\(preferBuiltInWhenOutputIsBluetooth ? "on" : "off") explicit_selection_resolved=\(hasResolvedSelection) default_output_transport=\(defaultOutputTransport) outcome=\(policyOutcome) reason=\(policyReason)"
     )
 
@@ -561,16 +561,22 @@ public final class MicrophoneCapture: @unchecked Sendable {
                 let error = MeetingAudioError.captureRuntimeFailure(
                     "microphone capture started but delivered no buffers within 2 seconds"
                 )
-                let elapsedSeconds = String(format: "%.3f", Self.firstBufferTimeoutSeconds)
+                let observer = self.handlerLock.withLock { self.stallObserver }
+                observer?(error)
+
+                let elapsedSeconds = String(
+                    format: "%.3f",
+                    locale: Locale(identifier: "en_US_POSIX"),
+                    Self.firstBufferTimeoutSeconds
+                )
                 let isRunning = self.sharedStream.diagnostics.engineRunning
                 let defaultInput = AudioCaptureDiagnostics.defaultInputDeviceSummary()
                 self.logger.warning(
                     "microphone_capture_no_buffers_within_timeout elapsed_s=\(elapsedSeconds, privacy: .public) isRunning=\(isRunning, privacy: .public) \(defaultInput, privacy: .public)"
                 )
-                AudioCaptureDiagnostics.append(
+                AudioCaptureDiagnostics.appendAsync(
                     "meeting_mic_capture_no_buffers_within_timeout elapsed_s=\(elapsedSeconds) isRunning=\(isRunning) \(defaultInput)"
                 )
-                self.handlerLock.withLock { self.stallObserver }?(error)
             }
             watchdogWorkItem = item
             return item

--- a/Sources/MacParakeetCore/Audio/MicrophoneCapture.swift
+++ b/Sources/MacParakeetCore/Audio/MicrophoneCapture.swift
@@ -134,16 +134,46 @@ public func meetingInputDeviceAttempts(
         if case .selected = attempt.source { return true }
         return false
     }
+    var defaultOutputTransport = "not_queried"
+    var policyOutcome = "skipped"
+    var policyReason = preferBuiltInWhenOutputIsBluetooth ? "no_built_in_microphone" : "preference_off"
+
+    func outputTransportLabel(_ outputIsBluetooth: Bool?) -> String {
+        switch outputIsBluetooth {
+        case true:
+            return "bluetooth"
+        case false:
+            return "other"
+        case nil:
+            return "unresolved-nil"
+        }
+    }
+
     if preferBuiltInWhenOutputIsBluetooth,
         let builtInDeviceID
     {
+        policyReason = "default_input_not_bluetooth"
         let shouldAvoidDefaultInput: Bool = {
             guard let defaultDeviceID else { return true }
             if defaultDeviceID == builtInDeviceID { return true }
             return defaultInputIsBluetooth(defaultDeviceID)
         }()
 
-        if shouldAvoidDefaultInput, outputIsBluetooth() != false {
+        var shouldAvoidDefaultOutput = false
+        if shouldAvoidDefaultInput {
+            let defaultOutputIsBluetooth = outputIsBluetooth()
+            shouldAvoidDefaultOutput = defaultOutputIsBluetooth != false
+            defaultOutputTransport = outputTransportLabel(defaultOutputIsBluetooth)
+            policyReason = defaultOutputIsBluetooth == false ? "default_output_not_bluetooth" : "built_in_promoted"
+            if hasResolvedSelection, defaultOutputIsBluetooth != false {
+                policyReason = "explicit_selection_resolved"
+            }
+            policyOutcome = shouldAvoidDefaultOutput
+                ? (hasResolvedSelection ? "skipped" : "fired")
+                : "skipped"
+        }
+
+        if shouldAvoidDefaultInput, shouldAvoidDefaultOutput {
             let selectedDeviceID = attempts.first { attempt in
                 if case .selected = attempt.source { return true }
                 return false
@@ -188,6 +218,9 @@ public func meetingInputDeviceAttempts(
             }
         }
     }
+    AudioCaptureDiagnostics.append(
+        "mic_attempts_bluetooth_output_policy preference=\(preferBuiltInWhenOutputIsBluetooth ? "on" : "off") explicit_selection_resolved=\(hasResolvedSelection) default_output_transport=\(defaultOutputTransport) outcome=\(policyOutcome) reason=\(policyReason)"
+    )
 
     return attempts
 }
@@ -201,6 +234,7 @@ public func meetingInputDeviceAttempts(
 public final class MicrophoneCapture: @unchecked Sendable {
     public typealias AudioBufferHandler = @Sendable (AVAudioPCMBuffer, AVAudioTime) -> Void
     public typealias StallObserver = @Sendable (MeetingAudioError) -> Void
+    private static let firstBufferTimeoutSeconds = 2.0
     private enum LifecycleState {
         case idle
         case starting
@@ -527,14 +561,22 @@ public final class MicrophoneCapture: @unchecked Sendable {
                 let error = MeetingAudioError.captureRuntimeFailure(
                     "microphone capture started but delivered no buffers within 2 seconds"
                 )
-                self.logger.warning("microphone_capture_no_buffers_within_timeout")
+                let elapsedSeconds = String(format: "%.3f", Self.firstBufferTimeoutSeconds)
+                let isRunning = self.sharedStream.diagnostics.engineRunning
+                let defaultInput = AudioCaptureDiagnostics.defaultInputDeviceSummary()
+                self.logger.warning(
+                    "microphone_capture_no_buffers_within_timeout elapsed_s=\(elapsedSeconds, privacy: .public) isRunning=\(isRunning, privacy: .public) \(defaultInput, privacy: .public)"
+                )
+                AudioCaptureDiagnostics.append(
+                    "meeting_mic_capture_no_buffers_within_timeout elapsed_s=\(elapsedSeconds) isRunning=\(isRunning) \(defaultInput)"
+                )
                 self.handlerLock.withLock { self.stallObserver }?(error)
             }
             watchdogWorkItem = item
             return item
         }
         if let workItem {
-            watchdogQueue.asyncAfter(deadline: .now() + 2, execute: workItem)
+            watchdogQueue.asyncAfter(deadline: .now() + Self.firstBufferTimeoutSeconds, execute: workItem)
         }
     }
 

--- a/Tests/MacParakeetTests/Audio/MicrophoneCaptureTests.swift
+++ b/Tests/MacParakeetTests/Audio/MicrophoneCaptureTests.swift
@@ -96,6 +96,38 @@ final class MicrophoneCaptureTests: XCTestCase {
         )
     }
 
+    func testNoBufferWatchdogAppendsDiagnosticsLine() async throws {
+        let platform = SharedMicTestPlatform()
+        let stream = SharedMicrophoneStream(platform: platform, bufferSize: 1024)
+        let capture = MicrophoneCapture(
+            sharedStream: stream,
+            permissionProvider: { true }
+        )
+        let stallBox = MicrophoneCaptureTestStallBox()
+        let beforeDiagnostics = currentDiagnosticsLogContents()
+
+        _ = try await capture.start(
+            processingMode: .raw,
+            handler: { _, _ in },
+            onStall: { error in stallBox.record(error) }
+        )
+        defer { capture.stop() }
+
+        let line = try await waitForDiagnosticsLine(
+            containing: "meeting_mic_capture_no_buffers_within_timeout",
+            after: beforeDiagnostics
+        )
+        let stallObserved = await waitUntil(timeoutSeconds: 1) { stallBox.recordedError != nil }
+        XCTAssertTrue(
+            stallObserved,
+            "The watchdog must still notify the stall observer."
+        )
+        XCTAssertTrue(line.contains("elapsed_s=2.000"))
+        XCTAssertTrue(line.contains("isRunning=true"))
+        XCTAssertTrue(line.contains("default_input="))
+        XCTAssertTrue(line.contains("default_input_transport="))
+    }
+
     func testSharedModeVPIOForwardsChannelZeroOnly() async throws {
         let platform = SharedMicTestPlatform()
         let stream = SharedMicrophoneStream(platform: platform, bufferSize: 1024)
@@ -437,10 +469,11 @@ final class MicrophoneCaptureTests: XCTestCase {
 
     // MARK: - Bluetooth-output avoidance (issues #481/#541/#409)
 
-    func testBluetoothOutputPrefersBuiltInWhenOnSystemDefault() {
+    func testBluetoothOutputPrefersBuiltInWhenOnSystemDefault() throws {
         // System default input is the Bluetooth headset (id 20); built-in is
         // id 30. With output on Bluetooth and no explicit selection, built-in
         // is promoted to the front so capture doesn't force HFP/SCO.
+        let beforeDiagnostics = currentDiagnosticsLogContents()
         let attempts = meetingInputDeviceAttempts(
             selectedUID: nil,
             selectedInputDeviceID: { _ in nil },
@@ -458,6 +491,15 @@ final class MicrophoneCaptureTests: XCTestCase {
             ],
             "Built-in must lead, with the Bluetooth system default kept as fallback"
         )
+        let line = try diagnosticsLine(
+            containing: "mic_attempts_bluetooth_output_policy",
+            after: beforeDiagnostics
+        )
+        XCTAssertTrue(line.contains("preference=on"))
+        XCTAssertTrue(line.contains("explicit_selection_resolved=false"))
+        XCTAssertTrue(line.contains("default_output_transport=bluetooth"))
+        XCTAssertTrue(line.contains("outcome=fired"))
+        XCTAssertTrue(line.contains("reason=built_in_promoted"))
     }
 
     func testBluetoothOutputPrefersBuiltInWhenOutputLookupIsUnavailable() {
@@ -534,10 +576,11 @@ final class MicrophoneCaptureTests: XCTestCase {
         )
     }
 
-    func testBluetoothOutputKeepsExplicitSelectionFirstAndPinsBuiltInBeforeDefaultFallback() {
+    func testBluetoothOutputKeepsExplicitSelectionFirstAndPinsBuiltInBeforeDefaultFallback() throws {
         // An explicit selection remains first, but if it fails during Bluetooth
         // route churn we still avoid floating to the unpinned headset default
         // before trying the pinned built-in mic.
+        let beforeDiagnostics = currentDiagnosticsLogContents()
         let attempts = meetingInputDeviceAttempts(
             selectedUID: "usb-mic",
             selectedInputDeviceID: { uid in uid == "usb-mic" ? AudioDeviceID(10) : nil },
@@ -556,6 +599,15 @@ final class MicrophoneCaptureTests: XCTestCase {
             ],
             "Explicit selection must stay first, with built-in pinned before the Bluetooth default fallback"
         )
+        let line = try diagnosticsLine(
+            containing: "mic_attempts_bluetooth_output_policy",
+            after: beforeDiagnostics
+        )
+        XCTAssertTrue(line.contains("preference=on"))
+        XCTAssertTrue(line.contains("explicit_selection_resolved=true"))
+        XCTAssertTrue(line.contains("default_output_transport=bluetooth"))
+        XCTAssertTrue(line.contains("outcome=skipped"))
+        XCTAssertTrue(line.contains("reason=explicit_selection_resolved"))
     }
 
     func testBluetoothOutputLeavesExplicitSelectionFallbackUntouchedForNonBluetoothDefaultInput() {
@@ -658,8 +710,9 @@ final class MicrophoneCaptureTests: XCTestCase {
         )
     }
 
-    func testBluetoothOutputRuleDisabledLeavesChainUntouched() {
+    func testBluetoothOutputRuleDisabledLeavesChainUntouched() throws {
         var queriedOutput = false
+        let beforeDiagnostics = currentDiagnosticsLogContents()
         let attempts = meetingInputDeviceAttempts(
             selectedUID: nil,
             selectedInputDeviceID: { _ in nil },
@@ -680,6 +733,15 @@ final class MicrophoneCaptureTests: XCTestCase {
             ]
         )
         XCTAssertFalse(queriedOutput, "Disabled rule must not query the output transport")
+        let line = try diagnosticsLine(
+            containing: "mic_attempts_bluetooth_output_policy",
+            after: beforeDiagnostics
+        )
+        XCTAssertTrue(line.contains("preference=off"))
+        XCTAssertTrue(line.contains("explicit_selection_resolved=false"))
+        XCTAssertTrue(line.contains("default_output_transport=not_queried"))
+        XCTAssertTrue(line.contains("outcome=skipped"))
+        XCTAssertTrue(line.contains("reason=preference_off"))
     }
 
     func testBluetoothOutputPromotesBuiltInWhenSavedSelectionUnresolvable() {
@@ -771,6 +833,68 @@ final class MicrophoneCaptureTests: XCTestCase {
         let buffer = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 256)!
         buffer.frameLength = 256
         return buffer
+    }
+
+    private func currentDiagnosticsLogContents() -> String {
+        (try? String(contentsOf: AudioCaptureDiagnostics.diagnosticLogURL(), encoding: .utf8)) ?? ""
+    }
+
+    private func diagnosticsLine(
+        containing marker: String,
+        after previousContents: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws -> String {
+        return try XCTUnwrap(
+            diagnosticsLineIfPresent(containing: marker, after: previousContents),
+            "Expected diagnostics line containing \(marker)",
+            file: file,
+            line: line
+        )
+    }
+
+    private func diagnosticsLineIfPresent(
+        containing marker: String,
+        after previousContents: String
+    ) -> String? {
+        guard let contents = try? String(contentsOf: AudioCaptureDiagnostics.diagnosticLogURL(), encoding: .utf8) else {
+            return nil
+        }
+        let newContents =
+            contents.hasPrefix(previousContents)
+            ? String(contents.dropFirst(previousContents.count))
+            : contents
+        return newContents.split(separator: "\n").map(String.init).last { $0.contains(marker) }
+    }
+
+    private func waitForDiagnosticsLine(
+        containing marker: String,
+        after previousContents: String,
+        timeoutSeconds: TimeInterval = 3,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws -> String {
+        let deadline = Date().addingTimeInterval(timeoutSeconds)
+        repeat {
+            if let line = diagnosticsLineIfPresent(containing: marker, after: previousContents) {
+                return line
+            }
+            try await Task.sleep(for: .milliseconds(25))
+        } while Date() < deadline
+        return try diagnosticsLine(containing: marker, after: previousContents, file: file, line: line)
+    }
+
+    private func waitUntil(
+        timeoutSeconds: TimeInterval,
+        pollInterval: Duration = .milliseconds(25),
+        condition: () -> Bool
+    ) async -> Bool {
+        let deadline = Date().addingTimeInterval(timeoutSeconds)
+        repeat {
+            if condition() { return true }
+            try? await Task.sleep(for: pollInterval)
+        } while Date() < deadline
+        return condition()
     }
 
     private func makeSharedMultiChannelFloatBuffer(

--- a/Tests/MacParakeetTests/Audio/MicrophoneCaptureTests.swift
+++ b/Tests/MacParakeetTests/Audio/MicrophoneCaptureTests.swift
@@ -469,7 +469,7 @@ final class MicrophoneCaptureTests: XCTestCase {
 
     // MARK: - Bluetooth-output avoidance (issues #481/#541/#409)
 
-    func testBluetoothOutputPrefersBuiltInWhenOnSystemDefault() throws {
+    func testBluetoothOutputPrefersBuiltInWhenOnSystemDefault() async throws {
         // System default input is the Bluetooth headset (id 20); built-in is
         // id 30. With output on Bluetooth and no explicit selection, built-in
         // is promoted to the front so capture doesn't force HFP/SCO.
@@ -491,8 +491,8 @@ final class MicrophoneCaptureTests: XCTestCase {
             ],
             "Built-in must lead, with the Bluetooth system default kept as fallback"
         )
-        let line = try diagnosticsLine(
-            containing: "mic_attempts_bluetooth_output_policy",
+        let line = try await waitForDiagnosticsLine(
+            containing: "mic_attempts_bluetooth_output_policy preference=on explicit_selection_resolved=false",
             after: beforeDiagnostics
         )
         XCTAssertTrue(line.contains("preference=on"))
@@ -576,7 +576,7 @@ final class MicrophoneCaptureTests: XCTestCase {
         )
     }
 
-    func testBluetoothOutputKeepsExplicitSelectionFirstAndPinsBuiltInBeforeDefaultFallback() throws {
+    func testBluetoothOutputKeepsExplicitSelectionFirstAndPinsBuiltInBeforeDefaultFallback() async throws {
         // An explicit selection remains first, but if it fails during Bluetooth
         // route churn we still avoid floating to the unpinned headset default
         // before trying the pinned built-in mic.
@@ -599,14 +599,14 @@ final class MicrophoneCaptureTests: XCTestCase {
             ],
             "Explicit selection must stay first, with built-in pinned before the Bluetooth default fallback"
         )
-        let line = try diagnosticsLine(
-            containing: "mic_attempts_bluetooth_output_policy",
+        let line = try await waitForDiagnosticsLine(
+            containing: "mic_attempts_bluetooth_output_policy preference=on explicit_selection_resolved=true",
             after: beforeDiagnostics
         )
         XCTAssertTrue(line.contains("preference=on"))
         XCTAssertTrue(line.contains("explicit_selection_resolved=true"))
         XCTAssertTrue(line.contains("default_output_transport=bluetooth"))
-        XCTAssertTrue(line.contains("outcome=skipped"))
+        XCTAssertTrue(line.contains("outcome=fired"))
         XCTAssertTrue(line.contains("reason=explicit_selection_resolved"))
     }
 
@@ -710,7 +710,7 @@ final class MicrophoneCaptureTests: XCTestCase {
         )
     }
 
-    func testBluetoothOutputRuleDisabledLeavesChainUntouched() throws {
+    func testBluetoothOutputRuleDisabledLeavesChainUntouched() async throws {
         var queriedOutput = false
         let beforeDiagnostics = currentDiagnosticsLogContents()
         let attempts = meetingInputDeviceAttempts(
@@ -733,8 +733,8 @@ final class MicrophoneCaptureTests: XCTestCase {
             ]
         )
         XCTAssertFalse(queriedOutput, "Disabled rule must not query the output transport")
-        let line = try diagnosticsLine(
-            containing: "mic_attempts_bluetooth_output_policy",
+        let line = try await waitForDiagnosticsLine(
+            containing: "mic_attempts_bluetooth_output_policy preference=off",
             after: beforeDiagnostics
         )
         XCTAssertTrue(line.contains("preference=off"))


### PR DESCRIPTION
## Summary

Adds shared-log observability for two audio-routing diagnostics gaps without changing routing, capture, or watchdog behavior.

| Question | What shared `dictation-audio.log` showed before | What it shows after |
| --- | --- | --- |
| Did the built-in-over-Bluetooth-output policy fire for this session, and why or why not? | Input attempt ordering only; no output-route policy decision. | `mic_attempts_bluetooth_output_policy ...` once per attempt-chain build, including preference state, explicit-selection state, output transport query result, outcome, and reason. |
| Did meeting mic capture stall with no buffers? | OSLog warning plus stall observer only; nothing in `AudioCaptureDiagnostics`. | `meeting_mic_capture_no_buffers_within_timeout ...` appended to the user-shareable audio diagnostics log alongside existing watchdog behavior. |

## Line formats

```text
mic_attempts_bluetooth_output_policy preference=<on|off> explicit_selection_resolved=<true|false> default_output_transport=<not_queried|bluetooth|other|unresolved-nil> outcome=<fired|skipped> reason=<preference_off|no_built_in_microphone|default_input_not_bluetooth|default_output_not_bluetooth|built_in_promoted|explicit_selection_resolved>
meeting_mic_capture_no_buffers_within_timeout elapsed_s=2.000 isRunning=<true|false> default_input=<present|none> default_input_transport=<none|built-in|bluetooth|usb|aggregate-...|...>
```

## Design Notes

- Scope follows Fable’s 2026-07-03 implementation brief and the parent plan `journal/2026-07-03-audio-routing-cluster-plan.md`.
- No routing changed: the Bluetooth-output policy keeps the existing guard ordering and only logs the HAL output state when the existing logic already queries it.
- Diagnostics writes added on startup-sensitive paths are queued through `AudioCaptureDiagnostics.appendAsync(...)` so best-effort file I/O does not block route construction or watchdog delivery.
- The meeting no-buffer watchdog delivers the existing stall observer before gathering default-input diagnostics, while preserving the OSLog warning and shared diagnostics line.
- C4 check: existing raw multichannel downmix coverage was present, so no new downmix test was added. Coverage cited: `ExtractChannelZeroTests.testRawMicrophoneMultiChannelDownmixesAllChannels` and `MicrophoneCaptureTests.testSharedModeRawDownmixesMultiChannelBuffers`.

## Validation

- `swift test --filter MicrophoneCaptureTests` - 32 tests, 0 failures.
- `swift test --filter AudioCaptureDiagnosticsTests` - 4 tests, 0 failures.
- `swift test --filter ExtractChannelZeroTests` - 7 tests, 0 failures.
- `swift build -c release` - passed locally on final head `f58c9ae27`.
- `git diff --check` - clean.
- Hosted CI `swift-test` passed twice on final head `f58c9ae27` (`21m21s` and `15m46s` jobs), including release build, smoke checks, Swift concurrency, Swift 6 language mode, and Swift Test.
- Hosted Greptile passed with confidence score 5/5 on `f58c9ae27`; Cubic AI review passed.
- Local Greptile CLI dispatch/show still fails before findings with `Native workflow expansion ... requires expansionContext`; hosted Greptile provided the final 5/5 gate.