### PR TITLE
Document accepted meeting AEC architecture

### DIFF
--- a/plans/active/2026-07-04-long-meeting-aec-policy.md
+++ b/plans/active/2026-07-04-long-meeting-aec-policy.md
@@ -247,5 +247,5 @@ runs on separate branches off `origin/main`.
   behavior for <2 h meetings is unchanged).
 - Watch `meeting_cleaned_mic` log lines for `predictedRenderTimeout`
   occurrences in diagnostics to learn how often real users hit 2 h+ meetings.
-- Phase 2 gets its own plan revision + ADR touch (ADR-026 provenance section)
+- Phase 2 gets its own plan revision + ADR touch (ADR-028 provenance section)
   when green-lit.

--- a/plans/active/2026-07-aec-artifact-provenance.md
+++ b/plans/active/2026-07-aec-artifact-provenance.md
@@ -6,5 +6,6 @@ support/QA must determine cleaned-vs-raw and why without app logs. Design:
 render-resolution summary (reason code, model version, render timing, delay
 estimate, probe stats) persisted as additive optional `echoSuppression` fields
 in meeting-recording-metadata.json, written when the readiness gate resolves
-(PR #671's taxonomy). Shipped with the echo-probe skip PR. Related: journal
-design rationale 2026-07-03; ADR-026 (pending).
+(PR #671's taxonomy, extended by #705's long-meeting guard). Shipped with the
+echo-probe skip PR. Related: journal design rationale 2026-07-03;
+[ADR-028](../../spec/adr/028-meeting-echo-cancellation.md).

--- a/spec/05-audio-pipeline.md
+++ b/spec/05-audio-pipeline.md
@@ -195,42 +195,14 @@ Mic Input    → SharedMicrophoneStream (+ Voice Processing I/O when active)┘ 
   `MeetingLiveAudioChunking` strategies. Single-source sessions skip the
   unselected stream and produce a mono `meeting.m4a`.
 - Raw capture applies no platform AEC/noise suppression/AGC. Meeting mic
-  conditioning starts in automatic mode: release bundles with LocalVQE assets
-  run `StreamingMeetingEchoSuppressor` over paired mic/system samples, while
-  local/dev bundles without those assets fall back to raw mic samples with
-  diagnostics. AEC-ready release bundles must include
-  `Contents/Frameworks/liblocalvqe.dylib` plus exactly one selected GGUF under
-  `Contents/Resources/MeetingEchoSuppression/`; distribution verification
-  checks the model checksum, required LocalVQE C symbols, executable bit, and
-  portable dylib references before the app can claim that path. The selected
-  bundled default is the v1.4 echo-only model
-  (`localvqe-v1.4-aec-200K-f32.gguf`). When the
-  suppressor runs it aligns the system reference to the
-  microphone using a runtime delay recovered from the audio by
-  `MeetingEchoDelayEstimator` (normalized cross-correlation, confidence-gated),
-  because the measurement harness showed that mic/reference time alignment is
-  the dominant factor in cancellation and the bulk clock offset can exceed any
-  practical filter span. `MACPARAKEET_MEETING_ECHO_REFERENCE_DELAY_MS` seeds the
-  estimate and overrides it when `MACPARAKEET_MEETING_ECHO_ADAPTIVE_DELAY` is
-  off; fixed/manual delay is capped to the adaptive search ceiling so reference
-  retention stays bounded. A silent far-end is treated as "nothing to align"
-  rather than forcing a lag. Transcript-layer system-dominance suppression and
+  conditioning is preview-only: release bundles with LocalVQE assets may run
+  `StreamingMeetingEchoSuppressor` over paired mic/system samples, while
+  local/dev bundles without those assets fall back to raw preview samples with
+  diagnostics. Transcript-layer system-dominance suppression and
   `MeetingTranscriptSourceReconciler` remain safety nets against obvious
   speaker bleed, not a complete AEC substitute. When VPIO is explicitly
   requested and engages, macOS applies AEC/noise suppression/AGC before buffers
   reach `MeetingRecordingService`.
-- Live suppression is **preview only**: `microphone.m4a` is always the raw mic.
-  After stop, when both source streams and trusted source-alignment metadata
-  exist, `MeetingCleanedMicRenderer` derives `microphone-cleaned.m4a` offline. It
-  re-decodes the raw mic + system to 16 kHz mono, re-aligns the reference by the
-  recorded `MeetingSourceAlignment` start offsets, and streams the pair through a
-  freshly built suppressor (clean filter state, not the live preview's adapted
-  taps). Output frames are either processor output or raw fallback for processor
-  failures; near-end fidelity is not inferred from a runtime energy heuristic,
-  and remains owned by model choice plus real speaker-mode QA. Single-source
-  meetings, missing AEC assets, render failures, and recovered recordings with
-  only synthetic alignment fall back to raw mic. Rendering never throws into
-  recorder finalize.
 - Audio is stored as separate M4A files (AAC 64kbps, 48kHz mono) per source
 - Source audio is written as fragmented M4A with 1-second movie fragments so kill-9 recovery can keep playable audio through the last committed fragment.
 - After recording stops, the captured source M4As are finalized and merged into
@@ -241,21 +213,43 @@ Mic Input    → SharedMicrophoneStream (+ Voice Processing I/O when active)┘ 
 - Final meeting STT does **not** transcribe `meeting.m4a`. A background queue
   transcribes the captured source files separately with the engine captured at
   recording start, then merges those fresh results by persisted
-  `MeetingSourceAlignment`. For the local (`Me`) microphone track,
-  `TranscriptionService` waits on the bounded
-  `MeetingCleanedMicrophoneReadiness` handle produced by stop/recovery. It uses
-  `microphone-cleaned.m4a` only after the render completes before its deadline
-  and the file is non-empty and decodable; timeout, invalid output, missing
-  reference, missing assets, render failure, or untrusted alignment select raw
-  `microphone.m4a` with a diagnostic reason. The system track is unchanged.
-  `MeetingRecordingOutput.microphoneTranscriptionURL` remains a cheap UI/list
-  helper, not the final-STT gate. `meeting.m4a` is kept as the playback/export
-  artifact. See
+  `MeetingSourceAlignment`. For the local (`Me`) microphone track, source
+  selection follows the echo-cancellation readiness gate below. The system track
+  is unchanged. `MeetingRecordingOutput.microphoneTranscriptionURL` remains a
+  cheap UI/list helper, not the final-STT gate. `meeting.m4a` is kept as the
+  playback/export artifact. See
   `docs/research/meeting-dual-stream-transcription-pipeline.md` for the full
   pipeline and tradeoffs.
 - Recovery locks and retention safety are a tested boundary contract. See [`spec/contracts/meeting-recovery-retention.md`](contracts/meeting-recovery-retention.md) before changing lock-file predicates or automatic meeting-audio deletion.
 - Live chunk enqueue keeps a conservative guard: when recent system energy strongly dominates processed mic energy for a short freshness window, mic chunks are skipped for live transcription only. Mic audio is still written to disk and included in final mix/output.
 - Joiner queue overflow, long-session sync lag, and runtime capture failures are emitted as diagnostics for observability (`MeetingAudioCaptureEvent.error` where available).
+
+### Meeting Echo Cancellation (AEC)
+
+Dual-source meeting capture preserves raw source artifacts:
+`microphone.m4a` and `system.m4a`, plus mixed `meeting.m4a` for playback and
+export. After stop, `MeetingCleanedMicRenderer` can derive
+`microphone-cleaned.m4a` offline from the raw mic and system reference using
+the LocalVQE echo-only v1.4 path with `MeetingEchoDelayEstimator` delay
+estimation. Before running the model, the echo probe can skip no-echo meetings
+(headphones or inaudible remote audio) and choose raw without manufacturing a
+cleaned file. For very long meetings, the duration guard skips upfront when the
+render is predicted to exceed the bounded final-STT deadline.
+
+Final STT waits on `MeetingCleanedMicrophoneReadiness` with a bounded,
+duration-scaled deadline before choosing the microphone source. It uses cleaned
+audio only when the render finishes and the artifact is non-empty and decodable;
+otherwise it falls back to raw mic. The source decision records a structured
+routing reason (`cleanedUsed`, `rawTimeout`, `rawInvalidArtifact`,
+`rawRenderFailed`, `rawMissingSystemReference`, `rawNoAECAssets`,
+`skippedNoEchoPath`, or `predictedRenderTimeout`). The render/skip summary is
+persisted to
+`meeting-recording-metadata.json` as optional `echoSuppression` provenance so
+shared artifact folders explain cleaned-vs-raw routing without app logs.
+
+[ADR-028](adr/028-meeting-echo-cancellation.md) is the architectural record.
+[`spec/contracts/meeting-artifacts-v1.md`](contracts/meeting-artifacts-v1.md)
+is the artifact and sidecar contract.
 
 ### Key Components
 
@@ -267,7 +261,7 @@ Mic Input    → SharedMicrophoneStream (+ Voice Processing I/O when active)┘ 
 | `MeetingAudioCaptureService` | Actor combining the selected source stream(s) into `AsyncStream<MeetingAudioCaptureEvent>` with unbounded buffering and runtime error emission where available |
 | `CaptureOrchestrator` | Owns ingest/join/offset/chunk flow for live preview |
 | `MicConditioner` | Meeting-side seam for mic samples; passthrough is the default, and an optional `StreamingMeetingEchoSuppressor` can use paired system reference samples when the runtime/model are available |
-| `MeetingCleanedMicRenderer` | Post-stop offline derivation of `microphone-cleaned.m4a` from the raw mic + system sources through a freshly built suppressor; skips when passthrough/single-source and never throws into finalize |
+| `MeetingCleanedMicRenderer` | Post-stop offline derivation of `microphone-cleaned.m4a` from the raw mic + system sources through a freshly built suppressor; skips when no echo path/single-source and never throws into finalize |
 | `LiveChunkTranscriber` | Owns live chunk queueing, cancellation, ordering, STT invocation |
 | `MeetingAudioStorageWriter` | Writes separate M4A files per selected source (mic and/or system) |
 | `MeetingRecordingMetadataStore` | Persists `MeetingSourceAlignment` for post-stop merge correctness |
@@ -326,7 +320,7 @@ the stopped meeting waits for that job to finish; once the slot is free,
     ├── system.m4a        # System audio when captured (AAC, 48kHz mono)
     ├── microphone-cleaned.m4a  # Optional derived echo-cancelled mic (16kHz mono); STT input for the "Me" track only after readiness/decodability gates pass
     ├── meeting.m4a       # Final playback/export artifact (stereo dual-source when both tracks exist; legacy fallback for downstream tools)
-    ├── meeting-recording-metadata.json  # Persisted source timing/alignment + speech engine for post-stop merge
+    ├── meeting-recording-metadata.json  # Persisted source timing/alignment + speech engine, optionally echoSuppression provenance
     ├── recording.lock     # Recording/awaiting-transcription recovery state, including notes and speech engine
     └── chunks/            # Live-preview scratch chunks
 ```

--- a/spec/README.md
+++ b/spec/README.md
@@ -113,6 +113,7 @@ All ADRs live in `spec/adr/`. These are locked -- they record decisions already 
 | [ADR-025](adr/025-meeting-capture-reliability.md) | Meeting capture reliability — mic-health watchdog + post-stop coverage repair (Phase A mic-health telemetry watchdog implemented; warning UI + repair proposed) |
 | [ADR-026](adr/026-asr-engine-strategy.md) | ASR engine and runtime strategy — local-only reaffirmed; two runtimes (FluidAudio primary, WhisperKit fallback); engines grow as variants not new cards; capability registry required before a new engine family; Apple SpeechTranscriber spike-only |
 | [ADR-027](adr/027-product-north-star.md) | Product north star — MacParakeet is the private speech memory of your Mac; Library (search + QA + export) becomes the center of gravity; agent access first-class; ambient capture parked (not rejected); session-based capture stands |
+| [ADR-028](adr/028-meeting-echo-cancellation.md) | Offline meeting echo cancellation via derived cleaned-mic artifact |
 
 ## Version Roadmap
 

--- a/spec/adr/028-meeting-echo-cancellation.md
+++ b/spec/adr/028-meeting-echo-cancellation.md
@@ -1,0 +1,131 @@
+# ADR-028: Offline Meeting Echo Cancellation via Derived Cleaned-Mic Artifact
+
+Status: Accepted (2026-07-03)
+
+## Context
+
+Meeting recording captures two sources: the microphone and system audio
+(remote participants). When the user plays remote audio through speakers,
+the microphone also captures it — delayed and room-colored. This bleed
+degrades transcription accuracy on the user's own speech and misattributes
+remote speech to the "Me" track. Users expect high-accuracy meeting
+transcripts; echo bleed is the largest accuracy defect in the
+speakers-playback case.
+
+Constraints that shaped the decision:
+
+- Local-first: all processing on-device.
+- The shared mic engine (ADR-015) deliberately avoids Apple's
+  voice-processing I/O; dictation and meetings share one plain
+  AVAudioEngine capture path, and raw audio must remain available.
+- The consumer of echo cancellation is transcription, not live playback —
+  there is no real-time requirement.
+- Meeting artifacts are durable user data; processing must be reversible
+  and debuggable.
+
+## Decision
+
+Perform echo cancellation OFFLINE, after recording stops, producing a
+derived artifact — `microphone-cleaned.m4a` — while preserving the raw
+microphone recording untouched.
+
+Pipeline (see `MeetingCleanedMicRenderer`, `MicConditioner`,
+`MeetingEchoDelayEstimator`, `MeetingEchoSuppressionConfiguration`, and
+`MeetingEchoSuppressionFactory`):
+
+1. The recorded system-audio track is the echo reference. It is captured
+   anyway for the meeting, giving a perfect reference most AEC systems
+   lack.
+2. Alignment: host-time recorded offset, plus periodic cross-correlation
+   bulk-delay estimation (scalar read-offset only; no sample mutation).
+3. Suppression: the LocalVQE neural model — echo-only variant (v1.4),
+   selected by a measured scoring gate (`MeetingAecModelScoringTests`,
+   issue #605 U5) — is the only stage that modifies samples. Echo-only
+   (no general denoising) minimizes distortion of the speech being
+   transcribed. No linear DSP pre-stage exists; adding one is deferred
+   until the double-talk metric (PR #669) demonstrates a measurable gap.
+4. Final meeting transcription prefers the cleaned mic for the "Me" track.
+
+Coordination (readiness gate, PR #671):
+
+- Stop schedules the render when the duration guard predicts it can finish
+  inside the bounded deadline; otherwise it skips upfront with
+  `predictedRenderTimeout`. Stop latency is never proportional to meeting
+  length.
+- Final transcription awaits render readiness (a Task handle, not file
+  polling) with a bounded, duration-scaled deadline before choosing the
+  microphone source.
+- Fallback to raw is intentional and observable via a structured reason
+  taxonomy: `cleanedUsed`, `rawTimeout`, `rawInvalidArtifact`,
+  `rawRenderFailed`, `rawMissingSystemReference`, `rawNoAECAssets`,
+  `skippedNoEchoPath`, `predictedRenderTimeout`. Silent raw fallback is a
+  defect.
+
+Render skip (echo probe, PR #676):
+
+- Before running the model, the delay estimator doubles as a cheap probe
+  over reference-energy windows. No correlation → no echo path (headphones
+  of any kind, or remote inaudible) → skip the render with
+  `skippedNoEchoPath`. Echo detection is measured from the artifacts, not
+  inferred from output-route metadata, so Bluetooth speakers and route
+  changes need no special cases and the recovery path behaves identically.
+- Each render/skip emits a per-session diagnostics summary (model version,
+  render duration and realtime factor, delay estimate, probe score, final
+  reason) so accuracy complaints are debuggable from one line.
+- The same render/skip summary is persisted into the session's
+  `meeting-recording-metadata.json` sidecar as additive optional
+  `echoSuppression` fields (`reasonCode` plus optional `modelVersion`,
+  `renderDurationMs`, `delayEstimateMs`, `probeBestCorrelation`), per
+  `spec/contracts/meeting-artifacts-v1.md`, so shared artifact folders
+  self-describe cleaned-vs-raw routing without app logs.
+
+The cleaned mic is exposed in the artifact manifest
+(`cleanedMicrophoneAudioPath`, `spec/contracts/meeting-artifacts-v1.md`).
+
+## Alternatives considered
+
+- **Live system AEC (Apple VPIO)** — rejected. Reverses ADR-015: forks the
+  shared capture path, destroys raw audio, and its far-end suppression
+  audibly ducks the user during double-talk (observed directly in earlier
+  testing; see also `../../docs/research/vpio-process-tap-conflict.md`). VPIO
+  optimizes live-call comfort; we optimize post-hoc transcript accuracy.
+- **Transcript-level echo removal** (delete mic-transcript segments that
+  duplicate the system transcript) — rejected. Bleed corrupts the user's
+  own words before ASR sees them; deleting duplicates cannot restore
+  accuracy and fails on overlapping speech.
+- **Linear DSP AEC only** (adaptive filter, WebRTC-AEC3 style) — rejected
+  as the sole mechanism. Leaves nonlinear residual (speaker distortion,
+  reverb, clock drift). May later be added as a pre-stage if measurement
+  justifies it.
+
+## Consequences
+
+Positive:
+
+- Raw audio preserved; cleaned is derived — past meetings can be
+  re-rendered when better models ship.
+- Offline processing with a known reference is strictly easier than live
+  AEC: precise alignment, lookahead, unconstrained compute.
+- Every raw-vs-cleaned decision is observable; no silent quality
+  degradation.
+
+Negative / accepted risks:
+
+- Double-talk over-suppression is the primary quality risk; it is tracked
+  by a dedicated harness metric (PR #669) rather than assumed away.
+- The bundled LocalVQE dylib + model are a permanent
+  signing/notarization/asset-gate liability
+  (`REQUIRE_MEETING_ECHO_ASSETS=1` build gate).
+- Render costs compute after each speakers-playback meeting; bounded by
+  the deadline policy and eliminated for no-echo meetings by the probe or
+  very long meetings by the duration guard.
+
+## References
+
+- Tracking issue #605 (U1–U5 PRs #638/#650/#651/#654/#656).
+- Readiness gate: PR #671. Echo probe + skip: PR #676. Long-meeting
+  duration guard: PR #705.
+- Double-talk metric: PR #669.
+- Prior art survey: `../../docs/research/2026-06-meeting-aec-open-issues-prior-art.md`.
+- Related ADRs: 014 (meeting recording), 015 (concurrent dictation/meeting,
+  shared engine), 019 (crash-resilient recording).


### PR DESCRIPTION
## Summary
Adds ADR-028 as the accepted record for offline meeting echo cancellation via a derived cleaned-mic artifact. Updates the audio-pipeline spec with a concise AEC routing summary, sidecar provenance pointer, and links to the authoritative artifact contract.

## Design
This is a docs-only alignment PR for the Fable brief dated 2026-07-04, after the cleaned-mic readiness gate (#671), echo-probe/provenance work (#676), and long-meeting duration guard (#705) landed on `origin/main`. The branch was rebased onto current `main` because ADR-026 and ADR-027 are now occupied, so the meeting AEC decision lands as ADR-028.

No Swift or contract files changed; `spec/contracts/meeting-artifacts-v1.md` already records the sidecar fields.

## Risk surface
The main review surface is documentation drift: ADR-028 should match the accepted architecture, `spec/05-audio-pipeline.md` should summarize rather than duplicate it, and the reason taxonomy should stay aligned with `MeetingCleanedMicrophoneRoutingReason`.

## Test evidence
- Verified ADR reason taxonomy matches `MeetingCleanedMicrophoneRoutingReason` on current `origin/main`, including `predictedRenderTimeout`.
- Verified modified Markdown relative links resolve.
- Ran `git diff --check origin/main...HEAD`.

## Author's Notes
No diagrams; the change is a decision record plus a spec pointer, not a new mechanism.
