### PR TITLE
Test dictation paste uses completed transcript

### DIFF
--- a/Tests/MacParakeetTests/DictationFlow/DictationFlowCoordinatorTests.swift
+++ b/Tests/MacParakeetTests/DictationFlow/DictationFlowCoordinatorTests.swift
@@ -25,6 +25,47 @@ final class DictationFlowCoordinatorTests: XCTestCase {
         harness.coordinator.cancelDictation()
     }
 
+    func testPersistentBackToBackDictationsPasteJustCompletedTranscript() async throws {
+        let harness = try await makeRecordingHarness()
+        await harness.stt.configureSequence(results: [
+            STTResult(text: "first dictated message"),
+            STTResult(text: "second dictated message"),
+        ])
+
+        harness.coordinator.startDictation(mode: .persistent, trigger: .hotkey)
+        let firstStarted = await waitUntil { self.isFlowRecording(harness.coordinator.flowStateForTesting) }
+        XCTAssertTrue(firstStarted)
+
+        harness.coordinator.stopDictation()
+        let firstPasted = await waitUntilAsync {
+            await harness.clipboard.snapshot().pasteCallCount == 1
+        }
+        XCTAssertTrue(firstPasted)
+        XCTAssertEqual(harness.coordinator.flowStateForTesting, .idle)
+
+        harness.coordinator.startDictation(mode: .persistent, trigger: .hotkey)
+        let secondStarted = await waitUntil { self.isFlowRecording(harness.coordinator.flowStateForTesting) }
+        XCTAssertTrue(secondStarted)
+
+        harness.coordinator.stopDictation()
+        let secondPasted = await waitUntilAsync {
+            await harness.clipboard.snapshot().pasteCallCount == 2
+        }
+        XCTAssertTrue(secondPasted)
+
+        let clipboardSnapshot = await harness.clipboard.snapshot()
+        XCTAssertEqual(
+            clipboardSnapshot.pastedTexts,
+            ["first dictated message ", "second dictated message "]
+        )
+        XCTAssertEqual(clipboardSnapshot.lastPastedText, "second dictated message ")
+
+        let savedTranscripts = try harness.repo.fetchAll(limit: nil).map(\.rawTranscript)
+        XCTAssertEqual(savedTranscripts.count, 2)
+        XCTAssertTrue(savedTranscripts.contains("first dictated message"))
+        XCTAssertTrue(savedTranscripts.contains("second dictated message"))
+    }
+
     func testSuccessfulMicPermissionRequestDismissesStaleStartFailure() async throws {
         let harness = try await makeMicPermissionHarness(
             microphonePermission: .notDetermined,
@@ -254,6 +295,7 @@ final class DictationFlowCoordinatorTests: XCTestCase {
         let dbManager = try DatabaseManager()
         let audio = MockAudioProcessor()
         let stt = MockSTTClient()
+        let clipboard = MockClipboardService()
         let repo = DictationRepository(dbQueue: dbManager.dbQueue)
         let service = DictationService(
             audioProcessor: audio,
@@ -275,7 +317,7 @@ final class DictationFlowCoordinatorTests: XCTestCase {
 
         let coordinator = DictationFlowCoordinator(
             dictationService: service,
-            clipboardService: MockClipboardService(),
+            clipboardService: clipboard,
             entitlementsService: entitlements,
             dictationRepo: repo,
             settingsViewModel: settings,
@@ -288,7 +330,13 @@ final class DictationFlowCoordinatorTests: XCTestCase {
             onPresentEntitlementsAlert: { _ in }
         )
 
-        return RecordingHarness(coordinator: coordinator)
+        return RecordingHarness(
+            coordinator: coordinator,
+            audio: audio,
+            stt: stt,
+            clipboard: clipboard,
+            repo: repo
+        )
     }
 
     private func makeTestDefaults(prefix: String) -> UserDefaults {
@@ -313,6 +361,18 @@ final class DictationFlowCoordinatorTests: XCTestCase {
         return condition()
     }
 
+    private func waitUntilAsync(
+        timeoutMs: UInt64 = 2_500,
+        condition: @escaping @MainActor () async -> Bool
+    ) async -> Bool {
+        let deadline = Date().addingTimeInterval(Double(timeoutMs) / 1000)
+        while Date() < deadline {
+            if await condition() { return true }
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        return await condition()
+    }
+
     private func isFlowRecording(_ state: DictationFlowState) -> Bool {
         if case .recording = state { return true }
         return false
@@ -326,6 +386,10 @@ final class DictationFlowCoordinatorTests: XCTestCase {
 
     private struct RecordingHarness {
         let coordinator: DictationFlowCoordinator
+        let audio: MockAudioProcessor
+        let stt: MockSTTClient
+        let clipboard: MockClipboardService
+        let repo: DictationRepository
     }
 }
 

--- a/Tests/MacParakeetTests/DictationFlow/DictationFlowCoordinatorTests.swift
+++ b/Tests/MacParakeetTests/DictationFlow/DictationFlowCoordinatorTests.swift
@@ -38,7 +38,8 @@ final class DictationFlowCoordinatorTests: XCTestCase {
 
         harness.coordinator.stopDictation()
         let firstPasted = await waitUntilAsync {
-            await harness.clipboard.snapshot().pasteCallCount == 1
+            let snapshot = await harness.clipboard.snapshot()
+            return snapshot.pastedTexts.count == 1 && harness.coordinator.flowStateForTesting == .idle
         }
         XCTAssertTrue(firstPasted)
         XCTAssertEqual(harness.coordinator.flowStateForTesting, .idle)
@@ -49,7 +50,8 @@ final class DictationFlowCoordinatorTests: XCTestCase {
 
         harness.coordinator.stopDictation()
         let secondPasted = await waitUntilAsync {
-            await harness.clipboard.snapshot().pasteCallCount == 2
+            let snapshot = await harness.clipboard.snapshot()
+            return snapshot.pastedTexts.count == 2 && harness.coordinator.flowStateForTesting == .idle
         }
         XCTAssertTrue(secondPasted)
 
@@ -355,8 +357,13 @@ final class DictationFlowCoordinatorTests: XCTestCase {
     ) async -> Bool {
         let deadline = Date().addingTimeInterval(Double(timeoutMs) / 1000)
         while Date() < deadline {
+            if Task.isCancelled { return false }
             if condition() { return true }
-            try? await Task.sleep(for: .milliseconds(5))
+            do {
+                try await Task.sleep(for: .milliseconds(5))
+            } catch {
+                return false
+            }
         }
         return condition()
     }
@@ -367,8 +374,13 @@ final class DictationFlowCoordinatorTests: XCTestCase {
     ) async -> Bool {
         let deadline = Date().addingTimeInterval(Double(timeoutMs) / 1000)
         while Date() < deadline {
+            if Task.isCancelled { return false }
             if await condition() { return true }
-            try? await Task.sleep(for: .milliseconds(5))
+            do {
+                try await Task.sleep(for: .milliseconds(5))
+            } catch {
+                return false
+            }
         }
         return await condition()
     }

--- a/Tests/MacParakeetTests/DictationFlow/DictationFlowStateMachineTests.swift
+++ b/Tests/MacParakeetTests/DictationFlow/DictationFlowStateMachineTests.swift
@@ -718,6 +718,20 @@ final class DictationFlowStateMachineTests: XCTestCase {
         XCTAssertFalse(effects.contains(.startDisplayDismissTimer(seconds: 0.8)))
     }
 
+    func testPasteSuccessAcceptsImmediatePersistentRestart() {
+        var m = machineInProcessing()
+        let gen = m.generation
+        _ = m.handle(.transcriptionCompleted(generation: gen))
+        _ = m.handle(.pasteSucceeded(generation: gen))
+
+        let effects = m.handle(.startRequested(mode: .persistent))
+
+        XCTAssertEqual(m.state, .checkingEntitlements(mode: .persistent))
+        XCTAssertEqual(m.generation, gen + 1)
+        XCTAssertTrue(effects.contains(.checkEntitlements))
+        XCTAssertTrue(effects.contains(.hideIdlePill))
+    }
+
     func testFinishingPasteFailed() {
         var m = machineInProcessing()
         let gen = m.generation

--- a/Tests/MacParakeetTests/Services/System/MockClipboardService.swift
+++ b/Tests/MacParakeetTests/Services/System/MockClipboardService.swift
@@ -4,6 +4,7 @@ import Foundation
 public actor MockClipboardService: ClipboardServiceProtocol {
     public struct Snapshot: Sendable {
         public let lastPastedText: String?
+        public let pastedTexts: [String]
         public let lastCopiedText: String?
         public let lastPostPasteAction: KeyAction?
         public let lastRestoresClipboard: Bool?
@@ -11,6 +12,7 @@ public actor MockClipboardService: ClipboardServiceProtocol {
     }
 
     public var lastPastedText: String?
+    public var pastedTexts: [String] = []
     public var lastCopiedText: String?
     public var lastPostPasteAction: KeyAction?
     public var lastRestoresClipboard: Bool?
@@ -22,6 +24,7 @@ public actor MockClipboardService: ClipboardServiceProtocol {
     public func snapshot() -> Snapshot {
         Snapshot(
             lastPastedText: lastPastedText,
+            pastedTexts: pastedTexts,
             lastCopiedText: lastCopiedText,
             lastPostPasteAction: lastPostPasteAction,
             lastRestoresClipboard: lastRestoresClipboard,
@@ -39,6 +42,7 @@ public actor MockClipboardService: ClipboardServiceProtocol {
             throw pasteError
         }
         lastPastedText = text
+        pastedTexts.append(text)
         lastRestoresClipboard = restoresClipboard
     }
 


### PR DESCRIPTION
## Summary

Adds regression coverage for issue #606: hands-free dictation must paste the transcript from the just-completed dictation, never the prior one. This is tests-only because current `origin/main` already contains the suspicious timing mitigation: commit `b2f9dd8d7` removed the success checkmark, the 200 ms pre-paste delay, and the 0.8 s post-paste dwell after the reported 0.6.24 build.

Verdict: I did not find a current-main coordinator bug that reads a stale transcript. The #606 report was filed against 0.6.24 build `20260621193207`, commit `390e5eeda65b`, which predates `b2f9dd8d7` by about four days.

## Design

The new coordinator test drives two persistent dictations through the real `DictationFlowCoordinator` + `DictationService` boundary with queued STT results. It asserts both sides of the bug signature: Library/History has both newly completed transcripts, and the paste service receives `first dictated message ` followed by `second dictated message `.

Root-cause evidence:

- History persistence happens before `DictationResult` returns from `DictationService.processCapturedAudio` (`dictationRepo.save(dictation)` before `return DictationResult(...)`).
- Current main consumes that result before sending `.transcriptionCompleted`, then snapshots `dictation`, `transcript`, and insertion style before the async paste task starts.
- Current main state-machine paste success returns directly to idle and reloads history, so an immediate hands-free restart is accepted.
- In 0.6.24, the coordinator slept 200 ms before paste and the state machine stayed in `finishing(.success)` behind a 0.8 s dismiss timer after paste success. Those windows were removed by `b2f9dd8d7`.

Spec alignment: this follows the investigation brief and `journal/2026-07-03-audio-routing-cluster-plan.md` C5 guidance. No audio/AEC paths were touched.

## How It Works

```mermaid
sequenceDiagram
    participant User
    participant Flow as DictationFlowCoordinator
    participant Service as DictationService
    participant DB as DictationRepository
    participant Paste as ClipboardService

    User->>Flow: stop persistent dictation B
    Flow->>Service: stopRecording(sessionID)
    Service->>DB: save(dictation B)
    Service-->>Flow: DictationResult(dictation B)
    Flow->>Flow: consumeDictationResult(B)
    Flow->>Flow: transcriptionCompleted(current generation)
    Flow->>Paste: pasteText(\"B \")
    Paste-->>Flow: paste succeeded
    Flow->>Flow: idle + reloadHistory
    User->>Flow: immediate next persistent start
```

## Risk Surface

Low. The branch changes test code only and expands the shared clipboard mock to keep paste history. The production paste/clipboard implementation is unchanged.

What I would review hardest: whether the coordinator regression is the right level for the #606 off-by-one symptom. I chose it because the reported split was “new transcript saved, old text pasted,” so the regression needs to cover the boundary between persisted result and paste dispatch.

## Test Evidence

- `git diff --check`
- `swift test --filter DictationFlowCoordinatorTests` - 15 tests passed
- `swift test --filter DictationFlowStateMachineTests` - 85 tests passed
- Hosted CI `swift-test` - 2 jobs passed (16m11s and 16m16s)
- Hosted Greptile Review - passed
- Cubic - passed

Local full `swift test` was started once after PR creation, but the shell session expired before final output was recoverable. I did not rerun it, to honor the one-full-suite limit; the hosted CI `swift-test` jobs are the final full-suite gate.

Author gate note: `no-mistakes` is not installed on PATH. The requested local Greptile fallback failed in Greptile tooling with `expansionContext` (review `87193559-6b07-4245-bf54-09d461028e52`), so I relied on hosted Greptile, Cubic, and CI.

## Author's Notes

No production fix is included because the live branch passed the new regression and the source/history evidence points to a timing-sensitive release-line issue already mitigated on main. A true current-build repro would need paste-service/target-app timing diagnostics, not speculative coordinator refactoring.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds regression tests for #606 to ensure hands-free dictation pastes the just-completed transcript, not the previous one. The suite covers back-to-back persistent sessions, asserts paste order via an enhanced `MockClipboardService`, pins immediate restart after paste success, and hardens async waits to reduce flakiness.

<sup>Written for commit 9ea8abd0629e930497677c0b333dbfa4965dc194. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/679?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

