### PR TITLE
Skip cleaned mic renders that cannot beat readiness cap

### DIFF
--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingCleanedMicrophoneReadiness.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingCleanedMicrophoneReadiness.swift
@@ -13,10 +13,10 @@ public enum MeetingCleanedMicrophoneRoutingReason: String, Sendable, Codable, Ca
 
 public struct MeetingCleanedMicrophoneReadinessPolicy: Sendable, Equatable {
     /// `docs/audits/2026-07-04-localvqe-aec-runtime-findings.md` measured
-    /// 11.67-12.59x realtime on an M4 Pro. 12.0 is the optimistic bound, so
-    /// the duration guard only skips renders that would time out even at the
-    /// best measured rate.
-    public static let bestMeasuredRealtimeFactor: Double = 12.0
+    /// 11.67-12.59x realtime on an M4 Pro. The fastest observed factor keeps
+    /// the duration guard limited to renders that would exceed the cap even
+    /// at the best measured rate.
+    public static let bestMeasuredRealtimeFactor: Double = 12.59
 
     public static let production = MeetingCleanedMicrophoneReadinessPolicy(
         floorSeconds: 60,

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingCleanedMicrophoneReadiness.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingCleanedMicrophoneReadiness.swift
@@ -8,14 +8,16 @@ public enum MeetingCleanedMicrophoneRoutingReason: String, Sendable, Codable, Ca
     case rawMissingSystemReference
     case rawNoAECAssets
     case skippedNoEchoPath
+    case predictedRenderTimeout
 }
 
 public struct MeetingCleanedMicrophoneReadinessPolicy: Sendable, Equatable {
-    /// The v1.4 LocalVQE AEC model measured on this worktree at 16.33x realtime
-    /// for the conditioning core: 60.0 s synthetic meeting audio in 3.674 s on
-    /// an Apple M4 Pro via `MeetingAecRenderThroughputTests`. A 0.25x duration
-    /// budget assumes only 4x realtime, leaving roughly 3x margin for file
-    /// decode/encode and cold system load while still bounding final-STT delay.
+    /// `docs/audits/2026-07-04-localvqe-aec-runtime-findings.md` measured
+    /// 11.67-12.59x realtime on an M4 Pro. 12.0 is the optimistic bound, so
+    /// the duration guard only skips renders that would time out even at the
+    /// best measured rate.
+    public static let bestMeasuredRealtimeFactor: Double = 12.0
+
     public static let production = MeetingCleanedMicrophoneReadinessPolicy(
         floorSeconds: 60,
         durationMultiplier: 0.25,
@@ -44,6 +46,12 @@ public struct MeetingCleanedMicrophoneReadinessPolicy: Sendable, Equatable {
             scaled = capSeconds
         }
         return max(floorSeconds, min(scaled, capSeconds))
+    }
+
+    public func shouldAttemptRender(for recordingDuration: TimeInterval) -> Bool {
+        guard recordingDuration.isFinite, recordingDuration > 0 else { return true }
+        return recordingDuration / Self.bestMeasuredRealtimeFactor <= timeoutSeconds(
+            for: recordingDuration)
     }
 }
 
@@ -457,6 +465,28 @@ enum MeetingCleanedMicrophoneRenderScheduler {
         )
     }
 
+    static func skipPredictedRenderTimeout(
+        outputURL: URL,
+        sessionID: UUID,
+        fileManager: FileManager,
+        eventName: String
+    ) -> MeetingCleanedMicrophoneReadiness {
+        discardArtifact(
+            at: outputURL,
+            sessionID: sessionID,
+            reason: "predicted_render_timeout",
+            fileManager: fileManager,
+            eventName: eventName
+        )
+        appendDiagnostic(
+            eventName: eventName,
+            sessionID: sessionID,
+            outcome: "skipped",
+            reason: .predictedRenderTimeout
+        )
+        return .notScheduled(reason: .predictedRenderTimeout)
+    }
+
     private static func candidateOutputURL(for outputURL: URL, sessionID: UUID) -> URL {
         let basename = outputURL.deletingPathExtension().lastPathComponent
         let pathExtension = outputURL.pathExtension.isEmpty ? "tmp" : outputURL.pathExtension
@@ -720,7 +750,7 @@ extension MeetingRecordingOutput {
                     probeBestCorrelation: existing.probeBestCorrelation
                 )
             case .rawTimeout, .rawRenderFailed, .rawMissingSystemReference, .rawNoAECAssets,
-                    .skippedNoEchoPath:
+                    .skippedNoEchoPath, .predictedRenderTimeout:
                 break
             }
         }

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingMetadata.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingMetadata.swift
@@ -225,4 +225,19 @@ extension MeetingSourceAlignment {
         let originSeconds = AVAudioTime.seconds(forHostTime: originHostTime)
         return Int(((startSeconds - originSeconds) * 1000).rounded())
     }
