### PR TITLE
Improve onboarding telemetry

### DIFF
--- a/Sources/MacParakeet/Onboarding/OnboardingWindowController.swift
+++ b/Sources/MacParakeet/Onboarding/OnboardingWindowController.swift
@@ -79,6 +79,7 @@ final class OnboardingWindowController: NSObject, NSWindowDelegate {
 
             let response = alert.runModal()
             if response == .alertSecondButtonReturn {
+                vm.markOnboardingDismissed()
                 onIncompleteDismiss()
                 allowCloseWithoutCompletion = true
                 close()

--- a/Sources/MacParakeet/Views/Onboarding/OnboardingFlowView.swift
+++ b/Sources/MacParakeet/Views/Onboarding/OnboardingFlowView.swift
@@ -70,6 +70,7 @@ struct OnboardingFlowView: View {
         .frame(width: windowWidth, height: windowHeight)
         .background(DesignSystem.Colors.background)
         .onAppear {
+            viewModel.markOnboardingShown()
             viewModel.startPermissionPolling()
             // Part B: kick the ~465 MB speech-model download off at onboarding
             // open so it overlaps the permission + hotkey steps. The Parakeet-vs-
@@ -134,6 +135,9 @@ struct OnboardingFlowView: View {
 
             VStack(alignment: .leading, spacing: 6) {
                 Label("Local-first. No audio uploads.", systemImage: "lock.shield")
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundStyle(.secondary)
+                Label("Setup metrics are non-identifying.", systemImage: "chart.bar.xaxis")
                     .font(DesignSystem.Typography.caption)
                     .foregroundStyle(.secondary)
                 Label("Paste needs Accessibility.", systemImage: "keyboard")
@@ -409,13 +413,13 @@ struct OnboardingFlowView: View {
                 )
                 featureRow(
                     icon: "bolt.fill",
-                    title: "Blazing fast",
-                    detail: "60 minutes of audio transcribed in ~23 seconds on Apple Silicon."
+                    title: "Ready before you need it",
+                    detail: "The local speech model downloads during setup so your first dictation is not a surprise wait."
                 )
                 featureRow(
                     icon: "lock.shield.fill",
-                    title: "100% local",
-                    detail: "Audio never leaves your Mac. No cloud STT. No accounts. Non-identifying diagnostics only."
+                    title: "Private by default",
+                    detail: "Audio and transcripts stay on your Mac. Setup telemetry is limited to non-identifying step and timing signals."
                 )
             }
         }
@@ -938,7 +942,7 @@ struct OnboardingFlowView: View {
     private func subtitleForStep(_ step: OnboardingViewModel.Step) -> String {
         switch step {
         case .welcome:
-            return "A fast, private voice app for Mac. Completely free."
+            return "Set up the permissions and local speech model that make dictation reliable."
         case .microphone:
             return "MacParakeet needs microphone permission to record your voice."
         case .accessibility:
@@ -951,7 +955,7 @@ struct OnboardingFlowView: View {
             }
             return "The speech model (~465 MB) downloads once. Usually quick on broadband, longer on slower connections."
         case .done:
-            return "You're all set. Start dictating or transcribe your first file."
+            return "Start with dictation. Meeting recording, files, and settings are ready when you need them."
         }
     }
 

--- a/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
+++ b/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
@@ -453,6 +453,17 @@ public enum TelemetryPermission: String, Sendable, Equatable {
     case calendar
 }
 
+public enum TelemetryOnboardingAction: String, Sendable, Equatable {
+    case viewed
+    case forward
+    case back
+    case jump
+    case completed
+    case dismissed
+    case engineReady = "engine_ready"
+    case engineFailed = "engine_failed"
+}
+
 /// Which capture surface a hotkey customization applies to. Lets us answer
 /// product questions like "do meeting hotkeys get customized as often as
 /// dictation?" and "which surface is most likely to land on a chord vs a
@@ -714,7 +725,14 @@ public enum TelemetryEventSpec: Sendable {
     case settingChanged(setting: TelemetrySettingName)
     case telemetryOptedOut
     case onboardingCompleted(durationSeconds: Double?)
-    case onboardingStep(step: String)
+    case onboardingStep(
+        step: String,
+        action: TelemetryOnboardingAction,
+        elapsedSeconds: Double?,
+        stepIndex: Int?,
+        totalSteps: Int?,
+        engineState: String?
+    )
     case licenseActivated
     case licenseActivationFailed(errorType: String, errorDetail: String? = nil)
     case trialStarted
@@ -1368,8 +1386,15 @@ extension TelemetryEventSpec {
             return Self.compactProps(
                 ("duration_seconds", durationSeconds.map(Self.format))
             )
-        case .onboardingStep(let step):
-            return ["step": step]
+        case .onboardingStep(let step, let action, let elapsedSeconds, let stepIndex, let totalSteps, let engineState):
+            return Self.compactProps(
+                ("step", step),
+                ("action", action.rawValue),
+                ("elapsed_seconds", elapsedSeconds.map(Self.format)),
+                ("step_index", stepIndex.map(String.init)),
+                ("total_steps", totalSteps.map(String.init)),
+                ("engine_state", engineState)
+            )
         case .licenseActivationFailed(let errorType, let errorDetail):
             var props = ["error_type": errorType]
             if let errorDetail = Self.sanitizedErrorDetail(errorDetail) { props["error_detail"] = errorDetail }
@@ -1776,7 +1801,7 @@ public enum TelemetryImplementedContract {
         .settingChanged: ["setting"],
         .telemetryOptedOut: [],
         .onboardingCompleted: [],
-        .onboardingStep: ["step"],
+        .onboardingStep: ["step", "action"],
         .licenseActivated: [],
         .licenseActivationFailed: ["error_type"],
         .trialStarted: [],

--- a/Sources/MacParakeetViewModels/OnboardingViewModel.swift
+++ b/Sources/MacParakeetViewModels/OnboardingViewModel.swift
@@ -39,6 +39,17 @@ public final class OnboardingViewModel {
             case .done: return "Ready"
             }
         }
+
+        public var telemetryName: String {
+            switch self {
+            case .welcome: return "welcome"
+            case .microphone: return "microphone"
+            case .accessibility: return "accessibility"
+            case .hotkey: return "hotkey"
+            case .engine: return "speech_model"
+            case .done: return "ready"
+            }
+        }
     }
 
     public enum EngineState: Sendable, Equatable {
@@ -81,8 +92,10 @@ public final class OnboardingViewModel {
     private let downloadWhisperModel: WhisperModelDownloader
     private let defaults: UserDefaults
     private let now: @Sendable () -> Date
+    private let startedAt: Date
     private let permissionPollingInterval: Duration
     private let warmUpStallTimeout: Duration
+    private var didEmitInitialStep = false
     private var engineGeneration: Int = 0
     private var refreshTask: Task<Void, Never>?
     private var permissionPollingTask: Task<Void, Never>?
@@ -140,6 +153,7 @@ public final class OnboardingViewModel {
         }
         self.defaults = defaults
         self.now = now
+        self.startedAt = now()
         self.permissionPollingInterval = permissionPollingInterval
         self.warmUpStallTimeout = warmUpStallTimeout
         self.whisperRecommendation = Self.recommendedWhisperLanguage(
@@ -155,8 +169,20 @@ public final class OnboardingViewModel {
         let completedAt = now()
         let iso = ISO8601DateFormatter().string(from: completedAt)
         defaults.set(iso, forKey: Self.onboardingCompletedKey)
-        Telemetry.send(.onboardingCompleted(durationSeconds: nil))
+        let durationSeconds = completedAt.timeIntervalSince(startedAt)
+        sendStepTelemetry(step: .done, action: .completed, at: completedAt)
+        Telemetry.send(.onboardingCompleted(durationSeconds: durationSeconds))
         return Completion(completedAt: completedAt)
+    }
+
+    public func markOnboardingShown() {
+        guard !didEmitInitialStep else { return }
+        didEmitInitialStep = true
+        sendStepTelemetry(step: step, action: .viewed)
+    }
+
+    public func markOnboardingDismissed() {
+        sendStepTelemetry(step: step, action: .dismissed)
     }
 
     public func resetOnboarding() {
@@ -189,7 +215,7 @@ public final class OnboardingViewModel {
         let currentRaw = step.rawValue
         guard let next = visible.first(where: { $0.rawValue > currentRaw }) else { return }
         step = next
-        Telemetry.send(.onboardingStep(step: next.title.lowercased()))
+        sendStepTelemetry(step: next, action: .forward)
         refresh()
     }
 
@@ -198,11 +224,13 @@ public final class OnboardingViewModel {
         let currentRaw = step.rawValue
         guard let prev = visible.last(where: { $0.rawValue < currentRaw }) else { return }
         step = prev
+        sendStepTelemetry(step: prev, action: .back)
         refresh()
     }
 
     public func jump(to target: Step) {
         step = target
+        sendStepTelemetry(step: target, action: .jump)
         refresh()
     }
 
@@ -291,6 +319,9 @@ public final class OnboardingViewModel {
     private func applyEngineWarmUpFailure(_ message: String) {
         engineBusy = false
         engineState = (step == .engine) ? .failed(message: message) : .idle
+        if step == .engine {
+            sendStepTelemetry(step: .engine, action: .engineFailed, engineState: "failed")
+        }
     }
 
     public func startEngineWarmUp() {
@@ -404,6 +435,7 @@ public final class OnboardingViewModel {
                     guard self.engineGeneration == generation, self.warmUpObservationToken == observationToken else { break observationLoop }
                     self.engineState = .ready
                     self.engineBusy = false
+                    self.sendStepTelemetry(step: .engine, action: .engineReady, engineState: "ready")
                     break observationLoop
                 case .failed(let message):
                     Telemetry.send(.modelDownloadFailed(
@@ -461,6 +493,7 @@ public final class OnboardingViewModel {
 
                 self.engineState = .ready
                 self.engineBusy = false
+                self.sendStepTelemetry(step: .engine, action: .engineReady, engineState: "ready")
             } catch is CancellationError {
                 guard self.engineGeneration == generation else { return }
                 self.engineState = .idle
@@ -671,6 +704,35 @@ public final class OnboardingViewModel {
             Task { [sttClient] in await sttClient.removeWarmUpObserver(id: id) }
         }
         warmUpObserverId = nil
+    }
+
+    private func sendStepTelemetry(
+        step: Step,
+        action: TelemetryOnboardingAction,
+        at date: Date? = nil,
+        engineState explicitEngineState: String? = nil
+    ) {
+        let visible = Self.visibleSteps
+        let stepIndex = visible.firstIndex(of: step).map { $0 + 1 }
+        let engineState = explicitEngineState ?? {
+            guard step == .engine else { return nil }
+            switch self.engineState {
+            case .idle: return "idle"
+            case .working: return "working"
+            case .ready: return "ready"
+            case .failed: return "failed"
+            }
+        }()
+        let elapsedSeconds = (date ?? now()).timeIntervalSince(startedAt)
+
+        Telemetry.send(.onboardingStep(
+            step: step.telemetryName,
+            action: action,
+            elapsedSeconds: elapsedSeconds,
+            stepIndex: stepIndex,
+            totalSteps: visible.count,
+            engineState: engineState
+        ))
     }
 
     /// Schedule (or reschedule) the warm-up stall watchdog. Cancels any

--- a/Sources/MacParakeetViewModels/OnboardingViewModel.swift
+++ b/Sources/MacParakeetViewModels/OnboardingViewModel.swift
@@ -92,10 +92,11 @@ public final class OnboardingViewModel {
     private let downloadWhisperModel: WhisperModelDownloader
     private let defaults: UserDefaults
     private let now: @Sendable () -> Date
-    private let startedAt: Date
+    private var startedAt: Date
     private let permissionPollingInterval: Duration
     private let warmUpStallTimeout: Duration
     private var didEmitInitialStep = false
+    private var completionForCurrentRun: Completion?
     private var engineGeneration: Int = 0
     private var refreshTask: Task<Void, Never>?
     private var permissionPollingTask: Task<Void, Never>?
@@ -166,13 +167,19 @@ public final class OnboardingViewModel {
     }
 
     public func markOnboardingCompleted() -> Completion {
+        if let completionForCurrentRun {
+            return completionForCurrentRun
+        }
+
         let completedAt = now()
         let iso = ISO8601DateFormatter().string(from: completedAt)
         defaults.set(iso, forKey: Self.onboardingCompletedKey)
         let durationSeconds = completedAt.timeIntervalSince(startedAt)
         sendStepTelemetry(step: .done, action: .completed, at: completedAt)
         Telemetry.send(.onboardingCompleted(durationSeconds: durationSeconds))
-        return Completion(completedAt: completedAt)
+        let completion = Completion(completedAt: completedAt)
+        completionForCurrentRun = completion
+        return completion
     }
 
     public func markOnboardingShown() {
@@ -189,6 +196,9 @@ public final class OnboardingViewModel {
         defaults.removeObject(forKey: Self.onboardingCompletedKey)
         step = .welcome
         engineState = .idle
+        startedAt = now()
+        didEmitInitialStep = false
+        completionForCurrentRun = nil
     }
 
     public func refresh() {

--- a/Tests/MacParakeetTests/TelemetryServiceTests.swift
+++ b/Tests/MacParakeetTests/TelemetryServiceTests.swift
@@ -1553,7 +1553,14 @@ final class TelemetryServiceTests: XCTestCase {
                 systemInfoIncluded: true,
                 errorType: nil
             ),
-            .onboardingStep(step: "microphone"),
+            .onboardingStep(
+                step: "microphone",
+                action: .forward,
+                elapsedSeconds: 1.0,
+                stepIndex: 2,
+                totalSteps: 6,
+                engineState: nil
+            ),
             .licenseActivationFailed(errorType: "invalid_key"),
             .keystrokeSnippetFired(action: "return"),
             .meetingRecordingStarted(),

--- a/Tests/MacParakeetTests/ViewModels/OnboardingViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/OnboardingViewModelTests.swift
@@ -58,6 +58,27 @@ private actor WhisperDownloadSpy {
     }
 }
 
+private final class OnboardingTestClock: @unchecked Sendable {
+    private let lock = NSLock()
+    private var date: Date
+
+    init(_ date: Date) {
+        self.date = date
+    }
+
+    func now() -> Date {
+        lock.lock()
+        defer { lock.unlock() }
+        return date
+    }
+
+    func set(_ date: Date) {
+        lock.lock()
+        self.date = date
+        lock.unlock()
+    }
+}
+
 private final class PollingPermissionService: PermissionServiceProtocol, @unchecked Sendable {
     private let microphoneCheckCount = OSAllocatedUnfairLock(initialState: 0)
 
@@ -868,6 +889,100 @@ final class OnboardingViewModelTests: XCTestCase {
         XCTAssertFalse(vm.hasCompletedOnboarding)
         _ = vm.markOnboardingCompleted()
         XCTAssertTrue(vm.hasCompletedOnboarding)
+    }
+
+    func testOnboardingCompletionTelemetryIncludesDuration() {
+        let telemetry = OnboardingTelemetrySpy()
+        Telemetry.configure(telemetry)
+        defer { Telemetry.configure(NoOpTelemetryService()) }
+
+        let perms = MockPermissionService()
+        let stt = MockSTTClient()
+        let suite = "com.macparakeet.tests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let clock = OnboardingTestClock(Date(timeIntervalSince1970: 100))
+
+        let vm = makeViewModel(
+            permissionService: perms,
+            sttClient: stt,
+            defaults: defaults,
+            now: { clock.now() }
+        )
+        clock.set(Date(timeIntervalSince1970: 142.5))
+
+        _ = vm.markOnboardingCompleted()
+
+        let events = telemetry.snapshot()
+        XCTAssertTrue(events.contains {
+            guard case .onboardingStep(let step, let action, let elapsedSeconds, let stepIndex, let totalSteps, let engineState) = $0 else {
+                return false
+            }
+            return step == "ready"
+                && action == .completed
+                && elapsedSeconds == 42.5
+                && stepIndex == 6
+                && totalSteps == 6
+                && engineState == nil
+        })
+        XCTAssertTrue(events.contains {
+            guard case .onboardingCompleted(let durationSeconds) = $0 else { return false }
+            return durationSeconds == 42.5
+        })
+    }
+
+    func testOnboardingNavigationTelemetryCapturesActionsAndStepIndexes() {
+        let telemetry = OnboardingTelemetrySpy()
+        Telemetry.configure(telemetry)
+        defer { Telemetry.configure(NoOpTelemetryService()) }
+
+        let perms = MockPermissionService()
+        let stt = MockSTTClient()
+        let suite = "com.macparakeet.tests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let clock = OnboardingTestClock(Date(timeIntervalSince1970: 10))
+
+        let vm = makeViewModel(
+            permissionService: perms,
+            sttClient: stt,
+            defaults: defaults,
+            now: { clock.now() }
+        )
+
+        vm.markOnboardingShown()
+        clock.set(Date(timeIntervalSince1970: 12))
+        vm.goNext()
+        clock.set(Date(timeIntervalSince1970: 15))
+        vm.goBack()
+        clock.set(Date(timeIntervalSince1970: 18))
+        vm.markOnboardingDismissed()
+
+        let steps = telemetry.snapshot().compactMap { event -> (String, TelemetryOnboardingAction, Double?, Int?, Int?)? in
+            guard case .onboardingStep(let step, let action, let elapsedSeconds, let stepIndex, let totalSteps, _) = event else {
+                return nil
+            }
+            return (step, action, elapsedSeconds, stepIndex, totalSteps)
+        }
+
+        XCTAssertEqual(steps.count, 4)
+        XCTAssertEqual(steps[0].0, "welcome")
+        XCTAssertEqual(steps[0].1, .viewed)
+        XCTAssertEqual(steps[0].2, 0)
+        XCTAssertEqual(steps[0].3, 1)
+        XCTAssertEqual(steps[0].4, 6)
+        XCTAssertEqual(steps[1].0, "microphone")
+        XCTAssertEqual(steps[1].1, .forward)
+        XCTAssertEqual(steps[1].2, 2)
+        XCTAssertEqual(steps[1].3, 2)
+        XCTAssertEqual(steps[2].0, "welcome")
+        XCTAssertEqual(steps[2].1, .back)
+        XCTAssertEqual(steps[2].2, 5)
+        XCTAssertEqual(steps[2].3, 1)
+        XCTAssertEqual(steps[3].0, "welcome")
+        XCTAssertEqual(steps[3].1, .dismissed)
+        XCTAssertEqual(steps[3].2, 8)
+        XCTAssertEqual(steps[3].3, 1)
     }
 
     func testEngineWarmUpWithProgressPhases() async throws {

--- a/Tests/MacParakeetTests/ViewModels/OnboardingViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/OnboardingViewModelTests.swift
@@ -931,6 +931,85 @@ final class OnboardingViewModelTests: XCTestCase {
         })
     }
 
+    func testOnboardingCompletionTelemetryIsIdempotentForCurrentRun() {
+        let telemetry = OnboardingTelemetrySpy()
+        Telemetry.configure(telemetry)
+        defer { Telemetry.configure(NoOpTelemetryService()) }
+
+        let perms = MockPermissionService()
+        let stt = MockSTTClient()
+        let suite = "com.macparakeet.tests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let clock = OnboardingTestClock(Date(timeIntervalSince1970: 100))
+
+        let vm = makeViewModel(
+            permissionService: perms,
+            sttClient: stt,
+            defaults: defaults,
+            now: { clock.now() }
+        )
+        clock.set(Date(timeIntervalSince1970: 120))
+        let first = vm.markOnboardingCompleted()
+        clock.set(Date(timeIntervalSince1970: 160))
+        let second = vm.markOnboardingCompleted()
+
+        XCTAssertEqual(first.completedAt, second.completedAt)
+        let completionEvents = telemetry.snapshot().filter {
+            if case .onboardingCompleted = $0 { return true }
+            return false
+        }
+        let completedSteps = telemetry.snapshot().filter {
+            guard case .onboardingStep(_, let action, _, _, _, _) = $0 else { return false }
+            return action == .completed
+        }
+        XCTAssertEqual(completionEvents.count, 1)
+        XCTAssertEqual(completedSteps.count, 1)
+    }
+
+    func testResetOnboardingRestartsTelemetryRunState() {
+        let telemetry = OnboardingTelemetrySpy()
+        Telemetry.configure(telemetry)
+        defer { Telemetry.configure(NoOpTelemetryService()) }
+
+        let perms = MockPermissionService()
+        let stt = MockSTTClient()
+        let suite = "com.macparakeet.tests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let clock = OnboardingTestClock(Date(timeIntervalSince1970: 100))
+
+        let vm = makeViewModel(
+            permissionService: perms,
+            sttClient: stt,
+            defaults: defaults,
+            now: { clock.now() }
+        )
+        vm.markOnboardingShown()
+        clock.set(Date(timeIntervalSince1970: 120))
+        _ = vm.markOnboardingCompleted()
+
+        clock.set(Date(timeIntervalSince1970: 200))
+        vm.resetOnboarding()
+        vm.markOnboardingShown()
+        clock.set(Date(timeIntervalSince1970: 230))
+        _ = vm.markOnboardingCompleted()
+
+        let shownSteps = telemetry.snapshot().compactMap { event -> Double? in
+            guard case .onboardingStep(_, let action, let elapsedSeconds, _, _, _) = event,
+                  action == .viewed
+            else { return nil }
+            return elapsedSeconds
+        }
+        let completionDurations = telemetry.snapshot().compactMap { event -> Double? in
+            guard case .onboardingCompleted(let durationSeconds) = event else { return nil }
+            return durationSeconds
+        }
+
+        XCTAssertEqual(shownSteps, [0, 0])
+        XCTAssertEqual(completionDurations, [20, 30])
+    }
+
     func testOnboardingNavigationTelemetryCapturesActionsAndStepIndexes() {
         let telemetry = OnboardingTelemetrySpy()
         Telemetry.configure(telemetry)

--- a/docs/audits/2026-07-04-onboarding-telemetry-review.md
+++ b/docs/audits/2026-07-04-onboarding-telemetry-review.md
@@ -1,0 +1,79 @@
+# Onboarding + Telemetry Review
+
+Date: 2026-07-04
+Source: Cloudflare D1 `macparakeet-telemetry` (`7372263e-6a0b-4c70-8188-8f1d6d16bf31`) and current app code.
+
+## Live Findings
+
+- Ingestion is current: D1 had 1,304,121 rows from 2026-03-13T19:00:00Z through 2026-07-04T06:57:46Z at review time.
+- The database is 709 MB. `wrangler d1 info` reported 196,905 rows written in the prior 24h, so retention and aggregation pressure remain real operational concerns.
+- Last 30 days, GUI release builds:
+  - Onboarding starters: 2,177
+  - Onboarding completers: 1,419
+  - Abandoned: 758 (34.8%)
+  - Same-session dictation try rate after completion: 52.4%
+  - Same-session dictation success rate after completion: 44.0%
+- Shorter windows:
+  - 7d: 425 starters, 291 completers, 31.5% abandon, 39.9% same-session dictation success
+  - 14d: 799 starters, 556 completers, 30.4% abandon, 42.6% same-session dictation success
+  - 30d: 2,177 starters, 1,419 completers, 34.8% abandon, 44.0% same-session dictation success
+
+## Step Drop-Off
+
+30-day distinct session transition rates:
+
+| Transition | Rate |
+|---|---:|
+| Microphone -> Accessibility | 95.3% |
+| Accessibility -> Hotkey | 86.9% |
+| Hotkey -> Speech Model | 98.9% |
+| Speech Model -> Ready | 81.2% |
+
+Furthest measured step for 30-day starters:
+
+| Furthest step | Sessions | Completed |
+|---|---:|---:|
+| Microphone | 97 | 0 |
+| Accessibility | 299 | 0 |
+| Hotkey | 20 | 2 |
+| Speech Model | 335 | 0 |
+| Ready | 1,421 | 1,417 |
+
+Speech Model is the biggest measured blocker. Accessibility is the second.
+
+## Model Setup Signals
+
+30-day GUI model-download telemetry:
+
+- `model_download_started local_speech_stack`: 1,730 sessions
+- `model_download_completed local_speech_stack`: 1,524 sessions
+- `model_download_failed WarmUpStalled`: 248 sessions
+- Other notable failures: `URLError.timedOut` 23 sessions, `HubClientError.downloadError` 18, `BackgroundWarmUpError` 16, `URLError.networkConnectionLost` 13
+
+Among onboarding sessions with model failures:
+
+- 123 sessions ended at Speech Model and did not complete.
+- 166 sessions still reached Ready and completed after a model failure.
+
+## Instrumentation Gaps Found
+
+- Existing `onboarding_completed` rows have missing `duration_seconds` in the last 30 days.
+- Existing `onboarding_step` only records the destination step on forward navigation, so it misses:
+  - welcome-only bounces
+  - back navigation
+  - sidebar jumps
+  - explicit setup dismissal
+  - engine ready versus engine failed terminal state
+- Existing step labels are human copy (`speech model`) rather than stable telemetry identifiers.
+
+## Change Direction
+
+Keep the six-step dictation-first onboarding contract from ADR-005. Do not add back meeting or calendar setup.
+
+Upgrade telemetry on the existing `onboarding_step` event instead of adding new event names, because the website Worker rejects unknown event names until its allowlist is deployed. The improved event should carry stable `step`, `action`, elapsed timing, step index, total steps, and optional engine state.
+
+Product priority after this review:
+
+1. Reduce Speech Model abandonment with better retry/failure measurement and more actionable recovery.
+2. Reduce Accessibility confusion without weakening the paste/hotkey requirement.
+3. Improve post-completion activation by nudging the first successful dictation, not just opening the app.

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -20,6 +20,10 @@
 > live enum to 100 events. The cross-repo
 > allowlist guard for that enum is tracked in
 > [`plans/active/2026-06-12-telemetry-allowlist-ci-guard.md`](../plans/active/2026-06-12-telemetry-allowlist-ci-guard.md).
+> Onboarding telemetry review: Codex (2026-07-04). Live D1 review found Speech
+> Model as the largest measured setup blocker, Accessibility second, and missing
+> completion durations on existing rows. See
+> [`docs/audits/2026-07-04-onboarding-telemetry-review.md`](audits/2026-07-04-onboarding-telemetry-review.md).
 
 ## Philosophy
 
@@ -190,7 +194,7 @@ when the question is "what happened to this operation?"
 | `app_launched` | — | How many active users? DAU/WAU/MAU? |
 | `app_quit` | `session_duration_seconds` | How long are sessions? |
 | `onboarding_completed` | `duration_seconds` | How long does setup take? |
-| `onboarding_step` | `step` (permissions, model_download, etc.) | Where do people get stuck in onboarding? |
+| `onboarding_step` | `step`, `action`, optional `elapsed_seconds`, `step_index`, `total_steps`, `engine_state` | Where do people get stuck in onboarding? Distinguishes viewed, forward/back/jump navigation, dismissed setup, engine ready/failed, and completion without adding a new allowlisted event name. |
 
 #### Activation analytics caveats (agents: read this)
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -194,7 +194,7 @@ when the question is "what happened to this operation?"
 | `app_launched` | — | How many active users? DAU/WAU/MAU? |
 | `app_quit` | `session_duration_seconds` | How long are sessions? |
 | `onboarding_completed` | `duration_seconds` | How long does setup take? |
-| `onboarding_step` | `step`, `action`, optional `elapsed_seconds`, `step_index`, `total_steps`, `engine_state` | Where do people get stuck in onboarding? Distinguishes viewed, forward/back/jump navigation, dismissed setup, engine ready/failed, and completion without adding a new allowlisted event name. |
+| `onboarding_step` | `step`, `action`, optional `elapsed_seconds`, `step_index`, `total_steps`, `engine_state` | Where do people get stuck in onboarding? `elapsed_seconds` is cumulative time since this onboarding window/run started, not per-step dwell time. `engine_state` is present only for Speech Model step events. Distinguishes viewed, forward/back/jump navigation, dismissed setup, engine ready/failed, and completion without adding a new allowlisted event name. |
 
 #### Activation analytics caveats (agents: read this)
 


### PR DESCRIPTION
## Summary

Onboarding telemetry can now explain where setup succeeds or breaks down instead of only counting forward step transitions. The existing `onboarding_step` event now carries stable step IDs, user action, cumulative elapsed time, step position, and Speech Model engine state; `onboarding_completed` now sends real duration and is idempotent for the current onboarding run.

The change is grounded in a live Cloudflare D1 review: the 30-day setup funnel showed ~35% abandonment, Speech Model as the largest measured blocker, Accessibility second, and missing completion durations on existing rows. Onboarding copy now makes the same privacy contract explicit: audio/transcripts stay local, and setup metrics are non-identifying.

## Design

- Keeps the existing `onboarding_step` event name so current website Worker allowlists continue accepting batches.
- Uses stable telemetry step IDs (`speech_model`, `ready`) instead of display copy such as `Speech Model`.
- Treats `elapsed_seconds` as cumulative time since the current onboarding window/run started; it is not per-step dwell time.
- Emits `engine_state` only for Speech Model step events.
- Makes completion telemetry idempotent per onboarding run and resets the run clock/state in `resetOnboarding()`.

## Risk Surface

- Telemetry schema consumers need to handle optional new props on an existing event. Old rows remain sparse by design.
- The biggest behavior-adjacent path is duplicate completion prevention; focused tests cover repeated completion calls and reset/re-onboarding timing.
- No audio, transcripts, prompt content, filenames, persistent identifiers, or new event names are introduced.

## Test Evidence

- `swift test --filter OnboardingViewModelTests` — 44 tests, 0 failures
- `swift test --filter TelemetryServiceTests` — 58 tests, 0 failures
- `git diff --check`
- Live D1 read against `macparakeet-telemetry` for 30d onboarding funnel, step drop-off, model failures, and completion-duration coverage

## Review Notes

- Greptile re-review on `d6171381d` reported 5/5 confidence and no blocking issues.
- Cubic's code findings were addressed by idempotent completion telemetry and reset-run-state coverage; the remaining docs wording findings were addressed in `bb3ffd953`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
