### PR TITLE
Default speaker diarization on where supported

### DIFF
--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -109,6 +109,10 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
 
 - `spec --json` now documents `meetings export` JSON stdout mode as
   `--stdout --format json`, matching the command's file-output default.
+- `transcribe` / `retranscribe` app-default speaker detection now resolves to
+  `on` for a fresh preference store. `config get speaker-detection` reports
+  `on` when unset; an explicit saved `off`, `--speaker-detection off`, or
+  `--no-diarize` still disables diarization.
 - Plain-text `retranscribe` validation/misuse failures now use exit code `2`,
   matching the JSON envelope path and the public exit-code contract.
 

--- a/Sources/CLI/Commands/ConfigCommand.swift
+++ b/Sources/CLI/Commands/ConfigCommand.swift
@@ -40,7 +40,7 @@ struct ConfigCommand: ParsableCommand {
                                     (multilingual build only)
           whisper-language          auto|<Whisper language code>    default: auto
           cohere-language           <Cohere language code>          default: en (no auto)
-          speaker-detection         on|off                          default: off
+          speaker-detection         on|off                          default: on
           auto-meeting-titles       on|off                          default: on
           voice-return-enabled      on|off                          default: off
           voice-return-triggers     phrase[|phrase...]              default: press return
@@ -326,7 +326,7 @@ struct ConfigCommand: ParsableCommand {
         case "cohere-language":
             return SpeechEnginePreference.cohereDefaultLanguage(defaults: store) ?? "en"
         case "speaker-detection":
-            let on = store.object(forKey: UserDefaultsAppRuntimePreferences.speakerDiarizationKey) as? Bool ?? false
+            let on = UserDefaultsAppRuntimePreferences.speakerDiarizationEnabled(defaults: store)
             return on ? "on" : "off"
         case "auto-meeting-titles":
             let on = store.object(forKey: UserDefaultsAppRuntimePreferences.autoGenerateMeetingTitlesKey) as? Bool ?? true

--- a/Sources/CLI/Commands/TranscribeCommand.swift
+++ b/Sources/CLI/Commands/TranscribeCommand.swift
@@ -321,7 +321,7 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
         switch option {
         case .appDefault:
             return ResolvedSpeakerDetection(
-                enabled: constraint != nil || (storedEnabled ?? false),
+                enabled: constraint != nil || (storedEnabled ?? UserDefaultsAppRuntimePreferences.defaultSpeakerDiarizationEnabled),
                 constraint: constraint
             )
         case .on:

--- a/Sources/MacParakeetCore/AppRuntimePreferences.swift
+++ b/Sources/MacParakeetCore/AppRuntimePreferences.swift
@@ -499,6 +499,7 @@ public final class UserDefaultsAppRuntimePreferences: AppRuntimePreferencesProto
     public static let autoGenerateMeetingTitlesKey = "autoGenerateMeetingTitles"
     public static let youtubeAudioQualityKey = "youtubeAudioQuality"
     public static let speakerDiarizationKey = "speakerDiarization"
+    public static let defaultSpeakerDiarizationEnabled = true
     public static let aiFormatterEnabledKey = "aiFormatterEnabled"
     public static let aiFormatterEnabledForDictationKey = "aiFormatterEnabledForDictation"
     public static let aiFormatterEnabledForTranscriptionsKey = "aiFormatterEnabledForTranscriptions"
@@ -563,6 +564,10 @@ public final class UserDefaultsAppRuntimePreferences: AppRuntimePreferencesProto
         return [defaultVoiceReturnTrigger]
     }
 
+    public static func speakerDiarizationEnabled(defaults: UserDefaults = .standard) -> Bool {
+        defaults.object(forKey: speakerDiarizationKey) as? Bool ?? defaultSpeakerDiarizationEnabled
+    }
+
     public var processingMode: Dictation.ProcessingMode {
         let raw = defaults.string(forKey: Self.processingModeKey)
         return Dictation.ProcessingMode(rawValue: raw ?? Dictation.ProcessingMode.raw.rawValue) ?? .raw
@@ -610,7 +615,7 @@ public final class UserDefaultsAppRuntimePreferences: AppRuntimePreferencesProto
     }
 
     public var shouldDiarize: Bool {
-        defaults.object(forKey: Self.speakerDiarizationKey) as? Bool ?? false
+        Self.speakerDiarizationEnabled(defaults: defaults)
     }
 
     public var aiFormatterEnabled: Bool {

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -720,7 +720,7 @@ public final class SettingsViewModel {
         saveTranscriptionAudio = defaults.object(forKey: UserDefaultsAppRuntimePreferences.saveTranscriptionAudioKey) as? Bool ?? true
         meetingAudioRetention = UserDefaultsAppRuntimePreferences.meetingAudioRetention(defaults: defaults)
         youtubeAudioQuality = YouTubeAudioQuality.current(defaults: defaults)
-        speakerDiarization = defaults.object(forKey: UserDefaultsAppRuntimePreferences.speakerDiarizationKey) as? Bool ?? false
+        speakerDiarization = UserDefaultsAppRuntimePreferences.speakerDiarizationEnabled(defaults: defaults)
         // Ensure auto-save folders are configured before reading paths.
         // Idempotent: existing user-chosen folders are preserved; only
         // unset bookmarks get the default. This guarantees the read

--- a/Tests/CLITests/ConfigCommandTests.swift
+++ b/Tests/CLITests/ConfigCommandTests.swift
@@ -68,6 +68,11 @@ final class ConfigCommandTests: XCTestCase {
         XCTAssertEqual(try ConfigCommand.read(key: "telemetry", defaults: defaults), "on")
     }
 
+    func testReadSpeakerDetectionReflectsExplicitFalse() throws {
+        defaults.set(false, forKey: UserDefaultsAppRuntimePreferences.speakerDiarizationKey)
+        XCTAssertEqual(try ConfigCommand.read(key: "speaker-detection", defaults: defaults), "off")
+    }
+
     func testReadAgentDefaultsReflectGUIFallbacks() throws {
         XCTAssertEqual(try ConfigCommand.read(key: "processing-mode", defaults: defaults), "raw")
         XCTAssertEqual(try ConfigCommand.read(key: "speech-engine", defaults: defaults), "parakeet")
@@ -76,7 +81,7 @@ final class ConfigCommandTests: XCTestCase {
         XCTAssertEqual(try ConfigCommand.read(key: "nemotron-language", defaults: defaults), "auto")
         XCTAssertEqual(try ConfigCommand.read(key: "whisper-language", defaults: defaults), "auto")
         XCTAssertEqual(try ConfigCommand.read(key: "cohere-language", defaults: defaults), "en")
-        XCTAssertEqual(try ConfigCommand.read(key: "speaker-detection", defaults: defaults), "off")
+        XCTAssertEqual(try ConfigCommand.read(key: "speaker-detection", defaults: defaults), "on")
         XCTAssertEqual(try ConfigCommand.read(key: "auto-meeting-titles", defaults: defaults), "on")
         XCTAssertEqual(try ConfigCommand.read(key: "voice-return-enabled", defaults: defaults), "off")
         XCTAssertEqual(try ConfigCommand.read(key: "voice-return-triggers", defaults: defaults), "press return")

--- a/Tests/CLITests/TranscribeCommandTests.swift
+++ b/Tests/CLITests/TranscribeCommandTests.swift
@@ -281,7 +281,8 @@ final class TranscribeCommandTests: XCTestCase {
 
     func testResolveSpeakerDetectionUsesStoredDefaultWhenRequested() {
         XCTAssertTrue(TranscribeCommand.resolveSpeakerDetection(.appDefault, storedEnabled: true, noDiarize: false))
-        XCTAssertFalse(TranscribeCommand.resolveSpeakerDetection(.appDefault, storedEnabled: nil, noDiarize: false))
+        XCTAssertTrue(TranscribeCommand.resolveSpeakerDetection(.appDefault, storedEnabled: nil, noDiarize: false))
+        XCTAssertFalse(TranscribeCommand.resolveSpeakerDetection(.appDefault, storedEnabled: false, noDiarize: false))
     }
 
     func testResolveSpeakerDetectionRespectsExplicitAndLegacyDisableFlag() {

--- a/Tests/MacParakeetTests/AppRuntimePreferencesTests.swift
+++ b/Tests/MacParakeetTests/AppRuntimePreferencesTests.swift
@@ -39,6 +39,21 @@ final class AppRuntimePreferencesTests: XCTestCase {
         XCTAssertTrue(preferences.shouldKeepDictationOnClipboard)
     }
 
+    func testSpeakerDiarizationDefaultsToTrueWhenUnset() {
+        let preferences = makePreferences()
+        XCTAssertTrue(preferences.shouldDiarize)
+    }
+
+    func testSpeakerDiarizationRespectsExplicitFalse() {
+        let suite = "app-runtime-prefs-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+        defaults.set(false, forKey: UserDefaultsAppRuntimePreferences.speakerDiarizationKey)
+
+        let preferences = UserDefaultsAppRuntimePreferences(defaults: defaults)
+        XCTAssertFalse(preferences.shouldDiarize)
+    }
+
     func testVoiceReturnTriggersAreDisabledWhenToggleIsOff() {
         let suite = "app-runtime-prefs-\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suite)!

--- a/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
@@ -228,7 +228,7 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.meetingAudioRetention, .keepForever)
         XCTAssertTrue(viewModel.saveMeetingAudio, "saveMeetingAudio should default to true")
         XCTAssertEqual(viewModel.youtubeAudioQuality, .m4a, "youtubeAudioQuality should default to Apple-friendly saved audio")
-        XCTAssertFalse(viewModel.speakerDiarization, "speakerDiarization should default to false")
+        XCTAssertTrue(viewModel.speakerDiarization, "speakerDiarization should default to true")
         XCTAssertEqual(viewModel.meetingHotkeyTrigger, .chord(modifiers: ["command", "shift"], keyCode: 46))
         XCTAssertEqual(viewModel.meetingAudioSourceMode, .microphoneAndSystem)
         XCTAssertFalse(viewModel.meetingAutoStopEnabled, "meeting auto-stop should default to false")
@@ -923,6 +923,15 @@ final class SettingsViewModelTests: XCTestCase {
         viewModel.speakerDiarization = true
 
         XCTAssertTrue(testDefaults.bool(forKey: UserDefaultsAppRuntimePreferences.speakerDiarizationKey))
+    }
+
+    func testSettingSpeakerDiarizationPersistsExplicitFalse() {
+        viewModel.speakerDiarization = false
+
+        XCTAssertEqual(
+            testDefaults.object(forKey: UserDefaultsAppRuntimePreferences.speakerDiarizationKey) as? Bool,
+            false
+        )
     }
 
     func testMeetingHotkeyPersistsToDedicatedDefaultsKey() {

--- a/docs/cli-testing.md
+++ b/docs/cli-testing.md
@@ -275,8 +275,8 @@ transcriptions and meetings; dictations reject those flags.
 ### Speaker Diarization
 
 Speaker detection follows the saved app/CLI preference by default. A fresh
-preference store resolves to `off`, matching the GUI default. Pin a run with
-the explicit option, or use the legacy alias to force it off:
+preference store resolves to `on`, matching the GUI default where supported.
+Pin a run with the explicit option, or use the legacy alias to force it off:
 
 ```bash
 swift run macparakeet-cli transcribe "<FILE>" --speaker-detection on

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -559,8 +559,9 @@ macparakeet-cli prompts run "<prompt-name>" \
   `--mode app-default`, `--downloaded-audio app-default`, and
   `--media-audio-quality app-default`) when you are intentionally checking
   GUI-default behavior. Pin explicit flags for reproducible agent tests.
-- `config get speaker-detection` reports the saved app-default value. Bare
-  `transcribe` and `--speaker-detection app-default` use that value; pass
+- `config get speaker-detection` reports the saved app-default value, which is
+  `on` for a fresh preference store. Bare `transcribe` and
+  `--speaker-detection app-default` use that value; pass
   `--speaker-detection on` or `off` to override it for one run. For known
   speaker counts, use per-run `--speaker-count`, `--speaker-min`, or
   `--speaker-max` instead of mutating the saved default.

--- a/spec/02-features.md
+++ b/spec/02-features.md
@@ -117,7 +117,7 @@ See [00-vision.md](./00-vision.md) for positioning and market context.
 2. Microphone permission
 3. Accessibility permission
 4. Hotkey instructions (configurable trigger + Esc)
-5. Speech stack setup (Parakeet; speaker detection is an opt-in Settings toggle, off by default; locale-aware Whisper setup for CJK macOS languages; Nemotron remains an explicit Beta choice after setup; Cohere remains an explicit batch-only choice after setup)
+5. Speech stack setup (Parakeet; speaker detection defaults on where supported and remains user-controllable in Settings; locale-aware Whisper setup for CJK macOS languages; Nemotron remains an explicit Beta choice after setup; Cohere remains an explicit batch-only choice after setup)
 6. Ready
 
 Meeting Recording and Calendar are opt-in and self-prompt on first use (see ADR-005 amendment, 2026-06-13).
@@ -1332,7 +1332,7 @@ new scheduling architecture.
 - Manual renaming: click speaker label to assign real name
 - Speaker colors in transcript view (visual differentiation)
 - Per-speaker analytics: speaking time, word count
-- Off by default for file transcription (opt-in Settings toggle); the CLI follows the saved preference — `--speaker-detection on` or a speaker-count constraint forces it on, `--no-diarize` forces it off
+- On by default where supported for file/URL transcription and meeting finalization with a system-audio track; the Settings toggle remains available, and the CLI follows the saved preference — `--speaker-detection off` / `--no-diarize` forces it off, while speaker-count constraints keep forcing it on for that run
 
 **Transcript with speakers:**
 
@@ -1393,8 +1393,8 @@ new scheduling architecture.
 - [x] Single-speaker files handled gracefully (one speaker label)
 - [x] Diarization failure is non-fatal (ASR result preserved)
 - [x] Progress shows "Identifying speakers..." headline
-- [x] Settings toggle for speaker detection (off by default, replaces planned Option-key alternate)
-- [x] CLI: `macparakeet-cli transcribe` follows the saved speaker-detection preference (off by default); `--speaker-detection on` / `--speaker-count` to force on, `--no-diarize` to force off
+- [x] Settings toggle for speaker detection (on by default where supported; explicit off is preserved)
+- [x] CLI: `macparakeet-cli transcribe` follows the saved speaker-detection preference (on by default when unset); `--speaker-detection off` / `--no-diarize` to force off, speaker-count constraints to force on
 
 ---
 

--- a/spec/adr/005-onboarding-first-run.md
+++ b/spec/adr/005-onboarding-first-run.md
@@ -39,7 +39,7 @@ While onboarding is visible, permission state is polled so changes made in Syste
 - Users get a guided, premium setup that reduces first-run friction.
 - Hotkey manager is restarted after onboarding to reliably start listening once Accessibility is granted.
 - The Parakeet STT model is downloaded/warmed during onboarding to reduce first-use latency for dictation.
-- If the user has enabled speaker detection (the toggle defaults off — ADR-010 amendment 2026-06-14), its diarization assets are also prepared before onboarding reports file transcription ready.
+- Speaker detection defaults on where supported (ADR-010 amendment 2026-07-03), so its diarization assets are prepared before onboarding reports file transcription ready when a diarization service is available.
 - Meeting Recording and Calendar steps are explicitly skippable. If skipped, the feature surfaces can still request the relevant permission later from first use or Settings.
 - Preflight checks fail fast with actionable guidance, reducing avoidable warm-up failures.
 - Onboarding completion is stored in `UserDefaults` as an ISO8601 timestamp.

--- a/spec/adr/010-speaker-diarization.md
+++ b/spec/adr/010-speaker-diarization.md
@@ -113,7 +113,7 @@ If diarization fails (e.g. `noSpeechDetected`, model error, timeout), the ASR re
 - Per-speaker analytics (speaking time, word count)
 - All export formats include speaker labels when available
 - Progress: "Identifying speakers..." sublabel with time estimate during diarization phase
-- Settings toggle to enable/disable diarization (on by default in the original decision; **shipped default is off** — see the 2026-06-14 amendment)
+- Settings toggle to enable/disable diarization (on by default where supported; explicit off remains respected — see the 2026-07-03 amendment)
 
 ### Always-on vs opt-in
 
@@ -129,14 +129,15 @@ If diarization fails (e.g. `noSpeechDetected`, model error, timeout), the ASR re
 
 Skip diarization for: dictation (single speaker by design), or when the Settings toggle is off.
 
-**CLI:** `macparakeet-cli transcribe` ~~runs diarization by default (backward compatibility)~~ does **not** diarize by default (corrected — see the 2026-06-14 amendment). Use `--no-diarize` to skip, or `--speaker-detection on` / a speaker-count constraint to force it on. Text output shows speaker labels at turn changes; JSON output includes all speaker data via Codable.
+**CLI:** `macparakeet-cli transcribe` follows the saved speaker-detection preference; when unset, the preference defaults to on where supported. Use `--no-diarize` / `--speaker-detection off` to skip, or a speaker-count constraint to force it on. Text output shows speaker labels at turn changes; JSON output includes all speaker data via Codable.
 
-**Readiness contract:** Diarization remains a separate service from the STT scheduler, but when speaker detection is enabled (off by default — see the 2026-06-14 amendment) the onboarding/ready-state path must account for diarization-model readiness before claiming file transcription is fully ready.
+**Readiness contract:** Diarization remains a separate service from the STT scheduler, but when speaker detection is enabled (on by default where supported — see the 2026-07-03 amendment) the onboarding/ready-state path must account for diarization-model readiness before claiming file transcription is fully ready.
 
 > **Amendment (2026-06-14):** Two corrections to keep this ADR faithful to the
-> shipped code.
+> shipped code at that point. The default-off correction below was superseded
+> by the 2026-07-03 amendment.
 >
-> **1. The shipped default is OFF, not on.** The "Speaker detection" toggle
+> **1. The shipped default was OFF, not on.** The "Speaker detection" toggle
 > defaults to off across the app — Settings, runtime preferences
 > (`AppRuntimePreferences.speakerDiarization`), and the CLI all resolve to off
 > unless the user opts in. The default was deliberately flipped on→off in commit
@@ -149,6 +150,16 @@ Skip diarization for: dictation (single speaker by design), or when the Settings
 > forces it off. (b) The readiness contract above applies only when the user has
 > enabled speaker detection — default onboarding does not fetch the ~130 MB
 > diarization assets.
+>
+> **Amendment (2026-07-03):** Meeting-corpus capture restored the default to
+> **ON where supported**. The `speakerDiarization` preference remains
+> UserDefaults-backed and user-controllable; an absent key resolves to on, while
+> an explicit stored `false` continues to disable speaker detection. Meetings
+> still only run diarization when a system-audio track exists, because the
+> meeting pipeline diarizes the isolated system side after capture. This aligns
+> with ADR-027's private speech-memory direction: speaker structure is only
+> recoverable while raw meeting audio exists, so capture-time diarization is the
+> last chance to preserve speaker labels in the corpus.
 >
 > **2. The FluidAudio dependency surface has grown.** The core decision above
 > still stands — MacParakeet ships only the offline batch pipeline and uses
@@ -217,7 +228,7 @@ Users can correct misattributions by renaming speakers. Missed speech is visible
 
 ### Negative
 
-- ~130 MB additional model download when the user enables speaker detection (off by default, so default onboarding skips it — see the 2026-06-14 amendment)
+- ~130 MB additional model download for default-on speaker detection where supported (see the 2026-07-03 amendment)
 - ~2-4% DER loss vs PyTorch reference due to CoreML fp16 quantization
 - Overlapping speech regions are trimmed (exclusive output) — words in overlap zones may get `speakerId = nil`
 - No cross-file speaker identity (Speaker 1 in file A is not linked to Speaker 1 in file B)

--- a/spec/adr/016-centralized-stt-runtime-scheduler.md
+++ b/spec/adr/016-centralized-stt-runtime-scheduler.md
@@ -181,7 +181,7 @@ It remains a separate service because:
 
 The STT control plane may coordinate with diarization for lifecycle/UI/reporting purposes, but diarization capacity policy remains separate.
 
-Keeping diarization out of the speech-slot scheduler does **not** mean product readiness may ignore it. When speaker detection is enabled (it is off by default — see ADR-010 amendment 2026-06-14), onboarding and ready-state UX must account for diarization-model readiness before claiming file transcription is fully prepared.
+Keeping diarization out of the speech-slot scheduler does **not** mean product readiness may ignore it. Speaker detection now defaults on where supported (see ADR-010 amendment 2026-07-03), so onboarding and ready-state UX must account for diarization-model readiness before claiming file transcription is fully prepared when a diarization service is available.
 
 ### 9. Progress must be job-scoped
 


### PR DESCRIPTION
## Summary

- Default speaker detection now resolves to on when the shared UserDefaults key is absent.
- Settings, CLI config, and CLI app-default transcription/retranscription all use the same default while preserving explicit off.
- Docs and CLI changelog now call out the user-visible default-on behavior for release notes.

## Design

Plan alignment: this implements Slice 4 from plans/active/2026-07-03-meeting-corpus-capture.md, Product decisions section 1. It also follows ADR-027 by preserving speaker structure at capture time so the local meeting corpus stays useful after raw audio is no longer available.

Storage analysis: the preference is UserDefaults-backed at UserDefaultsAppRuntimePreferences.speakerDiarizationKey. Reads use object(forKey:) as? Bool, which distinguishes never set from explicit false. This PR changes the absent-key fallback to true through UserDefaultsAppRuntimePreferences.speakerDiarizationEnabled(defaults:), while a stored false still returns false. That means existing users who never touched the setting intentionally move to default-on; users who explicitly turned speaker detection off remain off.

Meeting support boundary: the system-track guard is unchanged. Meeting diarization still requires a diarization service, shouldDiarize == true, and recording.sourceAlignment.system != nil before the system-side diarization path runs. Meetings without a system track still do nothing new.

One important scope note: the stored preference is shared across file/URL and meeting transcription. Flipping this default therefore also makes fresh/never-set CLI and file/URL app-default speaker detection resolve to on. The PR documents that in spec/02-features.md, docs/cli-testing.md, integrations/README.md, ADR-010, and Sources/CLI/CHANGELOG.md.

## Risk surface

- User-visible behavior change: fresh or never-set users can now get speaker-model preparation and post-STT diarization by default where supported.
- Runtime/pipeline risk is low: no diarization quality changes, no meeting system-track guard changes, no telemetry changes, no retention changes, and no UI changes.
- Escape hatch is unchanged: Settings explicit off, config set speaker-detection off, --speaker-detection off, and --no-diarize all still disable diarization.

## Test evidence

- swift test --filter AppRuntimePreferencesTests OR SettingsViewModelTests default and speaker-diarization tests OR ConfigCommandTests speaker defaults OR TranscribeCommandTests speaker default resolver
  - Result: selected focused run passed 45 tests, 0 failures.
  - Note: SwiftPM regex matching also selected LLMSettingsViewModelTests.testDefaultValuesAfterInit; no full suite was run.
- git diff --check
  - Result: passed.

## Post-Deploy Monitoring & Validation

No additional production monitoring required; this is a local UserDefaults fallback change with no service deploy. Release validation should include a clean-preference smoke of config get speaker-detection returning on, and an explicit stored off smoke returning off.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default speaker detection now resolves to on when the preference is unset, where supported. Settings, CLI, and app-default share one resolver; explicit off stays off, and meetings still only diarize when a system-audio track is present.

- New Features
  - Unset `speaker-detection` defaults to on; a saved false still disables it.
  - Settings, `config get speaker-detection`, and `--speaker-detection app-default` use the same default-on helper.
  - CLI help now shows default: on; `--speaker-detection off` and `--no-diarize` still disable diarization.
  - Docs, ADRs, and changelog updated to reflect default-on and the meeting system-track requirement.

<sup>Written for commit 71d8ac4ed1a28f5f6385e1d2cb24e59e6e59e1f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/688?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