+
+    var cleanedMicrophoneRenderDurationSeconds: TimeInterval {
+        [microphone?.durationSeconds, system?.durationSeconds]
+            .compactMap { $0 }
+            .max() ?? 0
+    }
+}
+
+extension MeetingSourceAlignment.Track {
+    var durationSeconds: TimeInterval {
+        guard writtenFrameCount > 0, sampleRate.isFinite, sampleRate > 0 else {
+            return 0
+        }
+        return Double(writtenFrameCount) / sampleRate
+    }
 }

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingRecoveryService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingRecoveryService.swift
@@ -50,6 +50,7 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
     /// the injected `echoSuppressionConfiguration`; resolves to passthrough
     /// (→ no cleaned file) without bundled AEC assets.
     private let micConditionerFactory: @Sendable () -> any MicConditioning
+    private let recordingDurationProvider: @Sendable ([TimeInterval], Date) -> TimeInterval
 
     public convenience init(
         meetingsRoot: URL = URL(fileURLWithPath: AppPaths.meetingRecordingsDir, isDirectory: true),
@@ -81,7 +82,10 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
         transcriptionRepo: TranscriptionRepositoryProtocol,
         audioConverter: AudioFileConverting = AudioFileConverter(),
         fileManager: FileManager = .default,
-        micConditionerFactory: @escaping @Sendable () -> any MicConditioning
+        micConditionerFactory: @escaping @Sendable () -> any MicConditioning,
+        recordingDurationProvider: @escaping @Sendable ([TimeInterval], Date) -> TimeInterval = { sourceDurations, startedAt in
+            sourceDurations.max() ?? max(0, Date().timeIntervalSince(startedAt))
+        }
     ) {
         self.meetingsRoot = meetingsRoot
         self.lockFileStore = lockFileStore
@@ -90,6 +94,7 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
         self.audioConverter = audioConverter
         self.fileManager = fileManager
         self.micConditionerFactory = micConditionerFactory
+        self.recordingDurationProvider = recordingDurationProvider
     }
 
     /// Minimum size (bytes) for either `microphone.m4a` or `system.m4a` to
@@ -217,22 +222,19 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
 
         let recoveredBySource = Dictionary(
             recoveredSources.map { ($0.source, $0.url) }, uniquingKeysWith: { first, _ in first })
+        // Clamp the provider output to non-negative. If the user's clock
+        // skewed backwards between lock-file write and recovery, fallback
+        // wall-clock duration can otherwise corrupt the recovered output.
+        let duration = max(0, recordingDurationProvider(recoveredSources.map(\.duration), lock.startedAt))
         let cleanedMicrophoneReadiness = scheduleCleanedMicrophoneRender(
             folderURL: folderURL,
             microphoneURL: recoveredBySource[.microphone],
             systemURL: recoveredBySource[.system],
             sourceAlignment: sourceAlignment,
-            sessionID: lock.sessionId
+            sessionID: lock.sessionId,
+            recordingDuration: duration
         )
 
