### PR TITLE
Snapshot calendar context for meeting recordings

### DIFF
--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -91,6 +91,11 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
 
 ### Added
 
+- `meetings show --json` and `meetings export --stdout --format json` now
+  include an optional local-only `calendarEventSnapshot` for meeting recordings
+  started from a calendar event or probably overlapping the current calendar
+  poll cache. The snapshot can include attendee/organizer names and emails;
+  these fields remain local user data and are not telemetry.
 - Added `retranscribe <record> --update` to rerun STT against retained source
   audio for an existing saved dictation, transcription, or meeting in place.
   Records resolve by UUID/prefix, with exact transcription/meeting title

--- a/Sources/CLI/Commands/MeetingsCommand.swift
+++ b/Sources/CLI/Commands/MeetingsCommand.swift
@@ -664,6 +664,7 @@ private struct MeetingRecord: Encodable {
     let speakers: [SpeakerInfo]?
     let diarizationSegments: [DiarizationSegmentRecord]?
     let transcriptSegments: [TranscriptSegmentRecord]?
+    let calendarEventSnapshot: MeetingCalendarSnapshot?
     let artifactFolderPath: String?
     let artifactManifestPath: String?
     let hasArtifactManifest: Bool
@@ -692,6 +693,7 @@ private struct MeetingRecord: Encodable {
         speakers = transcription.speakers
         diarizationSegments = transcription.diarizationSegments
         transcriptSegments = transcription.transcriptSegments
+        calendarEventSnapshot = transcription.calendarEventSnapshot
         let artifactFolder = MeetingArtifactStore.sessionFolderURL(for: transcription)
         artifactFolderPath = artifactFolder?.path
         let manifestPath = artifactFolder?

--- a/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
+++ b/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
@@ -289,6 +289,7 @@ final class AppEnvironmentConfigurer {
         coordinatorRefs.dictation = dictationCoordinator
 
         var meetingAutoStopCoordinator: MeetingAutoStopCoordinator?
+        var calendarCoordinator: MeetingAutoStartCoordinator?
         var isMeetingAutoStopObservingRecording = false
         let endMeetingAutoStopObservation = {
             guard isMeetingAutoStopObservingRecording else { return }
@@ -307,6 +308,9 @@ final class AppEnvironmentConfigurer {
             sttManager: env.sttScheduler,
             speechEngineSelectionProvider: { await env.sttScheduler.currentSpeechEngineSelection() },
             meetingAudioSourceModeProvider: { env.runtimePreferences.meetingAudioSourceMode },
+            probableCalendarSnapshotProvider: {
+                calendarCoordinator?.probableSnapshotForManualStart()
+            },
             llmService: hasLLMConfig ? env.llmService : nil,
             pillViewModel: meetingPillViewModel,
             onMenuBarIconUpdate: { _ in callbacks.onMenuBarIconUpdate() },
@@ -397,7 +401,6 @@ final class AppEnvironmentConfigurer {
         // unconditionally; we still gate creation on the meeting-recording
         // feature flag because calendar integration only makes sense when
         // the user can actually record meetings.
-        let calendarCoordinator: MeetingAutoStartCoordinator?
         if AppFeatures.meetingRecordingEnabled {
             let coordinator = MeetingAutoStartCoordinator(
                 calendarService: CalendarService.shared,
@@ -405,8 +408,8 @@ final class AppEnvironmentConfigurer {
                 isRecordingActive: { [weak meetingCoordinator] in
                     meetingCoordinator?.isMeetingRecordingActive ?? false
                 },
-                onAutoStartConfirmed: { [weak meetingCoordinator] title in
-                    meetingCoordinator?.startFromCalendar(title: title)
+                onAutoStartConfirmed: { [weak meetingCoordinator] snapshot in
+                    meetingCoordinator?.startFromCalendar(calendarEventSnapshot: snapshot)
                 }
             )
             coordinator.start()

--- a/Sources/MacParakeet/App/MeetingAutoStartCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingAutoStartCoordinator.swift
@@ -178,6 +178,7 @@ final class MeetingAutoStartCoordinator {
             queue: .main
         ) { [weak self] _ in
             Task { @MainActor [weak self] in
+                self?.latestPolledEvents = []
                 self?.logger.debug("EKEventStoreChanged — re-evaluating immediately")
                 await self?.pollAsync()
             }
@@ -455,12 +456,21 @@ final class MeetingAutoStartCoordinator {
     }
 
     func probableSnapshotForManualStart(now: Date = Date()) -> MeetingCalendarSnapshot? {
-        let overlapping = latestPolledEvents
+        guard settingsViewModel.calendarAutoStartMode != .off,
+              calendarService.permissionStatus == .granted
+        else {
+            return nil
+        }
+
+        let triggerFilter = settingsViewModel.meetingTriggerFilter
+        let overlapping = filterByIncludedCalendars(latestPolledEvents)
             .filter { event in
                 event.startTime <= now
                     && event.endTime >= now
                     && !event.isAllDay
                     && !event.userDeclined
+                    && event.userStatus != .pending
+                    && MeetingMonitor.passesTriggerFilter(event, filter: triggerFilter)
             }
             .sorted { lhs, rhs in
                 if lhs.isMeeting != rhs.isMeeting {

--- a/Sources/MacParakeet/App/MeetingAutoStartCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingAutoStartCoordinator.swift
@@ -39,12 +39,13 @@ final class MeetingAutoStartCoordinator {
     /// on `MeetingRecordingFlowCoordinator` (and so tests can stub them).
     private let isRecordingActive: @MainActor () -> Bool
     /// Called when the user (or countdown completion) commits to starting
-    /// an auto-start recording. The event title is forwarded so the
+    /// an auto-start recording. The event snapshot is forwarded so the
     /// recording flow can pre-name the saved transcription with the
-    /// calendar event name instead of the date-based default. Returns the
-    /// recording generation on success, or `nil` if the start was rejected
-    /// (state busy) — the coordinator only needs the non-nil/nil distinction.
-    private let onAutoStartConfirmed: @MainActor (_ title: String) -> Int?
+    /// calendar event name and persist the rest of the EventKit context.
+    /// Returns the recording generation on success, or `nil` if the start was
+    /// rejected (state busy) — the coordinator only needs the non-nil/nil
+    /// distinction.
+    private let onAutoStartConfirmed: @MainActor (_ snapshot: MeetingCalendarSnapshot) -> Int?
     private let toastController: MeetingCountdownToastController
     private let logger = Logger(subsystem: "com.macparakeet", category: "MeetingAutoStart")
 
@@ -65,6 +66,7 @@ final class MeetingAutoStartCoordinator {
     private var dismissedEventIds: Set<String> = []
     private var remindedEventIds: Set<String> = []
     private var countdownShownEventIds: Set<String> = []
+    private var latestPolledEvents: [CalendarEvent] = []
 
     // `nonisolated(unsafe)` so the nonisolated `deinit` can read these to
     // unregister observers. They're write-only after start() / stop() and
@@ -82,7 +84,7 @@ final class MeetingAutoStartCoordinator {
         calendarService: any CalendarServicing = CalendarService.shared,
         settingsViewModel: SettingsViewModel,
         isRecordingActive: @escaping @MainActor () -> Bool = { false },
-        onAutoStartConfirmed: @escaping @MainActor (_ title: String) -> Int? = { _ in nil },
+        onAutoStartConfirmed: @escaping @MainActor (_ snapshot: MeetingCalendarSnapshot) -> Int? = { _ in nil },
         toastController: MeetingCountdownToastController? = nil
     ) {
         self.calendarService = calendarService
@@ -136,6 +138,7 @@ final class MeetingAutoStartCoordinator {
         pollingTimer?.invalidate()
         pollingTimer = nil
         pollingInterval = 0
+        latestPolledEvents = []
         cleanupTask?.cancel()
         cleanupTask = nil
         toastController.close()
@@ -237,10 +240,12 @@ final class MeetingAutoStartCoordinator {
         // Fast-path guards before the (awaited) fetch.
         guard settingsViewModel.calendarAutoStartMode != .off else {
             toastController.close()
+            latestPolledEvents = []
             return
         }
         guard calendarService.permissionStatus == .granted else {
             toastController.close()
+            latestPolledEvents = []
             return
         }
 
@@ -252,6 +257,7 @@ final class MeetingAutoStartCoordinator {
             let raw = try await calendarService.fetchUpcomingEvents(days: 7)
             events = filterByIncludedCalendars(raw)
         } catch {
+            latestPolledEvents = []
             logger.error("Failed to fetch events: \(error.localizedDescription, privacy: .public)")
             return
         }
@@ -263,12 +269,15 @@ final class MeetingAutoStartCoordinator {
         let mode = settingsViewModel.calendarAutoStartMode
         guard mode != .off else {
             toastController.close()
+            latestPolledEvents = []
             return
         }
         guard calendarService.permissionStatus == .granted else {
             toastController.close()
+            latestPolledEvents = []
             return
         }
+        latestPolledEvents = events
 
         let config = currentConfig(mode: mode)
         let monitorEvents = MeetingMonitor.evaluate(
@@ -421,7 +430,8 @@ final class MeetingAutoStartCoordinator {
                 logger.info("Auto-start completion ignored — calendar auto-start is no longer enabled")
                 return
             }
-            guard onAutoStartConfirmed(event.title) != nil else {
+            let snapshot = MeetingCalendarSnapshot(event: event, confidence: .confirmed)
+            guard onAutoStartConfirmed(snapshot) != nil else {
                 // Start was rejected (state_busy — a prior recording is still
                 // wrapping up). Drop this occurrence's countdown-shown mark so
                 // it can retry on a later poll once the blocking recording
@@ -443,6 +453,28 @@ final class MeetingAutoStartCoordinator {
             return
         }
     }
+
+    func probableSnapshotForManualStart(now: Date = Date()) -> MeetingCalendarSnapshot? {
+        let overlapping = latestPolledEvents
+            .filter { event in
+                event.startTime <= now
+                    && event.endTime >= now
+                    && !event.isAllDay
+                    && !event.userDeclined
+            }
+            .sorted { lhs, rhs in
+                if lhs.isMeeting != rhs.isMeeting {
+                    return lhs.isMeeting && !rhs.isMeeting
+                }
+                return lhs.startTime > rhs.startTime
+            }
+        guard let event = overlapping.first else { return nil }
+        return MeetingCalendarSnapshot(
+            event: event,
+            confidence: .probable,
+            capturedAt: now
+        )
+    }
 }
 
 /// Hooks for unit tests. The `testHook_` prefix marks them as test-only
@@ -463,6 +495,10 @@ extension MeetingAutoStartCoordinator {
     }
 
     var testHook_pollAgainRequested: Bool { pollAgainRequested }
+
+    func testHook_probableSnapshotForManualStart(now: Date = Date()) -> MeetingCalendarSnapshot? {
+        probableSnapshotForManualStart(now: now)
+    }
 
     func testHook_simulateAutoStartConfirmed(eventId: String) {
         let event = CalendarEvent(

--- a/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
@@ -51,6 +51,7 @@ final class MeetingRecordingFlowCoordinator {
     private let speechEngineSelectionProvider: (@Sendable () async -> SpeechEngineSelection?)?
     private let meetingAudioSourceModeProvider: @MainActor @Sendable () -> MeetingAudioSourceMode
     private let frontmostApplicationProvider: any FrontmostApplicationProviding
+    private let probableCalendarSnapshotProvider: @MainActor @Sendable () -> MeetingCalendarSnapshot?
     private var llmService: LLMServiceProtocol?
     private let onMenuBarIconUpdate: (BreathWaveIcon.MenuBarState) -> Void
     private let onTranscriptionReady: (Transcription) -> Void
@@ -110,6 +111,9 @@ final class MeetingRecordingFlowCoordinator {
             .microphoneAndSystem
         },
         frontmostApplicationProvider: any FrontmostApplicationProviding = NSWorkspaceFrontmostApplicationProvider(),
+        probableCalendarSnapshotProvider: @escaping @MainActor @Sendable () -> MeetingCalendarSnapshot? = {
+            nil
+        },
         llmService: LLMServiceProtocol?,
         pillViewModel: MeetingRecordingPillViewModel,
         meetingTranscriptionQueue: MeetingTranscriptionQueue? = nil,
@@ -132,6 +136,7 @@ final class MeetingRecordingFlowCoordinator {
         self.speechEngineSelectionProvider = speechEngineSelectionProvider
         self.meetingAudioSourceModeProvider = meetingAudioSourceModeProvider
         self.frontmostApplicationProvider = frontmostApplicationProvider
+        self.probableCalendarSnapshotProvider = probableCalendarSnapshotProvider
         self.llmService = llmService
         self.pillViewModel = pillViewModel
         self.meetingTranscriptionQueue =
@@ -170,13 +175,13 @@ final class MeetingRecordingFlowCoordinator {
     /// which sets this and re-enters `toggleRecording`.
     private var pendingTrigger: TelemetryMeetingRecordingTrigger?
 
-    /// Pre-set title for the *next* `.startRecording` effect. Paired with
-    /// `pendingTrigger`: `startFromCalendar(title:)` sets both, the
-    /// `.startRecording` handler snapshots and clears both before the async
-    /// hop. Manual / hotkey starts set only the trigger, so the service falls
-    /// back to its date-based default title.
+    /// Pre-set title for the *next* `.startRecording` effect. Calendar-driven
+    /// starts also set `pendingCalendarEventSnapshot`. Manual / hotkey starts
+    /// set only the trigger and, when the latest calendar poll overlaps now,
+    /// a probable snapshot; they still fall back to the date-based title.
     private var pendingTitle: String?
     private var pendingStartContext: MeetingStartContext?
+    private var pendingCalendarEventSnapshot: MeetingCalendarSnapshot?
 
     /// Pause / resume the in-flight recording. The state flip happens AFTER
     /// the service confirms — an optimistic flip before the await would race
@@ -232,6 +237,9 @@ final class MeetingRecordingFlowCoordinator {
         pendingTitle = title
         pendingAudioSourceMode = sourceMode
         pendingStartContext = makeStartContext(trigger: resolvedTrigger, sourceMode: sourceMode)
+        pendingCalendarEventSnapshot = (resolvedTrigger == .manual && title == nil)
+            ? probableCalendarSnapshotProvider()
+            : nil
         currentMeetingOperationContext = ObservabilityOperationContext()
         sendEvent(.startRequested)
         return stateMachine.generation
@@ -320,6 +328,23 @@ final class MeetingRecordingFlowCoordinator {
     /// often back-to-back meetings actually collide in the wild. Returns the
     /// recording generation on success (or `nil` when the state was busy).
     @discardableResult
+    func startFromCalendar(calendarEventSnapshot: MeetingCalendarSnapshot) -> Int? {
+        guard stateMachine.state == .idle else {
+            Telemetry.send(.calendarAutoStartFailed(reason: "state_busy"))
+            return nil
+        }
+        pendingTrigger = .calendarAutoStart
+        pendingTitle = calendarEventSnapshot.title
+        pendingCalendarEventSnapshot = calendarEventSnapshot
+        let sourceMode = meetingAudioSourceModeProvider()
+        pendingAudioSourceMode = sourceMode
+        pendingStartContext = makeStartContext(trigger: .calendarAutoStart, sourceMode: sourceMode)
+        currentMeetingOperationContext = ObservabilityOperationContext()
+        sendEvent(.startRequested)
+        return stateMachine.generation
+    }
+
+    @discardableResult
     func startFromCalendar(title: String? = nil) -> Int? {
         guard stateMachine.state == .idle else {
             Telemetry.send(.calendarAutoStartFailed(reason: "state_busy"))
@@ -330,6 +355,7 @@ final class MeetingRecordingFlowCoordinator {
         let sourceMode = meetingAudioSourceModeProvider()
         pendingAudioSourceMode = sourceMode
         pendingStartContext = makeStartContext(trigger: .calendarAutoStart, sourceMode: sourceMode)
+        pendingCalendarEventSnapshot = nil
         currentMeetingOperationContext = ObservabilityOperationContext()
         sendEvent(.startRequested)
         return stateMachine.generation
@@ -352,6 +378,7 @@ final class MeetingRecordingFlowCoordinator {
         )
         pendingTrigger = nil
         pendingTitle = nil
+        pendingCalendarEventSnapshot = nil
         pendingAudioSourceMode = nil
         pendingStartContext = nil
         currentMeetingOperationContext = nil
@@ -549,11 +576,13 @@ final class MeetingRecordingFlowCoordinator {
             // can't smuggle a stale trigger / title into this start.
             let trigger = pendingTrigger
             let title = pendingTitle
+            let calendarEventSnapshot = pendingCalendarEventSnapshot
             let sourceMode = pendingAudioSourceMode ?? meetingAudioSourceModeProvider()
             let startContext = pendingStartContext
                 ?? makeStartContext(trigger: trigger ?? .manual, sourceMode: sourceMode)
             pendingTrigger = nil
             pendingTitle = nil
+            pendingCalendarEventSnapshot = nil
             pendingAudioSourceMode = nil
             pendingStartContext = nil
             let operationContext = currentMeetingOperationContext ?? ObservabilityOperationContext()
@@ -564,7 +593,8 @@ final class MeetingRecordingFlowCoordinator {
                     try await meetingRecordingService.startRecording(
                         title: title,
                         sourceMode: sourceMode,
-                        startContext: startContext
+                        startContext: startContext,
+                        calendarEventSnapshot: calendarEventSnapshot
                     )
                     let isSpeechModelReady = await self.sttManager?.isReady() ?? true
                     switch self.panelViewModel?.liveTranscriptStatus {
@@ -712,6 +742,7 @@ final class MeetingRecordingFlowCoordinator {
             let cancelledTrigger = currentMeetingTrigger ?? pendingTrigger.map(TelemetryMeetingOperationTrigger.init)
             pendingTrigger = nil
             pendingTitle = nil
+            pendingCalendarEventSnapshot = nil
             pendingAudioSourceMode = nil
             pendingStartContext = nil
             actionTask?.cancel()
@@ -1301,6 +1332,7 @@ extension MeetingRecordingFlowCoordinator {
         currentMeetingTrigger = nil
         pendingTrigger = nil
         pendingTitle = nil
+        pendingCalendarEventSnapshot = nil
         pendingAudioSourceMode = nil
         pendingStartContext = nil
         _ = stateMachine.handle(.startRequested)

--- a/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
@@ -237,7 +237,7 @@ final class MeetingRecordingFlowCoordinator {
         pendingTitle = title
         pendingAudioSourceMode = sourceMode
         pendingStartContext = makeStartContext(trigger: resolvedTrigger, sourceMode: sourceMode)
-        pendingCalendarEventSnapshot = (resolvedTrigger == .manual && title == nil)
+        pendingCalendarEventSnapshot = (resolvedTrigger != .calendarAutoStart && title == nil)
             ? probableCalendarSnapshotProvider()
             : nil
         currentMeetingOperationContext = ObservabilityOperationContext()

--- a/Sources/MacParakeetCore/Calendar/CalendarEvent.swift
+++ b/Sources/MacParakeetCore/Calendar/CalendarEvent.swift
@@ -2,10 +2,9 @@ import Foundation
 
 /// A calendar event fetched from EventKit at poll time.
 ///
-/// MacParakeet does **not** persist these — the coordinator fetches and
-/// discards on each poll tick. See ADR-017 §6 for the rationale. If we ever
-/// need to query event history (e.g., for retro-linking recordings to events),
-/// add a `CalendarEvent` table then.
+/// MacParakeet does not persist the polling cache, but a meeting recording may
+/// snapshot the triggering event onto its local transcript row and artifacts.
+/// See ADR-017 §6 for the current persistence boundary.
 public struct CalendarEvent: Codable, Sendable, Identifiable {
     /// EventKit's `EKEvent.eventIdentifier`. Stable across syncs but can
     /// change for recurring events when the user edits a single occurrence.
@@ -23,6 +22,9 @@ public struct CalendarEvent: Codable, Sendable, Identifiable {
     /// Other attendees — current user is filtered out at conversion time
     /// (their participation status is captured separately in `userStatus`).
     public var participants: [EventParticipant]
+
+    /// EventKit's organizer, when supplied by the backing calendar.
+    public var organizer: EventParticipant?
 
     public var isAllDay: Bool
 
@@ -55,6 +57,7 @@ public struct CalendarEvent: Codable, Sendable, Identifiable {
         location: String? = nil,
         meetUrl: String? = nil,
         participants: [EventParticipant] = [],
+        organizer: EventParticipant? = nil,
         isAllDay: Bool = false,
         calendarName: String? = nil,
         calendarIdentifier: String? = nil,
@@ -69,6 +72,7 @@ public struct CalendarEvent: Codable, Sendable, Identifiable {
         self.location = location
         self.meetUrl = meetUrl
         self.participants = participants
+        self.organizer = organizer
         self.isAllDay = isAllDay
         self.calendarName = calendarName
         self.calendarIdentifier = calendarIdentifier

--- a/Sources/MacParakeetCore/Calendar/CalendarService.swift
+++ b/Sources/MacParakeetCore/Calendar/CalendarService.swift
@@ -232,7 +232,9 @@ public actor CalendarService {
 
     private func convertParticipant(_ participant: EKParticipant) -> EventParticipant {
         let email: String? = {
-            let urlString = participant.url.absoluteString
+            guard let urlString = (participant.value(forKey: "URL") as? URL)?.absoluteString else {
+                return nil
+            }
             if urlString.hasPrefix("mailto:") {
                 return urlString.replacingOccurrences(of: "mailto:", with: "")
             }

--- a/Sources/MacParakeetCore/Calendar/CalendarService.swift
+++ b/Sources/MacParakeetCore/Calendar/CalendarService.swift
@@ -202,20 +202,9 @@ public actor CalendarService {
         let participants = (ekEvent.attendees ?? []).compactMap { attendee -> EventParticipant? in
             if attendee.isCurrentUser { return nil }
 
-            let email: String? = {
-                let urlString = attendee.url.absoluteString
-                if urlString.hasPrefix("mailto:") {
-                    return urlString.replacingOccurrences(of: "mailto:", with: "")
-                }
-                return nil
-            }()
-
-            return EventParticipant(
-                email: email,
-                name: attendee.name,
-                status: mapStatus(attendee.participantStatus)
-            )
+            return convertParticipant(attendee)
         }
+        let organizer = ekEvent.organizer.map(convertParticipant)
 
         let meetUrl = linkParser.extractMeetingUrl(
             location: ekEvent.location,
@@ -231,12 +220,29 @@ public actor CalendarService {
             location: ekEvent.location,
             meetUrl: meetUrl,
             participants: participants,
+            organizer: organizer,
             isAllDay: ekEvent.isAllDay,
             calendarName: ekEvent.calendar?.title,
             calendarIdentifier: ekEvent.calendar?.calendarIdentifier,
             userStatus: userStatus,
             externalId: ekEvent.calendarItemExternalIdentifier,
             syncedAt: Date()
+        )
+    }
+
+    private func convertParticipant(_ participant: EKParticipant) -> EventParticipant {
+        let email: String? = {
+            let urlString = participant.url.absoluteString
+            if urlString.hasPrefix("mailto:") {
+                return urlString.replacingOccurrences(of: "mailto:", with: "")
+            }
+            return nil
+        }()
+
+        return EventParticipant(
+            email: email,
+            name: participant.name,
+            status: mapStatus(participant.participantStatus)
         )
     }
 

--- a/Sources/MacParakeetCore/Calendar/MeetingLinkParser.swift
+++ b/Sources/MacParakeetCore/Calendar/MeetingLinkParser.swift
@@ -78,12 +78,13 @@ public struct MeetingLinkParser: Sendable {
     /// Friendly service name for UI ("Zoom", "Google Meet", …).
     public func identifyService(from url: String?) -> String? {
         guard let url, !url.isEmpty else { return nil }
-        if url.contains("zoom.us") || url.contains("zoomgov.com") { return "Zoom" }
-        if url.contains("meet.google.com") { return "Google Meet" }
-        if url.contains("teams.microsoft.com") { return "Microsoft Teams" }
-        if url.contains("webex.com") { return "Webex" }
-        if url.contains("around.co") { return "Around" }
-        if url.contains("whereby.com") { return "Whereby" }
+        let normalized = url.lowercased()
+        if normalized.contains("zoom.us") || normalized.contains("zoomgov.com") { return "Zoom" }
+        if normalized.contains("meet.google.com") { return "Google Meet" }
+        if normalized.contains("teams.microsoft.com") { return "Microsoft Teams" }
+        if normalized.contains("webex.com") { return "Webex" }
+        if normalized.contains("around.co") { return "Around" }
+        if normalized.contains("whereby.com") { return "Whereby" }
         return nil
     }
 

--- a/Sources/MacParakeetCore/Calendar/MeetingMonitor.swift
+++ b/Sources/MacParakeetCore/Calendar/MeetingMonitor.swift
@@ -70,7 +70,7 @@ public enum MeetingMonitor {
             guard !event.isAllDay else { return false }
             guard event.userStatus != .declined else { return false }
             guard !dismissedEventIds.contains(event.dedupeKey) else { return false }
-            return passesFilter(event, filter: config.triggerFilter)
+            return passesTriggerFilter(event, filter: config.triggerFilter)
         }
 
         var result: [MonitorEvent] = []
@@ -124,7 +124,7 @@ public enum MeetingMonitor {
         }
     }
 
-    private static func passesFilter(_ event: CalendarEvent, filter: MeetingTriggerFilter) -> Bool {
+    public static func passesTriggerFilter(_ event: CalendarEvent, filter: MeetingTriggerFilter) -> Bool {
         switch filter {
         case .allEvents:
             return true

--- a/Sources/MacParakeetCore/Database/DatabaseManager.swift
+++ b/Sources/MacParakeetCore/Database/DatabaseManager.swift
@@ -1050,8 +1050,8 @@ public final class DatabaseManager: Sendable {
         }
 
         // v0.25 — Local EventKit context snapshot for meeting recordings.
-        // Keep this raw SQL so historical migrations never instantiate the
-        // evolving Transcription Codable shape while the column is absent.
+        // Keep the ALTER raw SQL so historical migrations never instantiate
+        // the evolving Transcription Codable shape while the column is absent.
         migrator.registerMigration("v0.25-meeting-calendar-event-snapshot") { db in
             let columns = try db.columns(in: "transcriptions").map(\.name)
             if !columns.contains("calendarEventSnapshot") {

--- a/Sources/MacParakeetCore/Database/DatabaseManager.swift
+++ b/Sources/MacParakeetCore/Database/DatabaseManager.swift
@@ -1049,6 +1049,16 @@ public final class DatabaseManager: Sendable {
             }
         }
 
+        // v0.25 — Local EventKit context snapshot for meeting recordings.
+        // Keep this raw SQL so historical migrations never instantiate the
+        // evolving Transcription Codable shape while the column is absent.
+        migrator.registerMigration("v0.25-meeting-calendar-event-snapshot") { db in
+            let columns = try db.columns(in: "transcriptions").map(\.name)
+            if !columns.contains("calendarEventSnapshot") {
+                try db.execute(sql: "ALTER TABLE transcriptions ADD COLUMN calendarEventSnapshot TEXT")
+            }
+        }
+
         try migrator.migrate(dbQueue)
         try reconcileBuiltInPrompts()
         try reconcileBuiltInQuickPrompts()

--- a/Sources/MacParakeetCore/Models/MeetingCalendarSnapshot.swift
+++ b/Sources/MacParakeetCore/Models/MeetingCalendarSnapshot.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+public struct MeetingCalendarSnapshot: Codable, Sendable, Equatable {
+    public enum Confidence: String, Codable, Sendable {
+        case confirmed
+        case probable
+    }
+
+    public var confidence: Confidence
+    public var eventIdentifier: String
+    public var externalId: String?
+    public var title: String
+    public var scheduledStartAt: Date
+    public var scheduledEndAt: Date
+    public var attendees: [MeetingCalendarPerson]
+    public var organizer: MeetingCalendarPerson?
+    public var meetingURL: String?
+    public var meetingService: String?
+    public var capturedAt: Date
+
+    public init(
+        confidence: Confidence,
+        eventIdentifier: String,
+        externalId: String? = nil,
+        title: String,
+        scheduledStartAt: Date,
+        scheduledEndAt: Date,
+        attendees: [MeetingCalendarPerson] = [],
+        organizer: MeetingCalendarPerson? = nil,
+        meetingURL: String? = nil,
+        meetingService: String? = nil,
+        capturedAt: Date = Date()
+    ) {
+        self.confidence = confidence
+        self.eventIdentifier = eventIdentifier
+        self.externalId = externalId
+        self.title = title
+        self.scheduledStartAt = scheduledStartAt
+        self.scheduledEndAt = scheduledEndAt
+        self.attendees = attendees
+        self.organizer = organizer
+        self.meetingURL = meetingURL
+        self.meetingService = meetingService
+        self.capturedAt = capturedAt
+    }
+}
+
+public struct MeetingCalendarPerson: Codable, Sendable, Equatable {
+    public var name: String?
+    public var email: String?
+
+    public init(name: String? = nil, email: String? = nil) {
+        self.name = name
+        self.email = email
+    }
+}
+
+public extension MeetingCalendarSnapshot {
+    init(
+        event: CalendarEvent,
+        confidence: Confidence,
+        capturedAt: Date = Date()
+    ) {
+        self.init(
+            confidence: confidence,
+            eventIdentifier: event.id,
+            externalId: event.externalId,
+            title: event.title,
+            scheduledStartAt: event.startTime,
+            scheduledEndAt: event.endTime,
+            attendees: event.participants.map {
+                MeetingCalendarPerson(name: $0.name, email: $0.email)
+            },
+            organizer: event.organizer.map {
+                MeetingCalendarPerson(name: $0.name, email: $0.email)
+            },
+            meetingURL: event.meetUrl,
+            meetingService: MeetingLinkParser.shared.identifyService(from: event.meetUrl),
+            capturedAt: capturedAt
+        )
+    }
+}

--- a/Sources/MacParakeetCore/Models/Transcription.swift
+++ b/Sources/MacParakeetCore/Models/Transcription.swift
@@ -57,6 +57,10 @@ public struct Transcription: Codable, Identifiable, Sendable {
     /// Engine-specific model variant id (e.g. the Whisper model id).
     /// `nil` for engines without variants and for legacy rows.
     public var engineVariant: String?
+    /// Local calendar context captured when a meeting recording was started
+    /// from, or probably overlaps, an EventKit event. Contains attendee data
+    /// and remains local-only.
+    public var calendarEventSnapshot: MeetingCalendarSnapshot?
     /// Display-ready title derived from the transcript content at completion
     /// (substantive first sentence, filler-stripped). `nil` when the transcript
     /// is empty or when the row predates v0.9 backfill.
@@ -106,6 +110,7 @@ public struct Transcription: Codable, Identifiable, Sendable {
         meetingStartContext: MeetingStartContext? = nil,
         engine: String? = nil,
         engineVariant: String? = nil,
+        calendarEventSnapshot: MeetingCalendarSnapshot? = nil,
         derivedTitle: String? = nil,
         derivedSnippet: String? = nil,
         updatedAt: Date = Date()
@@ -141,6 +146,7 @@ public struct Transcription: Codable, Identifiable, Sendable {
         self.meetingStartContext = meetingStartContext
         self.engine = engine
         self.engineVariant = engineVariant
+        self.calendarEventSnapshot = calendarEventSnapshot
         self.derivedTitle = derivedTitle
         self.derivedSnippet = derivedSnippet
         self.updatedAt = updatedAt
@@ -254,6 +260,7 @@ extension Transcription: FetchableRecord, PersistableRecord {
         case speakerCount, speakers, diarizationSegments, transcriptSegments, chatMessages
         case status, errorMessage, exportPath, sourceURL
         case thumbnailURL, channelName, videoDescription, isFavorite, sourceType, recoveredFromCrash, isTranscriptEdited, userNotes, meetingStartContext, engine, engineVariant, derivedTitle, derivedSnippet, updatedAt
+        case calendarEventSnapshot
     }
 
     /// Backward-compatible decoding: `speakers` column may contain old `[String]` JSON
@@ -319,6 +326,7 @@ extension Transcription: FetchableRecord, PersistableRecord {
         meetingStartContext = (try? container.decodeIfPresent(MeetingStartContext.self, forKey: .meetingStartContext)) ?? nil
         engine = try container.decodeIfPresent(String.self, forKey: .engine)
         engineVariant = try container.decodeIfPresent(String.self, forKey: .engineVariant)
+        calendarEventSnapshot = (try? container.decodeIfPresent(MeetingCalendarSnapshot.self, forKey: .calendarEventSnapshot)) ?? nil
         derivedTitle = try container.decodeIfPresent(String.self, forKey: .derivedTitle)
         derivedSnippet = try container.decodeIfPresent(String.self, forKey: .derivedSnippet)
         updatedAt = try container.decode(Date.self, forKey: .updatedAt)

--- a/Sources/MacParakeetCore/Models/Transcription.swift
+++ b/Sources/MacParakeetCore/Models/Transcription.swift
@@ -326,7 +326,10 @@ extension Transcription: FetchableRecord, PersistableRecord {
         meetingStartContext = (try? container.decodeIfPresent(MeetingStartContext.self, forKey: .meetingStartContext)) ?? nil
         engine = try container.decodeIfPresent(String.self, forKey: .engine)
         engineVariant = try container.decodeIfPresent(String.self, forKey: .engineVariant)
-        calendarEventSnapshot = (try? container.decodeIfPresent(MeetingCalendarSnapshot.self, forKey: .calendarEventSnapshot)) ?? nil
+        calendarEventSnapshot = (try? container.decodeIfPresent(
+            MeetingCalendarSnapshot.self,
+            forKey: .calendarEventSnapshot
+        )) ?? nil
         derivedTitle = try container.decodeIfPresent(String.self, forKey: .derivedTitle)
         derivedSnippet = try container.decodeIfPresent(String.self, forKey: .derivedSnippet)
         updatedAt = try container.decode(Date.self, forKey: .updatedAt)

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingArtifactStore.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingArtifactStore.swift
@@ -35,6 +35,7 @@ public struct MeetingArtifactSnapshot: Codable, Sendable, Equatable {
     public let promptResultsPath: String
     public let promptResultsDirectoryPath: String
     public let promptResultCount: Int
+    public let calendarEventSnapshot: MeetingCalendarSnapshot?
 
     public init(
         schema: String = MeetingArtifactStore.schema,
@@ -48,7 +49,8 @@ public struct MeetingArtifactSnapshot: Codable, Sendable, Equatable {
         notesPath: String?,
         promptResultsPath: String,
         promptResultsDirectoryPath: String,
-        promptResultCount: Int
+        promptResultCount: Int,
+        calendarEventSnapshot: MeetingCalendarSnapshot? = nil
     ) {
         self.schema = schema
         self.schemaVersion = schemaVersion
@@ -62,6 +64,7 @@ public struct MeetingArtifactSnapshot: Codable, Sendable, Equatable {
         self.promptResultsPath = promptResultsPath
         self.promptResultsDirectoryPath = promptResultsDirectoryPath
         self.promptResultCount = promptResultCount
+        self.calendarEventSnapshot = calendarEventSnapshot
     }
 }
 
@@ -131,7 +134,8 @@ public final class MeetingArtifactStore: MeetingArtifactStoring, @unchecked Send
             notesPath: notesPath,
             promptResultsPath: promptResultsURL.path,
             promptResultsDirectoryPath: promptResultsDirectoryURL.path,
-            promptResultCount: promptResults.count
+            promptResultCount: promptResults.count,
+            calendarEventSnapshot: transcription.calendarEventSnapshot
         )
         try writeJSON(
             MeetingArtifactManifest(
@@ -259,6 +263,7 @@ private struct MeetingArtifactMeetingSummary: Codable {
     let language: String?
     let engine: String?
     let engineVariant: String?
+    let calendarEventSnapshot: MeetingCalendarSnapshot?
     let recoveredFromCrash: Bool
     let isTranscriptEdited: Bool
     let startContext: MeetingStartContext?
@@ -273,6 +278,7 @@ private struct MeetingArtifactMeetingSummary: Codable {
         language = transcription.language
         engine = transcription.engine
         engineVariant = transcription.engineVariant
+        calendarEventSnapshot = transcription.calendarEventSnapshot
         recoveredFromCrash = transcription.recoveredFromCrash
         isTranscriptEdited = transcription.isTranscriptEdited
         startContext = transcription.meetingStartContext
@@ -338,6 +344,7 @@ private struct MeetingArtifactTranscript: Codable {
     let language: String?
     let engine: String?
     let engineVariant: String?
+    let calendarEventSnapshot: MeetingCalendarSnapshot?
     let sourceURL: String?
     let sourceType: Transcription.SourceType
     let recoveredFromCrash: Bool
@@ -363,6 +370,7 @@ private struct MeetingArtifactTranscript: Codable {
         language = transcription.language
         engine = transcription.engine
         engineVariant = transcription.engineVariant
+        calendarEventSnapshot = transcription.calendarEventSnapshot
         sourceURL = transcription.sourceURL
         sourceType = transcription.sourceType
         recoveredFromCrash = transcription.recoveredFromCrash

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingLockFileStore.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingLockFileStore.swift
@@ -8,8 +8,8 @@ public enum MeetingRecordingLockState: String, Codable, Sendable, Equatable {
 
 public struct MeetingRecordingLockFile: Codable, Sendable, Equatable {
     /// Schema version is intentionally left at 1 because `notes`,
-    /// `speechEngine`, and `startContext` are backward-compatible additive
-    /// fields (`decodeIfPresent`).
+    /// `speechEngine`, `startContext`, and `calendarEventSnapshot` are
+    /// backward-compatible additive fields.
     /// See ADR-020 §9. The version guard in `MeetingRecordingLockFileStore.read()`
     /// uses `<=` so a lock file written by an OLDER app version is still
     /// readable; a future bump only needs to keep this property + bump the
@@ -27,6 +27,7 @@ public struct MeetingRecordingLockFile: Codable, Sendable, Equatable {
     public let state: MeetingRecordingLockState
     public let speechEngine: SpeechEngineSelection
     public let startContext: MeetingStartContext?
+    public let calendarEventSnapshot: MeetingCalendarSnapshot?
     /// Free-form notes the user typed during the meeting. Persisted on
     /// every notepad debounce so a crash recovers what the user had written
     /// up to the last debounce fire. Decoded independently of the rest of
@@ -44,6 +45,7 @@ public struct MeetingRecordingLockFile: Codable, Sendable, Equatable {
         case state
         case speechEngine
         case startContext
+        case calendarEventSnapshot
         case notes
     }
 
@@ -56,6 +58,7 @@ public struct MeetingRecordingLockFile: Codable, Sendable, Equatable {
         state: MeetingRecordingLockState = .recording,
         speechEngine: SpeechEngineSelection = SpeechEngineSelection(engine: .parakeet),
         startContext: MeetingStartContext? = nil,
+        calendarEventSnapshot: MeetingCalendarSnapshot? = nil,
         notes: String? = nil,
         folderURL: URL? = nil
     ) {
@@ -67,6 +70,7 @@ public struct MeetingRecordingLockFile: Codable, Sendable, Equatable {
         self.state = state
         self.speechEngine = speechEngine
         self.startContext = startContext
+        self.calendarEventSnapshot = calendarEventSnapshot
         self.notes = notes
         self.folderURL = folderURL
     }
@@ -82,6 +86,10 @@ public struct MeetingRecordingLockFile: Codable, Sendable, Equatable {
         speechEngine = try container.decodeIfPresent(SpeechEngineSelection.self, forKey: .speechEngine)
             ?? SpeechEngineSelection(engine: .parakeet)
         startContext = (try? container.decodeIfPresent(MeetingStartContext.self, forKey: .startContext)) ?? nil
+        calendarEventSnapshot = (try? container.decodeIfPresent(
+            MeetingCalendarSnapshot.self,
+            forKey: .calendarEventSnapshot
+        )) ?? nil
         // Notes are decoded independently — see ADR-020 §9. If a future encoder
         // bug or hand-edited file produces a malformed `notes` value, recovery
         // of the audio metadata still succeeds; only the typed notes are lost.
@@ -99,6 +107,7 @@ public struct MeetingRecordingLockFile: Codable, Sendable, Equatable {
         try container.encode(state, forKey: .state)
         try container.encode(speechEngine, forKey: .speechEngine)
         try container.encodeIfPresent(startContext, forKey: .startContext)
+        try container.encodeIfPresent(calendarEventSnapshot, forKey: .calendarEventSnapshot)
         try container.encodeIfPresent(notes, forKey: .notes)
     }
 
@@ -112,6 +121,7 @@ public struct MeetingRecordingLockFile: Codable, Sendable, Equatable {
             state: state,
             speechEngine: speechEngine,
             startContext: startContext,
+            calendarEventSnapshot: calendarEventSnapshot,
             notes: notes,
             folderURL: folderURL
         )
@@ -127,6 +137,7 @@ public struct MeetingRecordingLockFile: Codable, Sendable, Equatable {
             state: state,
             speechEngine: speechEngine,
             startContext: startContext,
+            calendarEventSnapshot: calendarEventSnapshot,
             notes: notes,
             folderURL: folderURL
         )
@@ -142,6 +153,7 @@ public struct MeetingRecordingLockFile: Codable, Sendable, Equatable {
             state: state,
             speechEngine: speechEngine,
             startContext: startContext,
+            calendarEventSnapshot: calendarEventSnapshot,
             notes: notes,
             folderURL: folderURL
         )

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingLockFileStore.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingLockFileStore.swift
@@ -86,6 +86,8 @@ public struct MeetingRecordingLockFile: Codable, Sendable, Equatable {
         speechEngine = try container.decodeIfPresent(SpeechEngineSelection.self, forKey: .speechEngine)
             ?? SpeechEngineSelection(engine: .parakeet)
         startContext = (try? container.decodeIfPresent(MeetingStartContext.self, forKey: .startContext)) ?? nil
+        // Calendar snapshots are best-effort context. A malformed optional
+        // snapshot must not block lock-file recovery of the audio metadata.
         calendarEventSnapshot = (try? container.decodeIfPresent(
             MeetingCalendarSnapshot.self,
             forKey: .calendarEventSnapshot

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingMetadata.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingMetadata.swift
@@ -56,18 +56,21 @@ public struct MeetingRecordingMetadata: Sendable, Codable, Equatable {
     public let speechEngineWasCaptured: Bool
     public let startContext: MeetingStartContext?
     public let echoSuppression: MeetingEchoSuppressionMetadata?
+    public let calendarEventSnapshot: MeetingCalendarSnapshot?
 
     public init(
         sourceAlignment: MeetingSourceAlignment,
         speechEngine: SpeechEngineSelection = SpeechEngineSelection(engine: .parakeet),
         startContext: MeetingStartContext? = nil,
-        echoSuppression: MeetingEchoSuppressionMetadata? = nil
+        echoSuppression: MeetingEchoSuppressionMetadata? = nil,
+        calendarEventSnapshot: MeetingCalendarSnapshot? = nil
     ) {
         self.sourceAlignment = sourceAlignment
         self.speechEngine = speechEngine
         self.speechEngineWasCaptured = true
         self.startContext = startContext
         self.echoSuppression = echoSuppression
+        self.calendarEventSnapshot = calendarEventSnapshot
     }
 
     private init(
@@ -75,13 +78,15 @@ public struct MeetingRecordingMetadata: Sendable, Codable, Equatable {
         speechEngine: SpeechEngineSelection,
         speechEngineWasCaptured: Bool,
         startContext: MeetingStartContext?,
-        echoSuppression: MeetingEchoSuppressionMetadata?
+        echoSuppression: MeetingEchoSuppressionMetadata?,
+        calendarEventSnapshot: MeetingCalendarSnapshot?
     ) {
         self.sourceAlignment = sourceAlignment
         self.speechEngine = speechEngine
         self.speechEngineWasCaptured = speechEngineWasCaptured
         self.startContext = startContext
         self.echoSuppression = echoSuppression
+        self.calendarEventSnapshot = calendarEventSnapshot
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -89,6 +94,7 @@ public struct MeetingRecordingMetadata: Sendable, Codable, Equatable {
         case speechEngine
         case startContext
         case echoSuppression
+        case calendarEventSnapshot
     }
 
     public init(from decoder: Decoder) throws {
@@ -102,6 +108,10 @@ public struct MeetingRecordingMetadata: Sendable, Codable, Equatable {
             MeetingEchoSuppressionMetadata.self,
             forKey: .echoSuppression
         )
+        calendarEventSnapshot = (try? container.decodeIfPresent(
+            MeetingCalendarSnapshot.self,
+            forKey: .calendarEventSnapshot
+        )) ?? nil
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -112,6 +122,7 @@ public struct MeetingRecordingMetadata: Sendable, Codable, Equatable {
         }
         try container.encodeIfPresent(startContext, forKey: .startContext)
         try container.encodeIfPresent(echoSuppression, forKey: .echoSuppression)
+        try container.encodeIfPresent(calendarEventSnapshot, forKey: .calendarEventSnapshot)
     }
 
     public func withEchoSuppression(
@@ -122,7 +133,8 @@ public struct MeetingRecordingMetadata: Sendable, Codable, Equatable {
             speechEngine: speechEngine,
             speechEngineWasCaptured: speechEngineWasCaptured,
             startContext: startContext,
-            echoSuppression: echoSuppression
+            echoSuppression: echoSuppression,
+            calendarEventSnapshot: calendarEventSnapshot
         )
     }
 }

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingOutput.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingOutput.swift
@@ -25,6 +25,8 @@ public struct MeetingRecordingOutput: Sendable, Equatable {
     /// post-meeting summary generation can steer on what the user emphasized
     /// (ADR-020). `nil` when the user took no notes.
     public let userNotes: String?
+    /// Local calendar context captured when the recording started.
+    public let calendarEventSnapshot: MeetingCalendarSnapshot?
 
     public init(
         sessionID: UUID,
@@ -39,7 +41,8 @@ public struct MeetingRecordingOutput: Sendable, Equatable {
         speechEngine: SpeechEngineSelection = SpeechEngineSelection(engine: .parakeet),
         speechEngineWasCaptured: Bool = true,
         startContext: MeetingStartContext? = nil,
-        userNotes: String? = nil
+        userNotes: String? = nil,
+        calendarEventSnapshot: MeetingCalendarSnapshot? = nil
     ) {
         self.init(
             sessionID: sessionID,
@@ -55,7 +58,8 @@ public struct MeetingRecordingOutput: Sendable, Equatable {
             speechEngine: speechEngine,
             speechEngineWasCaptured: speechEngineWasCaptured,
             startContext: startContext,
-            userNotes: userNotes
+            userNotes: userNotes,
+            calendarEventSnapshot: calendarEventSnapshot
         )
     }
 
@@ -73,7 +77,8 @@ public struct MeetingRecordingOutput: Sendable, Equatable {
         speechEngine: SpeechEngineSelection = SpeechEngineSelection(engine: .parakeet),
         speechEngineWasCaptured: Bool = true,
         startContext: MeetingStartContext? = nil,
-        userNotes: String? = nil
+        userNotes: String? = nil,
+        calendarEventSnapshot: MeetingCalendarSnapshot? = nil
     ) {
         self.sessionID = sessionID
         self.displayName = displayName
@@ -89,6 +94,7 @@ public struct MeetingRecordingOutput: Sendable, Equatable {
         self.speechEngineWasCaptured = speechEngineWasCaptured
         self.startContext = startContext
         self.userNotes = userNotes
+        self.calendarEventSnapshot = calendarEventSnapshot
     }
 
     /// The microphone audio to transcribe for the local ("Me") track: the
@@ -170,7 +176,8 @@ public struct MeetingRecordingOutput: Sendable, Equatable {
             sourceAlignment: metadata.sourceAlignment,
             speechEngine: metadata.speechEngine,
             speechEngineWasCaptured: metadata.speechEngineWasCaptured,
-            startContext: metadata.startContext
+            startContext: metadata.startContext,
+            calendarEventSnapshot: metadata.calendarEventSnapshot
         )
     }
 
@@ -206,5 +213,6 @@ public struct MeetingRecordingOutput: Sendable, Equatable {
             && lhs.speechEngineWasCaptured == rhs.speechEngineWasCaptured
             && lhs.startContext == rhs.startContext
             && lhs.userNotes == rhs.userNotes
+            && lhs.calendarEventSnapshot == rhs.calendarEventSnapshot
     }
 }

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingRecoveryService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingRecoveryService.swift
@@ -199,7 +199,8 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
             MeetingRecordingMetadata(
                 sourceAlignment: sourceAlignment,
                 speechEngine: lock.speechEngine,
-                startContext: lock.startContext
+                startContext: lock.startContext,
+                calendarEventSnapshot: lock.calendarEventSnapshot
             ),
             folderURL: folderURL
         )
@@ -247,7 +248,8 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
             sourceAlignment: sourceAlignment,
             speechEngine: lock.speechEngine,
             startContext: lock.startContext,
-            userNotes: lock.notes
+            userNotes: lock.notes,
+            calendarEventSnapshot: lock.calendarEventSnapshot
         )
 
         do {

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
@@ -39,7 +39,8 @@ public protocol MeetingRecordingServiceProtocol: Sendable {
     func startRecording(
         title: String?,
         sourceMode: MeetingAudioSourceMode?,
-        startContext: MeetingStartContext?
+        startContext: MeetingStartContext?,
+        calendarEventSnapshot: MeetingCalendarSnapshot?
     ) async throws
     func stopRecording() async throws -> MeetingRecordingOutput
     func completeTranscription(for recording: MeetingRecordingOutput) async
@@ -82,15 +83,20 @@ public extension MeetingRecordingServiceProtocol {
     /// Existing manual / hotkey callers use the no-arg form — the calendar
     /// path is the only caller that has a meaningful title to pass.
     func startRecording(title: String?) async throws {
-        try await startRecording(title: title, sourceMode: nil, startContext: nil)
+        try await startRecording(title: title, sourceMode: nil, startContext: nil, calendarEventSnapshot: nil)
     }
 
     func startRecording(title: String?, sourceMode: MeetingAudioSourceMode?) async throws {
-        try await startRecording(title: title, sourceMode: sourceMode, startContext: nil)
+        try await startRecording(
+            title: title,
+            sourceMode: sourceMode,
+            startContext: nil,
+            calendarEventSnapshot: nil
+        )
     }
 
     func startRecording() async throws {
-        try await startRecording(title: nil, sourceMode: nil, startContext: nil)
+        try await startRecording(title: nil, sourceMode: nil, startContext: nil, calendarEventSnapshot: nil)
     }
 }
 
@@ -138,6 +144,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         let mixedAudioURL: URL
         let speechEngine: SpeechEngineSelection
         let startContext: MeetingStartContext?
+        let calendarEventSnapshot: MeetingCalendarSnapshot?
 
         var supportsLiveChunkTranscription: Bool {
             speechEngine.engine != .cohere
@@ -398,7 +405,8 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
     public func startRecording(
         title: String? = nil,
         sourceMode: MeetingAudioSourceMode? = nil,
-        startContext: MeetingStartContext? = nil
+        startContext: MeetingStartContext? = nil,
+        calendarEventSnapshot: MeetingCalendarSnapshot? = nil
     ) async throws {
         guard currentSession == nil, startingSessionID == nil else {
             throw MeetingAudioError.alreadyRunning
@@ -435,7 +443,8 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
             systemAudioURL: writer.systemAudioURL,
             mixedAudioURL: writer.mixedAudioURL,
             speechEngine: speechEngine,
-            startContext: startContext
+            startContext: startContext,
+            calendarEventSnapshot: calendarEventSnapshot
         )
         self.writer = writer
         self.currentSession = session
@@ -448,6 +457,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
                 displayName: session.displayName,
                 speechEngine: session.speechEngine,
                 startContext: session.startContext,
+                calendarEventSnapshot: session.calendarEventSnapshot,
                 folderURL: session.folderURL
             )
             try lockFileStore.write(initialLock, folderURL: session.folderURL)
@@ -610,7 +620,8 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
                 MeetingRecordingMetadata(
                     sourceAlignment: sourceAlignment,
                     speechEngine: session.speechEngine,
-                    startContext: session.startContext
+                    startContext: session.startContext,
+                    calendarEventSnapshot: session.calendarEventSnapshot
                 ),
                 folderURL: session.folderURL
             )
@@ -656,6 +667,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
             displayName: session.displayName,
             speechEngine: session.speechEngine,
             startContext: session.startContext,
+            calendarEventSnapshot: session.calendarEventSnapshot,
             folderURL: session.folderURL
         ))
             .withNotes(finalNotes)
@@ -699,7 +711,8 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
             sourceAlignment: sourceAlignment,
             speechEngine: session.speechEngine,
             startContext: session.startContext,
-            userNotes: finalNotes
+            userNotes: finalNotes,
+            calendarEventSnapshot: session.calendarEventSnapshot
         )
 
         await liveChunkTranscriber.finishSession()
@@ -762,6 +775,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
             displayName: session.displayName,
             speechEngine: session.speechEngine,
             startContext: session.startContext,
+            calendarEventSnapshot: session.calendarEventSnapshot,
             folderURL: session.folderURL
         )
         let updated = base.withNotes(normalized)

--- a/Sources/MacParakeetCore/Services/TranscriptionService.swift
+++ b/Sources/MacParakeetCore/Services/TranscriptionService.swift
@@ -428,6 +428,7 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
             transcription.errorMessage = nil
             transcription.userNotes = transcription.userNotes ?? recording.userNotes
             transcription.meetingStartContext = transcription.meetingStartContext ?? recording.startContext
+            transcription.calendarEventSnapshot = transcription.calendarEventSnapshot ?? recording.calendarEventSnapshot
             transcription.updatedAt = Date()
             try transcriptionRepo.save(transcription)
 
@@ -519,6 +520,7 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
         transcription.fileSizeBytes = (try? FileManager.default.attributesOfItem(atPath: recording.mixedAudioURL.path)[.size] as? Int)
             .flatMap { $0 } ?? original.fileSizeBytes
         transcription.userNotes = original.userNotes ?? recording.userNotes
+        transcription.calendarEventSnapshot = original.calendarEventSnapshot ?? recording.calendarEventSnapshot
         let operation = TranscriptionOperationContext(
             source: .meeting,
             inputKind: .meeting,
@@ -1068,7 +1070,8 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
             sourceType: .meeting,
             userNotes: recording.userNotes,
             meetingStartContext: recording.startContext,
-            engine: recording.speechEngine.engine.rawValue
+            engine: recording.speechEngine.engine.rawValue,
+            calendarEventSnapshot: recording.calendarEventSnapshot
         )
     }
 

--- a/Tests/CLITests/MeetingsCommandTests.swift
+++ b/Tests/CLITests/MeetingsCommandTests.swift
@@ -520,6 +520,68 @@ final class MeetingsCommandTests: XCTestCase {
         ))
     }
 
+    func testShowJSONIncludesCalendarEventSnapshot() async throws {
+        let dbURL = temporaryDatabaseURL()
+        defer { try? FileManager.default.removeItem(at: dbURL) }
+
+        let scheduledStart = Date(timeIntervalSince1970: 1_720_000_000)
+        let scheduledEnd = Date(timeIntervalSince1970: 1_720_003_600)
+        let calendarSnapshot = MeetingCalendarSnapshot(
+            confidence: .confirmed,
+            eventIdentifier: "evt-cli",
+            externalId: "external-cli",
+            title: "CLI Contract Review",
+            scheduledStartAt: scheduledStart,
+            scheduledEndAt: scheduledEnd,
+            attendees: [
+                MeetingCalendarPerson(name: "Alice Example", email: "alice@example.com"),
+            ],
+            organizer: MeetingCalendarPerson(name: "Omar Organizer", email: "omar@example.com"),
+            meetingURL: "https://meet.google.com/abc-defg-hij",
+            meetingService: "Google Meet",
+            capturedAt: Date(timeIntervalSince1970: 1_720_000_010)
+        )
+        let db = try DatabaseManager(path: dbURL.path)
+        let transcriptionRepo = TranscriptionRepository(dbQueue: db.dbQueue)
+        let meeting = Transcription(
+            fileName: "CLI Contract Review",
+            rawTranscript: "Calendar context is local-only.",
+            status: .completed,
+            sourceType: .meeting,
+            calendarEventSnapshot: calendarSnapshot
+        )
+        try transcriptionRepo.save(meeting)
+
+        let showCommand = try MeetingsCommand.ShowSubcommand.parse([
+            meeting.id.uuidString,
+            "--json",
+            "--database", dbURL.path,
+        ])
+        let showOutput = try await captureStandardOutput {
+            try await showCommand.run()
+        }
+        let showPayload = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(showOutput.utf8)) as? [String: Any]
+        )
+        let snapshot = try XCTUnwrap(showPayload["calendarEventSnapshot"] as? [String: Any])
+
+        XCTAssertEqual(snapshot["confidence"] as? String, "confirmed")
+        XCTAssertEqual(snapshot["eventIdentifier"] as? String, "evt-cli")
+        XCTAssertEqual(snapshot["externalId"] as? String, "external-cli")
+        XCTAssertEqual(snapshot["title"] as? String, "CLI Contract Review")
+        let dateFormatter = ISO8601DateFormatter()
+        XCTAssertEqual(snapshot["scheduledStartAt"] as? String, dateFormatter.string(from: scheduledStart))
+        XCTAssertEqual(snapshot["scheduledEndAt"] as? String, dateFormatter.string(from: scheduledEnd))
+        XCTAssertEqual(snapshot["meetingURL"] as? String, "https://meet.google.com/abc-defg-hij")
+        XCTAssertEqual(snapshot["meetingService"] as? String, "Google Meet")
+        let attendees = try XCTUnwrap(snapshot["attendees"] as? [[String: Any]])
+        XCTAssertEqual(attendees.first?["name"] as? String, "Alice Example")
+        XCTAssertEqual(attendees.first?["email"] as? String, "alice@example.com")
+        let organizer = try XCTUnwrap(snapshot["organizer"] as? [String: Any])
+        XCTAssertEqual(organizer["name"] as? String, "Omar Organizer")
+        XCTAssertEqual(organizer["email"] as? String, "omar@example.com")
+    }
+
     func testFormatRawValues() {
         XCTAssertEqual(MeetingTranscriptFormat(rawValue: "text"), .text)
         XCTAssertEqual(MeetingTranscriptFormat(rawValue: "json"), .json)

--- a/Tests/MacParakeetTests/Calendar/MeetingAutoStartCoordinatorTests.swift
+++ b/Tests/MacParakeetTests/Calendar/MeetingAutoStartCoordinatorTests.swift
@@ -15,7 +15,7 @@ final class MeetingAutoStartCoordinatorTests: XCTestCase {
     /// Tracks calls to the recording-flow callbacks the coordinator makes.
     private var recordingActiveStub = false
     private var autoStartConfirmedCount = 0
-    private var autoStartConfirmedTitles: [String] = []
+    private var autoStartConfirmedSnapshots: [MeetingCalendarSnapshot] = []
     /// When true, the `onAutoStartConfirmed` stub mimics the real flow
     /// coordinator's `state_busy` rejection by returning nil — exercising the
     /// back-to-back retry path (#8).
@@ -34,7 +34,7 @@ final class MeetingAutoStartCoordinatorTests: XCTestCase {
         calendarService = MockCalendarService()
         recordingActiveStub = false
         autoStartConfirmedCount = 0
-        autoStartConfirmedTitles = []
+        autoStartConfirmedSnapshots = []
         simulateAutoStartBusy = false
     }
 
@@ -67,10 +67,10 @@ final class MeetingAutoStartCoordinatorTests: XCTestCase {
             calendarService: calendarService,
             settingsViewModel: settingsViewModel,
             isRecordingActive: { [weak self] in self?.recordingActiveStub ?? false },
-            onAutoStartConfirmed: { [weak self] title in
+            onAutoStartConfirmed: { [weak self] snapshot in
                 guard let self else { return nil }
                 self.autoStartConfirmedCount += 1
-                self.autoStartConfirmedTitles.append(title)
+                self.autoStartConfirmedSnapshots.append(snapshot)
                 if self.simulateAutoStartBusy {
                     // Mimic MeetingRecordingFlowCoordinator.startFromCalendar's
                     // synchronous state_busy path: reject with nil.
@@ -212,10 +212,46 @@ final class MeetingAutoStartCoordinatorTests: XCTestCase {
                        "Recording start callback must fire on .completed outcome")
         // Title forwarding: the calendar event name is what the saved
         // recording will be titled, not the date-based default.
-        XCTAssertEqual(autoStartConfirmedTitles, [uniqueTitle],
+        XCTAssertEqual(autoStartConfirmedSnapshots.map(\.title), [uniqueTitle],
                        "Auto-start must forward the event title so the saved recording is named after the meeting")
+        XCTAssertEqual(autoStartConfirmedSnapshots.first?.confidence, .confirmed)
+        XCTAssertEqual(autoStartConfirmedSnapshots.first?.eventIdentifier, "evt-1")
 
         coordinator.stop()
+    }
+
+    func testProbableManualStartSnapshotUsesLatestPollWithoutFetchingAgain() async throws {
+        calendarService.stubPermissionStatus = .granted
+        let currentEvent = event(
+            id: "evt-current",
+            title: "Customer Review",
+            startsIn: -60,
+            durationMinutes: 30,
+            meetUrl: "https://meet.google.com/abc-defg-hij"
+        )
+        calendarService.stubEvents = [currentEvent]
+        seedSettings(mode: .notify)
+
+        let coordinator = makeCoordinator()
+        coordinator.testHook_forcePoll()
+        await waitForPoll()
+        let fetchCountAfterPoll = calendarService.fetchUpcomingEventsCallCount
+
+        let snapshot = try XCTUnwrap(coordinator.testHook_probableSnapshotForManualStart())
+        XCTAssertEqual(snapshot.confidence, .probable)
+        XCTAssertEqual(snapshot.eventIdentifier, "evt-current")
+        XCTAssertEqual(snapshot.title, "Customer Review")
+        XCTAssertEqual(snapshot.meetingService, "Google Meet")
+        XCTAssertEqual(calendarService.fetchUpcomingEventsCallCount, fetchCountAfterPoll)
+    }
+
+    func testProbableManualStartSnapshotIsNilWithoutPollData() {
+        calendarService.stubPermissionStatus = .granted
+        seedSettings(mode: .notify)
+
+        let coordinator = makeCoordinator()
+
+        XCTAssertNil(coordinator.testHook_probableSnapshotForManualStart())
     }
 
     func testAutoStartCompletionIgnoredAfterModeTurnsOff() {

--- a/Tests/MacParakeetTests/Calendar/MeetingAutoStartCoordinatorTests.swift
+++ b/Tests/MacParakeetTests/Calendar/MeetingAutoStartCoordinatorTests.swift
@@ -114,6 +114,17 @@ final class MeetingAutoStartCoordinatorTests: XCTestCase {
         }
     }
 
+    private func waitForFetchCount(atLeast expected: Int) async -> Bool {
+        for _ in 0..<20 {
+            if calendarService.fetchUpcomingEventsCallCount >= expected {
+                return true
+            }
+            await Task.yield()
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return calendarService.fetchUpcomingEventsCallCount >= expected
+    }
+
     // MARK: - Lifecycle
 
     func testStopIsIdempotentAndDoesNotCrashIfNotStarted() {
@@ -243,6 +254,145 @@ final class MeetingAutoStartCoordinatorTests: XCTestCase {
         XCTAssertEqual(snapshot.title, "Customer Review")
         XCTAssertEqual(snapshot.meetingService, "Google Meet")
         XCTAssertEqual(calendarService.fetchUpcomingEventsCallCount, fetchCountAfterPoll)
+    }
+
+    func testProbableManualStartSnapshotHonorsCurrentExcludedCalendarsWithoutFetchingAgain() async throws {
+        calendarService.stubPermissionStatus = .granted
+        calendarService.stubEvents = [
+            event(
+                id: "evt-current",
+                title: "Excluded Customer Review",
+                startsIn: -60,
+                durationMinutes: 30,
+                meetUrl: "https://meet.google.com/abc-defg-hij"
+            ),
+        ]
+        seedSettings(mode: .notify)
+
+        let coordinator = makeCoordinator()
+        coordinator.testHook_forcePoll()
+        await waitForPoll()
+        let fetchCountAfterPoll = calendarService.fetchUpcomingEventsCallCount
+
+        settingsViewModel.calendarExcludedIdentifiers = ["cal-1"]
+
+        XCTAssertNil(coordinator.testHook_probableSnapshotForManualStart())
+        XCTAssertEqual(calendarService.fetchUpcomingEventsCallCount, fetchCountAfterPoll)
+    }
+
+    func testProbableManualStartSnapshotHonorsCurrentTriggerFilterWithoutFetchingAgain() async throws {
+        calendarService.stubPermissionStatus = .granted
+        calendarService.stubEvents = [
+            event(
+                id: "evt-current",
+                title: "No Link Calendar Block",
+                startsIn: -60,
+                durationMinutes: 30,
+                meetUrl: nil
+            ),
+        ]
+        seedSettings(mode: .notify, triggerFilter: .allEvents)
+
+        let coordinator = makeCoordinator()
+        coordinator.testHook_forcePoll()
+        await waitForPoll()
+        let fetchCountAfterPoll = calendarService.fetchUpcomingEventsCallCount
+
+        XCTAssertNotNil(coordinator.testHook_probableSnapshotForManualStart())
+
+        settingsViewModel.meetingTriggerFilter = .withLink
+
+        XCTAssertNil(coordinator.testHook_probableSnapshotForManualStart())
+        XCTAssertEqual(calendarService.fetchUpcomingEventsCallCount, fetchCountAfterPoll)
+    }
+
+    func testProbableManualStartSnapshotSkipsPendingInviteWithoutFetchingAgain() async throws {
+        calendarService.stubPermissionStatus = .granted
+        var pendingEvent = event(
+            id: "evt-current",
+            title: "Pending Customer Review",
+            startsIn: -60,
+            durationMinutes: 30,
+            meetUrl: "https://meet.google.com/abc-defg-hij"
+        )
+        pendingEvent.userStatus = .pending
+        calendarService.stubEvents = [pendingEvent]
+        seedSettings(mode: .notify)
+
+        let coordinator = makeCoordinator()
+        coordinator.testHook_forcePoll()
+        await waitForPoll()
+        let fetchCountAfterPoll = calendarService.fetchUpcomingEventsCallCount
+
+        XCTAssertNil(coordinator.testHook_probableSnapshotForManualStart())
+        XCTAssertEqual(calendarService.fetchUpcomingEventsCallCount, fetchCountAfterPoll)
+    }
+
+    func testCalendarChangeClearsProbableManualStartSnapshotUntilRefreshCompletes() async throws {
+        calendarService.stubPermissionStatus = .granted
+        let currentEvent = event(
+            id: "evt-current",
+            title: "Customer Review",
+            startsIn: -60,
+            durationMinutes: 30,
+            meetUrl: "https://meet.google.com/abc-defg-hij"
+        )
+        calendarService.stubEvents = [currentEvent]
+        seedSettings(mode: .notify)
+
+        let coordinator = makeCoordinator()
+        coordinator.start()
+        await waitForPoll()
+        let fetchCountAfterInitialPoll = calendarService.fetchUpcomingEventsCallCount
+
+        XCTAssertNotNil(coordinator.testHook_probableSnapshotForManualStart())
+
+        var declinedEvent = currentEvent
+        declinedEvent.userStatus = .declined
+        calendarService.stubEvents = [declinedEvent]
+        calendarService.holdNextFetch = true
+
+        NotificationCenter.default.post(name: .EKEventStoreChanged, object: nil)
+
+        let refreshStarted = await waitForFetchCount(atLeast: fetchCountAfterInitialPoll + 1)
+        XCTAssertTrue(refreshStarted, "Calendar-change notification should trigger an immediate refresh")
+        XCTAssertNil(
+            coordinator.testHook_probableSnapshotForManualStart(),
+            "Manual starts must not persist stale calendar details while the refresh is still in flight"
+        )
+
+        calendarService.releaseHeldFetch()
+        await waitForPoll()
+        XCTAssertNil(coordinator.testHook_probableSnapshotForManualStart())
+
+        coordinator.stop()
+    }
+
+    func testProbableManualStartSnapshotRequiresCurrentCalendarModeAndPermission() async throws {
+        calendarService.stubPermissionStatus = .granted
+        calendarService.stubEvents = [
+            event(
+                id: "evt-current",
+                title: "Customer Review",
+                startsIn: -60,
+                durationMinutes: 30,
+                meetUrl: "https://meet.google.com/abc-defg-hij"
+            ),
+        ]
+        seedSettings(mode: .notify)
+
+        let coordinator = makeCoordinator()
+        coordinator.testHook_forcePoll()
+        await waitForPoll()
+
+        XCTAssertNotNil(coordinator.testHook_probableSnapshotForManualStart())
+
+        settingsViewModel.calendarAutoStartMode = .off
+        XCTAssertNil(coordinator.testHook_probableSnapshotForManualStart())
+
+        settingsViewModel.calendarAutoStartMode = .notify
+        calendarService.stubPermissionStatus = .denied
+        XCTAssertNil(coordinator.testHook_probableSnapshotForManualStart())
     }
 
     func testProbableManualStartSnapshotIsNilWithoutPollData() {

--- a/Tests/MacParakeetTests/Calendar/MeetingLinkParserTests.swift
+++ b/Tests/MacParakeetTests/Calendar/MeetingLinkParserTests.swift
@@ -182,6 +182,7 @@ final class MeetingLinkParserTests: XCTestCase {
         XCTAssertEqual(parser.identifyService(from: "https://around.co/r/x"), "Around")
         XCTAssertEqual(parser.identifyService(from: "https://zoomgov.com/j/1"), "Zoom")
         XCTAssertEqual(parser.identifyService(from: "https://whereby.com/room"), "Whereby")
+        XCTAssertEqual(parser.identifyService(from: "HTTPS://MEET.GOOGLE.COM/abc"), "Google Meet")
         XCTAssertNil(parser.identifyService(from: "https://example.com"))
         XCTAssertNil(parser.identifyService(from: nil))
     }

--- a/Tests/MacParakeetTests/Database/DatabaseManagerTests.swift
+++ b/Tests/MacParakeetTests/Database/DatabaseManagerTests.swift
@@ -240,6 +240,17 @@ final class DatabaseManagerTests: XCTestCase {
         }
     }
 
+    func testCalendarEventSnapshotColumnExistsOnTranscriptions() throws {
+        let manager = try DatabaseManager()
+        try manager.dbQueue.read { db in
+            let columns = try db.columns(in: "transcriptions").map(\.name)
+            XCTAssertTrue(
+                columns.contains("calendarEventSnapshot"),
+                "transcriptions should preserve local calendar context captured at meeting start"
+            )
+        }
+    }
+
     func testMeetingStartContextMigrationToleratesExistingColumnWhenMigrationMarkerIsMissing() throws {
         let dbPath = FileManager.default.temporaryDirectory
             .appendingPathComponent("meeting_start_context_rerun_\(UUID().uuidString).db")
@@ -263,6 +274,34 @@ final class DatabaseManagerTests: XCTestCase {
                 db,
                 sql: "SELECT EXISTS(SELECT 1 FROM grdb_migrations WHERE identifier = ?)",
                 arguments: ["v0.24-meeting-start-context"]
+            ) ?? false
+            XCTAssertTrue(migrationRecorded)
+        }
+    }
+
+    func testCalendarEventSnapshotMigrationToleratesExistingColumnWhenMigrationMarkerIsMissing() throws {
+        let dbPath = FileManager.default.temporaryDirectory
+            .appendingPathComponent("calendar_event_snapshot_rerun_\(UUID().uuidString).db")
+            .path
+        defer { cleanupDatabaseFiles(atPath: dbPath) }
+
+        let manager1 = try DatabaseManager(path: dbPath)
+        try manager1.dbQueue.write { db in
+            try db.execute(
+                sql: "DELETE FROM grdb_migrations WHERE identifier = ?",
+                arguments: ["v0.25-meeting-calendar-event-snapshot"]
+            )
+        }
+
+        let manager2 = try DatabaseManager(path: dbPath)
+        try manager2.dbQueue.read { db in
+            let columns = try db.columns(in: "transcriptions").map(\.name)
+            XCTAssertTrue(columns.contains("calendarEventSnapshot"))
+
+            let migrationRecorded = try Bool.fetchOne(
+                db,
+                sql: "SELECT EXISTS(SELECT 1 FROM grdb_migrations WHERE identifier = ?)",
+                arguments: ["v0.25-meeting-calendar-event-snapshot"]
             ) ?? false
             XCTAssertTrue(migrationRecorded)
         }

--- a/Tests/MacParakeetTests/Database/TranscriptionRepositoryTests.swift
+++ b/Tests/MacParakeetTests/Database/TranscriptionRepositoryTests.swift
@@ -82,6 +82,35 @@ final class TranscriptionRepositoryTests: XCTestCase {
         )
     }
 
+    func testMeetingCalendarEventSnapshotRoundTrips() throws {
+        let snapshot = MeetingCalendarSnapshot(
+            confidence: .confirmed,
+            eventIdentifier: "event-123",
+            externalId: "external-456",
+            title: "Design Review",
+            scheduledStartAt: Date(timeIntervalSince1970: 1_720_000_000),
+            scheduledEndAt: Date(timeIntervalSince1970: 1_720_003_600),
+            attendees: [
+                MeetingCalendarPerson(name: "Alice Example", email: "alice@example.com"),
+                MeetingCalendarPerson(name: "Bob Example", email: "bob@example.com"),
+            ],
+            organizer: MeetingCalendarPerson(name: "Omar Organizer", email: "omar@example.com"),
+            meetingURL: "https://zoom.us/j/123456789",
+            meetingService: "Zoom",
+            capturedAt: Date(timeIntervalSince1970: 1_720_000_010)
+        )
+        let transcription = Transcription(
+            fileName: "Design Review",
+            sourceType: .meeting,
+            calendarEventSnapshot: snapshot
+        )
+        try repo.save(transcription)
+
+        let fetched = try XCTUnwrap(repo.fetch(id: transcription.id))
+
+        XCTAssertEqual(fetched.calendarEventSnapshot, snapshot)
+    }
+
     func testLegacyTranscriptionDecodesWithNilEngineFields() throws {
         let transcription = Transcription(fileName: "legacy.mp3")
         try repo.save(transcription)

--- a/Tests/MacParakeetTests/MeetingRecordingFlow/MeetingRecordingFlowCoordinatorTests.swift
+++ b/Tests/MacParakeetTests/MeetingRecordingFlow/MeetingRecordingFlowCoordinatorTests.swift
@@ -171,6 +171,43 @@ final class MeetingRecordingFlowCoordinatorTests: XCTestCase {
         XCTAssertEqual(snapshot.calendarEventSnapshots.first ?? nil, expectedSnapshot)
     }
 
+    func testHotkeyStartUsesLateAssignedProbableCalendarSnapshotProvider() async throws {
+        let expectedSnapshot = MeetingCalendarSnapshot(
+            confidence: .probable,
+            eventIdentifier: "evt-hotkey",
+            title: "Hotkey Calendar Overlap",
+            scheduledStartAt: Date().addingTimeInterval(-120),
+            scheduledEndAt: Date().addingTimeInterval(1200),
+            meetingURL: "https://meet.google.com/abc-defg-hij",
+            meetingService: "Google Meet"
+        )
+        let holder = ProbableCalendarSnapshotHolder()
+        let recordingService = MeetingRecordingServiceSpy(output: makeRecordingOutput())
+        let coordinator = MeetingRecordingFlowCoordinator(
+            meetingRecordingService: recordingService,
+            transcriptionService: MockTranscriptionService(),
+            permissionService: MockPermissionService(),
+            transcriptionRepo: MockTranscriptionRepository(),
+            conversationRepo: MockChatConversationRepository(),
+            quickPromptRepo: NoOpQuickPromptRepository(),
+            configStore: NoOpLLMConfigStore(),
+            probableCalendarSnapshotProvider: { holder.snapshot },
+            llmService: nil,
+            pillViewModel: MeetingRecordingPillViewModel(),
+            onMenuBarIconUpdate: { _ in },
+            onTranscriptionReady: { _ in }
+        )
+        holder.snapshot = expectedSnapshot
+
+        XCTAssertNotNil(coordinator.startRecording(trigger: .hotkey))
+        await coordinator.testHook_waitForActionTask()
+
+        let snapshot = await recordingService.snapshot()
+        XCTAssertEqual(snapshot.startCallCount, 1)
+        XCTAssertEqual(snapshot.startTitles, [nil])
+        XCTAssertEqual(snapshot.calendarEventSnapshots.first ?? nil, expectedSnapshot)
+    }
+
     func testCalendarStartPassesConfirmedSnapshotAsTitleAndContext() async throws {
         let expectedSnapshot = MeetingCalendarSnapshot(
             confidence: .confirmed,
@@ -599,6 +636,10 @@ private actor MeetingRecordingServiceSpy: MeetingRecordingServiceProtocol {
             calendarEventSnapshots: calendarEventSnapshots
         )
     }
+}
+
+private final class ProbableCalendarSnapshotHolder: @unchecked Sendable {
+    var snapshot: MeetingCalendarSnapshot?
 }
 
 private extension MockTranscriptionService {

--- a/Tests/MacParakeetTests/MeetingRecordingFlow/MeetingRecordingFlowCoordinatorTests.swift
+++ b/Tests/MacParakeetTests/MeetingRecordingFlow/MeetingRecordingFlowCoordinatorTests.swift
@@ -132,6 +132,77 @@ final class MeetingRecordingFlowCoordinatorTests: XCTestCase {
         XCTAssertEqual(queuedSelections, [false])
     }
 
+    func testManualStartPassesProbableCalendarSnapshotWithoutChangingTitle() async throws {
+        let expectedSnapshot = MeetingCalendarSnapshot(
+            confidence: .probable,
+            eventIdentifier: "evt-manual",
+            externalId: "external-manual",
+            title: "Manual Calendar Overlap",
+            scheduledStartAt: Date().addingTimeInterval(-120),
+            scheduledEndAt: Date().addingTimeInterval(1200),
+            attendees: [MeetingCalendarPerson(name: "Alice", email: "alice@example.com")],
+            organizer: MeetingCalendarPerson(name: "Omar", email: "omar@example.com"),
+            meetingURL: "https://zoom.us/j/123456789",
+            meetingService: "Zoom"
+        )
+        let recordingService = MeetingRecordingServiceSpy(output: makeRecordingOutput())
+        let coordinator = MeetingRecordingFlowCoordinator(
+            meetingRecordingService: recordingService,
+            transcriptionService: MockTranscriptionService(),
+            permissionService: MockPermissionService(),
+            transcriptionRepo: MockTranscriptionRepository(),
+            conversationRepo: MockChatConversationRepository(),
+            quickPromptRepo: NoOpQuickPromptRepository(),
+            configStore: NoOpLLMConfigStore(),
+            probableCalendarSnapshotProvider: { expectedSnapshot },
+            llmService: nil,
+            pillViewModel: MeetingRecordingPillViewModel(),
+            onMenuBarIconUpdate: { _ in },
+            onTranscriptionReady: { _ in }
+        )
+
+        XCTAssertNotNil(coordinator.startRecording(trigger: .manual))
+        await coordinator.testHook_waitForActionTask()
+
+        let snapshot = await recordingService.snapshot()
+        XCTAssertEqual(snapshot.startCallCount, 1)
+        XCTAssertEqual(snapshot.startTitles.count, 1)
+        XCTAssertNil(snapshot.startTitles[0])
+        XCTAssertEqual(snapshot.calendarEventSnapshots.first ?? nil, expectedSnapshot)
+    }
+
+    func testCalendarStartPassesConfirmedSnapshotAsTitleAndContext() async throws {
+        let expectedSnapshot = MeetingCalendarSnapshot(
+            confidence: .confirmed,
+            eventIdentifier: "evt-confirmed",
+            title: "Confirmed Calendar Start",
+            scheduledStartAt: Date(),
+            scheduledEndAt: Date().addingTimeInterval(1800)
+        )
+        let recordingService = MeetingRecordingServiceSpy(output: makeRecordingOutput())
+        let coordinator = MeetingRecordingFlowCoordinator(
+            meetingRecordingService: recordingService,
+            transcriptionService: MockTranscriptionService(),
+            permissionService: MockPermissionService(),
+            transcriptionRepo: MockTranscriptionRepository(),
+            conversationRepo: MockChatConversationRepository(),
+            quickPromptRepo: NoOpQuickPromptRepository(),
+            configStore: NoOpLLMConfigStore(),
+            probableCalendarSnapshotProvider: { nil },
+            llmService: nil,
+            pillViewModel: MeetingRecordingPillViewModel(),
+            onMenuBarIconUpdate: { _ in },
+            onTranscriptionReady: { _ in }
+        )
+
+        XCTAssertNotNil(coordinator.startFromCalendar(calendarEventSnapshot: expectedSnapshot))
+        await coordinator.testHook_waitForActionTask()
+
+        let snapshot = await recordingService.snapshot()
+        XCTAssertEqual(snapshot.startTitles, ["Confirmed Calendar Start"])
+        XCTAssertEqual(snapshot.calendarEventSnapshots.first ?? nil, expectedSnapshot)
+    }
+
     func testLiveAskChatPersistsBeforeQueuedFinalizeTearsDownPanel() async throws {
         let output = makeRecordingOutput()
         let recordingService = MeetingRecordingServiceSpy(output: output)
@@ -430,6 +501,7 @@ private actor MeetingRecordingServiceSpy: MeetingRecordingServiceProtocol {
         let title: String?
         let sourceMode: MeetingAudioSourceMode?
         let startContext: MeetingStartContext?
+        let calendarEventSnapshot: MeetingCalendarSnapshot?
     }
 
     private let output: MeetingRecordingOutput
@@ -437,6 +509,8 @@ private actor MeetingRecordingServiceSpy: MeetingRecordingServiceProtocol {
     var startCalls: [StartCall] = []
     var stopCallCount = 0
     var completedTranscriptionSessionIDs: [UUID] = []
+    var startTitles: [String?] = []
+    var calendarEventSnapshots: [MeetingCalendarSnapshot?] = []
 
     init(output: MeetingRecordingOutput) {
         self.output = output
@@ -445,14 +519,18 @@ private actor MeetingRecordingServiceSpy: MeetingRecordingServiceProtocol {
     func startRecording(
         title: String?,
         sourceMode: MeetingAudioSourceMode?,
-        startContext: MeetingStartContext?
+        startContext: MeetingStartContext?,
+        calendarEventSnapshot: MeetingCalendarSnapshot?
     ) async throws {
         startCallCount += 1
         startCalls.append(StartCall(
             title: title,
             sourceMode: sourceMode,
-            startContext: startContext
+            startContext: startContext,
+            calendarEventSnapshot: calendarEventSnapshot
         ))
+        startTitles.append(title)
+        calendarEventSnapshots.append(calendarEventSnapshot)
     }
 
     func stopRecording() async throws -> MeetingRecordingOutput {
@@ -508,13 +586,17 @@ private actor MeetingRecordingServiceSpy: MeetingRecordingServiceProtocol {
         startCallCount: Int,
         startCalls: [StartCall],
         stopCallCount: Int,
-        completedTranscriptionSessionIDs: [UUID]
+        completedTranscriptionSessionIDs: [UUID],
+        startTitles: [String?],
+        calendarEventSnapshots: [MeetingCalendarSnapshot?]
     ) {
         (
             startCallCount: startCallCount,
             startCalls: startCalls,
             stopCallCount: stopCallCount,
-            completedTranscriptionSessionIDs: completedTranscriptionSessionIDs
+            completedTranscriptionSessionIDs: completedTranscriptionSessionIDs,
+            startTitles: startTitles,
+            calendarEventSnapshots: calendarEventSnapshots
         )
     }
 }

--- a/Tests/MacParakeetTests/MeetingRecordingFlow/MeetingTranscriptionQueueTests.swift
+++ b/Tests/MacParakeetTests/MeetingRecordingFlow/MeetingTranscriptionQueueTests.swift
@@ -275,7 +275,8 @@ private actor QueueRecordingServiceSpy: MeetingRecordingServiceProtocol {
     func startRecording(
         title: String?,
         sourceMode: MeetingAudioSourceMode?,
-        startContext: MeetingStartContext?
+        startContext: MeetingStartContext?,
+        calendarEventSnapshot: MeetingCalendarSnapshot?
     ) async throws {}
 
     func stopRecording() async throws -> MeetingRecordingOutput {

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingArtifactStoreTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingArtifactStoreTests.swift
@@ -147,6 +147,42 @@ final class MeetingArtifactStoreTests: XCTestCase {
         XCTAssertEqual(files["cleanedMicrophoneAudioPath"] as? String, cleanedURL.path)
     }
 
+    func testMaterializeWritesCalendarSnapshotIntoArtifactMetadata() async throws {
+        let calendarSnapshot = makeCalendarSnapshot(confidence: .confirmed)
+        let transcription = makeMeeting(
+            notes: "Calendar context should travel with the artifact.",
+            calendarEventSnapshot: calendarSnapshot
+        )
+
+        let snapshot = try await MeetingArtifactStore().materialize(
+            transcription: transcription,
+            promptResults: []
+        )
+
+        XCTAssertEqual(snapshot.calendarEventSnapshot, calendarSnapshot)
+
+        let manifest = try jsonObject(at: URL(fileURLWithPath: snapshot.manifestPath))
+        let meeting = try XCTUnwrap(manifest["meeting"] as? [String: Any])
+        let manifestCalendar = try XCTUnwrap(meeting["calendarEventSnapshot"] as? [String: Any])
+        XCTAssertEqual(manifestCalendar["confidence"] as? String, "confirmed")
+        XCTAssertEqual(manifestCalendar["eventIdentifier"] as? String, "evt-artifact")
+        XCTAssertEqual(manifestCalendar["externalId"] as? String, "external-artifact")
+        XCTAssertEqual(manifestCalendar["title"] as? String, "Artifact Review")
+        XCTAssertEqual(manifestCalendar["meetingURL"] as? String, "https://teams.microsoft.com/l/meetup-join/abc")
+        XCTAssertEqual(manifestCalendar["meetingService"] as? String, "Microsoft Teams")
+        let attendees = try XCTUnwrap(manifestCalendar["attendees"] as? [[String: Any]])
+        XCTAssertEqual(attendees.first?["name"] as? String, "Alice Example")
+        XCTAssertEqual(attendees.first?["email"] as? String, "alice@example.com")
+        let organizer = try XCTUnwrap(manifestCalendar["organizer"] as? [String: Any])
+        XCTAssertEqual(organizer["name"] as? String, "Omar Organizer")
+        XCTAssertEqual(organizer["email"] as? String, "omar@example.com")
+
+        let transcript = try jsonObject(at: URL(fileURLWithPath: snapshot.transcriptPath))
+        let transcriptCalendar = try XCTUnwrap(transcript["calendarEventSnapshot"] as? [String: Any])
+        XCTAssertEqual(transcriptCalendar["eventIdentifier"] as? String, "evt-artifact")
+        XCTAssertEqual(transcriptCalendar["confidence"] as? String, "confirmed")
+    }
+
     func testMaterializeOmitsInvalidCleanedMicrophoneAudioPath() async throws {
         let cleanedURL = folderURL.appendingPathComponent("microphone-cleaned.m4a")
         try Data("partial m4a fragment".utf8).write(to: cleanedURL)
@@ -242,7 +278,8 @@ final class MeetingArtifactStoreTests: XCTestCase {
 
     private func makeMeeting(
         notes: String?,
-        startContext: MeetingStartContext? = nil
+        startContext: MeetingStartContext? = nil,
+        calendarEventSnapshot: MeetingCalendarSnapshot? = nil
     ) -> Transcription {
         Transcription(
             id: UUID(uuidString: "11111111-2222-3333-4444-555555555555")!,
@@ -278,7 +315,28 @@ final class MeetingArtifactStoreTests: XCTestCase {
             userNotes: notes,
             meetingStartContext: startContext,
             engine: "parakeet",
-            engineVariant: "v3"
+            engineVariant: "v3",
+            calendarEventSnapshot: calendarEventSnapshot
+        )
+    }
+
+    private func makeCalendarSnapshot(
+        confidence: MeetingCalendarSnapshot.Confidence
+    ) -> MeetingCalendarSnapshot {
+        MeetingCalendarSnapshot(
+            confidence: confidence,
+            eventIdentifier: "evt-artifact",
+            externalId: "external-artifact",
+            title: "Artifact Review",
+            scheduledStartAt: Date(timeIntervalSince1970: 1_720_000_000),
+            scheduledEndAt: Date(timeIntervalSince1970: 1_720_003_600),
+            attendees: [
+                MeetingCalendarPerson(name: "Alice Example", email: "alice@example.com"),
+            ],
+            organizer: MeetingCalendarPerson(name: "Omar Organizer", email: "omar@example.com"),
+            meetingURL: "https://teams.microsoft.com/l/meetup-join/abc",
+            meetingService: "Microsoft Teams",
+            capturedAt: Date(timeIntervalSince1970: 1_720_000_010)
         )
     }
 

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingLockFileStoreTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingLockFileStoreTests.swift
@@ -290,7 +290,7 @@ final class MeetingRecordingLockFileStoreTests: XCTestCase {
     }
 
     func testReadFromLockFileWithMalformedStartContextStillRecoversMetadata() throws {
-        let folderURL = tempRoot.appendingPathComponent("session")
+        let folderURL = tempRoot.appendingPathComponent("session-start-context")
         try FileManager.default.createDirectory(at: folderURL, withIntermediateDirectories: true)
         let json = """
         {
@@ -312,6 +312,30 @@ final class MeetingRecordingLockFileStoreTests: XCTestCase {
         XCTAssertNil(readLockFile.startContext, "malformed startContext must not block recovery")
         XCTAssertEqual(readLockFile.displayName, "Recoverable Session")
         XCTAssertEqual(readLockFile.sessionId, UUID(uuidString: "11111111-2222-3333-4444-555555555555"))
+    }
+
+    func testReadFromLockFileWithMalformedCalendarSnapshotStillRecoversMetadata() throws {
+        let folderURL = tempRoot.appendingPathComponent("session-calendar-snapshot")
+        try FileManager.default.createDirectory(at: folderURL, withIntermediateDirectories: true)
+        let json = """
+        {
+            "schemaVersion": 1,
+            "sessionId": "11111111-2222-3333-4444-555555555555",
+            "startedAt": "2026-04-25T12:00:00Z",
+            "pid": 123,
+            "displayName": "Recoverable Session",
+            "state": "recording",
+            "calendarEventSnapshot": 42
+        }
+        """
+        try Data(json.utf8).write(to: MeetingRecordingLockFileStore.lockFileURL(for: folderURL))
+
+        let readLockFile = try XCTUnwrap(store.read(folderURL: folderURL))
+        XCTAssertNil(
+            readLockFile.calendarEventSnapshot,
+            "malformed calendar snapshot must fall through to nil, not block recovery"
+        )
+        XCTAssertEqual(readLockFile.displayName, "Recoverable Session")
     }
 
     func testWithNotesPreservesEverythingElse() throws {

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingOutputTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingOutputTests.swift
@@ -414,6 +414,29 @@ final class MeetingRecordingOutputTests: XCTestCase {
         XCTAssertEqual(output.calendarEventSnapshot, calendarSnapshot)
     }
 
+    func testMetadataLoadIgnoresMalformedCalendarSnapshot() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let json = """
+        {
+            "sourceAlignment": {
+                "meetingOriginHostTime": null,
+                "microphone": null,
+                "system": null
+            },
+            "speechEngine": {
+                "engine": "parakeet"
+            },
+            "calendarEventSnapshot": 42
+        }
+        """
+        try Data(json.utf8).write(to: MeetingRecordingMetadataStore.metadataURL(for: dir))
+
+        let metadata = try MeetingRecordingMetadataStore.load(from: dir)
+        XCTAssertNil(metadata.calendarEventSnapshot)
+        XCTAssertEqual(metadata.speechEngine.engine, .parakeet)
+    }
+
     func testMetadataLoadReportsFailedContentsProbeAsUnreadableNotMissing() throws {
         let dir = try makeTempDir()
         defer { try? FileManager.default.removeItem(at: dir) }

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingOutputTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingOutputTests.swift
@@ -374,6 +374,46 @@ final class MeetingRecordingOutputTests: XCTestCase {
         XCTAssertNil(output.cleanedMicrophoneAudioURL)
     }
 
+    func testLoadArchivedPreservesCalendarSnapshotFromMetadata() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let calendarSnapshot = MeetingCalendarSnapshot(
+            confidence: .confirmed,
+            eventIdentifier: "evt-sidecar",
+            externalId: "external-sidecar",
+            title: "Sidecar Review",
+            scheduledStartAt: Date(timeIntervalSince1970: 1_720_000_000),
+            scheduledEndAt: Date(timeIntervalSince1970: 1_720_003_600),
+            attendees: [
+                MeetingCalendarPerson(name: "Alice Example", email: "alice@example.com"),
+            ],
+            organizer: MeetingCalendarPerson(name: "Omar Organizer", email: "omar@example.com"),
+            meetingURL: "https://zoom.us/j/123456789",
+            meetingService: "Zoom",
+            capturedAt: Date(timeIntervalSince1970: 1_720_000_010)
+        )
+        try MeetingRecordingMetadataStore.save(
+            MeetingRecordingMetadata(
+                sourceAlignment: MeetingSourceAlignment(
+                    meetingOriginHostTime: nil,
+                    microphone: nil,
+                    system: nil
+                ),
+                speechEngine: SpeechEngineSelection(engine: .parakeet),
+                calendarEventSnapshot: calendarSnapshot
+            ),
+            folderURL: dir
+        )
+
+        let output = try MeetingRecordingOutput.loadArchived(
+            displayName: "Archived",
+            mixedAudioURL: dir.appendingPathComponent("meeting.m4a"),
+            durationSeconds: 12
+        )
+
+        XCTAssertEqual(output.calendarEventSnapshot, calendarSnapshot)
+    }
+
     func testMetadataLoadReportsFailedContentsProbeAsUnreadableNotMissing() throws {
         let dir = try makeTempDir()
         defer { try? FileManager.default.removeItem(at: dir) }

--- a/spec/01-data-model.md
+++ b/spec/01-data-model.md
@@ -138,6 +138,7 @@ CREATE TABLE transcriptions (
     userNotes TEXT,                                      -- v0.8: meeting notes used to steer prompt results
     engine TEXT,                                         -- v0.8: STT engine (`parakeet` / `nemotron` / `whisper`)
     engineVariant TEXT,                                  -- v0.8: Engine-specific model variant
+    calendarEventSnapshot TEXT,                          -- v0.25: JSON local calendar context captured at meeting start
     derivedTitle TEXT,                                   -- v0.9: Display title derived from transcript content
     derivedSnippet TEXT,                                 -- v0.9: Display preview snippet derived from transcript content
     updatedAt TEXT NOT NULL                              -- ISO 8601 timestamp
@@ -155,7 +156,7 @@ CREATE INDEX idx_transcriptions_status_created_at ON transcriptions(status, crea
 - `language` stores the normalized detected/specified STT language code when available. New transcription service rows start unknown and are filled from the STT result; legacy/default rows may still contain `en`.
 - `speakerCount` and `speakers` are nullable, populated only when diarization is available (v0.4).
 - `filePath` is nullable because the original file may be moved or deleted after transcription.
-- For meeting recordings, `filePath` points to the mixed `meeting.m4a` artifact used for playback/export while retained. `meetingArtifactFolderPath` points to the durable session folder, so artifact actions and CLI output survive audio deletion or retention. The selected-source `microphone.m4a` and/or `system.m4a`, plus the `meeting-recording-metadata.json` sidecar, remain inside that same session folder while retained. The sidecar may include additive `echoSuppression` provenance (`reasonCode` plus optional model, render-timing, delay, and probe-correlation fields) after the cleaned-mic readiness gate resolves, so shared folders identify whether final STT used cleaned or raw mic and why. `meetingStartContext` stores the one-shot local-only start snapshot for meeting rows: trigger kind, configured source mode, and the frontmost app bundle id/name read at recording start. The folder is the first-class local artifact contract for the session; the canonical filename/schema contract lives in [`spec/contracts/meeting-artifacts-v1.md`](contracts/meeting-artifacts-v1.md). The DB row remains canonical; the folder is refreshed after meeting finalization, `macparakeet-cli meetings artifact`, meeting-note writes, and prompt-result writes.
+- For meeting recordings, `filePath` points to the mixed `meeting.m4a` artifact used for playback/export while retained. `meetingArtifactFolderPath` points to the durable session folder, so artifact actions and CLI output survive audio deletion or retention. The selected-source `microphone.m4a` and/or `system.m4a`, plus the `meeting-recording-metadata.json` sidecar, remain inside that same session folder while retained. The sidecar may include additive `echoSuppression` provenance (`reasonCode` plus optional model, render-timing, delay, and probe-correlation fields) after the cleaned-mic readiness gate resolves, so shared folders identify whether final STT used cleaned or raw mic and why. `meetingStartContext` stores the one-shot local-only start snapshot for meeting rows: trigger kind, configured source mode, and the frontmost app bundle id/name read at recording start. `calendarEventSnapshot` stores local EventKit context captured at start time for confirmed or probable calendar meetings. The folder is the first-class local artifact contract for the session; the canonical filename/schema contract lives in [`spec/contracts/meeting-artifacts-v1.md`](contracts/meeting-artifacts-v1.md). The DB row remains canonical; the folder is refreshed after meeting finalization, `macparakeet-cli meetings artifact`, meeting-note writes, and prompt-result writes.
 - The meeting artifact root defaults to `~/Library/Application Support/MacParakeet/meeting-recordings`, and can be changed for future sessions through `macparakeet-cli config set meeting-artifacts-folder <absolute-path>`. Existing sessions keep their own folder path through `transcriptions.meetingArtifactFolderPath`, falling back to the parent of `transcriptions.filePath` for legacy rows.
 - Saved meeting retranscribes reconstruct the archived meeting from that folder when the sidecar exists, so the library path can reuse the same aligned dual-source finalization flow as the immediate post-stop path.
 - `sourceURL` distinguishes URL-sourced transcriptions (YouTube) from local file transcriptions. Added in v0.3.
@@ -166,6 +167,7 @@ CREATE INDEX idx_transcriptions_status_created_at ON transcriptions(status, crea
 - `isTranscriptEdited` marks transcript text changed by the user after automatic processing. Added in v0.7.7.
 - `userNotes` stores free-form meeting notes typed during recording; prompt generation snapshots this value on `summaries.userNotesSnapshot`. Added in v0.8.
 - `engine` / `engineVariant` record the STT engine attribution for Parakeet, Nemotron Beta, Cohere, and optional WhisperKit paths. Added in v0.8; legacy rows keep `NULL`.
+- `calendarEventSnapshot` is a JSON blob for meeting rows only. It stores `confidence` (`confirmed` for calendar auto-start, `probable` for manual starts matched against the current poll cache), EventKit `eventIdentifier`, optional `externalId`, event title, scheduled start/end, attendee names/emails, organizer name/email, meeting URL/service, and capture timestamp. This is local user data and must not be sent in telemetry, including attendee counts. Added in v0.25.
 - `derivedTitle` / `derivedSnippet` cache display copy derived from the completed transcript. Added in v0.9 so Library cards do not need to recompute preview text on every render.
 - The legacy `summary` column was migrated into `summaries` in v0.7 and dropped in v0.7.6.
 - No FTS on transcriptions in v0.1. Search by filename or scroll the list. Revisit if the list grows large.
@@ -616,6 +618,7 @@ struct Transcription: Codable, Identifiable {
     var userNotes: String?              // v0.8 — Free-form meeting notes
     var engine: String?                 // v0.8 — STT engine (`parakeet` / `nemotron` / `whisper`)
     var engineVariant: String?          // v0.8 — Engine-specific model variant
+    var calendarEventSnapshot: MeetingCalendarSnapshot? // v0.25 — Local calendar context snapshot
     var derivedTitle: String?           // v0.9 — Display title derived from transcript text
     var derivedSnippet: String?         // v0.9 — Display preview snippet derived from transcript text
     var updatedAt: Date
@@ -1131,9 +1134,11 @@ migrator.registerMigration("v0.7-prompts-and-summaries") { db in
 // v0.18 — llm_runs metadata ledger
 // v0.19 — dictations.language
 // v0.20 — prompts.appliesToSources (auto-run source scoping; NULL = all sources)
+// v0.21 — AI Formatter profile metadata
 // v0.22 — transcriptions.meetingArtifactFolderPath
 // v0.23 — transcriptions.transcriptSegments
 // v0.24 — transcriptions.meetingStartContext
+// v0.25 — transcriptions.calendarEventSnapshot (raw SQL additive column)
 ```
 
 ### Migration Rules
@@ -1156,6 +1161,7 @@ migrator.registerMigration("v0.7-prompts-and-summaries") { db in
 | `transcriptions.meetingArtifactFolderPath` | v0.22 | Durable meeting artifact folder path retained after meeting audio deletion |
 | `transcriptions.transcriptSegments` | v0.23 | Durable meeting transcript segments (JSON) for stable per-transcript-version citations |
 | `transcriptions.meetingStartContext` | v0.24 | Local-only JSON start snapshot for meeting rows: trigger kind, configured source mode, and frontmost app bundle id/name |
+| `transcriptions.calendarEventSnapshot` | v0.25 | Local JSON EventKit context snapshot for meeting recordings |
 | `custom_words` | v0.2 | Vocabulary anchors and corrections |
 | `text_snippets` | v0.2 | Trigger-based text expansion |
 | `transcriptions.diarizationSegments` | v0.4 | Speaker diarization segments (JSON) |

--- a/spec/adr/017-calendar-meeting-auto-start.md
+++ b/spec/adr/017-calendar-meeting-auto-start.md
@@ -75,6 +75,8 @@ Oatmeal persists events to GRDB for its RAG/entity-extraction features. MacParak
 
 **Why:** Simpler, less to maintain, less data footprint, less surface to reason about for privacy. Recomputing on a 60-second poll is cheap (EventKit reads are near-instant).
 
+> **Amendment (2026-07-03): persist one meeting-start snapshot, not an event cache.** ADR-027's meeting-corpus direction (PR #680) changes the retention boundary for context available at recording start: context not captured then is lost forever. MacParakeet still does **not** persist a queryable calendar-event cache or EventKit repository. It now stores one local `calendarEventSnapshot` on each meeting transcription when a recording starts from a calendar event (`confirmed`) or, for manual starts, when the coordinator's current poll cache overlaps "now" (`probable`). The same snapshot is mirrored into meeting artifact metadata so exported/shared local folders are self-describing. Attendee and organizer names/emails are user data and remain local-only; they must never be sent in telemetry, including as counts.
+
 ### 7. Polling cadence: 60s baseline, 5s near events
 
 A single `Timer` in the coordinator fires every 60 seconds during idle periods. When the next matching event is within 2 minutes, the timer reschedules itself at 5-second intervals so countdown accuracy doesn't drift. After the event passes, it falls back to 60s.

--- a/spec/contracts/cli-json-v1.md
+++ b/spec/contracts/cli-json-v1.md
@@ -54,6 +54,11 @@ with human progress/status kept off stdout.
 - `meetings show --json` meeting objects can include optional `startContext`
   for meeting rows. When present it contains `triggerKind`, `sourceMode`, and
   optional `frontmostApplication` (`bundleIdentifier`, `localizedName`).
+- `meetings show --json` and `meetings export --stdout --format json` may
+  include `calendarEventSnapshot` for meeting recordings started from, or
+  probably overlapping, a calendar event. The field is additive and local-only;
+  attendee and organizer names/emails are user data and must not be mirrored
+  into telemetry.
 
 ## Failure Envelope
 

--- a/spec/contracts/meeting-artifacts-v1.md
+++ b/spec/contracts/meeting-artifacts-v1.md
@@ -59,7 +59,8 @@ The v1 folder can contain these stable filenames:
   `delayEstimateMs`, and `probeBestCorrelation` fields so shared artifact
   folders can explain cleaned-vs-raw microphone routing without app logs. It
   may also include additive `startContext` with the one-shot local start
-  snapshot.
+  snapshot. `calendarEventSnapshot`, when present, is local EventKit context
+  and can include attendee/organizer names and emails.
 - `manifest.json`: folder manifest.
 - `transcript.json`: transcript view.
 - `notes.md`: optional user notes view. Removed when notes are empty or nil.
@@ -84,6 +85,7 @@ The v1 folder can contain these stable filenames:
 - `promptResultsPath`
 - `promptResultsDirectoryPath`
 - `promptResultCount`
+- `calendarEventSnapshot`
 
 `manifest.json` keeps:
 
@@ -94,6 +96,11 @@ The v1 folder can contain these stable filenames:
 - `files`
 - `promptResults`
 
+`manifest.meeting.calendarEventSnapshot`, when present, keeps the same local
+EventKit snapshot shape as `transcriptions.calendarEventSnapshot`: confidence,
+event identifiers, scheduled time range, title, attendee/organizer names and
+emails, meeting URL/service, and capture timestamp.
+
 `manifest.files` keeps path fields for `folderPath`, `mixedAudioPath`,
 `microphoneAudioPath`, `cleanedMicrophoneAudioPath`, `systemAudioPath`,
 `metadataPath`, `manifestPath`, `transcriptPath`, `notesPath`,
@@ -103,7 +110,7 @@ The v1 folder can contain these stable filenames:
 `durationMs`, `status`, raw/clean/transcript text, word/speaker/diarization
 fields, durable `transcriptSegments`, `userNotes`, language/engine attribution,
 `sourceType`, `recoveredFromCrash`, `isTranscriptEdited`, and optional
-`startContext`.
+`startContext` and `calendarEventSnapshot`.
 
 `transcriptSegments` is an additive v1 field populated from the DB row when a
 meeting has durable segments. Each segment keeps `id`, `startMs`, `endMs`,
@@ -119,6 +126,11 @@ meeting retranscription may replace the array with newly minted segment IDs.
   `microphone_and_system`, or `system_only`)
 - `frontmostApplication`: optional object with `bundleIdentifier` and
   `localizedName`
+
+`calendarEventSnapshot`, when present, keeps local calendar context captured at
+recording start. It can include EventKit identifiers, title, scheduled
+start/end, attendee/organizer names and emails, meeting URL/service, confidence,
+and capture timestamp.
 
 ## Non-Stable Fields
 


### PR DESCRIPTION
## Summary

Implements Slice 1 of the meeting-corpus capture plan from #680: meeting recordings now preserve a local calendar event snapshot when started from calendar auto-start, and manual starts can attach a best-effort `probable` snapshot from the coordinator's existing poll cache. The snapshot includes EventKit identifiers, title, scheduled start/end, attendee and organizer names/emails as EventKit exposes them, detected meeting URL/service, confidence, and capture time.

## Design

Aligned with the #680 plan and ADR-027 north-star direction: context available at meeting start is copied onto the durable meeting record instead of being discarded after trigger time.

- Storage uses an additive `transcriptions.calendarEventSnapshot` JSON column, migrated with raw SQL to avoid historical migrations touching the evolving `Transcription` Codable shape.
- Calendar auto-start passes a `confirmed` `MeetingCalendarSnapshot` through the auto-start coordinator into the meeting recording flow and final transcription row.
- Manual meeting starts ask the existing auto-start coordinator for an overlapping event from already-polled data only; if none exists, they silently proceed without a snapshot.
- Meeting folders stay self-describing by mirroring the snapshot into `meeting-recording-metadata.json`, recovered recording output, `manifest.meeting.calendarEventSnapshot`, and `transcript.calendarEventSnapshot`.
- `macparakeet-cli meetings show --json` includes the optional snapshot on meeting records.
- ADR-017 §6, `spec/01-data-model.md`, `spec/contracts/meeting-artifacts-v1.md`, `spec/contracts/cli-json-v1.md`, and `Sources/CLI/CHANGELOG.md` are updated in this PR.

Deviation: no product-level deviation from the brief. I also carry the snapshot through `recording.lock` so crash recovery before finalization does not lose the start-time context.

## Risk surface

- DB migration: additive nullable TEXT column only; raw SQL migration intentionally avoids model-backed inserts/decodes.
- Persistence contract: new optional JSON fields only; older rows and older artifact metadata decode with `nil`.
- Runtime behavior: no UI change, no EventKit query/permission change for manual starts, and no retention/deletion changes.
- Privacy: attendee/organizer data is local user data; see statement below.

## Test evidence

- `swift test --filter MeetingAutoStartCoordinatorTests`
  - 12 tests, 0 failures
- `swift test --filter 'TranscriptionRepositoryTests|DatabaseManagerTests|MeetingArtifactStoreTests|MeetingRecordingOutputTests|MeetingRecordingFlowCoordinatorTests|MeetingsCommandTests'`
  - 126 tests, 0 failures
- `git diff --check`
  - passed

Per the slice brief, I did not run the full `swift test` suite.

## Privacy statement

I checked the telemetry diff path: attendee names/emails, organizer names/emails, and attendee counts are not sent to telemetry. The new snapshot is stored only in the local database, local meeting recording metadata/artifacts, and local CLI JSON output.

## Post-Deploy Monitoring & Validation

No additional production monitoring is required because this is local-only persistence/artifact/CLI behavior with no server-side surface and no telemetry payload change. Healthy validation is successful local migration plus presence of `calendarEventSnapshot` on newly calendar-started meeting rows/artifacts; failure signal would be migration or JSON decode errors in local logs during meeting finalization/recovery.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a local, private calendar event snapshot to meeting recordings at start. Calendar auto-starts save a confirmed snapshot; manual and hotkey starts attach a probable snapshot from the latest poll cache. Snapshots stay on-device, are mirrored into artifacts/CLI JSON, and are decoded defensively so malformed data never blocks recovery.

- New Features
  - Store `calendarEventSnapshot` on `transcriptions`: EventKit ids, title, scheduled start/end, attendees/organizer, meeting URL/service (case-insensitive), confidence, and capture time.
  - Manual/hotkey starts attach a probable snapshot from the coordinator’s current poll cache only (no new EventKit queries). They respect current auto-start mode, permission state, excluded calendars, and the same trigger filter as `MeetingMonitor`.
  - Calendar auto-start forwards a confirmed snapshot into the recording flow.
  - Mirror the snapshot into `recording.lock`, `meeting-recording-metadata.json`, `manifest.meeting.calendarEventSnapshot`, and `transcript.calendarEventSnapshot`.
  - `meetings show --json` and `meetings export --stdout --format json` include the optional snapshot.
  - Organizer data is preserved alongside attendees; meeting-service detection is case-insensitive.

- Migration
  - Add nullable TEXT column `transcriptions.calendarEventSnapshot` via raw SQL (v0.25); backward-compatible and optional.
  - Older rows/artifacts decode with `nil`. Lock files and metadata decode the snapshot best-effort; malformed values fall back to `nil`.
  - Privacy: attendee/organizer data remains local-only; not sent to telemetry.

<sup>Written for commit 7a45ce80cdad35ba2188f2f4b0b383678bc49af1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/687?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

