### PR TITLE
[codex] Stabilize flaky audio tests

### DIFF
--- a/Sources/MacParakeetCore/Audio/MicrophoneCapture.swift
+++ b/Sources/MacParakeetCore/Audio/MicrophoneCapture.swift
@@ -101,6 +101,28 @@ public func meetingInputDeviceAttempts(
     defaultInputIsBluetooth: (AudioDeviceID) -> Bool = { _ in true },
     outputIsBluetooth: () -> Bool? = { false }
 ) -> [MeetingInputDeviceAttempt] {
+    meetingInputDeviceAttempts(
+        selectedUID: selectedUID,
+        selectedInputDeviceID: selectedInputDeviceID,
+        defaultInputDevice: defaultInputDevice,
+        builtInMicrophone: builtInMicrophone,
+        preferBuiltInWhenOutputIsBluetooth: preferBuiltInWhenOutputIsBluetooth,
+        defaultInputIsBluetooth: defaultInputIsBluetooth,
+        outputIsBluetooth: outputIsBluetooth,
+        diagnosticsSink: { AudioCaptureDiagnostics.appendAsync($0) }
+    )
+}
+
+func meetingInputDeviceAttempts(
+    selectedUID: String?,
+    selectedInputDeviceID: (String) -> AudioDeviceID?,
+    defaultInputDevice: () -> AudioDeviceID?,
+    builtInMicrophone: () -> AudioDeviceID?,
+    preferBuiltInWhenOutputIsBluetooth: Bool = false,
+    defaultInputIsBluetooth: (AudioDeviceID) -> Bool = { _ in true },
+    outputIsBluetooth: () -> Bool? = { false },
+    diagnosticsSink: @Sendable (String) -> Void
+) -> [MeetingInputDeviceAttempt] {
     var attempts: [MeetingInputDeviceAttempt] = []
     var seenDeviceIDs = Set<AudioDeviceID>()
 
@@ -218,9 +240,9 @@ public func meetingInputDeviceAttempts(
             }
         }
     }
-    AudioCaptureDiagnostics.appendAsync(
+    let diagnosticsMessage =
         "mic_attempts_bluetooth_output_policy preference=\(preferBuiltInWhenOutputIsBluetooth ? "on" : "off") explicit_selection_resolved=\(hasResolvedSelection) default_output_transport=\(defaultOutputTransport) outcome=\(policyOutcome) reason=\(policyReason)"
-    )
+    diagnosticsSink(diagnosticsMessage)
 
     return attempts
 }

--- a/Sources/MacParakeetCore/Audio/MicrophoneCapture.swift
+++ b/Sources/MacParakeetCore/Audio/MicrophoneCapture.swift
@@ -109,7 +109,7 @@ public func meetingInputDeviceAttempts(
         preferBuiltInWhenOutputIsBluetooth: preferBuiltInWhenOutputIsBluetooth,
         defaultInputIsBluetooth: defaultInputIsBluetooth,
         outputIsBluetooth: outputIsBluetooth,
-        diagnosticsSink: { AudioCaptureDiagnostics.appendAsync($0) }
+        diagnosticsSink: AudioCaptureDiagnostics.appendAsync
     )
 }
 
