### PR TITLE
refactor(meeting-recording): route lock cleanup through a single settlement authority

### DIFF
--- a/Sources/MacParakeet/App/AppEnvironment.swift
+++ b/Sources/MacParakeet/App/AppEnvironment.swift
@@ -23,6 +23,7 @@ final class AppEnvironment {
     let sharedMicStream: SharedMicrophoneStream
     let audioProcessor: AudioProcessor
     let meetingRecordingService: MeetingRecordingService
+    let meetingRecordingSettlement: MeetingRecordingSettlement
     let meetingRecordingRecoveryService: MeetingRecordingRecoveryService
     let dictationService: DictationService
     let transcriptionService: TranscriptionService
@@ -143,6 +144,7 @@ final class AppEnvironment {
             // burst into a single warm-engine restart (issue #481).
             warmCaptureRefreshDebounce: 0.5
         )
+        let meetingRecordingLockFileStore = MeetingRecordingLockFileStore()
         meetingRecordingService = MeetingRecordingService(
             micProcessingMode: meetingMicProcessingMode,
             audioCaptureService: MeetingAudioCaptureService(
@@ -151,9 +153,14 @@ final class AppEnvironment {
                 sharedMicStream: sharedMicStream
             ),
             sttTranscriber: sttScheduler,
+            lockFileStore: meetingRecordingLockFileStore,
             // Wire the real feature flag here (the service defaults to fixed
             // chunking so tests stay deterministic regardless of the flag).
             isVadLiveChunkingEnabled: { AppFeatures.meetingVadLiveChunkingEnabled }
+        )
+        meetingRecordingSettlement = MeetingRecordingSettlement(
+            lockFileStore: meetingRecordingLockFileStore,
+            transcriptionRepo: transcriptionRepo
         )
         clipboardService = ClipboardService()
         systemMediaController = SystemMediaController()
@@ -345,8 +352,10 @@ final class AppEnvironment {
         )
 
         meetingRecordingRecoveryService = MeetingRecordingRecoveryService(
+            lockFileStore: meetingRecordingLockFileStore,
             transcriptionService: transcriptionService,
-            transcriptionRepo: transcriptionRepo
+            transcriptionRepo: transcriptionRepo,
+            settlement: meetingRecordingSettlement
         )
 
         derivedFieldsBackfill = DerivedFieldsBackfillService(dbQueue: databaseManager.dbQueue)

--- a/Sources/MacParakeet/App/AppEnvironment.swift
+++ b/Sources/MacParakeet/App/AppEnvironment.swift
@@ -354,8 +354,7 @@ final class AppEnvironment {
         meetingRecordingRecoveryService = MeetingRecordingRecoveryService(
             lockFileStore: meetingRecordingLockFileStore,
             transcriptionService: transcriptionService,
-            transcriptionRepo: transcriptionRepo,
-            settlement: meetingRecordingSettlement
+            transcriptionRepo: transcriptionRepo
         )
 
         derivedFieldsBackfill = DerivedFieldsBackfillService(dbQueue: databaseManager.dbQueue)

--- a/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
+++ b/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
@@ -313,6 +313,7 @@ final class AppEnvironmentConfigurer {
             },
             llmService: hasLLMConfig ? env.llmService : nil,
             pillViewModel: meetingPillViewModel,
+            meetingRecordingSettlement: env.meetingRecordingSettlement,
             onMenuBarIconUpdate: { _ in callbacks.onMenuBarIconUpdate() },
             onTranscriptionReady: { [weak self] transcription in
                 guard let self else { return }

--- a/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
@@ -116,6 +116,7 @@ final class MeetingRecordingFlowCoordinator {
         },
         llmService: LLMServiceProtocol?,
         pillViewModel: MeetingRecordingPillViewModel,
+        meetingRecordingSettlement: MeetingRecordingSettlement,
         meetingTranscriptionQueue: MeetingTranscriptionQueue? = nil,
         onMenuBarIconUpdate: @escaping (BreathWaveIcon.MenuBarState) -> Void,
         onTranscriptionReady: @escaping (Transcription) -> Void,
@@ -143,7 +144,7 @@ final class MeetingRecordingFlowCoordinator {
             meetingTranscriptionQueue
             ?? MeetingTranscriptionQueue(
                 transcriptionService: transcriptionService,
-                meetingRecordingService: meetingRecordingService
+                meetingRecordingSettlement: meetingRecordingSettlement
             )
         self.onMenuBarIconUpdate = onMenuBarIconUpdate
         self.onTranscriptionReady = onTranscriptionReady
@@ -702,9 +703,8 @@ final class MeetingRecordingFlowCoordinator {
                     self.currentMeetingTrigger = nil
                     self.sendEvent(.recordingQueued(generation: gen, transcriptionID: prepared.id))
                 } catch {
-                    if let stoppedOutput {
-                        await meetingRecordingService.finishTranscriptionAttempt(for: stoppedOutput)
-                    }
+                    // If stop already succeeded, the lock is already
+                    // awaitingTranscription. Leave it for recovery to retry.
                     if error is CancellationError {
                         self.sendMeetingOperation(
                             outcome: .cancelled,

--- a/Sources/MacParakeet/App/MeetingTranscriptionQueue.swift
+++ b/Sources/MacParakeet/App/MeetingTranscriptionQueue.swift
@@ -77,26 +77,35 @@ final class MeetingTranscriptionQueue {
     }
 
     private func process(_ item: Item) async {
+        let transcription: Transcription
         do {
-            let transcription = try await Observability.withOperationContext(item.operationContext) {
+            transcription = try await Observability.withOperationContext(item.operationContext) {
                 try await transcriptionService.finalizeMeetingTranscription(
                     recording: item.recording,
                     updating: item.transcriptionID,
                     onProgress: nil
                 )
             }
-            try await meetingRecordingSettlement.settleCompletedTranscription(
-                folderURL: item.recording.folderURL,
-                transcriptionID: transcription.id,
-                sessionID: item.recording.sessionID
-            )
-            finishActiveItem(.success(item: item, transcription: transcription))
         } catch {
             logger.error(
                 "queued_meeting_transcription_failed session=\(item.recording.sessionID.uuidString, privacy: .public) error_type=\(TelemetryErrorClassifier.classify(error), privacy: .public) error_detail=\(error.localizedDescription, privacy: .private)"
             )
             finishActiveItem(.failure(item: item, error: error))
+            return
         }
+
+        do {
+            try await meetingRecordingSettlement.settleCompletedTranscription(
+                folderURL: item.recording.folderURL,
+                transcriptionID: transcription.id,
+                sessionID: item.recording.sessionID
+            )
+        } catch {
+            logger.error(
+                "queued_meeting_settlement_failed_lock_retained_for_recovery session=\(item.recording.sessionID.uuidString, privacy: .public) error_type=\(TelemetryErrorClassifier.classify(error), privacy: .public) error_detail=\(error.localizedDescription, privacy: .private)"
+            )
+        }
+        finishActiveItem(.success(item: item, transcription: transcription))
     }
 
     private func finishActiveItem(_ completion: Completion) {

--- a/Sources/MacParakeet/App/MeetingTranscriptionQueue.swift
+++ b/Sources/MacParakeet/App/MeetingTranscriptionQueue.swift
@@ -29,7 +29,7 @@ final class MeetingTranscriptionQueue {
 
     private let logger = Logger(subsystem: "com.macparakeet", category: "MeetingTranscriptionQueue")
     private let transcriptionService: TranscriptionServiceProtocol
-    private let meetingRecordingService: MeetingRecordingServiceProtocol
+    private let meetingRecordingSettlement: MeetingRecordingSettlement
 
     private var pendingItems: [Item] = []
     private var activeItem: Item?
@@ -41,10 +41,10 @@ final class MeetingTranscriptionQueue {
 
     init(
         transcriptionService: TranscriptionServiceProtocol,
-        meetingRecordingService: MeetingRecordingServiceProtocol
+        meetingRecordingSettlement: MeetingRecordingSettlement
     ) {
         self.transcriptionService = transcriptionService
-        self.meetingRecordingService = meetingRecordingService
+        self.meetingRecordingSettlement = meetingRecordingSettlement
     }
 
     var snapshot: Snapshot {
@@ -85,13 +85,16 @@ final class MeetingTranscriptionQueue {
                     onProgress: nil
                 )
             }
-            await meetingRecordingService.completeTranscription(for: item.recording)
+            try await meetingRecordingSettlement.settleCompletedTranscription(
+                folderURL: item.recording.folderURL,
+                transcriptionID: transcription.id,
+                sessionID: item.recording.sessionID
+            )
             finishActiveItem(.success(item: item, transcription: transcription))
         } catch {
             logger.error(
                 "queued_meeting_transcription_failed session=\(item.recording.sessionID.uuidString, privacy: .public) error_type=\(TelemetryErrorClassifier.classify(error), privacy: .public) error_detail=\(error.localizedDescription, privacy: .private)"
             )
-            await meetingRecordingService.finishTranscriptionAttempt(for: item.recording)
             finishActiveItem(.failure(item: item, error: error))
         }
     }

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingArtifactPathAliases.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingArtifactPathAliases.swift
@@ -19,4 +19,18 @@ enum MeetingArtifactPathAliases {
         }
         return paths
     }
+
+    /// True when `candidate` names the same on-disk location as `url`. Exact
+    /// alias match first; falls back to case-insensitive comparison because
+    /// the default APFS volume is case-insensitive but case-preserving, so a
+    /// stored path may differ from a freshly derived one only by case.
+    static func matches(_ candidate: String, for url: URL) -> Bool {
+        let aliases = aliases(for: url)
+        if aliases.contains(candidate) {
+            return true
+        }
+        return aliases.contains {
+            $0.compare(candidate, options: .caseInsensitive) == .orderedSame
+        }
+    }
 }

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingArtifactPathAliases.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingArtifactPathAliases.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Canonical set of equivalent on-disk paths for a meeting artifact URL.
+/// Settlement's belongs-to-folder check and recovery's existing-row matching
+/// must agree on aliasing, so both go through this helper.
+enum MeetingArtifactPathAliases {
+    static func aliases(for url: URL) -> Set<String> {
+        var paths = Set([
+            url.path,
+            url.standardizedFileURL.path,
+            url.resolvingSymlinksInPath().path,
+        ])
+        for path in Array(paths) {
+            if path.hasPrefix("/private/var/") {
+                paths.insert(String(path.dropFirst("/private".count)))
+            } else if path.hasPrefix("/var/") {
+                paths.insert("/private" + path)
+            }
+        }
+        return paths
+    }
+}

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingRecoveryService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingRecoveryService.swift
@@ -43,6 +43,7 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
     private let lockFileStore: MeetingRecordingLockFileStoring
     private let transcriptionService: TranscriptionServiceProtocol
     private let transcriptionRepo: TranscriptionRepositoryProtocol
+    private let settlement: MeetingRecordingSettlement
     private let audioConverter: AudioFileConverting
     private let fileManager: FileManager
     /// Builds the echo suppressor used to re-derive `microphone-cleaned.m4a`
@@ -57,6 +58,7 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
         lockFileStore: MeetingRecordingLockFileStoring = MeetingRecordingLockFileStore(),
         transcriptionService: TranscriptionServiceProtocol,
         transcriptionRepo: TranscriptionRepositoryProtocol,
+        settlement: MeetingRecordingSettlement? = nil,
         audioConverter: AudioFileConverting = AudioFileConverter(),
         fileManager: FileManager = .default,
         echoSuppressionConfiguration: MeetingEchoSuppressionConfiguration = .fromEnvironment()
@@ -66,6 +68,10 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
             lockFileStore: lockFileStore,
             transcriptionService: transcriptionService,
             transcriptionRepo: transcriptionRepo,
+            settlement: settlement ?? MeetingRecordingSettlement(
+                lockFileStore: lockFileStore,
+                transcriptionRepo: transcriptionRepo
+            ),
             audioConverter: audioConverter,
             fileManager: fileManager,
             micConditionerFactory: {
@@ -80,6 +86,7 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
         lockFileStore: MeetingRecordingLockFileStoring = MeetingRecordingLockFileStore(),
         transcriptionService: TranscriptionServiceProtocol,
         transcriptionRepo: TranscriptionRepositoryProtocol,
+        settlement: MeetingRecordingSettlement? = nil,
         audioConverter: AudioFileConverting = AudioFileConverter(),
         fileManager: FileManager = .default,
         micConditionerFactory: @escaping @Sendable () -> any MicConditioning,
@@ -91,6 +98,10 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
         self.lockFileStore = lockFileStore
         self.transcriptionService = transcriptionService
         self.transcriptionRepo = transcriptionRepo
+        self.settlement = settlement ?? MeetingRecordingSettlement(
+            lockFileStore: lockFileStore,
+            transcriptionRepo: transcriptionRepo
+        )
         self.audioConverter = audioConverter
         self.fileManager = fileManager
         self.micConditionerFactory = micConditionerFactory
@@ -171,7 +182,7 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
 
         if let existing = try existingCompletedTranscription(for: mixedURL) {
             await writeNotesSidecar(for: lock, folderURL: folderURL)
-            return try completeExistingTranscription(existing, folderURL: folderURL, lock: lock)
+            return try await completeExistingTranscription(existing, folderURL: folderURL, lock: lock)
         }
         let incompleteRows = try existingIncompleteTranscriptions(for: mixedURL)
         let rowToUpdate = selectedIncompleteTranscription(from: incompleteRows)
@@ -265,7 +276,7 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
             } else {
                 transcription = try await transcriptionService.transcribeMeeting(recording: recording, onProgress: nil)
             }
-            return try completeRecovery(transcription, folderURL: folderURL, lock: lock)
+            return try await completeRecovery(transcription, folderURL: folderURL, lock: lock)
         } catch {
             logger.error("meeting_recovery_transcription_failed session=\(lock.sessionId.uuidString, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
             throw error
@@ -276,8 +287,12 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
         guard let folderURL = lock.folderURL else { return }
         if fileManager.fileExists(atPath: folderURL.path) {
             let mixedURL = folderURL.appendingPathComponent("meeting.m4a")
-            if try existingCompletedTranscription(for: mixedURL) != nil {
-                try lockFileStore.delete(folderURL: folderURL)
+            if let completed = try existingCompletedTranscription(for: mixedURL) {
+                try await settlement.settleCompletedTranscription(
+                    folderURL: folderURL,
+                    transcriptionID: completed.id,
+                    sessionID: lock.sessionId
+                )
                 logger.info("meeting_recovery_discard_cleaned_completed_session session=\(lock.sessionId.uuidString, privacy: .public)")
                 return
             }
@@ -432,20 +447,24 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
         _ transcription: Transcription,
         folderURL: URL,
         lock: MeetingRecordingLockFile
-    ) throws -> Transcription {
+    ) async throws -> Transcription {
         if lock.state == .awaitingTranscription {
-            try lockFileStore.delete(folderURL: folderURL)
+            try await settlement.settleCompletedTranscription(
+                folderURL: folderURL,
+                transcriptionID: transcription.id,
+                sessionID: lock.sessionId
+            )
             logger.info("meeting_recovery_cleaned_completed_session session=\(lock.sessionId.uuidString, privacy: .public)")
             return transcription
         }
-        return try completeRecovery(transcription, folderURL: folderURL, lock: lock)
+        return try await completeRecovery(transcription, folderURL: folderURL, lock: lock)
     }
 
     private func completeRecovery(
         _ transcription: Transcription,
         folderURL: URL,
         lock: MeetingRecordingLockFile
-    ) throws -> Transcription {
+    ) async throws -> Transcription {
         var recovered = transcription
         recovered.recoveredFromCrash = true
         // Carry forward any notes the user typed during the meeting (ADR-020 §9).
@@ -458,7 +477,11 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
         }
         recovered.updatedAt = Date()
         try transcriptionRepo.save(recovered)
-        try lockFileStore.delete(folderURL: folderURL)
+        try await settlement.settleCompletedTranscription(
+            folderURL: folderURL,
+            transcriptionID: recovered.id,
+            sessionID: lock.sessionId
+        )
         logger.info("meeting_recovery_completed session=\(lock.sessionId.uuidString, privacy: .public)")
         return recovered
     }

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingRecoveryService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingRecoveryService.swift
@@ -93,10 +93,12 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
         self.lockFileStore = lockFileStore
         self.transcriptionService = transcriptionService
         self.transcriptionRepo = transcriptionRepo
-        self.settlement = settlement ?? MeetingRecordingSettlement(
-            lockFileStore: lockFileStore,
-            transcriptionRepo: transcriptionRepo
-        )
+        self.settlement =
+            settlement
+            ?? MeetingRecordingSettlement(
+                lockFileStore: lockFileStore,
+                transcriptionRepo: transcriptionRepo
+            )
         self.audioConverter = audioConverter
         self.fileManager = fileManager
         self.micConditionerFactory = micConditionerFactory

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingRecoveryService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingRecoveryService.swift
@@ -58,7 +58,6 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
         lockFileStore: MeetingRecordingLockFileStoring = MeetingRecordingLockFileStore(),
         transcriptionService: TranscriptionServiceProtocol,
         transcriptionRepo: TranscriptionRepositoryProtocol,
-        settlement: MeetingRecordingSettlement? = nil,
         audioConverter: AudioFileConverting = AudioFileConverter(),
         fileManager: FileManager = .default,
         echoSuppressionConfiguration: MeetingEchoSuppressionConfiguration = .fromEnvironment()
@@ -68,10 +67,6 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
             lockFileStore: lockFileStore,
             transcriptionService: transcriptionService,
             transcriptionRepo: transcriptionRepo,
-            settlement: settlement ?? MeetingRecordingSettlement(
-                lockFileStore: lockFileStore,
-                transcriptionRepo: transcriptionRepo
-            ),
             audioConverter: audioConverter,
             fileManager: fileManager,
             micConditionerFactory: {

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingRecoveryService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingRecoveryService.swift
@@ -374,29 +374,13 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
     private func existingTranscriptions(for mixedURL: URL) throws -> [Transcription] {
         var seenIDs = Set<UUID>()
         var transcriptions: [Transcription] = []
-        for path in filePathAliases(for: mixedURL) {
+        for path in MeetingArtifactPathAliases.aliases(for: mixedURL) {
             for transcription in try transcriptionRepo.fetchByFilePath(path, sourceType: .meeting) {
                 guard seenIDs.insert(transcription.id).inserted else { continue }
                 transcriptions.append(transcription)
             }
         }
         return transcriptions
-    }
-
-    private func filePathAliases(for url: URL) -> Set<String> {
-        var paths = Set([
-            url.path,
-            url.standardizedFileURL.path,
-            url.resolvingSymlinksInPath().path,
-        ])
-        for path in Array(paths) {
-            if path.hasPrefix("/private/var/") {
-                paths.insert(String(path.dropFirst("/private".count)))
-            } else if path.hasPrefix("/var/") {
-                paths.insert("/private" + path)
-            }
-        }
-        return paths
     }
 
     private func existingIncompleteTranscriptions(for mixedURL: URL) throws -> [Transcription] {

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
@@ -60,7 +60,8 @@ public protocol MeetingRecordingServiceProtocol: Sendable {
     /// Persist the user's in-flight notepad text to the recording's lock file
     /// without changing the recording state. Called by the notes view model on
     /// every idle-debounce fire (ADR-020 §8). All `recording.lock` writes are
-    /// serialized through this actor — no other component touches the file —
+    /// serialized through this actor — no other component writes the file
+    /// (completion-path deletion is owned by `MeetingRecordingSettlement`) —
     /// so notes-saves cannot race with state-transition writes.
     func updateNotes(_ notes: String) async
     var isRecording: Bool { get async }

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
@@ -43,10 +43,6 @@ public protocol MeetingRecordingServiceProtocol: Sendable {
         calendarEventSnapshot: MeetingCalendarSnapshot?
     ) async throws
     func stopRecording() async throws -> MeetingRecordingOutput
-    func completeTranscription(for recording: MeetingRecordingOutput) async
-    /// Mark the final transcription attempt as ended without deleting the
-    /// recovery lock, leaving it available for retry.
-    func finishTranscriptionAttempt(for recording: MeetingRecordingOutput) async
     func cancelRecording() async
     /// Pause an active recording. No-op when no session is active or when
     /// already paused. The OS-level capture stays running (mic + ScreenCaptureKit
@@ -740,20 +736,6 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         )
         cleanupState()
         return output
-    }
-
-    public func completeTranscription(for recording: MeetingRecordingOutput) async {
-        do {
-            try lockFileStore.delete(folderURL: recording.folderURL)
-        } catch {
-            logger.error("meeting_recording_lock_cleanup_failed session=\(recording.sessionID.uuidString, privacy: .public) error_type=\(AudioCaptureDiagnostics.errorType(error), privacy: .public) error_detail=\(error.localizedDescription, privacy: .private)")
-        }
-        await finishTranscriptionAttempt(for: recording)
-    }
-
-    public func finishTranscriptionAttempt(for recording: MeetingRecordingOutput) async {
-        // The speech-engine lease is released at the durable stop boundary.
-        // Queue completion may happen while another meeting is recording.
     }
 
     public func updateNotes(_ notes: String) async {

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingSettlement.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingSettlement.swift
@@ -1,0 +1,136 @@
+import Foundation
+import OSLog
+
+/// Single owner of settled-lock deletion. `recording.lock` may be removed on
+/// the completion path only through this type, and only after verifying a
+/// completed Transcription row for the session is durably saved.
+public struct MeetingRecordingSettlement: Sendable {
+    private static let logger = Logger(
+        subsystem: "com.macparakeet.core",
+        category: "MeetingRecordingSettlement"
+    )
+
+    private let lockFileStore: MeetingRecordingLockFileStoring
+    private let transcriptionRepo: TranscriptionRepositoryProtocol
+
+    public init(
+        lockFileStore: MeetingRecordingLockFileStoring,
+        transcriptionRepo: TranscriptionRepositoryProtocol
+    ) {
+        self.lockFileStore = lockFileStore
+        self.transcriptionRepo = transcriptionRepo
+    }
+
+    /// Re-fetches the row by id and refuses unless it exists, is a meeting
+    /// transcription for this artifact folder, and `status == .completed`.
+    /// Delete I/O errors are logged only; recovery will re-settle next launch.
+    public func settleCompletedTranscription(
+        folderURL: URL,
+        transcriptionID: UUID,
+        sessionID: UUID
+    ) async throws {
+        guard let transcription = try transcriptionRepo.fetch(id: transcriptionID) else {
+            throw MeetingRecordingSettlementError.missingTranscription(
+                transcriptionID: transcriptionID,
+                sessionID: sessionID
+            )
+        }
+        guard transcription.sourceType == .meeting else {
+            throw MeetingRecordingSettlementError.notMeetingTranscription(
+                transcriptionID: transcriptionID,
+                sourceType: transcription.sourceType,
+                sessionID: sessionID
+            )
+        }
+        guard transcription.status == .completed else {
+            throw MeetingRecordingSettlementError.transcriptionNotCompleted(
+                transcriptionID: transcriptionID,
+                status: transcription.status,
+                sessionID: sessionID
+            )
+        }
+        guard Self.transcription(transcription, belongsTo: folderURL) else {
+            throw MeetingRecordingSettlementError.folderMismatch(
+                transcriptionID: transcriptionID,
+                folderPath: folderURL.path,
+                storedFolderPath: transcription.meetingArtifactFolderPath,
+                storedFilePath: transcription.filePath,
+                sessionID: sessionID
+            )
+        }
+
+        do {
+            try lockFileStore.delete(folderURL: folderURL)
+        } catch {
+            Self.logger.error(
+                "meeting_recording_settlement_lock_delete_failed session=\(sessionID.uuidString, privacy: .public) transcription=\(transcriptionID.uuidString, privacy: .public) error=\(error.localizedDescription, privacy: .private)"
+            )
+        }
+    }
+
+    private static func transcription(_ transcription: Transcription, belongsTo folderURL: URL) -> Bool {
+        let folderPaths = pathAliases(for: folderURL)
+        if let folderPath = transcription.meetingArtifactFolderPath,
+           folderPaths.contains(folderPath) {
+            return true
+        }
+
+        guard let filePath = transcription.filePath else { return false }
+        let meetingFilePaths = folderPaths.map {
+            URL(fileURLWithPath: $0, isDirectory: true)
+                .appendingPathComponent("meeting.m4a")
+                .path
+        }
+        return meetingFilePaths.contains(filePath)
+    }
+
+    private static func pathAliases(for url: URL) -> Set<String> {
+        var paths = Set([
+            url.path,
+            url.standardizedFileURL.path,
+            url.resolvingSymlinksInPath().path,
+        ])
+        for path in Array(paths) {
+            if path.hasPrefix("/private/var/") {
+                paths.insert(String(path.dropFirst("/private".count)))
+            } else if path.hasPrefix("/var/") {
+                paths.insert("/private" + path)
+            }
+        }
+        return paths
+    }
+}
+
+enum MeetingRecordingSettlementError: Error, LocalizedError, Equatable {
+    case missingTranscription(transcriptionID: UUID, sessionID: UUID)
+    case notMeetingTranscription(
+        transcriptionID: UUID,
+        sourceType: Transcription.SourceType,
+        sessionID: UUID
+    )
+    case transcriptionNotCompleted(
+        transcriptionID: UUID,
+        status: Transcription.TranscriptionStatus,
+        sessionID: UUID
+    )
+    case folderMismatch(
+        transcriptionID: UUID,
+        folderPath: String,
+        storedFolderPath: String?,
+        storedFilePath: String?,
+        sessionID: UUID
+    )
+
+    var errorDescription: String? {
+        switch self {
+        case let .missingTranscription(transcriptionID, sessionID):
+            return "Cannot settle meeting \(sessionID): transcription \(transcriptionID) does not exist."
+        case let .notMeetingTranscription(transcriptionID, sourceType, sessionID):
+            return "Cannot settle meeting \(sessionID): transcription \(transcriptionID) has source type \(sourceType.rawValue)."
+        case let .transcriptionNotCompleted(transcriptionID, status, sessionID):
+            return "Cannot settle meeting \(sessionID): transcription \(transcriptionID) is \(status.rawValue), not completed."
+        case let .folderMismatch(transcriptionID, folderPath, storedFolderPath, storedFilePath, sessionID):
+            return "Cannot settle meeting \(sessionID): transcription \(transcriptionID) does not belong to \(folderPath) (stored folder: \(storedFolderPath ?? "nil"), stored file: \(storedFilePath ?? "nil"))."
+        }
+    }
+}

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingSettlement.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingSettlement.swift
@@ -71,7 +71,8 @@ public struct MeetingRecordingSettlement: Sendable {
     private static func transcription(_ transcription: Transcription, belongsTo folderURL: URL) -> Bool {
         let folderPaths = MeetingArtifactPathAliases.aliases(for: folderURL)
         if let folderPath = transcription.meetingArtifactFolderPath,
-           folderPaths.contains(folderPath) {
+            folderPaths.contains(folderPath)
+        {
             return true
         }
 
@@ -110,11 +111,14 @@ enum MeetingRecordingSettlementError: Error, LocalizedError, Equatable {
         case let .missingTranscription(transcriptionID, sessionID):
             return "Cannot settle meeting \(sessionID): transcription \(transcriptionID) does not exist."
         case let .notMeetingTranscription(transcriptionID, sourceType, sessionID):
-            return "Cannot settle meeting \(sessionID): transcription \(transcriptionID) has source type \(sourceType.rawValue)."
+            return
+                "Cannot settle meeting \(sessionID): transcription \(transcriptionID) has source type \(sourceType.rawValue)."
         case let .transcriptionNotCompleted(transcriptionID, status, sessionID):
-            return "Cannot settle meeting \(sessionID): transcription \(transcriptionID) is \(status.rawValue), not completed."
+            return
+                "Cannot settle meeting \(sessionID): transcription \(transcriptionID) is \(status.rawValue), not completed."
         case let .folderMismatch(transcriptionID, folderPath, storedFolderPath, storedFilePath, sessionID):
-            return "Cannot settle meeting \(sessionID): transcription \(transcriptionID) does not belong to \(folderPath) (stored folder: \(storedFolderPath ?? "nil"), stored file: \(storedFilePath ?? "nil"))."
+            return
+                "Cannot settle meeting \(sessionID): transcription \(transcriptionID) does not belong to \(folderPath) (stored folder: \(storedFolderPath ?? "nil"), stored file: \(storedFilePath ?? "nil"))."
         }
     }
 }

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingSettlement.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingSettlement.swift
@@ -69,7 +69,7 @@ public struct MeetingRecordingSettlement: Sendable {
     }
 
     private static func transcription(_ transcription: Transcription, belongsTo folderURL: URL) -> Bool {
-        let folderPaths = pathAliases(for: folderURL)
+        let folderPaths = MeetingArtifactPathAliases.aliases(for: folderURL)
         if let folderPath = transcription.meetingArtifactFolderPath,
            folderPaths.contains(folderPath) {
             return true
@@ -82,22 +82,6 @@ public struct MeetingRecordingSettlement: Sendable {
                 .path
         }
         return meetingFilePaths.contains(filePath)
-    }
-
-    private static func pathAliases(for url: URL) -> Set<String> {
-        var paths = Set([
-            url.path,
-            url.standardizedFileURL.path,
-            url.resolvingSymlinksInPath().path,
-        ])
-        for path in Array(paths) {
-            if path.hasPrefix("/private/var/") {
-                paths.insert(String(path.dropFirst("/private".count)))
-            } else if path.hasPrefix("/var/") {
-                paths.insert("/private" + path)
-            }
-        }
-        return paths
     }
 }
 

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingSettlement.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingSettlement.swift
@@ -72,24 +72,21 @@ public struct MeetingRecordingSettlement: Sendable {
     }
 
     private static func transcription(_ transcription: Transcription, belongsTo folderURL: URL) -> Bool {
-        let folderPaths = MeetingArtifactPathAliases.aliases(for: folderURL)
         if let folderPath = transcription.meetingArtifactFolderPath,
-            folderPaths.contains(folderPath)
+            MeetingArtifactPathAliases.matches(folderPath, for: folderURL)
         {
             return true
         }
 
         guard let filePath = transcription.filePath else { return false }
-        let meetingFilePaths = folderPaths.map {
-            URL(fileURLWithPath: $0, isDirectory: true)
-                .appendingPathComponent("meeting.m4a")
-                .path
-        }
-        return meetingFilePaths.contains(filePath)
+        return MeetingArtifactPathAliases.matches(
+            filePath,
+            for: folderURL.appendingPathComponent("meeting.m4a")
+        )
     }
 }
 
-enum MeetingRecordingSettlementError: Error, LocalizedError, Equatable {
+enum MeetingRecordingSettlementError: Error, LocalizedError, Equatable, Sendable {
     case missingTranscription(transcriptionID: UUID, sessionID: UUID)
     case notMeetingTranscription(
         transcriptionID: UUID,

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingSettlement.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingSettlement.swift
@@ -23,7 +23,9 @@ public struct MeetingRecordingSettlement: Sendable {
 
     /// Re-fetches the row by id and refuses unless it exists, is a meeting
     /// transcription for this artifact folder, and `status == .completed`.
-    /// Delete I/O errors are logged only; recovery will re-settle next launch.
+    /// Delete I/O errors are logged and rethrown so callers can surface the
+    /// failed cleanup; the lock stays protective and recovery re-settles the
+    /// completed row on a later scan.
     public func settleCompletedTranscription(
         folderURL: URL,
         transcriptionID: UUID,
@@ -65,6 +67,7 @@ public struct MeetingRecordingSettlement: Sendable {
             Self.logger.error(
                 "meeting_recording_settlement_lock_delete_failed session=\(sessionID.uuidString, privacy: .public) transcription=\(transcriptionID.uuidString, privacy: .public) error=\(error.localizedDescription, privacy: .private)"
             )
+            throw error
         }
     }
 

--- a/Tests/MacParakeetTests/MeetingRecordingFlow/MeetingRecordingFlowCoordinatorTests.swift
+++ b/Tests/MacParakeetTests/MeetingRecordingFlow/MeetingRecordingFlowCoordinatorTests.swift
@@ -32,6 +32,7 @@ final class MeetingRecordingFlowCoordinatorTests: XCTestCase {
             sourceType: .meeting
         )
         await transcriptionService.configure(result: completedTranscription)
+        let settlementHarness = await makeSettlementHarness(transcriptionService: transcriptionService)
 
         var readyTranscriptions: [Transcription] = []
         var readySelections: [Bool] = []
@@ -39,12 +40,13 @@ final class MeetingRecordingFlowCoordinatorTests: XCTestCase {
             meetingRecordingService: recordingService,
             transcriptionService: transcriptionService,
             permissionService: MockPermissionService(),
-            transcriptionRepo: MockTranscriptionRepository(),
+            transcriptionRepo: settlementHarness.transcriptionRepo,
             conversationRepo: MockChatConversationRepository(),
             quickPromptRepo: NoOpQuickPromptRepository(),
             configStore: NoOpLLMConfigStore(),
             llmService: nil,
             pillViewModel: MeetingRecordingPillViewModel(),
+            meetingRecordingSettlement: settlementHarness.settlement,
             onMenuBarIconUpdate: { _ in },
             onTranscriptionReady: { transcription in
                 readyTranscriptions.append(transcription)
@@ -64,7 +66,6 @@ final class MeetingRecordingFlowCoordinatorTests: XCTestCase {
         XCTAssertEqual(coordinator.testHook_state, .idle)
         XCTAssertFalse(coordinator.isMeetingRecordingActive)
         XCTAssertEqual(recordingSnapshot.stopCallCount, 1)
-        XCTAssertTrue(recordingSnapshot.completedTranscriptionSessionIDs.isEmpty)
         XCTAssertEqual(transcriptionSnapshot.prepareMeetingCallCount, 1)
         XCTAssertEqual(transcriptionSnapshot.finalizeMeetingCallCount, 1)
         XCTAssertEqual(transcriptionSnapshot.transcribeCallCount, 0)
@@ -75,12 +76,11 @@ final class MeetingRecordingFlowCoordinatorTests: XCTestCase {
         await transcriptionService.releaseMeetingFinalization()
         await coordinator.testHook_waitForMeetingTranscriptionQueue()
 
-        let completedSnapshot = await recordingService.snapshot()
         let completedTranscriptionSnapshot = await transcriptionService.meetingFlowSnapshot()
-        XCTAssertEqual(completedSnapshot.completedTranscriptionSessionIDs, [output.sessionID])
         XCTAssertEqual(readyTranscriptions.map(\.id), completedTranscriptionSnapshot.finalizedMeetingTranscriptionIDs)
         XCTAssertEqual(readyTranscriptions.map(\.filePath), [completedTranscription.filePath])
         XCTAssertEqual(readySelections, [true])
+        XCTAssertEqual(settlementHarness.lockStore.deletes, [output.folderURL])
 
         let operation = try XCTUnwrap(telemetry.snapshot().compactMap(\.meetingOperationPayload).last)
         XCTAssertEqual(operation.outcome, .success)
@@ -95,18 +95,20 @@ final class MeetingRecordingFlowCoordinatorTests: XCTestCase {
         let recordingService = MeetingRecordingServiceSpy(output: output)
         let transcriptionService = MockTranscriptionService()
         await transcriptionService.holdMeetingFinalization()
+        let settlementHarness = await makeSettlementHarness(transcriptionService: transcriptionService)
 
         var queuedSelections: [Bool] = []
         let coordinator = MeetingRecordingFlowCoordinator(
             meetingRecordingService: recordingService,
             transcriptionService: transcriptionService,
             permissionService: MockPermissionService(),
-            transcriptionRepo: MockTranscriptionRepository(),
+            transcriptionRepo: settlementHarness.transcriptionRepo,
             conversationRepo: MockChatConversationRepository(),
             quickPromptRepo: NoOpQuickPromptRepository(),
             configStore: NoOpLLMConfigStore(),
             llmService: nil,
             pillViewModel: MeetingRecordingPillViewModel(),
+            meetingRecordingSettlement: settlementHarness.settlement,
             onMenuBarIconUpdate: { _ in },
             onTranscriptionReady: { _ in },
             onQueuedTranscriptionReady: { _, selectTranscription in
@@ -130,6 +132,7 @@ final class MeetingRecordingFlowCoordinatorTests: XCTestCase {
         await transcriptionService.releaseMeetingFinalization()
         await coordinator.testHook_waitForMeetingTranscriptionQueue()
         XCTAssertEqual(queuedSelections, [false])
+        XCTAssertEqual(settlementHarness.lockStore.deletes, [output.folderURL])
     }
 
     func testManualStartPassesProbableCalendarSnapshotWithoutChangingTitle() async throws {
@@ -157,6 +160,7 @@ final class MeetingRecordingFlowCoordinatorTests: XCTestCase {
             probableCalendarSnapshotProvider: { expectedSnapshot },
             llmService: nil,
             pillViewModel: MeetingRecordingPillViewModel(),
+            meetingRecordingSettlement: makeSettlement(),
             onMenuBarIconUpdate: { _ in },
             onTranscriptionReady: { _ in }
         )
@@ -194,6 +198,7 @@ final class MeetingRecordingFlowCoordinatorTests: XCTestCase {
             probableCalendarSnapshotProvider: { holder.snapshot },
             llmService: nil,
             pillViewModel: MeetingRecordingPillViewModel(),
+            meetingRecordingSettlement: makeSettlement(),
             onMenuBarIconUpdate: { _ in },
             onTranscriptionReady: { _ in }
         )
@@ -228,6 +233,7 @@ final class MeetingRecordingFlowCoordinatorTests: XCTestCase {
             probableCalendarSnapshotProvider: { nil },
             llmService: nil,
             pillViewModel: MeetingRecordingPillViewModel(),
+            meetingRecordingSettlement: makeSettlement(),
             onMenuBarIconUpdate: { _ in },
             onTranscriptionReady: { _ in }
         )
@@ -253,6 +259,7 @@ final class MeetingRecordingFlowCoordinatorTests: XCTestCase {
             sourceType: .meeting
         )
         await transcriptionService.configure(result: completedTranscription)
+        let settlementHarness = await makeSettlementHarness(transcriptionService: transcriptionService)
         let conversationRepo = MockChatConversationRepository()
         let llmService = MockLLMService()
         llmService.streamTokens = ["Answer saved"]
@@ -261,12 +268,13 @@ final class MeetingRecordingFlowCoordinatorTests: XCTestCase {
             meetingRecordingService: recordingService,
             transcriptionService: transcriptionService,
             permissionService: MockPermissionService(),
-            transcriptionRepo: MockTranscriptionRepository(),
+            transcriptionRepo: settlementHarness.transcriptionRepo,
             conversationRepo: conversationRepo,
             quickPromptRepo: NoOpQuickPromptRepository(),
             configStore: NoOpLLMConfigStore(),
             llmService: llmService,
             pillViewModel: MeetingRecordingPillViewModel(),
+            meetingRecordingSettlement: settlementHarness.settlement,
             onMenuBarIconUpdate: { _ in },
             onTranscriptionReady: { _ in }
         )
@@ -302,6 +310,7 @@ final class MeetingRecordingFlowCoordinatorTests: XCTestCase {
 
         let transcriptionSnapshot = await transcriptionService.meetingFlowSnapshot()
         XCTAssertEqual(transcriptionSnapshot.finalizedMeetingTranscriptionIDs, [savedConversation.transcriptionId])
+        XCTAssertEqual(settlementHarness.lockStore.deletes, [output.folderURL])
     }
 
     func testStartRecordingWhileActivelyRecordingIsRefused() {
@@ -381,6 +390,7 @@ final class MeetingRecordingFlowCoordinatorTests: XCTestCase {
             },
             llmService: nil,
             pillViewModel: MeetingRecordingPillViewModel(),
+            meetingRecordingSettlement: makeSettlement(),
             onMenuBarIconUpdate: { _ in },
             onTranscriptionReady: { _ in }
         )
@@ -451,6 +461,7 @@ final class MeetingRecordingFlowCoordinatorTests: XCTestCase {
             configStore: NoOpLLMConfigStore(),
             llmService: nil,
             pillViewModel: MeetingRecordingPillViewModel(),
+            meetingRecordingSettlement: makeSettlement(),
             onMenuBarIconUpdate: { _ in },
             onTranscriptionReady: { _ in }
         )
@@ -473,8 +484,36 @@ final class MeetingRecordingFlowCoordinatorTests: XCTestCase {
             frontmostApplicationProvider: StaticFrontmostApplicationProvider(frontmostApplication),
             llmService: nil,
             pillViewModel: MeetingRecordingPillViewModel(),
+            meetingRecordingSettlement: makeSettlement(),
             onMenuBarIconUpdate: { _ in },
             onTranscriptionReady: { _ in }
+        )
+    }
+
+    private func makeSettlement() -> MeetingRecordingSettlement {
+        MeetingRecordingSettlement(
+            lockFileStore: FlowRecordingLockFileStore(),
+            transcriptionRepo: MockTranscriptionRepository()
+        )
+    }
+
+    private func makeSettlementHarness(
+        transcriptionService: MockTranscriptionService
+    ) async -> (
+        transcriptionRepo: MockTranscriptionRepository,
+        lockStore: FlowRecordingLockFileStore,
+        settlement: MeetingRecordingSettlement
+    ) {
+        let transcriptionRepo = MockTranscriptionRepository()
+        await transcriptionService.persistFinalizedMeetings(to: transcriptionRepo)
+        let lockStore = FlowRecordingLockFileStore()
+        return (
+            transcriptionRepo,
+            lockStore,
+            MeetingRecordingSettlement(
+                lockFileStore: lockStore,
+                transcriptionRepo: transcriptionRepo
+            )
         )
     }
 
@@ -545,7 +584,6 @@ private actor MeetingRecordingServiceSpy: MeetingRecordingServiceProtocol {
     var startCallCount = 0
     var startCalls: [StartCall] = []
     var stopCallCount = 0
-    var completedTranscriptionSessionIDs: [UUID] = []
     var startTitles: [String?] = []
     var calendarEventSnapshots: [MeetingCalendarSnapshot?] = []
 
@@ -574,12 +612,6 @@ private actor MeetingRecordingServiceSpy: MeetingRecordingServiceProtocol {
         stopCallCount += 1
         return output
     }
-
-    func completeTranscription(for recording: MeetingRecordingOutput) async {
-        completedTranscriptionSessionIDs.append(recording.sessionID)
-    }
-
-    func finishTranscriptionAttempt(for recording: MeetingRecordingOutput) async {}
 
     func cancelRecording() async {}
 
@@ -623,7 +655,6 @@ private actor MeetingRecordingServiceSpy: MeetingRecordingServiceProtocol {
         startCallCount: Int,
         startCalls: [StartCall],
         stopCallCount: Int,
-        completedTranscriptionSessionIDs: [UUID],
         startTitles: [String?],
         calendarEventSnapshots: [MeetingCalendarSnapshot?]
     ) {
@@ -631,7 +662,6 @@ private actor MeetingRecordingServiceSpy: MeetingRecordingServiceProtocol {
             startCallCount: startCallCount,
             startCalls: startCalls,
             stopCallCount: stopCallCount,
-            completedTranscriptionSessionIDs: completedTranscriptionSessionIDs,
             startTitles: startTitles,
             calendarEventSnapshots: calendarEventSnapshots
         )
@@ -640,6 +670,23 @@ private actor MeetingRecordingServiceSpy: MeetingRecordingServiceProtocol {
 
 private final class ProbableCalendarSnapshotHolder: @unchecked Sendable {
     var snapshot: MeetingCalendarSnapshot?
+}
+
+private final class FlowRecordingLockFileStore: MeetingRecordingLockFileStoring, @unchecked Sendable {
+    private let lock = NSLock()
+    private(set) var deletes: [URL] = []
+
+    func write(_ file: MeetingRecordingLockFile, folderURL: URL) throws {}
+
+    func read(folderURL: URL) throws -> MeetingRecordingLockFile? { nil }
+
+    func delete(folderURL: URL) throws {
+        lock.withLock {
+            deletes.append(folderURL)
+        }
+    }
+
+    func discoverOrphans(meetingsRoot: URL) throws -> [MeetingRecordingLockFile] { [] }
 }
 
 private extension MockTranscriptionService {

--- a/Tests/MacParakeetTests/MeetingRecordingFlow/MeetingTranscriptionQueueTests.swift
+++ b/Tests/MacParakeetTests/MeetingRecordingFlow/MeetingTranscriptionQueueTests.swift
@@ -24,10 +24,12 @@ final class MeetingTranscriptionQueueTests: XCTestCase {
 
         let transcriptionSnapshot = await transcriptionService.snapshot()
         XCTAssertEqual(transcriptionSnapshot, [first.transcriptionID, second.transcriptionID])
-        XCTAssertEqual(lockStore.deletes, [
-            first.recording.folderURL,
-            second.recording.folderURL,
-        ])
+        XCTAssertEqual(
+            lockStore.deletes,
+            [
+                first.recording.folderURL,
+                second.recording.folderURL,
+            ])
     }
 
     func testQueueContinuesAfterFailedFinalize() async throws {
@@ -267,7 +269,8 @@ private actor QueueTranscriptionServiceSpy: TranscriptionServiceProtocol {
             throw QueueTestError.failed
         }
         let mismatched = settlementMismatchIDs.contains(transcriptionID)
-        let folderPath = mismatched
+        let folderPath =
+            mismatched
             ? "/nonexistent/other-folder"
             : recording.folderURL.path
         let transcription = Transcription(

--- a/Tests/MacParakeetTests/MeetingRecordingFlow/MeetingTranscriptionQueueTests.swift
+++ b/Tests/MacParakeetTests/MeetingRecordingFlow/MeetingTranscriptionQueueTests.swift
@@ -65,6 +65,37 @@ final class MeetingTranscriptionQueueTests: XCTestCase {
         XCTAssertEqual(lockStore.deletes, [second.recording.folderURL])
     }
 
+    func testSettlementRefusalAfterFinalizeStillReportsSuccessAndRetainsLock() async throws {
+        let transcriptionRepo = MockTranscriptionRepository()
+        let lockStore = QueueRecordingLockFileStore()
+        let transcriptionService = QueueTranscriptionServiceSpy(transcriptionRepo: transcriptionRepo)
+        let queue = MeetingTranscriptionQueue(
+            transcriptionService: transcriptionService,
+            meetingRecordingSettlement: MeetingRecordingSettlement(
+                lockFileStore: lockStore,
+                transcriptionRepo: transcriptionRepo
+            )
+        )
+        let item = makeItem(name: "A")
+        await transcriptionService.mismatchSettlementPaths(transcriptionID: item.transcriptionID)
+
+        var completions: [String] = []
+        queue.onCompletion = { completion in
+            switch completion {
+            case .success(let item, _):
+                completions.append("success:\(item.recording.displayName)")
+            case .failure(let item, _):
+                completions.append("failure:\(item.recording.displayName)")
+            }
+        }
+
+        queue.enqueue(item)
+        await queue.waitUntilIdle()
+
+        XCTAssertEqual(completions, ["success:A"])
+        XCTAssertTrue(lockStore.deletes.isEmpty)
+    }
+
     func testSnapshotCountsActiveAndPendingItems() async throws {
         let transcriptionRepo = MockTranscriptionRepository()
         let lockStore = QueueRecordingLockFileStore()
@@ -151,6 +182,7 @@ private actor QueueTranscriptionServiceSpy: TranscriptionServiceProtocol {
     private let transcriptionRepo: MockTranscriptionRepository
     private(set) var finalizedIDs: [UUID] = []
     private var failingIDs: Set<UUID> = []
+    private var settlementMismatchIDs: Set<UUID> = []
     var holdFinalization = false
     private var finalizationWaiters: [CheckedContinuation<Void, Never>] = []
 
@@ -168,6 +200,10 @@ private actor QueueTranscriptionServiceSpy: TranscriptionServiceProtocol {
 
     func fail(transcriptionID: UUID) {
         failingIDs.insert(transcriptionID)
+    }
+
+    func mismatchSettlementPaths(transcriptionID: UUID) {
+        settlementMismatchIDs.insert(transcriptionID)
     }
 
     func releaseFinalization() {
@@ -230,11 +266,15 @@ private actor QueueTranscriptionServiceSpy: TranscriptionServiceProtocol {
         if failingIDs.contains(transcriptionID) {
             throw QueueTestError.failed
         }
+        let mismatched = settlementMismatchIDs.contains(transcriptionID)
+        let folderPath = mismatched
+            ? "/nonexistent/other-folder"
+            : recording.folderURL.path
         let transcription = Transcription(
             id: transcriptionID,
             fileName: recording.displayName,
-            filePath: recording.mixedAudioURL.path,
-            meetingArtifactFolderPath: recording.folderURL.path,
+            filePath: mismatched ? folderPath + "/meeting.m4a" : recording.mixedAudioURL.path,
+            meetingArtifactFolderPath: folderPath,
             rawTranscript: "done",
             status: .completed,
             sourceType: .meeting

--- a/Tests/MacParakeetTests/MeetingRecordingFlow/MeetingTranscriptionQueueTests.swift
+++ b/Tests/MacParakeetTests/MeetingRecordingFlow/MeetingTranscriptionQueueTests.swift
@@ -5,11 +5,15 @@ import XCTest
 @MainActor
 final class MeetingTranscriptionQueueTests: XCTestCase {
     func testQueueFinalizesMeetingsFIFO() async throws {
-        let transcriptionService = QueueTranscriptionServiceSpy()
-        let recordingService = QueueRecordingServiceSpy()
+        let transcriptionRepo = MockTranscriptionRepository()
+        let lockStore = QueueRecordingLockFileStore()
+        let transcriptionService = QueueTranscriptionServiceSpy(transcriptionRepo: transcriptionRepo)
         let queue = MeetingTranscriptionQueue(
             transcriptionService: transcriptionService,
-            meetingRecordingService: recordingService
+            meetingRecordingSettlement: MeetingRecordingSettlement(
+                lockFileStore: lockStore,
+                transcriptionRepo: transcriptionRepo
+            )
         )
         let first = makeItem(name: "A")
         let second = makeItem(name: "B")
@@ -19,20 +23,23 @@ final class MeetingTranscriptionQueueTests: XCTestCase {
         await queue.waitUntilIdle()
 
         let transcriptionSnapshot = await transcriptionService.snapshot()
-        let recordingSnapshot = await recordingService.snapshot()
         XCTAssertEqual(transcriptionSnapshot, [first.transcriptionID, second.transcriptionID])
-        XCTAssertEqual(recordingSnapshot.completedSessionIDs, [
-            first.recording.sessionID,
-            second.recording.sessionID,
+        XCTAssertEqual(lockStore.deletes, [
+            first.recording.folderURL,
+            second.recording.folderURL,
         ])
     }
 
     func testQueueContinuesAfterFailedFinalize() async throws {
-        let transcriptionService = QueueTranscriptionServiceSpy()
-        let recordingService = QueueRecordingServiceSpy()
+        let transcriptionRepo = MockTranscriptionRepository()
+        let lockStore = QueueRecordingLockFileStore()
+        let transcriptionService = QueueTranscriptionServiceSpy(transcriptionRepo: transcriptionRepo)
         let queue = MeetingTranscriptionQueue(
             transcriptionService: transcriptionService,
-            meetingRecordingService: recordingService
+            meetingRecordingSettlement: MeetingRecordingSettlement(
+                lockFileStore: lockStore,
+                transcriptionRepo: transcriptionRepo
+            )
         )
         let first = makeItem(name: "A")
         let second = makeItem(name: "B")
@@ -53,20 +60,22 @@ final class MeetingTranscriptionQueueTests: XCTestCase {
         await queue.waitUntilIdle()
 
         let transcriptionSnapshot = await transcriptionService.snapshot()
-        let recordingSnapshot = await recordingService.snapshot()
         XCTAssertEqual(completions, ["failure:A", "success:B"])
         XCTAssertEqual(transcriptionSnapshot, [first.transcriptionID, second.transcriptionID])
-        XCTAssertEqual(recordingSnapshot.finishedAttemptSessionIDs, [first.recording.sessionID])
-        XCTAssertEqual(recordingSnapshot.completedSessionIDs, [second.recording.sessionID])
+        XCTAssertEqual(lockStore.deletes, [second.recording.folderURL])
     }
 
     func testSnapshotCountsActiveAndPendingItems() async throws {
-        let transcriptionService = QueueTranscriptionServiceSpy()
+        let transcriptionRepo = MockTranscriptionRepository()
+        let lockStore = QueueRecordingLockFileStore()
+        let transcriptionService = QueueTranscriptionServiceSpy(transcriptionRepo: transcriptionRepo)
         await transcriptionService.setHoldFinalization(true)
-        let recordingService = QueueRecordingServiceSpy()
         let queue = MeetingTranscriptionQueue(
             transcriptionService: transcriptionService,
-            meetingRecordingService: recordingService
+            meetingRecordingSettlement: MeetingRecordingSettlement(
+                lockFileStore: lockStore,
+                transcriptionRepo: transcriptionRepo
+            )
         )
         let first = makeItem(name: "A")
         let second = makeItem(name: "B")
@@ -139,10 +148,15 @@ final class MeetingTranscriptionQueueTests: XCTestCase {
 }
 
 private actor QueueTranscriptionServiceSpy: TranscriptionServiceProtocol {
+    private let transcriptionRepo: MockTranscriptionRepository
     private(set) var finalizedIDs: [UUID] = []
     private var failingIDs: Set<UUID> = []
     var holdFinalization = false
     private var finalizationWaiters: [CheckedContinuation<Void, Never>] = []
+
+    init(transcriptionRepo: MockTranscriptionRepository) {
+        self.transcriptionRepo = transcriptionRepo
+    }
 
     func snapshot() -> [UUID] {
         finalizedIDs
@@ -216,14 +230,17 @@ private actor QueueTranscriptionServiceSpy: TranscriptionServiceProtocol {
         if failingIDs.contains(transcriptionID) {
             throw QueueTestError.failed
         }
-        return Transcription(
+        let transcription = Transcription(
             id: transcriptionID,
             fileName: recording.displayName,
             filePath: recording.mixedAudioURL.path,
+            meetingArtifactFolderPath: recording.folderURL.path,
             rawTranscript: "done",
             status: .completed,
             sourceType: .meeting
         )
+        try transcriptionRepo.save(transcription)
+        return transcription
     }
 
     func retranscribe(
@@ -258,63 +275,21 @@ private actor QueueTranscriptionServiceSpy: TranscriptionServiceProtocol {
     }
 }
 
-private actor QueueRecordingServiceSpy: MeetingRecordingServiceProtocol {
-    private(set) var completedSessionIDs: [UUID] = []
-    private(set) var finishedAttemptSessionIDs: [UUID] = []
+private final class QueueRecordingLockFileStore: MeetingRecordingLockFileStoring, @unchecked Sendable {
+    private let lock = NSLock()
+    private(set) var deletes: [URL] = []
 
-    func snapshot() -> (
-        completedSessionIDs: [UUID],
-        finishedAttemptSessionIDs: [UUID]
-    ) {
-        (
-            completedSessionIDs: completedSessionIDs,
-            finishedAttemptSessionIDs: finishedAttemptSessionIDs
-        )
-    }
+    func write(_ file: MeetingRecordingLockFile, folderURL: URL) throws {}
 
-    func startRecording(
-        title: String?,
-        sourceMode: MeetingAudioSourceMode?,
-        startContext: MeetingStartContext?,
-        calendarEventSnapshot: MeetingCalendarSnapshot?
-    ) async throws {}
+    func read(folderURL: URL) throws -> MeetingRecordingLockFile? { nil }
 
-    func stopRecording() async throws -> MeetingRecordingOutput {
-        throw MeetingAudioError.notRunning
-    }
-
-    func completeTranscription(for recording: MeetingRecordingOutput) async {
-        completedSessionIDs.append(recording.sessionID)
-    }
-
-    func finishTranscriptionAttempt(for recording: MeetingRecordingOutput) async {
-        finishedAttemptSessionIDs.append(recording.sessionID)
-    }
-
-    func cancelRecording() async {}
-    func pauseRecording() async {}
-    func resumeRecording() async {}
-    func setMicrophoneMuted(_ muted: Bool) async -> MeetingMicrophoneMuteState {
-        MeetingMicrophoneMuteState(isMuted: muted, canMute: true)
-    }
-    func updateNotes(_ notes: String) async {}
-
-    var isRecording: Bool { false }
-    var isPaused: Bool { false }
-    var micLevel: Float { 0 }
-    var systemLevel: Float { 0 }
-    var elapsedSeconds: Int { 0 }
-    var captureMode: CaptureMode { .stopped }
-    var isMicrophoneMuted: Bool { false }
-    var canMuteMicrophone: Bool { false }
-    var microphoneMuteState: MeetingMicrophoneMuteState {
-        MeetingMicrophoneMuteState(isMuted: false, canMute: false)
-    }
-    var transcriptUpdates: AsyncStream<MeetingTranscriptUpdate> {
-        AsyncStream { continuation in
-            continuation.finish()
+    func delete(folderURL: URL) throws {
+        lock.withLock {
+            deletes.append(folderURL)
         }
     }
+
+    func discoverOrphans(meetingsRoot: URL) throws -> [MeetingRecordingLockFile] { [] }
 }
 
 private enum QueueTestError: Error {

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingRecoveryServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingRecoveryServiceTests.swift
@@ -111,21 +111,23 @@ final class MeetingRecordingRecoveryServiceTests: XCTestCase {
             case .awaitingLockNoRow:
                 break
             case .awaitingLockProcessingRow:
-                try transcriptionRepo.save(Transcription(
-                    fileName: fixture.lock.displayName,
-                    filePath: mixedURL.path,
-                    meetingArtifactFolderPath: fixture.folderURL.path,
-                    status: .processing,
-                    sourceType: .meeting
-                ))
+                try transcriptionRepo.save(
+                    Transcription(
+                        fileName: fixture.lock.displayName,
+                        filePath: mixedURL.path,
+                        meetingArtifactFolderPath: fixture.folderURL.path,
+                        status: .processing,
+                        sourceType: .meeting
+                    ))
             case .completedRowWithLock:
-                try transcriptionRepo.save(Transcription(
-                    fileName: fixture.lock.displayName,
-                    filePath: mixedURL.path,
-                    meetingArtifactFolderPath: fixture.folderURL.path,
-                    status: .completed,
-                    sourceType: .meeting
-                ))
+                try transcriptionRepo.save(
+                    Transcription(
+                        fileName: fixture.lock.displayName,
+                        filePath: mixedURL.path,
+                        meetingArtifactFolderPath: fixture.folderURL.path,
+                        status: .completed,
+                        sourceType: .meeting
+                    ))
             }
 
             let pending = try await recoveryService.discoverPendingRecoveries()
@@ -430,19 +432,22 @@ final class MeetingRecordingRecoveryServiceTests: XCTestCase {
 
     private func meetingRows(in folderURL: URL) throws -> [Transcription] {
         let folderPaths = MeetingArtifactPathAliases.aliases(for: folderURL)
-        let mixedPaths = Set(folderPaths.map {
-            URL(fileURLWithPath: $0, isDirectory: true)
-                .appendingPathComponent("meeting.m4a")
-                .path
-        })
+        let mixedPaths = Set(
+            folderPaths.map {
+                URL(fileURLWithPath: $0, isDirectory: true)
+                    .appendingPathComponent("meeting.m4a")
+                    .path
+            })
         return try transcriptionRepo.fetchAll(limit: nil).filter { transcription in
             guard transcription.sourceType == .meeting else { return false }
             if let folderPath = transcription.meetingArtifactFolderPath,
-               folderPaths.contains(folderPath) {
+                folderPaths.contains(folderPath)
+            {
                 return true
             }
             if let filePath = transcription.filePath,
-               mixedPaths.contains(filePath) {
+                mixedPaths.contains(filePath)
+            {
                 return true
             }
             return false

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingRecoveryServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingRecoveryServiceTests.swift
@@ -82,7 +82,12 @@ final class MeetingRecordingRecoveryServiceTests: XCTestCase {
         let fixture = try makeRecoverableSession()
         lockStore.deleteErrorsRemaining = 1
 
-        _ = try await recoveryService.recover(fixture.lock)
+        do {
+            _ = try await recoveryService.recover(fixture.lock)
+            XCTFail("Expected recover to surface the failed lock delete")
+        } catch {
+            XCTAssertTrue(error is RecoveryTestError)
+        }
         XCTAssertNotNil(try lockStore.read(folderURL: fixture.folderURL))
         XCTAssertEqual(transcriptionService.recordings.count, 1)
         XCTAssertEqual(transcriptionRepo.saved.count, 1)
@@ -250,6 +255,34 @@ final class MeetingRecordingRecoveryServiceTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: fixture.folderURL.path))
         XCTAssertTrue(FileManager.default.fileExists(atPath: mixedURL.path))
         XCTAssertNil(try lockStore.read(folderURL: fixture.folderURL))
+        XCTAssertNotNil(try transcriptionRepo.fetch(id: existing.id))
+    }
+
+    func testDiscardSurfacesFailedLockDeleteAndStaysRetryable() async throws {
+        let fixture = try makeRecoverableSession(lockState: .awaitingTranscription)
+        let mixedURL = fixture.folderURL.appendingPathComponent("meeting.m4a")
+        FileManager.default.createFile(atPath: mixedURL.path, contents: Data("mixed".utf8))
+        let existing = Transcription(
+            fileName: fixture.lock.displayName,
+            filePath: mixedURL.path,
+            status: .completed,
+            sourceType: .meeting
+        )
+        try transcriptionRepo.save(existing)
+        lockStore.deleteErrorsRemaining = 1
+
+        do {
+            try await recoveryService.discard(fixture.lock)
+            XCTFail("Expected discard to surface the failed lock delete")
+        } catch {
+            XCTAssertTrue(error is RecoveryTestError)
+        }
+        XCTAssertNotNil(try lockStore.read(folderURL: fixture.folderURL))
+
+        try await recoveryService.discard(fixture.lock)
+
+        XCTAssertNil(try lockStore.read(folderURL: fixture.folderURL))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: mixedURL.path))
         XCTAssertNotNil(try transcriptionRepo.fetch(id: existing.id))
     }
 

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingRecoveryServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingRecoveryServiceTests.swift
@@ -15,17 +15,7 @@ final class MeetingRecordingRecoveryServiceTests: XCTestCase {
         tempRoot = FileManager.default.temporaryDirectory
             .appendingPathComponent("MeetingRecordingRecoveryServiceTests-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
-        lockStore = RecoveryRecordingLockFileStore(processChecker: RecoveryProcessChecker(alivePIDs: []))
-        transcriptionRepo = RecordingTranscriptionRepository()
-        transcriptionService = RecoveryMockTranscriptionService()
-        audioConverter = RecoveryMockAudioConverter()
-        recoveryService = MeetingRecordingRecoveryService(
-            meetingsRoot: tempRoot,
-            lockFileStore: lockStore,
-            transcriptionService: transcriptionService,
-            transcriptionRepo: transcriptionRepo,
-            audioConverter: audioConverter
-        )
+        try resetRecoveryFixture()
     }
 
     override func tearDownWithError() throws {
@@ -92,14 +82,10 @@ final class MeetingRecordingRecoveryServiceTests: XCTestCase {
         let fixture = try makeRecoverableSession()
         lockStore.deleteErrorsRemaining = 1
 
-        do {
-            _ = try await recoveryService.recover(fixture.lock)
-            XCTFail("Expected first recovery to fail deleting the lock")
-        } catch {
-            XCTAssertNotNil(try lockStore.read(folderURL: fixture.folderURL))
-            XCTAssertEqual(transcriptionService.recordings.count, 1)
-            XCTAssertEqual(transcriptionRepo.saved.count, 1)
-        }
+        _ = try await recoveryService.recover(fixture.lock)
+        XCTAssertNotNil(try lockStore.read(folderURL: fixture.folderURL))
+        XCTAssertEqual(transcriptionService.recordings.count, 1)
+        XCTAssertEqual(transcriptionRepo.saved.count, 1)
 
         audioConverter.errorToThrow = RecoveryTestError.mixFailed
         let recovered = try await recoveryService.recover(fixture.lock)
@@ -109,6 +95,51 @@ final class MeetingRecordingRecoveryServiceTests: XCTestCase {
         XCTAssertEqual(transcriptionService.recordings.count, 1)
         XCTAssertEqual(transcriptionRepo.saved.count, 1)
         XCTAssertEqual(audioConverter.mixes.count, 1)
+    }
+
+    func testCrashPointSweepConvergesToCompletedRowDeletedLockAndPreservedAudio() async throws {
+        for point in RecoveryCrashPoint.allCases {
+            try resetRecoveryFixture()
+            let fixture = try makeRecoverableSession(lockState: .awaitingTranscription)
+            let mixedURL = fixture.folderURL.appendingPathComponent("meeting.m4a")
+            let microphoneURL = fixture.folderURL.appendingPathComponent("microphone.m4a")
+            let systemURL = fixture.folderURL.appendingPathComponent("system.m4a")
+            let microphoneBefore = try Data(contentsOf: microphoneURL)
+            let systemBefore = try Data(contentsOf: systemURL)
+
+            switch point {
+            case .awaitingLockNoRow:
+                break
+            case .awaitingLockProcessingRow:
+                try transcriptionRepo.save(Transcription(
+                    fileName: fixture.lock.displayName,
+                    filePath: mixedURL.path,
+                    meetingArtifactFolderPath: fixture.folderURL.path,
+                    status: .processing,
+                    sourceType: .meeting
+                ))
+            case .completedRowWithLock:
+                try transcriptionRepo.save(Transcription(
+                    fileName: fixture.lock.displayName,
+                    filePath: mixedURL.path,
+                    meetingArtifactFolderPath: fixture.folderURL.path,
+                    status: .completed,
+                    sourceType: .meeting
+                ))
+            }
+
+            let pending = try await recoveryService.discoverPendingRecoveries()
+            XCTAssertEqual(pending.map(\.sessionId), [fixture.lock.sessionId], "\(point)")
+
+            _ = try await recoveryService.recover(try XCTUnwrap(pending.first))
+
+            let rows = try meetingRows(in: fixture.folderURL)
+            XCTAssertEqual(rows.count, 1, "\(point)")
+            XCTAssertEqual(rows.first?.status, .completed, "\(point)")
+            XCTAssertNil(try lockStore.read(folderURL: fixture.folderURL), "\(point)")
+            XCTAssertEqual(try Data(contentsOf: microphoneURL), microphoneBefore, "\(point)")
+            XCTAssertEqual(try Data(contentsOf: systemURL), systemBefore, "\(point)")
+        }
     }
 
     func testRecoverSkipsCorruptSourceAndUsesRemainingPlayableAudio() async throws {
@@ -372,6 +403,66 @@ final class MeetingRecordingRecoveryServiceTests: XCTestCase {
         case valid
         case silent
         case corrupt
+    }
+
+    private enum RecoveryCrashPoint: CaseIterable {
+        case awaitingLockNoRow
+        case awaitingLockProcessingRow
+        case completedRowWithLock
+    }
+
+    private func resetRecoveryFixture() throws {
+        try? FileManager.default.removeItem(at: tempRoot)
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        lockStore = RecoveryRecordingLockFileStore(processChecker: RecoveryProcessChecker(alivePIDs: []))
+        transcriptionRepo = RecordingTranscriptionRepository()
+        transcriptionService = RecoveryMockTranscriptionService()
+        transcriptionService.transcriptionRepo = transcriptionRepo
+        audioConverter = RecoveryMockAudioConverter()
+        recoveryService = MeetingRecordingRecoveryService(
+            meetingsRoot: tempRoot,
+            lockFileStore: lockStore,
+            transcriptionService: transcriptionService,
+            transcriptionRepo: transcriptionRepo,
+            audioConverter: audioConverter
+        )
+    }
+
+    private func meetingRows(in folderURL: URL) throws -> [Transcription] {
+        let folderPaths = pathAliases(for: folderURL)
+        let mixedPaths = Set(folderPaths.map {
+            URL(fileURLWithPath: $0, isDirectory: true)
+                .appendingPathComponent("meeting.m4a")
+                .path
+        })
+        return try transcriptionRepo.fetchAll(limit: nil).filter { transcription in
+            guard transcription.sourceType == .meeting else { return false }
+            if let folderPath = transcription.meetingArtifactFolderPath,
+               folderPaths.contains(folderPath) {
+                return true
+            }
+            if let filePath = transcription.filePath,
+               mixedPaths.contains(filePath) {
+                return true
+            }
+            return false
+        }
+    }
+
+    private func pathAliases(for url: URL) -> Set<String> {
+        var paths = Set([
+            url.path,
+            url.standardizedFileURL.path,
+            url.resolvingSymlinksInPath().path,
+        ])
+        for path in Array(paths) {
+            if path.hasPrefix("/private/var/") {
+                paths.insert(String(path.dropFirst("/private".count)))
+            } else if path.hasPrefix("/var/") {
+                paths.insert("/private" + path)
+            }
+        }
+        return paths
     }
 
     // MARK: - ADR-020 §9 — recovered notes
@@ -755,6 +846,7 @@ private final class RecoveryMockTranscriptionService: TranscriptionServiceProtoc
     private(set) var finalizedRecordings: [MeetingRecordingOutput] = []
     private(set) var finalizedTranscriptionIDs: [UUID] = []
     private(set) var sourceDecisions: [MeetingCleanedMicrophoneSourceDecision] = []
+    var transcriptionRepo: RecordingTranscriptionRepository?
     var sourceResolutionPolicy: MeetingCleanedMicrophoneReadinessPolicy?
     var errorToThrow: Error?
 
@@ -790,12 +882,15 @@ private final class RecoveryMockTranscriptionService: TranscriptionServiceProtoc
         lock.withLock {
             recordings.append(recording)
         }
-        return Transcription(
+        let transcription = Transcription(
             fileName: recording.displayName,
             filePath: recording.mixedAudioURL.path,
+            meetingArtifactFolderPath: recording.folderURL.path,
             status: .completed,
             sourceType: .meeting
         )
+        try transcriptionRepo?.save(transcription)
+        return transcription
     }
 
     func prepareMeetingTranscription(recording: MeetingRecordingOutput) async throws -> Transcription {
@@ -820,13 +915,16 @@ private final class RecoveryMockTranscriptionService: TranscriptionServiceProtoc
             finalizedRecordings.append(recording)
             finalizedTranscriptionIDs.append(transcriptionID)
         }
-        return Transcription(
+        let transcription = Transcription(
             id: transcriptionID,
             fileName: recording.displayName,
             filePath: recording.mixedAudioURL.path,
+            meetingArtifactFolderPath: recording.folderURL.path,
             status: .completed,
             sourceType: .meeting
         )
+        try transcriptionRepo?.save(transcription)
+        return transcription
     }
 
     func retranscribe(

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingRecoveryServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingRecoveryServiceTests.swift
@@ -429,7 +429,7 @@ final class MeetingRecordingRecoveryServiceTests: XCTestCase {
     }
 
     private func meetingRows(in folderURL: URL) throws -> [Transcription] {
-        let folderPaths = pathAliases(for: folderURL)
+        let folderPaths = MeetingArtifactPathAliases.aliases(for: folderURL)
         let mixedPaths = Set(folderPaths.map {
             URL(fileURLWithPath: $0, isDirectory: true)
                 .appendingPathComponent("meeting.m4a")
@@ -447,22 +447,6 @@ final class MeetingRecordingRecoveryServiceTests: XCTestCase {
             }
             return false
         }
-    }
-
-    private func pathAliases(for url: URL) -> Set<String> {
-        var paths = Set([
-            url.path,
-            url.standardizedFileURL.path,
-            url.resolvingSymlinksInPath().path,
-        ])
-        for path in Array(paths) {
-            if path.hasPrefix("/private/var/") {
-                paths.insert(String(path.dropFirst("/private".count)))
-            } else if path.hasPrefix("/var/") {
-                paths.insert("/private" + path)
-            }
-        }
-        return paths
     }
 
     // MARK: - ADR-020 §9 — recovered notes

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingServiceTests.swift
@@ -204,7 +204,7 @@ final class MeetingRecordingServiceTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(lockStore.deletes.count, 1)
     }
 
-    func testStopRecordingKeepsLockUntilTranscriptionCompletes() async throws {
+    func testStopRecordingKeepsAwaitingTranscriptionLockAfterStop() async throws {
         let captureService = MockMeetingAudioCaptureService()
         let lockStore = RecordingLockFileStore()
         let service = MeetingRecordingService(
@@ -226,9 +226,6 @@ final class MeetingRecordingServiceTests: XCTestCase {
 
         XCTAssertTrue(lockStore.deletes.isEmpty)
         XCTAssertEqual(lockStore.writes.last?.file.state, .awaitingTranscription)
-
-        await service.completeTranscription(for: output)
-        XCTAssertEqual(lockStore.deletes, [output.folderURL])
     }
 
     func testStopRecordingFailsIfAwaitingTranscriptionLockWriteFails() async throws {
@@ -317,13 +314,9 @@ final class MeetingRecordingServiceTests: XCTestCase {
         XCTAssertEqual(lockStore.writes.last?.file.speechEngine, SpeechEngineSelection(engine: .whisper, language: "ko"))
         let activeLeaseCountAfterStop = await sttClient.activeLeaseCount
         XCTAssertEqual(activeLeaseCountAfterStop, 0)
-
-        await service.completeTranscription(for: output)
-        let activeLeaseCountAfterCompletion = await sttClient.activeLeaseCount
-        XCTAssertEqual(activeLeaseCountAfterCompletion, 0)
     }
 
-    func testFailedTranscriptionAttemptDoesNotDeleteAwaitingTranscriptionLock() async throws {
+    func testStoppedRecordingKeepsAwaitingTranscriptionLockWithoutSettlement() async throws {
         let captureService = MockMeetingAudioCaptureService()
         let lockStore = RecordingLockFileStore()
         let speechEngine = SpeechEngineSelection(engine: .whisper, language: "KO")
@@ -348,9 +341,6 @@ final class MeetingRecordingServiceTests: XCTestCase {
         let activeLeaseCountAfterStop = await sttClient.activeLeaseCount
         XCTAssertEqual(activeLeaseCountAfterStop, 0)
 
-        await service.finishTranscriptionAttempt(for: output)
-        let activeLeaseCountAfterFailure = await sttClient.activeLeaseCount
-        XCTAssertEqual(activeLeaseCountAfterFailure, 0)
         XCTAssertTrue(lockStore.deletes.isEmpty)
     }
 
@@ -379,14 +369,7 @@ final class MeetingRecordingServiceTests: XCTestCase {
         let activeLeaseCountAfterSecondStart = await sttClient.activeLeaseCount
         XCTAssertEqual(activeLeaseCountAfterSecondStart, 1)
 
-        await service.finishTranscriptionAttempt(for: firstOutput)
-        let activeLeaseCountAfterFailedFinalize = await sttClient.activeLeaseCount
-        XCTAssertEqual(activeLeaseCountAfterFailedFinalize, 1)
-
-        await service.completeTranscription(for: firstOutput)
-        let activeLeaseCountAfterSuccessfulFinalize = await sttClient.activeLeaseCount
-        XCTAssertEqual(activeLeaseCountAfterSuccessfulFinalize, 1)
-        XCTAssertEqual(lockStore.deletes, [firstOutput.folderURL])
+        XCTAssertTrue(lockStore.deletes.isEmpty)
 
         await service.cancelRecording()
         let activeLeaseCountAfterSecondCancel = await sttClient.activeLeaseCount
@@ -1712,8 +1695,6 @@ final class MeetingRecordingServiceTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: notesURL.path))
         let notesContent = try String(contentsOf: notesURL, encoding: .utf8)
         XCTAssertTrue(notesContent.contains("notes from the meeting"))
-
-        await service.completeTranscription(for: output)
     }
 
     func testStopRecordingDoesNotWriteNotesFileWhenNoNotesTaken() async throws {
@@ -1742,8 +1723,6 @@ final class MeetingRecordingServiceTests: XCTestCase {
             FileManager.default.fileExists(atPath: notesURL.path),
             "Empty-notes meeting should not produce a notes.md file"
         )
-
-        await service.completeTranscription(for: output)
     }
 
     // MARK: - Pause / Resume (issue #235)
@@ -1856,8 +1835,6 @@ final class MeetingRecordingServiceTests: XCTestCase {
         let counts = await sttClient.callCounts
         XCTAssertEqual(counts.microphone, 0)
         XCTAssertGreaterThanOrEqual(counts.system, 1)
-
-        await service.completeTranscription(for: output)
     }
 
     func testMicrophoneMutePreservesQueuedPreMuteAudioByHostTime() async throws {
@@ -1888,8 +1865,6 @@ final class MeetingRecordingServiceTests: XCTestCase {
         XCTAssertEqual(output.sourceAlignment.microphone?.firstHostTime, preMuteHostTime)
         let counts = await sttClient.callCounts
         XCTAssertGreaterThanOrEqual(counts.microphone, 1)
-
-        await service.completeTranscription(for: output)
     }
 
     func testMicrophoneMuteUnmuteAllowsLaterMicAudio() async throws {
@@ -1926,8 +1901,6 @@ final class MeetingRecordingServiceTests: XCTestCase {
 
         let counts = await sttClient.callCounts
         XCTAssertGreaterThanOrEqual(counts.microphone, 1)
-
-        await service.completeTranscription(for: output)
     }
 
     func testMicrophoneMuteIsUnavailableForSystemOnlyRecordings() async throws {
@@ -2076,8 +2049,6 @@ final class MeetingRecordingServiceTests: XCTestCase {
             output.durationSeconds,
             totalWallclock - 0.6
         )
-
-        await service.completeTranscription(for: output)
     }
 
     func testImmediatePauseKeepsAlreadyCapturedAudio() async throws {
@@ -2106,8 +2077,6 @@ final class MeetingRecordingServiceTests: XCTestCase {
 
         XCTAssertNotNil(output.sourceAlignment.microphone)
         XCTAssertEqual(output.sourceAlignment.microphone?.firstHostTime, prePauseHostTime)
-
-        await service.completeTranscription(for: output)
     }
 
     func testStopRecordingDrainsQueuedTailBuffers() async throws {
@@ -2135,8 +2104,6 @@ final class MeetingRecordingServiceTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: output.folderURL) }
 
         XCTAssertEqual(output.sourceAlignment.microphone?.lastHostTime, lastHostTime)
-
-        await service.completeTranscription(for: output)
     }
 
     func testStopRecordingWhilePausedSettlesOngoingPauseIntoDuration() async throws {
@@ -2175,8 +2142,6 @@ final class MeetingRecordingServiceTests: XCTestCase {
             totalWallclock - 0.6,
             "Stopping while paused must still subtract the in-flight pause interval"
         )
-
-        await service.completeTranscription(for: output)
     }
 
     func testBuffersDuringPauseAreDiscardedAndDoNotProduceTranscriptUpdates() async throws {

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingSettlementTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingSettlementTests.swift
@@ -77,6 +77,28 @@ final class MeetingRecordingSettlementTests: XCTestCase {
         XCTAssertEqual(lockStore.deletes, [folderURL])
     }
 
+    func testDeletesLockWhenStoredFolderPathDiffersOnlyByCase() async throws {
+        // APFS is case-insensitive but case-preserving: a stored artifact path
+        // that differs from the freshly derived session path only by case still
+        // names the same folder and must not false-refuse settlement.
+        let repo = MockTranscriptionRepository()
+        let lockStore = SettlementLockFileStore()
+        let settlement = MeetingRecordingSettlement(lockFileStore: lockStore, transcriptionRepo: repo)
+        let folderURL = makeFolderURL()
+        var transcription = makeTranscription(status: .completed, folderURL: folderURL)
+        transcription.meetingArtifactFolderPath = folderURL.path.uppercased()
+        transcription.filePath = nil
+        try repo.save(transcription)
+
+        try await settlement.settleCompletedTranscription(
+            folderURL: folderURL,
+            transcriptionID: transcription.id,
+            sessionID: UUID()
+        )
+
+        XCTAssertEqual(lockStore.deletes, [folderURL])
+    }
+
     func testRefusesWhenCompletedRowBelongsToDifferentFolder() async throws {
         let repo = MockTranscriptionRepository()
         let lockStore = SettlementLockFileStore()

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingSettlementTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingSettlementTests.swift
@@ -77,6 +77,79 @@ final class MeetingRecordingSettlementTests: XCTestCase {
         XCTAssertEqual(lockStore.deletes, [folderURL])
     }
 
+    func testRefusesWhenCompletedRowBelongsToDifferentFolder() async throws {
+        let repo = MockTranscriptionRepository()
+        let lockStore = SettlementLockFileStore()
+        let settlement = MeetingRecordingSettlement(lockFileStore: lockStore, transcriptionRepo: repo)
+        let transcription = makeTranscription(status: .completed, folderURL: makeFolderURL())
+        try repo.save(transcription)
+
+        do {
+            try await settlement.settleCompletedTranscription(
+                folderURL: makeFolderURL(),
+                transcriptionID: transcription.id,
+                sessionID: UUID()
+            )
+            XCTFail("Expected settlement to refuse a completed row from another folder")
+        } catch let error as MeetingRecordingSettlementError {
+            guard case .folderMismatch = error else {
+                XCTFail("Expected folderMismatch, got \(error)")
+                return
+            }
+            XCTAssertTrue(lockStore.deletes.isEmpty)
+        }
+    }
+
+    func testDeletesLockAcrossPrivateVarPathAliasBoundary() async throws {
+        let base = "/var/folders/settlement-tests/\(UUID().uuidString)"
+        let cases: [(stored: String, requested: String)] = [
+            (stored: base, requested: "/private" + base),
+            (stored: "/private" + base, requested: base),
+        ]
+        for (stored, requested) in cases {
+            let repo = MockTranscriptionRepository()
+            let lockStore = SettlementLockFileStore()
+            let settlement = MeetingRecordingSettlement(lockFileStore: lockStore, transcriptionRepo: repo)
+            let transcription = makeTranscription(
+                status: .completed,
+                folderURL: URL(fileURLWithPath: stored, isDirectory: true)
+            )
+            try repo.save(transcription)
+
+            let requestedURL = URL(fileURLWithPath: requested, isDirectory: true)
+            try await settlement.settleCompletedTranscription(
+                folderURL: requestedURL,
+                transcriptionID: transcription.id,
+                sessionID: UUID()
+            )
+
+            XCTAssertEqual(lockStore.deletes, [requestedURL])
+        }
+    }
+
+    func testDeletesLockWhenOnlyMeetingFilePathMatches() async throws {
+        let repo = MockTranscriptionRepository()
+        let lockStore = SettlementLockFileStore()
+        let settlement = MeetingRecordingSettlement(lockFileStore: lockStore, transcriptionRepo: repo)
+        let folderURL = makeFolderURL()
+        let transcription = Transcription(
+            fileName: "Recovered Team Sync",
+            filePath: folderURL.appendingPathComponent("meeting.m4a").path,
+            meetingArtifactFolderPath: nil,
+            status: .completed,
+            sourceType: .meeting
+        )
+        try repo.save(transcription)
+
+        try await settlement.settleCompletedTranscription(
+            folderURL: folderURL,
+            transcriptionID: transcription.id,
+            sessionID: UUID()
+        )
+
+        XCTAssertEqual(lockStore.deletes, [folderURL])
+    }
+
     func testLockDeleteErrorIsLogOnly() async throws {
         let repo = MockTranscriptionRepository()
         let lockStore = SettlementLockFileStore(errorToThrow: SettlementTestError.deleteFailed)

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingSettlementTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingSettlementTests.swift
@@ -150,7 +150,7 @@ final class MeetingRecordingSettlementTests: XCTestCase {
         XCTAssertEqual(lockStore.deletes, [folderURL])
     }
 
-    func testLockDeleteErrorIsLogOnly() async throws {
+    func testLockDeleteErrorIsRethrownSoCallersCanSurfaceFailedCleanup() async throws {
         let repo = MockTranscriptionRepository()
         let lockStore = SettlementLockFileStore(errorToThrow: SettlementTestError.deleteFailed)
         let settlement = MeetingRecordingSettlement(lockFileStore: lockStore, transcriptionRepo: repo)
@@ -158,11 +158,16 @@ final class MeetingRecordingSettlementTests: XCTestCase {
         let transcription = makeTranscription(status: .completed, folderURL: folderURL)
         try repo.save(transcription)
 
-        try await settlement.settleCompletedTranscription(
-            folderURL: folderURL,
-            transcriptionID: transcription.id,
-            sessionID: UUID()
-        )
+        do {
+            try await settlement.settleCompletedTranscription(
+                folderURL: folderURL,
+                transcriptionID: transcription.id,
+                sessionID: UUID()
+            )
+            XCTFail("Expected settlement to rethrow the lock delete error")
+        } catch {
+            XCTAssertTrue(error is SettlementTestError)
+        }
 
         XCTAssertEqual(lockStore.deletes, [folderURL])
     }

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingSettlementTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingSettlementTests.swift
@@ -1,0 +1,142 @@
+import Foundation
+import XCTest
+@testable import MacParakeetCore
+
+final class MeetingRecordingSettlementTests: XCTestCase {
+    private var tempRoot: URL!
+
+    override func setUpWithError() throws {
+        tempRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("MeetingRecordingSettlementTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: tempRoot)
+    }
+
+    func testRefusesWhenTranscriptionRowIsMissing() async throws {
+        let repo = MockTranscriptionRepository()
+        let lockStore = SettlementLockFileStore()
+        let settlement = MeetingRecordingSettlement(lockFileStore: lockStore, transcriptionRepo: repo)
+
+        do {
+            try await settlement.settleCompletedTranscription(
+                folderURL: makeFolderURL(),
+                transcriptionID: UUID(),
+                sessionID: UUID()
+            )
+            XCTFail("Expected settlement to refuse a missing transcription row")
+        } catch {
+            XCTAssertTrue(error is MeetingRecordingSettlementError)
+            XCTAssertTrue(lockStore.deletes.isEmpty)
+        }
+    }
+
+    func testRefusesWhenTranscriptionRowIsNotCompleted() async throws {
+        for status in [
+            Transcription.TranscriptionStatus.processing,
+            .error,
+            .cancelled,
+        ] {
+            let repo = MockTranscriptionRepository()
+            let lockStore = SettlementLockFileStore()
+            let settlement = MeetingRecordingSettlement(lockFileStore: lockStore, transcriptionRepo: repo)
+            let folderURL = makeFolderURL()
+            let transcription = makeTranscription(status: status, folderURL: folderURL)
+            try repo.save(transcription)
+
+            do {
+                try await settlement.settleCompletedTranscription(
+                    folderURL: folderURL,
+                    transcriptionID: transcription.id,
+                    sessionID: UUID()
+                )
+                XCTFail("Expected settlement to refuse \(status.rawValue) transcription row")
+            } catch {
+                XCTAssertTrue(error is MeetingRecordingSettlementError)
+                XCTAssertTrue(lockStore.deletes.isEmpty)
+            }
+        }
+    }
+
+    func testDeletesLockWhenTranscriptionRowIsCompleted() async throws {
+        let repo = MockTranscriptionRepository()
+        let lockStore = SettlementLockFileStore()
+        let settlement = MeetingRecordingSettlement(lockFileStore: lockStore, transcriptionRepo: repo)
+        let folderURL = makeFolderURL()
+        let transcription = makeTranscription(status: .completed, folderURL: folderURL)
+        try repo.save(transcription)
+
+        try await settlement.settleCompletedTranscription(
+            folderURL: folderURL,
+            transcriptionID: transcription.id,
+            sessionID: UUID()
+        )
+
+        XCTAssertEqual(lockStore.deletes, [folderURL])
+    }
+
+    func testLockDeleteErrorIsLogOnly() async throws {
+        let repo = MockTranscriptionRepository()
+        let lockStore = SettlementLockFileStore(errorToThrow: SettlementTestError.deleteFailed)
+        let settlement = MeetingRecordingSettlement(lockFileStore: lockStore, transcriptionRepo: repo)
+        let folderURL = makeFolderURL()
+        let transcription = makeTranscription(status: .completed, folderURL: folderURL)
+        try repo.save(transcription)
+
+        try await settlement.settleCompletedTranscription(
+            folderURL: folderURL,
+            transcriptionID: transcription.id,
+            sessionID: UUID()
+        )
+
+        XCTAssertEqual(lockStore.deletes, [folderURL])
+    }
+
+    private func makeFolderURL() -> URL {
+        tempRoot.appendingPathComponent(UUID().uuidString, isDirectory: true)
+    }
+
+    private func makeTranscription(
+        status: Transcription.TranscriptionStatus,
+        folderURL: URL
+    ) -> Transcription {
+        Transcription(
+            fileName: "Recovered Team Sync",
+            filePath: folderURL.appendingPathComponent("meeting.m4a").path,
+            meetingArtifactFolderPath: folderURL.path,
+            status: status,
+            sourceType: .meeting
+        )
+    }
+}
+
+private enum SettlementTestError: Error {
+    case deleteFailed
+}
+
+private final class SettlementLockFileStore: MeetingRecordingLockFileStoring, @unchecked Sendable {
+    private let lock = NSLock()
+    private let errorToThrow: Error?
+    private(set) var deletes: [URL] = []
+
+    init(errorToThrow: Error? = nil) {
+        self.errorToThrow = errorToThrow
+    }
+
+    func write(_ file: MeetingRecordingLockFile, folderURL: URL) throws {}
+
+    func read(folderURL: URL) throws -> MeetingRecordingLockFile? { nil }
+
+    func delete(folderURL: URL) throws {
+        lock.withLock {
+            deletes.append(folderURL)
+        }
+        if let errorToThrow {
+            throw errorToThrow
+        }
+    }
+
+    func discoverOrphans(meetingsRoot: URL) throws -> [MeetingRecordingLockFile] { [] }
+}

--- a/Tests/MacParakeetTests/ViewModels/ViewModelMocks.swift
+++ b/Tests/MacParakeetTests/ViewModels/ViewModelMocks.swift
@@ -375,6 +375,7 @@ actor MockTranscriptionService: SpeechEngineOverrideTranscriptionService {
     var preparedMeetingRecordings: [MeetingRecordingOutput] = []
     var finalizedMeetingRecordings: [MeetingRecordingOutput] = []
     var finalizedMeetingTranscriptionIDs: [UUID] = []
+    private var finalizedMeetingSaveHook: (@Sendable (Transcription) -> Void)?
     private var meetingFinalizationHeld = false
     private var meetingFinalizationContinuations: [CheckedContinuation<Void, Never>] = []
     /// Per-file overrides for batch tests, keyed by `fileURL.lastPathComponent`.
@@ -417,6 +418,12 @@ actor MockTranscriptionService: SpeechEngineOverrideTranscriptionService {
 
     func holdMeetingFinalization() {
         meetingFinalizationHeld = true
+    }
+
+    func persistFinalizedMeetings(to repository: MockTranscriptionRepository) {
+        finalizedMeetingSaveHook = { transcription in
+            try? repository.save(transcription)
+        }
     }
 
     func releaseMeetingFinalization() {
@@ -561,7 +568,9 @@ actor MockTranscriptionService: SpeechEngineOverrideTranscriptionService {
         )
         result.id = transcriptionID
         result.filePath = result.filePath ?? recording.mixedAudioURL.path
+        result.meetingArtifactFolderPath = result.meetingArtifactFolderPath ?? recording.folderURL.path
         result.sourceType = .meeting
+        finalizedMeetingSaveHook?(result)
         return result
     }
 

--- a/spec/05-audio-pipeline.md
+++ b/spec/05-audio-pipeline.md
@@ -272,6 +272,7 @@ Mic Input    → SharedMicrophoneStream (+ Voice Processing I/O when active)┘ 
 | `MeetingAudioStorageWriter` | Writes separate M4A files per selected source (mic and/or system) |
 | `MeetingRecordingMetadataStore` | Persists `MeetingSourceAlignment` for post-stop merge correctness |
 | `MeetingRecordingLockFileStore` | Persists in-progress session state, notes, and captured speech engine for crash recovery |
+| `MeetingRecordingSettlement` | Sole completion-path owner of `recording.lock` deletion; re-fetches the saved row and deletes the lock only after verifying a completed meeting Transcription for that artifact folder (see [meeting-recovery-retention contract](contracts/meeting-recovery-retention.md#lock-deletion-authority)) |
 | `MeetingTranscriptionQueue` | Owns FIFO background finalization for stopped meetings after audio + lock + Library stub are durable |
 | `MeetingTranscriptFinalizer` | Merges fresh per-source STT results into the final meeting transcript |
 
@@ -300,7 +301,9 @@ User clicks "Start Meeting Recording"
     → Send each source WAV to the captured local STT engine
     → Merge fresh per-source STT using persisted source offsets
     → Optionally refine the isolated system side with diarization
-    → Update the existing Transcription row and delete `recording.lock`
+    → Update the existing Transcription row, then settle: MeetingRecordingSettlement
+      verifies the completed row and deletes `recording.lock` (on failure the
+      lock stays for recovery to re-settle; the queue still reports success)
     → Navigate to transcription detail view only if no newer meeting recording is active
 ```
 

--- a/spec/adr/019-crash-resilient-meeting-recording.md
+++ b/spec/adr/019-crash-resilient-meeting-recording.md
@@ -167,6 +167,12 @@ post-stop pipeline:
    true` flag (new column or boolean in metadata).
 5. Delete `recording.lock` after successful save.
 
+The marker deletion step is owned by `MeetingRecordingSettlement`, which
+re-fetches the saved row and removes the lock only after verifying a completed
+meeting `Transcription` for that artifact folder. See the lock deletion
+authority rule in
+[`spec/contracts/meeting-recovery-retention.md`](../contracts/meeting-recovery-retention.md#lock-deletion-authority).
+
 Declining the prompt **keeps** the lock file and audio — the user
 can retry recovery later from a Settings affordance ("Pending
 recovery: 1 partial recording").

--- a/spec/contracts/meeting-recovery-retention.md
+++ b/spec/contracts/meeting-recovery-retention.md
@@ -97,10 +97,12 @@ Completion-path lock deletion is centralized in
 transcription id, and session id; settlement re-fetches the `Transcription`
 row and refuses to delete `recording.lock` unless the row exists, is a meeting
 transcription for that artifact folder, and has `status == .completed`.
-Lock-delete I/O failures are log-only: the lock remains protective and recovery
-can re-settle the completed row on the next launch. On the transcription-queue
-path a settlement error after a successful finalize is likewise log-only: the
-completed transcript is already durably saved, so the queue still reports
+Lock-delete I/O failures are logged and rethrown so callers can surface the
+failed cleanup (for example, discard must not report success while
+`recording.lock` is still on disk); the lock remains protective and recovery
+can re-settle the completed row on a later scan. On the transcription-queue
+path a settlement error after a successful finalize is caught by the queue:
+the completed transcript is already durably saved, so the queue still reports
 success and leaves the lock for recovery to re-settle.
 
 The non-settlement deletion paths are intentionally limited to flows that are
@@ -144,9 +146,10 @@ Focused coverage pins dead-PID `awaitingTranscription` reads, the distinction
 between active-session discovery and retention safety, completed recovery lock
 cleanup, and retention sweeps skipping valid, zero-byte, corrupt, and
 future-schema lock files. Settlement coverage pins refusal for missing or
-non-completed rows, log-only delete I/O failure, queue success/failure lock
-behavior, and crash-point convergence for awaiting locks with no row,
-processing rows, and completed rows whose lock is still present.
+non-completed rows, rethrown delete I/O failure (including discard surfacing a
+retained lock and staying retryable), queue success/failure lock behavior, and
+crash-point convergence for awaiting locks with no row, processing rows, and
+completed rows whose lock is still present.
 
 ## When this changes
 

--- a/spec/contracts/meeting-recovery-retention.md
+++ b/spec/contracts/meeting-recovery-retention.md
@@ -98,7 +98,10 @@ transcription id, and session id; settlement re-fetches the `Transcription`
 row and refuses to delete `recording.lock` unless the row exists, is a meeting
 transcription for that artifact folder, and has `status == .completed`.
 Lock-delete I/O failures are log-only: the lock remains protective and recovery
-can re-settle the completed row on the next launch.
+can re-settle the completed row on the next launch. On the transcription-queue
+path a settlement error after a successful finalize is likewise log-only: the
+completed transcript is already durably saved, so the queue still reports
+success and leaves the lock for recovery to re-settle.
 
 The non-settlement deletion paths are intentionally limited to flows that are
 not final-transcription completion:

--- a/spec/contracts/meeting-recovery-retention.md
+++ b/spec/contracts/meeting-recovery-retention.md
@@ -12,9 +12,11 @@ actions, and protect folders from automatic destructive sweeps.
 ## Producers
 
 - `MeetingRecordingService`: writes and rewrites `recording.lock` during
-  capture, stop, notes updates, and background finalization.
+  capture, stop, and notes updates.
+- `MeetingRecordingSettlement`: the only completion-path owner allowed to
+  delete `recording.lock` after final transcription.
 - `MeetingRecordingRecoveryService`: reads orphaned locks, recovers audio, and
-  deletes locks only after successful completion or explicit cleanup.
+  routes completed-session lock cleanup through settlement.
 - `MeetingAudioRetentionSweeper`: detaches completed meeting audio after the
   configured retention window.
 - `history clear-meeting-audio`: refuses clear-all when any readable lock
@@ -88,6 +90,29 @@ A malformed lock is a recovery or diagnostic problem, not permission to delete
 audio. Deletion is allowed only through explicit user discard/cleanup flows or
 after recovery/finalization removes the lock.
 
+## Lock Deletion Authority
+
+Completion-path lock deletion is centralized in
+`MeetingRecordingSettlement`. Callers must pass the session folder,
+transcription id, and session id; settlement re-fetches the `Transcription`
+row and refuses to delete `recording.lock` unless the row exists, is a meeting
+transcription for that artifact folder, and has `status == .completed`.
+Lock-delete I/O failures are log-only: the lock remains protective and recovery
+can re-settle the completed row on the next launch.
+
+The non-settlement deletion paths are intentionally limited to flows that are
+not final-transcription completion:
+
+- `MeetingRecordingService.cancelRecording()`: user cancel deletes the lock
+  and session folder because the user explicitly discarded the active capture.
+- Failed-start / failed-capture cleanup in `MeetingRecordingService`: startup
+  or no-audio failures delete the lock while also removing the unusable session
+  folder before any stopped recording is offered for transcription.
+- `MeetingRecordingRecoveryService.discard(_:)`: user discard of an incomplete
+  recovery removes the session folder. If a completed transcription already
+  exists, discard preserves the folder/audio and uses settlement to delete only
+  the lock.
+
 ## Non-Stable Fields
 
 - PID liveness is process-local and time-sensitive.
@@ -105,14 +130,20 @@ must preserve the file-presence retention barrier.
 ## Tests that enforce this
 
 - `MeetingRecordingLockFileStoreTests`
+- `MeetingRecordingSettlementTests`
 - `MeetingRecordingRecoveryServiceTests`
+- `MeetingTranscriptionQueueTests`
 - `MeetingAudioRetentionPolicyTests`
 - `MeetingAudioRetentionSweeperTests`
+- `MeetingRecordingServiceTests`
 
 Focused coverage pins dead-PID `awaitingTranscription` reads, the distinction
 between active-session discovery and retention safety, completed recovery lock
 cleanup, and retention sweeps skipping valid, zero-byte, corrupt, and
-future-schema lock files.
+future-schema lock files. Settlement coverage pins refusal for missing or
+non-completed rows, log-only delete I/O failure, queue success/failure lock
+behavior, and crash-point convergence for awaiting locks with no row,
+processing rows, and completed rows whose lock is still present.
 
 ## When this changes
 


### PR DESCRIPTION
## What

Reifies the final step of the meeting stop/finalize trust transaction — deleting `recording.lock` after final transcription — as a single Core owner, `MeetingRecordingSettlement`, which refuses to delete the lock unless a completed meeting `Transcription` row for that session folder is durably saved.

Previously this step was emergent behavior: `completeTranscription(for:)` was public protocol API that deleted the lock unconditionally, trusted call ordering in the App-layer queue, and recovery deleted locks through a separate direct-store path (three sites on main). A premature or misordered deletion would orphan audio invisibly — recovery discovery is lock-driven — and strand a `processing` row.

## How

- **`MeetingRecordingSettlement`** (Core): re-fetches the row by id; requires exists + `sourceType == .meeting` + `status == .completed` + artifact-folder ownership. Ownership matching goes through the shared `MeetingArtifactPathAliases` helper (also used by recovery row-lookup): `/var` ↔ `/private/var` aliases, exact match fast path, case-insensitive fallback for APFS.
- **Failure semantics**: refusal always throws. Lock-delete I/O errors are logged and rethrown so callers hear about failed cleanup; the lock stays protective and recovery re-settles the completed row on a later scan. The transcription queue treats a post-save settlement failure separately from a transcription failure — the meeting still reports success (the transcript is durably saved), while recovery `discard`/completion propagate the failure so "settled" can't silently mean "lock still on disk".
- `completeTranscription` / `finishTranscriptionAttempt` (a documented no-op) **removed** from `MeetingRecordingServiceProtocol`.
- All completion-path deletion sites route through settlement: queue success path, recovery `completeRecovery`, recovery already-completed cleanup, recovery `discard` completed-row branch.
- Deliberately unchanged: `stopRecording()` sequencing (zero diff); cancel / failed-start / no-audio / user-discard deletions (not final-transcription completion); recovery-specific row mutations.

## Contract & docs

- `spec/contracts/meeting-recovery-retention.md`: new **Lock Deletion Authority** section defining settlement as the only completion-path lock owner, with the non-settlement paths enumerated; enforcement-test list updated (same-PR rule for contract changes).
- ADR-019 §2 note pointing marker deletion at the settlement owner; `spec/05-audio-pipeline.md` synced.

## Tests

- `MeetingRecordingSettlementTests` (8): refusal on missing / non-completed / non-meeting / wrong-folder rows; deletion on completed; `/var` alias boundary; case-divergent stored path; delete-I/O propagation.
- Crash-point convergence sweep in `MeetingRecordingRecoveryServiceTests`: interruption after stop (lock, no row), after prepare (lock + `processing` row), after finalize (completed row, lock present) — each converges to exactly one completed row, lock deleted, audio untouched; failed discard is retryable and converges once the delete succeeds.
- Queue tests pin success ⟹ settled, failure ⟹ lock untouched, and post-save settlement failure ⟹ still a success completion.

## Gate evidence

- no-mistakes run `01KWP7F6178SW56164X719QCZ7`: intent/rebase/review/test (full suite)/document/lint/push/pr/ci all green; one review finding fixed in-pipeline (settlement-error decoupling + shared path aliases).
- Greptile: 3 review rounds, confidence 5/5, P1 (log-only discard swallow) fixed in `5eb2eae53`.
- Gemini + cubic findings (case-sensitive path match, Sendable, test coverage) fixed in `7d7ea4c69` / `643e9dca1`; all threads resolved.

Spec alignment: implements the settled recommendation from the 2026-07-04 stop/finalize architecture review — the durability half of the contract (stop + lock state machine + recovery replay) was already a real interface; settlement authority was the one emergent, dangerous piece. One deviation from the original brief, deliberate: lock-delete I/O errors went from log-only to log-and-rethrow after the queue grew its own catch (Greptile P1), which strictly improves on the brief's intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)