### PR TITLE
Capture meeting start context

### DIFF
--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -104,6 +104,10 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
   Each segment carries a UUID, start/end time, speaker/source label, text, and
   a word-index range into `wordTimestamps`, so agents can cite stable meeting
   transcript segments without deriving boundaries themselves.
+- `meetings show --json` and meeting JSON exports now include optional
+  `startContext` for rows recorded by versions that capture the local meeting
+  start snapshot. The field reports the trigger kind, configured source mode,
+  and frontmost app bundle id/name captured at recording start.
 
 ### Changed
 

--- a/Sources/CLI/Commands/MeetingsCommand.swift
+++ b/Sources/CLI/Commands/MeetingsCommand.swift
@@ -667,6 +667,7 @@ private struct MeetingRecord: Encodable {
     let artifactFolderPath: String?
     let artifactManifestPath: String?
     let hasArtifactManifest: Bool
+    let startContext: MeetingStartContext?
 
     init(_ transcription: Transcription, promptResultCount: Int = 0) {
         id = transcription.id
@@ -700,6 +701,7 @@ private struct MeetingRecord: Encodable {
         hasArtifactManifest = manifestPath.map {
             FileManager.default.fileExists(atPath: $0)
         } ?? false
+        startContext = transcription.meetingStartContext
     }
 }
 

--- a/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
@@ -50,6 +50,7 @@ final class MeetingRecordingFlowCoordinator {
     private let sttManager: (any STTRuntimeManaging)?
     private let speechEngineSelectionProvider: (@Sendable () async -> SpeechEngineSelection?)?
     private let meetingAudioSourceModeProvider: @MainActor @Sendable () -> MeetingAudioSourceMode
+    private let frontmostApplicationProvider: any FrontmostApplicationProviding
     private var llmService: LLMServiceProtocol?
     private let onMenuBarIconUpdate: (BreathWaveIcon.MenuBarState) -> Void
     private let onTranscriptionReady: (Transcription) -> Void
@@ -108,6 +109,7 @@ final class MeetingRecordingFlowCoordinator {
         meetingAudioSourceModeProvider: @escaping @MainActor @Sendable () -> MeetingAudioSourceMode = {
             .microphoneAndSystem
         },
+        frontmostApplicationProvider: any FrontmostApplicationProviding = NSWorkspaceFrontmostApplicationProvider(),
         llmService: LLMServiceProtocol?,
         pillViewModel: MeetingRecordingPillViewModel,
         meetingTranscriptionQueue: MeetingTranscriptionQueue? = nil,
@@ -129,6 +131,7 @@ final class MeetingRecordingFlowCoordinator {
         self.sttManager = sttManager
         self.speechEngineSelectionProvider = speechEngineSelectionProvider
         self.meetingAudioSourceModeProvider = meetingAudioSourceModeProvider
+        self.frontmostApplicationProvider = frontmostApplicationProvider
         self.llmService = llmService
         self.pillViewModel = pillViewModel
         self.meetingTranscriptionQueue =
@@ -173,6 +176,7 @@ final class MeetingRecordingFlowCoordinator {
     /// hop. Manual / hotkey starts set only the trigger, so the service falls
     /// back to its date-based default title.
     private var pendingTitle: String?
+    private var pendingStartContext: MeetingStartContext?
 
     /// Pause / resume the in-flight recording. The state flip happens AFTER
     /// the service confirms — an optimistic flip before the await would race
@@ -222,8 +226,12 @@ final class MeetingRecordingFlowCoordinator {
         trigger: TelemetryMeetingRecordingTrigger = .manual
     ) -> Int? {
         guard stateMachine.state == .idle else { return nil }
-        pendingTrigger = pendingTrigger ?? trigger
+        let resolvedTrigger = pendingTrigger ?? trigger
+        let sourceMode = meetingAudioSourceModeProvider()
+        pendingTrigger = resolvedTrigger
         pendingTitle = title
+        pendingAudioSourceMode = sourceMode
+        pendingStartContext = makeStartContext(trigger: resolvedTrigger, sourceMode: sourceMode)
         currentMeetingOperationContext = ObservabilityOperationContext()
         sendEvent(.startRequested)
         return stateMachine.generation
@@ -319,6 +327,9 @@ final class MeetingRecordingFlowCoordinator {
         }
         pendingTrigger = .calendarAutoStart
         pendingTitle = title
+        let sourceMode = meetingAudioSourceModeProvider()
+        pendingAudioSourceMode = sourceMode
+        pendingStartContext = makeStartContext(trigger: .calendarAutoStart, sourceMode: sourceMode)
         currentMeetingOperationContext = ObservabilityOperationContext()
         sendEvent(.startRequested)
         return stateMachine.generation
@@ -342,6 +353,7 @@ final class MeetingRecordingFlowCoordinator {
         pendingTrigger = nil
         pendingTitle = nil
         pendingAudioSourceMode = nil
+        pendingStartContext = nil
         currentMeetingOperationContext = nil
         currentMeetingTrigger = nil
         if wasCalendarTriggered {
@@ -378,12 +390,23 @@ final class MeetingRecordingFlowCoordinator {
         }
     }
 
+    private func makeStartContext(
+        trigger: TelemetryMeetingRecordingTrigger,
+        sourceMode: MeetingAudioSourceMode
+    ) -> MeetingStartContext {
+        MeetingStartContext(
+            triggerKind: MeetingStartContext.TriggerKind(trigger),
+            frontmostApplication: frontmostApplicationProvider.currentFrontmostApplication(),
+            sourceMode: sourceMode
+        )
+    }
+
     private func executeEffect(_ effect: MeetingRecordingFlowEffect) {
         switch effect {
         case .checkPermissions:
             let gen = stateMachine.generation
             actionTask = Task { @MainActor in
-                let sourceMode = meetingAudioSourceModeProvider()
+                let sourceMode = self.pendingAudioSourceMode ?? meetingAudioSourceModeProvider()
                 self.pendingAudioSourceMode = sourceMode
                 let microphoneGranted: Bool
                 let microphonePrompted: Bool
@@ -527,15 +550,22 @@ final class MeetingRecordingFlowCoordinator {
             let trigger = pendingTrigger
             let title = pendingTitle
             let sourceMode = pendingAudioSourceMode ?? meetingAudioSourceModeProvider()
+            let startContext = pendingStartContext
+                ?? makeStartContext(trigger: trigger ?? .manual, sourceMode: sourceMode)
             pendingTrigger = nil
             pendingTitle = nil
             pendingAudioSourceMode = nil
+            pendingStartContext = nil
             let operationContext = currentMeetingOperationContext ?? ObservabilityOperationContext()
             currentMeetingOperationContext = operationContext
             currentMeetingTrigger = trigger.map(TelemetryMeetingOperationTrigger.init)
             actionTask = Task { @MainActor in
                 do {
-                    try await meetingRecordingService.startRecording(title: title, sourceMode: sourceMode)
+                    try await meetingRecordingService.startRecording(
+                        title: title,
+                        sourceMode: sourceMode,
+                        startContext: startContext
+                    )
                     let isSpeechModelReady = await self.sttManager?.isReady() ?? true
                     switch self.panelViewModel?.liveTranscriptStatus {
                     case .some(.startingAudio) where isSpeechModelReady:
@@ -683,6 +713,7 @@ final class MeetingRecordingFlowCoordinator {
             pendingTrigger = nil
             pendingTitle = nil
             pendingAudioSourceMode = nil
+            pendingStartContext = nil
             actionTask?.cancel()
             actionTask = Task { @MainActor in
                 // Stop the in-flight debounce so it can't fire against a
@@ -1271,6 +1302,7 @@ extension MeetingRecordingFlowCoordinator {
         pendingTrigger = nil
         pendingTitle = nil
         pendingAudioSourceMode = nil
+        pendingStartContext = nil
         _ = stateMachine.handle(.startRequested)
         _ = stateMachine.handle(.permissionsGranted(generation: stateMachine.generation))
         _ = stateMachine.handle(.recordingStarted(generation: stateMachine.generation))

--- a/Sources/MacParakeetCore/AppRuntimePreferences.swift
+++ b/Sources/MacParakeetCore/AppRuntimePreferences.swift
@@ -357,7 +357,7 @@ public enum YouTubeAudioQuality: String, CaseIterable, Hashable, Sendable, Equat
     }
 }
 
-public enum MeetingAudioSourceMode: String, CaseIterable, Hashable, Sendable, Equatable {
+public enum MeetingAudioSourceMode: String, Codable, CaseIterable, Hashable, Sendable, Equatable {
     case microphoneAndSystem = "microphone_and_system"
     case microphoneOnly = "microphone_only"
     case systemOnly = "system_only"

--- a/Sources/MacParakeetCore/Database/DatabaseManager.swift
+++ b/Sources/MacParakeetCore/Database/DatabaseManager.swift
@@ -1040,6 +1040,15 @@ public final class DatabaseManager: Sendable {
             }
         }
 
+        // v0.24 — One-shot meeting start context. Raw SQL by design: migrations
+        // must not depend on the evolving Codable model shape for this JSON blob.
+        migrator.registerMigration("v0.24-meeting-start-context") { db in
+            let columns = try db.columns(in: "transcriptions").map(\.name)
+            if !columns.contains("meetingStartContext") {
+                try db.execute(sql: "ALTER TABLE transcriptions ADD COLUMN meetingStartContext TEXT")
+            }
+        }
+
         try migrator.migrate(dbQueue)
         try reconcileBuiltInPrompts()
         try reconcileBuiltInQuickPrompts()

--- a/Sources/MacParakeetCore/Models/MeetingStartContext.swift
+++ b/Sources/MacParakeetCore/Models/MeetingStartContext.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+public struct MeetingStartContext: Codable, Sendable, Equatable {
+    public enum TriggerKind: String, Codable, Sendable, Equatable, CaseIterable {
+        case manual
+        case hotkey
+        case calendarAutoStart = "calendar_auto_start"
+    }
+
+    public struct FrontmostApplication: Codable, Sendable, Equatable {
+        public let bundleIdentifier: String?
+        public let localizedName: String?
+
+        public init(bundleIdentifier: String?, localizedName: String?) {
+            self.bundleIdentifier = AppPromptContext.normalizedBundleIdentifier(bundleIdentifier)
+            self.localizedName = AppPromptContext.normalizedDisplayName(localizedName)
+        }
+    }
+
+    public let triggerKind: TriggerKind
+    public let frontmostApplication: FrontmostApplication?
+    public let sourceMode: MeetingAudioSourceMode
+
+    public init(
+        triggerKind: TriggerKind,
+        frontmostApplication: FrontmostApplication?,
+        sourceMode: MeetingAudioSourceMode
+    ) {
+        self.triggerKind = triggerKind
+        self.frontmostApplication = frontmostApplication
+        self.sourceMode = sourceMode
+    }
+}
+
+public extension MeetingStartContext.TriggerKind {
+    init(_ trigger: TelemetryMeetingRecordingTrigger) {
+        switch trigger {
+        case .manual:
+            self = .manual
+        case .hotkey:
+            self = .hotkey
+        case .calendarAutoStart:
+            self = .calendarAutoStart
+        }
+    }
+}

--- a/Sources/MacParakeetCore/Models/Transcription.swift
+++ b/Sources/MacParakeetCore/Models/Transcription.swift
@@ -316,7 +316,7 @@ extension Transcription: FetchableRecord, PersistableRecord {
         recoveredFromCrash = try container.decodeIfPresent(Bool.self, forKey: .recoveredFromCrash) ?? false
         isTranscriptEdited = try container.decodeIfPresent(Bool.self, forKey: .isTranscriptEdited) ?? false
         userNotes = try container.decodeIfPresent(String.self, forKey: .userNotes)
-        meetingStartContext = try container.decodeIfPresent(MeetingStartContext.self, forKey: .meetingStartContext)
+        meetingStartContext = (try? container.decodeIfPresent(MeetingStartContext.self, forKey: .meetingStartContext)) ?? nil
         engine = try container.decodeIfPresent(String.self, forKey: .engine)
         engineVariant = try container.decodeIfPresent(String.self, forKey: .engineVariant)
         derivedTitle = try container.decodeIfPresent(String.self, forKey: .derivedTitle)

--- a/Sources/MacParakeetCore/Models/Transcription.swift
+++ b/Sources/MacParakeetCore/Models/Transcription.swift
@@ -47,6 +47,9 @@ public struct Transcription: Codable, Identifiable, Sendable {
     /// summary generation (ADR-020 §3). `nil` for non-meeting transcripts
     /// and for meetings where the user took no notes.
     public var userNotes: String?
+    /// One-shot context captured when a meeting recording starts. `nil` for
+    /// non-meeting rows and legacy meetings.
+    public var meetingStartContext: MeetingStartContext?
     /// STT engine that produced this transcript (`"parakeet"` / `"nemotron"` /
     /// `"cohere"` / `"whisper"`).
     /// `nil` for rows created before the v0.8 engine-attribution migration.
@@ -100,6 +103,7 @@ public struct Transcription: Codable, Identifiable, Sendable {
         recoveredFromCrash: Bool = false,
         isTranscriptEdited: Bool = false,
         userNotes: String? = nil,
+        meetingStartContext: MeetingStartContext? = nil,
         engine: String? = nil,
         engineVariant: String? = nil,
         derivedTitle: String? = nil,
@@ -134,6 +138,7 @@ public struct Transcription: Codable, Identifiable, Sendable {
         self.recoveredFromCrash = recoveredFromCrash
         self.isTranscriptEdited = isTranscriptEdited
         self.userNotes = userNotes
+        self.meetingStartContext = meetingStartContext
         self.engine = engine
         self.engineVariant = engineVariant
         self.derivedTitle = derivedTitle
@@ -248,7 +253,7 @@ extension Transcription: FetchableRecord, PersistableRecord {
         case rawTranscript, cleanTranscript, wordTimestamps, language
         case speakerCount, speakers, diarizationSegments, transcriptSegments, chatMessages
         case status, errorMessage, exportPath, sourceURL
-        case thumbnailURL, channelName, videoDescription, isFavorite, sourceType, recoveredFromCrash, isTranscriptEdited, userNotes, engine, engineVariant, derivedTitle, derivedSnippet, updatedAt
+        case thumbnailURL, channelName, videoDescription, isFavorite, sourceType, recoveredFromCrash, isTranscriptEdited, userNotes, meetingStartContext, engine, engineVariant, derivedTitle, derivedSnippet, updatedAt
     }
 
     /// Backward-compatible decoding: `speakers` column may contain old `[String]` JSON
@@ -311,6 +316,7 @@ extension Transcription: FetchableRecord, PersistableRecord {
         recoveredFromCrash = try container.decodeIfPresent(Bool.self, forKey: .recoveredFromCrash) ?? false
         isTranscriptEdited = try container.decodeIfPresent(Bool.self, forKey: .isTranscriptEdited) ?? false
         userNotes = try container.decodeIfPresent(String.self, forKey: .userNotes)
+        meetingStartContext = try container.decodeIfPresent(MeetingStartContext.self, forKey: .meetingStartContext)
         engine = try container.decodeIfPresent(String.self, forKey: .engine)
         engineVariant = try container.decodeIfPresent(String.self, forKey: .engineVariant)
         derivedTitle = try container.decodeIfPresent(String.self, forKey: .derivedTitle)

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingArtifactStore.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingArtifactStore.swift
@@ -261,6 +261,7 @@ private struct MeetingArtifactMeetingSummary: Codable {
     let engineVariant: String?
     let recoveredFromCrash: Bool
     let isTranscriptEdited: Bool
+    let startContext: MeetingStartContext?
 
     init(_ transcription: Transcription) {
         id = transcription.id
@@ -274,6 +275,7 @@ private struct MeetingArtifactMeetingSummary: Codable {
         engineVariant = transcription.engineVariant
         recoveredFromCrash = transcription.recoveredFromCrash
         isTranscriptEdited = transcription.isTranscriptEdited
+        startContext = transcription.meetingStartContext
     }
 }
 
@@ -340,6 +342,7 @@ private struct MeetingArtifactTranscript: Codable {
     let sourceType: Transcription.SourceType
     let recoveredFromCrash: Bool
     let isTranscriptEdited: Bool
+    let startContext: MeetingStartContext?
 
     init(_ transcription: Transcription) {
         id = transcription.id
@@ -364,6 +367,7 @@ private struct MeetingArtifactTranscript: Codable {
         sourceType = transcription.sourceType
         recoveredFromCrash = transcription.recoveredFromCrash
         isTranscriptEdited = transcription.isTranscriptEdited
+        startContext = transcription.meetingStartContext
     }
 }
 

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingLockFileStore.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingLockFileStore.swift
@@ -7,8 +7,9 @@ public enum MeetingRecordingLockState: String, Codable, Sendable, Equatable {
 }
 
 public struct MeetingRecordingLockFile: Codable, Sendable, Equatable {
-    /// Schema version is intentionally left at 1 because `notes` and
-    /// `speechEngine` are backward-compatible additive fields (`decodeIfPresent`).
+    /// Schema version is intentionally left at 1 because `notes`,
+    /// `speechEngine`, and `startContext` are backward-compatible additive
+    /// fields (`decodeIfPresent`).
     /// See ADR-020 §9. The version guard in `MeetingRecordingLockFileStore.read()`
     /// uses `<=` so a lock file written by an OLDER app version is still
     /// readable; a future bump only needs to keep this property + bump the
@@ -25,6 +26,7 @@ public struct MeetingRecordingLockFile: Codable, Sendable, Equatable {
     public let displayName: String
     public let state: MeetingRecordingLockState
     public let speechEngine: SpeechEngineSelection
+    public let startContext: MeetingStartContext?
     /// Free-form notes the user typed during the meeting. Persisted on
     /// every notepad debounce so a crash recovers what the user had written
     /// up to the last debounce fire. Decoded independently of the rest of
@@ -41,6 +43,7 @@ public struct MeetingRecordingLockFile: Codable, Sendable, Equatable {
         case displayName
         case state
         case speechEngine
+        case startContext
         case notes
     }
 
@@ -52,6 +55,7 @@ public struct MeetingRecordingLockFile: Codable, Sendable, Equatable {
         displayName: String,
         state: MeetingRecordingLockState = .recording,
         speechEngine: SpeechEngineSelection = SpeechEngineSelection(engine: .parakeet),
+        startContext: MeetingStartContext? = nil,
         notes: String? = nil,
         folderURL: URL? = nil
     ) {
@@ -62,6 +66,7 @@ public struct MeetingRecordingLockFile: Codable, Sendable, Equatable {
         self.displayName = displayName
         self.state = state
         self.speechEngine = speechEngine
+        self.startContext = startContext
         self.notes = notes
         self.folderURL = folderURL
     }
@@ -76,6 +81,7 @@ public struct MeetingRecordingLockFile: Codable, Sendable, Equatable {
         state = try container.decodeIfPresent(MeetingRecordingLockState.self, forKey: .state) ?? .recording
         speechEngine = try container.decodeIfPresent(SpeechEngineSelection.self, forKey: .speechEngine)
             ?? SpeechEngineSelection(engine: .parakeet)
+        startContext = try container.decodeIfPresent(MeetingStartContext.self, forKey: .startContext)
         // Notes are decoded independently — see ADR-020 §9. If a future encoder
         // bug or hand-edited file produces a malformed `notes` value, recovery
         // of the audio metadata still succeeds; only the typed notes are lost.
@@ -92,6 +98,7 @@ public struct MeetingRecordingLockFile: Codable, Sendable, Equatable {
         try container.encode(displayName, forKey: .displayName)
         try container.encode(state, forKey: .state)
         try container.encode(speechEngine, forKey: .speechEngine)
+        try container.encodeIfPresent(startContext, forKey: .startContext)
         try container.encodeIfPresent(notes, forKey: .notes)
     }
 
@@ -104,6 +111,7 @@ public struct MeetingRecordingLockFile: Codable, Sendable, Equatable {
             displayName: displayName,
             state: state,
             speechEngine: speechEngine,
+            startContext: startContext,
             notes: notes,
             folderURL: folderURL
         )
@@ -118,6 +126,7 @@ public struct MeetingRecordingLockFile: Codable, Sendable, Equatable {
             displayName: displayName,
             state: state,
             speechEngine: speechEngine,
+            startContext: startContext,
             notes: notes,
             folderURL: folderURL
         )
@@ -132,6 +141,7 @@ public struct MeetingRecordingLockFile: Codable, Sendable, Equatable {
             displayName: displayName,
             state: state,
             speechEngine: speechEngine,
+            startContext: startContext,
             notes: notes,
             folderURL: folderURL
         )

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingLockFileStore.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingLockFileStore.swift
@@ -81,7 +81,7 @@ public struct MeetingRecordingLockFile: Codable, Sendable, Equatable {
         state = try container.decodeIfPresent(MeetingRecordingLockState.self, forKey: .state) ?? .recording
         speechEngine = try container.decodeIfPresent(SpeechEngineSelection.self, forKey: .speechEngine)
             ?? SpeechEngineSelection(engine: .parakeet)
-        startContext = try container.decodeIfPresent(MeetingStartContext.self, forKey: .startContext)
+        startContext = (try? container.decodeIfPresent(MeetingStartContext.self, forKey: .startContext)) ?? nil
         // Notes are decoded independently — see ADR-020 §9. If a future encoder
         // bug or hand-edited file produces a malformed `notes` value, recovery
         // of the audio metadata still succeeds; only the typed notes are lost.

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingMetadata.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingMetadata.swift
@@ -54,16 +54,19 @@ public struct MeetingRecordingMetadata: Sendable, Codable, Equatable {
     public let sourceAlignment: MeetingSourceAlignment
     public let speechEngine: SpeechEngineSelection
     public let speechEngineWasCaptured: Bool
+    public let startContext: MeetingStartContext?
     public let echoSuppression: MeetingEchoSuppressionMetadata?
 
     public init(
         sourceAlignment: MeetingSourceAlignment,
         speechEngine: SpeechEngineSelection = SpeechEngineSelection(engine: .parakeet),
+        startContext: MeetingStartContext? = nil,
         echoSuppression: MeetingEchoSuppressionMetadata? = nil
     ) {
         self.sourceAlignment = sourceAlignment
         self.speechEngine = speechEngine
         self.speechEngineWasCaptured = true
+        self.startContext = startContext
         self.echoSuppression = echoSuppression
     }
 
@@ -71,17 +74,20 @@ public struct MeetingRecordingMetadata: Sendable, Codable, Equatable {
         sourceAlignment: MeetingSourceAlignment,
         speechEngine: SpeechEngineSelection,
         speechEngineWasCaptured: Bool,
+        startContext: MeetingStartContext?,
         echoSuppression: MeetingEchoSuppressionMetadata?
     ) {
         self.sourceAlignment = sourceAlignment
         self.speechEngine = speechEngine
         self.speechEngineWasCaptured = speechEngineWasCaptured
+        self.startContext = startContext
         self.echoSuppression = echoSuppression
     }
 
     private enum CodingKeys: String, CodingKey {
         case sourceAlignment
         case speechEngine
+        case startContext
         case echoSuppression
     }
 
@@ -91,6 +97,7 @@ public struct MeetingRecordingMetadata: Sendable, Codable, Equatable {
         let decodedSpeechEngine = try container.decodeIfPresent(SpeechEngineSelection.self, forKey: .speechEngine)
         speechEngine = decodedSpeechEngine ?? SpeechEngineSelection(engine: .parakeet)
         speechEngineWasCaptured = decodedSpeechEngine != nil
+        startContext = try container.decodeIfPresent(MeetingStartContext.self, forKey: .startContext)
         echoSuppression = try container.decodeIfPresent(
             MeetingEchoSuppressionMetadata.self,
             forKey: .echoSuppression
@@ -103,6 +110,7 @@ public struct MeetingRecordingMetadata: Sendable, Codable, Equatable {
         if speechEngineWasCaptured {
             try container.encode(speechEngine, forKey: .speechEngine)
         }
+        try container.encodeIfPresent(startContext, forKey: .startContext)
         try container.encodeIfPresent(echoSuppression, forKey: .echoSuppression)
     }
 
@@ -113,6 +121,7 @@ public struct MeetingRecordingMetadata: Sendable, Codable, Equatable {
             sourceAlignment: sourceAlignment,
             speechEngine: speechEngine,
             speechEngineWasCaptured: speechEngineWasCaptured,
+            startContext: startContext,
             echoSuppression: echoSuppression
         )
     }

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingMetadata.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingMetadata.swift
@@ -97,7 +97,7 @@ public struct MeetingRecordingMetadata: Sendable, Codable, Equatable {
         let decodedSpeechEngine = try container.decodeIfPresent(SpeechEngineSelection.self, forKey: .speechEngine)
         speechEngine = decodedSpeechEngine ?? SpeechEngineSelection(engine: .parakeet)
         speechEngineWasCaptured = decodedSpeechEngine != nil
-        startContext = try container.decodeIfPresent(MeetingStartContext.self, forKey: .startContext)
+        startContext = (try? container.decodeIfPresent(MeetingStartContext.self, forKey: .startContext)) ?? nil
         echoSuppression = try container.decodeIfPresent(
             MeetingEchoSuppressionMetadata.self,
             forKey: .echoSuppression

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingOutput.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingOutput.swift
@@ -19,6 +19,7 @@ public struct MeetingRecordingOutput: Sendable, Equatable {
     public let sourceAlignment: MeetingSourceAlignment
     public let speechEngine: SpeechEngineSelection
     public let speechEngineWasCaptured: Bool
+    public let startContext: MeetingStartContext?
     /// Free-form notes the user typed during the meeting, captured at finalize
     /// time. Threaded through to `Transcription.userNotes` by the caller so
     /// post-meeting summary generation can steer on what the user emphasized
@@ -37,6 +38,7 @@ public struct MeetingRecordingOutput: Sendable, Equatable {
         sourceAlignment: MeetingSourceAlignment,
         speechEngine: SpeechEngineSelection = SpeechEngineSelection(engine: .parakeet),
         speechEngineWasCaptured: Bool = true,
+        startContext: MeetingStartContext? = nil,
         userNotes: String? = nil
     ) {
         self.init(
@@ -52,6 +54,7 @@ public struct MeetingRecordingOutput: Sendable, Equatable {
             sourceAlignment: sourceAlignment,
             speechEngine: speechEngine,
             speechEngineWasCaptured: speechEngineWasCaptured,
+            startContext: startContext,
             userNotes: userNotes
         )
     }
@@ -69,6 +72,7 @@ public struct MeetingRecordingOutput: Sendable, Equatable {
         sourceAlignment: MeetingSourceAlignment,
         speechEngine: SpeechEngineSelection = SpeechEngineSelection(engine: .parakeet),
         speechEngineWasCaptured: Bool = true,
+        startContext: MeetingStartContext? = nil,
         userNotes: String? = nil
     ) {
         self.sessionID = sessionID
@@ -83,6 +87,7 @@ public struct MeetingRecordingOutput: Sendable, Equatable {
         self.sourceAlignment = sourceAlignment
         self.speechEngine = speechEngine
         self.speechEngineWasCaptured = speechEngineWasCaptured
+        self.startContext = startContext
         self.userNotes = userNotes
     }
 
@@ -164,7 +169,8 @@ public struct MeetingRecordingOutput: Sendable, Equatable {
             durationSeconds: durationSeconds,
             sourceAlignment: metadata.sourceAlignment,
             speechEngine: metadata.speechEngine,
-            speechEngineWasCaptured: metadata.speechEngineWasCaptured
+            speechEngineWasCaptured: metadata.speechEngineWasCaptured,
+            startContext: metadata.startContext
         )
     }
 
@@ -198,6 +204,7 @@ public struct MeetingRecordingOutput: Sendable, Equatable {
             && lhs.sourceAlignment == rhs.sourceAlignment
             && lhs.speechEngine == rhs.speechEngine
             && lhs.speechEngineWasCaptured == rhs.speechEngineWasCaptured
+            && lhs.startContext == rhs.startContext
             && lhs.userNotes == rhs.userNotes
     }
 }

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingRecoveryService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingRecoveryService.swift
@@ -198,7 +198,8 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
         try MeetingRecordingMetadataStore.save(
             MeetingRecordingMetadata(
                 sourceAlignment: sourceAlignment,
-                speechEngine: lock.speechEngine
+                speechEngine: lock.speechEngine,
+                startContext: lock.startContext
             ),
             folderURL: folderURL
         )
@@ -245,6 +246,7 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
             durationSeconds: duration,
             sourceAlignment: sourceAlignment,
             speechEngine: lock.speechEngine,
+            startContext: lock.startContext,
             userNotes: lock.notes
         )
 

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
@@ -36,7 +36,11 @@ public protocol MeetingRecordingServiceProtocol: Sendable {
     /// `title` lets callers (e.g., the calendar auto-start path) pre-name
     /// the recording. `nil` or whitespace-only falls back to the default
     /// "Meeting <date>" label.
-    func startRecording(title: String?, sourceMode: MeetingAudioSourceMode?) async throws
+    func startRecording(
+        title: String?,
+        sourceMode: MeetingAudioSourceMode?,
+        startContext: MeetingStartContext?
+    ) async throws
     func stopRecording() async throws -> MeetingRecordingOutput
     func completeTranscription(for recording: MeetingRecordingOutput) async
     /// Mark the final transcription attempt as ended without deleting the
@@ -78,11 +82,15 @@ public extension MeetingRecordingServiceProtocol {
     /// Existing manual / hotkey callers use the no-arg form — the calendar
     /// path is the only caller that has a meaningful title to pass.
     func startRecording(title: String?) async throws {
-        try await startRecording(title: title, sourceMode: nil)
+        try await startRecording(title: title, sourceMode: nil, startContext: nil)
+    }
+
+    func startRecording(title: String?, sourceMode: MeetingAudioSourceMode?) async throws {
+        try await startRecording(title: title, sourceMode: sourceMode, startContext: nil)
     }
 
     func startRecording() async throws {
-        try await startRecording(title: nil, sourceMode: nil)
+        try await startRecording(title: nil, sourceMode: nil, startContext: nil)
     }
 }
 
@@ -129,6 +137,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         let systemAudioURL: URL
         let mixedAudioURL: URL
         let speechEngine: SpeechEngineSelection
+        let startContext: MeetingStartContext?
 
         var supportsLiveChunkTranscription: Bool {
             speechEngine.engine != .cohere
@@ -388,7 +397,8 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
 
     public func startRecording(
         title: String? = nil,
-        sourceMode: MeetingAudioSourceMode? = nil
+        sourceMode: MeetingAudioSourceMode? = nil,
+        startContext: MeetingStartContext? = nil
     ) async throws {
         guard currentSession == nil, startingSessionID == nil else {
             throw MeetingAudioError.alreadyRunning
@@ -424,7 +434,8 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
             microphoneAudioURL: writer.microphoneAudioURL,
             systemAudioURL: writer.systemAudioURL,
             mixedAudioURL: writer.mixedAudioURL,
-            speechEngine: speechEngine
+            speechEngine: speechEngine,
+            startContext: startContext
         )
         self.writer = writer
         self.currentSession = session
@@ -436,6 +447,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
                 pid: ProcessInfo.processInfo.processIdentifier,
                 displayName: session.displayName,
                 speechEngine: session.speechEngine,
+                startContext: session.startContext,
                 folderURL: session.folderURL
             )
             try lockFileStore.write(initialLock, folderURL: session.folderURL)
@@ -597,7 +609,8 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
             try MeetingRecordingMetadataStore.save(
                 MeetingRecordingMetadata(
                     sourceAlignment: sourceAlignment,
-                    speechEngine: session.speechEngine
+                    speechEngine: session.speechEngine,
+                    startContext: session.startContext
                 ),
                 folderURL: session.folderURL
             )
@@ -642,6 +655,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
             pid: ProcessInfo.processInfo.processIdentifier,
             displayName: session.displayName,
             speechEngine: session.speechEngine,
+            startContext: session.startContext,
             folderURL: session.folderURL
         ))
             .withNotes(finalNotes)
@@ -684,6 +698,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
             durationSeconds: durationSeconds,
             sourceAlignment: sourceAlignment,
             speechEngine: session.speechEngine,
+            startContext: session.startContext,
             userNotes: finalNotes
         )
 
@@ -746,6 +761,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
             pid: ProcessInfo.processInfo.processIdentifier,
             displayName: session.displayName,
             speechEngine: session.speechEngine,
+            startContext: session.startContext,
             folderURL: session.folderURL
         )
         let updated = base.withNotes(normalized)

--- a/Sources/MacParakeetCore/Services/System/FrontmostApplicationProvider.swift
+++ b/Sources/MacParakeetCore/Services/System/FrontmostApplicationProvider.swift
@@ -15,9 +15,13 @@ public struct NSWorkspaceFrontmostApplicationProvider: FrontmostApplicationProvi
             return nil
         }
 
-        return MeetingStartContext.FrontmostApplication(
+        let frontmost = MeetingStartContext.FrontmostApplication(
             bundleIdentifier: app.bundleIdentifier,
             localizedName: app.localizedName
         )
+        guard frontmost.bundleIdentifier != nil || frontmost.localizedName != nil else {
+            return nil
+        }
+        return frontmost
     }
 }

--- a/Sources/MacParakeetCore/Services/System/FrontmostApplicationProvider.swift
+++ b/Sources/MacParakeetCore/Services/System/FrontmostApplicationProvider.swift
@@ -1,0 +1,23 @@
+import AppKit
+import Foundation
+
+public protocol FrontmostApplicationProviding: Sendable {
+    @MainActor
+    func currentFrontmostApplication() -> MeetingStartContext.FrontmostApplication?
+}
+
+public struct NSWorkspaceFrontmostApplicationProvider: FrontmostApplicationProviding {
+    public init() {}
+
+    @MainActor
+    public func currentFrontmostApplication() -> MeetingStartContext.FrontmostApplication? {
+        guard let app = NSWorkspace.shared.frontmostApplication else {
+            return nil
+        }
+
+        return MeetingStartContext.FrontmostApplication(
+            bundleIdentifier: app.bundleIdentifier,
+            localizedName: app.localizedName
+        )
+    }
+}

--- a/Sources/MacParakeetCore/Services/TranscriptionService.swift
+++ b/Sources/MacParakeetCore/Services/TranscriptionService.swift
@@ -427,6 +427,7 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
             transcription.status = .processing
             transcription.errorMessage = nil
             transcription.userNotes = transcription.userNotes ?? recording.userNotes
+            transcription.meetingStartContext = transcription.meetingStartContext ?? recording.startContext
             transcription.updatedAt = Date()
             try transcriptionRepo.save(transcription)
 
@@ -1066,6 +1067,7 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
             status: .processing,
             sourceType: .meeting,
             userNotes: recording.userNotes,
+            meetingStartContext: recording.startContext,
             engine: recording.speechEngine.engine.rawValue
         )
     }

--- a/Tests/CLITests/MeetingsCommandTests.swift
+++ b/Tests/CLITests/MeetingsCommandTests.swift
@@ -293,6 +293,47 @@ final class MeetingsCommandTests: XCTestCase {
         assertSegmentPayload(transcriptSegments.first, id: segmentID)
     }
 
+    func testShowJSONIncludesMeetingStartContext() async throws {
+        let dbURL = temporaryDatabaseURL()
+        defer { try? FileManager.default.removeItem(at: dbURL) }
+        let db = try DatabaseManager(path: dbURL.path)
+        let transcriptionRepo = TranscriptionRepository(dbQueue: db.dbQueue)
+        let startContext = MeetingStartContext(
+            triggerKind: .calendarAutoStart,
+            frontmostApplication: .init(
+                bundleIdentifier: "COM.Google.Chrome",
+                localizedName: "Google Chrome"
+            ),
+            sourceMode: .microphoneAndSystem
+        )
+        let meeting = Transcription(
+            fileName: "Customer Sync",
+            rawTranscript: "We discussed onboarding.",
+            status: .completed,
+            sourceType: .meeting,
+            meetingStartContext: startContext
+        )
+        try transcriptionRepo.save(meeting)
+
+        let showCommand = try MeetingsCommand.ShowSubcommand.parse([
+            meeting.id.uuidString,
+            "--json",
+            "--database", dbURL.path,
+        ])
+        let showOutput = try await captureStandardOutput {
+            try await showCommand.run()
+        }
+        let showPayload = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(showOutput.utf8)) as? [String: Any]
+        )
+        let context = try XCTUnwrap(showPayload["startContext"] as? [String: Any])
+        XCTAssertEqual(context["triggerKind"] as? String, "calendar_auto_start")
+        XCTAssertEqual(context["sourceMode"] as? String, "microphone_and_system")
+        let app = try XCTUnwrap(context["frontmostApplication"] as? [String: Any])
+        XCTAssertEqual(app["bundleIdentifier"] as? String, "com.google.chrome")
+        XCTAssertEqual(app["localizedName"] as? String, "Google Chrome")
+    }
+
     func testArtifactSubcommandMaterializesMeetingFolder() async throws {
         let dbURL = temporaryDatabaseURL()
         let folderURL = FileManager.default.temporaryDirectory

--- a/Tests/MacParakeetTests/Database/DatabaseManagerTests.swift
+++ b/Tests/MacParakeetTests/Database/DatabaseManagerTests.swift
@@ -229,6 +229,17 @@ final class DatabaseManagerTests: XCTestCase {
         }
     }
 
+    func testMeetingStartContextColumnExistsOnTranscriptions() throws {
+        let manager = try DatabaseManager()
+        try manager.dbQueue.read { db in
+            let columns = try db.columns(in: "transcriptions").map(\.name)
+            XCTAssertTrue(
+                columns.contains("meetingStartContext"),
+                "transcriptions should store one-shot meeting start context JSON"
+            )
+        }
+    }
+
     func testUserNotesSnapshotColumnExistsOnSummaries() throws {
         let manager = try DatabaseManager()
         try manager.dbQueue.read { db in

--- a/Tests/MacParakeetTests/Database/DatabaseManagerTests.swift
+++ b/Tests/MacParakeetTests/Database/DatabaseManagerTests.swift
@@ -240,6 +240,34 @@ final class DatabaseManagerTests: XCTestCase {
         }
     }
 
+    func testMeetingStartContextMigrationToleratesExistingColumnWhenMigrationMarkerIsMissing() throws {
+        let dbPath = FileManager.default.temporaryDirectory
+            .appendingPathComponent("meeting_start_context_rerun_\(UUID().uuidString).db")
+            .path
+        defer { cleanupDatabaseFiles(atPath: dbPath) }
+
+        let manager1 = try DatabaseManager(path: dbPath)
+        try manager1.dbQueue.write { db in
+            try db.execute(
+                sql: "DELETE FROM grdb_migrations WHERE identifier = ?",
+                arguments: ["v0.24-meeting-start-context"]
+            )
+        }
+
+        let manager2 = try DatabaseManager(path: dbPath)
+        try manager2.dbQueue.read { db in
+            let columns = try db.columns(in: "transcriptions").map(\.name)
+            XCTAssertTrue(columns.contains("meetingStartContext"))
+
+            let migrationRecorded = try Bool.fetchOne(
+                db,
+                sql: "SELECT EXISTS(SELECT 1 FROM grdb_migrations WHERE identifier = ?)",
+                arguments: ["v0.24-meeting-start-context"]
+            ) ?? false
+            XCTAssertTrue(migrationRecorded)
+        }
+    }
+
     func testUserNotesSnapshotColumnExistsOnSummaries() throws {
         let manager = try DatabaseManager()
         try manager.dbQueue.read { db in

--- a/Tests/MacParakeetTests/Database/TranscriptionRepositoryTests.swift
+++ b/Tests/MacParakeetTests/Database/TranscriptionRepositoryTests.swift
@@ -91,6 +91,30 @@ final class TranscriptionRepositoryTests: XCTestCase {
         XCTAssertNil(fetched?.engineVariant)
     }
 
+    func testMeetingStartContextRoundTrips() throws {
+        let startContext = MeetingStartContext(
+            triggerKind: .hotkey,
+            frontmostApplication: .init(
+                bundleIdentifier: "COM.Example.Zoom",
+                localizedName: "Zoom"
+            ),
+            sourceMode: .microphoneAndSystem
+        )
+        let transcription = Transcription(
+            fileName: "meeting.m4a",
+            sourceType: .meeting,
+            meetingStartContext: startContext
+        )
+        try repo.save(transcription)
+
+        let fetched = try XCTUnwrap(repo.fetch(id: transcription.id))
+        XCTAssertEqual(fetched.meetingStartContext, startContext)
+        XCTAssertEqual(
+            fetched.meetingStartContext?.frontmostApplication?.bundleIdentifier,
+            "com.example.zoom"
+        )
+    }
+
     func testFetchAll() throws {
         let t1 = Transcription(
             createdAt: Date(timeIntervalSinceNow: -100),

--- a/Tests/MacParakeetTests/Database/TranscriptionRepositoryTests.swift
+++ b/Tests/MacParakeetTests/Database/TranscriptionRepositoryTests.swift
@@ -115,6 +115,30 @@ final class TranscriptionRepositoryTests: XCTestCase {
         )
     }
 
+    func testMalformedMeetingStartContextDoesNotBlockTranscriptionDecode() throws {
+        let transcription = Transcription(
+            fileName: "meeting.m4a",
+            rawTranscript: "Usable transcript",
+            sourceType: .meeting
+        )
+        try repo.save(transcription)
+        try dbQueue.write { db in
+            try db.execute(
+                sql: "UPDATE transcriptions SET meetingStartContext = ? WHERE id = ?",
+                arguments: [
+                    #"{"triggerKind":"future_trigger","sourceMode":"microphone_only"}"#,
+                    transcription.id.uuidString,
+                ]
+            )
+        }
+
+        let fetched = try XCTUnwrap(repo.fetch(id: transcription.id))
+        XCTAssertNil(fetched.meetingStartContext, "malformed start context should be dropped")
+        XCTAssertEqual(fetched.fileName, "meeting.m4a")
+        XCTAssertEqual(fetched.rawTranscript, "Usable transcript")
+        XCTAssertEqual(fetched.sourceType, .meeting)
+    }
+
     func testFetchAll() throws {
         let t1 = Transcription(
             createdAt: Date(timeIntervalSinceNow: -100),

--- a/Tests/MacParakeetTests/MeetingRecordingFlow/MeetingRecordingFlowCoordinatorTests.swift
+++ b/Tests/MacParakeetTests/MeetingRecordingFlow/MeetingRecordingFlowCoordinatorTests.swift
@@ -204,6 +204,61 @@ final class MeetingRecordingFlowCoordinatorTests: XCTestCase {
         XCTAssertEqual(coordinator.testHook_state, .recording)
     }
 
+    func testStartRecordingCapturesStartContextForDiscoveredStartPaths() async throws {
+        let app = MeetingStartContext.FrontmostApplication(
+            bundleIdentifier: "COM.Example.MeetingApp",
+            localizedName: "Meeting App"
+        )
+
+        let manualService = MeetingRecordingServiceSpy(output: makeRecordingOutput())
+        let manualCoordinator = makeStartContextCoordinator(
+            recordingService: manualService,
+            sourceMode: .microphoneOnly,
+            frontmostApplication: app
+        )
+        XCTAssertNotNil(manualCoordinator.startRecording(trigger: .manual))
+        try await waitForStartCall(on: manualService, coordinator: manualCoordinator)
+        var serviceSnapshot = await manualService.snapshot()
+        var start = try XCTUnwrap(serviceSnapshot.startCalls.first)
+        XCTAssertNil(start.title)
+        XCTAssertEqual(start.sourceMode, .microphoneOnly)
+        XCTAssertEqual(start.startContext?.triggerKind, .manual)
+        XCTAssertEqual(start.startContext?.frontmostApplication, app)
+        XCTAssertEqual(start.startContext?.sourceMode, .microphoneOnly)
+
+        let hotkeyService = MeetingRecordingServiceSpy(output: makeRecordingOutput())
+        let hotkeyCoordinator = makeStartContextCoordinator(
+            recordingService: hotkeyService,
+            sourceMode: .microphoneAndSystem,
+            frontmostApplication: app
+        )
+        XCTAssertNotNil(hotkeyCoordinator.startRecording(trigger: .hotkey))
+        try await waitForStartCall(on: hotkeyService, coordinator: hotkeyCoordinator)
+        serviceSnapshot = await hotkeyService.snapshot()
+        start = try XCTUnwrap(serviceSnapshot.startCalls.first)
+        XCTAssertNil(start.title)
+        XCTAssertEqual(start.sourceMode, .microphoneAndSystem)
+        XCTAssertEqual(start.startContext?.triggerKind, .hotkey)
+        XCTAssertEqual(start.startContext?.frontmostApplication, app)
+        XCTAssertEqual(start.startContext?.sourceMode, .microphoneAndSystem)
+
+        let calendarService = MeetingRecordingServiceSpy(output: makeRecordingOutput())
+        let calendarCoordinator = makeStartContextCoordinator(
+            recordingService: calendarService,
+            sourceMode: .systemOnly,
+            frontmostApplication: app
+        )
+        XCTAssertNotNil(calendarCoordinator.startFromCalendar(title: "Roadmap Review"))
+        try await waitForStartCall(on: calendarService, coordinator: calendarCoordinator)
+        serviceSnapshot = await calendarService.snapshot()
+        start = try XCTUnwrap(serviceSnapshot.startCalls.first)
+        XCTAssertEqual(start.title, "Roadmap Review")
+        XCTAssertEqual(start.sourceMode, .systemOnly)
+        XCTAssertEqual(start.startContext?.triggerKind, .calendarAutoStart)
+        XCTAssertEqual(start.startContext?.frontmostApplication, app)
+        XCTAssertEqual(start.startContext?.sourceMode, .systemOnly)
+    }
+
     func testCohereRecordingShowsLivePreviewUnsupportedCopy() async throws {
         let coordinator = MeetingRecordingFlowCoordinator(
             meetingRecordingService: MeetingRecordingServiceSpy(output: makeRecordingOutput()),
@@ -293,6 +348,43 @@ final class MeetingRecordingFlowCoordinatorTests: XCTestCase {
         )
     }
 
+    private func makeStartContextCoordinator(
+        recordingService: MeetingRecordingServiceSpy,
+        sourceMode: MeetingAudioSourceMode,
+        frontmostApplication: MeetingStartContext.FrontmostApplication?
+    ) -> MeetingRecordingFlowCoordinator {
+        MeetingRecordingFlowCoordinator(
+            meetingRecordingService: recordingService,
+            transcriptionService: MockTranscriptionService(),
+            permissionService: MockPermissionService(),
+            transcriptionRepo: MockTranscriptionRepository(),
+            conversationRepo: MockChatConversationRepository(),
+            quickPromptRepo: NoOpQuickPromptRepository(),
+            configStore: NoOpLLMConfigStore(),
+            meetingAudioSourceModeProvider: { sourceMode },
+            frontmostApplicationProvider: StaticFrontmostApplicationProvider(frontmostApplication),
+            llmService: nil,
+            pillViewModel: MeetingRecordingPillViewModel(),
+            onMenuBarIconUpdate: { _ in },
+            onTranscriptionReady: { _ in }
+        )
+    }
+
+    private func waitForStartCall(
+        on service: MeetingRecordingServiceSpy,
+        coordinator: MeetingRecordingFlowCoordinator
+    ) async throws {
+        for _ in 0..<3 {
+            await coordinator.testHook_waitForActionTask()
+            let snapshot = await service.snapshot()
+            if snapshot.startCallCount > 0 {
+                return
+            }
+            await Task.yield()
+        }
+        XCTFail("Expected recording service to receive startRecording.")
+    }
+
     private func makeRecordingOutput() -> MeetingRecordingOutput {
         let folder = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -320,9 +412,29 @@ final class MeetingRecordingFlowCoordinatorTests: XCTestCase {
     }
 }
 
+private struct StaticFrontmostApplicationProvider: FrontmostApplicationProviding {
+    private let frontmostApplication: MeetingStartContext.FrontmostApplication?
+
+    init(_ frontmostApplication: MeetingStartContext.FrontmostApplication?) {
+        self.frontmostApplication = frontmostApplication
+    }
+
+    @MainActor
+    func currentFrontmostApplication() -> MeetingStartContext.FrontmostApplication? {
+        frontmostApplication
+    }
+}
+
 private actor MeetingRecordingServiceSpy: MeetingRecordingServiceProtocol {
+    struct StartCall: Sendable, Equatable {
+        let title: String?
+        let sourceMode: MeetingAudioSourceMode?
+        let startContext: MeetingStartContext?
+    }
+
     private let output: MeetingRecordingOutput
     var startCallCount = 0
+    var startCalls: [StartCall] = []
     var stopCallCount = 0
     var completedTranscriptionSessionIDs: [UUID] = []
 
@@ -330,8 +442,17 @@ private actor MeetingRecordingServiceSpy: MeetingRecordingServiceProtocol {
         self.output = output
     }
 
-    func startRecording(title: String?, sourceMode: MeetingAudioSourceMode?) async throws {
+    func startRecording(
+        title: String?,
+        sourceMode: MeetingAudioSourceMode?,
+        startContext: MeetingStartContext?
+    ) async throws {
         startCallCount += 1
+        startCalls.append(StartCall(
+            title: title,
+            sourceMode: sourceMode,
+            startContext: startContext
+        ))
     }
 
     func stopRecording() async throws -> MeetingRecordingOutput {
@@ -383,9 +504,15 @@ private actor MeetingRecordingServiceSpy: MeetingRecordingServiceProtocol {
         }
     }
 
-    func snapshot() -> (startCallCount: Int, stopCallCount: Int, completedTranscriptionSessionIDs: [UUID]) {
+    func snapshot() -> (
+        startCallCount: Int,
+        startCalls: [StartCall],
+        stopCallCount: Int,
+        completedTranscriptionSessionIDs: [UUID]
+    ) {
         (
             startCallCount: startCallCount,
+            startCalls: startCalls,
             stopCallCount: stopCallCount,
             completedTranscriptionSessionIDs: completedTranscriptionSessionIDs
         )

--- a/Tests/MacParakeetTests/MeetingRecordingFlow/MeetingTranscriptionQueueTests.swift
+++ b/Tests/MacParakeetTests/MeetingRecordingFlow/MeetingTranscriptionQueueTests.swift
@@ -272,7 +272,11 @@ private actor QueueRecordingServiceSpy: MeetingRecordingServiceProtocol {
         )
     }
 
-    func startRecording(title: String?, sourceMode: MeetingAudioSourceMode?) async throws {}
+    func startRecording(
+        title: String?,
+        sourceMode: MeetingAudioSourceMode?,
+        startContext: MeetingStartContext?
+    ) async throws {}
 
     func stopRecording() async throws -> MeetingRecordingOutput {
         throw MeetingAudioError.notRunning

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingArtifactStoreTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingArtifactStoreTests.swift
@@ -24,7 +24,18 @@ final class MeetingArtifactStoreTests: XCTestCase {
     }
 
     func testMaterializeWritesFirstClassMeetingArtifactFiles() async throws {
-        let transcription = makeMeeting(notes: "Decision: ship\nOwner: Dana")
+        let startContext = MeetingStartContext(
+            triggerKind: .manual,
+            frontmostApplication: .init(
+                bundleIdentifier: "com.apple.MobileSMS",
+                localizedName: "Messages"
+            ),
+            sourceMode: .microphoneOnly
+        )
+        let transcription = makeMeeting(
+            notes: "Decision: ship\nOwner: Dana",
+            startContext: startContext
+        )
         let result = PromptResult(
             transcriptionId: transcription.id,
             promptName: "Executive Summary",
@@ -86,10 +97,13 @@ final class MeetingArtifactStoreTests: XCTestCase {
         let wordRange = try XCTUnwrap(transcriptSegments.first?["wordRange"] as? [String: Any])
         XCTAssertEqual(wordRange["startIndex"] as? Int, 0)
         XCTAssertEqual(wordRange["endIndexExclusive"] as? Int, 1)
+        assertStartContext(transcript["startContext"], equals: startContext)
 
         let manifest = try jsonObject(at: URL(fileURLWithPath: snapshot.manifestPath))
         XCTAssertEqual(manifest["schema"] as? String, MeetingArtifactStore.schema)
         XCTAssertEqual(manifest["schemaVersion"] as? Int, MeetingArtifactStore.schemaVersion)
+        let manifestMeeting = try XCTUnwrap(manifest["meeting"] as? [String: Any])
+        assertStartContext(manifestMeeting["startContext"], equals: startContext)
         let files = try XCTUnwrap(manifest["files"] as? [String: Any])
         XCTAssertEqual(files["folderPath"] as? String, folderURL.path)
         XCTAssertEqual(files["mixedAudioPath"] as? String, transcription.filePath)
@@ -226,7 +240,10 @@ final class MeetingArtifactStoreTests: XCTestCase {
         }
     }
 
-    private func makeMeeting(notes: String?) -> Transcription {
+    private func makeMeeting(
+        notes: String?,
+        startContext: MeetingStartContext? = nil
+    ) -> Transcription {
         Transcription(
             id: UUID(uuidString: "11111111-2222-3333-4444-555555555555")!,
             fileName: "Design Review",
@@ -259,8 +276,37 @@ final class MeetingArtifactStoreTests: XCTestCase {
             status: .completed,
             sourceType: .meeting,
             userNotes: notes,
+            meetingStartContext: startContext,
             engine: "parakeet",
             engineVariant: "v3"
+        )
+    }
+
+    private func assertStartContext(
+        _ value: Any?,
+        equals expected: MeetingStartContext,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        guard let context = value as? [String: Any] else {
+            return XCTFail("Expected startContext object.", file: file, line: line)
+        }
+        XCTAssertEqual(context["triggerKind"] as? String, expected.triggerKind.rawValue, file: file, line: line)
+        XCTAssertEqual(context["sourceMode"] as? String, expected.sourceMode.rawValue, file: file, line: line)
+        guard let app = context["frontmostApplication"] as? [String: Any] else {
+            return XCTFail("Expected frontmostApplication object.", file: file, line: line)
+        }
+        XCTAssertEqual(
+            app["bundleIdentifier"] as? String,
+            expected.frontmostApplication?.bundleIdentifier,
+            file: file,
+            line: line
+        )
+        XCTAssertEqual(
+            app["localizedName"] as? String,
+            expected.frontmostApplication?.localizedName,
+            file: file,
+            line: line
         )
     }
 

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingLockFileStoreTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingLockFileStoreTests.swift
@@ -289,6 +289,31 @@ final class MeetingRecordingLockFileStoreTests: XCTestCase {
         XCTAssertEqual(readLockFile.displayName, "Recoverable Session")
     }
 
+    func testReadFromLockFileWithMalformedStartContextStillRecoversMetadata() throws {
+        let folderURL = tempRoot.appendingPathComponent("session")
+        try FileManager.default.createDirectory(at: folderURL, withIntermediateDirectories: true)
+        let json = """
+        {
+            "schemaVersion": 1,
+            "sessionId": "11111111-2222-3333-4444-555555555555",
+            "startedAt": "2026-04-25T12:00:00Z",
+            "pid": 123,
+            "displayName": "Recoverable Session",
+            "state": "recording",
+            "startContext": {
+                "triggerKind": "future_trigger",
+                "sourceMode": "microphone_only"
+            }
+        }
+        """
+        try Data(json.utf8).write(to: MeetingRecordingLockFileStore.lockFileURL(for: folderURL))
+
+        let readLockFile = try XCTUnwrap(store.read(folderURL: folderURL))
+        XCTAssertNil(readLockFile.startContext, "malformed startContext must not block recovery")
+        XCTAssertEqual(readLockFile.displayName, "Recoverable Session")
+        XCTAssertEqual(readLockFile.sessionId, UUID(uuidString: "11111111-2222-3333-4444-555555555555"))
+    }
+
     func testWithNotesPreservesEverythingElse() throws {
         let lockFile = makeLockFile().withNotes("first note")
         let updated = lockFile.withNotes("second note")

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingOutputTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingOutputTests.swift
@@ -406,6 +406,40 @@ final class MeetingRecordingOutputTests: XCTestCase {
         XCTAssertEqual(metadata.echoSuppression?.reasonCode, .skippedNoEchoPath)
     }
 
+    func testMeetingRecordingMetadataRoundTripsStartContext() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let startContext = MeetingStartContext(
+            triggerKind: .calendarAutoStart,
+            frontmostApplication: .init(
+                bundleIdentifier: "us.zoom.xos",
+                localizedName: "zoom.us"
+            ),
+            sourceMode: .microphoneAndSystem
+        )
+        try MeetingRecordingMetadataStore.save(
+            MeetingRecordingMetadata(
+                sourceAlignment: MeetingSourceAlignment(
+                    meetingOriginHostTime: nil,
+                    microphone: nil,
+                    system: nil
+                ),
+                startContext: startContext
+            ),
+            folderURL: dir
+        )
+
+        let metadata = try MeetingRecordingMetadataStore.load(from: dir)
+        XCTAssertEqual(metadata.startContext, startContext)
+
+        let archived = try MeetingRecordingOutput.loadArchived(
+            displayName: "Recovered Meeting",
+            mixedAudioURL: dir.appendingPathComponent("meeting.m4a"),
+            durationSeconds: 12
+        )
+        XCTAssertEqual(archived.startContext, startContext)
+    }
+
     func testUpdateEchoSuppressionSavesThroughInjectedFileManager() throws {
         let dir = try makeTempDir()
         defer { try? FileManager.default.removeItem(at: dir) }

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingOutputTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingOutputTests.swift
@@ -440,6 +440,37 @@ final class MeetingRecordingOutputTests: XCTestCase {
         XCTAssertEqual(archived.startContext, startContext)
     }
 
+    func testMeetingRecordingMetadataWithMalformedStartContextStillLoads() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try saveAlignmentMetadata(in: dir)
+
+        let url = MeetingRecordingMetadataStore.metadataURL(for: dir)
+        var json = try XCTUnwrap(JSONSerialization.jsonObject(
+            with: Data(contentsOf: url)
+        ) as? [String: Any])
+        json["startContext"] = [
+            "triggerKind": "future_trigger",
+            "sourceMode": "microphone_only",
+        ]
+        let data = try JSONSerialization.data(
+            withJSONObject: json,
+            options: [.prettyPrinted, .sortedKeys]
+        )
+        try data.write(to: url, options: .atomic)
+
+        let metadata = try MeetingRecordingMetadataStore.load(from: dir)
+        XCTAssertNil(metadata.startContext, "malformed startContext must not block metadata load")
+        XCTAssertEqual(metadata.speechEngine.engine, .parakeet)
+
+        let archived = try MeetingRecordingOutput.loadArchived(
+            displayName: "Recovered Meeting",
+            mixedAudioURL: dir.appendingPathComponent("meeting.m4a"),
+            durationSeconds: 12
+        )
+        XCTAssertNil(archived.startContext)
+    }
+
     func testUpdateEchoSuppressionSavesThroughInjectedFileManager() throws {
         let dir = try makeTempDir()
         defer { try? FileManager.default.removeItem(at: dir) }

--- a/Tests/MacParakeetTests/Services/TranscriptionServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/TranscriptionServiceTests.swift
@@ -1549,7 +1549,18 @@ final class TranscriptionServiceTests: XCTestCase {
     }
 
     func testPrepareMeetingTranscriptionCreatesProcessingStubBeforeSTT() async throws {
-        let recording = try makeOneSourceMeetingRecording(displayName: "Queued Meeting")
+        let startContext = MeetingStartContext(
+            triggerKind: .manual,
+            frontmostApplication: .init(
+                bundleIdentifier: "com.apple.finder",
+                localizedName: "Finder"
+            ),
+            sourceMode: .microphoneOnly
+        )
+        let recording = try makeOneSourceMeetingRecording(
+            displayName: "Queued Meeting",
+            startContext: startContext
+        )
         defer { try? FileManager.default.removeItem(at: recording.folderURL) }
 
         let stub = try await service.prepareMeetingTranscription(recording: recording)
@@ -1564,10 +1575,12 @@ final class TranscriptionServiceTests: XCTestCase {
         XCTAssertEqual(stub.status, .processing)
         XCTAssertEqual(stub.sourceType, .meeting)
         XCTAssertEqual(stub.engine, SpeechEnginePreference.parakeet.rawValue)
+        XCTAssertEqual(stub.meetingStartContext, startContext)
 
         let fetched = try XCTUnwrap(transcriptionRepo.fetch(id: stub.id))
         XCTAssertEqual(fetched.status, .processing)
         XCTAssertEqual(fetched.filePath, recording.mixedAudioURL.path)
+        XCTAssertEqual(fetched.meetingStartContext, startContext)
         XCTAssertEqual(try transcriptionRepo.count(), 1)
     }
 
@@ -2704,7 +2717,10 @@ final class TranscriptionServiceTests: XCTestCase {
         }
     }
 
-    private func makeOneSourceMeetingRecording(displayName: String) throws -> MeetingRecordingOutput {
+    private func makeOneSourceMeetingRecording(
+        displayName: String,
+        startContext: MeetingStartContext? = nil
+    ) throws -> MeetingRecordingOutput {
         let recordingFolder = URL(fileURLWithPath: AppPaths.tempDir)
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         try FileManager.default.createDirectory(at: recordingFolder, withIntermediateDirectories: true)
@@ -2733,7 +2749,8 @@ final class TranscriptionServiceTests: XCTestCase {
                     sampleRate: 48_000
                 ),
                 system: nil
-            )
+            ),
+            startContext: startContext
         )
     }
 

--- a/spec/01-data-model.md
+++ b/spec/01-data-model.md
@@ -112,7 +112,7 @@ CREATE TABLE transcriptions (
     fileName TEXT NOT NULL,                            -- Original filename (e.g., "interview.mp3")
     filePath TEXT,                                     -- Original file path (nullable, may be moved/deleted)
     meetingArtifactFolderPath TEXT,                    -- v0.22: Durable meeting artifact folder path
-    meetingStartContext TEXT,                          -- v0.23: JSON one-shot meeting start context
+    meetingStartContext TEXT,                          -- v0.24: JSON one-shot meeting start context
     fileSizeBytes INTEGER,                             -- Original file size
     durationMs INTEGER,                                -- Audio/video duration in milliseconds
     rawTranscript TEXT,                                 -- Unprocessed STT output (nullable while processing)
@@ -590,7 +590,7 @@ struct Transcription: Codable, Identifiable {
     var fileName: String
     var filePath: String?
     var meetingArtifactFolderPath: String? // v0.22 — Durable meeting artifact folder
-    var meetingStartContext: MeetingStartContext? // v0.23 — One-shot meeting start context
+    var meetingStartContext: MeetingStartContext? // v0.24 — One-shot meeting start context
     var fileSizeBytes: Int?
     var durationMs: Int?
     var rawTranscript: String?
@@ -1132,7 +1132,8 @@ migrator.registerMigration("v0.7-prompts-and-summaries") { db in
 // v0.19 — dictations.language
 // v0.20 — prompts.appliesToSources (auto-run source scoping; NULL = all sources)
 // v0.22 — transcriptions.meetingArtifactFolderPath
-// v0.23 — transcriptions.meetingStartContext
+// v0.23 — transcriptions.transcriptSegments
+// v0.24 — transcriptions.meetingStartContext
 ```
 
 ### Migration Rules

--- a/spec/01-data-model.md
+++ b/spec/01-data-model.md
@@ -112,6 +112,7 @@ CREATE TABLE transcriptions (
     fileName TEXT NOT NULL,                            -- Original filename (e.g., "interview.mp3")
     filePath TEXT,                                     -- Original file path (nullable, may be moved/deleted)
     meetingArtifactFolderPath TEXT,                    -- v0.22: Durable meeting artifact folder path
+    meetingStartContext TEXT,                          -- v0.23: JSON one-shot meeting start context
     fileSizeBytes INTEGER,                             -- Original file size
     durationMs INTEGER,                                -- Audio/video duration in milliseconds
     rawTranscript TEXT,                                 -- Unprocessed STT output (nullable while processing)
@@ -154,7 +155,7 @@ CREATE INDEX idx_transcriptions_status_created_at ON transcriptions(status, crea
 - `language` stores the normalized detected/specified STT language code when available. New transcription service rows start unknown and are filled from the STT result; legacy/default rows may still contain `en`.
 - `speakerCount` and `speakers` are nullable, populated only when diarization is available (v0.4).
 - `filePath` is nullable because the original file may be moved or deleted after transcription.
-- For meeting recordings, `filePath` points to the mixed `meeting.m4a` artifact used for playback/export while retained. `meetingArtifactFolderPath` points to the durable session folder, so artifact actions and CLI output survive audio deletion or retention. The selected-source `microphone.m4a` and/or `system.m4a`, plus the `meeting-recording-metadata.json` sidecar, remain inside that same session folder while retained. The sidecar may include additive `echoSuppression` provenance (`reasonCode` plus optional model, render-timing, delay, and probe-correlation fields) after the cleaned-mic readiness gate resolves, so shared folders identify whether final STT used cleaned or raw mic and why. The folder is the first-class local artifact contract for the session; the canonical filename/schema contract lives in [`spec/contracts/meeting-artifacts-v1.md`](contracts/meeting-artifacts-v1.md). The DB row remains canonical; the folder is refreshed after meeting finalization, `macparakeet-cli meetings artifact`, meeting-note writes, and prompt-result writes.
+- For meeting recordings, `filePath` points to the mixed `meeting.m4a` artifact used for playback/export while retained. `meetingArtifactFolderPath` points to the durable session folder, so artifact actions and CLI output survive audio deletion or retention. The selected-source `microphone.m4a` and/or `system.m4a`, plus the `meeting-recording-metadata.json` sidecar, remain inside that same session folder while retained. The sidecar may include additive `echoSuppression` provenance (`reasonCode` plus optional model, render-timing, delay, and probe-correlation fields) after the cleaned-mic readiness gate resolves, so shared folders identify whether final STT used cleaned or raw mic and why. `meetingStartContext` stores the one-shot local-only start snapshot for meeting rows: trigger kind, configured source mode, and the frontmost app bundle id/name read at recording start. The folder is the first-class local artifact contract for the session; the canonical filename/schema contract lives in [`spec/contracts/meeting-artifacts-v1.md`](contracts/meeting-artifacts-v1.md). The DB row remains canonical; the folder is refreshed after meeting finalization, `macparakeet-cli meetings artifact`, meeting-note writes, and prompt-result writes.
 - The meeting artifact root defaults to `~/Library/Application Support/MacParakeet/meeting-recordings`, and can be changed for future sessions through `macparakeet-cli config set meeting-artifacts-folder <absolute-path>`. Existing sessions keep their own folder path through `transcriptions.meetingArtifactFolderPath`, falling back to the parent of `transcriptions.filePath` for legacy rows.
 - Saved meeting retranscribes reconstruct the archived meeting from that folder when the sidecar exists, so the library path can reuse the same aligned dual-source finalization flow as the immediate post-stop path.
 - `sourceURL` distinguishes URL-sourced transcriptions (YouTube) from local file transcriptions. Added in v0.3.
@@ -589,6 +590,7 @@ struct Transcription: Codable, Identifiable {
     var fileName: String
     var filePath: String?
     var meetingArtifactFolderPath: String? // v0.22 — Durable meeting artifact folder
+    var meetingStartContext: MeetingStartContext? // v0.23 — One-shot meeting start context
     var fileSizeBytes: Int?
     var durationMs: Int?
     var rawTranscript: String?
@@ -1129,6 +1131,8 @@ migrator.registerMigration("v0.7-prompts-and-summaries") { db in
 // v0.18 — llm_runs metadata ledger
 // v0.19 — dictations.language
 // v0.20 — prompts.appliesToSources (auto-run source scoping; NULL = all sources)
+// v0.22 — transcriptions.meetingArtifactFolderPath
+// v0.23 — transcriptions.meetingStartContext
 ```
 
 ### Migration Rules
@@ -1150,6 +1154,7 @@ migrator.registerMigration("v0.7-prompts-and-summaries") { db in
 | `transcriptions` | v0.1 | File transcription records |
 | `transcriptions.meetingArtifactFolderPath` | v0.22 | Durable meeting artifact folder path retained after meeting audio deletion |
 | `transcriptions.transcriptSegments` | v0.23 | Durable meeting transcript segments (JSON) for stable per-transcript-version citations |
+| `transcriptions.meetingStartContext` | v0.24 | Local-only JSON start snapshot for meeting rows: trigger kind, configured source mode, and frontmost app bundle id/name |
 | `custom_words` | v0.2 | Vocabulary anchors and corrections |
 | `text_snippets` | v0.2 | Trigger-based text expansion |
 | `transcriptions.diarizationSegments` | v0.4 | Speaker diarization segments (JSON) |

--- a/spec/contracts/cli-json-v1.md
+++ b/spec/contracts/cli-json-v1.md
@@ -51,6 +51,9 @@ with human progress/status kept off stdout.
   `wordRange.startIndex` / `wordRange.endIndexExclusive` into the same payload's
   `wordTimestamps` array. Callers that need stable citations should prefer
   these persisted segments over re-segmenting words.
+- `meetings show --json` meeting objects can include optional `startContext`
+  for meeting rows. When present it contains `triggerKind`, `sourceMode`, and
+  optional `frontmostApplication` (`bundleIdentifier`, `localizedName`).
 
 ## Failure Envelope
 

--- a/spec/contracts/meeting-artifacts-v1.md
+++ b/spec/contracts/meeting-artifacts-v1.md
@@ -57,7 +57,9 @@ The v1 folder can contain these stable filenames:
   sidecar. It may also include additive `echoSuppression` provenance with
   `reasonCode` plus optional `modelVersion`, `renderDurationMs`,
   `delayEstimateMs`, and `probeBestCorrelation` fields so shared artifact
-  folders can explain cleaned-vs-raw microphone routing without app logs.
+  folders can explain cleaned-vs-raw microphone routing without app logs. It
+  may also include additive `startContext` with the one-shot local start
+  snapshot.
 - `manifest.json`: folder manifest.
 - `transcript.json`: transcript view.
 - `notes.md`: optional user notes view. Removed when notes are empty or nil.
@@ -88,7 +90,7 @@ The v1 folder can contain these stable filenames:
 - `schema`
 - `schemaVersion`
 - `generatedAt`
-- `meeting`
+- `meeting` (including optional `startContext`)
 - `files`
 - `promptResults`
 
@@ -100,7 +102,8 @@ The v1 folder can contain these stable filenames:
 `transcript.json` keeps meeting essentials: `id`, `title`, timestamps,
 `durationMs`, `status`, raw/clean/transcript text, word/speaker/diarization
 fields, durable `transcriptSegments`, `userNotes`, language/engine attribution,
-`sourceType`, `recoveredFromCrash`, and `isTranscriptEdited`.
+`sourceType`, `recoveredFromCrash`, `isTranscriptEdited`, and optional
+`startContext`.
 
 `transcriptSegments` is an additive v1 field populated from the DB row when a
 meeting has durable segments. Each segment keeps `id`, `startMs`, `endMs`,
@@ -108,6 +111,14 @@ meeting has durable segments. Each segment keeps `id`, `startMs`, `endMs`,
 (`startIndex`, `endIndexExclusive`) into the same transcript's
 `wordTimestamps` array. Segment IDs are stable for that transcript version;
 meeting retranscription may replace the array with newly minted segment IDs.
+
+`startContext`, when present, keeps the recording-start snapshot:
+
+- `triggerKind`: `manual`, `hotkey`, or `calendar_auto_start`
+- `sourceMode`: configured meeting source mode at start (`microphone_only`,
+  `microphone_and_system`, or `system_only`)
+- `frontmostApplication`: optional object with `bundleIdentifier` and
+  `localizedName`
 
 ## Non-Stable Fields
 


### PR DESCRIPTION
## Summary

Implements Slice 2 of the meeting-corpus capture plan from #680: every new meeting recording now carries a one-shot local start-context snapshot with trigger kind, configured audio source mode, and the frontmost app identity captured at recording start.

## Design

- Added `MeetingStartContext` with `triggerKind`, optional `frontmostApplication`, and `sourceMode`.
- Enumerated the real start paths in this checkout and captured them in `MeetingRecordingFlowCoordinator`: manual, hotkey, and calendar auto-start.
- Added an AppKit-backed `NSWorkspaceFrontmostApplicationProvider` in Core for a single frontmost-app read at start.
- Threaded the context through recording locks, `meeting-recording-metadata.json`, recovery, `MeetingRecordingOutput`, `Transcription.meetingStartContext`, meeting artifact `manifest.json` / `transcript.json`, and `macparakeet-cli meetings show --json` / export JSON.
- Added raw SQL migration `v0.23-meeting-start-context`; it intentionally does not reference the evolving Codable model type.
- Kept ADR-024 activity detection disabled: no coordinator resurrection, no polling, no timers, no new permissions, and no UI changes.

Deviations from the slice wording:

- No CLI trigger kind was added because the current `meetings` CLI has list/show/transcript/notes/results/artifact/export subcommands and no recording-start entry point.
- The existing show command exposes JSON via `--json`, not `--format json`; this PR updates that actual contract.

## Risk surface

- Database risk is low: nullable additive `TEXT` column, raw SQL migration, and legacy rows decode `nil`.
- Contract risk is additive: artifact and CLI JSON receive optional `startContext` fields only.
- Privacy risk is contained to local storage and local CLI/artifact output. I checked telemetry sources with `rg -n "MeetingStartContext|meetingStartContext|startContext|frontmostApplication|localizedName" Sources/MacParakeetCore/Services/Telemetry Sources/CLI/Commands/CLITelemetry.swift`; there are no matches, so frontmost-app info is not emitted to telemetry.
- Behavior risk is limited to richer persisted records; recording flow, permissions, and UI behavior are otherwise unchanged.

## Test evidence

```bash
swift test --filter 'MeetingRecordingFlowCoordinatorTests/testStartRecordingCapturesStartContextForDiscoveredStartPaths|DatabaseManagerTests/testMeetingStartContextColumnExistsOnTranscriptions|TranscriptionRepositoryTests/testMeetingStartContextRoundTrips|TranscriptionServiceTests/testPrepareMeetingTranscriptionCreatesProcessingStubBeforeSTT|MeetingRecordingOutputTests/testMeetingRecordingMetadataRoundTripsStartContext|MeetingArtifactStoreTests/testMaterializeWritesFirstClassMeetingArtifactFiles|MeetingsCommandTests/testShowJSONIncludesMeetingStartContext'
```

Result: 7 selected XCTest cases, 0 failures.

Covered tests:

- `DatabaseManagerTests/testMeetingStartContextColumnExistsOnTranscriptions`
- `TranscriptionRepositoryTests/testMeetingStartContextRoundTrips`
- `TranscriptionServiceTests/testPrepareMeetingTranscriptionCreatesProcessingStubBeforeSTT`
- `MeetingRecordingOutputTests/testMeetingRecordingMetadataRoundTripsStartContext`
- `MeetingArtifactStoreTests/testMaterializeWritesFirstClassMeetingArtifactFiles`
- `MeetingsCommandTests/testShowJSONIncludesMeetingStartContext`
- `MeetingRecordingFlowCoordinatorTests/testStartRecordingCapturesStartContextForDiscoveredStartPaths`

Additional checks:

```bash
git diff --check
rg -n "MeetingStartContext|meetingStartContext|startContext|frontmostApplication|localizedName" Sources/MacParakeetCore/Services/Telemetry Sources/CLI/Commands/CLITelemetry.swift
```

Results: whitespace check passed; telemetry grep returned no matches.

## Privacy statement

Frontmost-app bundle id/name is user data. This PR keeps it local-only in the app database, meeting sidecar/artifact JSON, and local CLI JSON output, and does not add it to telemetry.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: this is a local-only app/database/artifact change with no server-side deploy path. Healthy signal is successful migration plus new meeting rows showing optional `startContext`; failure signal is missing context on newly-started meetings or decode/write errors in local logs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a one-shot local meeting start snapshot (trigger kind, configured source mode, and frontmost app) for each new recording. Data is stored in the DB and artifacts, exposed in CLI JSON, and decoding is hardened to ignore malformed values.

- New Features
  - Added MeetingStartContext for manual, hotkey, and calendar auto-start.
  - Read frontmost app once via NSWorkspaceFrontmostApplicationProvider; skip empty app objects.
  - Threaded through lock files, meeting sidecar metadata, recovery, MeetingRecordingOutput, Transcription.meetingStartContext, artifact manifest/transcript.json, and `meetings show --json`.
  - Defensive decoding across DB/lock/sidecar drops malformed or future values without blocking reads.
  - Local-only and additive; no telemetry or UI changes.

- Migration
  - New raw SQL migration v0.24 adds nullable `transcriptions.meetingStartContext`, guarded so reruns succeed when the column already exists.
  - Backward compatible: legacy rows decode nil; new JSON fields are optional.

<sup>Written for commit 1c2db6de0c1a0b5f2d7129d62398938c66351f9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/686?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

