### PR TITLE
fix: polish app-aware formatter readiness

### DIFF
--- a/Sources/MacParakeet/Views/Settings/LLMSettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/LLMSettingsView.swift
@@ -571,19 +571,17 @@ struct LLMSettingsView: View {
                     smartDefaultCard(categoryDefault)
                 }
             }
-            .disabled(!viewModel.aiFormatterSmartDefaultsEnabled)
             .opacity(viewModel.aiFormatterSmartDefaultsEnabled ? 1 : 0.55)
 
-            // The preview stays readable for individually-disabled categories
-            // (so a prompt can be read before deciding to enable it) — the
-            // footer copy switches to reflect the off state instead of giving
-            // stale "turn this type off" advice.
-            if viewModel.aiFormatterSmartDefaultsEnabled,
-               let selected = selectedSmartDefaultCategory,
+            // The preview stays readable even when smart defaults or an
+            // individual category are off, so a prompt can be inspected before
+            // deciding to let it run.
+            if let selected = selectedSmartDefaultCategory,
                let categoryDefault = AIFormatterSmartDefaults.categoryDefault(for: selected) {
                 smartDefaultPromptPreview(
                     categoryDefault,
-                    isCategoryEnabled: viewModel.isAIFormatterSmartDefaultEnabled(selected)
+                    isMasterEnabled: viewModel.aiFormatterSmartDefaultsEnabled,
+                    isCategoryEnabled: viewModel.isAIFormatterSmartDefaultCategoryEnabled(selected)
                 )
             }
         }