-        // Clamp the wall-clock fallback to non-negative. If the user's clock
-        // skewed (NTP correction backwards, manual time change) between when
-        // the lock file was written and when recovery runs, `startedAt` can
-        // be in the future and `timeIntervalSince` returns a negative number —
-        // a malformed duration that would corrupt the recovered output.
-        let durationFromSources = recoveredSources.map(\.duration).max()
-        let durationFallback = max(0, Date().timeIntervalSince(lock.startedAt))
-        let duration = durationFromSources ?? durationFallback
         let recording = MeetingRecordingOutput(
             sessionID: lock.sessionId,
             displayName: lock.displayName,
@@ -287,10 +289,21 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
         microphoneURL: URL?,
         systemURL: URL?,
         sourceAlignment: MeetingSourceAlignment,
-        sessionID: UUID
+        sessionID: UUID,
+        recordingDuration: TimeInterval
     ) -> MeetingCleanedMicrophoneReadiness {
         let outputURL = folderURL.appendingPathComponent(
             MeetingCleanedMicRenderer.cleanedMicrophoneFileName)
+        guard MeetingCleanedMicrophoneReadinessPolicy.production.shouldAttemptRender(
+            for: recordingDuration
+        ) else {
+            return MeetingCleanedMicrophoneRenderScheduler.skipPredictedRenderTimeout(
+                outputURL: outputURL,
+                sessionID: sessionID,
+                fileManager: fileManager,
+                eventName: "meeting_recovery_cleaned_mic"
+            )
+        }
         return MeetingCleanedMicrophoneRenderScheduler.schedule(
             outputURL: outputURL,
             microphoneURL: microphoneURL,

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
@@ -669,11 +669,14 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         }
         paused = false
         let durationSeconds = max(0, activeRecordingSeconds(startedAt: session.startedAt, asOf: now))
+        // The render guard models audio work, so use captured media duration
+        // rather than user-facing wall-clock meeting duration.
+        let renderDurationSeconds = sourceAlignment.cleanedMicrophoneRenderDurationSeconds
         let cleanedMicrophoneReadiness = scheduleCleanedMicrophoneRender(
             session: session,
             availableSources: availableSources,
             sourceAlignment: sourceAlignment,
-            recordingDuration: durationSeconds
+            renderDuration: renderDurationSeconds
         )
         let output = MeetingRecordingOutput(
             sessionID: session.id,
@@ -1285,12 +1288,12 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         session: Session,
         availableSources: Set<AudioSource>,
         sourceAlignment: MeetingSourceAlignment,
-        recordingDuration: TimeInterval
+        renderDuration: TimeInterval
     ) -> MeetingCleanedMicrophoneReadiness {
         let outputURL = session.folderURL.appendingPathComponent(
             MeetingCleanedMicRenderer.cleanedMicrophoneFileName)
         guard MeetingCleanedMicrophoneReadinessPolicy.production.shouldAttemptRender(
-            for: recordingDuration
+            for: renderDuration
         ) else {
             return MeetingCleanedMicrophoneRenderScheduler.skipPredictedRenderTimeout(
                 outputURL: outputURL,

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
@@ -167,6 +167,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
 
     private let logger = Logger(subsystem: "com.macparakeet.core", category: "MeetingRecordingService")
     private let clock = ContinuousClock()
+    private let wallClockNow: @Sendable () -> Date
     private let audioCaptureService: any MeetingAudioCapturing
     private let audioConverter: any AudioFileConverting
     private let fileManager: FileManager
@@ -294,6 +295,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         isVadLiveChunkingEnabled: @escaping @Sendable () -> Bool = { false },
         micConditionerFactory: @escaping @Sendable () -> any MicConditioning,
         cleanedMicConditionerFactory: (@Sendable () -> any MicConditioning)? = nil,
+        wallClockNow: @escaping @Sendable () -> Date = { Date() },
         cleanedMicrophoneReadinessScheduler: @escaping MeetingCleanedMicrophoneReadinessScheduling = { outputURL, microphoneURL, systemURL, sourceAlignment, sessionID, conditionerFactory, fileManager, eventName in
             MeetingCleanedMicrophoneRenderScheduler.schedule(
                 outputURL: outputURL,
@@ -315,6 +317,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         self.isVadLiveChunkingEnabled = isVadLiveChunkingEnabled
         self.micConditionerFactory = micConditionerFactory
         self.cleanedMicConditionerFactory = cleanedMicConditionerFactory ?? micConditionerFactory
+        self.wallClockNow = wallClockNow
         self.cleanedMicrophoneReadinessScheduler = cleanedMicrophoneReadinessScheduler
         self.liveChunkTranscriber = LiveChunkTranscriber(sttTranscriber: sttTranscriber)
         self.speechEngineSessionManager = sttTranscriber as? any SpeechEngineSessionManaging
@@ -338,7 +341,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
 
     public var elapsedSeconds: Int {
         guard let startedAt = currentSession?.startedAt else { return 0 }
-        return max(0, Int(activeRecordingSeconds(startedAt: startedAt, asOf: Date())))
+        return max(0, Int(activeRecordingSeconds(startedAt: startedAt, asOf: wallClockNow())))
     }
 
     public var captureMode: CaptureMode {
@@ -408,10 +411,10 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         let chunkFolderURL = folderURL.appendingPathComponent("chunks", isDirectory: true)
         try fileManager.createDirectory(at: chunkFolderURL, withIntermediateDirectories: true)
         // Single timestamp shared between displayName fallback and
-        // startedAt — back-to-back `Date()` calls would only diverge if
+        // startedAt — back-to-back wall clock reads would only diverge if
         // the clock ticked over a minute boundary between them, which is
         // vanishingly rare but trivially avoidable.
-        let now = Date()
+        let now = wallClockNow()
         let speechEngineLease = await speechEngineSessionManager?.beginSpeechEngineSession()
         currentSpeechEngineLease = speechEngineLease
         let speechEngine = speechEngineLease?.selection ?? SpeechEngineSelection(engine: .parakeet)
@@ -575,7 +578,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
             AudioCaptureDiagnostics.append(
                 captureHealthSummaryLine(
                     session: session,
-                    durationSeconds: activeRecordingSeconds(startedAt: session.startedAt, asOf: Date()),
+                    durationSeconds: activeRecordingSeconds(startedAt: session.startedAt, asOf: wallClockNow()),
                     writerMetrics: writerMetrics,
                     captureFailed: captureFailed
                 )
@@ -656,22 +659,22 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         }
         currentLockFile = awaitingLock
 
-        let cleanedMicrophoneReadiness = scheduleCleanedMicrophoneRender(
-            session: session,
-            availableSources: availableSources,
-            sourceAlignment: sourceAlignment
-        )
-
         // Stop while paused: settle the in-flight pause interval into the
         // accumulated total so the persisted duration only reflects time
         // actually recording.
-        let now = Date()
+        let now = wallClockNow()
         if let pausedAtSnapshot = pausedAt {
             accumulatedPausedDuration += now.timeIntervalSince(pausedAtSnapshot)
             pausedAt = nil
         }
         paused = false
         let durationSeconds = max(0, activeRecordingSeconds(startedAt: session.startedAt, asOf: now))
+        let cleanedMicrophoneReadiness = scheduleCleanedMicrophoneRender(
+            session: session,
+            availableSources: availableSources,
+            sourceAlignment: sourceAlignment,
+            recordingDuration: durationSeconds
+        )
         let output = MeetingRecordingOutput(
             sessionID: session.id,
             displayName: session.displayName,
@@ -762,7 +765,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
     public func pauseRecording() async {
         guard currentSession != nil, !paused, !captureFailed else { return }
         paused = true
-        pausedAt = Date()
+        pausedAt = wallClockNow()
         pausedHostTime = Self.currentAudioHostTime()
         // Zero levels so live UI reads "no signal" the moment the user
         // pauses, instead of decaying from the EMA over the next few
@@ -793,7 +796,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
     public func resumeRecording() async {
         guard currentSession != nil, paused, !captureFailed else { return }
         if let pausedAt {
-            accumulatedPausedDuration += Date().timeIntervalSince(pausedAt)
+            accumulatedPausedDuration += wallClockNow().timeIntervalSince(pausedAt)
         }
         if let pausedHostTime {
             appendCompletedPauseHostTimeRange(start: pausedHostTime, end: Self.currentAudioHostTime())
@@ -1281,10 +1284,21 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
     private func scheduleCleanedMicrophoneRender(
         session: Session,
         availableSources: Set<AudioSource>,
-        sourceAlignment: MeetingSourceAlignment
+        sourceAlignment: MeetingSourceAlignment,
+        recordingDuration: TimeInterval
     ) -> MeetingCleanedMicrophoneReadiness {
         let outputURL = session.folderURL.appendingPathComponent(
             MeetingCleanedMicRenderer.cleanedMicrophoneFileName)
+        guard MeetingCleanedMicrophoneReadinessPolicy.production.shouldAttemptRender(
+            for: recordingDuration
+        ) else {
+            return MeetingCleanedMicrophoneRenderScheduler.skipPredictedRenderTimeout(
+                outputURL: outputURL,
+                sessionID: session.id,
+                fileManager: fileManager,
+                eventName: "meeting_cleaned_mic"
+            )
+        }
         return cleanedMicrophoneReadinessScheduler(
             outputURL,
             availableSources.contains(.microphone) ? session.microphoneAudioURL : nil,

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingCleanedMicrophoneReadinessPolicyTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingCleanedMicrophoneReadinessPolicyTests.swift
@@ -3,6 +3,14 @@ import XCTest
 @testable import MacParakeetCore
 
 final class MeetingCleanedMicrophoneReadinessPolicyTests: XCTestCase {
+    func testBestMeasuredRealtimeFactorUsesFastestAuditedThroughput() {
+        XCTAssertEqual(
+            MeetingCleanedMicrophoneReadinessPolicy.bestMeasuredRealtimeFactor,
+            12.59,
+            accuracy: 0.001
+        )
+    }
+
     func testShouldAttemptRenderAtProductionBoundary() {
         let policy = MeetingCleanedMicrophoneReadinessPolicy.production
         let threshold =
@@ -52,5 +60,77 @@ final class MeetingCleanedMicrophoneReadinessPolicyTests: XCTestCase {
         XCTAssertTrue(policy.shouldAttemptRender(for: -1))
         XCTAssertTrue(policy.shouldAttemptRender(for: .infinity))
         XCTAssertTrue(policy.shouldAttemptRender(for: .nan))
+    }
+}
+
+final class MeetingSourceAlignmentDurationTests: XCTestCase {
+    func testCleanedMicRenderDurationUsesLongestCapturedSource() {
+        let alignment = MeetingSourceAlignment(
+            meetingOriginHostTime: nil,
+            microphone: .init(
+                firstHostTime: nil,
+                lastHostTime: nil,
+                startOffsetMs: 0,
+                writtenFrameCount: 48_000 * 120,
+                sampleRate: 48_000
+            ),
+            system: .init(
+                firstHostTime: nil,
+                lastHostTime: nil,
+                startOffsetMs: 0,
+                writtenFrameCount: 48_000 * 90,
+                sampleRate: 48_000
+            )
+        )
+
+        XCTAssertEqual(alignment.cleanedMicrophoneRenderDurationSeconds, 120, accuracy: 0.001)
+    }
+
+    func testCleanedMicRenderDurationTreatsInvalidMetricsAsUnknown() {
+        let alignment = MeetingSourceAlignment(
+            meetingOriginHostTime: nil,
+            microphone: .init(
+                firstHostTime: nil,
+                lastHostTime: nil,
+                startOffsetMs: 0,
+                writtenFrameCount: -1,
+                sampleRate: 48_000
+            ),
+            system: .init(
+                firstHostTime: nil,
+                lastHostTime: nil,
+                startOffsetMs: 0,
+                writtenFrameCount: 48_000,
+                sampleRate: 0
+            )
+        )
+
+        XCTAssertEqual(alignment.cleanedMicrophoneRenderDurationSeconds, 0, accuracy: 0.001)
+    }
+
+    func testCapturedMediaDurationFeedsPredictedTimeoutPolicy() {
+        let policy = MeetingCleanedMicrophoneReadinessPolicy.production
+        let threshold =
+            policy.capSeconds
+            * MeetingCleanedMicrophoneReadinessPolicy
+            .bestMeasuredRealtimeFactor
+        let sampleRate = 48_000.0
+        let alignment = MeetingSourceAlignment(
+            meetingOriginHostTime: nil,
+            microphone: .init(
+                firstHostTime: nil,
+                lastHostTime: nil,
+                startOffsetMs: 0,
+                writtenFrameCount: Int64(((threshold + 1) * sampleRate).rounded()),
+                sampleRate: sampleRate
+            ),
+            system: nil
+        )
+
+        XCTAssertFalse(
+            policy.shouldAttemptRender(
+                for: alignment.cleanedMicrophoneRenderDurationSeconds
+            )
+        )
     }
 }

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingCleanedMicrophoneReadinessPolicyTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingCleanedMicrophoneReadinessPolicyTests.swift
@@ -1,0 +1,56 @@
+import Foundation
+import XCTest
+@testable import MacParakeetCore
+
+final class MeetingCleanedMicrophoneReadinessPolicyTests: XCTestCase {
+    func testShouldAttemptRenderAtProductionBoundary() {
+        let policy = MeetingCleanedMicrophoneReadinessPolicy.production
+        let threshold =
+            policy.capSeconds
+            * MeetingCleanedMicrophoneReadinessPolicy
+            .bestMeasuredRealtimeFactor
+
+        XCTAssertTrue(policy.shouldAttemptRender(for: threshold - 0.001))
+        XCTAssertTrue(policy.shouldAttemptRender(for: threshold))
+        XCTAssertFalse(policy.shouldAttemptRender(for: threshold + 0.001))
+    }
+
+    func testShouldAttemptRenderUsesFloorWhenItDominatesTimeout() {
+        let policy = MeetingCleanedMicrophoneReadinessPolicy(
+            floorSeconds: 5,
+            durationMultiplier: 0.01,
+            capSeconds: 1_000
+        )
+        let floorThreshold =
+            policy.floorSeconds
+            * MeetingCleanedMicrophoneReadinessPolicy
+            .bestMeasuredRealtimeFactor
+
+        XCTAssertTrue(policy.shouldAttemptRender(for: floorThreshold))
+        XCTAssertFalse(policy.shouldAttemptRender(for: floorThreshold + 0.001))
+    }
+
+    func testShouldAttemptRenderUsesCapWhenItDominatesTimeout() {
+        let policy = MeetingCleanedMicrophoneReadinessPolicy(
+            floorSeconds: 0,
+            durationMultiplier: 1,
+            capSeconds: 3
+        )
+        let capThreshold =
+            policy.capSeconds
+            * MeetingCleanedMicrophoneReadinessPolicy
+            .bestMeasuredRealtimeFactor
+
+        XCTAssertTrue(policy.shouldAttemptRender(for: capThreshold))
+        XCTAssertFalse(policy.shouldAttemptRender(for: capThreshold + 0.001))
+    }
+
+    func testShouldAttemptRenderForZeroAndUnknownDurations() {
+        let policy = MeetingCleanedMicrophoneReadinessPolicy.production
+
+        XCTAssertTrue(policy.shouldAttemptRender(for: 0))
+        XCTAssertTrue(policy.shouldAttemptRender(for: -1))
+        XCTAssertTrue(policy.shouldAttemptRender(for: .infinity))
+        XCTAssertTrue(policy.shouldAttemptRender(for: .nan))
+    }
+}

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingRecoveryServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingRecoveryServiceTests.swift
@@ -306,6 +306,48 @@ final class MeetingRecordingRecoveryServiceTests: XCTestCase {
         XCTAssertEqual(metadata.echoSuppression?.reasonCode, .skippedNoEchoPath)
     }
 
+    func testRecoverSkipsCleanedMicWhenDurationPredictsRenderTimeout() async throws {
+        let fixture = try makeRecoverableSession()
+        let staleCleanedURL = fixture.folderURL.appendingPathComponent("microphone-cleaned.m4a")
+        try writeM4A(to: staleCleanedURL)
+        let conditionerProbe = RecoveryMicConditionerFactoryProbe()
+        let threshold = MeetingCleanedMicrophoneReadinessPolicy.production.capSeconds
+            * MeetingCleanedMicrophoneReadinessPolicy.bestMeasuredRealtimeFactor
+        transcriptionService.sourceResolutionPolicy = .production
+        recoveryService = MeetingRecordingRecoveryService(
+            meetingsRoot: tempRoot,
+            lockFileStore: lockStore,
+            transcriptionService: transcriptionService,
+            transcriptionRepo: transcriptionRepo,
+            audioConverter: audioConverter,
+            micConditionerFactory: { @Sendable in conditionerProbe.make() },
+            recordingDurationProvider: { _, _ in threshold + 1 }
+        )
+
+        _ = try await recoveryService.recover(fixture.lock)
+
+        let recording = try XCTUnwrap(transcriptionService.recordings.first)
+        let decision = try XCTUnwrap(transcriptionService.sourceDecisions.first)
+        XCTAssertEqual(recording.durationSeconds, threshold + 1, accuracy: 0.001)
+        XCTAssertNil(recording.cleanedMicrophoneAudioURL)
+        XCTAssertEqual(
+            conditionerProbe.buildCount,
+            0,
+            "above-threshold recovery must not construct the cleaned-mic render task"
+        )
+        XCTAssertEqual(decision.reason, .predictedRenderTimeout)
+        XCTAssertEqual(decision.url, fixture.folderURL.appendingPathComponent("microphone.m4a"))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: staleCleanedURL.path))
+        let metadata = try MeetingRecordingMetadataStore.load(from: fixture.folderURL)
+        XCTAssertEqual(metadata.echoSuppression?.reasonCode, .predictedRenderTimeout)
+        let log = try String(contentsOf: AudioCaptureDiagnostics.diagnosticLogURL(), encoding: .utf8)
+        XCTAssertTrue(
+            log.contains(
+                "meeting_recovery_cleaned_mic session=\(fixture.lock.sessionId.uuidString) outcome=skipped reason=predictedRenderTimeout"
+            )
+        )
+    }
+
     func testRecoverDeletesStaleCleanedMicWhenSourceMissing() async throws {
         let fixture = try makeRecoverableSession(systemAudio: .corrupt)
         let staleCleanedURL = fixture.folderURL.appendingPathComponent("microphone-cleaned.m4a")

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingServiceTests.swift
@@ -1542,7 +1542,7 @@ final class MeetingRecordingServiceTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: cleanedURL.path))
     }
 
-    func testStopRecordingSkipsCleanedMicWhenDurationPredictsRenderTimeout() async throws {
+    func testStopRecordingUsesMediaDurationForCleanedMicTimeoutGuard() async throws {
         let captureService = MockMeetingAudioCaptureService()
         let wallClock = MeetingTestWallClock(
             now: Date(timeIntervalSince1970: 1_700_000_000)
@@ -1581,21 +1581,15 @@ final class MeetingRecordingServiceTests: XCTestCase {
         XCTAssertNil(output.cleanedMicrophoneAudioURL)
         XCTAssertEqual(
             schedulerProbe.callCount,
-            0,
-            "above-threshold meetings must not construct the cleaned-mic render task"
+            1,
+            "above-threshold wall-clock duration must not skip a short captured media render"
         )
 
         let decision = try await output.resolvedMicrophoneTranscriptionSource()
-        XCTAssertEqual(decision.reason, .predictedRenderTimeout)
+        XCTAssertEqual(decision.reason, .rawRenderFailed)
         XCTAssertEqual(decision.url, output.microphoneAudioURL)
         let metadata = try MeetingRecordingMetadataStore.load(from: output.folderURL)
-        XCTAssertEqual(metadata.echoSuppression?.reasonCode, .predictedRenderTimeout)
-        let log = try String(contentsOf: AudioCaptureDiagnostics.diagnosticLogURL(), encoding: .utf8)
-        XCTAssertTrue(
-            log.contains(
-                "meeting_cleaned_mic session=\(output.sessionID.uuidString) outcome=skipped reason=predictedRenderTimeout"
-            )
-        )
+        XCTAssertEqual(metadata.echoSuppression?.reasonCode, .rawRenderFailed)
     }
 
     private func makeMonoFloatBuffer(frameCount: Int, sampleValue: Float) -> AVAudioPCMBuffer? {

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingServiceTests.swift
@@ -1542,6 +1542,62 @@ final class MeetingRecordingServiceTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: cleanedURL.path))
     }
 
+    func testStopRecordingSkipsCleanedMicWhenDurationPredictsRenderTimeout() async throws {
+        let captureService = MockMeetingAudioCaptureService()
+        let wallClock = MeetingTestWallClock(
+            now: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+        let schedulerProbe = MeetingCleanedMicSchedulerProbe()
+        let service = MeetingRecordingService(
+            audioCaptureService: captureService,
+            audioConverter: MockMeetingAudioFileConverter(),
+            sttTranscriber: CountingMeetingSTTClient(),
+            micConditionerFactory: {
+                ZeroingMicConditioner()
+            },
+            wallClockNow: {
+                wallClock.now
+            },
+            cleanedMicrophoneReadinessScheduler: { _, _, _, _, _, _, _, _ in
+                schedulerProbe.recordCall()
+                return .notScheduled(reason: .rawRenderFailed)
+            }
+        )
+
+        try await service.startRecording()
+        let threshold = MeetingCleanedMicrophoneReadinessPolicy.production.capSeconds
+            * MeetingCleanedMicrophoneReadinessPolicy.bestMeasuredRealtimeFactor
+        wallClock.advance(by: threshold + 1)
+        let microphoneBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 4_800, sampleValue: 0.25))
+        let systemBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 4_800, sampleValue: 0.25))
+        let time = AVAudioTime(hostTime: AVAudioTime.hostTime(forSeconds: 100.0))
+        await captureService.yield(.microphoneBuffer(microphoneBuffer, time))
+        await captureService.yield(.systemBuffer(systemBuffer, time))
+
+        let output = try await service.stopRecording()
+        defer { try? FileManager.default.removeItem(at: output.folderURL) }
+
+        XCTAssertEqual(output.durationSeconds, threshold + 1, accuracy: 0.001)
+        XCTAssertNil(output.cleanedMicrophoneAudioURL)
+        XCTAssertEqual(
+            schedulerProbe.callCount,
+            0,
+            "above-threshold meetings must not construct the cleaned-mic render task"
+        )
+
+        let decision = try await output.resolvedMicrophoneTranscriptionSource()
+        XCTAssertEqual(decision.reason, .predictedRenderTimeout)
+        XCTAssertEqual(decision.url, output.microphoneAudioURL)
+        let metadata = try MeetingRecordingMetadataStore.load(from: output.folderURL)
+        XCTAssertEqual(metadata.echoSuppression?.reasonCode, .predictedRenderTimeout)
+        let log = try String(contentsOf: AudioCaptureDiagnostics.diagnosticLogURL(), encoding: .utf8)
+        XCTAssertTrue(
+            log.contains(
+                "meeting_cleaned_mic session=\(output.sessionID.uuidString) outcome=skipped reason=predictedRenderTimeout"
+            )
+        )
+    }
+
     private func makeMonoFloatBuffer(frameCount: Int, sampleValue: Float) -> AVAudioPCMBuffer? {
         guard let format = AVAudioFormat(
             commonFormat: .pcmFormatFloat32,
@@ -2838,6 +2894,40 @@ private final class MeetingMicConditionerFactoryProbe: @unchecked Sendable {
             count += 1
         }
         return ZeroingMicConditioner()
+    }
+}
+
+private final class MeetingCleanedMicSchedulerProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+
+    var callCount: Int {
+        lock.withLock { count }
+    }
+
+    func recordCall() {
+        lock.withLock {
+            count += 1
+        }
+    }
+}
+
+private final class MeetingTestWallClock: @unchecked Sendable {
+    private let lock = NSLock()
+    private var current: Date
+
+    init(now: Date) {
+        current = now
+    }
+
+    var now: Date {
+        lock.withLock { current }
+    }
+
+    func advance(by seconds: TimeInterval) {
+        lock.withLock {
+            current = current.addingTimeInterval(seconds)
+        }
     }
 }
 


### PR DESCRIPTION
## What changed
- Added `MeetingCleanedMicrophoneReadinessPolicy.bestMeasuredRealtimeFactor = 12.59` from the fastest measured LocalVQE runtime in `docs/audits/2026-07-04-localvqe-aec-runtime-findings.md`, plus the derived `shouldAttemptRender(for:)` predicate.
- Added the log-only `predictedRenderTimeout` routing reason, surfaced through `meeting_cleaned_mic` / `meeting_recovery_cleaned_mic` diagnostics and echo-suppression metadata.
- Applied the guard before constructing cleaned-mic render work in both normal stop and recovery. Normal stop uses captured media duration from source alignment; recovery uses recovered source durations. Unknown, zero, and under-threshold durations still attempt the existing render path.

## Why
The readiness wait caps at 600 seconds and cancels/discards outputs on timeout. With the fastest measured factor of 12.59x realtime, the current threshold is `600 s * 12.59 = 7,554 s` (about 2h 6m). The code does not hardcode 7,554; it uses `recordingDuration / bestMeasuredRealtimeFactor <= timeoutSeconds(for:)`, so future cap/floor/multiplier changes flow through the policy.

Normal stop deliberately uses media duration, not wall-clock meeting duration, because the renderer only processes frames actually captured. This prevents a long elapsed session with short partial media from being routed to raw mic when the cleaned render could still finish within the readiness cap.

## Risk and scope
This intentionally does not touch `MeetingCleanedMicRenderer`, suppressor internals, STT scheduler routing, diarization defaults, telemetry event names, UI, or settings. The main review surface is whether both scheduling paths use the duration of media that would actually be rendered.

## Test evidence
- `swift test --filter MeetingCleanedMicrophoneReadinessPolicyTests` - 5 tests, 0 failures.
- `swift test --filter MeetingSourceAlignmentDurationTests` - 3 tests, 0 failures.
- `swift test --filter DurationPredictsRenderTimeout` - 1 test, 0 failures.
- `swift test --filter MeetingRecording` - 198 tests, 1 skipped, 0 failures.
- `git diff --check`.
- Ran `scripts/dev/format.sh`; it was fast but reformatted broad unrelated code, so that churn was reverted and the final diff is scoped to this change.

## Spec alignment
Conforms to `plans/active/2026-07-04-long-meeting-aec-policy.md` Phase 1a; the governing plan lands via #694. Deviation: normal stop now uses captured media duration for the render guard so it matches the render workload instead of elapsed wall-clock duration. Phase 1b benchmark data may later justify tightening the threshold.
