### PR TITLE
fix: require valid long-meeting benchmark renders

### DIFF
--- a/Tests/MacParakeetTests/Benchmarks/LongMeetingPipelineBenchmarkTests.swift
+++ b/Tests/MacParakeetTests/Benchmarks/LongMeetingPipelineBenchmarkTests.swift
@@ -37,6 +37,8 @@ final class LongMeetingPipelineBenchmarkTests: XCTestCase {
     private static let localVQELibraryKey = "MACPARAKEET_TEST_LOCALVQE_LIBRARY"
     private static let localVQEModelKey = "MACPARAKEET_TEST_LOCALVQE_MODEL"
     private static let localVQEModelSHAKey = "MACPARAKEET_TEST_LOCALVQE_MODEL_SHA256"
+    private static let benchmarkRenderTimeoutFloorSeconds: TimeInterval = 60
+    private static let benchmarkRenderTimeoutMultiplier: Double = 6
 
     func testDefaultDualTrackMeetingPostStopPipelineBenchmark() async throws {
         let env = ProcessInfo.processInfo.environment
@@ -70,6 +72,7 @@ final class LongMeetingPipelineBenchmarkTests: XCTestCase {
             updating: queued.id,
             onProgress: nil
         )
+        try assertCleanedMicrophonePipelineValidity(recording: cleanedRecording)
 
         let rows = collector.rows()
         XCTAssertFalse(rows.isEmpty)
@@ -126,9 +129,10 @@ final class LongMeetingPipelineBenchmarkTests: XCTestCase {
         env: [String: String],
         collector: StageMetricsCollector
     ) async throws -> MeetingRecordingOutput {
+        let stage = "decode+aec_render"
         let outputURL = recording.folderURL.appendingPathComponent(
             MeetingCleanedMicRenderer.cleanedMicrophoneFileName)
-        let readiness = try await collector.measure(stage: "decode+aec_render") {
+        let renderedURL = try await collector.measure(stage: stage) { () async throws -> URL in
             let readiness = MeetingCleanedMicrophoneRenderScheduler.schedule(
                 outputURL: outputURL,
                 microphoneURL: recording.microphoneAudioURL,
@@ -139,10 +143,30 @@ final class LongMeetingPipelineBenchmarkTests: XCTestCase {
                 fileManager: .default,
                 eventName: "long_meeting_pipeline_bench_cleaned_mic"
             )
-            _ = try await readiness.awaitCompletion(
-                timeoutSeconds: max(60, recording.durationSeconds * 2)
+            // Benchmark-only safety valve: this must measure the render to completion,
+            // not production's user-facing fallback budget.
+            let timeoutSeconds = Self.benchmarkRenderTimeoutSeconds(
+                for: recording.durationSeconds
             )
-            return readiness
+            let completion = try await readiness.awaitCompletion(timeoutSeconds: timeoutSeconds)
+            switch completion {
+            case .rendered(let url, _):
+                collector.setOutcome("rendered", for: stage)
+                return url
+            case .fallback(let reason, _):
+                let outcome = "fallback:\(reason.rawValue)"
+                collector.setOutcome(outcome, for: stage)
+                throw benchmarkFailure(
+                    "Cleaned microphone render did not complete: \(outcome)"
+                )
+            case nil:
+                let reason = MeetingCleanedMicrophoneRoutingReason.rawTimeout
+                let outcome = "fallback:\(reason.rawValue)"
+                collector.setOutcome(outcome, for: stage)
+                throw benchmarkFailure(
+                    "Cleaned microphone render timed out after benchmark-only safety cap \(String(format: "%.1f", timeoutSeconds))s: \(outcome)"
+                )
+            }
         }
 
         return MeetingRecordingOutput(
@@ -152,7 +176,7 @@ final class LongMeetingPipelineBenchmarkTests: XCTestCase {
             mixedAudioURL: recording.mixedAudioURL,
             microphoneAudioURL: recording.microphoneAudioURL,
             systemAudioURL: recording.systemAudioURL,
-            cleanedMicrophoneAudioURL: readiness.outputURL,
+            cleanedMicrophoneAudioURL: renderedURL,
             cleanedMicrophoneReadiness: nil,
             durationSeconds: recording.durationSeconds,
             sourceAlignment: recording.sourceAlignment,
@@ -160,6 +184,37 @@ final class LongMeetingPipelineBenchmarkTests: XCTestCase {
             speechEngineWasCaptured: recording.speechEngineWasCaptured,
             userNotes: recording.userNotes
         )
+    }
+
+    private static func benchmarkRenderTimeoutSeconds(for recordingDuration: TimeInterval) -> TimeInterval {
+        max(benchmarkRenderTimeoutFloorSeconds, recordingDuration * benchmarkRenderTimeoutMultiplier)
+    }
+
+    private func assertCleanedMicrophonePipelineValidity(recording: MeetingRecordingOutput) throws {
+        let cleanedURL = recording.folderURL.appendingPathComponent(
+            MeetingCleanedMicRenderer.cleanedMicrophoneFileName
+        )
+        guard FileManager.default.fileExists(atPath: cleanedURL.path) else {
+            throw benchmarkFailure("Cleaned microphone artifact is missing: \(cleanedURL.path)")
+        }
+        guard recording.validatedMicrophoneTranscriptionURL() == cleanedURL else {
+            throw benchmarkFailure(
+                "Final STT routing did not select the cleaned microphone artifact: \(cleanedURL.path)"
+            )
+        }
+
+        let metadata = try MeetingRecordingMetadataStore.load(from: recording.folderURL)
+        let reason = metadata.echoSuppression?.reasonCode
+        guard reason == .cleanedUsed else {
+            throw benchmarkFailure(
+                "Final STT routing metadata is not cleanedUsed: \(reason?.rawValue ?? "missing")"
+            )
+        }
+    }
+
+    private func benchmarkFailure(_ message: String) -> BenchmarkError {
+        XCTFail(message)
+        return .invalidFixture(message)
     }
 
     private func makeFixture(env: [String: String], runID: String) async throws -> BenchmarkFixture {
@@ -416,11 +471,11 @@ final class LongMeetingPipelineBenchmarkTests: XCTestCase {
             "- Recording duration: \(String(format: "%.3f", recording.durationSeconds)) s",
             "- Synthetic fixture: \(fixture.synthetic ? "yes" : "no")",
             "",
-            "| Run | Fixture | Stage | Recording duration (s) | Elapsed (s) | Realtime factor | Peak RSS delta (MB) |",
-            "|---|---|---|---:|---:|---:|---:|",
+            "| Run | Fixture | Stage | Outcome | Recording duration (s) | Elapsed (s) | Realtime factor | Peak RSS delta (MB) |",
+            "|---|---|---|---|---:|---:|---:|---:|",
         ]
         lines += rows.map { row in
-            "| \(runID) | \(fixture.name) | \(row.stage) | \(String(format: "%.3f", recording.durationSeconds)) | \(String(format: "%.4f", row.elapsedSeconds)) | \(String(format: "%.2fx", row.realtimeFactor)) | \(String(format: "%.1f", row.peakRSSDeltaMB)) |"
+            "| \(runID) | \(fixture.name) | \(row.stage) | \(row.outcome ?? "-") | \(String(format: "%.3f", recording.durationSeconds)) | \(String(format: "%.4f", row.elapsedSeconds)) | \(String(format: "%.2fx", row.realtimeFactor)) | \(String(format: "%.1f", row.peakRSSDeltaMB)) |"
         }
         return lines.joined(separator: "\n")
     }
@@ -494,6 +549,7 @@ private enum BenchmarkError: Error, LocalizedError {
 private final class StageMetricsCollector: @unchecked Sendable {
     struct Row: Equatable {
         let stage: String
+        let outcome: String?
         let elapsedSeconds: Double
         let realtimeFactor: Double
         let peakRSSDeltaMB: Double
@@ -521,6 +577,7 @@ private final class StageMetricsCollector: @unchecked Sendable {
     private let recordingDurationSeconds: Double
     private let lock = NSLock()
     private var running: [String: RunningStage] = [:]
+    private var outcomes: [String: String] = [:]
     private var completedRows: [Row] = []
 
     init(recordingDurationSeconds: Double) {
@@ -551,23 +608,30 @@ private final class StageMetricsCollector: @unchecked Sendable {
     func end(_ stage: String) {
         let now = ProcessInfo.processInfo.systemUptime
         let rss = Self.currentResidentRSS()
-        let run = lock.withLock { () -> RunningStage? in
+        let result = lock.withLock { () -> (RunningStage, String?)? in
             guard let run = running.removeValue(forKey: stage) else { return nil }
             run.peakRSS = max(run.peakRSS, rss)
-            return run
+            return (run, outcomes.removeValue(forKey: stage))
         }
-        guard let run else { return }
+        guard let (run, outcome) = result else { return }
         run.timer?.cancel()
         let elapsed = max(0, now - run.startedAt)
         let peakDelta = run.peakRSS > run.baselineRSS ? run.peakRSS - run.baselineRSS : 0
         let row = Row(
             stage: run.stage,
+            outcome: outcome,
             elapsedSeconds: elapsed,
             realtimeFactor: elapsed > 0 ? recordingDurationSeconds / elapsed : 0,
             peakRSSDeltaMB: Double(peakDelta) / 1_048_576.0
         )
         lock.withLock {
             completedRows.append(row)
+        }
+    }
+
+    func setOutcome(_ outcome: String, for stage: String) {
+        lock.withLock {
+            outcomes[stage] = outcome
         }
     }
 

--- a/Tests/MacParakeetTests/Benchmarks/LongMeetingPipelineBenchmarkTests.swift
+++ b/Tests/MacParakeetTests/Benchmarks/LongMeetingPipelineBenchmarkTests.swift
@@ -203,7 +203,14 @@ final class LongMeetingPipelineBenchmarkTests: XCTestCase {
             )
         }
 
-        let metadata = try MeetingRecordingMetadataStore.load(from: recording.folderURL)
+        let metadata: MeetingRecordingMetadata
+        do {
+            metadata = try MeetingRecordingMetadataStore.load(from: recording.folderURL)
+        } catch {
+            throw benchmarkFailure(
+                "Failed to load meeting recording metadata for \(recording.folderURL.path): \(error.localizedDescription)"
+            )
+        }
         let reason = metadata.echoSuppression?.reasonCode
         guard reason == .cleanedUsed else {
             throw benchmarkFailure(
@@ -213,8 +220,7 @@ final class LongMeetingPipelineBenchmarkTests: XCTestCase {
     }
 
     private func benchmarkFailure(_ message: String) -> BenchmarkError {
-        XCTFail(message)
-        return .invalidFixture(message)
+        .invalidFixture(message)
     }
 
     private func makeFixture(env: [String: String], runID: String) async throws -> BenchmarkFixture {


### PR DESCRIPTION
## Summary

Long-meeting benchmark runs can no longer publish successful-looking AEC measurements after cleaned-mic render fallback. The harness now treats only `.rendered` completion as valid, uses a benchmark-only 6x-duration safety cap instead of the old 2x timeout, records the `decode+aec_render` outcome in the markdown table, and fails after final transcription unless `microphone-cleaned.m4a` exists and metadata records `cleanedUsed` routing.

The defect this closes: the first real 42.7-minute run discarded `awaitCompletion`, timed out at ~5127.7s, continued on raw mic fallback, recorded `echoSuppression.reasonCode = rawInvalidArtifact`, and still printed a table that looked like a successful full-pipeline measurement.

Spec alignment: `plans/active/2026-07-04-long-meeting-aec-policy.md` Phase 1b (this PR closes the harness-validity gap found in its first real run).

## Validation

- `swift test --filter LongMeetingPipelineBenchmark` with the gate unset: passed with the single benchmark test skipped.
- Rebased onto current `origin/main`, then reran `swift test --filter LongMeetingPipelineBenchmark` with the gate unset: passed with the single benchmark test skipped.
- `git diff --check`: passed.
- LocalVQE assets verified present before runs:
  - `/Users/dmoon/code/macparakeet-worktrees/latest-main-run/.build/meeting-echo-assets/lib/liblocalvqe.dylib`
  - `/Users/dmoon/code/macparakeet-worktrees/latest-main-run/.build/meeting-echo-assets/model/localvqe-v1.4-aec-200K-f32.gguf`

## Clean Run Status

The requested clean data run could not complete all three fixtures honestly:

- Smoke fixture `58C24721-9E24-4661-824E-32F9EECE8CA6` failed immediately with `fallback:skippedNoEchoPath`. No result table was emitted, which is the new intended behavior for fallback.
- Mid fixture `8FA83AD0-DDE6-449A-8274-9BBB64B29B98` rendered and passed the validity gate, but the render time was wildly off the audit baseline: `3010.8895s` at `0.51x` versus the prior AEC-only audit's `124.01s` at `12.50x`.
- Long fixture `7FF9C81D-74EF-4F73-AA91-0422397EFA75` was not run. The brief said to stop if cleaned-mic render landed more than 2x slower than the 42.7-minute audit anchor; the mid fixture was about 24.3x slower than its own audit row, so continuing to the 42.7-minute run would have burned hours on dirty data.

Machine context was recorded before runs. The final pre-mid snapshot after waiting for Swift/external CPU work to clear was: `Load Avg: 3.48, 5.00, 6.48`; `CPU usage: 10.30% user, 11.49% sys, 78.19% idle`.

### Mid Fixture Table

```markdown
### Long Meeting Full Pipeline Benchmark - 2026-07-04T10:37:14Z

- Fixture: 8FA83AD0-DDE6-449A-8274-9BBB64B29B98
- Source: /Users/dmoon/Library/Application Support/MacParakeet/meeting-recordings/8FA83AD0-DDE6-449A-8274-9BBB64B29B98
- Working copy: /tmp/claude-502/-Users-dmoon-code-macparakeet/b0d028ac-a245-4222-b6fc-76e336fe62bf/scratchpad/bench-work/5F88E9DD-20C8-45A0-A121-4B0C88FA41C4/8FA83AD0-DDE6-449A-8274-9BBB64B29B98
- Recording duration: 1549.500 s
- Synthetic fixture: no

| Run | Fixture | Stage | Outcome | Recording duration (s) | Elapsed (s) | Realtime factor | Peak RSS delta (MB) |
|---|---|---|---|---:|---:|---:|---:|
| 2026-07-04T10:37:14Z | 8FA83AD0-DDE6-449A-8274-9BBB64B29B98 | decode+aec_render | rendered | 1549.500 | 3010.8895 | 0.51x | 306.3 |
| 2026-07-04T10:37:14Z | 8FA83AD0-DDE6-449A-8274-9BBB64B29B98 | mic_stt | - | 1549.500 | 5.3006 | 292.33x | 199.1 |
| 2026-07-04T10:37:14Z | 8FA83AD0-DDE6-449A-8274-9BBB64B29B98 | system_stt | - | 1549.500 | 4.7117 | 328.86x | 98.5 |
| 2026-07-04T10:37:14Z | 8FA83AD0-DDE6-449A-8274-9BBB64B29B98 | diarization | - | 1549.500 | 6.0642 | 255.52x | 424.1 |
| 2026-07-04T10:37:14Z | 8FA83AD0-DDE6-449A-8274-9BBB64B29B98 | finalize_merge | - | 1549.500 | 0.0906 | 17109.25x | 0.4 |
```

## Post-Deploy Monitoring & Validation

No production monitoring is required because this is a tests-only benchmark harness change. Healthy signal for future benchmark runs: `decode+aec_render` reports `Outcome = rendered`, `microphone-cleaned.m4a` exists in the copied working fixture, and meeting metadata records `echoSuppression.reasonCode = cleanedUsed`. Failure signal: any fallback or timeout fails the benchmark instead of appending a successful-looking table.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent long-meeting benchmarks from reporting success unless the cleaned-mic render actually completes. Fail on any fallback or timeout, and clearly show render outcomes in the results.

- **Bug Fixes**
  - Treat `decode+aec_render` as valid only on `.rendered`; record fallback/timeout outcome, show it in the table, then fail.
  - Use a benchmark-only 6× duration cap (min 60s) to measure render completion.
  - After transcription, require `microphone-cleaned.m4a` to exist, be the selected STT source, and `echoSuppression.reasonCode = cleanedUsed`; include fixture path in metadata-load errors and remove redundant `XCTFail`.

<sup>Written for commit f5405fb67f563a3af30427e566a64a0e7da6bb3c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/703?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