@@ -121,7 +121,7 @@ func meetingInputDeviceAttempts(
     preferBuiltInWhenOutputIsBluetooth: Bool = false,
     defaultInputIsBluetooth: (AudioDeviceID) -> Bool = { _ in true },
     outputIsBluetooth: () -> Bool? = { false },
-    diagnosticsSink: @Sendable (String) -> Void
+    diagnosticsSink: (String) -> Void
 ) -> [MeetingInputDeviceAttempt] {
     var attempts: [MeetingInputDeviceAttempt] = []
     var seenDeviceIDs = Set<AudioDeviceID>()

--- a/Tests/MacParakeetTests/Audio/AudioRecorderFormatChangeTests.swift
+++ b/Tests/MacParakeetTests/Audio/AudioRecorderFormatChangeTests.swift
@@ -1103,18 +1103,6 @@ final class AudioRecorderFormatChangeTests: XCTestCase {
 
     private func pollUntil(
         timeout: Duration,
-        condition: @Sendable () -> Bool
-    ) async -> Bool {
-        let deadline = ContinuousClock.now.advanced(by: timeout)
-        while ContinuousClock.now < deadline {
-            if condition() { return true }
-            try? await Task.sleep(for: .milliseconds(10))
-        }
-        return condition()
-    }
-
-    private func pollUntil(
-        timeout: Duration,
         condition: @Sendable () async -> Bool
     ) async -> Bool {
         let deadline = ContinuousClock.now.advanced(by: timeout)

--- a/Tests/MacParakeetTests/Audio/AudioRecorderFormatChangeTests.swift
+++ b/Tests/MacParakeetTests/Audio/AudioRecorderFormatChangeTests.swift
@@ -201,9 +201,14 @@ final class AudioRecorderFormatChangeTests: XCTestCase {
 
         let startTask = Task { try await recorder.start() }
         let waitingForFirstBuffer = await pollUntil(timeout: .seconds(2)) {
-            stream.diagnostics.activeSubscriberCount == 1 && stream.diagnostics.engineRunning
+            await recorder.isRecording
+                && stream.diagnostics.activeSubscriberCount == 1
+                && stream.diagnostics.engineRunning
         }
-        XCTAssertTrue(waitingForFirstBuffer, "expected start() to own a subscriber before first-buffer gate")
+        XCTAssertTrue(
+            waitingForFirstBuffer,
+            "expected start() to claim the recorder before waiting on the first-buffer gate"
+        )
 
         do {
             _ = try await recorder.stop()
@@ -1106,6 +1111,18 @@ final class AudioRecorderFormatChangeTests: XCTestCase {
             try? await Task.sleep(for: .milliseconds(10))
         }
         return condition()
+    }
+
+    private func pollUntil(
+        timeout: Duration,
+        condition: @Sendable () async -> Bool
+    ) async -> Bool {
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        while ContinuousClock.now < deadline {
+            if await condition() { return true }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return await condition()
     }
 
     private func makeFormat(

--- a/Tests/MacParakeetTests/Audio/MicrophoneCaptureTests.swift
+++ b/Tests/MacParakeetTests/Audio/MicrophoneCaptureTests.swift
@@ -469,18 +469,19 @@ final class MicrophoneCaptureTests: XCTestCase {
 
     // MARK: - Bluetooth-output avoidance (issues #481/#541/#409)
 
-    func testBluetoothOutputPrefersBuiltInWhenOnSystemDefault() async throws {
+    func testBluetoothOutputPrefersBuiltInWhenOnSystemDefault() throws {
         // System default input is the Bluetooth headset (id 20); built-in is
         // id 30. With output on Bluetooth and no explicit selection, built-in
         // is promoted to the front so capture doesn't force HFP/SCO.
-        let beforeDiagnostics = currentDiagnosticsLogContents()
+        let diagnostics = MicrophoneCaptureDiagnosticsRecorder()
         let attempts = meetingInputDeviceAttempts(
             selectedUID: nil,
             selectedInputDeviceID: { _ in nil },
             defaultInputDevice: { AudioDeviceID(20) },
             builtInMicrophone: { AudioDeviceID(30) },
             preferBuiltInWhenOutputIsBluetooth: true,
-            outputIsBluetooth: { true }
+            outputIsBluetooth: { true },
+            diagnosticsSink: { diagnostics.record($0) }
         )
 
         XCTAssertEqual(
@@ -491,10 +492,7 @@ final class MicrophoneCaptureTests: XCTestCase {
             ],
             "Built-in must lead, with the Bluetooth system default kept as fallback"
         )
-        let line = try await waitForDiagnosticsLine(
-            containing: "mic_attempts_bluetooth_output_policy preference=on explicit_selection_resolved=false",
-            after: beforeDiagnostics
-        )
+        let line = try XCTUnwrap(diagnostics.lastMessage)
         XCTAssertTrue(line.contains("preference=on"))
         XCTAssertTrue(line.contains("explicit_selection_resolved=false"))
         XCTAssertTrue(line.contains("default_output_transport=bluetooth"))
@@ -576,18 +574,19 @@ final class MicrophoneCaptureTests: XCTestCase {
         )
     }
 
-    func testBluetoothOutputKeepsExplicitSelectionFirstAndPinsBuiltInBeforeDefaultFallback() async throws {
+    func testBluetoothOutputKeepsExplicitSelectionFirstAndPinsBuiltInBeforeDefaultFallback() throws {
         // An explicit selection remains first, but if it fails during Bluetooth
         // route churn we still avoid floating to the unpinned headset default
         // before trying the pinned built-in mic.
-        let beforeDiagnostics = currentDiagnosticsLogContents()
+        let diagnostics = MicrophoneCaptureDiagnosticsRecorder()
         let attempts = meetingInputDeviceAttempts(
             selectedUID: "usb-mic",
             selectedInputDeviceID: { uid in uid == "usb-mic" ? AudioDeviceID(10) : nil },
             defaultInputDevice: { AudioDeviceID(20) },
             builtInMicrophone: { AudioDeviceID(30) },
             preferBuiltInWhenOutputIsBluetooth: true,
-            outputIsBluetooth: { true }
+            outputIsBluetooth: { true },
+            diagnosticsSink: { diagnostics.record($0) }
         )
 
         XCTAssertEqual(
@@ -599,10 +598,7 @@ final class MicrophoneCaptureTests: XCTestCase {
             ],
             "Explicit selection must stay first, with built-in pinned before the Bluetooth default fallback"
         )
-        let line = try await waitForDiagnosticsLine(
-            containing: "mic_attempts_bluetooth_output_policy preference=on explicit_selection_resolved=true",
-            after: beforeDiagnostics
-        )
+        let line = try XCTUnwrap(diagnostics.lastMessage)
         XCTAssertTrue(line.contains("preference=on"))
         XCTAssertTrue(line.contains("explicit_selection_resolved=true"))
         XCTAssertTrue(line.contains("default_output_transport=bluetooth"))
@@ -710,9 +706,9 @@ final class MicrophoneCaptureTests: XCTestCase {
         )
     }
 
-    func testBluetoothOutputRuleDisabledLeavesChainUntouched() async throws {
+    func testBluetoothOutputRuleDisabledLeavesChainUntouched() throws {
         var queriedOutput = false
-        let beforeDiagnostics = currentDiagnosticsLogContents()
+        let diagnostics = MicrophoneCaptureDiagnosticsRecorder()
         let attempts = meetingInputDeviceAttempts(
             selectedUID: nil,
             selectedInputDeviceID: { _ in nil },
@@ -722,7 +718,8 @@ final class MicrophoneCaptureTests: XCTestCase {
             outputIsBluetooth: {
                 queriedOutput = true
                 return true
-            }
+            },
+            diagnosticsSink: { diagnostics.record($0) }
         )
 
         XCTAssertEqual(
@@ -733,10 +730,7 @@ final class MicrophoneCaptureTests: XCTestCase {
             ]
         )
         XCTAssertFalse(queriedOutput, "Disabled rule must not query the output transport")
-        let line = try await waitForDiagnosticsLine(
-            containing: "mic_attempts_bluetooth_output_policy preference=off",
-            after: beforeDiagnostics
-        )
+        let line = try XCTUnwrap(diagnostics.lastMessage)
         XCTAssertTrue(line.contains("preference=off"))
         XCTAssertTrue(line.contains("explicit_selection_resolved=false"))
         XCTAssertTrue(line.contains("default_output_transport=not_queried"))
@@ -948,6 +942,21 @@ private final class MicrophoneCaptureTestCounter: @unchecked Sendable {
     private var _value = 0
     func increment() { lock.withLock { _value += 1 } }
     var value: Int { lock.withLock { _value } }
+}
+
+private final class MicrophoneCaptureDiagnosticsRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var messages: [String] = []
+
+    var lastMessage: String? {
+        lock.withLock { messages.last }
+    }
+
+    func record(_ message: String) {
+        lock.withLock {
+            messages.append(message)
+        }
+    }
 }
 
 private struct MicrophoneCaptureTestBufferSnapshot {


### PR DESCRIPTION
## Summary
- Stabilize Bluetooth policy diagnostics assertions by injecting an internal synchronous diagnostics sink in tests while keeping the public `meetingInputDeviceAttempts` API unchanged.
- Tighten `AudioRecorderFormatChangeTests.testSharedModeStopDuringFirstBufferWaitCleansUpRecorder` so it waits for `AudioRecorder` to claim `recording` before exercising the zero-sample stop path.

## Root Cause
- #693: the affected tests were asserting async diagnostics by diffing the shared XCTest diagnostics log, which can pick up unrelated async log lines during full-suite or parallel runs.
- #697: the test used `SharedMicrophoneStream` subscriber state as a proxy for recorder readiness, but the stream can be running before `AudioRecorder.start()` has set `recording = true`; in that earlier state, `stop()` correctly reports `Not recording`.

## Impact
No runtime behavior change. Production diagnostics still flow through `AudioCaptureDiagnostics.appendAsync`; the test-only path captures the same diagnostic string synchronously.

Fixes #693
Fixes #697

## Verification
- `git diff --check`
- `swift test --filter MicrophoneCaptureTests`
- `swift test --filter AudioRecorderFormatChangeTests`
- `swift test --parallel --filter MicrophoneCaptureTests`
- `swift test --parallel --filter AudioRecorderFormatChangeTests`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes flaky audio tests by adding an internal `meetingInputDeviceAttempts(..., diagnosticsSink:)` for tests to capture diagnostics synchronously, and by waiting for `await recorder.isRecording` before zero-sample stop tests. Runtime behavior is unchanged; the public API and production diagnostics still use `AudioCaptureDiagnostics.appendAsync`; fixes #693 and #697.

<sup>Written for commit a71de998e506bd4764d2a3c7e182ecc61ce0a0f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/700?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

