### PR TITLE
Polish per-meeting speaker rename UX

### DIFF
--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
@@ -2935,7 +2935,7 @@ struct TranscriptResultView: View {
                         .fill(DesignSystem.Colors.surfaceElevated.opacity(0.45))
                 )
             }
-            Text("Speaker labels are approximate. Click a name to rename.")
+            Text("Speaker labels are approximate.")
                 .font(DesignSystem.Typography.caption)
                 .foregroundStyle(DesignSystem.Colors.textTertiary)
             } // end if speakerOverviewExpanded
@@ -2961,34 +2961,62 @@ struct TranscriptResultView: View {
                     commitSpeakerRename()
                 }
                 .onExitCommand {
-                    editingSpeakerId = nil
+                    cancelSpeakerRename()
                 }
                 .onChange(of: speakerRenameFocused) {
                     if !speakerRenameFocused {
                         commitSpeakerRename()
                     }
                 }
+                .accessibilityLabel("Speaker name")
+                .accessibilityHint("Press Return or move focus away to save. Press Escape to cancel.")
         } else {
-            Text(speaker.label)
-                .font(DesignSystem.Typography.caption.weight(.semibold))
-                .foregroundStyle(color)
-                .onTapGesture {
-                    // Commit any in-flight rename before switching
-                    if editingSpeakerId != nil {
-                        commitSpeakerRename()
+            HStack(spacing: 6) {
+                Text(speaker.label)
+                    .font(DesignSystem.Typography.caption.weight(.semibold))
+                    .foregroundStyle(color)
+                    .onTapGesture {
+                        beginSpeakerRename(speaker)
                     }
-                    editingSpeakerId = speaker.id
-                    editingSpeakerLabel = speaker.label
+
+                Button {
+                    beginSpeakerRename(speaker)
+                } label: {
+                    Image(systemName: "pencil")
+                        .font(.system(size: 11, weight: .semibold))
+                        .frame(width: 20, height: 20)
                 }
-                .help("Click to rename")
+                .parakeetAction(.subtle)
+                .controlSize(.small)
+                .help("Rename \(speaker.label)")
+                .accessibilityLabel("Rename \(speaker.label)")
+                .accessibilityHint("Edits this speaker label for this meeting only.")
+            }
         }
+    }
+
+    private func beginSpeakerRename(_ speaker: SpeakerInfo) {
+        if editingSpeakerId != nil, editingSpeakerId != speaker.id {
+            commitSpeakerRename()
+        }
+        editingSpeakerId = speaker.id
+        editingSpeakerLabel = speaker.label
     }
 
     private func commitSpeakerRename() {
         guard let speakerId = editingSpeakerId else { return }
-        viewModel.renameSpeaker(id: speakerId, to: editingSpeakerLabel)
-        rebuildSegmentCache()
+        let trimmed = editingSpeakerLabel.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty {
+            viewModel.renameSpeaker(id: speakerId, to: trimmed)
+            rebuildSegmentCache()
+        }
+        cancelSpeakerRename()
+    }
+
+    private func cancelSpeakerRename() {
         editingSpeakerId = nil
+        editingSpeakerLabel = ""
+        speakerRenameFocused = false
     }
 
 

--- a/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
@@ -206,6 +206,7 @@ public final class TranscriptionViewModel {
     private var activeProgressWhisperVariant: String?
     private var activeProgressNemotronVariant: NemotronModelVariant?
     private var activeDropRequestID: UUID?
+    private var speakerRenameGenerations: [UUID: Int] = [:]
     private var dropPendingCount = 0
     private var dropCollectedURLs: [URL] = []
     private static let configurationError = "Transcription services are unavailable. Please try again."
@@ -1247,6 +1248,8 @@ public final class TranscriptionViewModel {
         let previousCurrentSpeakers = speakers
         let transcriptionIndex = transcriptions.firstIndex(where: { $0.id == transcription.id })
         let previousListSpeakers = transcriptionIndex.flatMap { transcriptions[$0].speakers }
+        let renameGeneration = (speakerRenameGenerations[transcription.id] ?? 0) + 1
+        speakerRenameGenerations[transcription.id] = renameGeneration
         speakers[index].label = trimmed
         transcription.speakers = speakers
         currentTranscription = transcription
@@ -1255,7 +1258,7 @@ public final class TranscriptionViewModel {
         }
         guard let transcriptionRepo else { return }
         let transcriptionID = transcription.id
-        Task { [weak self, transcriptionRepo, transcriptionID, speakers, previousCurrentSpeakers, previousListSpeakers] in
+        Task { [weak self, transcriptionRepo, transcriptionID, speakers, previousCurrentSpeakers, previousListSpeakers, renameGeneration] in
             do {
                 try await Task.detached(priority: .utility) {
                     try transcriptionRepo.updateSpeakers(id: transcriptionID, speakers: speakers)
@@ -1264,6 +1267,7 @@ public final class TranscriptionViewModel {
                 let errorType = TelemetryErrorClassifier.classify(error)
                 self?.handleSpeakerRenamePersistenceFailure(
                     transcriptionID: transcriptionID,
+                    generation: renameGeneration,
                     previousCurrentSpeakers: previousCurrentSpeakers,
                     previousListSpeakers: previousListSpeakers,
                     errorType: errorType
@@ -1274,10 +1278,12 @@ public final class TranscriptionViewModel {
 
     private func handleSpeakerRenamePersistenceFailure(
         transcriptionID: UUID,
+        generation: Int,
         previousCurrentSpeakers: [SpeakerInfo],
         previousListSpeakers: [SpeakerInfo]?,
         errorType: String
     ) {
+        guard speakerRenameGenerations[transcriptionID] == generation else { return }
         if var currentTranscription, currentTranscription.id == transcriptionID {
             currentTranscription.speakers = previousCurrentSpeakers
             self.currentTranscription = currentTranscription

--- a/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
@@ -1247,6 +1247,9 @@ public final class TranscriptionViewModel {
         speakers[index].label = trimmed
         transcription.speakers = speakers
         currentTranscription = transcription
+        if let transcriptionIndex = transcriptions.firstIndex(where: { $0.id == transcription.id }) {
+            transcriptions[transcriptionIndex].speakers = speakers
+        }
         do {
             try transcriptionRepo?.updateSpeakers(id: transcription.id, speakers: speakers)
         } catch {

--- a/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
@@ -1244,17 +1244,49 @@ public final class TranscriptionViewModel {
         guard let index = speakers.firstIndex(where: { $0.id == speakerId }) else { return }
         let trimmed = newLabel.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty, speakers[index].label != trimmed else { return }
+        let previousCurrentSpeakers = speakers
+        let transcriptionIndex = transcriptions.firstIndex(where: { $0.id == transcription.id })
+        let previousListSpeakers = transcriptionIndex.flatMap { transcriptions[$0].speakers }
         speakers[index].label = trimmed
         transcription.speakers = speakers
         currentTranscription = transcription
-        if let transcriptionIndex = transcriptions.firstIndex(where: { $0.id == transcription.id }) {
+        if let transcriptionIndex {
             transcriptions[transcriptionIndex].speakers = speakers
         }
-        do {
-            try transcriptionRepo?.updateSpeakers(id: transcription.id, speakers: speakers)
-        } catch {
-            logger.error("Failed to persist speaker rename error_type=\(TelemetryErrorClassifier.classify(error), privacy: .public)")
+        guard let transcriptionRepo else { return }
+        let transcriptionID = transcription.id
+        Task { [weak self, transcriptionRepo, transcriptionID, speakers, previousCurrentSpeakers, previousListSpeakers] in
+            do {
+                try await Task.detached(priority: .utility) {
+                    try transcriptionRepo.updateSpeakers(id: transcriptionID, speakers: speakers)
+                }.value
+            } catch {
+                let errorType = TelemetryErrorClassifier.classify(error)
+                self?.handleSpeakerRenamePersistenceFailure(
+                    transcriptionID: transcriptionID,
+                    previousCurrentSpeakers: previousCurrentSpeakers,
+                    previousListSpeakers: previousListSpeakers,
+                    errorType: errorType
+                )
+            }
         }
+    }
+
+    private func handleSpeakerRenamePersistenceFailure(
+        transcriptionID: UUID,
+        previousCurrentSpeakers: [SpeakerInfo],
+        previousListSpeakers: [SpeakerInfo]?,
+        errorType: String
+    ) {
+        if var currentTranscription, currentTranscription.id == transcriptionID {
+            currentTranscription.speakers = previousCurrentSpeakers
+            self.currentTranscription = currentTranscription
+        }
+        if let index = transcriptions.firstIndex(where: { $0.id == transcriptionID }) {
+            transcriptions[index].speakers = previousListSpeakers
+        }
+        setError(message: "Failed to save speaker rename. The previous label was restored.")
+        logger.error("Failed to persist speaker rename error_type=\(errorType, privacy: .public)")
     }
 
     public func renameCurrentTranscription(to newFileName: String) {

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
@@ -2,6 +2,40 @@ import XCTest
 @testable import MacParakeetCore
 @testable import MacParakeetViewModels
 
+private final class SlowFirstSpeakerUpdateFailure: @unchecked Sendable {
+    private let lock = NSLock()
+    private var startedFirstUpdate = false
+    private var updateCount = 0
+
+    var firstUpdateStarted: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return startedFirstUpdate
+    }
+
+    var count: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return updateCount
+    }
+
+    func handleUpdate(id _: UUID, speakers _: [SpeakerInfo]?) throws {
+        let callNumber: Int
+        lock.lock()
+        updateCount += 1
+        callNumber = updateCount
+        if callNumber == 1 {
+            startedFirstUpdate = true
+        }
+        lock.unlock()
+
+        if callNumber == 1 {
+            Thread.sleep(forTimeInterval: 0.2)
+            throw NSError(domain: "test", code: 1)
+        }
+    }
+}
+
 @MainActor
 final class TranscriptionViewModelTests: XCTestCase {
     var viewModel: TranscriptionViewModel!
@@ -1357,6 +1391,43 @@ final class TranscriptionViewModelTests: XCTestCase {
         XCTAssertEqual(unchanged?.speakers?[0].label, "Other speaker")
         XCTAssertEqual(mockRepo.updateSpeakersCalls.count, 1)
         XCTAssertEqual(viewModel.errorMessage, "Failed to save speaker rename. The previous label was restored.")
+    }
+
+    func testRenameSpeakerStaleFailureDoesNotClobberLaterSuccessfulRename() async throws {
+        let speakers = [
+            SpeakerInfo(id: "S1", label: "Speaker 1"),
+            SpeakerInfo(id: "S2", label: "Speaker 2")
+        ]
+        let t = Transcription(fileName: "meeting.wav", speakers: speakers, status: .completed)
+        let probe = SlowFirstSpeakerUpdateFailure()
+        mockRepo.transcriptions = [t]
+        mockRepo.updateSpeakersHandler = { id, speakers in
+            try probe.handleUpdate(id: id, speakers: speakers)
+        }
+
+        viewModel.configure(transcriptionService: mockService, transcriptionRepo: mockRepo)
+        viewModel.currentTranscription = t
+
+        viewModel.renameSpeaker(id: "S1", to: "Alice")
+        try await waitUntil {
+            probe.firstUpdateStarted
+        }
+
+        viewModel.renameSpeaker(id: "S1", to: "Bob")
+        XCTAssertEqual(viewModel.currentTranscription?.speakers?[0].label, "Bob")
+
+        try await waitUntil {
+            probe.count == 2
+        }
+        try await Task.sleep(for: .milliseconds(300))
+
+        XCTAssertEqual(viewModel.currentTranscription?.speakers?[0].label, "Bob")
+        XCTAssertEqual(viewModel.currentTranscription?.speakers?[1].label, "Speaker 2")
+
+        let updated = viewModel.transcriptions.first { $0.id == t.id }
+        XCTAssertEqual(updated?.speakers?[0].label, "Bob")
+        XCTAssertEqual(updated?.speakers?[1].label, "Speaker 2")
+        XCTAssertNil(viewModel.errorMessage)
     }
 
     func testRenameSpeakerPersistsToRepo() async throws {

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
@@ -1299,6 +1299,32 @@ final class TranscriptionViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.currentTranscription?.speakers?[1].label, "Speaker 2")
     }
 
+    func testRenameSpeakerUpdatesMatchingTranscriptionsRow() {
+        let speakers = [
+            SpeakerInfo(id: "S1", label: "Speaker 1"),
+            SpeakerInfo(id: "S2", label: "Speaker 2")
+        ]
+        let t = Transcription(fileName: "meeting.wav", speakers: speakers, status: .completed)
+        let other = Transcription(
+            fileName: "other.wav",
+            speakers: [SpeakerInfo(id: "S1", label: "Other speaker")],
+            status: .completed
+        )
+        mockRepo.transcriptions = [t, other]
+
+        viewModel.configure(transcriptionService: mockService, transcriptionRepo: mockRepo)
+        viewModel.currentTranscription = t
+
+        viewModel.renameSpeaker(id: "S1", to: "Sarah")
+
+        let updated = viewModel.transcriptions.first { $0.id == t.id }
+        XCTAssertEqual(updated?.speakers?[0].label, "Sarah")
+        XCTAssertEqual(updated?.speakers?[1].label, "Speaker 2")
+
+        let unchanged = viewModel.transcriptions.first { $0.id == other.id }
+        XCTAssertEqual(unchanged?.speakers?[0].label, "Other speaker")
+    }
+
     func testRenameSpeakerPersistsToRepo() {
         let speakers = [SpeakerInfo(id: "S1", label: "Speaker 1")]
         let t = Transcription(fileName: "test.mp3", speakers: speakers, status: .completed)

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
@@ -1325,7 +1325,41 @@ final class TranscriptionViewModelTests: XCTestCase {
         XCTAssertEqual(unchanged?.speakers?[0].label, "Other speaker")
     }
 
-    func testRenameSpeakerPersistsToRepo() {
+    func testRenameSpeakerPersistenceFailureRevertsInMemoryState() async throws {
+        let speakers = [
+            SpeakerInfo(id: "S1", label: "Speaker 1"),
+            SpeakerInfo(id: "S2", label: "Speaker 2")
+        ]
+        let t = Transcription(fileName: "meeting.wav", speakers: speakers, status: .completed)
+        let other = Transcription(
+            fileName: "other.wav",
+            speakers: [SpeakerInfo(id: "S1", label: "Other speaker")],
+            status: .completed
+        )
+        mockRepo.transcriptions = [t, other]
+        mockRepo.updateSpeakersError = NSError(domain: "test", code: 1)
+
+        viewModel.configure(transcriptionService: mockService, transcriptionRepo: mockRepo)
+        viewModel.currentTranscription = t
+
+        viewModel.renameSpeaker(id: "S1", to: "Sarah")
+
+        try await waitUntil {
+            self.viewModel.currentTranscription?.speakers?[0].label == "Speaker 1"
+        }
+        XCTAssertEqual(viewModel.currentTranscription?.speakers?[1].label, "Speaker 2")
+
+        let reverted = viewModel.transcriptions.first { $0.id == t.id }
+        XCTAssertEqual(reverted?.speakers?[0].label, "Speaker 1")
+        XCTAssertEqual(reverted?.speakers?[1].label, "Speaker 2")
+
+        let unchanged = viewModel.transcriptions.first { $0.id == other.id }
+        XCTAssertEqual(unchanged?.speakers?[0].label, "Other speaker")
+        XCTAssertEqual(mockRepo.updateSpeakersCalls.count, 1)
+        XCTAssertEqual(viewModel.errorMessage, "Failed to save speaker rename. The previous label was restored.")
+    }
+
+    func testRenameSpeakerPersistsToRepo() async throws {
         let speakers = [SpeakerInfo(id: "S1", label: "Speaker 1")]
         let t = Transcription(fileName: "test.mp3", speakers: speakers, status: .completed)
         mockRepo.transcriptions = [t]
@@ -1335,6 +1369,9 @@ final class TranscriptionViewModelTests: XCTestCase {
 
         viewModel.renameSpeaker(id: "S1", to: "Alice")
 
+        try await waitUntil {
+            self.mockRepo.updateSpeakersCalls.count == 1
+        }
         XCTAssertEqual(mockRepo.updateSpeakersCalls.count, 1)
         XCTAssertEqual(mockRepo.updateSpeakersCalls[0].speakers?[0].label, "Alice")
     }

--- a/Tests/MacParakeetTests/ViewModels/ViewModelMocks.swift
+++ b/Tests/MacParakeetTests/ViewModels/ViewModelMocks.swift
@@ -140,6 +140,7 @@ final class MockTranscriptionRepository: TranscriptionRepositoryProtocol, @unche
     var updateMeetingArtifactFolderPathCalls: [(id: UUID, folderPath: String?)] = []
     var updateFilePathError: Error?
     var updateSpeakersError: Error?
+    var updateSpeakersHandler: (@Sendable (UUID, [SpeakerInfo]?) throws -> Void)?
     var saveError: Error?
 
     func save(_ transcription: Transcription) throws {
@@ -213,6 +214,9 @@ final class MockTranscriptionRepository: TranscriptionRepositoryProtocol, @unche
 
     func updateSpeakers(id: UUID, speakers: [SpeakerInfo]?) throws {
         updateSpeakersCalls.append((id: id, speakers: speakers))
+        if let updateSpeakersHandler {
+            try updateSpeakersHandler(id, speakers)
+        }
         if let updateSpeakersError {
             throw updateSpeakersError
         }

--- a/Tests/MacParakeetTests/ViewModels/ViewModelMocks.swift
+++ b/Tests/MacParakeetTests/ViewModels/ViewModelMocks.swift
@@ -139,6 +139,7 @@ final class MockTranscriptionRepository: TranscriptionRepositoryProtocol, @unche
     var updateFilePathCalls: [(id: UUID, filePath: String?)] = []
     var updateMeetingArtifactFolderPathCalls: [(id: UUID, folderPath: String?)] = []
     var updateFilePathError: Error?
+    var updateSpeakersError: Error?
     var saveError: Error?
 
     func save(_ transcription: Transcription) throws {
@@ -212,6 +213,9 @@ final class MockTranscriptionRepository: TranscriptionRepositoryProtocol, @unche
 
     func updateSpeakers(id: UUID, speakers: [SpeakerInfo]?) throws {
         updateSpeakersCalls.append((id: id, speakers: speakers))
+        if let updateSpeakersError {
+            throw updateSpeakersError
+        }
         if let idx = transcriptions.firstIndex(where: { $0.id == id }) {
             transcriptions[idx].speakers = speakers
             transcriptions[idx].updatedAt = Date()


### PR DESCRIPTION
## Summary
Implements U5 from the meeting health/artifacts/speaker-rename plan in PR #706.

- Adds one visible pencil edit affordance beside each speaker name in the speaker overview while preserving the existing inline label edit path.
- Keeps valid per-meeting speaker label edits in sync between `currentTranscription`, the matching row in `transcriptions`, and the existing `updateSpeakers` persistence path.
- Commits non-empty labels on Return or focus loss, cancels on Escape, leaves empty edits as a revert/no-op, and keeps duplicate labels allowed.

## Spec alignment
This follows U5/R25-R31 from the plan branch in PR #706. Rename remains per-meeting and display-label-only; it does not rewrite word speaker IDs, diarization segments, source attribution, or introduce profiles/merge semantics. Turn headers do not gain rename controls.

Artifact refresh status: deferred. `TranscriptionViewModel` does not currently receive a `MeetingArtifactStoring` dependency, and `TranscriptionServiceProtocol` does not expose the private artifact materialization path, so a rename commit cannot cleanly trigger artifact refresh without adding a new cross-layer dependency. Exported/derived artifacts will refresh on the next existing artifact/export action.

No new row/turn identity test was added because identity and scroll targeting remain keyed by stable `speaker.id`; label changes do not alter those identifiers.

## Risk surface
The changed surface is limited to speaker overview rename UX and in-memory view-model list consistency after valid rename. Meeting artifact rendering, CLI output, `TranscriptSegmenter` Markdown rendering, specs/contracts, capture, recording, health, AEC, and diarization were left untouched.

## Test evidence
- Red proof before implementation: `swift test --filter TranscriptionViewModelTests` failed on `testRenameSpeakerUpdatesMatchingTranscriptionsRow` because the matching `transcriptions` row still had `Speaker 1`.
- Focused green after implementation: `swift test --filter TranscriptionViewModelTests` passed, 107 tests, 0 failures.
- Focused green after UI polish: `swift test --filter TranscriptionViewModelTests` passed, 107 tests, 0 failures.
- Formatting command run: `scripts/dev/format.sh` completed, but produced repo-wide formatter churn outside U5; that uncommitted churn was reverted so this PR stays scoped.
- Hygiene: `git diff --check` passed.
- Final gate: `swift test` passed, 4432 tests, 15 skipped, 0 failures; Swift Testing suites also passed.
