### PR TITLE
Capability registry: decide Phase A field set

### DIFF
--- a/plans/active/2026-07-03-stt-capability-registry.md
+++ b/plans/active/2026-07-03-stt-capability-registry.md
@@ -53,13 +53,27 @@ wave is the cheap ordering.
 
 ### Phase A — capability registry, read-only adoption (the bulk of the win)
 
-1. Define `EngineCapabilities` (small, deliberate field set — start from:
-   `supportsNativeLiveDictation`, `supportsTailPreview`,
-   `providesWordTimestamps`, `supportedLanguages`/language policy,
-   `schedulingClass` (concurrent / cohereSingleFlight),
-   `minimumMemoryBytes: UInt64?`,
-   `modelLifecycle` (download size, deletable, variants), telemetry
-   identity (`telemetryModelKind`, `telemetryEngineVariant`)).
+1. Define `EngineCapabilities` — field set DECIDED 2026-07-04 (design
+   grilling). Admission test: a field earns a row only if it is a stable
+   fact about the engine/variant consulted by existing call sites — not a
+   policy, not a mechanism, not speculation. Two-part structure:
+   - **Behavioral capabilities** (each kills existing switch sites):
+     `supportsNativeLiveDictation` (backed by the NativeLiveDictating
+     conformance invariant), `supportsTailPreview`,
+     `providesWordTimestamps`, `supportedLanguages`/language policy,
+     `supportsCustomVocabulary` (consumed by the custom-vocabulary plan
+     for honest UI gating).
+   - **Declarative metadata**: `modelLifecycle` (download size, deletable,
+     variants, `minimumMemoryBytes: UInt64?` — the Cohere 16 GB gate reads
+     this; it is asset metadata, not a behavioral capability) and telemetry
+     identity (`telemetryModelKind`, `telemetryEngineVariant` — makes
+     wrong-label emission for a new variant structurally impossible).
+   - **Cut: `schedulingClass`.** Exactly one engine is exclusive-admission
+     (Cohere) and a "generic" class named after it is a costume, not an
+     abstraction. `STTScheduler` keeps its explicit Cohere single-flight
+     special case. Reintroduce only when a second exclusive-admission
+     engine actually lands — registry rows are cheap to add later;
+     speculative fields widen what every variant must declare, forever.
 2. Build the exhaustively-keyed registry over `(SpeechEnginePreference,
    variant)`; totality + invariant tests (e.g. "an engine claiming native
    live must conform to `NativeLiveDictating`" — compile-time where


### PR DESCRIPTION
## Summary
Records the design-grilling decision for the registry plan's field set before Phase A dispatch: behavioral capabilities vs declarative metadata split; `supportsCustomVocabulary` added (the custom-vocab plan consumes it); `minimumMemoryBytes` demoted into `modelLifecycle` metadata (Cohere 16 GB gate reads it, but nothing behavioral gates on it); `schedulingClass` cut — one-engine abstractions named after the engine aren't abstractions, and the scheduler's explicit Cohere single-flight case stays put until a second exclusive-admission engine exists.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Docs-only: decide and document the Phase A capability registry field set, splitting it into behavioral capabilities and declarative metadata. Adds `supportsCustomVocabulary`, moves `minimumMemoryBytes` into `modelLifecycle` metadata, and removes `schedulingClass` (scheduler keeps the explicit Cohere single-flight case until a second exclusive-admission engine exists).

<sup>Written for commit 2d0c11f3167df2e046e715368c87c51cd8d727e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/701?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

