### PR TITLE
Allow OpenAI-compatible LAN HTTP in Settings

### DIFF
--- a/Sources/MacParakeet/Views/Settings/LLMSettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/LLMSettingsView.swift
@@ -284,6 +284,7 @@ struct LLMSettingsView: View {
                     Image(systemName: "exclamationmark.triangle.fill")
                         .font(.system(size: 11, weight: .semibold))
                         .foregroundStyle(DesignSystem.Colors.warningAmber)
+                        .accessibilityHidden(true)
                     Text("Prompt text, transcript context, and API keys may be visible on the network.")
                         .font(DesignSystem.Typography.caption)
                         .foregroundStyle(DesignSystem.Colors.warningAmber)

--- a/Sources/MacParakeet/Views/Settings/LLMSettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/LLMSettingsView.swift
@@ -93,6 +93,12 @@ struct LLMSettingsView: View {
                                 .frame(width: 220)
                         }
 
+                        if viewModel.selectedProviderID == .openaiCompatible {
+                            Divider()
+
+                            localNetworkHTTPSection
+                        }
+
                         Divider()
                     }
 
@@ -247,6 +253,41 @@ struct LLMSettingsView: View {
                     Text("Dictation, transcription, and meeting recording work without AI setup.")
                         .font(DesignSystem.Typography.caption)
                         .foregroundStyle(.secondary)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+    }
+
+    private var localNetworkHTTPSection: some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+            HStack(alignment: .top, spacing: DesignSystem.Spacing.md) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Local-network HTTP")
+                        .font(DesignSystem.Typography.body)
+                    Text("Allow http:// endpoints for self-hosted OpenAI-compatible servers on a trusted LAN or VPN.")
+                        .font(DesignSystem.Typography.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Spacer(minLength: DesignSystem.Spacing.md)
+
+                Toggle("Allow HTTP", isOn: $viewModel.allowInsecureLocalNetworkHTTP)
+                    .toggleStyle(.switch)
+                    .font(DesignSystem.Typography.caption.weight(.medium))
+                    .fixedSize()
+            }
+
+            if viewModel.allowInsecureLocalNetworkHTTP {
+                HStack(alignment: .top, spacing: 6) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(DesignSystem.Colors.warningAmber)
+                    Text("Prompt text, transcript context, and API keys may be visible on the network.")
+                        .font(DesignSystem.Typography.caption)
+                        .foregroundStyle(DesignSystem.Colors.warningAmber)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
@@ -1504,31 +1545,62 @@ struct LLMSettingsView: View {
         }
     }
 
