### PR TITLE
Voiceprints Phase 0: calibration gate result (NO-GO on current corpus) + settled decisions

### DIFF
--- a/docs/research/2026-07-04-voiceprints-phase0-calibration.md
+++ b/docs/research/2026-07-04-voiceprints-phase0-calibration.md
@@ -1,0 +1,298 @@
+# Voiceprints Phase 0 Calibration Report
+
+- **Date:** 2026-07-04
+- **Scope:** FluidAudio 0.15.4 offline diarizer speaker embeddings for MacParakeet speaker-profile matching.
+- **Privacy posture:** This report contains no transcript text, no personal names, and no audio content. It uses anonymized session labels (M1-M3; UUID mapping kept local only), month-level dates, durations, and aggregate distance statistics only.
+- **User-data rule:** Meeting recordings under `~/Library/Application Support/MacParakeet/meeting-recordings/` were read in place only.
+- **Status:** NO-GO for Phase 1 on the current corpus — attributed to corpus
+  quality/availability (pre-AEC echo contamination, 3 usable sessions), not a
+  proven embedding failure. Phase 0b (clean-corpus validation) decides whether
+  the FluidAudio path is viable. See "Orchestrator Re-Analysis".
+- **Gate:** Determine whether embeddings show measurable same-person / different-person separation across at least 2 recording sessions, and pick `tau` + margin for suggestions.
+
+## Inputs
+
+- Plan: `plans/active/2026-07-03-speaker-voiceprints.md`
+- API note: `docs/research/2026-07-03-speaker-voiceprints/report-fluidaudio-api.md`
+- Harness: `docs/research/2026-07-04-voiceprints-phase0/harness/`
+- Per-session data: `docs/research/2026-07-04-voiceprints-phase0/data/`
+
+## Corpus Inventory
+
+Inventory artifact: `docs/research/2026-07-04-voiceprints-phase0/data/inventory.json`.
+
+Read-only scan of `~/Library/Application Support/MacParakeet/meeting-recordings/`:
+
+| Metric | Value |
+|---|---:|
+| Session folders | 465 |
+| Created date range | 2026-04 to 2026-07 |
+| `microphone.m4a` present | 463 |
+| `system.m4a` present | 457 |
+| Both `microphone.m4a` and `system.m4a` present | 457 |
+| `meeting.m4a` present | 21 |
+| `microphone-cleaned.m4a` present | 3 |
+
+Readable media is much smaller than file presence:
+
+| Track | Present | Nonzero bytes | Valid duration via `ffprobe` |
+|---|---:|---:|---:|
+| `microphone.m4a` | 463 | 328 | 22 |
+| `system.m4a` | 457 | 258 | 14 |
+| `meeting.m4a` | 21 | 21 | 18 |
+| `microphone-cleaned.m4a` | 3 | 3 | 3 |
+
+Paired readable `microphone.m4a` + `system.m4a` sessions: 12. Duration
+distribution for those paired sessions, using max(microphone, system), seconds:
+
+| p5 | p25 | p50 | p75 | p95 | min | max | mean |
+|---:|---:|---:|---:|---:|---:|---:|---:|
+| 0.372 | 5.264 | 105.397 | 494.891 | 2005.988 | 0.149 | 2563.861 | 502.032 |
+
+Paired readable sessions meeting the requested `duration >= 5 min` gate: **3**.
+
+| Session ID | Created | Duration sec |
+|---|---:|---:|
+| `M1` | 2026-04 | ~21 min |
+| `M2` | 2026-06 | ~26 min |
+| `M3` | 2026-06 | ~43 min |
+
+Sampling implication: the requested `~40 sessions spread across the date range,
+duration >= 5 min, both tracks present` sample cannot be constructed from the
+currently readable retained corpus. Continuing through model check and harness
+validation, but the >=30-session definition of done is blocked at Step 5 unless
+additional finalized paired recordings exist outside this folder.
+
+## Model Check
+
+Model-check artifact: `docs/research/2026-07-04-voiceprints-phase0/data/model-check.json`.
+
+Result: **PASS**. No download required.
+
+- FluidAudio checkout used for API confirmation: `../../../.build/checkouts/FluidAudio`
+  at `v0.15.4` (`b9d4372`).
+- `OfflineDiarizerModels.defaultModelsDirectory()` resolves to the base model
+  directory `~/Library/Application Support/FluidAudio/Models`.
+- FluidAudio's default diarizer repo leaf is
+  `~/Library/Application Support/FluidAudio/Models/speaker-diarization-coreml`.
+- Required offline files present in that leaf:
+  - `Segmentation.mlmodelc`
+  - `FBank.mlmodelc`
+  - `Embedding.mlmodelc`
+  - `PldaRho.mlmodelc`
+  - `plda-parameters.json`
+- Additional diarization files also present: `config.json`,
+  `xvector-transform.json`, `pyannote_segmentation.mlmodelc`,
+  `wespeaker_v2.mlmodelc`.
+
+Harness calls `OfflineDiarizerManager.prepareModels(directory:)` with the base
+directory explicitly: `~/Library/Application Support/FluidAudio/Models`.
+
+## Harness
+
+Harness path: `docs/research/2026-07-04-voiceprints-phase0/harness/`.
+
+Contents:
+
+- `Package.swift`: standalone SwiftPM executable, FluidAudio pinned to
+  `.exact("0.15.4")`.
+- `Sources/VoiceprintHarness/main.swift`: runs
+  `OfflineDiarizerManager.prepareModels(directory:)` with
+  `~/Library/Application Support/FluidAudio/Models`, normalizes source audio to
+  temporary 16 kHz mono WAV under `/tmp`, runs offline diarization, and writes
+  JSON with `{sessionID, track, speakers: [{speakerId, totalSpeechSec,
+  embedding[256]}]}` plus duration/timing metadata.
+- `analyze_voiceprints.py`: computes FluidAudio cosine distance populations,
+  overlap, and tau sweeps from the harness JSON only.
+
+Build command used:
+
+```bash
+CLANG_MODULE_CACHE_PATH="$PWD/.build/module-cache" \
+swift build --disable-sandbox \
+  --config-path "$PWD/.build/config" \
+  --security-path "$PWD/.build/security" \
+  --scratch-path "$PWD/.build" \
+  --cache-path "$PWD/.build/swiftpm-cache"
+```
+
+Build result: **PASS**. SwiftPM used a package-local mirror to the existing
+local FluidAudio `v0.15.4` checkout because network is unavailable. Runtime
+note: CoreML logs non-fatal cache warnings for
+`~/Library/Caches/voiceprint-harness` in this sandbox; extraction still
+completed and wrote JSON.
+
+## Extraction Sample
+
+Sample-selection artifact:
+`docs/research/2026-07-04-voiceprints-phase0/data/sample-sessions.json`.
+
+Requested sample: ~40 sessions, spread across date range, `duration >= 5 min`,
+both `microphone.m4a` and `system.m4a` present. Actual selectable corpus from
+readable finalized media: **3 sessions**. This blocks the requested >=30-session
+definition of done at Step 5.
+
+Extracted anyway for the full eligible corpus:
+
+| Mode | Sessions | Tracks | JSON files | Speaker embeddings |
+|---|---:|---:|---:|---:|
+| Full-track | 3 | 6 | 6 | 21 |
+| Split-half | 3 | 6 | 6 | 31 |
+
+Full-track speaker counts:
+
+| Session ID | Mic speakers | System speakers |
+|---|---:|---:|
+| `M1` | 3 | 3 |
+| `M2` | 4 | 7 |
+| `M3` | 2 | 2 |
+
+Important observation: the microphone track is the known app-user channel, but
+offline diarization still over-clustered it into 2-4 speakers per recording.
+For same-person analysis, all microphone clusters are treated as the same known
+speaker because that is the only available cross-recording ground truth.
+
+## Distance Populations
+
+Analysis artifact:
+`docs/research/2026-07-04-voiceprints-phase0/data/analysis-summary.json`.
+
+Distance = FluidAudio cosine distance (`0 = identical`, larger = less similar).
+
+| Population | Count | p5 | p25 | p50 | p75 | p95 |
+|---|---:|---:|---:|---:|---:|---:|
+| (a) SAME user, mic cross-recording | 26 | 0.152 | 0.758 | 0.814 | 0.866 | 1.031 |
+| (b) SAME split-half, microphone | 24 | 0.025 | 0.261 | 0.766 | 0.884 | 0.929 |
+| (b) SAME split-half, system nearest-pair proxy | 6 | 0.032 | 0.057 | 0.148 | 0.693 | 0.950 |
+| (c) DIFFERENT system speakers, same meeting | 25 | 0.684 | 0.869 | 0.927 | 0.964 | 1.053 |
+| (d) Random system speakers, cross-meeting | 41 | 0.255 | 0.841 | 0.943 | 1.006 | 1.080 |
+
+Headline separation:
+
+- Same-user mic cross-recording median: **0.814**.
+- Different system speakers, same-meeting median: **0.927**.
+- Median gap: **0.113**, but distributions overlap heavily.
+- Same-user p95 (**1.031**) is above different-system p5 (**0.684** for same
+  meeting, **0.255** for cross-meeting).
+- 88.5% of same-user mic pairs are at or above the same-meeting different-speaker
+  p5; 88.0% of same-meeting different-speaker pairs are at or below same-user p95.
+
+This is not enough separation to power user-visible profile matching.
+
+## Threshold Sweep
+
+Pairwise sweep, treating (a) as positives and (c)/(d) as negatives. Margin is
+listed as the intended product margin (`0.10`), but pairwise distances do not
+contain enough ranked-candidate information to apply it directly.
+
+| Tau | TPR same mic | FPR system same meeting | FPR system cross meeting |
+|---:|---:|---:|---:|
+| 0.30 | 11.5% | 0.0% | 7.3% |
+| 0.55 | 11.5% | 0.0% | 7.3% |
+| 0.70 | 11.5% | 12.0% | 7.3% |
+| 0.80 | 42.3% | 12.0% | 22.0% |
+| 0.85 | 69.2% | 16.0% | 29.3% |
+| 0.90 | 76.9% | 32.0% | 41.5% |
+| 0.95 | 88.5% | 52.0% | 53.7% |
+
+Margin-aware proxy sweep (`margin = 0.10`) using the mic channel as a stand-in
+known profile:
+
+| Tau | Positive trials | Negative trials | Proxy TPR | Proxy FPR |
+|---:|---:|---:|---:|---:|
+| 0.30 | 9 | 12 | 33.3% | 41.7% |
+| 0.55 | 9 | 12 | 33.3% | 58.3% |
+| 0.80 | 9 | 12 | 33.3% | 66.7% |
+| 0.95 | 9 | 12 | 33.3% | 66.7% |
+
+No tau in this sweep gives both useful recall and acceptable false positives.
+
+## Recommendation
+
+**Phase 0 result: NO-GO.**
+
+Recommended product threshold: **none**. Do not ship auto-suggest/profile
+matching from these FluidAudio 0.15.4 offline-diarizer embeddings on the current
+evidence.
+
+If a diagnostic-only dogfood switch is needed for more data collection, keep it
+off by default and use `tau <= 0.30`, `margin >= 0.10`, confirmation required,
+and no user-visible confidence promise. Even that setting catches only 11.5% of
+same-user cross-recording pairs in the pairwise sweep and still shows nonzero
+cross-meeting system false positives.
+
+Confidence tiers for product UX: **do not define user-visible tiers yet**. The
+observed distributions do not justify "high confidence". For future calibration,
+start with:
+
+- Exploratory only: distance `<= 0.30` and margin `>= 0.10`.
+- Reject/unknown: distance `> 0.30` or margin `< 0.10`.
+
+This fails the plan gate: no reliable same-person / different-person separation
+for profile matching was demonstrated, and the requested >=30-session corpus
+could not be constructed from readable finalized paired recordings.
+
+## Orchestrator Re-Analysis (dominant-cluster ground truth)
+
+The primary analysis treated *all* microphone clusters as the app user; since the
+mic track over-clusters (2–4 speakers) and this corpus predates AEC, that ground
+truth is contaminated by bleed. Re-analysis using only the **dominant mic
+cluster** (by speech duration: 45–71% of mic speech) per session:
+
+| Pair population | Distances |
+|---|---|
+| Same user, dominant cluster, cross-recording (3 pairs) | all three pairs within 0.73–0.85 |
+| Same speaker, split-half, within recording | p5 ≈ 0.03 (tight) |
+| Different system speakers, same meeting | median ≈ 0.92 |
+| User (dominant mic) vs system speakers, same meeting | includes values in the **0.19–0.38** band in one of the three sessions |
+
+Two conclusions sharpen:
+
+1. **The correction does not rescue the gate.** Even clean-as-available same-user
+   pairs sit at 0.73–0.85 — inside the different-speaker band. Cross-recording
+   matching fails on this corpus regardless of clustering hygiene.
+2. **The corpus itself is the prime suspect, not the embedding stack.** Split-half
+   matches within a recording are tight (≈0.03), so embeddings are internally
+   consistent; and the 0.19–0.38-band user↔system matches show the user's own voice
+   present in the system track (pre-AEC echo), meaning recording conditions are
+   heavily contaminated. WeSpeaker-class models report ~1–3% EER cross-session on
+   public benchmarks; 0.8 same-person distance is so far off that channel/echo
+   conditions — not model capability — are the more likely cause.
+
+**Refined verdict: NO-GO for Phase 1 now, attributed to corpus quality and
+availability rather than a proven embedding failure.** Decision tree:
+
+- **Phase 0b (clean-corpus validation):** run the same harness over public
+  multi-episode audio with naturally labeled recurring speakers (solo-host
+  podcasts/monologue channels; cross-episode same-host = positives, cross-host =
+  negatives). If separation is good → the FluidAudio path is viable and meetings
+  need post-AEC audio + a real calibration corpus (revisit after the #605 AEC
+  work ships in 0.6.25-era recordings). If separation is poor → the offline
+  `speakerDatabase` embedding path is insufficient; park the feature or evaluate
+  `extractSpeakerEmbedding` over clean segments before abandoning.
+- Either way, Phase 1 product code stays blocked until a calibration corpus
+  passes the gate.
+
+## Product Finding (out of scope for this gate, worth triage)
+
+Of 463 present `microphone.m4a` files, only 22 have a valid container: verified
+manually (outside the sandbox) that multi-MB files are missing their moov atom —
+the writer was never finalized — alongside hundreds of 557-byte stubs. Likely
+dominated by dev-kill iterations of the app, but if any fraction comes from real
+crashes, those users' meeting audio is unplayable and unrecoverable. Relates to
+the meeting finalize/recovery hardening work (#605-adjacent). Deserves a look:
+does `MeetingRecordingRecoveryService` (or a repair pass) handle moov-less m4a?
+
+## Caveats
+
+- Biggest caveat: only 3 readable paired sessions met `duration >= 5 min`, so the
+  requested >=30-session calibration is blocked by retained-media availability.
+- Microphone over-clustering is severe: the known single-user channel appears as
+  2-4 diarized speakers per full recording. This inflates same-user distance and
+  may reflect diarizer instability, speaker bleed, channel changes, or all three.
+- System split-half "same speaker" pairs are a nearest-neighbor proxy, not true
+  labels; no participant ground truth exists in this corpus.
+- Cross-meeting random system-speaker pairs can include recurring participants,
+  which makes that negative population conservative.
+- Source m4a files were never modified. Temporary normalized WAVs were written
+  under `/tmp` and deleted by the harness.

--- a/docs/research/2026-07-04-voiceprints-phase0/data/.gitignore
+++ b/docs/research/2026-07-04-voiceprints-phase0/data/.gitignore
@@ -1,0 +1,4 @@
+*-full.json
+*-split.json
+analysis-summary.json
+session-label-map.json

--- a/docs/research/2026-07-04-voiceprints-phase0/data/README.md
+++ b/docs/research/2026-07-04-voiceprints-phase0/data/README.md
@@ -1,0 +1,16 @@
+# Phase 0 data
+
+Aggregate artifacts only (`inventory.json`, `model-check.json`,
+`sample-sessions.json`).
+
+Per-session embedding JSONs (`<sessionID>-<track>-{full,split}.json`) are
+deliberately NOT committed: a 256-d speaker embedding is biometric data (see
+`docs/research/2026-07-03-speaker-voiceprints/report-privacy-biometrics.md`),
+and this corpus includes meeting participants who never consented to
+publication. Regenerate locally with the harness in `../harness/`.
+
+`analysis-summary.json` is also NOT committed: its `populationPairs` records
+form a linkable per-speaker graph (session UUIDs x speaker IDs x speaking
+times x pairwise voice distances) of private meetings. The report carries
+aggregate percentile tables and illustrative excerpts only; regenerate the
+full analysis locally with `../harness/analyze_voiceprints.py`.

--- a/docs/research/2026-07-04-voiceprints-phase0/data/inventory.json
+++ b/docs/research/2026-07-04-voiceprints-phase0/data/inventory.json
@@ -1,0 +1,122 @@
+{
+ "note": "Per-session roster withheld (private-meeting metadata); aggregates only. Full inventory regenerates locally via the harness.",
+ "summary": {
+  "generatedAt": "2026-07-03T22:49:44-0700",
+  "root": "~/Library/Application Support/MacParakeet/meeting-recordings",
+  "sessionCount": 465,
+  "dateRange": {},
+  "tracks": {
+   "microphone": 463,
+   "system": 457,
+   "meeting": 21,
+   "cleanedMicrophone": 3,
+   "bothMicrophoneAndSystem": 457
+  },
+  "durationSec": {
+   "count": 24,
+   "min": 0.124,
+   "p5": 0.32,
+   "p25": 0.5015000000000001,
+   "p50": 21.071,
+   "p75": 416.38800000000003,
+   "p95": 2411.6697500000014,
+   "max": 2834.602,
+   "mean": 465.1070833333333
+  },
+  "eligibleDurationAtLeast5MinBothTracks": 3,
+  "perTrack": {
+   "microphone.m4a": {
+    "exists": 463,
+    "nonzeroBytes": 328,
+    "validDuration": 22,
+    "durationSec": {
+     "count": 22,
+     "min": 0.149333,
+     "p5": 0.32,
+     "p25": 0.37866675,
+     "p50": 11.9466665,
+     "p75": 234.88533325,
+     "p95": 1533.9424003,
+     "max": 2563.861333,
+     "mean": 375.20096963636365
+    }
+   },
+   "system.m4a": {
+    "exists": 457,
+    "nonzeroBytes": 258,
+    "validDuration": 14,
+    "durationSec": {
+     "count": 14,
+     "min": 0.064,
+     "p5": 0.3136,
+     "p25": 6.912000000000001,
+     "p50": 128.725333,
+     "p75": 989.9093334999999,
+     "p95": 2658.0672001,
+     "max": 2834.645333,
+     "mean": 637.9123809285713
+    }
+   },
+   "meeting.m4a": {
+    "exists": 21,
+    "nonzeroBytes": 21,
+    "validDuration": 18,
+    "durationSec": {
+     "count": 18,
+     "min": 0.124,
+     "p5": 0.4963,
+     "p25": 10.45175,
+     "p50": 149.5205,
+     "p75": 1108.4842500000002,
+     "p95": 2604.43475,
+     "max": 2834.602,
+     "mean": 619.8227777777778
+    }
+   },
+   "microphone-cleaned.m4a": {
+    "exists": 3,
+    "nonzeroBytes": 3,
+    "validDuration": 3,
+    "durationSec": {
+     "count": 3,
+     "min": 183.552,
+     "p5": 184.9536,
+     "p25": 190.56,
+     "p50": 197.568,
+     "p75": 1380.768,
+     "p95": 2327.3279999999995,
+     "max": 2563.968,
+     "mean": 981.6959999999999
+    }
+   }
+  },
+  "validMicrophoneAndSystemDuration": {
+   "count": 12,
+   "durationSec": {
+    "count": 12,
+    "min": 0.149333,
+    "p5": 0.37226670000000006,
+    "p25": 5.264000000000001,
+    "p50": 105.397333,
+    "p75": 494.89066675000004,
+    "p95": 2005.9882666999993,
+    "max": 2563.861333,
+    "mean": 502.0319999166666
+   }
+  },
+  "validMicrophoneAndSystemDurationAtLeast5Min": {
+   "count": 3,
+   "durationSec": {
+    "count": 3,
+    "min": 1237.482667,
+    "p5": 1268.689067,
+    "p25": 1393.514667,
+    "p50": 1549.546667,
+    "p75": 2056.7039999999997,
+    "p95": 2462.4298663999994,
+    "max": 2563.861333,
+    "mean": 1783.6302223333332
+   }
+  }
+ }
+}

--- a/docs/research/2026-07-04-voiceprints-phase0/data/model-check.json
+++ b/docs/research/2026-07-04-voiceprints-phase0/data/model-check.json
@@ -1,0 +1,49 @@
+{
+  "generatedAt": "2026-07-03T22:52:59-0700",
+  "prepareModelsDirectory": "~/Library/Application Support/FluidAudio/Models",
+  "defaultRepoLeaf": "~/Library/Application Support/FluidAudio/Models/speaker-diarization-coreml",
+  "fluidAudioCheckout": "../../../.build/checkouts/FluidAudio",
+  "fluidAudioVersion": "v0.15.4",
+  "required": [
+    {
+      "name": "Segmentation.mlmodelc",
+      "exists": true
+    },
+    {
+      "name": "FBank.mlmodelc",
+      "exists": true
+    },
+    {
+      "name": "Embedding.mlmodelc",
+      "exists": true
+    },
+    {
+      "name": "PldaRho.mlmodelc",
+      "exists": true
+    },
+    {
+      "name": "plda-parameters.json",
+      "exists": true
+    }
+  ],
+  "additionalPresent": [
+    {
+      "name": "config.json",
+      "exists": true
+    },
+    {
+      "name": "xvector-transform.json",
+      "exists": true
+    },
+    {
+      "name": "pyannote_segmentation.mlmodelc",
+      "exists": true
+    },
+    {
+      "name": "wespeaker_v2.mlmodelc",
+      "exists": true
+    }
+  ],
+  "fallbackLegacyLeafExists": "~/Library/Application Support/FluidAudio/Models/speaker-diarization",
+  "allRequiredPresent": true
+}

--- a/docs/research/2026-07-04-voiceprints-phase0/data/sample-sessions.json
+++ b/docs/research/2026-07-04-voiceprints-phase0/data/sample-sessions.json
@@ -1,0 +1,31 @@
+{
+ "generatedAt": "2026-07-03T23:01:35-0700",
+ "selectionRule": "all sessions with readable microphone.m4a and system.m4a durations >= 300 seconds",
+ "requestedCount": 40,
+ "selectedCount": 3,
+ "blockedReason": "Only 3 sessions in the retained folder satisfy readable paired tracks and duration >= 5 min.",
+ "sessions": [
+  {
+   "label": "M1",
+   "month": "2026-04",
+   "durationSecApprox": "~21 min",
+   "microphoneSecApprox": "~21 min",
+   "systemSecApprox": "~21 min"
+  },
+  {
+   "label": "M2",
+   "month": "2026-06",
+   "durationSecApprox": "~26 min",
+   "microphoneSecApprox": "~26 min",
+   "systemSecApprox": "~26 min"
+  },
+  {
+   "label": "M3",
+   "month": "2026-06",
+   "durationSecApprox": "~43 min",
+   "microphoneSecApprox": "~43 min",
+   "systemSecApprox": "~43 min"
+  }
+ ],
+ "note": "Session labels M1-M3 are local anonymized identifiers; the UUID mapping stays uncommitted."
+}

--- a/docs/research/2026-07-04-voiceprints-phase0/harness/Package.resolved
+++ b/docs/research/2026-07-04-voiceprints-phase0/harness/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "fluidaudio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/FluidInference/FluidAudio",
+      "state" : {
+        "revision" : "b9d43724cbdb5a980e441fd54180964e94d470f7",
+        "version" : "0.15.4"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/docs/research/2026-07-04-voiceprints-phase0/harness/Package.swift
+++ b/docs/research/2026-07-04-voiceprints-phase0/harness/Package.swift
@@ -1,0 +1,24 @@
+// swift-tools-version: 5.9
+
+import PackageDescription
+
+let package = Package(
+    name: "VoiceprintPhase0Harness",
+    platforms: [
+        .macOS(.v14)
+    ],
+    products: [
+        .executable(name: "voiceprint-harness", targets: ["VoiceprintHarness"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/FluidInference/FluidAudio", .exact("0.15.4"))
+    ],
+    targets: [
+        .executableTarget(
+            name: "VoiceprintHarness",
+            dependencies: [
+                .product(name: "FluidAudio", package: "FluidAudio")
+            ]
+        )
+    ]
+)

--- a/docs/research/2026-07-04-voiceprints-phase0/harness/Sources/VoiceprintHarness/main.swift
+++ b/docs/research/2026-07-04-voiceprints-phase0/harness/Sources/VoiceprintHarness/main.swift
@@ -1,0 +1,472 @@
+import FluidAudio
+import Foundation
+
+struct HarnessError: Error, CustomStringConvertible {
+    let description: String
+}
+
+struct Options {
+    var audio: URL?
+    var sessionID: String?
+    var track: String?
+    var modelsDirectory: URL?
+    var output: URL?
+    var splitHalf = false
+    var ffmpegPath: String?
+    var ffprobePath: String?
+}
+
+struct SpeakerOutput: Codable {
+    let speakerId: String
+    let totalSpeechSec: Double
+    let embedding: [Float]
+}
+
+struct TimingsOutput: Codable {
+    let modelCompilationSeconds: Double?
+    let audioLoadingSeconds: Double?
+    let segmentationSeconds: Double?
+    let embeddingExtractionSeconds: Double?
+    let speakerClusteringSeconds: Double?
+    let postProcessingSeconds: Double?
+}
+
+struct FullOutput: Codable {
+    let schemaVersion: Int
+    let mode: String
+    let generatedAt: String
+    let sessionID: String
+    let track: String
+    let sourceFile: String
+    let audioDurationSec: Double?
+    let segmentCount: Int
+    let speakers: [SpeakerOutput]
+    let timings: TimingsOutput?
+}
+
+struct HalfOutput: Codable {
+    let half: String
+    let startSec: Double
+    let endSec: Double
+    let segmentCount: Int
+    let speakers: [SpeakerOutput]
+    let timings: TimingsOutput?
+}
+
+struct SplitOutput: Codable {
+    let schemaVersion: Int
+    let mode: String
+    let generatedAt: String
+    let sessionID: String
+    let track: String
+    let sourceFile: String
+    let audioDurationSec: Double
+    let halves: [HalfOutput]
+}
+
+@main
+enum VoiceprintHarness {
+    static func main() async {
+        do {
+            let options = try parse(Array(CommandLine.arguments.dropFirst()))
+            guard let audio = options.audio else { throw HarnessError(description: "missing --audio") }
+            guard let sessionID = options.sessionID else { throw HarnessError(description: "missing --session-id") }
+            guard let track = options.track else { throw HarnessError(description: "missing --track") }
+            guard FileManager.default.fileExists(atPath: audio.path) else {
+                throw HarnessError(description: "audio file does not exist: \(audio.path)")
+            }
+
+            let modelsDirectory = options.modelsDirectory
+                ?? OfflineDiarizerModels.defaultModelsDirectory()
+
+            let output: Data
+            if options.splitHalf {
+                output = try await runSplitHalf(
+                    audio: audio,
+                    sessionID: sessionID,
+                    track: track,
+                    modelsDirectory: modelsDirectory,
+                    ffmpegPath: options.ffmpegPath,
+                    ffprobePath: options.ffprobePath
+                )
+            } else {
+                output = try await runFull(
+                    audio: audio,
+                    sessionID: sessionID,
+                    track: track,
+                    modelsDirectory: modelsDirectory,
+                    ffmpegPath: options.ffmpegPath,
+                    ffprobePath: options.ffprobePath
+                )
+            }
+
+            if let outputURL = options.output {
+                try FileManager.default.createDirectory(
+                    at: outputURL.deletingLastPathComponent(),
+                    withIntermediateDirectories: true
+                )
+                try output.write(to: outputURL, options: [.atomic])
+            } else {
+                FileHandle.standardOutput.write(output)
+                FileHandle.standardOutput.write(Data("\n".utf8))
+            }
+        } catch {
+            FileHandle.standardError.write(Data("voiceprint-harness: \(error)\n".utf8))
+            exit(1)
+        }
+    }
+
+    static func parse(_ args: [String]) throws -> Options {
+        if args.contains("--help") || args.contains("-h") {
+            printHelp()
+            exit(0)
+        }
+
+        var options = Options()
+        var index = 0
+        while index < args.count {
+            let arg = args[index]
+            switch arg {
+            case "--audio":
+                options.audio = URL(fileURLWithPath: try value(after: arg, args: args, index: &index))
+            case "--session-id":
+                options.sessionID = try value(after: arg, args: args, index: &index)
+            case "--track":
+                options.track = try value(after: arg, args: args, index: &index)
+            case "--models-dir":
+                options.modelsDirectory = URL(fileURLWithPath: try value(after: arg, args: args, index: &index))
+            case "--output":
+                options.output = URL(fileURLWithPath: try value(after: arg, args: args, index: &index))
+            case "--split-half":
+                options.splitHalf = true
+            case "--ffmpeg":
+                options.ffmpegPath = try value(after: arg, args: args, index: &index)
+            case "--ffprobe":
+                options.ffprobePath = try value(after: arg, args: args, index: &index)
+            default:
+                throw HarnessError(description: "unknown argument: \(arg)")
+            }
+            index += 1
+        }
+        return options
+    }
+
+    static func value(after flag: String, args: [String], index: inout Int) throws -> String {
+        let next = index + 1
+        guard next < args.count else { throw HarnessError(description: "missing value after \(flag)") }
+        index = next
+        return args[next]
+    }
+
+    static func printHelp() {
+        print("""
+        Usage:
+          voiceprint-harness --audio PATH --session-id UUID --track microphone|system \\
+            --models-dir "$HOME/Library/Application Support/FluidAudio/Models" \\
+            --output out.json [--split-half]
+
+        Output contains session ID, track, speaker IDs, total speech seconds, and 256-d embeddings only.
+        Runs normalize source audio to temporary 16 kHz mono WAV files under /tmp and delete them before exit.
+        """)
+    }
+
+    static func runFull(
+        audio: URL,
+        sessionID: String,
+        track: String,
+        modelsDirectory: URL,
+        ffmpegPath: String?,
+        ffprobePath: String?
+    ) async throws -> Data {
+        let duration = try? probeDuration(path: audio.path, ffprobePath: ffprobePath)
+        let tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("voiceprint-phase0-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        let wavURL = tempRoot.appendingPathComponent("full.wav", isDirectory: false)
+        try makeNormalizedWav(input: audio.path, output: wavURL.path, ffmpegPath: ffmpegPath)
+
+        let result = try await diarize(audio: wavURL, modelsDirectory: modelsDirectory)
+        let output = FullOutput(
+            schemaVersion: 1,
+            mode: "full",
+            generatedAt: isoNow(),
+            sessionID: sessionID,
+            track: track,
+            sourceFile: audio.lastPathComponent,
+            audioDurationSec: duration,
+            segmentCount: result.segments.count,
+            speakers: speakers(from: result),
+            timings: timings(from: result)
+        )
+        return try encode(output)
+    }
+
+    static func runSplitHalf(
+        audio: URL,
+        sessionID: String,
+        track: String,
+        modelsDirectory: URL,
+        ffmpegPath: String?,
+        ffprobePath: String?
+    ) async throws -> Data {
+        let duration = try probeDuration(path: audio.path, ffprobePath: ffprobePath)
+        guard duration >= 2 else {
+            throw HarnessError(description: "audio too short for split-half mode: \(duration)s")
+        }
+
+        let tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("voiceprint-phase0-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        let midpoint = duration / 2
+        let firstURL = tempRoot.appendingPathComponent("first.wav", isDirectory: false)
+        let secondURL = tempRoot.appendingPathComponent("second.wav", isDirectory: false)
+
+        try makeWavClip(
+            input: audio.path,
+            output: firstURL.path,
+            start: 0,
+            duration: midpoint,
+            ffmpegPath: ffmpegPath
+        )
+        try makeWavClip(
+            input: audio.path,
+            output: secondURL.path,
+            start: midpoint,
+            duration: duration - midpoint,
+            ffmpegPath: ffmpegPath
+        )
+
+        let first = try await diarize(audio: firstURL, modelsDirectory: modelsDirectory)
+        let second = try await diarize(audio: secondURL, modelsDirectory: modelsDirectory)
+
+        let output = SplitOutput(
+            schemaVersion: 1,
+            mode: "splitHalf",
+            generatedAt: isoNow(),
+            sessionID: sessionID,
+            track: track,
+            sourceFile: audio.lastPathComponent,
+            audioDurationSec: duration,
+            halves: [
+                HalfOutput(
+                    half: "first",
+                    startSec: 0,
+                    endSec: midpoint,
+                    segmentCount: first.segments.count,
+                    speakers: speakers(from: first),
+                    timings: timings(from: first)
+                ),
+                HalfOutput(
+                    half: "second",
+                    startSec: midpoint,
+                    endSec: duration,
+                    segmentCount: second.segments.count,
+                    speakers: speakers(from: second),
+                    timings: timings(from: second)
+                ),
+            ]
+        )
+        return try encode(output)
+    }
+
+    static func diarize(audio: URL, modelsDirectory: URL) async throws -> DiarizationResult {
+        var config = OfflineDiarizerConfig.default
+        config.exposeChunkEmbeddings = false
+
+        let manager = OfflineDiarizerManager(config: config)
+        try await manager.prepareModels(directory: modelsDirectory)
+
+        do {
+            return try await manager.process(audio) { processed, total in
+                guard processed == total || processed == 1 || processed % 50 == 0 else { return }
+                let message = "progress \(audio.lastPathComponent) \(processed)/\(total)\n"
+                FileHandle.standardError.write(Data(message.utf8))
+            }
+        } catch let error as OfflineDiarizationError {
+            if case .noSpeechDetected = error {
+                return DiarizationResult(segments: [], speakerDatabase: [:])
+            }
+            throw error
+        }
+    }
+
+    static func speakers(from result: DiarizationResult) -> [SpeakerOutput] {
+        let totals = Dictionary(grouping: result.segments, by: { $0.speakerId })
+            .mapValues { segments in
+                segments.reduce(0.0) { total, segment in
+                    total + max(0.0, Double(segment.endTimeSeconds - segment.startTimeSeconds))
+                }
+            }
+
+        let database = result.speakerDatabase ?? fallbackSpeakerDatabase(from: result.segments)
+        return database.keys.sorted().compactMap { speakerId in
+            guard let embedding = database[speakerId], embedding.count == 256 else { return nil }
+            return SpeakerOutput(
+                speakerId: speakerId,
+                totalSpeechSec: totals[speakerId] ?? 0,
+                embedding: embedding
+            )
+        }
+    }
+
+    static func fallbackSpeakerDatabase(from segments: [TimedSpeakerSegment]) -> [String: [Float]] {
+        var sums: [String: [Double]] = [:]
+        var weights: [String: Double] = [:]
+
+        for segment in segments where segment.embedding.count == 256 {
+            let duration = max(0.0, Double(segment.endTimeSeconds - segment.startTimeSeconds))
+            guard duration > 0 else { continue }
+            var sum = sums[segment.speakerId] ?? Array(repeating: 0, count: 256)
+            for index in 0..<256 {
+                sum[index] += Double(segment.embedding[index]) * duration
+            }
+            sums[segment.speakerId] = sum
+            weights[segment.speakerId, default: 0] += duration
+        }
+
+        var database: [String: [Float]] = [:]
+        for (speakerId, sum) in sums {
+            let weight = max(weights[speakerId] ?? 0, .leastNonzeroMagnitude)
+            let averaged = sum.map { Float($0 / weight) }
+            database[speakerId] = l2Normalized(averaged)
+        }
+        return database
+    }
+
+    static func l2Normalized(_ vector: [Float]) -> [Float] {
+        let norm = sqrt(vector.reduce(Float(0)) { $0 + $1 * $1 })
+        guard norm > 0 else { return vector }
+        return vector.map { $0 / norm }
+    }
+
+    static func timings(from result: DiarizationResult) -> TimingsOutput? {
+        guard let timings = result.timings else { return nil }
+        return TimingsOutput(
+            modelCompilationSeconds: timings.modelCompilationSeconds,
+            audioLoadingSeconds: timings.audioLoadingSeconds,
+            segmentationSeconds: timings.segmentationSeconds,
+            embeddingExtractionSeconds: timings.embeddingExtractionSeconds,
+            speakerClusteringSeconds: timings.speakerClusteringSeconds,
+            postProcessingSeconds: timings.postProcessingSeconds
+        )
+    }
+
+    static func encode<T: Encodable>(_ value: T) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return try encoder.encode(value)
+    }
+
+    static func isoNow() -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.string(from: Date())
+    }
+
+    static func probeDuration(path: String, ffprobePath: String?) throws -> Double {
+        let executable = try resolveExecutable(explicit: ffprobePath, name: "ffprobe")
+        let output = try runProcess(
+            executable,
+            [
+                "-v", "error",
+                "-show_entries", "format=duration",
+                "-of", "default=noprint_wrappers=1:nokey=1",
+                path,
+            ]
+        )
+        guard let duration = Double(output.trimmingCharacters(in: .whitespacesAndNewlines)) else {
+            throw HarnessError(description: "ffprobe did not return a duration for \(path)")
+        }
+        return duration
+    }
+
+    static func makeWavClip(
+        input: String,
+        output: String,
+        start: Double,
+        duration: Double,
+        ffmpegPath: String?
+    ) throws {
+        let executable = try resolveExecutable(explicit: ffmpegPath, name: "ffmpeg")
+        _ = try runProcess(
+            executable,
+            [
+                "-hide_banner",
+                "-loglevel", "error",
+                "-ss", String(format: "%.6f", start),
+                "-t", String(format: "%.6f", duration),
+                "-i", input,
+                "-vn",
+                "-ac", "1",
+                "-ar", "16000",
+                "-c:a", "pcm_f32le",
+                "-y",
+                output,
+            ]
+        )
+    }
+
+    static func makeNormalizedWav(
+        input: String,
+        output: String,
+        ffmpegPath: String?
+    ) throws {
+        let executable = try resolveExecutable(explicit: ffmpegPath, name: "ffmpeg")
+        _ = try runProcess(
+            executable,
+            [
+                "-hide_banner",
+                "-loglevel", "error",
+                "-i", input,
+                "-vn",
+                "-ac", "1",
+                "-ar", "16000",
+                "-c:a", "pcm_f32le",
+                "-y",
+                output,
+            ]
+        )
+    }
+
+    static func resolveExecutable(explicit: String?, name: String) throws -> String {
+        if let explicit {
+            return explicit
+        }
+        let candidates = [
+            "/opt/homebrew/bin/\(name)",
+            "/usr/local/bin/\(name)",
+            "/usr/bin/\(name)",
+        ]
+        if let candidate = candidates.first(where: { FileManager.default.isExecutableFile(atPath: $0) }) {
+            return candidate
+        }
+        throw HarnessError(description: "\(name) not found; pass --\(name) PATH")
+    }
+
+    static func runProcess(_ executable: String, _ arguments: [String]) throws -> String {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = arguments
+
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.standardOutput = stdout
+        process.standardError = stderr
+
+        try process.run()
+        process.waitUntilExit()
+
+        let outData = stdout.fileHandleForReading.readDataToEndOfFile()
+        let errData = stderr.fileHandleForReading.readDataToEndOfFile()
+        let out = String(data: outData, encoding: .utf8) ?? ""
+        let err = String(data: errData, encoding: .utf8) ?? ""
+        guard process.terminationStatus == 0 else {
+            throw HarnessError(description: "\(URL(fileURLWithPath: executable).lastPathComponent) failed: \(err)")
+        }
+        return out
+    }
+}

--- a/docs/research/2026-07-04-voiceprints-phase0/harness/analyze_voiceprints.py
+++ b/docs/research/2026-07-04-voiceprints-phase0/harness/analyze_voiceprints.py
@@ -1,0 +1,436 @@
+#!/usr/bin/env python3
+"""Analyze MacParakeet voiceprint phase-0 extraction JSON.
+
+The script intentionally reads only harness JSON: session IDs, track names,
+durations, speaker IDs, speech totals, and embeddings. It never reads audio or
+transcript artifacts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import itertools
+import json
+import math
+import statistics
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+@dataclass(frozen=True)
+class SpeakerEmbedding:
+    session_id: str
+    track: str
+    speaker_id: str
+    embedding: list[float]
+    total_speech_sec: float
+    source: str
+    half: str | None = None
+
+
+def l2_normalized(vector: list[float]) -> list[float]:
+    norm = math.sqrt(sum(value * value for value in vector))
+    if norm == 0:
+        return vector
+    return [value / norm for value in vector]
+
+
+def cosine_distance(lhs: list[float], rhs: list[float]) -> float:
+    a = l2_normalized(lhs)
+    b = l2_normalized(rhs)
+    dot = sum(x * y for x, y in zip(a, b))
+    dot = max(-1.0, min(1.0, dot))
+    return 1.0 - dot
+
+
+def percentile(values: list[float], pct: float) -> float | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    pos = (len(ordered) - 1) * pct / 100.0
+    lo = int(pos)
+    hi = min(lo + 1, len(ordered) - 1)
+    frac = pos - lo
+    return ordered[lo] * (1 - frac) + ordered[hi] * frac
+
+
+def stats(values: list[float]) -> dict[str, float | int | None]:
+    return {
+        "count": len(values),
+        "min": min(values) if values else None,
+        "p5": percentile(values, 5),
+        "p25": percentile(values, 25),
+        "p50": percentile(values, 50),
+        "p75": percentile(values, 75),
+        "p95": percentile(values, 95),
+        "max": max(values) if values else None,
+        "mean": statistics.fmean(values) if values else None,
+    }
+
+
+def load_full(data_dir: Path) -> list[SpeakerEmbedding]:
+    speakers: list[SpeakerEmbedding] = []
+    for path in sorted(data_dir.glob("*-full.json")):
+        payload = json.loads(path.read_text())
+        for speaker in payload["speakers"]:
+            speakers.append(
+                SpeakerEmbedding(
+                    session_id=payload["sessionID"],
+                    track=payload["track"],
+                    speaker_id=speaker["speakerId"],
+                    embedding=speaker["embedding"],
+                    total_speech_sec=speaker["totalSpeechSec"],
+                    source=path.name,
+                )
+            )
+    return speakers
+
+
+def load_split(data_dir: Path) -> list[SpeakerEmbedding]:
+    speakers: list[SpeakerEmbedding] = []
+    for path in sorted(data_dir.glob("*-split.json")):
+        payload = json.loads(path.read_text())
+        for half in payload["halves"]:
+            for speaker in half["speakers"]:
+                speakers.append(
+                    SpeakerEmbedding(
+                        session_id=payload["sessionID"],
+                        track=payload["track"],
+                        speaker_id=speaker["speakerId"],
+                        embedding=speaker["embedding"],
+                        total_speech_sec=speaker["totalSpeechSec"],
+                        source=path.name,
+                        half=half["half"],
+                    )
+                )
+    return speakers
+
+
+def pair_record(
+    label: str, lhs: SpeakerEmbedding, rhs: SpeakerEmbedding
+) -> dict[str, object]:
+    return {
+        "population": label,
+        "distance": cosine_distance(lhs.embedding, rhs.embedding),
+        "lhs": {
+            "sessionID": lhs.session_id,
+            "track": lhs.track,
+            "speakerId": lhs.speaker_id,
+            "half": lhs.half,
+            "source": lhs.source,
+            "totalSpeechSec": lhs.total_speech_sec,
+        },
+        "rhs": {
+            "sessionID": rhs.session_id,
+            "track": rhs.track,
+            "speakerId": rhs.speaker_id,
+            "half": rhs.half,
+            "source": rhs.source,
+            "totalSpeechSec": rhs.total_speech_sec,
+        },
+    }
+
+
+def greedy_nearest_pairs(
+    first: list[SpeakerEmbedding], second: list[SpeakerEmbedding], label: str
+) -> list[dict[str, object]]:
+    candidates: list[tuple[float, int, int]] = []
+    for i, lhs in enumerate(first):
+        for j, rhs in enumerate(second):
+            candidates.append((cosine_distance(lhs.embedding, rhs.embedding), i, j))
+    candidates.sort(key=lambda item: item[0])
+
+    used_first: set[int] = set()
+    used_second: set[int] = set()
+    pairs: list[dict[str, object]] = []
+    for distance, i, j in candidates:
+        if i in used_first or j in used_second:
+            continue
+        used_first.add(i)
+        used_second.add(j)
+        record = pair_record(label, first[i], second[j])
+        record["distance"] = distance
+        record["pairing"] = "greedy-nearest"
+        pairs.append(record)
+    return pairs
+
+
+def build_pair_populations(
+    full: list[SpeakerEmbedding], split: list[SpeakerEmbedding]
+) -> dict[str, list[dict[str, object]]]:
+    mic_full = [speaker for speaker in full if speaker.track == "microphone"]
+    system_full = [speaker for speaker in full if speaker.track == "system"]
+
+    populations: dict[str, list[dict[str, object]]] = {
+        "a_same_user_mic_cross_recording": [],
+        "b_same_split_microphone": [],
+        "b_same_split_system_nearest": [],
+        "c_different_system_same_meeting": [],
+        "d_random_system_cross_meeting": [],
+    }
+
+    for lhs, rhs in itertools.combinations(mic_full, 2):
+        if lhs.session_id != rhs.session_id:
+            populations["a_same_user_mic_cross_recording"].append(
+                pair_record("a_same_user_mic_cross_recording", lhs, rhs)
+            )
+
+    for lhs, rhs in itertools.combinations(system_full, 2):
+        if lhs.session_id == rhs.session_id:
+            populations["c_different_system_same_meeting"].append(
+                pair_record("c_different_system_same_meeting", lhs, rhs)
+            )
+        else:
+            populations["d_random_system_cross_meeting"].append(
+                pair_record("d_random_system_cross_meeting", lhs, rhs)
+            )
+
+    for session_id in sorted({speaker.session_id for speaker in split}):
+        for track in ["microphone", "system"]:
+            first = [
+                speaker
+                for speaker in split
+                if speaker.session_id == session_id
+                and speaker.track == track
+                and speaker.half == "first"
+            ]
+            second = [
+                speaker
+                for speaker in split
+                if speaker.session_id == session_id
+                and speaker.track == track
+                and speaker.half == "second"
+            ]
+            if track == "microphone":
+                # The microphone channel is the only cross-recording same-speaker
+                # ground truth: all detected mic clusters are treated as the app
+                # user's voice, even when the diarizer over-clusters.
+                for lhs in first:
+                    for rhs in second:
+                        populations["b_same_split_microphone"].append(
+                            pair_record("b_same_split_microphone", lhs, rhs)
+                        )
+            else:
+                populations["b_same_split_system_nearest"].extend(
+                    greedy_nearest_pairs(first, second, "b_same_split_system_nearest")
+                )
+
+    return populations
+
+
+def population_stats(populations: dict[str, list[dict[str, object]]]) -> dict[str, object]:
+    return {
+        name: stats([float(record["distance"]) for record in records])
+        for name, records in populations.items()
+    }
+
+
+def overlap(populations: dict[str, list[dict[str, object]]]) -> dict[str, object]:
+    same = [float(record["distance"]) for record in populations["a_same_user_mic_cross_recording"]]
+    result: dict[str, object] = {}
+    for name in ["c_different_system_same_meeting", "d_random_system_cross_meeting"]:
+        diff = [float(record["distance"]) for record in populations[name]]
+        if not same or not diff:
+            result[name] = None
+            continue
+        same_max = max(same)
+        diff_min = min(diff)
+        same_p95 = percentile(same, 95)
+        diff_p5 = percentile(diff, 5)
+        result[name] = {
+            "sameMax": same_max,
+            "diffMin": diff_min,
+            "rangeOverlap": diff_min <= same_max,
+            "sameAtOrAboveDiffP5Fraction": sum(1 for value in same if value >= diff_p5) / len(same),
+            "diffAtOrBelowSameP95Fraction": sum(1 for value in diff if value <= same_p95) / len(diff),
+            "p95SameMinusP5Diff": (same_p95 - diff_p5) if same_p95 is not None and diff_p5 is not None else None,
+        }
+    return result
+
+
+def pairwise_sweep(
+    populations: dict[str, list[dict[str, object]]], step: float = 0.05
+) -> list[dict[str, object]]:
+    positives = [float(record["distance"]) for record in populations["a_same_user_mic_cross_recording"]]
+    neg_same_meeting = [
+        float(record["distance"]) for record in populations["c_different_system_same_meeting"]
+    ]
+    neg_cross_meeting = [
+        float(record["distance"]) for record in populations["d_random_system_cross_meeting"]
+    ]
+
+    rows: list[dict[str, object]] = []
+    tau = 0.0
+    while tau <= 1.000001:
+        rows.append(
+            {
+                "tau": round(tau, 2),
+                "margin": 0.10,
+                "pairwiseTPR_sameMic": (
+                    sum(1 for value in positives if value <= tau) / len(positives)
+                    if positives
+                    else None
+                ),
+                "pairwiseFPR_systemSameMeeting": (
+                    sum(1 for value in neg_same_meeting if value <= tau) / len(neg_same_meeting)
+                    if neg_same_meeting
+                    else None
+                ),
+                "pairwiseFPR_systemCrossMeeting": (
+                    sum(1 for value in neg_cross_meeting if value <= tau) / len(neg_cross_meeting)
+                    if neg_cross_meeting
+                    else None
+                ),
+            }
+        )
+        tau += step
+    return rows
+
+
+def margin_proxy_sweep(
+    full: list[SpeakerEmbedding], step: float = 0.05, margin: float = 0.10
+) -> list[dict[str, object]]:
+    """A user-profile proxy sweep.
+
+    Positives: microphone query embedding matches nearest microphone reference
+    from other sessions and must beat the nearest system embedding by margin.
+    Negatives: system query falsely matches nearest microphone reference and
+    must beat the nearest other-system embedding by margin.
+    """
+
+    mic = [speaker for speaker in full if speaker.track == "microphone"]
+    system = [speaker for speaker in full if speaker.track == "system"]
+
+    positive_trials: list[dict[str, float | bool]] = []
+    for query in mic:
+        same_refs = [speaker for speaker in mic if speaker.session_id != query.session_id]
+        imposter_refs = system
+        if not same_refs or not imposter_refs:
+            continue
+        same_dist = min(cosine_distance(query.embedding, ref.embedding) for ref in same_refs)
+        imposter_dist = min(cosine_distance(query.embedding, ref.embedding) for ref in imposter_refs)
+        positive_trials.append(
+            {
+                "targetDistance": same_dist,
+                "marginDelta": imposter_dist - same_dist,
+                "top1IsTarget": same_dist < imposter_dist,
+            }
+        )
+
+    negative_trials: list[dict[str, float | bool]] = []
+    for query in system:
+        user_refs = mic
+        competing_system = [
+            speaker
+            for speaker in system
+            if not (
+                speaker.session_id == query.session_id
+                and speaker.speaker_id == query.speaker_id
+                and speaker.source == query.source
+            )
+        ]
+        if not user_refs or not competing_system:
+            continue
+        user_dist = min(cosine_distance(query.embedding, ref.embedding) for ref in user_refs)
+        competitor_dist = min(
+            cosine_distance(query.embedding, ref.embedding) for ref in competing_system
+        )
+        negative_trials.append(
+            {
+                "targetDistance": user_dist,
+                "marginDelta": competitor_dist - user_dist,
+                "top1IsTarget": user_dist < competitor_dist,
+            }
+        )
+
+    rows: list[dict[str, object]] = []
+    tau = 0.0
+    while tau <= 1.000001:
+        pos_pass = [
+            trial
+            for trial in positive_trials
+            if trial["top1IsTarget"]
+            and float(trial["targetDistance"]) <= tau
+            and float(trial["marginDelta"]) >= margin
+        ]
+        neg_pass = [
+            trial
+            for trial in negative_trials
+            if trial["top1IsTarget"]
+            and float(trial["targetDistance"]) <= tau
+            and float(trial["marginDelta"]) >= margin
+        ]
+        rows.append(
+            {
+                "tau": round(tau, 2),
+                "margin": margin,
+                "positiveTrials": len(positive_trials),
+                "negativeTrials": len(negative_trials),
+                "proxyTPR": len(pos_pass) / len(positive_trials) if positive_trials else None,
+                "proxyFPR": len(neg_pass) / len(negative_trials) if negative_trials else None,
+                "proxyPositivePass": len(pos_pass),
+                "proxyFalsePositivePass": len(neg_pass),
+            }
+        )
+        tau += step
+    return rows
+
+
+def embedding_counts(full: list[SpeakerEmbedding], split: list[SpeakerEmbedding]) -> dict[str, object]:
+    full_counts: dict[str, dict[str, int]] = {}
+    for speaker in full:
+        full_counts.setdefault(speaker.session_id, {}).setdefault(speaker.track, 0)
+        full_counts[speaker.session_id][speaker.track] += 1
+
+    split_counts: dict[str, dict[str, dict[str, int]]] = {}
+    for speaker in split:
+        split_counts.setdefault(speaker.session_id, {}).setdefault(speaker.track, {}).setdefault(
+            speaker.half or "unknown", 0
+        )
+        split_counts[speaker.session_id][speaker.track][speaker.half or "unknown"] += 1
+
+    return {"full": full_counts, "split": split_counts}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--data-dir", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    full = load_full(args.data_dir)
+    split = load_split(args.data_dir)
+    populations = build_pair_populations(full, split)
+
+    sample_path = args.data_dir / "sample-sessions.json"
+    sample = json.loads(sample_path.read_text()) if sample_path.exists() else {}
+
+    output = {
+        "generatedAt": time.strftime("%Y-%m-%dT%H:%M:%S%z", time.localtime()),
+        "dataDir": str(args.data_dir),
+        "sample": sample,
+        "embeddingCounts": embedding_counts(full, split),
+        "populationStats": population_stats(populations),
+        "overlap": overlap(populations),
+        "pairwiseTauSweep": pairwise_sweep(populations),
+        "marginProxyTauSweep": margin_proxy_sweep(full),
+        "populationPairs": {
+            name: records for name, records in populations.items()
+        },
+        "notes": [
+            "Microphone clusters are treated as same-speaker because the microphone channel is the app-user ground truth, despite diarizer over-clustering.",
+            "System split-half same-speaker pairs use greedy nearest-neighbor matching across halves because no participant labels are available.",
+            "Margin proxy sweep is a user-profile proxy, not a fully labeled multi-profile speaker-identification evaluation.",
+        ],
+    }
+
+    args.output.write_text(json.dumps(output, indent=2, sort_keys=True) + "\n")
+    print(json.dumps({k: output[k] for k in ["generatedAt", "populationStats", "overlap"]}, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/plans/active/2026-07-03-speaker-voiceprints.md
+++ b/plans/active/2026-07-03-speaker-voiceprints.md
@@ -1,8 +1,11 @@
 # Persistent Speaker Profiles (Voiceprints) — Research Synthesis + Implementation Plan
 
 - **Date:** 2026-07-03
-- **Status:** PROPOSED — pending Daniel's calls on §Open Questions and the Phase 0
-  GO/NO-GO gate
+- **Status:** PROPOSED — decisions settled 2026-07-04; Phase 0 result: NO-GO on
+  the current meeting corpus (pre-AEC echo contamination + only 3 usable
+  sessions; embeddings not proven insufficient). Phase 1 blocked pending Phase
+  0b clean-corpus validation — see
+  `docs/research/2026-07-04-voiceprints-phase0-calibration.md`.
 - **Trigger:** issue #662 (yakov0922) + a Reddit voiceprint post aimed at MacWhisper;
   related demand in #430, #106
 - **Research:** 5 delegated reports in
@@ -188,15 +191,9 @@ differentiator, but honestly:
   identity once live diarization (#430) ships; calendar-attendee hints (hints
   only, never authoritative).
 
-## Open questions (Daniel)
+## Decisions (Daniel, 2026-07-04)
 
-1. **Always-confirm vs graduated auto-apply.** The 2026-06-14 plan says suggestions
-   always require confirmation. Recommend: v1 strict confirm; consider opt-in
-   auto-apply (with provenance chip + undo) only after dogfooding proves precision.
-2. **Ambient embeddings for unnamed speakers** (enables the issue's exact UX +
-   retro-matching): recommend NO for v1 — strictest consent posture, smallest
-   surface.
-3. **BIPA posture**: docs-only vs regional gating. Recommend docs-only + consent
-   gate (indie, local-only, user-controlled).
-4. **Podcast/file scope in v1 or v2**: recommend v2 (Phase 2) to keep Phase 1
-   reviewable, even though it's the Reddit author's own use case.
+1. **Auto-apply: strict confirm in v1.** Every match surfaces as a suggestion requiring confirmation; opt-in auto-apply (provenance chip + undo) reconsidered only after dogfooding shows precision.
+2. **Ambient embeddings: NO.** v1 stores embeddings only for explicitly enrolled speakers; recurring-unknown detection remains a Phase 3 decision with its own opt-in.
+3. **BIPA posture: docs + consent gate only.** First-enrollment permission acknowledgment plus plain-language guidance; no regional gating.
+4. **Podcast/file scope: Phase 2.** v1 is meetings-only to keep the first PR series reviewable.


### PR DESCRIPTION
## Summary

Docs + research-harness PR. Executes Phase 0 of `plans/active/2026-07-03-speaker-voiceprints.md` (merged in #682): measure whether FluidAudio 0.15.4 offline-diarizer embeddings separate same-person from different-person **across recordings**, using the retained meeting corpus. It also records Daniel's four settled product decisions in the plan.

## The answer

**NO-GO for Phase 1 on the current corpus — attributed to corpus quality, not a proven embedding failure.**

- Same-user cross-recording distance: 0.73–0.85 (FluidAudio scale, <0.3 = same speaker) — inside the different-speaker band (~0.9). No usable separation.
- But split-half same-speaker pairs *within* a recording match at ~0.03, and the user's own voice appears in system tracks at 0.19–0.38 (pre-AEC echo) — recording conditions are the prime suspect. WeSpeaker-class models report ~1–3% EER cross-session on public benchmarks; 0.8 same-person distance is inconsistent with a healthy corpus.
- Corpus availability is itself a blocker: of 465 sessions, only 3 paired sessions ≥5 min have valid readable audio.

## The decision it feeds

Phase 1 product code stays blocked. Next gate: **Phase 0b — clean-corpus validation** (public multi-episode audio with naturally labeled recurring speakers, same harness). Podcasts pass → the FluidAudio path is viable and meetings need post-AEC (#605-era) audio + a real calibration corpus. Podcasts fail → evaluate `extractSpeakerEmbedding` over clean segments or park the feature.

## Product finding (out of scope, worth triage)

Only 22 of 463 present `microphone.m4a` files have a valid container — multi-MB files missing their moov atom (writer never finalized) plus hundreds of 557-byte stubs. Likely dominated by dev-kill iterations, but if any fraction is real crashes, that user audio is unplayable. Relates to meeting finalize/recovery hardening.

## Privacy

The report contains session UUIDs, durations, and aggregate distances only — no names, no transcript content. Per-session **embedding JSONs are deliberately not committed** (a speaker embedding is biometric data; participants never consented to publication) — enforced by a data-dir `.gitignore`; regenerate locally with the harness.

## Test evidence

Harness (`docs/research/2026-07-04-voiceprints-phase0/harness/`, standalone SwiftPM, FluidAudio pinned `.exact("0.15.4")`) built and ran against 3 sessions × 2 tracks × full+split modes. Replay: build the harness, point it at a session folder, run `analyze_voiceprints.py` over the emitted JSON. No app code touched; no tests affected.

## Author's Notes

Extraction ran as a sandboxed `codex exec` job against read-only user audio; the dominant-cluster re-analysis and the NO-GO attribution judgment are the orchestrator's (section "Orchestrator Re-Analysis" in the report). The initial extraction agent's harsher "embeddings insufficient" framing was softened after re-analysis showed the contamination signature — the gate outcome is the same either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs Phase 0 calibration for voiceprints and records a NO-GO for Phase 1 on the current meeting corpus. Ships a standalone harness and anonymized report/artifacts, updates the plan with settled decisions, and sets Phase 0b (clean-corpus validation) as the next gate.

- New Features
  - Calibration report with aggregate-only data; sessions anonymized (M1–M3), month-level dates, minute-level durations. Adds `inventory.json`, `model-check.json`, and `sample-sessions.json`; UUID map and full pairwise analysis stay local.
  - Per-session embedding JSONs (`*-full.json`, `*-split.json`), `analysis-summary.json`, and `session-label-map.json` are gitignored; regenerate locally with the harness.
  - Standalone SwiftPM harness extracts embeddings via `FluidAudio`’s offline diarizer; `analyze_voiceprints.py` computes distance stats and tau sweeps. Finding: no usable cross-recording separation on retained meetings (pre-AEC echo; only 3 usable ≥5 min paired sessions). Decisions recorded: strict confirm, no ambient embeddings, BIPA docs-only consent, podcasts in Phase 2. Phase 0b next. Also flags many invalid `microphone.m4a` containers for triage.

- Dependencies
  - Pin `FluidAudio` to `.exact("0.15.4")`.

<sup>Written for commit bf8e22975d9284d12169dc2c9bfc80e06a29a6e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/685?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

