### PR TITLE
test: add long meeting pipeline benchmark harness

### DIFF
--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingFinalizationBenchmarkObserver.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingFinalizationBenchmarkObserver.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+struct MeetingFinalizationBenchmarkObserver: Sendable {
+    enum Stage: String, Sendable {
+        case microphoneSTT = "mic_stt"
+        case systemSTT = "system_stt"
+        case diarization
+        case finalizeMerge = "finalize_merge"
+    }
+
+    private let onStageStart: @Sendable (Stage) -> Void
+    private let onStageEnd: @Sendable (Stage) -> Void
+
+    init(
+        onStageStart: @escaping @Sendable (Stage) -> Void,
+        onStageEnd: @escaping @Sendable (Stage) -> Void
+    ) {
+        self.onStageStart = onStageStart
+        self.onStageEnd = onStageEnd
+    }
+
+    func stageDidStart(_ stage: Stage) {
+        onStageStart(stage)
+    }
+
+    func stageDidEnd(_ stage: Stage) {
+        onStageEnd(stage)
+    }
+}

--- a/Sources/MacParakeetCore/Services/TranscriptionService.swift
+++ b/Sources/MacParakeetCore/Services/TranscriptionService.swift
@@ -1161,20 +1161,24 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
                 onProgress: onProgress
             )
 
-            meetingFinalizationBenchmarkObserver?.stageDidStart(.diarization)
             let systemDiarization: MeetingTranscriptFinalizer.SystemDiarization?