-    @ViewBuilder
     private var privacyInfo: some View {
         let isLocal = viewModel.isLocalConfiguration
         let isCLI = viewModel.selectedProviderID == .localCLI
-        HStack(spacing: DesignSystem.Spacing.sm) {
-            Image(systemName: isLocal ? "lock.fill" : "arrow.up.right.circle")
-                .font(.system(size: 12))
-                .foregroundStyle(isLocal ? DesignSystem.Colors.successGreen : DesignSystem.Colors.warningAmber)
+        let usesInsecureHTTP = viewModel.usesInsecureLocalNetworkHTTP
+        let usesTrustedLocal = isLocal && !usesInsecureHTTP
+        let tint: Color
+        let iconName: String
+        if usesTrustedLocal {
+            tint = DesignSystem.Colors.successGreen
+            iconName = "lock.fill"
+        } else if usesInsecureHTTP {
+            tint = DesignSystem.Colors.warningAmber
+            iconName = "exclamationmark.triangle.fill"
+        } else {
+            tint = DesignSystem.Colors.warningAmber
+            iconName = "arrow.up.right.circle"
+        }
 
-            Text(isLocal
-                 ? "Transcript text is sent only to your local AI endpoint."
-                 : isCLI
-                    ? "Runs a command on this Mac. The command may contact its own service."
-                    : "Transcription stays local. Transcript text is sent only when you run an AI action.")
-                .font(DesignSystem.Typography.caption)
-                .foregroundStyle(.secondary)
+        return HStack(spacing: DesignSystem.Spacing.sm) {
+            Image(systemName: iconName)
+                .font(.system(size: 12))
+                .foregroundStyle(tint)
+
+            Text(
+                privacyInfoMessage(
+                    isLocal: isLocal,
+                    isCLI: isCLI,
+                    usesInsecureHTTP: usesInsecureHTTP
+                )
+            )
+            .font(DesignSystem.Typography.caption)
+            .foregroundStyle(.secondary)
         }
         .padding(DesignSystem.Spacing.sm)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(
             RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius)
-                .fill(isLocal
-                      ? DesignSystem.Colors.successGreen.opacity(0.06)
-                      : DesignSystem.Colors.warningAmber.opacity(0.06))
+                .fill(tint.opacity(0.06))
         )
+    }
+
+    private func privacyInfoMessage(
+        isLocal: Bool,
+        isCLI: Bool,
+        usesInsecureHTTP: Bool
+    ) -> String {
+        if usesInsecureHTTP {
+            return "Transcript text is sent to your local AI endpoint over HTTP. Use a trusted network."
+        }
+        if isLocal {
+            return "Transcript text is sent only to your local AI endpoint."
+        }
+        if isCLI {
+            return "Runs a command on this Mac. The command may contact its own service."
+        }
+        return "Transcription stays local. Transcript text is sent only when you run an AI action."
     }
 
     private var configurationActionsRow: some View {

--- a/Sources/MacParakeetCore/Models/LLMProvider.swift
+++ b/Sources/MacParakeetCore/Models/LLMProvider.swift
@@ -313,14 +313,15 @@ public struct LLMProviderConfig: Codable, Sendable, Equatable {
     public static func openaiCompatible(
         apiKey: String? = nil,
         model: String,
-        baseURL: URL
+        baseURL: URL,
+        isLocal: Bool? = nil
     ) -> LLMProviderConfig {
         LLMProviderConfig(
             id: .openaiCompatible,
             baseURL: baseURL,
             apiKey: apiKey,
             modelName: model,
-            isLocal: Self.isLoopbackEndpoint(baseURL)
+            isLocal: isLocal ?? Self.isLoopbackEndpoint(baseURL)
         )
     }
 

--- a/Sources/MacParakeetViewModels/LLMSettingsDraft.swift
+++ b/Sources/MacParakeetViewModels/LLMSettingsDraft.swift
@@ -1,5 +1,6 @@
 import Foundation
 import MacParakeetCore
+import Network
 
 public struct LLMSettingsDraft: Equatable, Sendable {
     public enum ValidationError: LocalizedError, Equatable {
@@ -161,7 +162,7 @@ public struct LLMSettingsDraft: Equatable, Sendable {
         else {
             return false
         }
-        return Self.isNonLoopbackHTTP(url)
+        return Self.isAllowedInsecureLocalNetworkHTTP(url)
     }
 
     public func buildConfig(
@@ -289,6 +290,9 @@ public struct LLMSettingsDraft: Equatable, Sendable {
             return nil
         }
         if providerID == .openaiCompatible {
+            guard Self.isAllowedInsecureLocalNetworkHTTP(url) else {
+                return .invalidBaseURL
+            }
             return allowInsecureLocalNetworkHTTP ? nil : .localNetworkHTTPRequiresOptIn
         }
         return .invalidBaseURL
@@ -299,18 +303,62 @@ public struct LLMSettingsDraft: Equatable, Sendable {
         allowInsecureLocalNetworkHTTP: Bool
     ) -> Bool {
         LLMProviderConfig.isLoopbackEndpoint(url)
-            || (allowInsecureLocalNetworkHTTP && isNonLoopbackHTTP(url))
+            || (allowInsecureLocalNetworkHTTP && isAllowedInsecureLocalNetworkHTTP(url))
     }
 
-    private static func isNonLoopbackHTTP(_ url: URL) -> Bool {
-        url.scheme?.lowercased() == "http"
-            && !LLMProviderConfig.isLoopbackEndpoint(url)
-            && url.host != nil
+    private static func isAllowedInsecureLocalNetworkHTTP(_ url: URL) -> Bool {
+        guard url.scheme?.lowercased() == "http" else {
+            return false
+        }
+        guard !LLMProviderConfig.isLoopbackEndpoint(url) else {
+            return false
+        }
+        guard let host = normalizedHost(from: url) else {
+            return false
+        }
+        return isLocalNetworkHost(host)
+    }
+
+    private static func normalizedHost(from url: URL) -> String? {
+        guard let host = url.host?.trimmingCharacters(in: .whitespacesAndNewlines), !host.isEmpty else {
+            return nil
+        }
+        return host.lowercased().trimmingCharacters(in: CharacterSet(charactersIn: "."))
+    }
+
+    private static func isLocalNetworkHost(_ host: String) -> Bool {
+        if host.hasSuffix(".local") {
+            return true
+        }
+        if let address = IPv4Address(host) {
+            return isLocalNetworkIPv4(Array(address.rawValue))
+        }
+        if let address = IPv6Address(host) {
+            return isLocalNetworkIPv6(Array(address.rawValue))
+        }
+        return false
+    }
+
+    private static func isLocalNetworkIPv4(_ bytes: [UInt8]) -> Bool {
+        guard bytes.count == 4 else { return false }
+        let first = bytes[0]
+        let second = bytes[1]
+        return first == 10
+            || (first == 172 && (16...31).contains(second))
+            || (first == 192 && second == 168)
+            || (first == 169 && second == 254)
+            || (first == 100 && (64...127).contains(second))
+    }
+
+    private static func isLocalNetworkIPv6(_ bytes: [UInt8]) -> Bool {
+        guard bytes.count == 16 else { return false }
+        return (bytes[0] & 0xFE) == 0xFC
+            || (bytes[0] == 0xFE && (bytes[1] & 0xC0) == 0x80)
     }
 
     private static func shouldRestoreLocalNetworkHTTPOptIn(from config: LLMProviderConfig) -> Bool {
         config.id == .openaiCompatible
             && config.isLocal
-            && isNonLoopbackHTTP(config.baseURL)
+            && isAllowedInsecureLocalNetworkHTTP(config.baseURL)
     }
 }

--- a/Sources/MacParakeetViewModels/LLMSettingsDraft.swift
+++ b/Sources/MacParakeetViewModels/LLMSettingsDraft.swift
@@ -7,6 +7,7 @@ public struct LLMSettingsDraft: Equatable, Sendable {
         case missingModelSelection
         case missingCustomModel
         case invalidBaseURL
+        case localNetworkHTTPRequiresOptIn
         case missingCommandTemplate
 
         public var errorDescription: String? {
@@ -19,6 +20,8 @@ public struct LLMSettingsDraft: Equatable, Sendable {
                 return "Enter a custom model ID."
             case .invalidBaseURL:
                 return "Enter a valid base URL. Remote endpoints must use https."
+            case .localNetworkHTTPRequiresOptIn:
+                return "Turn on local-network HTTP or use https."
             case .missingCommandTemplate:
                 return "Enter a CLI command."
             }
@@ -31,6 +34,7 @@ public struct LLMSettingsDraft: Equatable, Sendable {
     public var useCustomModel: Bool
     public var customModelName: String
     public var baseURLOverride: String
+    public var allowInsecureLocalNetworkHTTP: Bool
 
     // Local CLI fields
     public var commandTemplate: String
@@ -45,6 +49,7 @@ public struct LLMSettingsDraft: Equatable, Sendable {
         useCustomModel: Bool = false,
         customModelName: String = "",
         baseURLOverride: String = "",
+        allowInsecureLocalNetworkHTTP: Bool = false,
         commandTemplate: String = "",
         selectedCLITemplate: LocalCLITemplate? = nil,
         cliTimeoutSeconds: Double = LocalCLIConfig.defaultTimeout,
@@ -56,6 +61,7 @@ public struct LLMSettingsDraft: Equatable, Sendable {
         self.useCustomModel = useCustomModel
         self.customModelName = customModelName
         self.baseURLOverride = baseURLOverride
+        self.allowInsecureLocalNetworkHTTP = allowInsecureLocalNetworkHTTP
         self.commandTemplate = commandTemplate
         self.selectedCLITemplate = selectedCLITemplate
         self.cliTimeoutSeconds = max(LocalCLIConfig.minimumTimeout, cliTimeoutSeconds)
@@ -118,9 +124,15 @@ public struct LLMSettingsDraft: Equatable, Sendable {
             return .invalidBaseURL
         }
         if !trimmedBaseURLOverride.isEmpty {
-            guard let overrideURL = URL(string: trimmedBaseURLOverride),
-                  Self.isAllowedBaseURLOverride(overrideURL, providerID: providerID) else {
+            guard let overrideURL = URL(string: trimmedBaseURLOverride) else {
                 return .invalidBaseURL
+            }
+            if let validationError = Self.baseURLValidationError(
+                overrideURL,
+                providerID: providerID,
+                allowInsecureLocalNetworkHTTP: allowInsecureLocalNetworkHTTP
+            ) {
+                return validationError
             }
         }
         return nil
@@ -134,9 +146,22 @@ public struct LLMSettingsDraft: Equatable, Sendable {
         guard let providerID else { return false }
         if providerID == .openaiCompatible,
            let url = URL(string: trimmedBaseURLOverride) {
-            return LLMProviderConfig.isLoopbackEndpoint(url)
+            return Self.isOpenAICompatibleLocalConfiguration(
+                url,
+                allowInsecureLocalNetworkHTTP: allowInsecureLocalNetworkHTTP
+            )
         }
         return providerID.isLocal
+    }
+
+    public var usesInsecureLocalNetworkHTTP: Bool {
+        guard providerID == .openaiCompatible,
+              allowInsecureLocalNetworkHTTP,
+              let url = URL(string: trimmedBaseURLOverride)
+        else {
+            return false
+        }
+        return Self.isNonLoopbackHTTP(url)
     }
 
     public func buildConfig(
@@ -157,8 +182,12 @@ public struct LLMSettingsDraft: Equatable, Sendable {
             guard let override = URL(string: trimmedBaseURLOverride) else {
                 throw ValidationError.invalidBaseURL
             }
-            guard Self.isAllowedBaseURLOverride(override, providerID: providerID) else {
-                throw ValidationError.invalidBaseURL
+            if let validationError = Self.baseURLValidationError(
+                override,
+                providerID: providerID,
+                allowInsecureLocalNetworkHTTP: allowInsecureLocalNetworkHTTP
+            ) {
+                throw validationError
             }
             baseURL = override
         } else if let defaultURL = URL(string: defaultBaseURL), !defaultBaseURL.isEmpty {
@@ -171,7 +200,11 @@ public struct LLMSettingsDraft: Equatable, Sendable {
             return .openaiCompatible(
                 apiKey: trimmedAPIKey.isEmpty ? nil : trimmedAPIKey,
                 model: effectiveModelName,
-                baseURL: baseURL
+                baseURL: baseURL,
+                isLocal: Self.isOpenAICompatibleLocalConfiguration(
+                    baseURL,
+                    allowInsecureLocalNetworkHTTP: allowInsecureLocalNetworkHTTP
+                )
             )
         }
 
@@ -199,6 +232,7 @@ public struct LLMSettingsDraft: Equatable, Sendable {
             useCustomModel: false,
             customModelName: "",
             baseURLOverride: "",
+            allowInsecureLocalNetworkHTTP: false,
             commandTemplate: cliConfig?.commandTemplate ?? "",
             selectedCLITemplate: selectedCLITemplate,
             cliTimeoutSeconds: cliConfig?.timeoutSeconds ?? LocalCLIConfig.defaultTimeout,
@@ -223,6 +257,7 @@ public struct LLMSettingsDraft: Equatable, Sendable {
             useCustomModel: !isSuggestedModel,
             customModelName: isSuggestedModel ? "" : config.modelName,
             baseURLOverride: config.baseURL.absoluteString == defaultBaseURL ? "" : config.baseURL.absoluteString,
+            allowInsecureLocalNetworkHTTP: Self.shouldRestoreLocalNetworkHTTPOptIn(from: config),
             commandTemplate: cliConfig?.commandTemplate ?? "",
             selectedCLITemplate: selectedCLITemplate,
             cliTimeoutSeconds: cliConfig?.timeoutSeconds ?? LocalCLIConfig.defaultTimeout,
@@ -230,22 +265,52 @@ public struct LLMSettingsDraft: Equatable, Sendable {
         )
     }
 
-    private static func isAllowedBaseURLOverride(_ url: URL, providerID: LLMProviderID) -> Bool {
+    private static func baseURLValidationError(
+        _ url: URL,
+        providerID: LLMProviderID,
+        allowInsecureLocalNetworkHTTP: Bool
+    ) -> ValidationError? {
         guard let scheme = url.scheme?.lowercased(),
               url.host != nil else {
-            return false
+            return .invalidBaseURL
         }
         if scheme == "https" {
-            return true
+            return nil
         }
         guard scheme == "http" else {
-            return false
+            return .invalidBaseURL
         }
         // Local providers (Ollama, LM Studio) may be reachable over any host the
         // user configures — LAN IP, mDNS hostname, Tailscale, 0.0.0.0 bind, etc.
         if providerID.isLocal {
-            return true
+            return nil
         }
-        return LLMProviderConfig.isLoopbackEndpoint(url)
+        if providerID == .openaiCompatible && LLMProviderConfig.isLoopbackEndpoint(url) {
+            return nil
+        }
+        if providerID == .openaiCompatible {
+            return allowInsecureLocalNetworkHTTP ? nil : .localNetworkHTTPRequiresOptIn
+        }
+        return .invalidBaseURL
+    }
+
+    private static func isOpenAICompatibleLocalConfiguration(
+        _ url: URL,
+        allowInsecureLocalNetworkHTTP: Bool
+    ) -> Bool {
+        LLMProviderConfig.isLoopbackEndpoint(url)
+            || (allowInsecureLocalNetworkHTTP && isNonLoopbackHTTP(url))
+    }
+
+    private static func isNonLoopbackHTTP(_ url: URL) -> Bool {
+        url.scheme?.lowercased() == "http"
+            && !LLMProviderConfig.isLoopbackEndpoint(url)
+            && url.host != nil
+    }
+
+    private static func shouldRestoreLocalNetworkHTTPOptIn(from config: LLMProviderConfig) -> Bool {
+        config.id == .openaiCompatible
+            && config.isLocal
+            && isNonLoopbackHTTP(config.baseURL)
     }
 }

--- a/Sources/MacParakeetViewModels/LLMSettingsDraft.swift
+++ b/Sources/MacParakeetViewModels/LLMSettingsDraft.swift
@@ -333,10 +333,16 @@ public struct LLMSettingsDraft: Equatable, Sendable {
         if let address = IPv4Address(host) {
             return isLocalNetworkIPv4(Array(address.rawValue))
         }
-        if let address = IPv6Address(host) {
+        if let address = IPv6Address(ipv6HostWithoutScope(host)) {
             return isLocalNetworkIPv6(Array(address.rawValue))
         }
         return false
+    }
+
+    private static func ipv6HostWithoutScope(_ host: String) -> String {
+        host.split(separator: "%", maxSplits: 1, omittingEmptySubsequences: false)
+            .first
+            .map(String.init) ?? host
     }
 
     private static func isLocalNetworkIPv4(_ bytes: [UInt8]) -> Bool {

--- a/Sources/MacParakeetViewModels/LLMSettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/LLMSettingsViewModel.swift
@@ -187,6 +187,15 @@ public final class LLMSettingsViewModel {
         }
     }
 
+    public var allowInsecureLocalNetworkHTTP: Bool {
+        get { draft.allowInsecureLocalNetworkHTTP }
+        set {
+            var nextDraft = draft
+            nextDraft.allowInsecureLocalNetworkHTTP = newValue
+            updateDraft(nextDraft)
+        }
+    }
+
     public var baseURLPlaceholder: String {
         guard let providerID = draft.providerID else { return "https://..." }
         let fallback = providerID == .openaiCompatible ? "https://api.example.com/v1" : "https://..."
@@ -315,6 +324,10 @@ public final class LLMSettingsViewModel {
 
     public var isLocalConfiguration: Bool {
         draft.isLocalConfiguration
+    }
+
+    public var usesInsecureLocalNetworkHTTP: Bool {
+        draft.usesInsecureLocalNetworkHTTP
     }
 
     public var validationMessage: String? {
@@ -539,6 +552,7 @@ public final class LLMSettingsViewModel {
             baseURL: String,
             modelName: String,
             apiKey: String?,
+            isLocal: Bool,
             localCLIConfig: LocalCLIConfig?
         )
     }
@@ -1122,6 +1136,7 @@ public final class LLMSettingsViewModel {
         draft.providerID == snapshot.providerID
             && draft.trimmedAPIKey == snapshot.trimmedAPIKey
             && draft.trimmedBaseURLOverride == snapshot.trimmedBaseURLOverride
+            && draft.allowInsecureLocalNetworkHTTP == snapshot.allowInsecureLocalNetworkHTTP
     }
 
     private func reconcileModelSelection(with models: [String], snapshot: LLMSettingsDraft) {
@@ -1181,6 +1196,7 @@ public final class LLMSettingsViewModel {
                 baseURL: Self.defaultBaseURL(for: providerID),
                 modelName: "cli",
                 apiKey: nil,
+                isLocal: false,
                 localCLIConfig: LocalCLIConfig(
                     commandTemplate: draft.trimmedCommandTemplate,
                     timeoutSeconds: draft.cliTimeoutSeconds
@@ -1193,6 +1209,7 @@ public final class LLMSettingsViewModel {
             baseURL: draftBaseURL(for: providerID),
             modelName: draft.effectiveModelName,
             apiKey: providerID.supportsAPIKey ? draft.trimmedAPIKey : nil,
+            isLocal: draft.isLocalConfiguration,
             localCLIConfig: nil
         )
     }
@@ -1204,6 +1221,7 @@ public final class LLMSettingsViewModel {
             baseURL: config.baseURL.absoluteString,
             modelName: config.modelName,
             apiKey: config.id.supportsAPIKey ? (config.apiKey ?? "") : nil,
+            isLocal: config.isLocal,
             localCLIConfig: config.id == .localCLI ? cliConfigStore?.load() : nil
         )
     }

--- a/Tests/MacParakeetTests/ViewModels/LLMSettingsDraftTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/LLMSettingsDraftTests.swift
@@ -83,6 +83,76 @@ final class LLMSettingsDraftTests: XCTestCase {
         XCTAssertEqual(config?.isLocal, true)
     }
 
+    func testOpenAICompatibleRejectsPublicHTTPHostEvenWithExplicitOptIn() {
+        let draft = LLMSettingsDraft(
+            providerID: .openaiCompatible,
+            useCustomModel: true,
+            customModelName: "local-model",
+            baseURLOverride: "http://example.com/v1",
+            allowInsecureLocalNetworkHTTP: true
+        )
+
+        XCTAssertEqual(draft.validationError, .invalidBaseURL)
+        XCTAssertFalse(draft.isLocalConfiguration)
+        XCTAssertFalse(draft.usesInsecureLocalNetworkHTTP)
+    }
+
+    func testOpenAICompatibleRejectsPublicHTTPAddressEvenWithExplicitOptIn() {
+        let draft = LLMSettingsDraft(
+            providerID: .openaiCompatible,
+            useCustomModel: true,
+            customModelName: "local-model",
+            baseURLOverride: "http://8.8.8.8/v1",
+            allowInsecureLocalNetworkHTTP: true
+        )
+
+        XCTAssertEqual(draft.validationError, .invalidBaseURL)
+        XCTAssertFalse(draft.isLocalConfiguration)
+        XCTAssertFalse(draft.usesInsecureLocalNetworkHTTP)
+    }
+
+    func testOpenAICompatibleAllowsCGNATHTTPWithExplicitOptIn() {
+        let draft = LLMSettingsDraft(
+            providerID: .openaiCompatible,
+            useCustomModel: true,
+            customModelName: "local-model",
+            baseURLOverride: "http://100.64.0.42:8000/v1",
+            allowInsecureLocalNetworkHTTP: true
+        )
+
+        XCTAssertNil(draft.validationError)
+        XCTAssertTrue(draft.isLocalConfiguration)
+        XCTAssertTrue(draft.usesInsecureLocalNetworkHTTP)
+    }
+
+    func testOpenAICompatibleAllowsPrivateIPv6HTTPWithExplicitOptIn() {
+        let draft = LLMSettingsDraft(
+            providerID: .openaiCompatible,
+            useCustomModel: true,
+            customModelName: "local-model",
+            baseURLOverride: "http://[fd12:3456::1]:8000/v1",
+            allowInsecureLocalNetworkHTTP: true
+        )
+
+        XCTAssertNil(draft.validationError)
+        XCTAssertTrue(draft.isLocalConfiguration)
+        XCTAssertTrue(draft.usesInsecureLocalNetworkHTTP)
+    }
+
+    func testOpenAICompatibleAllowsMDNSHTTPWithExplicitOptIn() {
+        let draft = LLMSettingsDraft(
+            providerID: .openaiCompatible,
+            useCustomModel: true,
+            customModelName: "local-model",
+            baseURLOverride: "http://studio.local:8000/v1",
+            allowInsecureLocalNetworkHTTP: true
+        )
+
+        XCTAssertNil(draft.validationError)
+        XCTAssertTrue(draft.isLocalConfiguration)
+        XCTAssertTrue(draft.usesInsecureLocalNetworkHTTP)
+    }
+
     // Regression: #118 — 0.0.0.0 bind addresses (common Ollama config) must be accepted.
     func testOllamaWildcardBindBaseURLIsAllowed() {
         let draft = LLMSettingsDraft(
@@ -227,5 +297,26 @@ final class LLMSettingsDraftTests: XCTestCase {
         XCTAssertTrue(draft.allowInsecureLocalNetworkHTTP)
         XCTAssertTrue(draft.usesInsecureLocalNetworkHTTP)
         XCTAssertNil(draft.validationError)
+    }
+
+    func testOpenAICompatibleStoredPublicHTTPConfigDoesNotRestoreOptIn() {
+        let config = LLMProviderConfig(
+            id: .openaiCompatible,
+            baseURL: URL(string: "http://example.com/v1")!,
+            apiKey: nil,
+            modelName: "remote-model",
+            isLocal: true
+        )
+
+        let draft = LLMSettingsDraft.fromStoredConfig(
+            config,
+            suggestedModels: [],
+            defaultModelName: "",
+            defaultBaseURL: ""
+        )
+
+        XCTAssertFalse(draft.allowInsecureLocalNetworkHTTP)
+        XCTAssertFalse(draft.usesInsecureLocalNetworkHTTP)
+        XCTAssertEqual(draft.validationError, .invalidBaseURL)
     }
 }

--- a/Tests/MacParakeetTests/ViewModels/LLMSettingsDraftTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/LLMSettingsDraftTests.swift
@@ -139,6 +139,20 @@ final class LLMSettingsDraftTests: XCTestCase {
         XCTAssertTrue(draft.usesInsecureLocalNetworkHTTP)
     }
 
+    func testOpenAICompatibleAllowsScopedLinkLocalIPv6HTTPWithExplicitOptIn() {
+        let draft = LLMSettingsDraft(
+            providerID: .openaiCompatible,
+            useCustomModel: true,
+            customModelName: "local-model",
+            baseURLOverride: "http://[fe80::1%25en0]:8000/v1",
+            allowInsecureLocalNetworkHTTP: true
+        )
+
+        XCTAssertNil(draft.validationError)
+        XCTAssertTrue(draft.isLocalConfiguration)
+        XCTAssertTrue(draft.usesInsecureLocalNetworkHTTP)
+    }
+
     func testOpenAICompatibleAllowsMDNSHTTPWithExplicitOptIn() {
         let draft = LLMSettingsDraft(
             providerID: .openaiCompatible,

--- a/Tests/MacParakeetTests/ViewModels/LLMSettingsDraftTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/LLMSettingsDraftTests.swift
@@ -51,9 +51,9 @@ final class LLMSettingsDraftTests: XCTestCase {
         XCTAssertNil(draft.validationError)
     }
 
-    // Preserves PR #109's tightening: remote providers (including OpenAI-compatible
-    // shims) must use HTTPS unless the user is pointing at loopback.
-    func testOpenAICompatibleRejectsHTTPOnLANHost() {
+    // Preserves PR #109's tightening: OpenAI-compatible LAN HTTP needs an
+    // explicit local-network opt-in unless the user is pointing at loopback.
+    func testOpenAICompatibleRejectsHTTPOnLANHostWithoutOptIn() {
         let draft = LLMSettingsDraft(
             providerID: .openaiCompatible,
             useCustomModel: true,
@@ -61,7 +61,26 @@ final class LLMSettingsDraftTests: XCTestCase {
             baseURLOverride: "http://192.168.1.5:8000/v1"
         )
 
-        XCTAssertEqual(draft.validationError, .invalidBaseURL)
+        XCTAssertEqual(draft.validationError, .localNetworkHTTPRequiresOptIn)
+    }
+
+    func testOpenAICompatibleAllowsHTTPOnLANHostWithExplicitOptIn() throws {
+        let draft = LLMSettingsDraft(
+            providerID: .openaiCompatible,
+            useCustomModel: true,
+            customModelName: "local-model",
+            baseURLOverride: "http://192.168.1.5:8000/v1",
+            allowInsecureLocalNetworkHTTP: true
+        )
+
+        XCTAssertNil(draft.validationError)
+        XCTAssertTrue(draft.isLocalConfiguration)
+        XCTAssertTrue(draft.usesInsecureLocalNetworkHTTP)
+
+        let config = try draft.buildConfig(defaultBaseURL: "")
+        XCTAssertEqual(config?.id, .openaiCompatible)
+        XCTAssertEqual(config?.baseURL.absoluteString, "http://192.168.1.5:8000/v1")
+        XCTAssertEqual(config?.isLocal, true)
     }
 
     // Regression: #118 — 0.0.0.0 bind addresses (common Ollama config) must be accepted.
@@ -187,5 +206,26 @@ final class LLMSettingsDraftTests: XCTestCase {
 
         XCTAssertEqual(config?.id, .openaiCompatible)
         XCTAssertEqual(config?.isLocal, false)
+    }
+
+    func testOpenAICompatibleStoredLocalNetworkHTTPConfigRestoresOptIn() {
+        let config = LLMProviderConfig(
+            id: .openaiCompatible,
+            baseURL: URL(string: "http://192.168.1.5:8000/v1")!,
+            apiKey: nil,
+            modelName: "local-model",
+            isLocal: true
+        )
+
+        let draft = LLMSettingsDraft.fromStoredConfig(
+            config,
+            suggestedModels: [],
+            defaultModelName: "",
+            defaultBaseURL: ""
+        )
+
+        XCTAssertTrue(draft.allowInsecureLocalNetworkHTTP)
+        XCTAssertTrue(draft.usesInsecureLocalNetworkHTTP)
+        XCTAssertNil(draft.validationError)
     }
 }

--- a/Tests/MacParakeetTests/ViewModels/LLMSettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/LLMSettingsViewModelTests.swift
@@ -1694,6 +1694,47 @@ final class LLMSettingsViewModelTests: XCTestCase {
         XCTAssertNil(saved?.apiKey)
     }
 
+    func testOpenAICompatibleLANHTTPRequiresExplicitOptIn() {
+        viewModel.configure(configStore: mockConfigStore, llmClient: mockClient)
+        viewModel.selectedProviderID = .openaiCompatible
+        viewModel.customModelName = "local-model"
+        viewModel.baseURLOverride = "http://192.168.1.5:8000/v1"
+
+        XCTAssertFalse(viewModel.canSave)
+        XCTAssertEqual(viewModel.validationMessage, "Turn on local-network HTTP or use https.")
+        XCTAssertFalse(viewModel.isLocalConfiguration)
+        XCTAssertFalse(viewModel.usesInsecureLocalNetworkHTTP)
+
+        viewModel.allowInsecureLocalNetworkHTTP = true
+
+        XCTAssertTrue(viewModel.canSave)
+        XCTAssertTrue(viewModel.isLocalConfiguration)
+        XCTAssertTrue(viewModel.usesInsecureLocalNetworkHTTP)
+
+        viewModel.saveConfiguration()
+
+        let saved = mockConfigStore.config
+        XCTAssertEqual(saved?.id, .openaiCompatible)
+        XCTAssertEqual(saved?.baseURL.absoluteString, "http://192.168.1.5:8000/v1")
+        XCTAssertEqual(saved?.isLocal, true)
+    }
+
+    func testHasUnsavedChangesTracksOpenAICompatibleLANHTTPOptIn() {
+        viewModel.configure(configStore: mockConfigStore, llmClient: mockClient)
+        viewModel.selectedProviderID = .openaiCompatible
+        viewModel.customModelName = "local-model"
+        viewModel.baseURLOverride = "http://192.168.1.5:8000/v1"
+        viewModel.allowInsecureLocalNetworkHTTP = true
+        viewModel.saveConfiguration()
+
+        XCTAssertFalse(viewModel.hasUnsavedChanges)
+
+        viewModel.allowInsecureLocalNetworkHTTP = false
+
+        XCTAssertTrue(viewModel.hasUnsavedChanges)
+        XCTAssertFalse(viewModel.canSave)
+    }
+
     func testOpenAICompatibleLoopbackEndpointIsTreatedAsLocal() {
         viewModel.configure(configStore: mockConfigStore, llmClient: mockClient)
         viewModel.selectedProviderID = .openaiCompatible


### PR DESCRIPTION
## Summary
Settings now supports the LAN HTTP path users were missing for self-hosted OpenAI-compatible LLM servers. Non-loopback `http://` endpoints still fail closed until the user turns on an explicit “Allow HTTP” opt-in; when enabled for a local-network host, the saved config is treated as local and Settings shows HTTP-specific network visibility copy.

## Design
- Preserve existing defaults: HTTPS endpoints, loopback HTTP, Ollama, and LM Studio behavior are unchanged.
- Scope the new opt-in to OpenAI-compatible LLM providers in Settings; shortcut remapping and transcription endpoints remain separate work.
- Reuse the existing LLM provider config shape by persisting the local intent in `isLocal`, avoiding a separate preferences path.

## How It Works
| Settings endpoint | Behavior |
|---|---|
| OpenAI-compatible `https://...` | Allowed as before, non-local unless otherwise local. |
| OpenAI-compatible loopback `http://127.0.0.1...` | Allowed as before and treated as local. |
| OpenAI-compatible local-network `http://...` | Private/link-local IPv4, CGNAT/Tailscale `100.64.0.0/10`, IPv6 ULA/link-local including scoped link-local forms such as `[fe80::1%25en0]`, and `.local` hostnames require “Allow HTTP”; then save as local and show HTTP warnings. Public HTTP hosts and addresses remain invalid. |
| Ollama / LM Studio LAN HTTP | Allowed as before. |

## Risk Surface
- Privacy: cleartext HTTP can expose prompts, transcript context, and API keys on the network, so the opt-in, local-host restriction, and warning copy are the primary controls.
- Persistence: saved LAN HTTP configs should reload with the opt-in restored, while HTTPS, loopback, public HTTP, and cloud configs should stay unchanged.
- Async Settings state: model-list results include the opt-in in their snapshot guard so stale discovery results do not apply after toggling HTTP.

## Test Evidence
- `swift test --filter LLMSettingsDraftTests`
- `swift test --filter LLMSettingsViewModelTests`
- `swift test --filter LLMConfigCommandTests`
- `swift test --filter LLMConfigStoreTests`
- `git diff --check`
- `xcrun swift-format lint Sources/MacParakeet/Views/Settings/LLMSettingsView.swift Sources/MacParakeetCore/Models/LLMProvider.swift Sources/MacParakeetViewModels/LLMSettingsDraft.swift Sources/MacParakeetViewModels/LLMSettingsViewModel.swift Tests/MacParakeetTests/ViewModels/LLMSettingsDraftTests.swift Tests/MacParakeetTests/ViewModels/LLMSettingsViewModelTests.swift` exits 0; remaining warnings are pre-existing in touched files.

Full `swift test` is left to CI; the local runs cover the touched LLM settings, persistence, and CLI compatibility paths.

## Related
Related: #664

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5_Codex-000000)
