### PR TITLE
Persist durable meeting transcript segments

### DIFF
--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -99,6 +99,11 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
   processing-mode, and transcription/meeting speaker-detection overrides as
   `transcribe` where applicable, and emits either `--json` or `--envelope`
   machine-readable output.
+- `meetings show --json` and `meetings transcript --format json` now include
+  additive `transcriptSegments` for meetings finalized with durable segments.
+  Each segment carries a UUID, start/end time, speaker/source label, text, and
+  a word-index range into `wordTimestamps`, so agents can cite stable meeting
+  transcript segments without deriving boundaries themselves.
 
 ### Changed
 

--- a/Sources/CLI/Commands/MeetingsCommand.swift
+++ b/Sources/CLI/Commands/MeetingsCommand.swift
@@ -663,6 +663,7 @@ private struct MeetingRecord: Encodable {
     let speakerCount: Int?
     let speakers: [SpeakerInfo]?
     let diarizationSegments: [DiarizationSegmentRecord]?
+    let transcriptSegments: [TranscriptSegmentRecord]?
     let artifactFolderPath: String?
     let artifactManifestPath: String?
     let hasArtifactManifest: Bool
@@ -689,6 +690,7 @@ private struct MeetingRecord: Encodable {
         speakerCount = transcription.speakerCount
         speakers = transcription.speakers
         diarizationSegments = transcription.diarizationSegments
+        transcriptSegments = transcription.transcriptSegments
         let artifactFolder = MeetingArtifactStore.sessionFolderURL(for: transcription)
         artifactFolderPath = artifactFolder?.path
         let manifestPath = artifactFolder?
@@ -709,6 +711,7 @@ private struct MeetingTranscriptRecord: Encodable {
     let transcript: String
     let wordTimestamps: [WordTimestamp]?
     let speakers: [SpeakerInfo]?
+    let transcriptSegments: [TranscriptSegmentRecord]?
 
     init(_ transcription: Transcription) {
         id = transcription.id
@@ -718,6 +721,7 @@ private struct MeetingTranscriptRecord: Encodable {
         transcript = preferredTranscriptText(transcription)
         wordTimestamps = transcription.wordTimestamps
         speakers = transcription.speakers
+        transcriptSegments = transcription.transcriptSegments
     }
 }
 

--- a/Sources/CLI/Commands/SpecCommand.swift
+++ b/Sources/CLI/Commands/SpecCommand.swift
@@ -889,7 +889,7 @@ private extension CLISpecCommand {
                 CLISpecParameter.flag("--envelope", summary: "Wrap JSON output in an ok/data/meta success envelope."),
                 databaseOption,
             ],
-            output: "MeetingRecord object with transcript, notes, and prompt-result count."
+            output: "MeetingRecord object with transcript, transcriptSegments, notes, and prompt-result count."
         ),
         CLISpecCommand(
             ["meetings", "transcript"],
@@ -900,7 +900,7 @@ private extension CLISpecCommand {
                 CLISpecParameter.option("--format", valueName: "text|json|srt|vtt", summary: "Transcript output format."),
                 databaseOption,
             ],
-            output: "MeetingTranscriptRecord object for --format json."
+            output: "MeetingTranscriptRecord object with transcriptSegments for --format json."
         ),
         CLISpecCommand(
             ["meetings", "notes", "get"],

--- a/Sources/MacParakeetCore/Database/DatabaseManager.swift
+++ b/Sources/MacParakeetCore/Database/DatabaseManager.swift
@@ -1031,6 +1031,15 @@ public final class DatabaseManager: Sendable {
             }
         }
 
+        // v0.23 — Durable meeting transcript segments. Raw SQL is intentional:
+        // historical migrations must not depend on the evolving Codable model.
+        migrator.registerMigration("v0.23-transcript-segments") { db in
+            let columns = try db.columns(in: "transcriptions").map(\.name)
+            if !columns.contains("transcriptSegments") {
+                try db.execute(sql: "ALTER TABLE transcriptions ADD COLUMN transcriptSegments TEXT")
+            }
+        }
+
         try migrator.migrate(dbQueue)
         try reconcileBuiltInPrompts()
         try reconcileBuiltInQuickPrompts()

--- a/Sources/MacParakeetCore/Models/Transcription.swift
+++ b/Sources/MacParakeetCore/Models/Transcription.swift
@@ -29,6 +29,7 @@ public struct Transcription: Codable, Identifiable, Sendable {
     public var speakerCount: Int?
     public var speakers: [SpeakerInfo]?
     public var diarizationSegments: [DiarizationSegmentRecord]?
+    public var transcriptSegments: [TranscriptSegmentRecord]?
     public var chatMessages: [ChatMessage]?
     public var status: TranscriptionStatus
     public var errorMessage: String?
@@ -85,6 +86,7 @@ public struct Transcription: Codable, Identifiable, Sendable {
         speakerCount: Int? = nil,
         speakers: [SpeakerInfo]? = nil,
         diarizationSegments: [DiarizationSegmentRecord]? = nil,
+        transcriptSegments: [TranscriptSegmentRecord]? = nil,
         chatMessages: [ChatMessage]? = nil,
         status: TranscriptionStatus = .processing,
         errorMessage: String? = nil,
@@ -118,6 +120,7 @@ public struct Transcription: Codable, Identifiable, Sendable {
         self.speakerCount = speakerCount
         self.speakers = speakers
         self.diarizationSegments = diarizationSegments
+        self.transcriptSegments = transcriptSegments
         self.chatMessages = chatMessages
         self.status = status
         self.errorMessage = errorMessage
@@ -199,13 +202,51 @@ public struct DiarizationSegmentRecord: Codable, Sendable, Equatable {
     }
 }
 
+public struct TranscriptSegmentWordRange: Codable, Sendable, Equatable {
+    public var startIndex: Int
+    public var endIndexExclusive: Int
+
+    public init(startIndex: Int, endIndexExclusive: Int) {
+        self.startIndex = startIndex
+        self.endIndexExclusive = endIndexExclusive
+    }
+}
+
+public struct TranscriptSegmentRecord: Codable, Sendable, Equatable, Identifiable {
+    public var id: UUID
+    public var startMs: Int
+    public var endMs: Int
+    public var speakerId: String?
+    public var speakerLabel: String
+    public var text: String
+    public var wordRange: TranscriptSegmentWordRange
+
+    public init(
+        id: UUID = UUID(),
+        startMs: Int,
+        endMs: Int,
+        speakerId: String?,
+        speakerLabel: String,
+        text: String,
+        wordRange: TranscriptSegmentWordRange
+    ) {
+        self.id = id
+        self.startMs = startMs
+        self.endMs = endMs
+        self.speakerId = speakerId
+        self.speakerLabel = speakerLabel
+        self.text = text
+        self.wordRange = wordRange
+    }
+}
+
 extension Transcription: FetchableRecord, PersistableRecord {
     public static let databaseTableName = "transcriptions"
 
     public enum Columns: String, ColumnExpression {
         case id, createdAt, fileName, filePath, meetingArtifactFolderPath, fileSizeBytes, durationMs
         case rawTranscript, cleanTranscript, wordTimestamps, language
-        case speakerCount, speakers, diarizationSegments, chatMessages
+        case speakerCount, speakers, diarizationSegments, transcriptSegments, chatMessages
         case status, errorMessage, exportPath, sourceURL
         case thumbnailURL, channelName, videoDescription, isFavorite, sourceType, recoveredFromCrash, isTranscriptEdited, userNotes, engine, engineVariant, derivedTitle, derivedSnippet, updatedAt
     }
@@ -250,6 +291,7 @@ extension Transcription: FetchableRecord, PersistableRecord {
         }
 
         diarizationSegments = try container.decodeIfPresent([DiarizationSegmentRecord].self, forKey: .diarizationSegments)
+        transcriptSegments = try container.decodeIfPresent([TranscriptSegmentRecord].self, forKey: .transcriptSegments)
         chatMessages = try container.decodeIfPresent([ChatMessage].self, forKey: .chatMessages)
         status = try container.decode(TranscriptionStatus.self, forKey: .status)
         errorMessage = try container.decodeIfPresent(String.self, forKey: .errorMessage)

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingArtifactStore.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingArtifactStore.swift
@@ -331,6 +331,7 @@ private struct MeetingArtifactTranscript: Codable {
     let speakerCount: Int?
     let speakers: [SpeakerInfo]?
     let diarizationSegments: [DiarizationSegmentRecord]?
+    let transcriptSegments: [TranscriptSegmentRecord]?
     let userNotes: String?
     let language: String?
     let engine: String?
@@ -354,6 +355,7 @@ private struct MeetingArtifactTranscript: Codable {
         speakerCount = transcription.speakerCount
         speakers = transcription.speakers
         diarizationSegments = transcription.diarizationSegments
+        transcriptSegments = transcription.transcriptSegments
         userNotes = transcription.userNotes
         language = transcription.language
         engine = transcription.engine

--- a/Sources/MacParakeetCore/Services/TranscriptionService.swift
+++ b/Sources/MacParakeetCore/Services/TranscriptionService.swift
@@ -1144,6 +1144,11 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
             transcription.speakers = finalized.speakers
             transcription.speakerCount = finalized.speakers.isEmpty ? nil : finalized.speakers.count
             transcription.diarizationSegments = finalized.diarizationSegments.isEmpty ? nil : finalized.diarizationSegments
+            let transcriptSegments = TranscriptSegmenter.materializeSegments(
+                words: corrected.words,
+                speakers: finalized.speakers
+            )
+            transcription.transcriptSegments = transcriptSegments.isEmpty ? nil : transcriptSegments
 
             lifecycleStage = .postProcessing
             let completed = try await completeTranscription(
@@ -1612,6 +1617,7 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
         transcription.speakerCount = nil
         transcription.speakers = nil
         transcription.diarizationSegments = nil
+        transcription.transcriptSegments = nil
         transcription.status = .processing
         transcription.errorMessage = nil
         transcription.exportPath = nil

--- a/Sources/MacParakeetCore/Utilities/TranscriptSegmenter.swift
+++ b/Sources/MacParakeetCore/Utilities/TranscriptSegmenter.swift
@@ -44,54 +44,32 @@ public struct SpeakerStatistics: Sendable {
 public enum TranscriptSegmenter {
     /// Group word timestamps into segments based on punctuation, gaps, and speaker changes.
     public static func groupIntoSegments(words: [WordTimestamp]) -> [TranscriptSegment] {
-        guard !words.isEmpty else { return [] }
-
-        var segments: [TranscriptSegment] = []
-        var currentWords: [String] = []
-        var segmentStart = words[0].startMs
-        var segmentSpeaker = words[0].speakerId
-
-        for (i, word) in words.enumerated() {
-            let isLast = i == words.count - 1
-            let speakerChanged = word.speakerId != nil && word.speakerId != segmentSpeaker
-
-            // Flush current segment on speaker change before adding this word
-            if speakerChanged && !currentWords.isEmpty {
-                segments.append(TranscriptSegment(
-                    startMs: segmentStart,
-                    text: currentWords.joined(separator: " "),
-                    speakerId: segmentSpeaker
-                ))
-                currentWords = []
-                segmentStart = word.startMs
-                segmentSpeaker = word.speakerId
-            }
-
-            currentWords.append(word.word)
-            // Track speaker (nil words inherit current speaker)
-            if word.speakerId != nil {
-                segmentSpeaker = word.speakerId
-            }
-
-            let endsWithPunctuation = word.word.last.map { ".!?".contains($0) } ?? false
-            let hasLongGap = i + 1 < words.count && (words[i + 1].startMs - word.endMs) > 1500
-            let tooLong = currentWords.count >= 40
-
-            if isLast || (endsWithPunctuation && currentWords.count >= 3) || hasLongGap || tooLong {
-                segments.append(TranscriptSegment(
-                    startMs: segmentStart,
-                    text: currentWords.joined(separator: " "),
-                    speakerId: segmentSpeaker
-                ))
-                currentWords = []
-                if !isLast {
-                    segmentStart = words[i + 1].startMs
-                    segmentSpeaker = words[i + 1].speakerId ?? segmentSpeaker
-                }
-            }
+        segmentBoundaries(words: words).map {
+            TranscriptSegment(startMs: $0.startMs, text: $0.text, speakerId: $0.speakerId)
         }
+    }
 
-        return segments
+    /// Materialize durable segments with IDs and word-index ranges into `words`.
+    public static func materializeSegments(
+        words: [WordTimestamp],
+        speakers: [SpeakerInfo]? = nil,
+        idGenerator: () -> UUID = { UUID() }
+    ) -> [TranscriptSegmentRecord] {
+        var speakersByID: [String: String] = [:]
+        for speaker in speakers ?? [] where speakersByID[speaker.id] == nil {
+            speakersByID[speaker.id] = speaker.label
+        }
+        return segmentBoundaries(words: words).map { boundary in
+            TranscriptSegmentRecord(
+                id: idGenerator(),
+                startMs: boundary.startMs,
+                endMs: boundary.endMs,
+                speakerId: boundary.speakerId,
+                speakerLabel: speakerLabel(for: boundary.speakerId, speakersByID: speakersByID),
+                text: boundary.text,
+                wordRange: boundary.wordRange
+            )
+        }
     }
 
     /// Group segments into consecutive speaker turns.
@@ -165,4 +143,88 @@ public enum TranscriptSegmenter {
         let normalized = parts.joined(separator: " ").trimmingCharacters(in: .whitespacesAndNewlines)
         return normalized.isEmpty ? "transcript" : normalized
     }
+
+    private static func segmentBoundaries(words: [WordTimestamp]) -> [SegmentBoundary] {
+        guard !words.isEmpty else { return [] }
+
+        var boundaries: [SegmentBoundary] = []
+        var currentWords: [String] = []
+        var segmentStartIndex = 0
+        var segmentStart = words[0].startMs
+        var segmentSpeaker = words[0].speakerId
+
+        func appendBoundary(endIndexExclusive: Int, speakerId: String?) {
+            guard !currentWords.isEmpty else { return }
+            let lastWord = words[endIndexExclusive - 1]
+            boundaries.append(SegmentBoundary(
+                startMs: segmentStart,
+                endMs: lastWord.endMs,
+                text: currentWords.joined(separator: " "),
+                speakerId: speakerId,
+                wordRange: TranscriptSegmentWordRange(
+                    startIndex: segmentStartIndex,
+                    endIndexExclusive: endIndexExclusive
+                )
+            ))
+        }
+
+        for (i, word) in words.enumerated() {
+            let isLast = i == words.count - 1
+            let speakerChanged = word.speakerId != nil && word.speakerId != segmentSpeaker
+
+            // Flush current segment on speaker change before adding this word.
+            if speakerChanged && !currentWords.isEmpty {
+                appendBoundary(endIndexExclusive: i, speakerId: segmentSpeaker)
+                currentWords = []
+                segmentStartIndex = i
+                segmentStart = word.startMs
+                segmentSpeaker = word.speakerId
+            }
+
+            currentWords.append(word.word)
+            // Track speaker (nil words inherit current speaker).
+            if word.speakerId != nil {
+                segmentSpeaker = word.speakerId
+            }
+
+            let endsWithPunctuation = word.word.last.map { ".!?".contains($0) } ?? false
+            let hasLongGap = i + 1 < words.count && (words[i + 1].startMs - word.endMs) > 1500
+            let tooLong = currentWords.count >= 40
+
+            if isLast || (endsWithPunctuation && currentWords.count >= 3) || hasLongGap || tooLong {
+                appendBoundary(endIndexExclusive: i + 1, speakerId: segmentSpeaker)
+                currentWords = []
+                if !isLast {
+                    segmentStartIndex = i + 1
+                    segmentStart = words[i + 1].startMs
+                    segmentSpeaker = words[i + 1].speakerId ?? segmentSpeaker
+                }
+            }
+        }
+
+        return boundaries
+    }
+
+    private static func speakerLabel(
+        for speakerId: String?,
+        speakersByID: [String: String]
+    ) -> String {
+        guard let speakerId else { return "Unknown Speaker" }
+        if let label = speakersByID[speakerId]?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !label.isEmpty {
+            return label
+        }
+        if let source = AudioSource(rawValue: speakerId) {
+            return source.displayLabel
+        }
+        return speakerId
+    }
+}
+
+private struct SegmentBoundary {
+    let startMs: Int
+    let endMs: Int
+    let text: String
+    let speakerId: String?
+    let wordRange: TranscriptSegmentWordRange
 }

--- a/Tests/CLITests/MeetingsCommandTests.swift
+++ b/Tests/CLITests/MeetingsCommandTests.swift
@@ -235,6 +235,64 @@ final class MeetingsCommandTests: XCTestCase {
         XCTAssertTrue(markdownExportOutput.contains("- Prompt results: 1"))
     }
 
+    func testMeetingJSONSurfacesExposeTranscriptSegments() async throws {
+        let dbURL = temporaryDatabaseURL()
+        defer { try? FileManager.default.removeItem(at: dbURL) }
+        let db = try DatabaseManager(path: dbURL.path)
+        let transcriptionRepo = TranscriptionRepository(dbQueue: db.dbQueue)
+        let segmentID = UUID(uuidString: "44444444-4444-4444-4444-444444444444")!
+        let meeting = Transcription(
+            fileName: "Segment Review",
+            rawTranscript: "Ship the durable segment contract.",
+            wordTimestamps: [
+                WordTimestamp(word: "Ship", startMs: 0, endMs: 200, confidence: 0.98, speakerId: "microphone"),
+                WordTimestamp(word: "it.", startMs: 220, endMs: 360, confidence: 0.98, speakerId: "microphone"),
+            ],
+            transcriptSegments: [
+                TranscriptSegmentRecord(
+                    id: segmentID,
+                    startMs: 0,
+                    endMs: 360,
+                    speakerId: "microphone",
+                    speakerLabel: "Me",
+                    text: "Ship it.",
+                    wordRange: TranscriptSegmentWordRange(startIndex: 0, endIndexExclusive: 2)
+                ),
+            ],
+            status: .completed,
+            sourceType: .meeting
+        )
+        try transcriptionRepo.save(meeting)
+
+        let showCommand = try MeetingsCommand.ShowSubcommand.parse([
+            meeting.id.uuidString,
+            "--json",
+            "--database", dbURL.path,
+        ])
+        let showOutput = try await captureStandardOutput {
+            try await showCommand.run()
+        }
+        let showPayload = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(showOutput.utf8)) as? [String: Any]
+        )
+        let showSegments = try XCTUnwrap(showPayload["transcriptSegments"] as? [[String: Any]])
+        assertSegmentPayload(showSegments.first, id: segmentID)
+
+        let transcriptCommand = try MeetingsCommand.TranscriptSubcommand.parse([
+            meeting.id.uuidString,
+            "--format", "json",
+            "--database", dbURL.path,
+        ])
+        let transcriptOutput = try await captureStandardOutput {
+            try await transcriptCommand.run()
+        }
+        let transcriptPayload = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(transcriptOutput.utf8)) as? [String: Any]
+        )
+        let transcriptSegments = try XCTUnwrap(transcriptPayload["transcriptSegments"] as? [[String: Any]])
+        assertSegmentPayload(transcriptSegments.first, id: segmentID)
+    }
+
     func testArtifactSubcommandMaterializesMeetingFolder() async throws {
         let dbURL = temporaryDatabaseURL()
         let folderURL = FileManager.default.temporaryDirectory
@@ -448,5 +506,27 @@ final class MeetingsCommandTests: XCTestCase {
                 line: line
             )
         }
+    }
+
+    private func assertSegmentPayload(
+        _ payload: [String: Any]?,
+        id: UUID,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        guard let payload else {
+            return XCTFail("Expected segment payload", file: file, line: line)
+        }
+        XCTAssertEqual(payload["id"] as? String, id.uuidString, file: file, line: line)
+        XCTAssertEqual(payload["startMs"] as? Int, 0, file: file, line: line)
+        XCTAssertEqual(payload["endMs"] as? Int, 360, file: file, line: line)
+        XCTAssertEqual(payload["speakerId"] as? String, "microphone", file: file, line: line)
+        XCTAssertEqual(payload["speakerLabel"] as? String, "Me", file: file, line: line)
+        XCTAssertEqual(payload["text"] as? String, "Ship it.", file: file, line: line)
+        guard let wordRange = payload["wordRange"] as? [String: Any] else {
+            return XCTFail("Expected wordRange", file: file, line: line)
+        }
+        XCTAssertEqual(wordRange["startIndex"] as? Int, 0, file: file, line: line)
+        XCTAssertEqual(wordRange["endIndexExclusive"] as? Int, 2, file: file, line: line)
     }
 }

--- a/Tests/MacParakeetTests/Database/DatabaseManagerTests.swift
+++ b/Tests/MacParakeetTests/Database/DatabaseManagerTests.swift
@@ -44,6 +44,15 @@ final class DatabaseManagerTests: XCTestCase {
         }
     }
 
+    func testTranscriptSegmentsMigrationAddsTranscriptionColumn() throws {
+        let manager = try DatabaseManager()
+
+        try manager.dbQueue.read { db in
+            let columns = try db.columns(in: "transcriptions").map(\.name)
+            XCTAssertTrue(columns.contains("transcriptSegments"))
+        }
+    }
+
     func testFileBackedConnectionsWaitForShortWriteLock() throws {
         let dbPath = FileManager.default.temporaryDirectory
             .appendingPathComponent("macparakeet-lock-wait-\(UUID().uuidString).db")

--- a/Tests/MacParakeetTests/Database/TranscriptionRepositoryTests.swift
+++ b/Tests/MacParakeetTests/Database/TranscriptionRepositoryTests.swift
@@ -47,6 +47,41 @@ final class TranscriptionRepositoryTests: XCTestCase {
         XCTAssertEqual(fetched?.engineVariant, SpeechEnginePreference.defaultWhisperModelVariant)
     }
 
+    func testTranscriptSegmentsRoundTrip() throws {
+        let segmentID = UUID(uuidString: "33333333-3333-3333-3333-333333333333")!
+        let transcription = Transcription(
+            fileName: "Design Review",
+            wordTimestamps: [
+                WordTimestamp(word: "Ship", startMs: 0, endMs: 200, confidence: 0.98, speakerId: "microphone"),
+            ],
+            transcriptSegments: [
+                TranscriptSegmentRecord(
+                    id: segmentID,
+                    startMs: 0,
+                    endMs: 200,
+                    speakerId: "microphone",
+                    speakerLabel: "Me",
+                    text: "Ship",
+                    wordRange: TranscriptSegmentWordRange(startIndex: 0, endIndexExclusive: 1)
+                ),
+            ],
+            status: .completed,
+            sourceType: .meeting
+        )
+        try repo.save(transcription)
+
+        let fetched = try XCTUnwrap(repo.fetch(id: transcription.id))
+        XCTAssertEqual(fetched.transcriptSegments?.count, 1)
+        XCTAssertEqual(fetched.transcriptSegments?.first?.id, segmentID)
+        XCTAssertEqual(fetched.transcriptSegments?.first?.startMs, 0)
+        XCTAssertEqual(fetched.transcriptSegments?.first?.endMs, 200)
+        XCTAssertEqual(fetched.transcriptSegments?.first?.speakerLabel, "Me")
+        XCTAssertEqual(
+            fetched.transcriptSegments?.first?.wordRange,
+            TranscriptSegmentWordRange(startIndex: 0, endIndexExclusive: 1)
+        )
+    }
+
     func testLegacyTranscriptionDecodesWithNilEngineFields() throws {
         let transcription = Transcription(fileName: "legacy.mp3")
         try repo.save(transcription)

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingArtifactStoreTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingArtifactStoreTests.swift
@@ -75,6 +75,17 @@ final class MeetingArtifactStoreTests: XCTestCase {
         XCTAssertEqual(transcript["transcript"] as? String, "Clean transcript.")
         XCTAssertEqual(transcript["sourceType"] as? String, "meeting")
         XCTAssertEqual(transcript["userNotes"] as? String, "Decision: ship\nOwner: Dana")
+        let transcriptSegments = try XCTUnwrap(transcript["transcriptSegments"] as? [[String: Any]])
+        XCTAssertEqual(transcriptSegments.count, 1)
+        XCTAssertEqual(
+            transcriptSegments.first?["id"] as? String,
+            UUID(uuidString: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")!.uuidString
+        )
+        XCTAssertEqual(transcriptSegments.first?["speakerLabel"] as? String, "Speaker 1")
+        XCTAssertEqual(transcriptSegments.first?["text"] as? String, "Clean")
+        let wordRange = try XCTUnwrap(transcriptSegments.first?["wordRange"] as? [String: Any])
+        XCTAssertEqual(wordRange["startIndex"] as? Int, 0)
+        XCTAssertEqual(wordRange["endIndexExclusive"] as? Int, 1)
 
         let manifest = try jsonObject(at: URL(fileURLWithPath: snapshot.manifestPath))
         XCTAssertEqual(manifest["schema"] as? String, MeetingArtifactStore.schema)
@@ -233,6 +244,17 @@ final class MeetingArtifactStoreTests: XCTestCase {
             ],
             diarizationSegments: [
                 DiarizationSegmentRecord(speakerId: "S1", startMs: 0, endMs: 1000),
+            ],
+            transcriptSegments: [
+                TranscriptSegmentRecord(
+                    id: UUID(uuidString: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")!,
+                    startMs: 0,
+                    endMs: 400,
+                    speakerId: "S1",
+                    speakerLabel: "Speaker 1",
+                    text: "Clean",
+                    wordRange: TranscriptSegmentWordRange(startIndex: 0, endIndexExclusive: 1)
+                ),
             ],
             status: .completed,
             sourceType: .meeting,

--- a/Tests/MacParakeetTests/Services/TranscriptionServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/TranscriptionServiceTests.swift
@@ -2010,6 +2010,63 @@ final class TranscriptionServiceTests: XCTestCase {
         XCTAssertEqual(capturedPromptResults.first?.content, "Ship the artifact refresh.")
     }
 
+    func testRetranscribeMeetingMintsNewTranscriptSegmentIDs() async throws {
+        let recording = try makeOneSourceMeetingRecording(displayName: "Segment Rerun")
+        defer { try? FileManager.default.removeItem(at: recording.folderURL) }
+
+        let oldSegmentID = UUID(uuidString: "55555555-5555-5555-5555-555555555555")!
+        let original = Transcription(
+            fileName: "Segment Rerun",
+            filePath: recording.mixedAudioURL.path,
+            rawTranscript: "Old segment.",
+            wordTimestamps: [
+                WordTimestamp(word: "Old", startMs: 0, endMs: 200, confidence: 0.9, speakerId: "microphone"),
+            ],
+            transcriptSegments: [
+                TranscriptSegmentRecord(
+                    id: oldSegmentID,
+                    startMs: 0,
+                    endMs: 200,
+                    speakerId: "microphone",
+                    speakerLabel: "Me",
+                    text: "Old",
+                    wordRange: TranscriptSegmentWordRange(startIndex: 0, endIndexExclusive: 1)
+                ),
+            ],
+            status: .completed,
+            sourceType: .meeting
+        )
+        try transcriptionRepo.save(original)
+        await mockSTT.configure(result: STTResult(
+            text: "Fresh segment",
+            words: [
+                TimestampedWord(word: "Fresh", startMs: 0, endMs: 300, confidence: 0.9),
+                TimestampedWord(word: "segment", startMs: 320, endMs: 620, confidence: 0.9),
+            ]
+        ))
+        let service = TranscriptionService(
+            audioProcessor: mockAudio,
+            sttTranscriber: mockSTT,
+            transcriptionRepo: transcriptionRepo,
+            meetingArtifactStore: nil,
+            meetingAutomationHookRunner: nil
+        )
+
+        let result = try await service.retranscribeMeeting(existing: original, recording: recording)
+
+        XCTAssertEqual(result.id, original.id)
+        let segment = try XCTUnwrap(result.transcriptSegments?.first)
+        XCTAssertNotEqual(segment.id, oldSegmentID)
+        XCTAssertEqual(segment.text, "Fresh segment")
+        XCTAssertEqual(segment.speakerId, "microphone")
+        XCTAssertEqual(segment.speakerLabel, "Me")
+        XCTAssertEqual(segment.wordRange, TranscriptSegmentWordRange(startIndex: 0, endIndexExclusive: 2))
+
+        let fetched = try XCTUnwrap(transcriptionRepo.fetch(id: original.id))
+        XCTAssertEqual(fetched.transcriptSegments?.first?.id, segment.id)
+        XCTAssertNotEqual(fetched.transcriptSegments?.first?.id, oldSegmentID)
+    }
+
     func testTranscribeMeetingFailsWhenCapturedSpeechEngineCannotBeRouted() async throws {
         let recordingFolder = URL(fileURLWithPath: AppPaths.tempDir)
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -2340,6 +2397,7 @@ final class TranscriptionServiceTests: XCTestCase {
 
         XCTAssertEqual(result.rawTranscript, "Hello, there.")
         XCTAssertEqual(result.wordTimestamps, [])
+        XCTAssertNil(result.transcriptSegments)
     }
 
     func testTranscribeMeetingPreservesContiguousDualSourceModelText() async throws {

--- a/Tests/MacParakeetTests/Utilities/TranscriptSegmenterTests.swift
+++ b/Tests/MacParakeetTests/Utilities/TranscriptSegmenterTests.swift
@@ -91,6 +91,60 @@ final class TranscriptSegmenterTests: XCTestCase {
         XCTAssertEqual(segments.last?.speakerId, "s1")
     }
 
+    func testMaterializeSegmentsAddsDurableIdentityEndTimeLabelsAndWordRanges() {
+        let words = [
+            WordTimestamp(word: "This", startMs: 0, endMs: 120, confidence: 0.9, speakerId: "s1"),
+            WordTimestamp(word: "is", startMs: 140, endMs: 220, confidence: 0.9, speakerId: "s1"),
+            WordTimestamp(word: "done.", startMs: 240, endMs: 520, confidence: 0.9, speakerId: "s1"),
+            WordTimestamp(word: "Remote", startMs: 640, endMs: 820, confidence: 0.9, speakerId: "s2"),
+            WordTimestamp(word: "answer", startMs: 840, endMs: 1_000, confidence: 0.9, speakerId: "s2"),
+        ]
+        var ids = [
+            UUID(uuidString: "11111111-1111-1111-1111-111111111111")!,
+            UUID(uuidString: "22222222-2222-2222-2222-222222222222")!,
+        ]
+
+        let segments = TranscriptSegmenter.materializeSegments(
+            words: words,
+            speakers: [
+                SpeakerInfo(id: "s1", label: "Dana"),
+                SpeakerInfo(id: "s2", label: "Riley"),
+            ],
+            idGenerator: { ids.removeFirst() }
+        )
+
+        XCTAssertEqual(segments.map(\.id), [
+            UUID(uuidString: "11111111-1111-1111-1111-111111111111")!,
+            UUID(uuidString: "22222222-2222-2222-2222-222222222222")!,
+        ])
+        XCTAssertEqual(segments.map(\.text), ["This is done.", "Remote answer"])
+        XCTAssertEqual(segments.map(\.startMs), [0, 640])
+        XCTAssertEqual(segments.map(\.endMs), [520, 1_000])
+        XCTAssertEqual(segments.map(\.speakerId), ["s1", "s2"])
+        XCTAssertEqual(segments.map(\.speakerLabel), ["Dana", "Riley"])
+        XCTAssertEqual(segments.map(\.wordRange), [
+            TranscriptSegmentWordRange(startIndex: 0, endIndexExclusive: 3),
+            TranscriptSegmentWordRange(startIndex: 3, endIndexExclusive: 5),
+        ])
+
+        let presentationSegments = TranscriptSegmenter.groupIntoSegments(words: words)
+        XCTAssertEqual(presentationSegments.map(\.text), segments.map(\.text))
+        XCTAssertEqual(presentationSegments.map(\.startMs), segments.map(\.startMs))
+        XCTAssertEqual(presentationSegments.map(\.speakerId), segments.map(\.speakerId))
+    }
+
+    func testMaterializeSegmentsUsesSourceLabelsWhenSpeakerRosterIsAbsent() {
+        let words = [
+            WordTimestamp(word: "Local", startMs: 0, endMs: 100, confidence: 0.9, speakerId: "microphone"),
+            WordTimestamp(word: "track.", startMs: 120, endMs: 240, confidence: 0.9, speakerId: "microphone"),
+            WordTimestamp(word: "Remote", startMs: 260, endMs: 400, confidence: 0.9, speakerId: "system"),
+        ]
+
+        let segments = TranscriptSegmenter.materializeSegments(words: words)
+
+        XCTAssertEqual(segments.map(\.speakerLabel), ["Me", "Others"])
+    }
+
     // MARK: - groupIntoSpeakerTurns
 
     func testEmptySegmentsReturnsEmptyTurns() {

--- a/spec/01-data-model.md
+++ b/spec/01-data-model.md
@@ -121,6 +121,7 @@ CREATE TABLE transcriptions (
     speakerCount INTEGER,                              -- Number of detected speakers (v0.4 diarization)
     speakers TEXT,                                      -- JSON: [{"id":"S1","label":"Speaker 1"},{"id":"S2","label":"Sarah"}] (v0.4 diarization)
     diarizationSegments TEXT,                           -- JSON: [{"speakerId":"S1","startMs":0,"endMs":5000},...] (v0.4 diarization)
+    transcriptSegments TEXT,                            -- v0.23: JSON durable meeting transcript segments with UUIDs and word ranges
     chatMessages TEXT,                                  -- v0.4: JSON array of LLM chat messages
     status TEXT NOT NULL DEFAULT 'processing',          -- 'processing', 'completed', 'error', 'cancelled'
     errorMessage TEXT,                                  -- Error details if status='error'
@@ -149,6 +150,7 @@ CREATE INDEX idx_transcriptions_status_created_at ON transcriptions(status, crea
 
 **Notes:**
 - `wordTimestamps` is a JSON text column, not a separate table. One transcription = one blob of timestamps. GRDB can decode this via `Codable`.
+- `transcriptSegments` is a JSON text column populated for finalized meeting recordings. Each segment has a UUID, start/end times, speaker/source label, text, and a half-open `wordRange` (`startIndex`, `endIndexExclusive`) into the persisted `wordTimestamps` array. Segment IDs are stable for that transcript version; retranscribing a meeting replaces the transcript version and may mint new segment IDs. Non-meeting transcriptions leave this `NULL`.
 - `language` stores the normalized detected/specified STT language code when available. New transcription service rows start unknown and are filled from the STT result; legacy/default rows may still contain `en`.
 - `speakerCount` and `speakers` are nullable, populated only when diarization is available (v0.4).
 - `filePath` is nullable because the original file may be moved or deleted after transcription.
@@ -172,6 +174,7 @@ CREATE INDEX idx_transcriptions_status_created_at ON transcriptions(status, crea
 - `speakers`: JSON array of `SpeakerInfo` objects mapping stable IDs to display labels (e.g., `[{"id":"S1","label":"Speaker 1"},{"id":"S2","label":"Sarah"}]`). Rename updates the `label` field only — no word rewrite needed.
 - `diarizationSegments`: JSON array of raw diarization segments (e.g., `[{"speakerId":"S1","startMs":0,"endMs":5000}]`). Used for accurate speaking time analytics. Nil if diarization not run or failed.
 - Speaker assignment per word is stored via `speakerId` on each `WordTimestamp` entry using **stable IDs** (`"S1"`, `"S2"`) — not display labels. Display labels are resolved via the `speakers` mapping.
+- `transcriptSegments`: JSON array of durable meeting transcript segments derived from the persisted word array with `TranscriptSegmenter`. Readers should use this array for citations instead of re-segmenting words. Nil for legacy rows and non-meeting transcriptions.
 - All diarization fields are nullable. If diarization fails, ASR result is still persisted with these fields as nil.
 
 ---
@@ -595,6 +598,7 @@ struct Transcription: Codable, Identifiable {
     var speakerCount: Int?
     var speakers: [SpeakerInfo]?
     var diarizationSegments: [DiarizationSegmentRecord]?
+    var transcriptSegments: [TranscriptSegmentRecord]? // v0.23 — Durable meeting citation segments
     var chatMessages: [ChatMessage]?        // v0.4 — Legacy (migrated to chat_conversations in v0.5)
     var status: TranscriptionStatus
     var errorMessage: String?
@@ -631,6 +635,21 @@ struct Transcription: Codable, Identifiable {
         var speakerId: String     // "S1", "S2"
         var startMs: Int
         var endMs: Int
+    }
+
+    struct TranscriptSegmentRecord: Codable, Sendable {
+        var id: UUID
+        var startMs: Int
+        var endMs: Int
+        var speakerId: String?
+        var speakerLabel: String
+        var text: String
+        var wordRange: TranscriptSegmentWordRange
+    }
+
+    struct TranscriptSegmentWordRange: Codable, Sendable {
+        var startIndex: Int
+        var endIndexExclusive: Int
     }
 
     enum TranscriptionStatus: String, Codable {
@@ -1130,6 +1149,7 @@ migrator.registerMigration("v0.7-prompts-and-summaries") { db in
 | ~~`dictations_fts`~~ | ~~v0.1~~ | ~~Full-text search for dictations~~ (dropped in v0.5 — never queried) |
 | `transcriptions` | v0.1 | File transcription records |
 | `transcriptions.meetingArtifactFolderPath` | v0.22 | Durable meeting artifact folder path retained after meeting audio deletion |
+| `transcriptions.transcriptSegments` | v0.23 | Durable meeting transcript segments (JSON) for stable per-transcript-version citations |
 | `custom_words` | v0.2 | Vocabulary anchors and corrections |
 | `text_snippets` | v0.2 | Trigger-based text expansion |
 | `transcriptions.diarizationSegments` | v0.4 | Speaker diarization segments (JSON) |

--- a/spec/contracts/cli-json-v1.md
+++ b/spec/contracts/cli-json-v1.md
@@ -45,6 +45,12 @@ with human progress/status kept off stdout.
   (`is_built_in`, `created_at`), which predates this convention; its keys are
   frozen for v1 and would only change at a major boundary. New commands use
   camelCase.
+- `meetings show --json` and `meetings transcript --format json` expose
+  `transcriptSegments` when the meeting row has durable segments. Each segment
+  contains `id`, `startMs`, `endMs`, `speakerId`, `speakerLabel`, `text`, and
+  `wordRange.startIndex` / `wordRange.endIndexExclusive` into the same payload's
+  `wordTimestamps` array. Callers that need stable citations should prefer
+  these persisted segments over re-segmenting words.
 
 ## Failure Envelope
 
@@ -101,8 +107,9 @@ breaking contract change and requires explicit version/changelog treatment.
 
 Focused coverage pins spec conventions, failure-envelope fields, exit code
 entries, JSON wrapper failure envelopes, JSON validation exit-code
-normalization, agent-facing meeting commands, command-level JSON failure
-envelopes, and `--json`/`--envelope` mutual exclusion.
+normalization, agent-facing meeting commands including durable transcript
+segments, command-level JSON failure envelopes, and `--json`/`--envelope`
+mutual exclusion.
 
 ## When this changes
 

--- a/spec/contracts/meeting-artifacts-v1.md
+++ b/spec/contracts/meeting-artifacts-v1.md
@@ -99,8 +99,15 @@ The v1 folder can contain these stable filenames:
 
 `transcript.json` keeps meeting essentials: `id`, `title`, timestamps,
 `durationMs`, `status`, raw/clean/transcript text, word/speaker/diarization
-fields, `userNotes`, language/engine attribution, `sourceType`,
-`recoveredFromCrash`, and `isTranscriptEdited`.
+fields, durable `transcriptSegments`, `userNotes`, language/engine attribution,
+`sourceType`, `recoveredFromCrash`, and `isTranscriptEdited`.
+
+`transcriptSegments` is an additive v1 field populated from the DB row when a
+meeting has durable segments. Each segment keeps `id`, `startMs`, `endMs`,
+`speakerId`, `speakerLabel`, `text`, and a half-open `wordRange`
+(`startIndex`, `endIndexExclusive`) into the same transcript's
+`wordTimestamps` array. Segment IDs are stable for that transcript version;
+meeting retranscription may replace the array with newly minted segment IDs.
 
 ## Non-Stable Fields
 
@@ -140,9 +147,9 @@ already deleted.
 
 Focused coverage pins stable filenames, schema/schemaVersion, manifest path
 references, transcript essentials, `notes.md` deletion, refreshed
-`prompt-results/` contents, non-meeting rejection, CLI artifact envelope fields,
-retained-out audio, full deletion after audio detach, and artifact-folder path
-preservation.
+`prompt-results/` contents, durable transcript segments in `transcript.json`,
+non-meeting rejection, CLI artifact envelope fields, retained-out audio, full
+deletion after audio detach, and artifact-folder path preservation.
 
 ## When this changes
 


### PR DESCRIPTION
## Summary

Materializes durable transcript segments for finalized meeting recordings so agents can cite stable meeting evidence by segment. The new records live on the transcription row as `transcriptSegments` JSON and are projected into `transcript.json`, `meetings show --json`, and `meetings transcript --format json`.

## Design

This implements Slice 3 of the meeting-corpus capture plan from PR #680. Segment boundaries reuse `TranscriptSegmenter` by refactoring the existing presentation grouping into a shared boundary pass, then mapping those boundaries into persisted records with UUID, start/end time, speaker/source label, text, and a half-open `wordRange` into `wordTimestamps`.

Persistence choice: DB JSON alongside the transcript. This matches the existing `wordTimestamps`, `speakers`, and `diarizationSegments` storage pattern, keeps CLI reads direct, and lets `MeetingArtifactStore` keep the folder self-describing by copying the canonical row into `transcript.json`.

ID stability contract: segment IDs are stable for the current transcript version. Meeting retranscription clears the old segment array and materializes a new one, so new IDs may be minted. UI grouping is unchanged in this slice.

Deviation from brief: none intended. Scope remains meetings only; dictation/file transcription paths do not materialize segments.

## Risk surface

- Adds a raw-SQL SQLite migration for `transcriptions.transcriptSegments`.
- Adds optional JSON fields to CLI and artifact outputs; this is additive for existing consumers.
- Refactors the segmenter internals, covered by existing segmenter tests plus new durable-record assertions.
- Does not switch UI rendering to persisted segments.

## Test evidence

Focused tests only, per the slice brief:

```bash
swift test --filter TranscriptSegmenterTests
swift test --filter TranscriptionRepositoryTests/testTranscriptSegmentsRoundTrip
swift test --filter DatabaseManagerTests/testTranscriptSegmentsMigrationAddsTranscriptionColumn
swift test --filter MeetingArtifactStoreTests/testMaterializeWritesFirstClassMeetingArtifactFiles
swift test --filter MeetingsCommandTests/testMeetingJSONSurfacesExposeTranscriptSegments
swift test --filter TranscriptionServiceTests/testRetranscribeMeetingMintsNewTranscriptSegmentIDs
swift test --filter SpecCommandTests
git diff --check
```

All passed locally. I did not run the full suite.

## Privacy statement

Transcript content is user data and remains local-only. I checked the transcription completion telemetry path: it emits coarse metadata such as duration, word count, speaker count, engine, and language, not transcript text, words, or segment bodies. This PR adds no telemetry for `transcriptSegments` and does not send transcript content anywhere.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds durable meeting transcript segments so agents can cite stable segments by ID. Segments are persisted for finalized meeting transcriptions and exposed in CLI JSON and the meeting artifact folder.

- **New Features**
  - Persist `transcriptSegments` on `transcriptions`: UUID, start/end ms, speakerId/`speakerLabel`, text, and half-open `wordRange` into `wordTimestamps`.
  - Materialize at meeting finalization after word correction; retranscribing clears and remints IDs for the new transcript version.
  - Expose in `meetings show --json`, `meetings transcript --format json`, and `transcript.json` in the meeting artifact folder. Boundaries reuse `TranscriptSegmenter`; meetings only.

- **Migration**
  - Add SQLite column `transcriptions.transcriptSegments` via raw-SQL migration. Additive; no UI or breaking changes.

<sup>Written for commit 221778a6dee4ada846f91a062df1ba54797a30dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/684?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