-            do {
-                systemDiarization = try await diarizeMeetingSystemIfNeeded(
-                    recording: recording,
-                    sourceWavURLs: sourceWavURLs,
-                    requested: diarizationRequested,
-                    lifecycleStage: &lifecycleStage,
-                    onProgress: onProgress
-                )
-                meetingFinalizationBenchmarkObserver?.stageDidEnd(.diarization)
-            } catch {
-                meetingFinalizationBenchmarkObserver?.stageDidEnd(.diarization)
-                throw error
+            if diarizationRequested {
+                meetingFinalizationBenchmarkObserver?.stageDidStart(.diarization)
+                do {
+                    systemDiarization = try await diarizeMeetingSystemIfNeeded(
+                        recording: recording,
+                        sourceWavURLs: sourceWavURLs,
+                        requested: true,
+                        lifecycleStage: &lifecycleStage,
+                        onProgress: onProgress
+                    )
+                    meetingFinalizationBenchmarkObserver?.stageDidEnd(.diarization)
+                } catch {
+                    meetingFinalizationBenchmarkObserver?.stageDidEnd(.diarization)
+                    throw error
+                }
+            } else {
+                systemDiarization = nil
             }
 
             meetingFinalizationBenchmarkObserver?.stageDidStart(.finalizeMerge)
@@ -1316,7 +1320,6 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
         for (index, source) in activeSources.enumerated() {
             let benchmarkStage: MeetingFinalizationBenchmarkObserver.Stage =
                 source == .microphone ? .microphoneSTT : .systemSTT
-            meetingFinalizationBenchmarkObserver?.stageDidStart(benchmarkStage)
             do {
                 let fileURL = meetingAudioURL(
                     for: source,
@@ -1331,16 +1334,24 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
 
                 lifecycleStage = .stt
                 onProgress?(.transcribing(percent: Int((Double(index) / Double(max(activeSources.count, 1))) * 100)))
-                let result = try await transcribeSpeech(
-                    audioPath: wavURL.path,
-                    job: .meetingFinalize,
-                    speechEngine: speechEngine,
-                    onProgress: meetingSourceProgressMapper(
-                        sourceIndex: index,
-                        sourceCount: activeSources.count,
-                        onProgress: onProgress
+                let result: STTResult
+                meetingFinalizationBenchmarkObserver?.stageDidStart(benchmarkStage)
+                do {
+                    result = try await transcribeSpeech(
+                        audioPath: wavURL.path,
+                        job: .meetingFinalize,
+                        speechEngine: speechEngine,
+                        onProgress: meetingSourceProgressMapper(
+                            sourceIndex: index,
+                            sourceCount: activeSources.count,
+                            onProgress: onProgress
+                        )
                     )
-                )
+                    meetingFinalizationBenchmarkObserver?.stageDidEnd(benchmarkStage)
+                } catch {
+                    meetingFinalizationBenchmarkObserver?.stageDidEnd(benchmarkStage)
+                    throw error
+                }
 
                 outputs.append(
                     .init(
@@ -1349,10 +1360,6 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
                         startOffsetMs: recording.sourceAlignment.track(for: source)?.startOffsetMs ?? 0
                     )
                 )
-                meetingFinalizationBenchmarkObserver?.stageDidEnd(benchmarkStage)
-            } catch {
-                meetingFinalizationBenchmarkObserver?.stageDidEnd(benchmarkStage)
-                throw error
             }
         }
 

--- a/Sources/MacParakeetCore/Services/TranscriptionService.swift
+++ b/Sources/MacParakeetCore/Services/TranscriptionService.swift
@@ -241,6 +241,7 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
     private let meetingArtifactStore: MeetingArtifactStoring?
     private let meetingAutomationHookRunner: MeetingAutomationHookRunning?
     private let meetingCleanedMicrophoneReadinessPolicy: MeetingCleanedMicrophoneReadinessPolicy
+    private let meetingFinalizationBenchmarkObserver: MeetingFinalizationBenchmarkObserver?
 
     public init(
         audioProcessor: AudioProcessorProtocol,
@@ -270,6 +271,66 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
         meetingAutomationHookRunner: MeetingAutomationHookRunning? = MeetingAutomationHookRunner(),
         meetingCleanedMicrophoneReadinessPolicy: MeetingCleanedMicrophoneReadinessPolicy = .production
     ) {
+        self.init(
+            audioProcessor: audioProcessor,
+            sttTranscriber: sttTranscriber,
+            transcriptionRepo: transcriptionRepo,
+            promptResultRepo: promptResultRepo,
+            entitlements: entitlements,
+            customWordRepo: customWordRepo,
+            snippetRepo: snippetRepo,
+            processingMode: processingMode,
+            llmService: llmService,
+            llmRunRepo: llmRunRepo,
+            shouldUseAIFormatter: shouldUseAIFormatter,
+            aiFormatterPromptTemplate: aiFormatterPromptTemplate,
+            shouldAutoGenerateMeetingTitles: shouldAutoGenerateMeetingTitles,
+            shouldKeepDownloadedAudio: shouldKeepDownloadedAudio,
+            shouldDiarize: shouldDiarize,
+            youtubeDownloader: youtubeDownloader,
+            podcastResolver: podcastResolver,
+            podcastSearchResolver: podcastSearchResolver,
+            podcastAudioFetcher: podcastAudioFetcher,
+            diarizationService: diarizationService,
+            mediaMetadataExtractor: mediaMetadataExtractor,
+            thumbnailCache: thumbnailCache,
+            playbackConverter: playbackConverter,
+            meetingArtifactStore: meetingArtifactStore,
+            meetingAutomationHookRunner: meetingAutomationHookRunner,
+            meetingCleanedMicrophoneReadinessPolicy: meetingCleanedMicrophoneReadinessPolicy,
+            meetingFinalizationBenchmarkObserver: nil
+        )
+    }
+
+    init(
+        audioProcessor: AudioProcessorProtocol,
+        sttTranscriber: STTTranscribing,
+        transcriptionRepo: TranscriptionRepositoryProtocol,
+        promptResultRepo: PromptResultRepositoryProtocol? = nil,
+        entitlements: EntitlementsChecking? = nil,
+        customWordRepo: CustomWordRepositoryProtocol? = nil,
+        snippetRepo: TextSnippetRepositoryProtocol? = nil,
+        processingMode: (@Sendable () -> Dictation.ProcessingMode)? = nil,
+        llmService: LLMServiceProtocol? = nil,
+        llmRunRepo: LLMRunRepositoryProtocol? = nil,
+        shouldUseAIFormatter: (@Sendable () -> Bool)? = nil,
+        aiFormatterPromptTemplate: (@Sendable () -> String)? = nil,
+        shouldAutoGenerateMeetingTitles: (@Sendable () -> Bool)? = nil,
+        shouldKeepDownloadedAudio: (@Sendable () -> Bool)? = nil,
+        shouldDiarize: (@Sendable () -> Bool)? = nil,
+        youtubeDownloader: YouTubeDownloading? = nil,
+        podcastResolver: PodcastResolving? = nil,
+        podcastSearchResolver: PodcastSearchResolving? = nil,
+        podcastAudioFetcher: PodcastAudioFetching? = nil,
+        diarizationService: DiarizationServiceProtocol? = nil,
+        mediaMetadataExtractor: MediaMetadataExtracting = AVMediaMetadataExtractor(),
+        thumbnailCache: ThumbnailCaching = ThumbnailCacheService.shared,
+        playbackConverter: YouTubeAudioPlaybackConverting = YouTubeAudioPlaybackConverter(),
+        meetingArtifactStore: MeetingArtifactStoring? = MeetingArtifactStore(),
+        meetingAutomationHookRunner: MeetingAutomationHookRunning? = MeetingAutomationHookRunner(),
+        meetingCleanedMicrophoneReadinessPolicy: MeetingCleanedMicrophoneReadinessPolicy = .production,
+        meetingFinalizationBenchmarkObserver: MeetingFinalizationBenchmarkObserver?
+    ) {
         self.audioProcessor = audioProcessor
         self.sttTranscriber = sttTranscriber
         self.transcriptionRepo = transcriptionRepo
@@ -297,6 +358,7 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
         self.meetingArtifactStore = meetingArtifactStore
         self.meetingAutomationHookRunner = meetingAutomationHookRunner
         self.meetingCleanedMicrophoneReadinessPolicy = meetingCleanedMicrophoneReadinessPolicy
+        self.meetingFinalizationBenchmarkObserver = meetingFinalizationBenchmarkObserver
     }
 
     public func transcribe(
@@ -1099,18 +1161,28 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
                 onProgress: onProgress
             )
 
-            let systemDiarization = try await diarizeMeetingSystemIfNeeded(
-                recording: recording,
-                sourceWavURLs: sourceWavURLs,
-                requested: diarizationRequested,
-                lifecycleStage: &lifecycleStage,
-                onProgress: onProgress
-            )
+            meetingFinalizationBenchmarkObserver?.stageDidStart(.diarization)
+            let systemDiarization: MeetingTranscriptFinalizer.SystemDiarization?
+            do {
+                systemDiarization = try await diarizeMeetingSystemIfNeeded(
+                    recording: recording,
+                    sourceWavURLs: sourceWavURLs,
+                    requested: diarizationRequested,
+                    lifecycleStage: &lifecycleStage,
+                    onProgress: onProgress
+                )
+                meetingFinalizationBenchmarkObserver?.stageDidEnd(.diarization)
+            } catch {
+                meetingFinalizationBenchmarkObserver?.stageDidEnd(.diarization)
+                throw error
+            }
 
+            meetingFinalizationBenchmarkObserver?.stageDidStart(.finalizeMerge)
             let finalized = MeetingTranscriptFinalizer.finalize(
                 sourceTranscripts: sourceResults,
                 systemDiarization: systemDiarization
             )
+            meetingFinalizationBenchmarkObserver?.stageDidEnd(.finalizeMerge)
 
             // Apply the user's Vocabulary corrections to the meeting transcript.
             // Meetings otherwise never run custom words — the deterministic
@@ -1242,37 +1314,46 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
             : nil
 
         for (index, source) in activeSources.enumerated() {
-            let fileURL = meetingAudioURL(
-                for: source,
-                recording: recording,
-                microphoneDecision: microphoneDecision
-            )
-            lifecycleStage = .audioConversion
-            onProgress?(.converting)
-            let wavURL = try await audioProcessor.convert(fileURL: fileURL)
-            temporaryWavURLs.append(wavURL)
-            sourceWavURLs[source] = wavURL
-
-            lifecycleStage = .stt
-            onProgress?(.transcribing(percent: Int((Double(index) / Double(max(activeSources.count, 1))) * 100)))
-            let result = try await transcribeSpeech(
-                audioPath: wavURL.path,
-                job: .meetingFinalize,
-                speechEngine: speechEngine,
-                onProgress: meetingSourceProgressMapper(
-                    sourceIndex: index,
-                    sourceCount: activeSources.count,
-                    onProgress: onProgress
+            let benchmarkStage: MeetingFinalizationBenchmarkObserver.Stage =
+                source == .microphone ? .microphoneSTT : .systemSTT
+            meetingFinalizationBenchmarkObserver?.stageDidStart(benchmarkStage)
+            do {
+                let fileURL = meetingAudioURL(
+                    for: source,
+                    recording: recording,
+                    microphoneDecision: microphoneDecision
                 )
-            )
+                lifecycleStage = .audioConversion
+                onProgress?(.converting)
+                let wavURL = try await audioProcessor.convert(fileURL: fileURL)
+                temporaryWavURLs.append(wavURL)
+                sourceWavURLs[source] = wavURL
 
-            outputs.append(
-                .init(
-                    source: source,
-                    result: result,
-                    startOffsetMs: recording.sourceAlignment.track(for: source)?.startOffsetMs ?? 0
+                lifecycleStage = .stt
+                onProgress?(.transcribing(percent: Int((Double(index) / Double(max(activeSources.count, 1))) * 100)))
+                let result = try await transcribeSpeech(
+                    audioPath: wavURL.path,
+                    job: .meetingFinalize,
+                    speechEngine: speechEngine,
+                    onProgress: meetingSourceProgressMapper(
+                        sourceIndex: index,
+                        sourceCount: activeSources.count,
+                        onProgress: onProgress
+                    )
                 )
-            )
+
+                outputs.append(
+                    .init(
+                        source: source,
+                        result: result,
+                        startOffsetMs: recording.sourceAlignment.track(for: source)?.startOffsetMs ?? 0
+                    )
+                )
+                meetingFinalizationBenchmarkObserver?.stageDidEnd(benchmarkStage)
+            } catch {
+                meetingFinalizationBenchmarkObserver?.stageDidEnd(benchmarkStage)
+                throw error
+            }
         }
 
         return outputs

--- a/Tests/MacParakeetTests/Benchmarks/LongMeetingPipelineBenchmarkTests.swift
+++ b/Tests/MacParakeetTests/Benchmarks/LongMeetingPipelineBenchmarkTests.swift
@@ -1,0 +1,632 @@
+import AVFoundation
+import Darwin
+import XCTest
+@testable import MacParakeetCore
+
+/// Env-gated full post-stop meeting pipeline benchmark.
+///
+/// Default `swift test` skips this test immediately. Run with a retained
+/// metadata-backed dual-track meeting session folder:
+///
+///   MACPARAKEET_LONG_MEETING_PIPELINE_BENCH=1 \
+///   MACPARAKEET_LONG_MEETING_SESSION="/Users/dmoon/Library/Application Support/MacParakeet/meeting-recordings/<session-id>" \
+///   MACPARAKEET_TEST_LOCALVQE_LIBRARY=/path/to/liblocalvqe.dylib \
+///   MACPARAKEET_TEST_LOCALVQE_MODEL=/path/to/localvqe-v1.4-aec-200K-f32.gguf \
+///   MACPARAKEET_LONG_MEETING_RESULTS_FILE=.codex/long-meeting-pipeline-bench/results.md \
+///   swift test --filter LongMeetingPipelineBenchmarkTests
+///
+/// The harness copies the source session into `MACPARAKEET_LONG_MEETING_WORK_DIR`
+/// or `.codex/long-meeting-pipeline-bench/runs/<uuid>` before writing any derived
+/// artifacts. It appends a pasteable markdown table to the results file.
+///
+/// If no retained fixture is available, an explicit synthetic smoke fixture can
+/// be generated instead:
+///
+///   MACPARAKEET_LONG_MEETING_PIPELINE_BENCH=1 \
+///   MACPARAKEET_LONG_MEETING_SYNTHETIC_SECONDS=30 \
+///   MACPARAKEET_TEST_LOCALVQE_LIBRARY=/path/to/liblocalvqe.dylib \
+///   MACPARAKEET_TEST_LOCALVQE_MODEL=/path/to/localvqe-v1.4-aec-200K-f32.gguf \
+///   swift test --filter LongMeetingPipelineBenchmarkTests
+final class LongMeetingPipelineBenchmarkTests: XCTestCase {
+    private static let enabledKey = "MACPARAKEET_LONG_MEETING_PIPELINE_BENCH"
+    private static let sessionKey = "MACPARAKEET_LONG_MEETING_SESSION"
+    private static let syntheticSecondsKey = "MACPARAKEET_LONG_MEETING_SYNTHETIC_SECONDS"
+    private static let workDirKey = "MACPARAKEET_LONG_MEETING_WORK_DIR"
+    private static let resultsFileKey = "MACPARAKEET_LONG_MEETING_RESULTS_FILE"
+    private static let parakeetVariantKey = "MACPARAKEET_LONG_MEETING_PARAKEET_VARIANT"
+    private static let localVQELibraryKey = "MACPARAKEET_TEST_LOCALVQE_LIBRARY"
+    private static let localVQEModelKey = "MACPARAKEET_TEST_LOCALVQE_MODEL"
+    private static let localVQEModelSHAKey = "MACPARAKEET_TEST_LOCALVQE_MODEL_SHA256"
+
+    func testDefaultDualTrackMeetingPostStopPipelineBenchmark() async throws {
+        let env = ProcessInfo.processInfo.environment
+        try XCTSkipUnless(
+            env[Self.enabledKey] == "1",
+            "Set \(Self.enabledKey)=1 to run the long-meeting full-pipeline benchmark."
+        )
+
+        let runID = ISO8601DateFormatter().string(from: Date())
+        let fixture = try await makeFixture(env: env, runID: runID)
+        let recording = try await loadRecording(from: fixture.folderURL)
+        try preflightModelsAndAssets(recording: recording, env: env)
+
+        let collector = StageMetricsCollector(recordingDurationSeconds: recording.durationSeconds)
+        let cleanedRecording = try await renderCleanedMicrophone(
+            recording: recording,
+            env: env,
+            collector: collector
+        )
+
+        let repository = BenchmarkTranscriptionRepository()
+        let service = makeBenchmarkService(
+            recording: cleanedRecording,
+            env: env,
+            repository: repository,
+            collector: collector
+        )
+        let queued = try await service.prepareMeetingTranscription(recording: cleanedRecording)
+        _ = try await service.finalizeMeetingTranscription(
+            recording: cleanedRecording,
+            updating: queued.id,
+            onProgress: nil
+        )
+
+        let rows = collector.rows()
+        XCTAssertFalse(rows.isEmpty)
+        let table = renderMarkdownTable(
+            runID: runID,
+            fixture: fixture,
+            recording: cleanedRecording,
+            rows: rows
+        )
+        print("\n\(table)\n")
+        try append(table: table, env: env)
+    }
+
+    private func makeBenchmarkService(
+        recording: MeetingRecordingOutput,
+        env: [String: String],
+        repository: BenchmarkTranscriptionRepository,
+        collector: StageMetricsCollector
+    ) -> TranscriptionService {
+        let parakeetVariant = Self.parakeetVariant(from: env)
+        let sttClient = STTClient(
+            parakeetModelVariant: parakeetVariant,
+            speechEngine: recording.speechEngine.engine,
+            nemotronModelVariant: SpeechEnginePreference.nemotronModelVariant(),
+            whisperModelVariant: SpeechEnginePreference.whisperModelVariant()
+        )
+        let observer = MeetingFinalizationBenchmarkObserver(
+            onStageStart: { stage in
+                collector.begin(stage.markdownName)
+            },
+            onStageEnd: { stage in
+                collector.end(stage.markdownName)
+            }
+        )
+
+        return TranscriptionService(
+            audioProcessor: AudioProcessor(),
+            sttTranscriber: sttClient,
+            transcriptionRepo: repository,
+            processingMode: { .raw },
+            shouldUseAIFormatter: { false },
+            shouldAutoGenerateMeetingTitles: { false },
+            shouldDiarize: { true },
+            diarizationService: DiarizationService(),
+            meetingArtifactStore: nil,
+            meetingAutomationHookRunner: nil,
+            meetingCleanedMicrophoneReadinessPolicy: .production,
+            meetingFinalizationBenchmarkObserver: observer
+        )
+    }
+
+    private func renderCleanedMicrophone(
+        recording: MeetingRecordingOutput,
+        env: [String: String],
+        collector: StageMetricsCollector
+    ) async throws -> MeetingRecordingOutput {
+        let outputURL = recording.folderURL.appendingPathComponent(
+            MeetingCleanedMicRenderer.cleanedMicrophoneFileName)
+        let readiness = try await collector.measure(stage: "decode+aec_render") {
+            let readiness = MeetingCleanedMicrophoneRenderScheduler.schedule(
+                outputURL: outputURL,
+                microphoneURL: recording.microphoneAudioURL,
+                systemURL: recording.systemAudioURL,
+                sourceAlignment: recording.sourceAlignment,
+                sessionID: recording.sessionID,
+                conditionerFactory: { Self.makeLocalVQEConditioner(env: env) },
+                fileManager: .default,
+                eventName: "long_meeting_pipeline_bench_cleaned_mic"
+            )
+            _ = try await readiness.awaitCompletion(
+                timeoutSeconds: max(60, recording.durationSeconds * 2)
+            )
+            return readiness
+        }
+
+        return MeetingRecordingOutput(
+            sessionID: recording.sessionID,
+            displayName: recording.displayName,
+            folderURL: recording.folderURL,
+            mixedAudioURL: recording.mixedAudioURL,
+            microphoneAudioURL: recording.microphoneAudioURL,
+            systemAudioURL: recording.systemAudioURL,
+            cleanedMicrophoneAudioURL: readiness.outputURL,
+            cleanedMicrophoneReadiness: nil,
+            durationSeconds: recording.durationSeconds,
+            sourceAlignment: recording.sourceAlignment,
+            speechEngine: recording.speechEngine,
+            speechEngineWasCaptured: recording.speechEngineWasCaptured,
+            userNotes: recording.userNotes
+        )
+    }
+
+    private func makeFixture(env: [String: String], runID: String) async throws -> BenchmarkFixture {
+        let workRoot = URL(fileURLWithPath: env[Self.workDirKey] ?? ".codex/long-meeting-pipeline-bench/runs")
+            .standardizedFileURL
+        try FileManager.default.createDirectory(at: workRoot, withIntermediateDirectories: true)
+        let runFolder = workRoot.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: runFolder, withIntermediateDirectories: true)
+
+        if let sessionPath = nonEmpty(env[Self.sessionKey]) {
+            let source = URL(fileURLWithPath: sessionPath, isDirectory: true).standardizedFileURL
+            let destination = runFolder.appendingPathComponent(source.lastPathComponent, isDirectory: true)
+            try copySessionFolder(from: source, to: destination)
+            return BenchmarkFixture(
+                name: source.lastPathComponent,
+                folderURL: destination,
+                sourceDescription: source.path,
+                synthetic: false
+            )
+        }
+
+        guard let secondsText = nonEmpty(env[Self.syntheticSecondsKey]),
+            let seconds = Double(secondsText),
+            seconds > 0
+        else {
+            throw XCTSkip(
+                "Set \(Self.sessionKey) to a retained meeting session folder, or set \(Self.syntheticSecondsKey) for an explicit synthetic smoke fixture."
+            )
+        }
+
+        let folder = runFolder.appendingPathComponent("synthetic-\(runID)", isDirectory: true)
+        try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+        try await makeSyntheticFixture(durationSeconds: seconds, folderURL: folder)
+        return BenchmarkFixture(
+            name: "synthetic-\(String(format: "%.0f", seconds))s",
+            folderURL: folder,
+            sourceDescription: "generated synthetic dual-track fixture",
+            synthetic: true
+        )
+    }
+
+    private func copySessionFolder(from source: URL, to destination: URL) throws {
+        guard FileManager.default.fileExists(atPath: source.path) else {
+            throw BenchmarkError.missingRequiredPath(source.path)
+        }
+        try FileManager.default.copyItem(at: source, to: destination)
+        try FileManager.default.removeItemIfExists(
+            at: destination.appendingPathComponent(MeetingCleanedMicRenderer.cleanedMicrophoneFileName)
+        )
+    }
+
+    private func loadRecording(from folderURL: URL) async throws -> MeetingRecordingOutput {
+        let microphoneURL = folderURL.appendingPathComponent("microphone.m4a")
+        let systemURL = folderURL.appendingPathComponent("system.m4a")
+        let mixedURL = existingMixedAudioURL(in: folderURL) ?? microphoneURL
+
+        guard FileManager.default.fileExists(atPath: microphoneURL.path) else {
+            throw BenchmarkError.missingRequiredPath(microphoneURL.path)
+        }
+        guard FileManager.default.fileExists(atPath: systemURL.path) else {
+            throw BenchmarkError.missingRequiredPath(systemURL.path)
+        }
+        let metadataURL = MeetingRecordingMetadataStore.metadataURL(for: folderURL)
+        guard FileManager.default.fileExists(atPath: metadataURL.path) else {
+            throw BenchmarkError.missingRequiredPath(metadataURL.path)
+        }
+
+        let duration = try await audioDuration(microphoneURL)
+        guard duration > 0 else {
+            throw BenchmarkError.invalidFixture("Microphone source has zero duration: \(microphoneURL.path)")
+        }
+        let recording = try MeetingRecordingOutput.loadArchived(
+            displayName: folderURL.lastPathComponent,
+            mixedAudioURL: mixedURL,
+            durationSeconds: duration
+        )
+        guard recording.sourceAlignment.microphone != nil, recording.sourceAlignment.system != nil else {
+            throw BenchmarkError.invalidFixture(
+                "Fixture metadata must include both microphone and system source alignment tracks: \(folderURL.path)"
+            )
+        }
+        return recording
+    }
+
+    private func existingMixedAudioURL(in folderURL: URL) -> URL? {
+        let candidates = ["meeting.m4a", "mixed.m4a"].map { folderURL.appendingPathComponent($0) }
+        return candidates.first { FileManager.default.fileExists(atPath: $0.path) }
+    }
+
+    private func preflightModelsAndAssets(recording: MeetingRecordingOutput, env: [String: String]) throws {
+        _ = try requiredFile(env[Self.localVQELibraryKey], name: Self.localVQELibraryKey)
+        let modelURL = try requiredFile(env[Self.localVQEModelKey], name: Self.localVQEModelKey)
+        if let expectedSHA = nonEmpty(env[Self.localVQEModelSHAKey])?.lowercased() {
+            let actualSHA = try MeetingEchoSuppressionFactory.sha256Hex(for: modelURL)
+            guard actualSHA == expectedSHA else {
+                throw BenchmarkError.invalidFixture(
+                    "\(Self.localVQEModelSHAKey) mismatch for \(modelURL.path): expected \(expectedSHA), got \(actualSHA)"
+                )
+            }
+        }
+        switch recording.speechEngine.engine {
+        case .parakeet:
+            let variant = Self.parakeetVariant(from: env)
+            if variant.usesUnifiedEngine {
+                guard ParakeetUnifiedEngine.isModelCached() else {
+                    throw BenchmarkError.missingModel("Parakeet Unified is not downloaded.")
+                }
+            } else if let version = variant.asrModelVersion {
+                guard STTClient.isModelCached(version: version) else {
+                    throw BenchmarkError.missingModel("Parakeet \(variant.rawValue) is not downloaded.")
+                }
+            }
+        case .nemotron:
+            guard
+                STTClient.isNemotronModelCached(
+                    modelVariant: SpeechEnginePreference.nemotronModelVariant(),
+                    language: recording.speechEngine.language
+                )
+            else {
+                throw BenchmarkError.missingModel("Nemotron is not downloaded.")
+            }
+        case .whisper:
+            let variant = SpeechEnginePreference.whisperModelVariant()
+            guard WhisperEngine.isModelDownloaded(model: variant) else {
+                throw BenchmarkError.missingModel("Whisper \(variant) is not downloaded.")
+            }
+        case .cohere:
+            guard CohereTranscribeEngine.isModelCached() else {
+                throw BenchmarkError.missingModel("Cohere Transcribe is not downloaded.")
+            }
+        }
+
+        guard DiarizationService.isModelCached() else {
+            throw BenchmarkError.missingModel("Diarization models are not downloaded.")
+        }
+    }
+
+    private func requiredFile(_ rawPath: String?, name: String) throws -> URL {
+        guard let path = nonEmpty(rawPath) else {
+            throw BenchmarkError.missingRequiredPath("Missing \(name)")
+        }
+        let url = URL(fileURLWithPath: path).standardizedFileURL
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            throw BenchmarkError.missingRequiredPath(url.path)
+        }
+        return url
+    }
+
+    private static func makeLocalVQEConditioner(env: [String: String]) -> any MicConditioning {
+        MeetingEchoSuppressionFactory.makeConditioner(
+            configuration: MeetingEchoSuppressionConfiguration(
+                mode: .dynamicLibrary,
+                libraryURL: env[localVQELibraryKey].map(URL.init(fileURLWithPath:)),
+                modelURL: env[localVQEModelKey].map(URL.init(fileURLWithPath:)),
+                modelSHA256: env[localVQEModelSHAKey],
+                sampleRate: MeetingCleanedMicRenderer.renderSampleRate,
+                frameSize: MeetingEchoSuppressionConfiguration.defaultFrameSize,
+                adaptiveReferenceDelay: true
+            ),
+            bundle: Bundle(for: LongMeetingPipelineBenchmarkTests.self)
+        )
+    }
+
+    private static func parakeetVariant(from env: [String: String]) -> ParakeetModelVariant {
+        nonEmpty(env[parakeetVariantKey]).flatMap(ParakeetModelVariant.init(rawValue:))
+            ?? SpeechEnginePreference.parakeetModelVariant()
+    }
+
+    private func makeSyntheticFixture(durationSeconds: Double, folderURL: URL) async throws {
+        let sampleRate = MeetingCleanedMicRenderer.renderSampleRate
+        let sampleCount = max(sampleRate, Int(durationSeconds * Double(sampleRate)))
+        let echoDelay = 120
+        var farEnd = [Float](repeating: 0, count: sampleCount)
+        var microphone = [Float](repeating: 0, count: sampleCount)
+
+        for index in 0..<sampleCount {
+            let t = Double(index) / Double(sampleRate)
+            let system = Float(sin(2 * Double.pi * 440 * t) * 0.18)
+            let near = Float(sin(2 * Double.pi * 220 * t) * 0.14)
+            farEnd[index] = system
+            let echo = index >= echoDelay ? farEnd[index - echoDelay] * 0.45 : 0
+            microphone[index] = near + echo
+        }
+
+        let microphoneURL = folderURL.appendingPathComponent("microphone.m4a")
+        let systemURL = folderURL.appendingPathComponent("system.m4a")
+        try await MeetingCleanedMicRenderer.encodeMonoFloat(
+            microphone,
+            sampleRate: sampleRate,
+            to: microphoneURL,
+            fileManager: .default
+        )
+        try await MeetingCleanedMicRenderer.encodeMonoFloat(
+            farEnd,
+            sampleRate: sampleRate,
+            to: systemURL,
+            fileManager: .default
+        )
+        try FileManager.default.copyItem(at: microphoneURL, to: folderURL.appendingPathComponent("meeting.m4a"))
+
+        let track = MeetingSourceAlignment.Track(
+            firstHostTime: nil,
+            lastHostTime: nil,
+            startOffsetMs: 0,
+            writtenFrameCount: Int64(sampleCount),
+            sampleRate: Double(sampleRate)
+        )
+        let metadata = MeetingRecordingMetadata(
+            sourceAlignment: MeetingSourceAlignment(
+                meetingOriginHostTime: nil,
+                microphone: track,
+                system: track
+            ),
+            speechEngine: SpeechEngineSelection(engine: .parakeet)
+        )
+        try MeetingRecordingMetadataStore.save(metadata, folderURL: folderURL)
+    }
+
+    private func renderMarkdownTable(
+        runID: String,
+        fixture: BenchmarkFixture,
+        recording: MeetingRecordingOutput,
+        rows: [StageMetricsCollector.Row]
+    ) -> String {
+        var lines = [
+            "### Long Meeting Full Pipeline Benchmark - \(runID)",
+            "",
+            "- Fixture: \(fixture.name)",
+            "- Source: \(fixture.sourceDescription)",
+            "- Working copy: \(fixture.folderURL.path)",
+            "- Recording duration: \(String(format: "%.3f", recording.durationSeconds)) s",
+            "- Synthetic fixture: \(fixture.synthetic ? "yes" : "no")",
+            "",
+            "| Run | Fixture | Stage | Recording duration (s) | Elapsed (s) | Realtime factor | Peak RSS delta (MB) |",
+            "|---|---|---|---:|---:|---:|---:|",
+        ]
+        lines += rows.map { row in
+            "| \(runID) | \(fixture.name) | \(row.stage) | \(String(format: "%.3f", recording.durationSeconds)) | \(String(format: "%.4f", row.elapsedSeconds)) | \(String(format: "%.2fx", row.realtimeFactor)) | \(String(format: "%.1f", row.peakRSSDeltaMB)) |"
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    private func append(table: String, env: [String: String]) throws {
+        let outputURL = URL(
+            fileURLWithPath: env[Self.resultsFileKey] ?? ".codex/long-meeting-pipeline-bench/results.md"
+        )
+        .standardizedFileURL
+        try FileManager.default.createDirectory(
+            at: outputURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let payload = "\n\n\(table)\n"
+        if FileManager.default.fileExists(atPath: outputURL.path) {
+            let handle = try FileHandle(forWritingTo: outputURL)
+            defer { try? handle.close() }
+            try handle.seekToEnd()
+            try handle.write(contentsOf: Data(payload.utf8))
+        } else {
+            try Data(payload.utf8).write(to: outputURL)
+        }
+        print("Long meeting pipeline benchmark results appended to \(outputURL.path)")
+    }
+
+    private func audioDuration(_ url: URL) async throws -> TimeInterval {
+        let asset = AVURLAsset(url: url)
+        let tracks = try await asset.loadTracks(withMediaType: .audio)
+        guard !tracks.isEmpty else {
+            throw BenchmarkError.invalidFixture("No audio track in \(url.path)")
+        }
+        return try await asset.load(.duration).seconds
+    }
+
+    private func nonEmpty(_ value: String?) -> String? {
+        Self.nonEmpty(value)
+    }
+
+    private static func nonEmpty(_ value: String?) -> String? {
+        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed?.isEmpty == false ? trimmed : nil
+    }
+}
+
+private extension MeetingFinalizationBenchmarkObserver.Stage {
+    var markdownName: String { rawValue }
+}
+
+private struct BenchmarkFixture {
+    let name: String
+    let folderURL: URL
+    let sourceDescription: String
+    let synthetic: Bool
+}
+
+private enum BenchmarkError: Error, LocalizedError {
+    case missingRequiredPath(String)
+    case missingModel(String)
+    case invalidFixture(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .missingRequiredPath(let path):
+            "Required benchmark path is missing: \(path)"
+        case .missingModel(let message), .invalidFixture(let message):
+            message
+        }
+    }
+}
+
+private final class StageMetricsCollector: @unchecked Sendable {
+    struct Row: Equatable {
+        let stage: String
+        let elapsedSeconds: Double
+        let realtimeFactor: Double
+        let peakRSSDeltaMB: Double
+    }
+
+    private final class RunningStage {
+        let stage: String
+        let startedAt: TimeInterval
+        let baselineRSS: UInt64
+        var peakRSS: UInt64
+        var timer: DispatchSourceTimer?
+
+        init(stage: String, startedAt: TimeInterval, baselineRSS: UInt64) {
+            self.stage = stage
+            self.startedAt = startedAt
+            self.baselineRSS = baselineRSS
+            self.peakRSS = baselineRSS
+        }
+    }
+
+    private let recordingDurationSeconds: Double
+    private let lock = NSLock()
+    private var running: [String: RunningStage] = [:]
+    private var completedRows: [Row] = []
+
+    init(recordingDurationSeconds: Double) {
+        self.recordingDurationSeconds = recordingDurationSeconds
+    }
+
+    func begin(_ stage: String) {
+        let baselineRSS = Self.currentResidentRSS()
+        let run = RunningStage(
+            stage: stage,
+            startedAt: ProcessInfo.processInfo.systemUptime,
+            baselineRSS: baselineRSS
+        )
+        let timer = DispatchSource.makeTimerSource(
+            queue: DispatchQueue(label: "com.macparakeet.long-meeting-bench.\(stage)")
+        )
+        timer.schedule(deadline: .now(), repeating: .milliseconds(100))
+        timer.setEventHandler { [weak self] in
+            self?.sample(stage)
+        }
+        run.timer = timer
+        lock.withLock {
+            running[stage] = run
+        }
+        timer.resume()
+    }
+
+    func end(_ stage: String) {
+        let now = ProcessInfo.processInfo.systemUptime
+        let rss = Self.currentResidentRSS()
+        let run = lock.withLock { () -> RunningStage? in
+            guard let run = running.removeValue(forKey: stage) else { return nil }
+            run.peakRSS = max(run.peakRSS, rss)
+            return run
+        }
+        guard let run else { return }
+        run.timer?.cancel()
+        let elapsed = max(0, now - run.startedAt)
+        let peakDelta = run.peakRSS > run.baselineRSS ? run.peakRSS - run.baselineRSS : 0
+        let row = Row(
+            stage: run.stage,
+            elapsedSeconds: elapsed,
+            realtimeFactor: elapsed > 0 ? recordingDurationSeconds / elapsed : 0,
+            peakRSSDeltaMB: Double(peakDelta) / 1_048_576.0
+        )
+        lock.withLock {
+            completedRows.append(row)
+        }
+    }
+
+    func measure<T>(stage: String, operation: () async throws -> T) async throws -> T {
+        begin(stage)
+        do {
+            let value = try await operation()
+            end(stage)
+            return value
+        } catch {
+            end(stage)
+            throw error
+        }
+    }
+
+    func rows() -> [Row] {
+        lock.withLock { completedRows }
+    }
+
+    private func sample(_ stage: String) {
+        let rss = Self.currentResidentRSS()
+        lock.withLock {
+            guard let run = running[stage] else { return }
+            run.peakRSS = max(run.peakRSS, rss)
+        }
+    }
+
+    private static func currentResidentRSS() -> UInt64 {
+        var info = mach_task_basic_info()
+        var count = mach_msg_type_number_t(MemoryLayout<mach_task_basic_info>.stride / MemoryLayout<integer_t>.stride)
+        let result = withUnsafeMutablePointer(to: &info) { pointer in
+            pointer.withMemoryRebound(to: integer_t.self, capacity: Int(count)) { rebound in
+                task_info(
+                    mach_task_self_,
+                    task_flavor_t(MACH_TASK_BASIC_INFO),
+                    rebound,
+                    &count
+                )
+            }
+        }
+        guard result == KERN_SUCCESS else { return 0 }
+        return UInt64(info.resident_size)
+    }
+}
+
+private final class BenchmarkTranscriptionRepository: TranscriptionRepositoryProtocol, @unchecked Sendable {
+    private let lock = NSLock()
+    private var records: [UUID: Transcription] = [:]
+
+    func save(_ transcription: Transcription) throws {
+        lock.withLock {
+            records[transcription.id] = transcription
+        }
+    }
+
+    func fetch(id: UUID) throws -> Transcription? {
+        lock.withLock { records[id] }
+    }
+
+    func fetchAll(limit: Int?) throws -> [Transcription] {
+        let all = lock.withLock { Array(records.values) }
+        guard let limit else { return all }
+        return Array(all.prefix(limit))
+    }
+
+    func delete(id: UUID) throws -> Bool {
+        lock.withLock { records.removeValue(forKey: id) != nil }
+    }
+
+    func deleteAll() throws {
+        lock.withLock { records.removeAll() }
+    }
+
+    func updateStatus(id: UUID, status: Transcription.TranscriptionStatus, errorMessage: String?) throws {
+        lock.withLock {
+            guard var record = records[id] else { return }
+            record.status = status
+            record.errorMessage = errorMessage
+            records[id] = record
+        }
+    }
+}
+
+private extension FileManager {
+    func removeItemIfExists(at url: URL) throws {
+        guard fileExists(atPath: url.path) else { return }
+        try removeItem(at: url)
+    }
+}

--- a/Tests/MacParakeetTests/Benchmarks/LongMeetingPipelineBenchmarkTests.swift
+++ b/Tests/MacParakeetTests/Benchmarks/LongMeetingPipelineBenchmarkTests.swift
@@ -202,13 +202,29 @@ final class LongMeetingPipelineBenchmarkTests: XCTestCase {
     }
 
     private func copySessionFolder(from source: URL, to destination: URL) throws {
-        guard FileManager.default.fileExists(atPath: source.path) else {
-            throw BenchmarkError.missingRequiredPath(source.path)
-        }
+        try validateSourceSessionFolder(source)
         try FileManager.default.copyItem(at: source, to: destination)
         try FileManager.default.removeItemIfExists(
             at: destination.appendingPathComponent(MeetingCleanedMicRenderer.cleanedMicrophoneFileName)
         )
+    }
+
+    private func validateSourceSessionFolder(_ source: URL) throws {
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: source.path, isDirectory: &isDirectory),
+              isDirectory.boolValue
+        else {
+            throw BenchmarkError.missingRequiredPath(source.path)
+        }
+
+        let requiredURLs = [
+            source.appendingPathComponent("microphone.m4a"),
+            source.appendingPathComponent("system.m4a"),
+            MeetingRecordingMetadataStore.metadataURL(for: source)
+        ]
+        for url in requiredURLs where !FileManager.default.fileExists(atPath: url.path) {
+            throw BenchmarkError.missingRequiredPath(url.path)
+        }
     }
 
     private func loadRecording(from folderURL: URL) async throws -> MeetingRecordingOutput {
@@ -488,6 +504,10 @@ private final class StageMetricsCollector: @unchecked Sendable {
             self.startedAt = startedAt
             self.baselineRSS = baselineRSS
             self.peakRSS = baselineRSS
+        }
+
+        deinit {
+            timer?.cancel()
         }
     }
 

--- a/Tests/MacParakeetTests/Benchmarks/LongMeetingPipelineBenchmarkTests.swift
+++ b/Tests/MacParakeetTests/Benchmarks/LongMeetingPipelineBenchmarkTests.swift
@@ -225,6 +225,13 @@ final class LongMeetingPipelineBenchmarkTests: XCTestCase {
         for url in requiredURLs where !FileManager.default.fileExists(atPath: url.path) {
             throw BenchmarkError.missingRequiredPath(url.path)
         }
+
+        let metadata = try MeetingRecordingMetadataStore.load(from: source)
+        guard metadata.sourceAlignment.microphone != nil, metadata.sourceAlignment.system != nil else {
+            throw BenchmarkError.invalidFixture(
+                "Source metadata must include both microphone and system source alignment tracks before copying: \(source.path)"
+            )
+        }
     }
 
     private func loadRecording(from folderURL: URL) async throws -> MeetingRecordingOutput {


### PR DESCRIPTION
## Summary

Operators can now run an env-gated XCTest benchmark against a retained dual-track meeting session to measure the default post-stop pipeline: cleaned mic render, mic STT, system STT, diarization, and final transcript merge. The harness validates retained meeting inputs before copying them into `.codex/long-meeting-pipeline-bench/runs/<uuid>`, preflights local LocalVQE/STT/diarization assets, and appends a pasteable markdown table for audit docs.

Plan context: this implements Phase 1b from `plans/active/2026-07-04-long-meeting-aec-policy.md`, which is currently proposed in PR #694 and is not part of this branch or current `main`.

## How To Run

```bash
MACPARAKEET_LONG_MEETING_PIPELINE_BENCH=1 \
MACPARAKEET_LONG_MEETING_SESSION="$HOME/Library/Application Support/MacParakeet/meeting-recordings/<session-id>" \
MACPARAKEET_TEST_LOCALVQE_LIBRARY="/path/to/liblocalvqe.dylib" \
MACPARAKEET_TEST_LOCALVQE_MODEL="/path/to/localvqe-v1.4-aec-200K-f32.gguf" \
MACPARAKEET_LONG_MEETING_RESULTS_FILE=".codex/long-meeting-pipeline-bench/results.md" \
swift test --filter LongMeetingPipelineBenchmarkTests
```

Required env vars: `MACPARAKEET_LONG_MEETING_PIPELINE_BENCH=1`, `MACPARAKEET_LONG_MEETING_SESSION`, `MACPARAKEET_TEST_LOCALVQE_LIBRARY`, and `MACPARAKEET_TEST_LOCALVQE_MODEL`.

Optional env vars: `MACPARAKEET_TEST_LOCALVQE_MODEL_SHA256`, `MACPARAKEET_LONG_MEETING_RESULTS_FILE`, `MACPARAKEET_LONG_MEETING_WORK_DIR`, `MACPARAKEET_LONG_MEETING_PARAKEET_VARIANT`, and `MACPARAKEET_LONG_MEETING_SYNTHETIC_SECONDS` for explicit synthetic smoke fixtures.

## Smoke Run

Retained dual-track fixture: `58C24721-9E24-4661-824E-32F9EECE8CA6`.

| Run | Fixture | Stage | Recording duration (s) | Elapsed (s) | Realtime factor | Peak RSS delta (MB) |
|---|---|---|---:|---:|---:|---:|
| 2026-07-04T08:48:22Z | 58C24721-9E24-4661-824E-32F9EECE8CA6 | decode+aec_render | 9.000 | 0.0306 | 293.98x | 4.8 |
| 2026-07-04T08:48:22Z | 58C24721-9E24-4661-824E-32F9EECE8CA6 | mic_stt | 9.000 | 0.3320 | 27.11x | 65.3 |
| 2026-07-04T08:48:22Z | 58C24721-9E24-4661-824E-32F9EECE8CA6 | system_stt | 9.000 | 0.0754 | 119.36x | 0.9 |
| 2026-07-04T08:48:22Z | 58C24721-9E24-4661-824E-32F9EECE8CA6 | diarization | 9.000 | 0.3148 | 28.59x | 56.2 |
| 2026-07-04T08:48:22Z | 58C24721-9E24-4661-824E-32F9EECE8CA6 | finalize_merge | 9.000 | 0.0002 | 51873.20x | 0.0 |

## Seams Added

- `MeetingFinalizationBenchmarkObserver`: package-internal instrumentation seam for stage start/end callbacks inside the real `TranscriptionService` meeting finalization flow.
- Internal `TranscriptionService` initializer overload accepts the observer; the public initializer stays unchanged and production callers use nil instrumentation.

## Validation

- `env -u MACPARAKEET_LONG_MEETING_PIPELINE_BENCH swift test --filter LongMeetingPipelineBenchmarkTests` (skipped; default focused run unaffected)
- `swift test --filter TranscriptionServiceTests`
- Retained dual-track smoke command above with local LocalVQE/STT/diarization models present
- `git diff --check`

## Post-Deploy Monitoring & Validation

No production runtime monitoring required. This is a default-off benchmark harness with an inert package-internal observer seam; validation is operator-run by invoking the gated command and confirming all five stage rows are emitted before pasting results into the audit doc.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an env-gated XCTest benchmark that runs the full post-stop meeting pipeline on a retained dual-track session and outputs a pasteable results table. Adds an internal observer seam and hardens safety/metrics with early metadata validation and tighter stage timing; aligns with Phase 1b of the long-meeting AEC policy.

- New Features
  - End-to-end run: cleaned mic render, mic STT, system STT, diarization, final merge.
  - Copies the source session to scratch; validates session metadata before copying; supports an explicit synthetic fixture.
  - Preflights LocalVQE/STT/diarization assets; appends a markdown table with elapsed time, realtime factor, peak RSS delta.
  - Default-off via `MACPARAKEET_LONG_MEETING_PIPELINE_BENCH=1`; normal `swift test` skips.

- Refactors
  - Added `MeetingFinalizationBenchmarkObserver` for stage start/end callbacks.
  - Internal `TranscriptionService` initializer accepts the observer; public initializer unchanged (nil in production).
  - Tightened timing/metrics: STT timers bracket only `transcribeSpeech`; diarization row only when requested; RSS sampler canceled on teardown; finalize merge timed.

<sup>Written for commit 26cae8c6225afb23ef3a88ddc3a8065274490898. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/696?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

