### PR TITLE
Speed up meeting echo delay estimation

### DIFF
--- a/Sources/MacParakeetCore/Services/Capture/MeetingEchoDelayEstimator.swift
+++ b/Sources/MacParakeetCore/Services/Capture/MeetingEchoDelayEstimator.swift
@@ -1,3 +1,4 @@
+import Accelerate
 import Foundation
 
 /// The result of estimating how far the microphone's echo lags the system-audio
@@ -74,38 +75,27 @@ struct MeetingEchoDelayEstimator: Sendable {
         return micEmphasized.withUnsafeBufferPointer { mic in
             refEmphasized.withUnsafeBufferPointer { ref in
                 var micEnergy: Float = 0
-                for n in windowStart..<count {
-                    micEnergy += mic[n] * mic[n]
-                }
+                let vectorLength = vDSP_Length(windowLength)
+                let micStart = mic.baseAddress!.advanced(by: windowStart)
+                vDSP_dotpr(micStart, 1, micStart, 1, &micEnergy, vectorLength)
                 guard micEnergy > 0 else { return nil }
-
-                var refEnergies: [Float] = []
-                refEnergies.reserveCapacity(maxLagSamples + 1)
-                var currentRefEnergy: Float = 0
-                for n in windowStart..<count {
-                    let r = ref[n]
-                    currentRefEnergy += r * r
-                }
-                refEnergies.append(currentRefEnergy)
-                if maxLagSamples > 0 {
-                    for lag in 1...maxLagSamples {
-                        let removed = ref[count - lag]
-                        let added = ref[windowStart - lag]
-                        currentRefEnergy += added * added - removed * removed
-                        refEnergies.append(max(0, currentRefEnergy))
-                    }
-                }
 
                 var bestLag = 0
                 var bestScore: Float = 0  // |normalized correlation|
                 for lag in 0...maxLagSamples {
-                    let refEnergy = refEnergies[lag]
+                    let refStart = ref.baseAddress!.advanced(by: windowStart - lag)
+                    var refEnergy: Float = 0
+                    vDSP_dotpr(refStart, 1, refStart, 1, &refEnergy, vectorLength)
                     guard refEnergy > 0 else { continue }
                     var cross: Float = 0
-                    for n in windowStart..<count {
-                        let r = ref[n - lag]
-                        cross += mic[n] * r
-                    }
+                    vDSP_dotpr(
+                        micStart,
+                        1,
+                        refStart,
+                        1,
+                        &cross,
+                        vectorLength
+                    )
                     let normalized = cross / (micEnergy * refEnergy).squareRoot()
                     let score = min(1, abs(normalized))
                     if score > bestScore {

--- a/Tests/MacParakeetTests/Services/Capture/MeetingEchoDelayEstimatorTests.swift
+++ b/Tests/MacParakeetTests/Services/Capture/MeetingEchoDelayEstimatorTests.swift
@@ -1,3 +1,5 @@
+import Foundation
+import Dispatch
 import XCTest
 @testable import MacParakeetCore
 
@@ -15,8 +17,9 @@ final class MeetingEchoDelayEstimatorTests: XCTestCase {
 
         let estimate = estimator.estimate(microphone: scenario.mic, reference: scenario.farEnd)
         XCTAssertNotNil(estimate)
-        print("[AEC] delay estimate (far-end-only): \(estimate?.delaySamples ?? -1) samples, "
-            + "confidence \(String(format: "%.2f", estimate?.confidence ?? 0))")
+        print(
+            "[AEC] delay estimate (far-end-only): \(estimate?.delaySamples ?? -1) samples, "
+                + "confidence \(String(format: "%.2f", estimate?.confidence ?? 0))")
         XCTAssertEqual(estimate!.delaySamples, 600, accuracy: 2, "recovers the true bulk delay")
         XCTAssertGreaterThan(estimate!.confidence, 0.5, "a clean echo is a confident estimate")
     }
@@ -29,8 +32,9 @@ final class MeetingEchoDelayEstimatorTests: XCTestCase {
 
         let estimate = estimator.estimate(microphone: scenario.mic, reference: scenario.farEnd)
         XCTAssertNotNil(estimate, "the echo is still findable when the local speaker overlaps it")
-        print("[AEC] delay estimate (double-talk): \(estimate?.delaySamples ?? -1) samples, "
-            + "confidence \(String(format: "%.2f", estimate?.confidence ?? 0))")
+        print(
+            "[AEC] delay estimate (double-talk): \(estimate?.delaySamples ?? -1) samples, "
+                + "confidence \(String(format: "%.2f", estimate?.confidence ?? 0))")
         XCTAssertEqual(estimate!.delaySamples, 600, accuracy: 5, "locks onto the dominant tap despite near-end energy")
     }
 
@@ -70,6 +74,67 @@ final class MeetingEchoDelayEstimatorTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(estimate!.confidence, 0)
     }
 
+    func testKnownLagConfidenceMatchesScalarFormula() {
+        let farOnly = MeetingAecScenarioFactory.make(
+            name: "far-end-only",
+            nearEndActive: false,
+            farEndActive: true,
+            echoPath: MeetingAecEchoPath(taps: [(delay: 600, gain: 0.6)])
+        )
+        let doubleTalk = MeetingAecScenarioFactory.make(
+            name: "double-talk",
+            nearEndActive: true,
+            farEndActive: true,
+            echoPath: MeetingAecEchoPath(
+                taps: [(delay: 600, gain: 0.6), (delay: 640, gain: 0.25), (delay: 680, gain: 0.12)])
+        )
+        let representative = Self.makeRepresentativeFixture()
+        let cases = [
+            (name: "far-end-only", microphone: farOnly.mic, reference: farOnly.farEnd, delay: 600),
+            (name: "double-talk", microphone: doubleTalk.mic, reference: doubleTalk.farEnd, delay: 600),
+            (
+                name: "representative-window", microphone: representative.microphone,
+                reference: representative.reference, delay: representative.delay
+            ),
+        ]
+
+        for testCase in cases {
+            let estimate = estimator.estimate(microphone: testCase.microphone, reference: testCase.reference)
+
+            XCTAssertNotNil(estimate, testCase.name)
+            XCTAssertEqual(estimate!.delaySamples, testCase.delay, "keeps the same chosen lag for \(testCase.name)")
+            XCTAssertEqual(
+                estimate!.confidence,
+                Self.scalarConfidence(
+                    microphone: testCase.microphone,
+                    reference: testCase.reference,
+                    lag: testCase.delay,
+                    estimator: estimator
+                )!,
+                accuracy: 0.0001,
+                "keeps the normalized-correlation value equivalent to the scalar formula for \(testCase.name)"
+            )
+        }
+    }
+
+    func testRepresentativeEstimateCompletesWithinSanityBudget() {
+        let fixture = Self.makeRepresentativeFixture()
+        _ = estimator.estimate(microphone: fixture.microphone, reference: fixture.reference)
+
+        let start = DispatchTime.now().uptimeNanoseconds
+        let estimate = estimator.estimate(microphone: fixture.microphone, reference: fixture.reference)
+        let elapsedMs = Double(DispatchTime.now().uptimeNanoseconds - start) / 1_000_000
+
+        XCTAssertNotNil(estimate)
+        XCTAssertEqual(estimate!.delaySamples, fixture.delay)
+        print("[AEC] estimator representative call: \(String(format: "%.2f", elapsedMs)) ms")
+        XCTAssertLessThan(
+            elapsedMs,
+            200,
+            "representative delay estimation should stay comfortably below offline-render throughput limits"
+        )
+    }
+
     /// The money test: a large bulk delay (600 samples) that a fixed zero offset
     /// cannot align. Uses the oracle subtractor so the result reflects *alignment*
     /// alone, not a filter's incidental ability to predict a periodic reference —
@@ -95,9 +160,66 @@ final class MeetingEchoDelayEstimatorTests: XCTestCase {
         let estimatedOut = MeetingAecRunner.run(estimated, scenario: scenario)
         let estimatedERLE = MeetingAecMetrics.erleDB(mic: scenario.mic, output: estimatedOut, over: window)
 
-        print("[AEC] cancellation vs delay handling: static-zero \(String(format: "%.1f", zeroERLE)) dB "
-            + "-> estimated-delay \(String(format: "%.1f", estimatedERLE)) dB")
+        print(
+            "[AEC] cancellation vs delay handling: static-zero \(String(format: "%.1f", zeroERLE)) dB "
+                + "-> estimated-delay \(String(format: "%.1f", estimatedERLE)) dB")
         XCTAssertLessThan(zeroERLE, 5, "a large bulk delay is uncancellable with a static zero offset")
         XCTAssertGreaterThan(estimatedERLE, 20, "the estimated delay realigns the reference and cancels the echo")
+    }
+
+    private static func makeRepresentativeFixture(
+        delay: Int = 600,
+        maxLagSamples: Int = 1_600,
+        analysisWindowSamples: Int = 8_192
+    ) -> (microphone: [Float], reference: [Float], delay: Int) {
+        let sampleCount = maxLagSamples + analysisWindowSamples
+        let scenario = MeetingAecScenarioFactory.make(
+            name: "representative-estimator-window",
+            nearEndActive: true,
+            farEndActive: true,
+            echoPath: MeetingAecEchoPath(taps: [(delay: delay, gain: 0.6)]),
+            sampleCount: sampleCount,
+            noiseLevel: 0.0001
+        )
+        return (scenario.mic, scenario.farEnd, delay)
+    }
+
+    private static func scalarConfidence(
+        microphone: [Float],
+        reference: [Float],
+        lag: Int,
+        estimator: MeetingEchoDelayEstimator
+    ) -> Float? {
+        let count = min(microphone.count, reference.count)
+        guard count > estimator.maxLagSamples + 1, lag >= 0, lag <= estimator.maxLagSamples else { return nil }
+
+        let micEmphasized = preEmphasized(microphone, coefficient: estimator.preEmphasis, count: count)
+        let refEmphasized = preEmphasized(reference, coefficient: estimator.preEmphasis, count: count)
+        let windowLength = min(estimator.analysisWindowSamples, count - estimator.maxLagSamples)
+        let windowStart = count - windowLength
+
+        var micEnergy: Float = 0
+        var refEnergy: Float = 0
+        var cross: Float = 0
+        for n in windowStart..<count {
+            let mic = micEmphasized[n]
+            let ref = refEmphasized[n - lag]
+            micEnergy += mic * mic
+            refEnergy += ref * ref
+            cross += mic * ref
+        }
+        guard micEnergy > 0, refEnergy > 0 else { return nil }
+        let normalized = cross / (micEnergy * refEnergy).squareRoot()
+        return min(1, abs(normalized))
+    }
+
+    private static func preEmphasized(_ signal: [Float], coefficient: Float, count: Int) -> [Float] {
+        guard coefficient != 0, count > 0 else { return Array(signal.prefix(count)) }
+        var out = [Float](repeating: 0, count: count)
+        out[0] = signal[0]
+        for n in 1..<count {
+            out[n] = signal[n] - coefficient * signal[n - 1]
+        }
+        return out
     }
 }

--- a/Tests/MacParakeetTests/Services/Capture/MeetingEchoDelayEstimatorTests.swift
+++ b/Tests/MacParakeetTests/Services/Capture/MeetingEchoDelayEstimatorTests.swift
@@ -8,6 +8,11 @@ import XCTest
 /// static offset, and recovering it from the audio restores it.
 final class MeetingEchoDelayEstimatorTests: XCTestCase {
 
+    /// Regression tripwire, not benchmark evidence. The scalar implementation
+    /// measured around 1,394 ms for this fixture; this budget leaves debug/CI
+    /// scheduling headroom while still catching a return to scalar-speed work.
+    private static let representativeEstimateBudgetMs: Double = 1_000
+
     private let estimator = MeetingEchoDelayEstimator()
 
     func testRecoversBulkDelayOnFarEndOnly() {
@@ -130,8 +135,8 @@ final class MeetingEchoDelayEstimatorTests: XCTestCase {
         print("[AEC] estimator representative call: \(String(format: "%.2f", elapsedMs)) ms")
         XCTAssertLessThan(
             elapsedMs,
-            200,
-            "representative delay estimation should stay comfortably below offline-render throughput limits"
+            Self.representativeEstimateBudgetMs,
+            "representative delay estimation should stay comfortably below the scalar-regression budget"
         )
     }
 


### PR DESCRIPTION
## Summary
Adaptive reference-delay estimation stays on, but `MeetingEchoDelayEstimator` now scores each lag with Accelerate/vDSP dot products instead of Swift scalar nested loops. The cadence, windowing, pre-emphasis, confidence gate, suppressor frame carry, and offline/live adaptive-delay semantics are unchanged.

## Root cause recap
Fable-reviewed sub-stage timing traced the slowdown to this path:

`MeetingCleanedMicRenderer.render` -> `alignAndCondition` -> `StreamingMeetingEchoSuppressor.condition` -> `MeetingEchoDelayEstimator.estimate`

The estimator is active when `adaptiveReferenceDelay` is true and is invoked every 0.5 s of audio. The old normalized cross-correlation searched every lag with a Swift loop over every window sample, costing about **1.39 s per call**. On the retained 1549.5 s fixture, disabling the estimator rendered in **120.29 s / 12.88x**, while adaptive-on render fell to roughly **0.5x realtime**. Related long-meeting runtime context: [`docs/audits/2026-07-04-localvqe-aec-runtime-findings.md`](https://github.com/moona3k/macparakeet/blob/main/docs/audits/2026-07-04-localvqe-aec-runtime-findings.md).

## Design
This keeps the settled estimator shape and optimizes only the math:

- use `vDSP_dotpr` for microphone energy, reference energy, and cross-correlation over each lag window
- keep the existing most-recent window selection and pre-emphasis
- keep the existing `minConfidence` gate and nil behavior for silence/weak correlation
- keep default live capture cadence unchanged
- do not disable or sparsify offline adaptive delay

One detail worth calling out: the denominator uses the same vDSP primitive as the numerator. A mixed scalar/vector reduction can move identical-signal normalized correlation just below `1.0`, which would change the clamped `minConfidence == 1` behavior.

Spec alignment: this unblocks the real-meeting benchmark threshold gate in [`plans/active/2026-07-04-long-meeting-aec-policy.md`](https://github.com/moona3k/macparakeet/blob/main/plans/active/2026-07-04-long-meeting-aec-policy.md) while preserving the adaptive cleaned-mic path required for issue #605.

## Evidence
Estimator-level before/after on the representative 1,600-lag / 8,192-window call:

| Version | Per-call elapsed | Notes |
|---|---:|---|
| Before | 1393.78 ms | Red perf guard on scalar implementation |
| After | 4.75 ms | `swift test --filter MeetingEchoDelayEstimatorTests` |

Known-lag equivalence:

| Vector | Chosen lag | Scalar confidence parity |
|---|---:|---|
| far-end-only | 600 | within 1e-4 |
| double-talk | 600 | within 1e-4 |
| representative-window | 600 | within 1e-4 |

End-to-end retained fixture, adaptive delay ON:

| Version | Fixture duration | decode+aec_render elapsed | Realtime factor | Cleaned artifact |
|---|---:|---:|---:|---|
| Before | 1549.500 s | roughly 0.5x realtime | ~0.5x | bottlenecked |
| After | 1549.500 s | 132.5490 s | 11.69x | `microphone-cleaned.m4a` present, 4.5 MB |

Full benchmark row from this branch:

| Run | Fixture | Stage | Recording duration (s) | Elapsed (s) | Realtime factor | Peak RSS delta (MB) |
|---|---|---|---:|---:|---:|---:|
| 2026-07-04T12:29:44Z | 8FA83AD0-DDE6-449A-8274-9BBB64B29B98 | decode+aec_render | 1549.500 | 132.5490 | 11.69x | 308.7 |

## Verification
- `swift test --filter MeetingEchoDelayEstimatorTests`
- `swift test --filter MeetingAec`
- `swift test --filter MeetingEchoSuppressorTests/testAdaptiveSuppressorRecoversLargeBulkDelayFromZeroSeed`
- Env-gated `swift test --filter LongMeetingPipelineBenchmarkTests` with:
  - `MACPARAKEET_LONG_MEETING_PIPELINE_BENCH=1`
  - `MACPARAKEET_LONG_MEETING_SESSION=/Users/dmoon/Library/Application Support/MacParakeet/meeting-recordings/8FA83AD0-DDE6-449A-8274-9BBB64B29B98`
  - LocalVQE assets from `/Users/dmoon/code/macparakeet-worktrees/latest-main-run/.build/meeting-echo-assets/`
- Manual artifact check: copied run folder contains `microphone-cleaned.m4a` (4.5 MB)
- `git diff --check`

## Risk surface
The main risk is numerical drift in the delay estimator. The new test coverage checks exact known lags and scalar normalized-correlation parity within `1e-4` on the existing far-end-only/double-talk vectors plus a representative production-sized window.

No cadence, readiness, provenance, LocalVQE binding, or fallback policy changes are included.

## Post-Deploy Monitoring & Validation
- Watch logs for `meeting_echo_delay_adopted` with reasonable `delay_samples` and confidence values.
- Watch cleaned-mic render readiness: healthy signal is successful `microphone-cleaned.m4a` creation before readiness timeout; failure signal is timeout/raw fallback on meetings that should complete under the policy threshold.
- Re-run the env-gated retained-fixture benchmark after merge if CI or hardware changes are suspected; healthy threshold is `decode+aec_render >= 10x` on the 1549.5 s fixture.
- Rollback trigger: adaptive-on render falls below 10x on the retained fixture, known-lag tests regress, or cleaned artifact creation fails while raw inputs are valid.
- Validation window: next local long-meeting benchmark / #605 QA pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Vectorized the echo delay estimator using `vDSP` dot products to remove the offline AEC bottleneck while keeping cadence, gating, and behavior unchanged. Long‑meeting render returns to 11.69x realtime on the 1549.5 s fixture.

- **Performance**
  - Uses `Accelerate`/`vDSP` for mic/ref energy and cross‑correlation when scoring lags.
  - Estimator call: ~1393.78 ms -> 4.75 ms on 1,600‑lag / 8,192‑window.
  - End‑to‑end (adaptive ON): 132.55 s for 1549.5 s recording (11.69x).

- **Verification**
  - Known‑lag tests match scalar normalized correlation within 1e‑4 (far‑end‑only, double‑talk, representative window).
  - Perf sanity guard is now a 1,000 ms scalar‑regression tripwire to avoid flaky microbenchmarks.

<sup>Written for commit 0f705ab0ec63fc7661d9183f9b8559a0479e213d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/704?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