@@ -591,7 +589,9 @@ struct LLMSettingsView: View {
     }
 
     private func smartDefaultCard(_ categoryDefault: AIFormatterSmartDefaults.CategoryDefault) -> some View {
-        let isEnabled = viewModel.isAIFormatterSmartDefaultEnabled(categoryDefault.category)
+        let isMasterEnabled = viewModel.aiFormatterSmartDefaultsEnabled
+        let isCategoryEnabled = viewModel.isAIFormatterSmartDefaultCategoryEnabled(categoryDefault.category)
+        let isEffectivelyEnabled = isMasterEnabled && isCategoryEnabled
         let isSelected = selectedSmartDefaultCategory == categoryDefault.category
 
         return HStack(spacing: 6) {
@@ -601,11 +601,11 @@ struct LLMSettingsView: View {
                 HStack(spacing: 6) {
                     Image(systemName: smartDefaultIcon(for: categoryDefault.category))
                         .font(.system(size: 11, weight: .semibold))
-                        .foregroundStyle(isEnabled ? DesignSystem.Colors.accent : Color.secondary)
+                        .foregroundStyle(isEffectivelyEnabled ? DesignSystem.Colors.accent : Color.secondary)
                         .frame(width: 16, height: 16)
                     Text(categoryDefault.name)
                         .font(DesignSystem.Typography.caption.weight(.medium))
-                        .foregroundStyle(isEnabled ? DesignSystem.Colors.textPrimary : DesignSystem.Colors.textSecondary)
+                        .foregroundStyle(isEffectivelyEnabled ? DesignSystem.Colors.textPrimary : DesignSystem.Colors.textSecondary)
                         .lineLimit(1)
                     Spacer(minLength: 0)
                 }
@@ -618,15 +618,16 @@ struct LLMSettingsView: View {
             Toggle(
                 "",
                 isOn: Binding(
-                    get: { viewModel.isAIFormatterSmartDefaultEnabled(categoryDefault.category) },
+                    get: { viewModel.isAIFormatterSmartDefaultCategoryEnabled(categoryDefault.category) },
                     set: { viewModel.setAIFormatterSmartDefault(categoryDefault.category, enabled: $0) }
                 )
             )
             .labelsHidden()
             .toggleStyle(.switch)
             .controlSize(.mini)
+            .disabled(!isMasterEnabled)
             .accessibilityLabel("Enable the \(categoryDefault.name) smart default")
-            .accessibilityValue(isEnabled ? "Enabled" : "Disabled")
+            .accessibilityValue(isEffectivelyEnabled ? "Enabled" : "Disabled")
         }
         .padding(.horizontal, 9)
         .padding(.vertical, 6)
@@ -646,6 +647,7 @@ struct LLMSettingsView: View {
 
     private func smartDefaultPromptPreview(
         _ categoryDefault: AIFormatterSmartDefaults.CategoryDefault,
+        isMasterEnabled: Bool,
         isCategoryEnabled: Bool
     ) -> some View {
         VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
@@ -688,7 +690,9 @@ struct LLMSettingsView: View {
             .clipShape(RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius))
 
             Text(
-                isCategoryEnabled
+                !isMasterEnabled
+                    ? "Smart defaults are off — this prompt will not run unless you turn Smart defaults on."
+                    : isCategoryEnabled
                     ? "To format \(categoryDefault.name) apps differently, turn this type off or add a custom profile below — custom profiles always win."
                     : "This type is off — dictation into \(categoryDefault.name) apps uses your fallback prompt unless a custom profile matches."
             )

--- a/Sources/MacParakeet/Views/Settings/LLMSettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/LLMSettingsView.swift
@@ -592,6 +592,11 @@ struct LLMSettingsView: View {
         let isMasterEnabled = viewModel.aiFormatterSmartDefaultsEnabled
         let isCategoryEnabled = viewModel.isAIFormatterSmartDefaultCategoryEnabled(categoryDefault.category)
         let isEffectivelyEnabled = isMasterEnabled && isCategoryEnabled
+        let accessibilityValue = isEffectivelyEnabled
+            ? "Enabled"
+            : isCategoryEnabled
+            ? "Enabled, inactive while Smart defaults are off"
+            : "Disabled"
         let isSelected = selectedSmartDefaultCategory == categoryDefault.category
 
         return HStack(spacing: 6) {
@@ -601,11 +606,11 @@ struct LLMSettingsView: View {
                 HStack(spacing: 6) {
                     Image(systemName: smartDefaultIcon(for: categoryDefault.category))
                         .font(.system(size: 11, weight: .semibold))
-                        .foregroundStyle(isEffectivelyEnabled ? DesignSystem.Colors.accent : Color.secondary)
+                        .foregroundStyle(isCategoryEnabled ? DesignSystem.Colors.accent : Color.secondary)
                         .frame(width: 16, height: 16)
                     Text(categoryDefault.name)
                         .font(DesignSystem.Typography.caption.weight(.medium))
-                        .foregroundStyle(isEffectivelyEnabled ? DesignSystem.Colors.textPrimary : DesignSystem.Colors.textSecondary)
+                        .foregroundStyle(isCategoryEnabled ? DesignSystem.Colors.textPrimary : DesignSystem.Colors.textSecondary)
                         .lineLimit(1)
                     Spacer(minLength: 0)
                 }
@@ -627,7 +632,7 @@ struct LLMSettingsView: View {
             .controlSize(.mini)
             .disabled(!isMasterEnabled)
             .accessibilityLabel("Enable the \(categoryDefault.name) smart default")
-            .accessibilityValue(isEffectivelyEnabled ? "Enabled" : "Disabled")
+            .accessibilityValue(accessibilityValue)
         }
         .padding(.horizontal, 9)
         .padding(.vertical, 6)

--- a/Sources/MacParakeetViewModels/LLMSettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/LLMSettingsViewModel.swift
@@ -464,6 +464,10 @@ public final class LLMSettingsViewModel {
         aiFormatterSmartDefaultsPolicy.allowsCategory(category)
     }
 
+    public func isAIFormatterSmartDefaultCategoryEnabled(_ category: TelemetryAppCategory) -> Bool {
+        !aiFormatterSmartDefaultsPolicy.disabledCategories.contains(category)
+    }
+
     public func setAIFormatterSmartDefault(_ category: TelemetryAppCategory, enabled: Bool) {
         if enabled {
             aiFormatterSmartDefaultsPolicy.disabledCategories.remove(category)

--- a/Tests/MacParakeetTests/ViewModels/LLMSettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/LLMSettingsViewModelTests.swift
@@ -736,6 +736,8 @@ final class LLMSettingsViewModelTests: XCTestCase {
         XCTAssertFalse(reloaded.aiFormatterSmartDefaultsEnabled)
         XCTAssertFalse(reloaded.isAIFormatterSmartDefaultEnabled(.browser))
         XCTAssertFalse(reloaded.isAIFormatterSmartDefaultEnabled(.email))
+        XCTAssertFalse(reloaded.isAIFormatterSmartDefaultCategoryEnabled(.browser))
+        XCTAssertTrue(reloaded.isAIFormatterSmartDefaultCategoryEnabled(.email))
         XCTAssertFalse(reloaded.aiFormatterSmartDefaultsPolicy.disabledCategories.contains(.email))
     }
 

--- a/docs/audits/2026-06-14-ai-formatter-profiles-qa.md
+++ b/docs/audits/2026-06-14-ai-formatter-profiles-qa.md
@@ -1,19 +1,22 @@
 # AI Formatter Profiles — QA Review — 2026-06-14
 
-> **Status:** ACTIVE. Focused QA pass on the **app-aware AI Formatter
+> **Status:** HISTORICAL QA + CURRENT ALIGNMENT NOTE. Focused QA pass on the **app-aware AI Formatter
 > profiles** feature (REQ-LLM-004), gated by
-> `AppFeatures.aiFormatterProfilesEnabled` (enabled 2026-06-10, `main`-only —
-> not yet in a tagged release). Covers the data model, persistence, dictation
-> routing, History provenance, Settings UI, feature flag, and settings search.
-> Combines automated tests, a live database-migration check, real-data
-> inspection, a driven-GUI screenshot walkthrough, and a manual code review.
-> One real (low-severity) bug was found and fixed in this same change; one
-> harmless pre-release dev artifact was identified and explained.
+> `AppFeatures.aiFormatterProfilesEnabled`. This 2026-06-14 run tested the
+> feature with the flag enabled on `main`; the current release flag is false
+> after the 2026-06-14 hold-out, so the feature remains code-complete and
+> hidden until the flag is flipped. Covers the data model, persistence,
+> dictation routing, History provenance, Settings UI, feature flag, and
+> settings search. Combines automated tests, a live database-migration check,
+> real-data inspection, a driven-GUI screenshot walkthrough, and a manual code
+> review. One real (low-severity) bug was found and fixed in this same change;
+> one harmless pre-release dev artifact was identified and explained.
 
 | | Result |
 |---|---|
-| Feature flag | `AppFeatures.aiFormatterProfilesEnabled = true` |
-| Requirement | REQ-LLM-004 (`spec/kernel/requirements.yaml`) |
+| QA feature flag (2026-06-14 run) | `AppFeatures.aiFormatterProfilesEnabled = true` |
+| Current release flag (2026-07-04 alignment check) | `AppFeatures.aiFormatterProfilesEnabled = false` |
+| Requirement | Legacy REQ-LLM-004 (`docs/historical/requirements-legacy.yaml`); current behavior is authoritative in `spec/11-llm-integration.md` and `spec/02-features.md` |
 | QA base commit | `origin/main` `98b4aeef1` |
 | Focused formatter test suites | **212 tests, 0 failures** |
 | Full `swift test` (with the fix in this change) | **green (exit 0)** |
@@ -89,6 +92,13 @@ independent **Use for transcripts** (default on) and **Use for dictation**
 The smart-default prompt rendered in the live UI matches the shipped source
 (`AIFormatterSmartDefaults.swift`) **verbatim**, including the `{{TRANSCRIPT}}`
 placeholder — see the Email screenshot in §6.
+
+**2026-07-04 alignment note:** the Settings UI now keeps smart-default prompt
+previews readable even when the master "Smart defaults" switch is off. The grid
+dims, per-category switches are disabled while the master switch is off, and
+runtime resolution still skips the smart-default tier entirely. This matches
+`spec/11-llm-integration.md` and `spec/02-features.md`: prompts are inspectable
+before they can run, and turning the tier off restores fallback-prompt routing.
 
 ### Live database evidence
 
@@ -230,3 +240,8 @@ formatter-failure path — was found by code review, **fixed**, and **pinned wit
 a regression test** in this same change. The full suite is green with the fix.
 No other defects were found; the one suspicious DB row was traced to a harmless
 pre-release dev artifact.
+
+As of the 2026-07-04 alignment check, the implementation remains hidden by
+`AppFeatures.aiFormatterProfilesEnabled = false`. Flipping the flag back to
+`true` should be a release/configuration decision, not a schema or migration
+change.

--- a/docs/historical/requirements-legacy.yaml
+++ b/docs/historical/requirements-legacy.yaml
@@ -137,7 +137,7 @@ REQ-LLM-003:
   status: implemented
 
 REQ-LLM-004:
-  description: Dictation AI Formatter supports local exact-app and app-category prompt profiles, built-in category smart defaults (readable in Settings, toggleable via a master switch and per-category switches), fallback prompt routing, and local-only routing provenance surfaced in dictation History
+  description: Dictation AI Formatter supports local exact-app and app-category prompt profiles, built-in category smart defaults (readable in Settings even when the master switch is off, toggleable via a master switch and per-category switches), fallback prompt routing, and local-only routing provenance surfaced in dictation History
   version: v0.6
   # Code-complete and QA'd, but AppFeatures.aiFormatterProfilesEnabled was gated
   # back to false on 2026-06-14 to hold the feature out of v0.6.23; ships in a

--- a/plans/completed/2026-06-10-app-aware-formatter-ship-polish.md
+++ b/plans/completed/2026-06-10-app-aware-formatter-ship-polish.md
@@ -2,7 +2,9 @@
 
 > Status: **IMPLEMENTED** (2026-06-10)
 > Date: 2026-06-10
-> Requirement: REQ-LLM-004 (`spec/kernel/requirements.yaml`)
+> Requirement: legacy REQ-LLM-004 (`docs/historical/requirements-legacy.yaml`);
+> current authoritative behavior is in `spec/11-llm-integration.md` and
+> `spec/02-features.md`
 > Prior art: PR #419 (profiles), PR #428 (smart defaults), `6cd4a7034` (flag pulled
 > "while the profile UX is refined"), issues #117 / #412.
 
@@ -82,10 +84,16 @@ hatch, and nothing is hidden.
    - DB: category-enum↔CHECK drift guard over `allCases` round-trip; v0.21
      hidden-row scrub upgrade-path test; v0.21 marker-missing re-run test.
    - Search index + repo error copy updates.
-7. **Docs + flag**: spec/11, 12, 02, README, requirements.yaml, traceability,
-   CLAUDE.md, telemetry note (`default_prompt_used` step change), brainstorm
-   amendment note; flip `aiFormatterProfilesEnabled = true` as an isolated
-   final commit.
+7. **Docs + flag**: spec/11, 12, 02, README, legacy requirements record,
+   traceability, CLAUDE.md, telemetry note (`default_prompt_used` step change),
+   brainstorm amendment note; the original ship-polish sequence flipped
+   `aiFormatterProfilesEnabled = true` as an isolated final commit.
+
+   **Postscript:** the flag was re-gated to `false` on 2026-06-14 to hold the
+   feature out of the v0.6.23 release train. The 2026-07-04 alignment pass kept
+   the implementation flag-off and clarified the Settings behavior: built-in
+   smart-default prompts remain readable while the master switch is off, but
+   the tier cannot run until the master switch is enabled.
 
 ## Out of scope
 

--- a/spec/02-features.md
+++ b/spec/02-features.md
@@ -917,7 +917,7 @@ Important constraints:
 - formatter routing is per-surface: "Use for transcripts" (file/URL/meeting, default on) and "Use for dictation" (default off) toggles in AI settings, each ANDed with provider availability (#408, #493)
 - transcription formatter input is capped at `AIFormatter.maxTranscriptionInputChars` (20k chars); longer transcripts (hour-long meetings) skip straight to deterministic cleanup because a full-rewrite response can stall slow providers until timeout (#493)
 - dictation formatter prompts route through local exact-app profiles, local coarse-category profiles, built-in coarse-category smart defaults, and then the fallback formatter prompt
-- built-in smart defaults are user-controllable: a master switch plus per-category switches (UserDefaults-backed `AIFormatterSmartDefaultsPolicy`), and every built-in prompt is readable in Settings; with the tier off, zero-profile prompt selection is byte-for-byte the legacy fallback-prompt behavior
+- built-in smart defaults are user-controllable: a master switch plus per-category switches (UserDefaults-backed `AIFormatterSmartDefaultsPolicy`), and every built-in prompt is readable in Settings even when the master switch is off; with the tier off, zero-profile prompt selection is byte-for-byte the legacy fallback-prompt behavior
 - file/YouTube transcription formatter prompts continue to use the fallback formatter prompt in V1
 - browser hostname/domain matching is not attempted in V1; browser apps can match exact browser profiles or the coarse `browser` category only
 - formatter falls back to deterministic cleanup if the provider errors or times out

--- a/spec/11-llm-integration.md
+++ b/spec/11-llm-integration.md
@@ -379,11 +379,14 @@ defaults before calling `LLMService`:
 The smart-default tier is user-controllable through
 `AIFormatterSmartDefaultsPolicy` (UserDefaults-backed, no schema change): a
 master "Smart defaults" switch plus per-category switches in Settings, where
-each built-in prompt is also readable before it ever runs. With the master
-switch off (or a category switched off), resolution skips that tier entirely,
-so a user who tuned the fallback prompt gets byte-for-byte pre-profiles
-behavior wherever no custom profile matches. Profile-fetch failures degrade to
-the fallback prompt and are logged via OSLog (`AIFormatter` category).
+each built-in prompt is also readable before it ever runs. The prompt preview
+remains readable when the master switch is off; the grid dims and per-category
+switches are disabled until the master switch is turned back on. With the
+master switch off (or a category switched off), resolution skips that tier
+entirely, so a user who tuned the fallback prompt gets byte-for-byte
+pre-profiles behavior wherever no custom profile matches. Profile-fetch
+failures degrade to the fallback prompt and are logged via OSLog
+(`AIFormatter` category).
 
 Saved dictation rows surface their routing provenance in History: rows
 formatted by an app or category profile (custom or smart default) show a small


### PR DESCRIPTION
## Summary

App-aware formatter smart defaults are now inspectable before they can run. When the master Smart defaults switch is off, the Settings grid stays readable, category toggles are disabled, and the preview copy makes clear that routing still falls back to the global prompt.

This also aligns the local specs, historical requirement, completed plan, and QA audit with the current release posture: the feature is code-complete, still hidden behind `AppFeatures.aiFormatterProfilesEnabled = false`, and can be flipped later without a schema or migration change.

Related: #117, #412

## Validation

- `git diff --check`
- `swift test --filter LLMSettingsViewModelTests` - 124 tests, 0 failures

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the app-aware formatter UI so built‑in smart‑default prompts stay readable when Smart defaults are off, routing still falls back to the global prompt, and docs/specs align with the current flag‑off posture (`AppFeatures.aiFormatterProfilesEnabled = false`).

- **New Features**
  - Keep prompt previews readable with the master switch off; dim the grid only.
  - Disable per‑category switches until the master switch is on.
  - Use category‑level state for card icon/text colors when the master is off to avoid double‑dimming; improve toggle accessibility to indicate “Enabled, inactive while Smart defaults are off.”
  - Update preview copy to state the prompt will not run while the tier is off and that fallback routing applies.

- **Refactors**
  - Expose category‑level configured state separately from effective routing in the view model, with tests covering the distinction.

<sup>Written for commit 3180beb19e7e37e02a4be8d1f3142d85a0cfc09b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/683?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

