### PR TITLE
Clarify meeting audio removal consequences

### DIFF
--- a/Sources/CLI/Commands/HistoryCommand.swift
+++ b/Sources/CLI/Commands/HistoryCommand.swift
@@ -328,7 +328,8 @@ struct DeleteTranscriptionSubcommand: ParsableCommand {
 struct DeleteMeetingAudioSubcommand: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "delete-meeting-audio",
-        abstract: "Delete stored audio for a meeting transcript while keeping the transcript."
+        abstract: "Delete stored audio for a meeting transcript while keeping the transcript.",
+        discussion: "This permanently removes audio needed for re-transcription and speaker detection/backfill."
     )
 
     @Argument(help: "The UUID, UUID prefix, or file name of the meeting transcription.")
@@ -356,7 +357,9 @@ struct DeleteMeetingAudioSubcommand: ParsableCommand {
         }
 
         if result.removedOwnedAudio {
-            print("Detached managed meeting audio for: \"\(transcription.fileName)\"")
+            print(
+                "Detached managed meeting audio for: \"\(transcription.fileName)\". Audio was permanently removed; re-transcription and speaker detection/backfill are no longer possible for this recording."
+            )
         } else {
             print("No meeting audio attached for: \"\(transcription.fileName)\"")
         }

--- a/Sources/CLI/Commands/SpecCommand.swift
+++ b/Sources/CLI/Commands/SpecCommand.swift
@@ -372,7 +372,7 @@ private extension CLISpecCommand {
         ),
         CLISpecCommand(
             ["history", "delete-meeting-audio"],
-            summary: "Detach and delete stored audio for one meeting transcript while keeping the transcript row.",
+            summary: "Detach and delete stored audio for one meeting transcript while keeping the transcript row; removed audio cannot be used for re-transcription or speaker detection/backfill.",
             readOnly: false,
             jsonMode: "none",
             arguments: [.argument("id", summary: "Meeting transcription UUID, UUID prefix, or file name.")],

--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingDeletionCopy.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingDeletionCopy.swift
@@ -25,7 +25,7 @@ enum MeetingDeletionCopy {
     static let fullDeleteMenuTitle = "Delete Meeting"
 
     static func singleAudioOnlyMessage(surface: Surface) -> String {
-        "This removes the saved audio for this meeting. The meeting stays in \(surface.name) with its transcript. Notes, AI results, and chats stay too if they exist. Playback and retranscription will no longer be available unless you saved a copy of the audio."
+        "This permanently deletes the saved audio for this meeting. The meeting stays in \(surface.name) with its transcript. Notes, AI results, and chats stay too if they exist. Playback and re-transcription will no longer be available, and MacParakeet will not be able to detect or backfill speakers for this recording."
     }
 
     static func bulkAudioOnlyMessage(
@@ -38,10 +38,10 @@ enum MeetingDeletionCopy {
         let meetingWord = count == 1 ? "meeting" : "meetings"
         let meetingSubject = count == 1 ? "The meeting stays" : "The meetings stay"
         let transcriptObject = count == 1 ? "its transcript" : "their transcripts"
-        let savedCopy = count == 1 ? "a copy" : "copies"
+        let recordingObject = count == 1 ? "this recording" : "these recordings"
         let prefix = skippedCount > 0 ? "\(selectedCount) selected \(selectedWord). " : ""
         var message =
-            "\(prefix)This removes saved audio from \(count) \(meetingWord). \(meetingSubject) in \(surface.name) with \(transcriptObject). Notes, AI results, and chats stay too if they exist. Playback and retranscription will no longer be available unless you saved \(savedCopy) of the audio."
+            "\(prefix)This permanently deletes saved audio from \(count) \(meetingWord). \(meetingSubject) in \(surface.name) with \(transcriptObject). Notes, AI results, and chats stay too if they exist. Playback and re-transcription will no longer be available, and MacParakeet will not be able to detect or backfill speakers for \(recordingObject)."
         if skippedCount > 0 {
             if skippedCount == 1 {
                 message += " 1 selected meeting already has no saved audio, so it will be skipped."

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -1967,7 +1967,7 @@ struct SettingsView: View {
                 }
             }
 
-            Text("Transcripts stay. Removing audio disables playback and retranscription unless you saved a copy.")
+            Text("Transcripts stay. Auto-removed audio is deleted permanently; playback and re-transcription will no longer be available, and MacParakeet cannot detect or backfill speakers for swept meetings.")
                 .font(DesignSystem.Typography.caption)
                 .foregroundStyle(.secondary)
         }
@@ -2016,9 +2016,9 @@ struct SettingsView: View {
         case .keepForever:
             return ""
         case .deleteAfterDays(let days):
-            return "MacParakeet will remove saved meeting audio older than \(MeetingAudioRetention.normalizedDeleteAfterDays(days)) days. Transcripts stay, and notes, AI results, and chats stay if they exist. Playback and retranscription will no longer be available for meetings whose audio has been removed."
+            return "MacParakeet will remove saved meeting audio older than \(MeetingAudioRetention.normalizedDeleteAfterDays(days)) days. Transcripts stay, and notes, AI results, and chats stay if they exist. Playback and re-transcription will no longer be available, and MacParakeet cannot detect or backfill speakers for swept meetings."
         case .deleteImmediately:
-            return "MacParakeet will remove saved audio after each final transcript is saved. The meeting stays with its transcript, and notes, AI results, and chats stay if they exist. Playback and retranscription will no longer be available unless you saved a copy of the audio."
+            return "MacParakeet will remove saved audio after each final transcript is saved. The meeting stays with its transcript, and notes, AI results, and chats stay if they exist. Playback and re-transcription will no longer be available, and MacParakeet cannot detect or backfill speakers for swept meetings."
         }
     }
 

--- a/Tests/CLITests/HistoryCommandTests.swift
+++ b/Tests/CLITests/HistoryCommandTests.swift
@@ -198,6 +198,7 @@ final class HistoryCommandTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: systemAudioURL.path))
         XCTAssertTrue(FileManager.default.fileExists(atPath: notesURL.path))
         XCTAssertTrue(output.contains("Detached managed meeting audio"))
+        XCTAssertTrue(output.contains("re-transcription and speaker detection/backfill are no longer possible"))
     }
 
     func testClearMeetingAudioCommandRemovesAudioAndPreservesArtifactFolders() throws {

--- a/Tests/CLITests/SpecCommandTests.swift
+++ b/Tests/CLITests/SpecCommandTests.swift
@@ -194,6 +194,9 @@ final class SpecCommandTests: XCTestCase {
         let promptSetOptions = try XCTUnwrap(promptsSet["options"] as? [[String: Any]])
         XCTAssertTrue(promptSetOptions.contains { ($0["name"] as? String) == "--source" })
 
+        let deleteMeetingAudio = try XCTUnwrap(commands.first { ($0["path"] as? [String]) == ["history", "delete-meeting-audio"] })
+        XCTAssertTrue((deleteMeetingAudio["summary"] as? String)?.contains("re-transcription or speaker detection/backfill") == true)
+
         for path in [
             ["prompts", "run"],
             ["llm", "summarize"],

--- a/Tests/MacParakeetTests/Views/MeetingDeletionCopyTests.swift
+++ b/Tests/MacParakeetTests/Views/MeetingDeletionCopyTests.swift
@@ -6,10 +6,12 @@ final class MeetingDeletionCopyTests: XCTestCase {
     func testAudioOnlyCopyKeepsMeetingAndNamesOptionalArtifacts() {
         let message = MeetingDeletionCopy.singleAudioOnlyMessage(surface: .library)
 
-        XCTAssertTrue(message.contains("removes the saved audio"))
+        XCTAssertTrue(message.contains("permanently deletes the saved audio"))
         XCTAssertTrue(message.contains("meeting stays in Library"))
         XCTAssertTrue(message.contains("Notes, AI results, and chats stay too if they exist"))
-        XCTAssertTrue(message.contains("Playback and retranscription will no longer be available"))
+        XCTAssertTrue(message.contains("Playback and re-transcription will no longer be available"))
+        XCTAssertTrue(message.contains("detect or backfill speakers for this recording"))
+        XCTAssertEqual(message.components(separatedBy: "permanently").count - 1, 1)
     }
 
     func testFullDeleteCopyDeletesOptionalArtifactsOnlyIfTheyExist() {
@@ -36,8 +38,9 @@ final class MeetingDeletionCopyTests: XCTestCase {
         )
 
         XCTAssertTrue(message.contains("3 selected meetings"))
-        XCTAssertTrue(message.contains("removes saved audio from 1 meeting"))
+        XCTAssertTrue(message.contains("permanently deletes saved audio from 1 meeting"))
         XCTAssertTrue(message.contains("meeting stays in Meetings"))
+        XCTAssertTrue(message.contains("detect or backfill speakers for this recording"))
         XCTAssertTrue(message.contains("2 selected meetings already have no saved audio"))
     }
 
@@ -49,7 +52,8 @@ final class MeetingDeletionCopyTests: XCTestCase {
         )
 
         XCTAssertFalse(message.contains("3 selected meetings"))
-        XCTAssertTrue(message.contains("removes saved audio from 3 meetings"))
+        XCTAssertTrue(message.contains("permanently deletes saved audio from 3 meetings"))
+        XCTAssertTrue(message.contains("detect or backfill speakers for these recordings"))
     }
 
     func testBulkAudioOnlyCopyUsesSingularSkippedGrammar() {
@@ -76,7 +80,7 @@ final class MeetingDeletionCopyTests: XCTestCase {
         )
 
         XCTAssertTrue(message.contains("7 selected meetings"))
-        XCTAssertTrue(message.contains("removes saved audio from 2 meetings"))
+        XCTAssertTrue(message.contains("permanently deletes saved audio from 2 meetings"))
         XCTAssertTrue(message.contains("meetings stay in Library"))
         XCTAssertTrue(message.contains("5 selected meetings already have no saved audio"))
     }


### PR DESCRIPTION
## Summary
- Update shared Remove Audio confirmation copy for single and bulk meeting audio removal in Library, Meetings, and transcript detail surfaces.
- Update the Settings meeting audio retention description and existing auto-removal confirmation copy.
- Update `history delete-meeting-audio` help/output copy and the CLI spec summary.

## Exact copy added per surface

### Remove Audio action
Single-recording confirmation template:

> This permanently deletes the saved audio for this meeting. The meeting stays in `surface.name` with its transcript. Notes, AI results, and chats stay too if they exist. Playback and re-transcription will no longer be available, and MacParakeet will not be able to detect or backfill speakers for this recording.

Bulk confirmation template:

> This permanently deletes saved audio from `count` `meetingWord`. `meetingSubject` in `surface.name` with `transcriptObject`. Notes, AI results, and chats stay too if they exist. Playback and re-transcription will no longer be available, and MacParakeet will not be able to detect or backfill speakers for `recordingObject`.

### Retention setting
Storage row description:

> Transcripts stay. Auto-removed audio is deleted permanently; playback and re-transcription will no longer be available, and MacParakeet cannot detect or backfill speakers for swept meetings.

Delete-after confirmation template:

> MacParakeet will remove saved meeting audio older than `N` days. Transcripts stay, and notes, AI results, and chats stay if they exist. Playback and re-transcription will no longer be available, and MacParakeet cannot detect or backfill speakers for swept meetings.

Delete-immediately confirmation:

> MacParakeet will remove saved audio after each final transcript is saved. The meeting stays with its transcript, and notes, AI results, and chats stay if they exist. Playback and re-transcription will no longer be available, and MacParakeet cannot detect or backfill speakers for swept meetings.

### CLI
`history delete-meeting-audio --help` discussion:

> This permanently removes audio needed for re-transcription and speaker detection/backfill.

Deletion confirmation output:

> Detached managed meeting audio for: `"<name>"`. Audio was permanently removed; re-transcription and speaker detection/backfill are no longer possible for this recording.

CLI spec summary:

> Detach and delete stored audio for one meeting transcript while keeping the transcript row; removed audio cannot be used for re-transcription or speaker detection/backfill.

## Risk surface
- Very low: copy-only change plus focused assertion updates.
- No cleanup behavior changes; raw meeting audio deletion still uses the existing deletion paths.
- No telemetry changes.

## Verification
- `git diff --check`
- `swift test --filter MeetingDeletionCopyTests`
- `swift test --filter HistoryCommandTests/testDeleteMeetingAudioCommandKeepsTranscriptAndClearsFilePath`
- `swift test --filter SpecCommandTests/testSpecCatalogDocumentsAgentAutomationFamilies`
- `swift build`

## Post-Deploy Monitoring & Validation
No additional operational monitoring required. This PR only changes warning/help text and focused copy assertions; it does not alter runtime deletion, retention, or telemetry behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies that removing meeting audio is permanent across Library, Meetings, transcript detail, Settings retention, and the CLI. After deletion, playback and re-transcription stop working, MacParakeet cannot detect/backfill speakers, and the transcript remains (notes/AI results/chats stay if present); no behavior change.

<sup>Written for commit 0ea9ddff4f45b975a586f0b680aab47070c2a1a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/689?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

