### PR TITLE
Add meeting source health UI

### DIFF
--- a/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
@@ -220,9 +220,12 @@ final class MeetingRecordingFlowCoordinator {
         microphoneMuteToggleTask?.cancel()
         microphoneMuteToggleTask = Task { @MainActor [meetingRecordingService, weak self] in
             let microphoneMuteState = await meetingRecordingService.setMicrophoneMuted(wantMuted)
+            let captureHealth = await meetingRecordingService.captureHealth
             guard !Task.isCancelled, let self else { return }
             self.panelViewModel?.isMicrophoneMuted = microphoneMuteState.isMuted
             self.panelViewModel?.canToggleMicrophoneMute = microphoneMuteState.canMute
+            self.panelViewModel?.captureHealth = captureHealth
+            self.pillViewModel.captureHealth = captureHealth
         }
     }
 
@@ -493,22 +496,25 @@ final class MeetingRecordingFlowCoordinator {
             // celebration from the previous meeting (back-to-back): cancel its
             // dismiss/min-display tasks so they can't tear down this fresh pill.
             cancelSavedCompletion()
+            let initialSourceMode = pendingAudioSourceMode ?? meetingAudioSourceModeProvider()
+            let initialCaptureHealth = MeetingCaptureHealthSummary.starting(sourceMode: initialSourceMode)
             let vm = pillViewModel
             vm.onStop = { [weak self] in self?.toggleRecording() }
             vm.onPauseToggle = { [weak self] in self?.togglePause() }
             vm.elapsedSeconds = 0
             vm.micLevel = 0
             vm.systemLevel = 0
+            vm.captureHealth = initialCaptureHealth
             vm.state = .recording
             let panelVM = panelViewModel ?? MeetingRecordingPanelViewModel()
             panelVM.state = .recording
             panelVM.elapsedSeconds = 0
             panelVM.micLevel = 0
             panelVM.systemLevel = 0
+            panelVM.captureHealth = initialCaptureHealth
             panelVM.isPaused = false
             panelVM.isMicrophoneMuted = false
-            panelVM.canToggleMicrophoneMute =
-                (pendingAudioSourceMode ?? meetingAudioSourceModeProvider()).capturesMicrophone
+            panelVM.canToggleMicrophoneMute = initialSourceMode.capturesMicrophone
             panelVM.updateLiveTranscriptStatus(.startingAudio)
             panelVM.updatePreviewLines([], isTranscriptionLagging: false)
             refreshInitialLiveTranscriptStatus(for: panelVM)
@@ -647,6 +653,7 @@ final class MeetingRecordingFlowCoordinator {
             cancelSavedCompletion()
             pillViewModel.micLevel = 0
             pillViewModel.systemLevel = 0
+            pillViewModel.captureHealth = .notRecording
             pillViewModel.state = .completing
             pillController?.refreshState()
             pillViewModel.onCompletionAnimationFinished = { [weak self] in
@@ -660,6 +667,7 @@ final class MeetingRecordingFlowCoordinator {
             panelViewModel?.state = .transcribing
             panelViewModel?.micLevel = 0
             panelViewModel?.systemLevel = 0
+            panelViewModel?.captureHealth = .notRecording
             hideMeetingPanel()
 
         case .stopRecordingAndTranscribe:
@@ -896,6 +904,7 @@ final class MeetingRecordingFlowCoordinator {
         pillViewModel.elapsedSeconds = 0
         pillViewModel.micLevel = 0
         pillViewModel.systemLevel = 0
+        pillViewModel.captureHealth = .notRecording
         pillViewModel.state = .idle
         teardownMeetingPanel()
         onFlowReturnedToIdle()
@@ -960,6 +969,7 @@ final class MeetingRecordingFlowCoordinator {
                 let elapsedSeconds = await meetingRecordingService.elapsedSeconds
                 let captureMode = await meetingRecordingService.captureMode
                 let microphoneMuteState = await meetingRecordingService.microphoneMuteState
+                let captureHealth = await meetingRecordingService.captureHealth
 
                 guard !Task.isCancelled else { break }
                 if pillViewModel.micLevel != micLevel {
@@ -970,6 +980,9 @@ final class MeetingRecordingFlowCoordinator {
                 }
                 if pillViewModel.elapsedSeconds != elapsedSeconds {
                     pillViewModel.elapsedSeconds = elapsedSeconds
+                }
+                if pillViewModel.captureHealth != captureHealth {
+                    pillViewModel.captureHealth = captureHealth
                 }
                 if let panelViewModel {
                     if panelViewModel.elapsedSeconds != elapsedSeconds {
@@ -993,6 +1006,9 @@ final class MeetingRecordingFlowCoordinator {
                     }
                     if panelViewModel.canToggleMicrophoneMute != microphoneMuteState.canMute {
                         panelViewModel.canToggleMicrophoneMute = microphoneMuteState.canMute
+                    }
+                    if panelViewModel.captureHealth != captureHealth {
+                        panelViewModel.captureHealth = captureHealth
                     }
                 }
                 // Pause/resume reconciliation (issue #235). The user-facing

--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingRecordingPanelView.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingRecordingPanelView.swift
@@ -252,6 +252,10 @@ struct MeetingRecordingPanelView: View {
                 }
             }
 
+            if viewModel.showsSourceHealthChips {
+                MeetingSourceHealthChips(chips: viewModel.sourceHealthChips)
+            }
+
             if viewModel.showsLaggingIndicator {
                 Label("Transcript preview is catching up", systemImage: "exclamationmark.triangle.fill")
                     .font(DesignSystem.Typography.caption.weight(.semibold))

--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingRecordingPillView.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingRecordingPillView.swift
@@ -157,6 +157,7 @@ struct MeetingRecordingPillView: View {
 
     private var sacredRecordingPill: some View {
         let isPaused = viewModel.isPaused
+        let healthWarning = viewModel.mirroredSourceHealthWarning
         return VStack(spacing: 0) {
             ZStack {
                 MerkabaPillIcon(
@@ -248,11 +249,17 @@ struct MeetingRecordingPillView: View {
                 .transition(.opacity.combined(with: .scale(scale: 0.8)))
             }
         }
+        .overlay(alignment: .bottomTrailing) {
+            if let healthWarning {
+                MeetingSourceHealthGlyph(chip: healthWarning)
+                    .offset(x: 4, y: 4)
+            }
+        }
         .accessibilityElement(children: .combine)
         .accessibilityLabel(
             isPaused
-                ? "Meeting recording paused, \(viewModel.formattedElapsed) elapsed"
-                : "Recording meeting, \(viewModel.formattedElapsed) elapsed"
+                ? "Meeting recording paused, \(viewModel.formattedElapsed) elapsed\(healthSuffix(healthWarning))"
+                : "Recording meeting, \(viewModel.formattedElapsed) elapsed\(healthSuffix(healthWarning))"
         )
         .accessibilityAction {
             onTap?()
@@ -273,5 +280,9 @@ struct MeetingRecordingPillView: View {
                     .strokeBorder(DesignSystem.Colors.pillBorder, lineWidth: 1)
             )
             .cardShadow(DesignSystem.Shadows.meetingPill)
+    }
+
+    private func healthSuffix(_ warning: MeetingSourceHealthChip?) -> String {
+        warning.map { ", \($0.label)" } ?? ""
     }
 }

--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingSourceHealthChips.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingSourceHealthChips.swift
@@ -1,0 +1,102 @@
+import MacParakeetViewModels
+import SwiftUI
+
+struct MeetingSourceHealthChips: View {
+    let chips: [MeetingSourceHealthChip]
+
+    var body: some View {
+        ViewThatFits(in: .horizontal) {
+            HStack(spacing: 6) {
+                ForEach(chips) { chip in
+                    MeetingSourceHealthChipView(chip: chip, showsText: true)
+                }
+            }
+
+            HStack(spacing: 6) {
+                ForEach(chips) { chip in
+                    MeetingSourceHealthChipView(chip: chip, showsText: false)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+struct MeetingSourceHealthGlyph: View {
+    let chip: MeetingSourceHealthChip
+
+    var body: some View {
+        Image(systemName: chip.symbolName)
+            .font(.system(size: 9, weight: .bold))
+            .foregroundStyle(healthForegroundColor(for: chip.severity))
+            .frame(width: 18, height: 18)
+            .background(
+                Circle()
+                    .fill(healthBackgroundColor(for: chip.severity))
+            )
+            .overlay(
+                Circle()
+                    .strokeBorder(healthForegroundColor(for: chip.severity).opacity(0.35), lineWidth: 0.7)
+            )
+            .help(chip.label)
+            .accessibilityLabel(chip.label)
+    }
+}
+
+struct MeetingSourceHealthInlineBadge: View {
+    let chip: MeetingSourceHealthChip
+
+    var body: some View {
+        MeetingSourceHealthChipView(chip: chip, showsText: true)
+            .fixedSize(horizontal: true, vertical: false)
+    }
+}
+
+private struct MeetingSourceHealthChipView: View {
+    let chip: MeetingSourceHealthChip
+    let showsText: Bool
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Image(systemName: chip.symbolName)
+                .font(.system(size: 10, weight: .semibold))
+
+            if showsText {
+                Text(chip.label)
+                    .font(.system(size: 10, weight: .semibold))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.9)
+            }
+        }
+        .foregroundStyle(healthForegroundColor(for: chip.severity))
+        .padding(.horizontal, showsText ? 8 : 6)
+        .padding(.vertical, 4)
+        .background(
+            Capsule()
+                .fill(healthBackgroundColor(for: chip.severity))
+        )
+        .overlay(
+            Capsule()
+                .strokeBorder(healthForegroundColor(for: chip.severity).opacity(0.25), lineWidth: 0.6)
+        )
+        .help(chip.label)
+        .accessibilityLabel(chip.label)
+    }
+}
+
+private func healthForegroundColor(for severity: MeetingSourceHealthSeverity) -> Color {
+    switch severity {
+    case .neutral:
+        return DesignSystem.Colors.textTertiary
+    case .good:
+        return DesignSystem.Colors.successGreen
+    case .warning:
+        return DesignSystem.Colors.warningAmber
+    case .critical:
+        return DesignSystem.Colors.errorRed
+    }
+}
+
+private func healthBackgroundColor(for severity: MeetingSourceHealthSeverity) -> Color {
+    healthForegroundColor(for: severity).opacity(severity == .neutral ? 0.10 : 0.13)
+}

--- a/Sources/MacParakeet/Views/Transcription/MeetingRecordingTile.swift
+++ b/Sources/MacParakeet/Views/Transcription/MeetingRecordingTile.swift
@@ -205,9 +205,15 @@ struct MeetingRecordingTile: View {
                         .font(DesignSystem.Typography.sectionTitle)
                         .foregroundStyle(DesignSystem.Colors.textPrimary)
                 }
-                Text(viewModel.formattedElapsed)
-                    .font(.system(size: 15, weight: .semibold).monospacedDigit())
-                    .foregroundStyle(DesignSystem.Colors.textSecondary)
+                HStack(spacing: 8) {
+                    Text(viewModel.formattedElapsed)
+                        .font(.system(size: 15, weight: .semibold).monospacedDigit())
+                        .foregroundStyle(DesignSystem.Colors.textSecondary)
+
+                    if let warning = viewModel.mirroredSourceHealthWarning {
+                        MeetingSourceHealthInlineBadge(chip: warning)
+                    }
+                }
                 backgroundTranscriptionBadge
             }
 
@@ -351,9 +357,9 @@ struct MeetingRecordingTile: View {
         case .idle:
             return permissionState.isReady ? "Record meeting" : "\(permissionState.title): \(permissionState.detail)"
         case .recording:
-            return "Recording meeting, \(viewModel.formattedElapsed) elapsed"
+            return "Recording meeting, \(viewModel.formattedElapsed) elapsed\(sourceHealthAccessibilitySuffix)"
         case .paused:
-            return "Meeting recording paused, \(viewModel.formattedElapsed) elapsed"
+            return "Meeting recording paused, \(viewModel.formattedElapsed) elapsed\(sourceHealthAccessibilitySuffix)"
         case .completing, .transcribing:
             return "Transcribing meeting"
         case .completed:
@@ -367,6 +373,10 @@ struct MeetingRecordingTile: View {
         // Tile body is informational; Start / Stop buttons carry the
         // action hints themselves.
         ""
+    }
+
+    private var sourceHealthAccessibilitySuffix: String {
+        viewModel.mirroredSourceHealthWarning.map { ", \($0.label)" } ?? ""
     }
 }
 

--- a/Sources/MacParakeetCore/Audio/MeetingAudioCaptureService.swift
+++ b/Sources/MacParakeetCore/Audio/MeetingAudioCaptureService.swift
@@ -5,6 +5,7 @@ import OSLog
 public enum MeetingAudioCaptureEvent: Sendable {
     case microphoneBuffer(AVAudioPCMBuffer, AVAudioTime)
     case systemBuffer(AVAudioPCMBuffer, AVAudioTime)
+    case microphoneHealth(MeetingMicHealthMonitor.HealthEvent)
     case sourceInterrupted(source: AudioSource, error: MeetingAudioError)
     case error(MeetingAudioError)
 }
@@ -190,7 +191,10 @@ public actor MeetingAudioCaptureService {
                             )
                             return
                         }
-                        self?.micHealthObserver.observeMicrophoneBuffer(copy)
+                        let healthEvents = self?.micHealthObserver.observeMicrophoneBuffer(copy) ?? []
+                        for healthEvent in healthEvents {
+                            self?.eventSink.emit(.microphoneHealth(healthEvent))
+                        }
                         self?.eventSink.emit(.microphoneBuffer(copy, time))
                     },
                     onStall: { [weak self] error in
@@ -214,7 +218,10 @@ public actor MeetingAudioCaptureService {
                             )
                             return
                         }
-                        self?.micHealthObserver.observeSystemBuffer(copy)
+                        let healthEvents = self?.micHealthObserver.observeSystemBuffer(copy) ?? []
+                        for healthEvent in healthEvents {
+                            self?.eventSink.emit(.microphoneHealth(healthEvent))
+                        }
                         self?.eventSink.emit(.systemBuffer(copy, time))
                     },
                     onStall: { [weak self] error in
@@ -402,17 +409,17 @@ private final class MeetingMicHealthTelemetryObserver: @unchecked Sendable {
         }
     }
 
-    func observeMicrophoneBuffer(_ buffer: AVAudioPCMBuffer) {
-        guard shouldObserve else { return }
-        observe(
+    func observeMicrophoneBuffer(_ buffer: AVAudioPCMBuffer) -> [MeetingMicHealthMonitor.HealthEvent] {
+        guard shouldObserve else { return [] }
+        return observe(
             micSignal: .init(isNonSilent: buffer.rmsLevel >= config.nonSilentLevelThreshold),
             systemSignal: nil
         )
     }
 
-    func observeSystemBuffer(_ buffer: AVAudioPCMBuffer) {
-        guard shouldObserve else { return }
-        observe(
+    func observeSystemBuffer(_ buffer: AVAudioPCMBuffer) -> [MeetingMicHealthMonitor.HealthEvent] {
+        guard shouldObserve else { return [] }
+        return observe(
             micSignal: nil,
             systemSignal: .init(isNonSilent: buffer.rmsLevel >= config.nonSilentLevelThreshold)
         )
@@ -425,13 +432,15 @@ private final class MeetingMicHealthTelemetryObserver: @unchecked Sendable {
     private func observe(
         micSignal: MeetingMicHealthMonitor.AudioSignal?,
         systemSignal: MeetingMicHealthMonitor.AudioSignal?
-    ) {
+    ) -> [MeetingMicHealthMonitor.HealthEvent] {
         let now = nowProvider()
         // Resolve which signatures are newly reported *inside* the lock (the monitor
         // state and the dedup set are both mutated from the audio callback thread),
         // then emit telemetry outside it so `Telemetry.send` never runs under the lock.
-        let freshStalls: [(MeetingMicHealthMonitor.StallSignature, Int)] = lock.withLock {
-            guard isObserving else { return [] }
+        let observed = lock.withLock {
+            guard isObserving else {
+                return (events: [MeetingMicHealthMonitor.HealthEvent](), freshStalls: [(MeetingMicHealthMonitor.StallSignature, Int)]())
+            }
             let events = monitor.ingest(micSignal: micSignal, systemSignal: systemSignal, now: now)
             var fresh: [(MeetingMicHealthMonitor.StallSignature, Int)] = []
             for event in events {
@@ -443,12 +452,13 @@ private final class MeetingMicHealthTelemetryObserver: @unchecked Sendable {
                     fresh.append((signature, elapsedMs))
                 }
             }
-            return fresh
+            return (events, fresh)
         }
 
-        for (signature, elapsedMs) in freshStalls {
+        for (signature, elapsedMs) in observed.freshStalls {
             Telemetry.send(.micStallDetected(signature: .init(signature), elapsedMs: elapsedMs))
         }
+        return observed.events
     }
 }
 

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingCaptureHealth.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingCaptureHealth.swift
@@ -143,6 +143,22 @@ public struct MeetingCaptureHealthSummary: Sendable, Equatable, Codable {
         system: MeetingSourceHealth(source: .system, status: .notSelected)
     )
 
+    public static func starting(sourceMode: MeetingAudioSourceMode) -> MeetingCaptureHealthSummary {
+        MeetingCaptureHealthSummary(
+            sourceMode: sourceMode,
+            microphone: MeetingSourceHealth(
+                source: .microphone,
+                status: sourceMode.capturesMicrophone ? .starting : .notSelected,
+                recoveryAction: sourceMode.capturesMicrophone ? nil : .changeSourceMode
+            ),
+            system: MeetingSourceHealth(
+                source: .system,
+                status: sourceMode.capturesSystemAudio ? .starting : .notSelected,
+                recoveryAction: sourceMode.capturesSystemAudio ? nil : .changeSourceMode
+            )
+        )
+    }
+
     public var isDegraded: Bool {
         microphone.status.isDegraded || system.status.isDegraded
     }

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingCaptureHealth.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingCaptureHealth.swift
@@ -1,0 +1,320 @@
+import Foundation
+
+public struct MeetingSourceHealth: Sendable, Equatable, Codable {
+    public enum Source: String, Sendable, Equatable, Codable {
+        case microphone
+        case system
+
+        init(_ source: AudioSource) {
+            switch source {
+            case .microphone:
+                self = .microphone
+            case .system:
+                self = .system
+            }
+        }
+    }
+
+    public enum Status: String, Sendable, Equatable, Codable {
+        case notSelected
+        case starting
+        case live
+        case muted
+        case silent
+        case stalled
+        case interrupted
+        case unavailable
+
+        public var isDegraded: Bool {
+            switch self {
+            case .muted, .silent, .stalled, .interrupted, .unavailable:
+                return true
+            case .notSelected, .starting, .live:
+                return false
+            }
+        }
+    }
+
+    public enum RecoveryAction: String, Sendable, Equatable, Codable {
+        case changeSourceMode
+        case unmuteMicrophone
+        case checkMicrophoneInput
+        case openMicrophoneSettings
+        case openSystemAudioSettings
+        case restartRecording
+    }
+
+    public var source: Source
+    public var status: Status
+    public var level: Float
+    public var lastBufferAt: Date?
+    public var detail: String?
+    public var recoveryAction: RecoveryAction?
+
+    public init(
+        source: Source,
+        status: Status,
+        level: Float = 0,
+        lastBufferAt: Date? = nil,
+        detail: String? = nil,
+        recoveryAction: RecoveryAction? = nil
+    ) {
+        self.source = source
+        self.status = status
+        self.level = level
+        self.lastBufferAt = lastBufferAt
+        self.detail = detail
+        self.recoveryAction = recoveryAction
+    }
+
+    public var label: String {
+        switch (source, status) {
+        case (.microphone, .notSelected):
+            return "Mic not recorded"
+        case (.system, .notSelected):
+            return "System not recorded"
+        case (.microphone, .starting):
+            return "Mic starting"
+        case (.system, .starting):
+            return "System starting"
+        case (.microphone, .live):
+            return "Mic live"
+        case (.system, .live):
+            return "System live"
+        case (.microphone, .muted):
+            return "Mic muted"
+        case (.system, .muted):
+            return "System muted"
+        case (.microphone, .silent):
+            return "Mic may be silent"
+        case (.system, .silent):
+            return "System may be silent"
+        case (.microphone, .stalled):
+            return "Mic may be stalled"
+        case (.system, .stalled):
+            return "System may be stalled"
+        case (.microphone, .interrupted):
+            return "Mic interrupted"
+        case (.system, .interrupted):
+            return "System audio interrupted"
+        case (.microphone, .unavailable):
+            return "Mic unavailable"
+        case (.system, .unavailable):
+            return "System unavailable"
+        }
+    }
+
+    var degradationPriority: Int? {
+        switch status {
+        case .unavailable:
+            return 0
+        case .interrupted:
+            return 1
+        case .stalled:
+            return 2
+        case .muted:
+            return 3
+        case .silent:
+            return 4
+        case .notSelected, .starting, .live:
+            return nil
+        }
+    }
+}
+
+public struct MeetingCaptureHealthSummary: Sendable, Equatable, Codable {
+    public var sourceMode: MeetingAudioSourceMode
+    public var microphone: MeetingSourceHealth
+    public var system: MeetingSourceHealth
+
+    public init(
+        sourceMode: MeetingAudioSourceMode,
+        microphone: MeetingSourceHealth,
+        system: MeetingSourceHealth
+    ) {
+        self.sourceMode = sourceMode
+        self.microphone = microphone
+        self.system = system
+    }
+
+    public static let notRecording = MeetingCaptureHealthSummary(
+        sourceMode: .microphoneAndSystem,
+        microphone: MeetingSourceHealth(source: .microphone, status: .notSelected),
+        system: MeetingSourceHealth(source: .system, status: .notSelected)
+    )
+
+    public var isDegraded: Bool {
+        microphone.status.isDegraded || system.status.isDegraded
+    }
+
+    public var primaryMessage: String? {
+        primaryDegradedSource?.label
+    }
+
+    public var primaryDegradedSource: MeetingSourceHealth? {
+        [microphone, system]
+            .filter { $0.status.isDegraded }
+            .sorted { lhs, rhs in
+                (lhs.degradationPriority ?? Int.max) < (rhs.degradationPriority ?? Int.max)
+            }
+            .first
+    }
+
+    public static func reduce(
+        sourceMode: MeetingAudioSourceMode,
+        microphoneLevel: Float,
+        systemLevel: Float,
+        lastBufferAt: [AudioSource: Date],
+        isMicrophoneMuted: Bool,
+        microphoneStarted: Bool,
+        interruptedSources: Set<AudioSource>,
+        activeMicrophoneStall: MeetingMicHealthMonitor.StallSignature?,
+        captureFailed: Bool
+    ) -> MeetingCaptureHealthSummary {
+        let microphone = sourceHealth(
+            source: .microphone,
+            sourceMode: sourceMode,
+            level: microphoneLevel,
+            lastBufferAt: lastBufferAt[.microphone],
+            isMicrophoneMuted: isMicrophoneMuted,
+            microphoneStarted: microphoneStarted,
+            interruptedSources: interruptedSources,
+            activeMicrophoneStall: activeMicrophoneStall,
+            captureFailed: captureFailed
+        )
+        let system = sourceHealth(
+            source: .system,
+            sourceMode: sourceMode,
+            level: systemLevel,
+            lastBufferAt: lastBufferAt[.system],
+            isMicrophoneMuted: isMicrophoneMuted,
+            microphoneStarted: microphoneStarted,
+            interruptedSources: interruptedSources,
+            activeMicrophoneStall: activeMicrophoneStall,
+            captureFailed: captureFailed
+        )
+        return MeetingCaptureHealthSummary(
+            sourceMode: sourceMode,
+            microphone: microphone,
+            system: system
+        )
+    }
+
+    private static func sourceHealth(
+        source: AudioSource,
+        sourceMode: MeetingAudioSourceMode,
+        level: Float,
+        lastBufferAt: Date?,
+        isMicrophoneMuted: Bool,
+        microphoneStarted: Bool,
+        interruptedSources: Set<AudioSource>,
+        activeMicrophoneStall: MeetingMicHealthMonitor.StallSignature?,
+        captureFailed: Bool
+    ) -> MeetingSourceHealth {
+        let selected = source == .microphone
+            ? sourceMode.capturesMicrophone
+            : sourceMode.capturesSystemAudio
+        guard selected else {
+            return MeetingSourceHealth(
+                source: MeetingSourceHealth.Source(source),
+                status: .notSelected,
+                detail: "The selected meeting source mode does not record this channel.",
+                recoveryAction: .changeSourceMode
+            )
+        }
+
+        if captureFailed {
+            let status: MeetingSourceHealth.Status = interruptedSources.contains(source)
+                ? .interrupted
+                : .unavailable
+            return MeetingSourceHealth(
+                source: MeetingSourceHealth.Source(source),
+                status: status,
+                level: 0,
+                lastBufferAt: lastBufferAt,
+                recoveryAction: recoveryAction(for: source, status: status)
+            )
+        }
+
+        if interruptedSources.contains(source) {
+            return MeetingSourceHealth(
+                source: MeetingSourceHealth.Source(source),
+                status: .interrupted,
+                level: 0,
+                lastBufferAt: lastBufferAt,
+                recoveryAction: .restartRecording
+            )
+        }
+
+        if source == .microphone, isMicrophoneMuted {
+            return MeetingSourceHealth(
+                source: .microphone,
+                status: .muted,
+                level: 0,
+                lastBufferAt: lastBufferAt,
+                recoveryAction: .unmuteMicrophone
+            )
+        }
+
+        if source == .microphone, activeMicrophoneStall != nil {
+            return MeetingSourceHealth(
+                source: .microphone,
+                status: .stalled,
+                level: level,
+                lastBufferAt: lastBufferAt,
+                recoveryAction: .checkMicrophoneInput
+            )
+        }
+
+        if source == .microphone, !microphoneStarted, lastBufferAt == nil {
+            return MeetingSourceHealth(
+                source: .microphone,
+                status: .unavailable,
+                level: 0,
+                recoveryAction: .openMicrophoneSettings
+            )
+        }
+
+        guard let lastBufferAt else {
+            return MeetingSourceHealth(
+                source: MeetingSourceHealth.Source(source),
+                status: .starting,
+                level: 0
+            )
+        }
+
+        let clampedLevel = max(0, min(1, level))
+        let status: MeetingSourceHealth.Status = clampedLevel < AudioCaptureHealth.silentInputMaximumLevel
+            ? .silent
+            : .live
+        return MeetingSourceHealth(
+            source: MeetingSourceHealth.Source(source),
+            status: status,
+            level: clampedLevel,
+            lastBufferAt: lastBufferAt,
+            recoveryAction: recoveryAction(for: source, status: status)
+        )
+    }
+
+    private static func recoveryAction(
+        for source: AudioSource,
+        status: MeetingSourceHealth.Status
+    ) -> MeetingSourceHealth.RecoveryAction? {
+        switch (source, status) {
+        case (.microphone, .silent):
+            return .checkMicrophoneInput
+        case (.system, .silent):
+            return .openSystemAudioSettings
+        case (.microphone, .unavailable):
+            return .openMicrophoneSettings
+        case (.system, .unavailable):
+            return .openSystemAudioSettings
+        case (_, .interrupted):
+            return .restartRecording
+        case (.microphone, .muted):
+            return .unmuteMicrophone
+        default:
+            return nil
+        }
+    }
+}

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingCaptureHealth.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingCaptureHealth.swift
@@ -262,33 +262,35 @@ public struct MeetingCaptureHealthSummary: Sendable, Equatable, Codable {
             )
         }
 
-        if source == .microphone, isMicrophoneMuted {
-            return MeetingSourceHealth(
-                source: .microphone,
-                status: .muted,
-                level: 0,
-                lastBufferAt: lastBufferAt,
-                recoveryAction: .unmuteMicrophone
-            )
-        }
+        if source == .microphone {
+            if isMicrophoneMuted {
+                return MeetingSourceHealth(
+                    source: .microphone,
+                    status: .muted,
+                    level: 0,
+                    lastBufferAt: lastBufferAt,
+                    recoveryAction: .unmuteMicrophone
+                )
+            }
 
-        if source == .microphone, activeMicrophoneStall != nil {
-            return MeetingSourceHealth(
-                source: .microphone,
-                status: .stalled,
-                level: level,
-                lastBufferAt: lastBufferAt,
-                recoveryAction: .checkMicrophoneInput
-            )
-        }
+            if activeMicrophoneStall != nil {
+                return MeetingSourceHealth(
+                    source: .microphone,
+                    status: .stalled,
+                    level: level,
+                    lastBufferAt: lastBufferAt,
+                    recoveryAction: .checkMicrophoneInput
+                )
+            }
 
-        if source == .microphone, !microphoneStarted, lastBufferAt == nil {
-            return MeetingSourceHealth(
-                source: .microphone,
-                status: .unavailable,
-                level: 0,
-                recoveryAction: .openMicrophoneSettings
-            )
+            if !microphoneStarted, lastBufferAt == nil {
+                return MeetingSourceHealth(
+                    source: .microphone,
+                    status: .unavailable,
+                    level: 0,
+                    recoveryAction: .openMicrophoneSettings
+                )
+            }
         }
 
         guard let lastBufferAt else {

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingCaptureHealth.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingCaptureHealth.swift
@@ -185,6 +185,7 @@ public struct MeetingCaptureHealthSummary: Sendable, Equatable, Codable {
         microphoneStarted: Bool,
         interruptedSources: Set<AudioSource>,
         activeMicrophoneStall: MeetingMicHealthMonitor.StallSignature?,
+        microphoneStartedWithoutBufferTimedOut: Bool,
         systemStartedWithoutBufferTimedOut: Bool,
         captureFailed: Bool
     ) -> MeetingCaptureHealthSummary {
@@ -197,6 +198,7 @@ public struct MeetingCaptureHealthSummary: Sendable, Equatable, Codable {
             microphoneStarted: microphoneStarted,
             interruptedSources: interruptedSources,
             activeMicrophoneStall: activeMicrophoneStall,
+            microphoneStartedWithoutBufferTimedOut: microphoneStartedWithoutBufferTimedOut,
             systemStartedWithoutBufferTimedOut: systemStartedWithoutBufferTimedOut,
             captureFailed: captureFailed
         )
@@ -209,6 +211,7 @@ public struct MeetingCaptureHealthSummary: Sendable, Equatable, Codable {
             microphoneStarted: microphoneStarted,
             interruptedSources: interruptedSources,
             activeMicrophoneStall: activeMicrophoneStall,
+            microphoneStartedWithoutBufferTimedOut: microphoneStartedWithoutBufferTimedOut,
             systemStartedWithoutBufferTimedOut: systemStartedWithoutBufferTimedOut,
             captureFailed: captureFailed
         )
@@ -228,6 +231,7 @@ public struct MeetingCaptureHealthSummary: Sendable, Equatable, Codable {
         microphoneStarted: Bool,
         interruptedSources: Set<AudioSource>,
         activeMicrophoneStall: MeetingMicHealthMonitor.StallSignature?,
+        microphoneStartedWithoutBufferTimedOut: Bool,
         systemStartedWithoutBufferTimedOut: Bool,
         captureFailed: Bool
     ) -> MeetingSourceHealth {
@@ -282,6 +286,16 @@ public struct MeetingCaptureHealthSummary: Sendable, Equatable, Codable {
                     source: .microphone,
                     status: .stalled,
                     level: level,
+                    lastBufferAt: lastBufferAt,
+                    recoveryAction: .checkMicrophoneInput
+                )
+            }
+
+            if microphoneStartedWithoutBufferTimedOut {
+                return MeetingSourceHealth(
+                    source: .microphone,
+                    status: .stalled,
+                    level: 0,
                     lastBufferAt: lastBufferAt,
                     recoveryAction: .checkMicrophoneInput
                 )

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingCaptureHealth.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingCaptureHealth.swift
@@ -185,6 +185,7 @@ public struct MeetingCaptureHealthSummary: Sendable, Equatable, Codable {
         microphoneStarted: Bool,
         interruptedSources: Set<AudioSource>,
         activeMicrophoneStall: MeetingMicHealthMonitor.StallSignature?,
+        systemStartedWithoutBufferTimedOut: Bool,
         captureFailed: Bool
     ) -> MeetingCaptureHealthSummary {
         let microphone = sourceHealth(
@@ -196,6 +197,7 @@ public struct MeetingCaptureHealthSummary: Sendable, Equatable, Codable {
             microphoneStarted: microphoneStarted,
             interruptedSources: interruptedSources,
             activeMicrophoneStall: activeMicrophoneStall,
+            systemStartedWithoutBufferTimedOut: systemStartedWithoutBufferTimedOut,
             captureFailed: captureFailed
         )
         let system = sourceHealth(
@@ -207,6 +209,7 @@ public struct MeetingCaptureHealthSummary: Sendable, Equatable, Codable {
             microphoneStarted: microphoneStarted,
             interruptedSources: interruptedSources,
             activeMicrophoneStall: activeMicrophoneStall,
+            systemStartedWithoutBufferTimedOut: systemStartedWithoutBufferTimedOut,
             captureFailed: captureFailed
         )
         return MeetingCaptureHealthSummary(
@@ -225,6 +228,7 @@ public struct MeetingCaptureHealthSummary: Sendable, Equatable, Codable {
         microphoneStarted: Bool,
         interruptedSources: Set<AudioSource>,
         activeMicrophoneStall: MeetingMicHealthMonitor.StallSignature?,
+        systemStartedWithoutBufferTimedOut: Bool,
         captureFailed: Bool
     ) -> MeetingSourceHealth {
         let selected = source == .microphone
@@ -291,6 +295,16 @@ public struct MeetingCaptureHealthSummary: Sendable, Equatable, Codable {
                     recoveryAction: .openMicrophoneSettings
                 )
             }
+        }
+
+        if source == .system, systemStartedWithoutBufferTimedOut {
+            return MeetingSourceHealth(
+                source: .system,
+                status: .stalled,
+                level: 0,
+                lastBufferAt: lastBufferAt,
+                recoveryAction: .restartRecording
+            )
         }
 
         guard let lastBufferAt else {

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
@@ -390,7 +390,9 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         guard currentSession != nil else {
             return .notRecording
         }
-        let sourceMode = captureHealthMetrics.sourceMode ?? .microphoneAndSystem
+        guard let sourceMode = captureHealthMetrics.sourceMode else {
+            return .starting(sourceMode: .microphoneAndSystem)
+        }
         return MeetingCaptureHealthSummary.reduce(
             sourceMode: sourceMode,
             microphoneLevel: latestLevels.microphone,

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
@@ -254,6 +254,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
     private var latestLevels = MeetingAudioLevels()
     private var sourceHealthLastBufferAt: [AudioSource: Date] = [:]
     private var activeMicrophoneStall: MeetingMicHealthMonitor.StallSignature?
+    private var recentMicrophoneRms: Float = 0
     private var recentSystemRms: Float = 0
     private var recentProcessedMicRms: Float = 0
     private var latestSystemSignalAt: ContinuousClock.Instant?
@@ -395,8 +396,8 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         }
         return MeetingCaptureHealthSummary.reduce(
             sourceMode: sourceMode,
-            microphoneLevel: latestLevels.microphone,
-            systemLevel: latestLevels.system,
+            microphoneLevel: microphoneCaptureHealthRms,
+            systemLevel: recentSystemRms,
             lastBufferAt: sourceHealthLastBufferAt,
             isMicrophoneMuted: microphoneMuteState.isMuted,
             microphoneStarted: captureHealthMetrics.microphoneStarted,
@@ -506,6 +507,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
             captureHealthMetrics = CaptureHealthMetrics()
             sourceHealthLastBufferAt = [:]
             activeMicrophoneStall = nil
+            recentMicrophoneRms = 0
             recentSystemRms = 0
             recentProcessedMicRms = 0
             latestSystemSignalAt = nil
@@ -816,6 +818,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         // pauses, instead of decaying from the EMA over the next few
         // hundred ms. Same reasoning as the `failCapture` path.
         latestLevels = MeetingAudioLevels()
+        recentMicrophoneRms = 0
         recentSystemRms = 0
         recentProcessedMicRms = 0
         latestSystemSignalAt = nil
@@ -862,6 +865,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         if muted {
             microphoneMutedHostTime = Self.currentAudioHostTime()
             latestLevels.microphone = 0
+            recentMicrophoneRms = 0
             recentProcessedMicRms = 0
         } else {
             if let microphoneMutedHostTime {
@@ -958,6 +962,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
                 try writer?.write(recordingBuffer, source: .microphone)
                 if handling == .recordAndProcess {
                     latestLevels.microphone = muted ? 0 : recordingBuffer.rmsLevel
+                    updateMicrophoneRms(with: latestLevels.microphone)
                     if let samples = AudioChunker.extractAndResample(from: recordingBuffer) {
                         await ingestResampledSamples(
                             samples,
@@ -1031,6 +1036,9 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
     private func failCapture(_ error: Error) async {
         captureFailed = true
         latestLevels = MeetingAudioLevels()
+        recentMicrophoneRms = 0
+        recentSystemRms = 0
+        recentProcessedMicRms = 0
         microphoneMuted = false
         activeMicrophoneStall = nil
         microphoneMutedHostTime = nil
@@ -1496,6 +1504,14 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         return size.uint64Value
     }
 
+    private var microphoneCaptureHealthRms: Float {
+        recentProcessedMicRms > 0 ? recentProcessedMicRms : recentMicrophoneRms
+    }
+
+    private func updateMicrophoneRms(with bufferRms: Float) {
+        recentMicrophoneRms = exponentialMovingAverage(previous: recentMicrophoneRms, sample: bufferRms)
+    }
+
     private func updateSystemRms(with bufferRms: Float) {
         recentSystemRms = exponentialMovingAverage(previous: recentSystemRms, sample: bufferRms)
         if bufferRms > Self.systemActiveFloor {
@@ -1602,6 +1618,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         sourceHealthLastBufferAt = [:]
         activeMicrophoneStall = nil
         interruptedSources = []
+        recentMicrophoneRms = 0
         recentSystemRms = 0
         recentProcessedMicRms = 0
         latestSystemSignalAt = nil

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
@@ -123,6 +123,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         var sourceMode: MeetingAudioSourceMode?
         var requestedMicMode: MeetingMicProcessingMode?
         var effectiveMicMode: MeetingMicProcessingEffectiveMode?
+        var captureStartedAt: Date?
         var microphoneStarted = false
         var microphoneFirstBufferSeen = false
         var systemFirstBufferSeen = false
@@ -269,6 +270,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
     private static let systemDominanceRatio: Float = 10.0
     private static let systemActiveFloor: Float = 0.02
     private static let systemSignalFreshnessWindow: Duration = .milliseconds(750)
+    private static let systemFirstBufferStallGraceSeconds: TimeInterval = 12
     private static let rmsEpsilon: Float = 0.0001
     private static let chunkSignalFloor: Float = 0.00025
     private static let syncLagEmaAlpha: Double = 0.2
@@ -403,8 +405,26 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
             microphoneStarted: captureHealthMetrics.microphoneStarted,
             interruptedSources: interruptedSources,
             activeMicrophoneStall: activeMicrophoneStall,
+            systemStartedWithoutBufferTimedOut: systemStartedWithoutBufferTimedOut,
             captureFailed: captureFailed
         )
+    }
+
+    private var systemStartedWithoutBufferTimedOut: Bool {
+        guard !paused,
+              !captureFailed,
+              captureHealthMetrics.sourceMode?.capturesSystemAudio == true,
+              sourceHealthLastBufferAt[.system] == nil,
+              !interruptedSources.contains(.system),
+              let captureStartedAt = captureHealthMetrics.captureStartedAt
+        else {
+            return false
+        }
+
+        return activeRecordingSeconds(
+            startedAt: captureStartedAt,
+            asOf: wallClockNow()
+        ) >= Self.systemFirstBufferStallGraceSeconds
     }
 
     /// Wallclock-since-start minus all pause time (completed + ongoing).
@@ -532,6 +552,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
             captureHealthMetrics.sourceMode = captureStartReport.sourceMode
             captureHealthMetrics.requestedMicMode = captureStartReport.microphone.requestedMode
             captureHealthMetrics.effectiveMicMode = captureStartReport.microphone.effectiveMode
+            captureHealthMetrics.captureStartedAt = wallClockNow()
             captureHealthMetrics.microphoneStarted = captureStartReport.microphoneStarted
             configureMicConditioner(from: captureStartReport)
             processingTask = Task { [weak self] in

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
@@ -270,7 +270,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
     private static let systemDominanceRatio: Float = 10.0
     private static let systemActiveFloor: Float = 0.02
     private static let systemSignalFreshnessWindow: Duration = .milliseconds(750)
-    private static let systemFirstBufferStallGraceSeconds: TimeInterval = 12
+    private static let sourceFirstBufferStallGraceSeconds: TimeInterval = 12
     private static let rmsEpsilon: Float = 0.0001
     private static let chunkSignalFloor: Float = 0.00025
     private static let syncLagEmaAlpha: Double = 0.2
@@ -405,17 +405,37 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
             microphoneStarted: captureHealthMetrics.microphoneStarted,
             interruptedSources: interruptedSources,
             activeMicrophoneStall: activeMicrophoneStall,
+            microphoneStartedWithoutBufferTimedOut: microphoneStartedWithoutBufferTimedOut,
             systemStartedWithoutBufferTimedOut: systemStartedWithoutBufferTimedOut,
             captureFailed: captureFailed
         )
     }
 
+    private var microphoneStartedWithoutBufferTimedOut: Bool {
+        guard captureHealthMetrics.microphoneStarted else {
+            return false
+        }
+        return sourceStartedWithoutBufferTimedOut(.microphone)
+    }
+
     private var systemStartedWithoutBufferTimedOut: Bool {
+        sourceStartedWithoutBufferTimedOut(.system)
+    }
+
+    private func sourceStartedWithoutBufferTimedOut(_ source: AudioSource) -> Bool {
+        let sourceSelected: Bool
+        switch source {
+        case .microphone:
+            sourceSelected = captureHealthMetrics.sourceMode?.capturesMicrophone == true
+        case .system:
+            sourceSelected = captureHealthMetrics.sourceMode?.capturesSystemAudio == true
+        }
+
         guard !paused,
               !captureFailed,
-              captureHealthMetrics.sourceMode?.capturesSystemAudio == true,
-              sourceHealthLastBufferAt[.system] == nil,
-              !interruptedSources.contains(.system),
+              sourceSelected,
+              sourceHealthLastBufferAt[source] == nil,
+              !interruptedSources.contains(source),
               let captureStartedAt = captureHealthMetrics.captureStartedAt
         else {
             return false
@@ -424,7 +444,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         return activeRecordingSeconds(
             startedAt: captureStartedAt,
             asOf: wallClockNow()
-        ) >= Self.systemFirstBufferStallGraceSeconds
+        ) >= Self.sourceFirstBufferStallGraceSeconds
     }
 
     /// Wallclock-since-start minus all pause time (completed + ongoing).

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
@@ -73,6 +73,7 @@ public protocol MeetingRecordingServiceProtocol: Sendable {
     var isMicrophoneMuted: Bool { get async }
     var canMuteMicrophone: Bool { get async }
     var microphoneMuteState: MeetingMicrophoneMuteState { get async }
+    var captureHealth: MeetingCaptureHealthSummary { get async }
     var transcriptUpdates: AsyncStream<MeetingTranscriptUpdate> { get async }
 }
 
@@ -94,6 +95,10 @@ public extension MeetingRecordingServiceProtocol {
 
     func startRecording() async throws {
         try await startRecording(title: nil, sourceMode: nil, startContext: nil, calendarEventSnapshot: nil)
+    }
+
+    var captureHealth: MeetingCaptureHealthSummary {
+        get async { .notRecording }
     }
 }
 
@@ -247,6 +252,8 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
     private var sourceCaptureMetrics: [AudioSource: SourceCaptureMetrics] = [:]
     private var captureHealthMetrics = CaptureHealthMetrics()
     private var latestLevels = MeetingAudioLevels()
+    private var sourceHealthLastBufferAt: [AudioSource: Date] = [:]
+    private var activeMicrophoneStall: MeetingMicHealthMonitor.StallSignature?
     private var recentSystemRms: Float = 0
     private var recentProcessedMicRms: Float = 0
     private var latestSystemSignalAt: ContinuousClock.Instant?
@@ -379,6 +386,24 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         return MeetingMicrophoneMuteState(isMuted: canMute && microphoneMuted, canMute: canMute)
     }
 
+    public var captureHealth: MeetingCaptureHealthSummary {
+        guard currentSession != nil else {
+            return .notRecording
+        }
+        let sourceMode = captureHealthMetrics.sourceMode ?? .microphoneAndSystem
+        return MeetingCaptureHealthSummary.reduce(
+            sourceMode: sourceMode,
+            microphoneLevel: latestLevels.microphone,
+            systemLevel: latestLevels.system,
+            lastBufferAt: sourceHealthLastBufferAt,
+            isMicrophoneMuted: microphoneMuteState.isMuted,
+            microphoneStarted: captureHealthMetrics.microphoneStarted,
+            interruptedSources: interruptedSources,
+            activeMicrophoneStall: activeMicrophoneStall,
+            captureFailed: captureFailed
+        )
+    }
+
     /// Wallclock-since-start minus all pause time (completed + ongoing).
     /// Used for both the live elapsed timer and the persisted
     /// `MeetingRecordingOutput.durationSeconds`.
@@ -477,6 +502,8 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
             interruptedSources = []
             sourceCaptureMetrics = [:]
             captureHealthMetrics = CaptureHealthMetrics()
+            sourceHealthLastBufferAt = [:]
+            activeMicrophoneStall = nil
             recentSystemRms = 0
             recentProcessedMicRms = 0
             latestSystemSignalAt = nil
@@ -964,9 +991,20 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         case .sourceInterrupted(let source, let error):
             guard !captureFailed else { return }
             await handleSourceInterruption(source: source, error: error)
+        case .microphoneHealth(let event):
+            handleMicrophoneHealthEvent(event)
         case .error(let error):
             guard !captureFailed else { return }
             await failCapture(error)
+        }
+    }
+
+    private func handleMicrophoneHealthEvent(_ event: MeetingMicHealthMonitor.HealthEvent) {
+        switch event {
+        case .stallSuspected(let signature, _):
+            activeMicrophoneStall = signature
+        case .recovered:
+            activeMicrophoneStall = nil
         }
     }
 
@@ -992,6 +1030,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         captureFailed = true
         latestLevels = MeetingAudioLevels()
         microphoneMuted = false
+        activeMicrophoneStall = nil
         microphoneMutedHostTime = nil
         completedMicrophoneMuteHostTimeRanges = []
         logger.error("meeting_capture_failed error_type=\(AudioCaptureDiagnostics.errorType(error), privacy: .public) error_detail=\(error.localizedDescription, privacy: .private)")
@@ -1170,6 +1209,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
     }
 
     private func recordCaptureMetrics(for source: AudioSource, time: AVAudioTime) {
+        sourceHealthLastBufferAt[source] = wallClockNow()
         guard time.isHostTimeValid else { return }
         var metrics = sourceCaptureMetrics[source] ?? SourceCaptureMetrics()
         if metrics.firstHostTime == nil {
@@ -1557,6 +1597,8 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         latestLevels = MeetingAudioLevels()
         sourceCaptureMetrics = [:]
         captureHealthMetrics = CaptureHealthMetrics()
+        sourceHealthLastBufferAt = [:]
+        activeMicrophoneStall = nil
         interruptedSources = []
         recentSystemRms = 0
         recentProcessedMicRms = 0

--- a/Sources/MacParakeetViewModels/MeetingRecordingPanelViewModel.swift
+++ b/Sources/MacParakeetViewModels/MeetingRecordingPanelViewModel.swift
@@ -41,6 +41,7 @@ public final class MeetingRecordingPanelViewModel {
     public var elapsedSeconds: Int = 0
     public var micLevel: Float = 0
     public var systemLevel: Float = 0
+    public var captureHealth: MeetingCaptureHealthSummary = .notRecording
     /// Mirrors `MeetingRecordingService.isPaused`, set by the flow
     /// coordinator's polling task.
     public var isPaused: Bool = false
@@ -159,6 +160,7 @@ public final class MeetingRecordingPanelViewModel {
         elapsedSeconds = 0
         micLevel = 0
         systemLevel = 0
+        captureHealth = .notRecording
         isPaused = false
         isMicrophoneMuted = false
         canToggleMicrophoneMute = false
@@ -256,6 +258,17 @@ public final class MeetingRecordingPanelViewModel {
         // would render as a flat dot pretending to listen. Fall back to the
         // simple status indicator instead so the paused state reads honestly.
         state == .recording && !isPaused
+    }
+
+    public var sourceHealthChips: [MeetingSourceHealthChip] {
+        guard state == .recording, captureHealth != .notRecording else {
+            return []
+        }
+        return MeetingSourceHealthChip.chips(for: captureHealth, includeNotSelected: true)
+    }
+
+    public var showsSourceHealthChips: Bool {
+        !sourceHealthChips.isEmpty
     }
 
     public func updateLiveTranscriptStatus(_ status: LiveTranscriptStatus) {

--- a/Sources/MacParakeetViewModels/MeetingRecordingPillViewModel.swift
+++ b/Sources/MacParakeetViewModels/MeetingRecordingPillViewModel.swift
@@ -1,3 +1,4 @@
+import MacParakeetCore
 import SwiftUI
 
 @MainActor @Observable
@@ -18,6 +19,7 @@ public final class MeetingRecordingPillViewModel {
     public var elapsedSeconds: Int = 0
     public var micLevel: Float = 0
     public var systemLevel: Float = 0
+    public var captureHealth: MeetingCaptureHealthSummary = .notRecording
     public var backgroundTranscriptionCount: Int = 0
     public var onStop: (() -> Void)?
     public var onPauseToggle: (() -> Void)?
@@ -43,5 +45,14 @@ public final class MeetingRecordingPillViewModel {
     public var isPaused: Bool {
         if case .paused = state { return true }
         return false
+    }
+
+    public var mirroredSourceHealthWarning: MeetingSourceHealthChip? {
+        switch state {
+        case .recording, .paused:
+            return MeetingSourceHealthChip.primaryDegraded(for: captureHealth)
+        case .idle, .completing, .transcribing, .completed, .error:
+            return nil
+        }
     }
 }

--- a/Sources/MacParakeetViewModels/MeetingSourceHealthPresentation.swift
+++ b/Sources/MacParakeetViewModels/MeetingSourceHealthPresentation.swift
@@ -1,0 +1,83 @@
+import Foundation
+import MacParakeetCore
+
+public enum MeetingSourceHealthSeverity: Sendable, Equatable {
+    case neutral
+    case good
+    case warning
+    case critical
+}
+
+public struct MeetingSourceHealthChip: Identifiable, Sendable, Equatable {
+    public let source: MeetingSourceHealth.Source
+    public let status: MeetingSourceHealth.Status
+    public let label: String
+    public let symbolName: String
+    public let severity: MeetingSourceHealthSeverity
+    public let isDegraded: Bool
+
+    public var id: String {
+        source.rawValue
+    }
+
+    public init(_ health: MeetingSourceHealth) {
+        self.source = health.source
+        self.status = health.status
+        self.label = health.label
+        self.symbolName = Self.symbolName(source: health.source, status: health.status)
+        self.severity = Self.severity(for: health.status)
+        self.isDegraded = health.status.isDegraded
+    }
+
+    public static func chips(
+        for summary: MeetingCaptureHealthSummary,
+        includeNotSelected: Bool
+    ) -> [MeetingSourceHealthChip] {
+        [summary.microphone, summary.system]
+            .filter { includeNotSelected || $0.status != .notSelected }
+            .map(MeetingSourceHealthChip.init)
+    }
+
+    public static func primaryDegraded(
+        for summary: MeetingCaptureHealthSummary
+    ) -> MeetingSourceHealthChip? {
+        summary.primaryDegradedSource.map(MeetingSourceHealthChip.init)
+    }
+
+    private static func severity(for status: MeetingSourceHealth.Status) -> MeetingSourceHealthSeverity {
+        switch status {
+        case .live:
+            return .good
+        case .muted, .silent, .stalled:
+            return .warning
+        case .interrupted, .unavailable:
+            return .critical
+        case .notSelected, .starting:
+            return .neutral
+        }
+    }
+
+    private static func symbolName(
+        source: MeetingSourceHealth.Source,
+        status: MeetingSourceHealth.Status
+    ) -> String {
+        switch (source, status) {
+        case (.microphone, .live):
+            return "mic.fill"
+        case (.microphone, .muted), (.microphone, .notSelected):
+            return "mic.slash.fill"
+        case (.microphone, .silent), (.microphone, .stalled), (.microphone, .interrupted), (.microphone, .unavailable):
+            return "exclamationmark.triangle.fill"
+        case (.microphone, .starting):
+            return "mic"
+        case (.system, .live):
+            return "speaker.wave.2.fill"
+        case (.system, .notSelected):
+            return "speaker.slash.fill"
+        case (.system, .silent), (.system, .stalled), (.system, .interrupted), (.system, .unavailable):
+            return "exclamationmark.triangle.fill"
+        case (.system, .starting), (.system, .muted):
+            return "speaker.wave.2"
+        }
+    }
+}

--- a/Tests/MacParakeetTests/Audio/MeetingAudioCaptureServiceTests.swift
+++ b/Tests/MacParakeetTests/Audio/MeetingAudioCaptureServiceTests.swift
@@ -754,6 +754,8 @@ private actor CapturedMeetingCaptureEvents {
             microphoneBufferCount += 1
         case .systemBuffer:
             systemBufferCount += 1
+        case .microphoneHealth:
+            break
         case .sourceInterrupted:
             break
         case .error:

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingServiceTests.swift
@@ -645,6 +645,169 @@ final class MeetingRecordingServiceTests: XCTestCase {
         XCTAssertEqual(output.sourceAlignment.system?.lastHostTime, firstSystemHostTime)
     }
 
+    func testCaptureHealthReportsMicrophoneAndSystemLiveAfterBuffers() async throws {
+        let captureService = MockMeetingAudioCaptureService()
+        let service = MeetingRecordingService(
+            audioCaptureService: captureService,
+            audioConverter: MockMeetingAudioFileConverter(),
+            sttTranscriber: CountingMeetingSTTClient()
+        )
+
+        try await service.startRecording()
+        let microphoneBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 4_800, sampleValue: 0.25))
+        let systemBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 4_800, sampleValue: 0.25))
+        await captureService.yield(.microphoneBuffer(
+            microphoneBuffer,
+            AVAudioTime(hostTime: AVAudioTime.hostTime(forSeconds: 100.0))
+        ))
+        await captureService.yield(.systemBuffer(
+            systemBuffer,
+            AVAudioTime(hostTime: AVAudioTime.hostTime(forSeconds: 100.1))
+        ))
+
+        let health = try await waitForCaptureHealth(service) {
+            $0.microphone.status == .live && $0.system.status == .live
+        }
+        XCTAssertEqual(health.sourceMode, .microphoneAndSystem)
+        XCTAssertFalse(health.isDegraded)
+        XCTAssertNil(health.primaryMessage)
+        XCTAssertGreaterThan(health.microphone.level, 0)
+        XCTAssertGreaterThan(health.system.level, 0)
+        XCTAssertNotNil(health.microphone.lastBufferAt)
+        XCTAssertNotNil(health.system.lastBufferAt)
+
+        await service.cancelRecording()
+    }
+
+    func testCaptureHealthMarksSystemNotSelectedForMicrophoneOnly() async throws {
+        let captureService = MockMeetingAudioCaptureService(
+            startReport: MeetingAudioCaptureStartReport(
+                sourceMode: .microphoneOnly,
+                microphone: MeetingMicrophoneCaptureStartReport(requestedMode: .raw, effectiveMode: .raw)
+            )
+        )
+        let service = MeetingRecordingService(
+            audioCaptureService: captureService,
+            audioConverter: MockMeetingAudioFileConverter(),
+            sttTranscriber: CountingMeetingSTTClient()
+        )
+
+        try await service.startRecording(sourceMode: .microphoneOnly)
+
+        let health = await service.captureHealth
+        XCTAssertEqual(health.sourceMode, .microphoneOnly)
+        XCTAssertEqual(health.system.status, .notSelected)
+        XCTAssertEqual(health.system.label, "System not recorded")
+        XCTAssertEqual(health.system.recoveryAction, .changeSourceMode)
+        XCTAssertFalse(health.system.status.isDegraded)
+
+        await service.cancelRecording()
+    }
+
+    func testCaptureHealthMarksMicrophoneNotSelectedForSystemOnly() async throws {
+        let captureService = MockMeetingAudioCaptureService(
+            startReport: MeetingAudioCaptureStartReport(sourceMode: .systemOnly)
+        )
+        let service = MeetingRecordingService(
+            audioCaptureService: captureService,
+            audioConverter: MockMeetingAudioFileConverter(),
+            sttTranscriber: CountingMeetingSTTClient()
+        )
+
+        try await service.startRecording(sourceMode: .systemOnly)
+
+        let health = await service.captureHealth
+        XCTAssertEqual(health.sourceMode, .systemOnly)
+        XCTAssertEqual(health.microphone.status, .notSelected)
+        XCTAssertEqual(health.microphone.label, "Mic not recorded")
+        XCTAssertEqual(health.microphone.recoveryAction, .changeSourceMode)
+        XCTAssertFalse(health.microphone.status.isDegraded)
+
+        await service.cancelRecording()
+    }
+
+    func testCaptureHealthMarksUserMutedMicrophone() async throws {
+        let captureService = MockMeetingAudioCaptureService()
+        let service = MeetingRecordingService(
+            audioCaptureService: captureService,
+            audioConverter: MockMeetingAudioFileConverter(),
+            sttTranscriber: CountingMeetingSTTClient()
+        )
+
+        try await service.startRecording()
+        let muteState = await service.setMicrophoneMuted(true)
+
+        let health = await service.captureHealth
+        XCTAssertEqual(muteState, MeetingMicrophoneMuteState(isMuted: true, canMute: true))
+        XCTAssertEqual(health.microphone.status, .muted)
+        XCTAssertEqual(health.microphone.label, "Mic muted")
+        XCTAssertEqual(health.microphone.recoveryAction, .unmuteMicrophone)
+        XCTAssertTrue(health.isDegraded)
+        XCTAssertEqual(health.primaryMessage, "Mic muted")
+
+        await service.cancelRecording()
+    }
+
+    func testCaptureHealthMarksSystemInterruption() async throws {
+        let captureService = MockMeetingAudioCaptureService()
+        let service = MeetingRecordingService(
+            audioCaptureService: captureService,
+            audioConverter: MockMeetingAudioFileConverter(),
+            sttTranscriber: CountingMeetingSTTClient()
+        )
+
+        try await service.startRecording()
+        await captureService.yield(.sourceInterrupted(
+            source: .system,
+            error: .captureRuntimeFailure("simulated system stream interruption")
+        ))
+
+        let health = try await waitForCaptureHealth(service) {
+            $0.system.status == .interrupted
+        }
+        XCTAssertEqual(health.system.label, "System audio interrupted")
+        XCTAssertEqual(health.system.recoveryAction, .restartRecording)
+        XCTAssertEqual(health.primaryMessage, "System audio interrupted")
+        let captureMode = await service.captureMode
+        XCTAssertEqual(captureMode, .full)
+
+        await service.cancelRecording()
+    }
+
+    func testCaptureHealthMarksMicStallAndRecovery() async throws {
+        let captureService = MockMeetingAudioCaptureService()
+        let service = MeetingRecordingService(
+            audioCaptureService: captureService,
+            audioConverter: MockMeetingAudioFileConverter(),
+            sttTranscriber: CountingMeetingSTTClient()
+        )
+
+        try await service.startRecording()
+        await captureService.yield(.microphoneHealth(.stallSuspected(signature: .micSilent, elapsedMs: 3_000)))
+
+        let stalledHealth = try await waitForCaptureHealth(service) {
+            $0.microphone.status == .stalled
+        }
+        XCTAssertEqual(stalledHealth.microphone.label, "Mic may be stalled")
+        XCTAssertEqual(stalledHealth.microphone.recoveryAction, .checkMicrophoneInput)
+        XCTAssertEqual(stalledHealth.primaryMessage, "Mic may be stalled")
+
+        await captureService.yield(.microphoneHealth(.recovered))
+        let microphoneBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 4_800, sampleValue: 0.25))
+        await captureService.yield(.microphoneBuffer(
+            microphoneBuffer,
+            AVAudioTime(hostTime: AVAudioTime.hostTime(forSeconds: 101.0))
+        ))
+
+        let recoveredHealth = try await waitForCaptureHealth(service) {
+            $0.microphone.status == .live
+        }
+        XCTAssertEqual(recoveredHealth.microphone.label, "Mic live")
+        XCTAssertNil(recoveredHealth.primaryMessage)
+
+        await service.cancelRecording()
+    }
+
     func testStopRecordingPreservesCrossStreamHostTimeOffsetsInSourceAlignment() async throws {
         let captureService = MockMeetingAudioCaptureService()
         let audioConverter = MockMeetingAudioFileConverter()
@@ -1328,6 +1491,25 @@ final class MeetingRecordingServiceTests: XCTestCase {
             if startedAt.duration(to: .now) > timeout {
                 XCTFail("Timed out waiting for system level predicate")
                 return
+            }
+            try await Task.sleep(for: .milliseconds(20))
+        }
+    }
+
+    private func waitForCaptureHealth(
+        _ service: MeetingRecordingService,
+        timeout: Duration = .seconds(1),
+        _ predicate: @escaping (MeetingCaptureHealthSummary) -> Bool
+    ) async throws -> MeetingCaptureHealthSummary {
+        let startedAt = ContinuousClock.now
+        while true {
+            let health = await service.captureHealth
+            if predicate(health) {
+                return health
+            }
+            if startedAt.duration(to: .now) > timeout {
+                XCTFail("Timed out waiting for capture health predicate; latest health: \(health)")
+                return health
             }
             try await Task.sleep(for: .milliseconds(20))
         }

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingServiceTests.swift
@@ -776,7 +776,9 @@ final class MeetingRecordingServiceTests: XCTestCase {
 
     func testCaptureHealthMarksStartedSystemWithoutBuffersStalledAfterGraceAndRecoversOnFirstBuffer() async throws {
         let wallClock = MeetingTestWallClock(now: Date(timeIntervalSince1970: 1_700_000_000))
-        let captureService = MockMeetingAudioCaptureService()
+        let captureService = MockMeetingAudioCaptureService(
+            startReport: MeetingAudioCaptureStartReport(sourceMode: .systemOnly)
+        )
         let service = MeetingRecordingService(
             audioCaptureService: captureService,
             audioConverter: MockMeetingAudioFileConverter(),
@@ -789,7 +791,7 @@ final class MeetingRecordingServiceTests: XCTestCase {
             }
         )
 
-        try await service.startRecording()
+        try await service.startRecording(sourceMode: .systemOnly)
         wallClock.advance(by: 11)
         await service.pauseRecording()
         wallClock.advance(by: 5)
@@ -817,6 +819,51 @@ final class MeetingRecordingServiceTests: XCTestCase {
             $0.system.status == .live
         }
         XCTAssertEqual(recoveredHealth.system.label, "System live")
+        XCTAssertNil(recoveredHealth.primaryMessage)
+
+        await service.cancelRecording()
+    }
+
+    func testCaptureHealthMarksMicOnlyStartedWithoutBuffersStalledAfterGraceAndRecoversOnFirstBuffer() async throws {
+        let wallClock = MeetingTestWallClock(now: Date(timeIntervalSince1970: 1_700_000_000))
+        let captureService = MockMeetingAudioCaptureService(
+            startReport: MeetingAudioCaptureStartReport(
+                sourceMode: .microphoneOnly,
+                microphone: MeetingMicrophoneCaptureStartReport(requestedMode: .raw, effectiveMode: .raw)
+            )
+        )
+        let service = MeetingRecordingService(
+            audioCaptureService: captureService,
+            audioConverter: MockMeetingAudioFileConverter(),
+            sttTranscriber: CountingMeetingSTTClient(),
+            micConditionerFactory: {
+                PassthroughMicConditioner()
+            },
+            wallClockNow: {
+                wallClock.now
+            }
+        )
+
+        try await service.startRecording(sourceMode: .microphoneOnly)
+        wallClock.advance(by: 12.1)
+
+        let stalledHealth = await service.captureHealth
+        XCTAssertEqual(stalledHealth.microphone.status, .stalled)
+        XCTAssertEqual(stalledHealth.microphone.label, "Mic may be stalled")
+        XCTAssertEqual(stalledHealth.microphone.recoveryAction, .checkMicrophoneInput)
+        XCTAssertNil(stalledHealth.microphone.lastBufferAt)
+        XCTAssertEqual(stalledHealth.primaryMessage, "Mic may be stalled")
+
+        let microphoneBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 4_800, sampleValue: 0.25))
+        await captureService.yield(.microphoneBuffer(
+            microphoneBuffer,
+            AVAudioTime(hostTime: AVAudioTime.hostTime(forSeconds: 100.0))
+        ))
+
+        let recoveredHealth = try await waitForCaptureHealth(service) {
+            $0.microphone.status == .live
+        }
+        XCTAssertEqual(recoveredHealth.microphone.label, "Mic live")
         XCTAssertNil(recoveredHealth.primaryMessage)
 
         await service.cancelRecording()

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingServiceTests.swift
@@ -808,6 +808,62 @@ final class MeetingRecordingServiceTests: XCTestCase {
         await service.cancelRecording()
     }
 
+    func testCaptureHealthMarksStartedMicWithoutBuffersStalledAfterMonitorEvent() async throws {
+        let captureService = MockMeetingAudioCaptureService()
+        let service = MeetingRecordingService(
+            audioCaptureService: captureService,
+            audioConverter: MockMeetingAudioFileConverter(),
+            sttTranscriber: CountingMeetingSTTClient()
+        )
+
+        try await service.startRecording()
+        await captureService.yield(.microphoneHealth(.stallSuspected(signature: .micMissing, elapsedMs: 3_000)))
+
+        let health = try await waitForCaptureHealth(service) {
+            $0.microphone.status == .stalled
+        }
+        XCTAssertEqual(health.microphone.label, "Mic may be stalled")
+        XCTAssertEqual(health.microphone.recoveryAction, .checkMicrophoneInput)
+        XCTAssertNil(health.microphone.lastBufferAt)
+        XCTAssertEqual(health.primaryMessage, "Mic may be stalled")
+
+        await service.cancelRecording()
+    }
+
+    func testCaptureHealthShowsMutedDuringActiveMicStallAndStalledAfterUnmute() async throws {
+        let captureService = MockMeetingAudioCaptureService()
+        let service = MeetingRecordingService(
+            audioCaptureService: captureService,
+            audioConverter: MockMeetingAudioFileConverter(),
+            sttTranscriber: CountingMeetingSTTClient()
+        )
+
+        try await service.startRecording()
+        await captureService.yield(.microphoneHealth(.stallSuspected(signature: .micSilent, elapsedMs: 3_000)))
+        _ = try await waitForCaptureHealth(service) {
+            $0.microphone.status == .stalled
+        }
+
+        let muteState = await service.setMicrophoneMuted(true)
+        let mutedHealth = await service.captureHealth
+        XCTAssertEqual(muteState, MeetingMicrophoneMuteState(isMuted: true, canMute: true))
+        XCTAssertEqual(mutedHealth.microphone.status, .muted)
+        XCTAssertEqual(mutedHealth.microphone.label, "Mic muted")
+        XCTAssertEqual(mutedHealth.microphone.recoveryAction, .unmuteMicrophone)
+        XCTAssertEqual(mutedHealth.primaryMessage, "Mic muted")
+
+        let unmuteState = await service.setMicrophoneMuted(false)
+        let unmutedHealth = try await waitForCaptureHealth(service) {
+            $0.microphone.status == .stalled
+        }
+        XCTAssertEqual(unmuteState, MeetingMicrophoneMuteState(isMuted: false, canMute: true))
+        XCTAssertEqual(unmutedHealth.microphone.label, "Mic may be stalled")
+        XCTAssertEqual(unmutedHealth.microphone.recoveryAction, .checkMicrophoneInput)
+        XCTAssertEqual(unmutedHealth.primaryMessage, "Mic may be stalled")
+
+        await service.cancelRecording()
+    }
+
     func testStopRecordingPreservesCrossStreamHostTimeOffsetsInSourceAlignment() async throws {
         let captureService = MockMeetingAudioCaptureService()
         let audioConverter = MockMeetingAudioFileConverter()

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingServiceTests.swift
@@ -774,6 +774,54 @@ final class MeetingRecordingServiceTests: XCTestCase {
         await service.cancelRecording()
     }
 
+    func testCaptureHealthMarksStartedSystemWithoutBuffersStalledAfterGraceAndRecoversOnFirstBuffer() async throws {
+        let wallClock = MeetingTestWallClock(now: Date(timeIntervalSince1970: 1_700_000_000))
+        let captureService = MockMeetingAudioCaptureService()
+        let service = MeetingRecordingService(
+            audioCaptureService: captureService,
+            audioConverter: MockMeetingAudioFileConverter(),
+            sttTranscriber: CountingMeetingSTTClient(),
+            micConditionerFactory: {
+                PassthroughMicConditioner()
+            },
+            wallClockNow: {
+                wallClock.now
+            }
+        )
+
+        try await service.startRecording()
+        wallClock.advance(by: 11)
+        await service.pauseRecording()
+        wallClock.advance(by: 5)
+
+        let pausedHealth = await service.captureHealth
+        XCTAssertEqual(pausedHealth.system.status, .starting)
+
+        await service.resumeRecording()
+        wallClock.advance(by: 1.1)
+
+        let stalledHealth = await service.captureHealth
+        XCTAssertEqual(stalledHealth.system.status, .stalled)
+        XCTAssertEqual(stalledHealth.system.label, "System may be stalled")
+        XCTAssertEqual(stalledHealth.system.recoveryAction, .restartRecording)
+        XCTAssertNil(stalledHealth.system.lastBufferAt)
+        XCTAssertEqual(stalledHealth.primaryMessage, "System may be stalled")
+
+        let systemBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 4_800, sampleValue: 0.25))
+        await captureService.yield(.systemBuffer(
+            systemBuffer,
+            AVAudioTime(hostTime: AVAudioTime.hostTime(forSeconds: 100.0))
+        ))
+
+        let recoveredHealth = try await waitForCaptureHealth(service) {
+            $0.system.status == .live
+        }
+        XCTAssertEqual(recoveredHealth.system.label, "System live")
+        XCTAssertNil(recoveredHealth.primaryMessage)
+
+        await service.cancelRecording()
+    }
+
     func testCaptureHealthMarksMicStallAndRecovery() async throws {
         let captureService = MockMeetingAudioCaptureService()
         let service = MeetingRecordingService(

--- a/Tests/MacParakeetTests/ViewModels/MeetingRecordingPanelViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/MeetingRecordingPanelViewModelTests.swift
@@ -44,6 +44,52 @@ final class MeetingRecordingPanelViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.showsLaggingIndicator)
     }
 
+    func testSourceHealthChipsMirrorDualSourceHealth() {
+        let viewModel = MeetingRecordingPanelViewModel()
+        viewModel.state = .recording
+        viewModel.captureHealth = makeCaptureHealth(
+            microphone: MeetingSourceHealth(source: .microphone, status: .live, level: 0.7),
+            system: MeetingSourceHealth(source: .system, status: .interrupted)
+        )
+
+        let chips = viewModel.sourceHealthChips
+
+        XCTAssertTrue(viewModel.showsSourceHealthChips)
+        XCTAssertEqual(chips.map(\.label), ["Mic live", "System audio interrupted"])
+        XCTAssertEqual(chips.map(\.severity), [.good, .critical])
+        XCTAssertEqual(chips.map(\.symbolName), ["mic.fill", "exclamationmark.triangle.fill"])
+    }
+
+    func testSourceHealthChipsIncludeNotRecordedSingleSourceState() {
+        let viewModel = MeetingRecordingPanelViewModel()
+        viewModel.state = .recording
+        viewModel.captureHealth = makeCaptureHealth(
+            sourceMode: .microphoneOnly,
+            microphone: MeetingSourceHealth(source: .microphone, status: .live, level: 0.8),
+            system: MeetingSourceHealth(source: .system, status: .notSelected)
+        )
+
+        let chips = viewModel.sourceHealthChips
+
+        XCTAssertEqual(chips.map(\.label), ["Mic live", "System not recorded"])
+        XCTAssertEqual(chips.last?.severity, .neutral)
+        XCTAssertFalse(chips.last?.isDegraded ?? true)
+    }
+
+    func testSourceHealthChipsHideOutsideRecording() {
+        let viewModel = MeetingRecordingPanelViewModel()
+        viewModel.captureHealth = makeCaptureHealth(
+            microphone: MeetingSourceHealth(source: .microphone, status: .live, level: 0.5),
+            system: MeetingSourceHealth(source: .system, status: .live, level: 0.5)
+        )
+
+        XCTAssertTrue(viewModel.sourceHealthChips.isEmpty)
+        XCTAssertFalse(viewModel.showsSourceHealthChips)
+
+        viewModel.state = .recording
+        XCTAssertFalse(viewModel.sourceHealthChips.isEmpty)
+    }
+
     func testWordCountUpdatesWhenExistingSegmentGrows() {
         let viewModel = MeetingRecordingPanelViewModel()
         let initialLines = [
@@ -320,6 +366,7 @@ final class MeetingRecordingPanelViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.elapsedSeconds, 0)
         XCTAssertEqual(viewModel.micLevel, 0)
         XCTAssertEqual(viewModel.systemLevel, 0)
+        XCTAssertEqual(viewModel.captureHealth, .notRecording)
         XCTAssertFalse(viewModel.isMicrophoneMuted)
         XCTAssertFalse(viewModel.canToggleMicrophoneMute)
         XCTAssertTrue(viewModel.previewLines.isEmpty)
@@ -351,6 +398,18 @@ final class MeetingRecordingPanelViewModelTests: XCTestCase {
         // Sanity: the composed notes VM is non-nil and starts empty.
         XCTAssertEqual(viewModel.notesViewModel.notesText, "")
         XCTAssertEqual(viewModel.notesViewModel.wordCount, 0)
+    }
+
+    private func makeCaptureHealth(
+        sourceMode: MeetingAudioSourceMode = .microphoneAndSystem,
+        microphone: MeetingSourceHealth,
+        system: MeetingSourceHealth
+    ) -> MeetingCaptureHealthSummary {
+        MeetingCaptureHealthSummary(
+            sourceMode: sourceMode,
+            microphone: microphone,
+            system: system
+        )
     }
 
     func testResetClearsComposedNotesViewModel() {

--- a/Tests/MacParakeetTests/ViewModels/MeetingRecordingPillViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/MeetingRecordingPillViewModelTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+@testable import MacParakeetCore
 @testable import MacParakeetViewModels
 
 @MainActor
@@ -51,5 +52,54 @@ final class MeetingRecordingPillViewModelTests: XCTestCase {
 
         viewModel.elapsedSeconds = 600
         XCTAssertEqual(viewModel.formattedElapsed, "10:00")
+    }
+
+    func testMirroredSourceHealthWarningUsesPrimaryDegradedStateWhileRecording() {
+        let viewModel = MeetingRecordingPillViewModel()
+        viewModel.state = .recording
+        viewModel.captureHealth = MeetingCaptureHealthSummary(
+            sourceMode: .microphoneAndSystem,
+            microphone: MeetingSourceHealth(source: .microphone, status: .muted),
+            system: MeetingSourceHealth(source: .system, status: .interrupted)
+        )
+
+        let warning = viewModel.mirroredSourceHealthWarning
+
+        XCTAssertEqual(warning?.label, "System audio interrupted")
+        XCTAssertEqual(warning?.severity, .critical)
+        XCTAssertEqual(warning?.symbolName, "exclamationmark.triangle.fill")
+    }
+
+    func testMirroredSourceHealthWarningAlsoShowsWhilePaused() {
+        let viewModel = MeetingRecordingPillViewModel()
+        viewModel.state = .paused
+        viewModel.captureHealth = MeetingCaptureHealthSummary(
+            sourceMode: .microphoneAndSystem,
+            microphone: MeetingSourceHealth(source: .microphone, status: .stalled),
+            system: MeetingSourceHealth(source: .system, status: .live, level: 0.5)
+        )
+
+        XCTAssertEqual(viewModel.mirroredSourceHealthWarning?.label, "Mic may be stalled")
+    }
+
+    func testMirroredSourceHealthWarningHidesForHealthyOrNonRecordingStates() {
+        let viewModel = MeetingRecordingPillViewModel()
+        viewModel.state = .recording
+        viewModel.captureHealth = MeetingCaptureHealthSummary(
+            sourceMode: .microphoneAndSystem,
+            microphone: MeetingSourceHealth(source: .microphone, status: .live, level: 0.5),
+            system: MeetingSourceHealth(source: .system, status: .live, level: 0.5)
+        )
+
+        XCTAssertNil(viewModel.mirroredSourceHealthWarning)
+
+        viewModel.captureHealth = MeetingCaptureHealthSummary(
+            sourceMode: .microphoneAndSystem,
+            microphone: MeetingSourceHealth(source: .microphone, status: .silent),
+            system: MeetingSourceHealth(source: .system, status: .live, level: 0.5)
+        )
+        viewModel.state = .transcribing
+
+        XCTAssertNil(viewModel.mirroredSourceHealthWarning)
     }
 }


### PR DESCRIPTION
## Summary
Implements U1 and U2 from the meeting health plan: the recording service now exposes a structured microphone/system source-health summary, and the live meeting UI renders that state in the panel, pill, and meeting tile. The user-visible result is a concise signal for muted, silent, stalled, interrupted, unavailable, or intentionally unrecorded sources without changing recording, STT, AEC, artifact, or telemetry behavior.

## Design
Governing plan: [PR #706](https://github.com/moona3k/macparakeet/pull/706), [`plans/active/2026-07-04-meeting-health-artifacts-speaker-rename.md`](https://github.com/moona3k/macparakeet/blob/plan/meeting-health-artifacts-speaker-rename/plans/active/2026-07-04-meeting-health-artifacts-speaker-rename.md).

This PR implements only U1 and U2. It derives health from facts the recorder already owns: selected source mode, latest mic/system levels, last-buffer timestamps, mic mute state, mic-health monitor events, and system-source interruption state. The Audio-layer change only forwards existing `MeetingMicHealthMonitor.HealthEvent` values on the meeting capture stream; monitor thresholds and telemetry emission stay unchanged.

Deviations: none from U1/U2 behavior. I did run `scripts/dev/format.sh`; it produced broad unrelated formatter churn in pre-existing files, so I reverted that uncommitted churn to keep this PR scoped.

## How It Works
```mermaid
flowchart LR
    Capture[MeetingAudioCaptureService] --> Events[Audio buffers + source events]
    Capture --> MicHealth[Mic health events]
    Events --> Recorder[MeetingRecordingService]
    MicHealth --> Recorder
    Recorder --> Summary[MeetingCaptureHealthSummary]
    Summary --> Coordinator[MeetingRecordingFlowCoordinator]
    Coordinator --> Panel[Panel chips]
    Coordinator --> Pill[Pill warning]
    Coordinator --> Tile[Meeting tile glyph]
```

## Risk Surface
Review hardest around source-health priority, stale-buffer timing, and teardown/reset behavior. The UI intentionally stays non-blocking: degraded health is surfaced as guidance, not as a recording failure. Deliberately out of scope: AEC/source-trust logic, cleaned mic artifacts, STT routing, CLI surfaces, speaker rename, recovery automation, and new telemetry event names.

## Test Evidence
- `swift test --filter MeetingRecordingServiceTests` - 70 tests passed, including the six U1 scenarios.
- `swift test --filter MeetingRecordingPanelViewModelTests` - 29 tests passed.
- `swift test --filter MeetingRecordingPillViewModelTests` - 6 tests passed.
- `scripts/dev/format.sh` - ran; unrelated formatter churn was reverted before commit.
- `git diff --check` - passed.
- `swift test` - ran exactly once as the final full-suite gate: 4,443 tests executed, 15 skipped, 1 failure reported in the aggregate summary. The persisted output was truncated before the failed assertion line; I did not run a second full suite. Per the brief's allowed flaky rerun path, I reran the known flaky `DictationFlowCoordinatorTests.testPillStartedPersistentRecordingSyncsFnHotkeyToStop` once and it passed.

## Author's Notes
Manual QA still worth doing on a real dual-source recording: verify panel chips update after mute/unmute and system-audio interruption, and verify the pill/tile only show the primary degraded source.