### PR TITLE
Migrate STT live read sites to capability registry

### DIFF
--- a/Sources/MacParakeet/App/AppEnvironment.swift
+++ b/Sources/MacParakeet/App/AppEnvironment.swift
@@ -364,44 +364,44 @@ final class AppEnvironment {
     nonisolated static func shouldAttemptLiveDictationTranscription(
         speechEngine: SpeechEnginePreference = SpeechEnginePreference.current(),
         parakeetModelVariant: ParakeetModelVariant = SpeechEnginePreference.parakeetModelVariant(),
+        nemotronModelVariant: NemotronModelVariant = SpeechEnginePreference.nemotronModelVariant(),
+        whisperModelVariant: String = SpeechEnginePreference.whisperModelVariant(),
         liveDictationStreamingEnabled: Bool = AppFeatures.liveDictationStreamingEnabled
     ) -> Bool {
         guard liveDictationStreamingEnabled else { return false }
-        switch speechEngine {
-        case .nemotron:
-            // Both Nemotron builds stream live dictation partials from
-            // their FluidAudio streaming managers.
-            return true
-        case .parakeet:
-            return parakeetModelVariant.usesUnifiedEngine
-        case .whisper:
-            return false
-        case .cohere:
-            // Batch engine: record-then-transcribe, no live partials.
-            return false
-        }
+        return SpeechEngineCapabilityRegistry.capabilities(
+            for: speechEngine,
+            parakeetModelVariant: parakeetModelVariant,
+            nemotronModelVariant: nemotronModelVariant,
+            whisperModelVariant: whisperModelVariant
+        )?.supportsNativeLiveDictation == true
     }
 
     nonisolated static func dictationPreviewSpeechEngine(
         speechEngine: SpeechEnginePreference = SpeechEnginePreference.current(),
         parakeetModelVariant: ParakeetModelVariant = SpeechEnginePreference.parakeetModelVariant(),
+        nemotronModelVariant: NemotronModelVariant = SpeechEnginePreference.nemotronModelVariant(),
+        whisperModelVariant: String = SpeechEnginePreference.whisperModelVariant(),
         liveDictationStreamingEnabled: Bool = AppFeatures.liveDictationStreamingEnabled
-    ) -> SpeechEngineSelection? {
+    ) -> SpeechEngineCapabilitySelection? {
         guard liveDictationStreamingEnabled else { return nil }
-        switch speechEngine {
-        case .parakeet:
-            guard !parakeetModelVariant.usesUnifiedEngine else {
-                return nil
-            }
-            return SpeechEngineSelection(engine: .parakeet)
-        case .nemotron:
-            return nil
-        case .whisper:
-            return nil
-        case .cohere:
-            // No display-preview path; Cohere finalizes on stop.
+        // Product policy still limits the display-preview lane to Parakeet TDT
+        // while this feature rides the live-dictation flag; the registry answers
+        // whether the selected Parakeet variant actually has that tail-preview path.
+        guard speechEngine == .parakeet else { return nil }
+        guard let capabilities = SpeechEngineCapabilityRegistry.capabilities(
+            for: speechEngine,
+            parakeetModelVariant: parakeetModelVariant,
+            nemotronModelVariant: nemotronModelVariant,
+            whisperModelVariant: whisperModelVariant
+        ) else {
             return nil
         }
+        guard capabilities.supportsTailPreview else { return nil }
+        return SpeechEngineCapabilitySelection(
+            selection: SpeechEngineSelection(engine: .parakeet),
+            capabilities: capabilities
+        )
     }
 
     nonisolated static func syncAIFormatterAvailabilityWithLLMConfiguration(

--- a/Sources/MacParakeetCore/STT/STTRuntime.swift
+++ b/Sources/MacParakeetCore/STT/STTRuntime.swift
@@ -47,6 +47,7 @@ protocol STTRuntimeProtocol: Sendable {
         onProgress: (@Sendable (String) -> Void)?
     ) async throws
     func currentSpeechEngineSelection() async -> SpeechEngineSelection
+    func currentSpeechEngineCapabilities() async -> SpeechEngineCapabilities
 }
 
 extension STTRuntimeProtocol {
@@ -233,15 +234,20 @@ public actor STTRuntime: STTRuntimeProtocol {
         activeTranscriptionCount += 1
         defer { activeTranscriptionCount -= 1 }
 
+        let capabilities = capabilities(for: selection.engine)
+        guard capabilities.supportsTailPreview else {
+            throw tailPreviewUnsupportedError(for: capabilities.key)
+        }
+
         switch selection.engine {
         case .parakeet:
             return try await transcribeParakeetPreview(samples: samples)
         case .whisper:
             return try await transcribeWhisperPreview(samples: samples, language: selection.language)
         case .nemotron:
-            throw STTError.transcriptionFailed("Nemotron uses native live dictation partials and does not support display-preview transcription.")
+            throw tailPreviewUnsupportedError(for: capabilities.key)
         case .cohere:
-            throw STTError.transcriptionFailed("Cohere uses record-then-transcribe dictation and does not support display-preview transcription.")
+            throw tailPreviewUnsupportedError(for: capabilities.key)
         }
     }
 
@@ -251,6 +257,10 @@ public actor STTRuntime: STTRuntimeProtocol {
     ) async throws {
         guard liveDictationSession == nil else {
             throw STTError.engineBusy
+        }
+        let capabilities = capabilities(for: speechEngine)
+        guard capabilities.supportsNativeLiveDictation else {
+            throw STTLiveDictationTranscriptionError.unsupportedEngine(capabilities.key.engine)
         }
         let engine: any NativeLiveDictating
         let language: String?
@@ -853,28 +863,27 @@ public actor STTRuntime: STTRuntimeProtocol {
     }
 
     public func isReady() async -> Bool {
-        if speechEngine == .nemotron {
-            if nemotronModelVariant.isEnglishOnly {
+        switch capabilities(for: speechEngine).key {
+        case .nemotron(let variant):
+            if variant.isEnglishOnly {
                 return await nemotronEnglishEngine?.isReady() ?? false
             }
             return await nemotronEngine?.isReady() ?? false
-        }
-        if speechEngine == .whisper {
+        case .whisper:
             return await whisperEngine?.isReady() ?? false
-        }
-        if speechEngine == .cohere {
+        case .cohere:
             return await cohereEngine?.isReady() ?? false
-        }
+        case .parakeet(let variant):
+            // Parakeet engine: Unified reports through its own engine actor.
+            if variant.usesUnifiedEngine {
+                return await parakeetUnifiedEngine?.isReady() ?? false
+            }
 
-        // Parakeet engine: Unified reports through its own engine actor.
-        if currentParakeetVariant.usesUnifiedEngine {
-            return await parakeetUnifiedEngine?.isReady() ?? false
+            guard let interactiveManager, let backgroundManager else { return false }
+            let interactiveReady = await interactiveManager.isAvailable
+            let backgroundReady = await backgroundManager.isAvailable
+            return interactiveReady && backgroundReady
         }
-
-        guard let interactiveManager, let backgroundManager else { return false }
-        let interactiveReady = await interactiveManager.isAvailable
-        let backgroundReady = await backgroundManager.isAvailable
-        return interactiveReady && backgroundReady
     }
 
     public func shutdown() async {
@@ -1271,6 +1280,10 @@ public actor STTRuntime: STTRuntimeProtocol {
             engine: speechEngine,
             language: defaultLanguage(for: speechEngine)
         )
+    }
+
+    public func currentSpeechEngineCapabilities() async -> SpeechEngineCapabilities {
+        capabilities(for: speechEngine)
     }
 
     public nonisolated static func isModelCached(version: AsrModelVersion = .v3) -> Bool {
@@ -1782,39 +1795,32 @@ public actor STTRuntime: STTRuntimeProtocol {
     }
 
     private func telemetryModelKind(for engine: SpeechEnginePreference) -> TelemetryModelKind {
-        switch engine {
-        case .parakeet:
-            .parakeetSTT
-        case .nemotron:
-            .nemotronSTT
-        case .whisper:
-            .whisperSTT
-        case .cohere:
-            .cohereSTT
-        }
+        capabilities(for: engine).telemetryIdentity.modelKind
     }
 
     private func telemetryEngineVariant(for engine: SpeechEnginePreference) -> String? {
-        switch engine {
-        case .parakeet:
-            // Surface the active Parakeet build (v2/v3/unified) so model-load
-            // telemetry can measure variant adoption and impact (issues #311,
-            // #398, #520). Read the source-of-truth variant directly so unified —
-            // which has no `AsrModelVersion` — is attributed correctly rather than
-            // collapsing to the `modelVersion` placeholder.
-            currentParakeetVariant.rawValue
-        case .nemotron:
-            nemotronModelVariant.rawValue
-        case .whisper:
-            whisperModelVariant
-        case .cohere:
-            // Surface the active compute policy (ane/gpu) so model-load
-            // telemetry can compare the two backends' load/latency posture.
-            CohereTranscribeEngine.ComputePolicy.current(defaults: defaults).rawValue
-        }
+        capabilities(for: engine).telemetryIdentity.engineVariant.value(defaults: defaults)
     }
 
     private func defaultLanguage(for engine: SpeechEnginePreference) -> String? {
+        let languagePolicy = capabilities(for: engine).supportedLanguages
+        switch languagePolicy.mode {
+        case .automatic:
+            return languagePolicy.defaultLanguage
+        case .fixed:
+            // Preserve the existing persisted-selection behavior for Nemotron:
+            // the English-only build ignores the language hint at execution
+            // time, while the stored multilingual default stays visible.
+            if engine == .nemotron {
+                return SpeechEnginePreference.nemotronDefaultLanguage(defaults: defaults)
+            }
+            return languagePolicy.defaultLanguage
+        case .selectable:
+            return selectableDefaultLanguage(for: engine)
+        }
+    }
+
+    private func selectableDefaultLanguage(for engine: SpeechEnginePreference) -> String? {
         switch engine {
         case .parakeet:
             nil
@@ -1824,6 +1830,38 @@ public actor STTRuntime: STTRuntimeProtocol {
             SpeechEnginePreference.whisperDefaultLanguage(defaults: defaults)
         case .cohere:
             SpeechEnginePreference.cohereDefaultLanguage(defaults: defaults)
+        }
+    }
+
+    private func capabilities(for engine: SpeechEnginePreference) -> SpeechEngineCapabilities {
+        SpeechEngineCapabilityRegistry.capabilities(for: variantKey(for: engine))
+    }
+
+    private func variantKey(for engine: SpeechEnginePreference) -> SpeechEngineVariantKey {
+        switch engine {
+        case .parakeet:
+            .parakeet(currentParakeetVariant)
+        case .nemotron:
+            .nemotron(nemotronModelVariant)
+        case .whisper:
+            .whisper(WhisperModelVariant.normalize(whisperModelVariant) ?? .largeV3Turbo632MB)
+        case .cohere:
+            .cohere
+        }
+    }
+
+    private func tailPreviewUnsupportedError(for key: SpeechEngineVariantKey) -> STTError {
+        switch key {
+        case .parakeet(.unified):
+            STTError.transcriptionFailed("Parakeet Unified uses native live dictation partials and does not support display-preview transcription.")
+        case .parakeet:
+            STTError.transcriptionFailed("Parakeet TDT supports display-preview transcription.")
+        case .nemotron:
+            STTError.transcriptionFailed("Nemotron uses native live dictation partials and does not support display-preview transcription.")
+        case .whisper:
+            STTError.transcriptionFailed("Whisper supports display-preview transcription.")
+        case .cohere:
+            STTError.transcriptionFailed("Cohere uses record-then-transcribe dictation and does not support display-preview transcription.")
         }
     }
 

--- a/Sources/MacParakeetCore/STT/STTRuntime.swift
+++ b/Sources/MacParakeetCore/STT/STTRuntime.swift
@@ -869,7 +869,7 @@ public actor STTRuntime: STTRuntimeProtocol {
                 return await nemotronEnglishEngine?.isReady() ?? false
             }
             return await nemotronEngine?.isReady() ?? false
-        case .whisper:
+        case .whisper(_):
             return await whisperEngine?.isReady() ?? false
         case .cohere:
             return await cohereEngine?.isReady() ?? false
@@ -1854,11 +1854,11 @@ public actor STTRuntime: STTRuntimeProtocol {
         switch key {
         case .parakeet(.unified):
             STTError.transcriptionFailed("Parakeet Unified uses native live dictation partials and does not support display-preview transcription.")
-        case .parakeet:
+        case .parakeet(_):
             STTError.transcriptionFailed("Parakeet TDT supports display-preview transcription.")
-        case .nemotron:
+        case .nemotron(_):
             STTError.transcriptionFailed("Nemotron uses native live dictation partials and does not support display-preview transcription.")
-        case .whisper:
+        case .whisper(_):
             STTError.transcriptionFailed("Whisper supports display-preview transcription.")
         case .cohere:
             STTError.transcriptionFailed("Cohere uses record-then-transcribe dictation and does not support display-preview transcription.")

--- a/Sources/MacParakeetCore/STT/STTScheduler.swift
+++ b/Sources/MacParakeetCore/STT/STTScheduler.swift
@@ -222,12 +222,9 @@ public actor STTScheduler: STTManaging, STTDictationPreviewTranscribing, SpeechE
         let id = UUID()
         liveDictationSession = .active(id)
         do {
-            let selection = await runtime.currentSpeechEngineSelection()
-            // Selection only carries the engine family. `STTRuntime` owns the
-            // active Parakeet sub-variant and rejects TDT v2/v3 below; the
-            // scheduler only filters families with no native live path at all.
-            guard selection.engine == .nemotron || selection.engine == .parakeet else {
-                throw STTLiveDictationTranscriptionError.unsupportedEngine(selection.engine)
+            let capabilities = await runtime.currentSpeechEngineCapabilities()
+            guard capabilities.supportsNativeLiveDictation else {
+                throw STTLiveDictationTranscriptionError.unsupportedEngine(capabilities.key.engine)
             }
             try await runtime.beginLiveDictationTranscription(
                 sessionID: id,
@@ -496,7 +493,9 @@ public actor STTScheduler: STTManaging, STTDictationPreviewTranscribing, SpeechE
                 )
             }
         }
-        return SpeechEngineLease(id: sessionID, selection: await runtime.currentSpeechEngineSelection())
+        let selection = await runtime.currentSpeechEngineSelection()
+        let capabilities = await runtime.currentSpeechEngineCapabilities()
+        return SpeechEngineLease(id: sessionID, selection: selection, capabilities: capabilities)
     }
 
     public func endSpeechEngineSession(_ lease: SpeechEngineLease) async {

--- a/Sources/MacParakeetCore/STT/SpeechEngineCapabilities.swift
+++ b/Sources/MacParakeetCore/STT/SpeechEngineCapabilities.swift
@@ -151,6 +151,41 @@ public enum SpeechEngineCapabilityRegistry {
         return capabilities
     }
 
+    public static func variantKey(
+        for engine: SpeechEnginePreference,
+        parakeetModelVariant: ParakeetModelVariant = SpeechEnginePreference.defaultParakeetModelVariant,
+        nemotronModelVariant: NemotronModelVariant = SpeechEnginePreference.defaultNemotronModelVariant,
+        whisperModelVariant: String = SpeechEnginePreference.defaultWhisperModelVariant
+    ) -> SpeechEngineVariantKey? {
+        switch engine {
+        case .parakeet:
+            .parakeet(parakeetModelVariant)
+        case .nemotron:
+            .nemotron(nemotronModelVariant)
+        case .whisper:
+            WhisperModelVariant.normalize(whisperModelVariant).map(SpeechEngineVariantKey.whisper)
+        case .cohere:
+            .cohere
+        }
+    }
+
+    public static func capabilities(
+        for engine: SpeechEnginePreference,
+        parakeetModelVariant: ParakeetModelVariant = SpeechEnginePreference.defaultParakeetModelVariant,
+        nemotronModelVariant: NemotronModelVariant = SpeechEnginePreference.defaultNemotronModelVariant,
+        whisperModelVariant: String = SpeechEnginePreference.defaultWhisperModelVariant
+    ) -> SpeechEngineCapabilities? {
+        guard let key = variantKey(
+            for: engine,
+            parakeetModelVariant: parakeetModelVariant,
+            nemotronModelVariant: nemotronModelVariant,
+            whisperModelVariant: whisperModelVariant
+        ) else {
+            return nil
+        }
+        return capabilities(for: key)
+    }
+
     private static func makeParakeetRows() -> [SpeechEngineCapabilities] {
         ParakeetModelVariant.allCases.map { variant in
             SpeechEngineCapabilities(

--- a/Sources/MacParakeetCore/Services/Dictation/DictationService.swift
+++ b/Sources/MacParakeetCore/Services/Dictation/DictationService.swift
@@ -109,7 +109,7 @@ public actor DictationService: DictationServiceProtocol {
     private let aiFormatterPromptResolver: any AIFormatterPromptResolving
     private let shouldAttemptLiveDictationTranscription: @Sendable () -> Bool
     private let shouldShowDictationPreview: @Sendable () -> Bool
-    private let dictationPreviewSpeechEngine: @Sendable () -> SpeechEngineSelection?
+    private let dictationPreviewSpeechEngine: @Sendable () -> SpeechEngineCapabilitySelection?
     private let markFirstDictationCompleted: (@Sendable () -> Void)?
     private let cancelWindow: Duration
     private let dictationPreviewInterval: Duration
@@ -170,7 +170,7 @@ public actor DictationService: DictationServiceProtocol {
         aiFormatterPromptResolver: (any AIFormatterPromptResolving)? = nil,
         shouldAttemptLiveDictationTranscription: (@Sendable () -> Bool)? = nil,
         shouldShowDictationPreview: (@Sendable () -> Bool)? = nil,
-        dictationPreviewSpeechEngine: (@Sendable () -> SpeechEngineSelection?)? = nil,
+        dictationPreviewSpeechEngine: (@Sendable () -> SpeechEngineCapabilitySelection?)? = nil,
         markFirstDictationCompleted: (@Sendable () -> Void)? = nil,
         cancelWindow: Duration = .seconds(5),
         dictationPreviewInterval: Duration = .seconds(1),
@@ -911,8 +911,9 @@ public actor DictationService: DictationServiceProtocol {
         guard let previewTranscriber = sttTranscriber as? any STTDictationPreviewTranscribing else {
             return nil
         }
-        guard let speechEngine = dictationPreviewSpeechEngine() else { return nil }
-        guard speechEngine.engine != .nemotron, speechEngine.engine != .cohere else { return nil }
+        guard let previewSpeechEngine = dictationPreviewSpeechEngine() else { return nil }
+        guard previewSpeechEngine.capabilities.supportsTailPreview else { return nil }
+        let speechEngine = previewSpeechEngine.selection
 
         var continuation: AsyncStream<[Float]>.Continuation?
         let stream = AsyncStream<[Float]>(bufferingPolicy: .bufferingNewest(120)) {

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
@@ -145,7 +145,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         let calendarEventSnapshot: MeetingCalendarSnapshot?
 
         var supportsLiveChunkTranscription: Bool {
-            speechEngineCapabilities?.providesWordTimestamps ?? (speechEngine.engine != .cohere)
+            speechEngineCapabilities?.providesWordTimestamps == true
         }
     }
 
@@ -433,9 +433,15 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         let now = wallClockNow()
         let speechEngineLease = await speechEngineSessionManager?.beginSpeechEngineSession()
         currentSpeechEngineLease = speechEngineLease
-        let speechEngine = speechEngineLease?.selection ?? SpeechEngineSelection(engine: .parakeet)
-        let speechEngineCapabilities = speechEngineLease?.capabilities
-            ?? Self.defaultCapabilities(for: speechEngine)
+        let speechEngine: SpeechEngineSelection
+        let speechEngineCapabilities: SpeechEngineCapabilities?
+        if let speechEngineLease {
+            speechEngine = speechEngineLease.selection
+            speechEngineCapabilities = speechEngineLease.capabilities
+        } else {
+            speechEngine = SpeechEngineSelection(engine: .parakeet)
+            speechEngineCapabilities = SpeechEngineCapabilityRegistry.capabilities(for: .parakeet(.v3))
+        }
         let session = Session(
             id: sessionID,
             displayName: Self.resolveDisplayName(title: title, fallbackDate: now),
@@ -561,10 +567,6 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
     private func isMissingFileError(_ error: Error) -> Bool {
         let nsError = error as NSError
         return nsError.domain == NSCocoaErrorDomain && nsError.code == NSFileNoSuchFileError
-    }
-
-    private static func defaultCapabilities(for selection: SpeechEngineSelection) -> SpeechEngineCapabilities? {
-        SpeechEngineCapabilityRegistry.capabilities(for: selection.engine)
     }
 
     private func validateStartStillCurrent(_ session: Session) async throws {

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
@@ -140,11 +140,12 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         let systemAudioURL: URL
         let mixedAudioURL: URL
         let speechEngine: SpeechEngineSelection
+        let speechEngineCapabilities: SpeechEngineCapabilities?
         let startContext: MeetingStartContext?
         let calendarEventSnapshot: MeetingCalendarSnapshot?
 
         var supportsLiveChunkTranscription: Bool {
-            speechEngine.engine != .cohere
+            speechEngineCapabilities?.providesWordTimestamps ?? (speechEngine.engine != .cohere)
         }
     }
 
@@ -433,6 +434,8 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         let speechEngineLease = await speechEngineSessionManager?.beginSpeechEngineSession()
         currentSpeechEngineLease = speechEngineLease
         let speechEngine = speechEngineLease?.selection ?? SpeechEngineSelection(engine: .parakeet)
+        let speechEngineCapabilities = speechEngineLease?.capabilities
+            ?? Self.defaultCapabilities(for: speechEngine)
         let session = Session(
             id: sessionID,
             displayName: Self.resolveDisplayName(title: title, fallbackDate: now),
@@ -443,6 +446,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
             systemAudioURL: writer.systemAudioURL,
             mixedAudioURL: writer.mixedAudioURL,
             speechEngine: speechEngine,
+            speechEngineCapabilities: speechEngineCapabilities,
             startContext: startContext,
             calendarEventSnapshot: calendarEventSnapshot
         )
@@ -557,6 +561,10 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
     private func isMissingFileError(_ error: Error) -> Bool {
         let nsError = error as NSError
         return nsError.domain == NSCocoaErrorDomain && nsError.code == NSFileNoSuchFileError
+    }
+
+    private static func defaultCapabilities(for selection: SpeechEngineSelection) -> SpeechEngineCapabilities? {
+        SpeechEngineCapabilityRegistry.capabilities(for: selection.engine)
     }
 
     private func validateStartStillCurrent(_ session: Session) async throws {

--- a/Sources/MacParakeetCore/SpeechEnginePreference.swift
+++ b/Sources/MacParakeetCore/SpeechEnginePreference.swift
@@ -562,12 +562,38 @@ public struct SpeechEngineSelection: Codable, Equatable, Sendable {
     }
 }
 
+public struct SpeechEngineCapabilitySelection: Equatable, Sendable {
+    public let selection: SpeechEngineSelection
+    public let capabilities: SpeechEngineCapabilities
+
+    public init(selection: SpeechEngineSelection, capabilities: SpeechEngineCapabilities) {
+        precondition(
+            selection.engine == capabilities.key.engine,
+            "SpeechEngineCapabilitySelection engine mismatch: \(selection.engine.rawValue) != \(capabilities.key.engine.rawValue)"
+        )
+        self.selection = selection
+        self.capabilities = capabilities
+    }
+}
+
 public struct SpeechEngineLease: Equatable, Sendable {
     public let id: UUID
     public let selection: SpeechEngineSelection
+    public let capabilities: SpeechEngineCapabilities?
 
-    public init(id: UUID = UUID(), selection: SpeechEngineSelection) {
+    public init(
+        id: UUID = UUID(),
+        selection: SpeechEngineSelection,
+        capabilities: SpeechEngineCapabilities? = nil
+    ) {
+        if let capabilities {
+            precondition(
+                selection.engine == capabilities.key.engine,
+                "SpeechEngineLease engine mismatch: \(selection.engine.rawValue) != \(capabilities.key.engine.rawValue)"
+            )
+        }
         self.id = id
         self.selection = selection
+        self.capabilities = capabilities
     }
 }

--- a/Tests/MacParakeetTests/App/AppEnvironmentTests.swift
+++ b/Tests/MacParakeetTests/App/AppEnvironmentTests.swift
@@ -14,6 +14,32 @@ final class AppEnvironmentTests: XCTestCase {
         ))
     }
 
+    func testParakeetDictationRoutingUsesVariantCapabilities() {
+        XCTAssertFalse(AppEnvironment.shouldAttemptLiveDictationTranscription(
+            speechEngine: .parakeet,
+            parakeetModelVariant: .v3,
+            liveDictationStreamingEnabled: true
+        ))
+        let tdtPreview = AppEnvironment.dictationPreviewSpeechEngine(
+            speechEngine: .parakeet,
+            parakeetModelVariant: .v3,
+            liveDictationStreamingEnabled: true
+        )
+        XCTAssertEqual(tdtPreview?.selection, SpeechEngineSelection(engine: .parakeet))
+        XCTAssertEqual(tdtPreview?.capabilities.key, .parakeet(.v3))
+
+        XCTAssertTrue(AppEnvironment.shouldAttemptLiveDictationTranscription(
+            speechEngine: .parakeet,
+            parakeetModelVariant: .unified,
+            liveDictationStreamingEnabled: true
+        ))
+        XCTAssertNil(AppEnvironment.dictationPreviewSpeechEngine(
+            speechEngine: .parakeet,
+            parakeetModelVariant: .unified,
+            liveDictationStreamingEnabled: true
+        ))
+    }
+
     func testSyncAIFormatterAvailabilityWritesTrueWhenProviderExists() {
         let (suiteName, defaults) = makeDefaults()
         defer { defaults.removePersistentDomain(forName: suiteName) }

--- a/Tests/MacParakeetTests/STT/STTSchedulerTests.swift
+++ b/Tests/MacParakeetTests/STT/STTSchedulerTests.swift
@@ -70,7 +70,10 @@ final class STTSchedulerTests: XCTestCase {
 
     func testLiveDictationBeginAllowsParakeetSelectionForUnifiedRuntime() async throws {
         let runtime = MockSTTRuntime()
-        await runtime.setCurrentSelection(SpeechEngineSelection(engine: .parakeet))
+        await runtime.setCurrentSelection(
+            SpeechEngineSelection(engine: .parakeet),
+            capabilities: SpeechEngineCapabilityRegistry.capabilities(for: .parakeet(.unified))
+        )
         let scheduler = STTScheduler(runtimeProvider: runtime, meetingLiveChunkBacklogLimit: 8)
 
         let sessionID = try await scheduler.beginLiveDictationTranscription { _ in }
@@ -82,6 +85,42 @@ final class STTSchedulerTests: XCTestCase {
         XCTAssertEqual(result.engine, .parakeet)
         let liveDictationSamples = await runtime.liveDictationSamples
         XCTAssertEqual(liveDictationSamples, [[0.1, 0.2]])
+    }
+
+    func testLiveDictationBeginRejectsParakeetTDTCapabilityBeforeRuntimeBegin() async throws {
+        let runtime = MockSTTRuntime()
+        await runtime.setCurrentSelection(
+            SpeechEngineSelection(engine: .parakeet),
+            capabilities: SpeechEngineCapabilityRegistry.capabilities(for: .parakeet(.v3))
+        )
+        let scheduler = STTScheduler(runtimeProvider: runtime, meetingLiveChunkBacklogLimit: 8)
+
+        do {
+            _ = try await scheduler.beginLiveDictationTranscription { _ in }
+            XCTFail("Expected Parakeet TDT to be rejected by the capability gate")
+        } catch let error as STTLiveDictationTranscriptionError {
+            XCTAssertEqual(error, .unsupportedEngine(.parakeet))
+        } catch {
+            XCTFail("Expected unsupportedEngine, got \(error)")
+        }
+
+        let hasActiveSession = await runtime.hasActiveLiveDictationSession
+        XCTAssertFalse(hasActiveSession)
+    }
+
+    func testSessionLeaseCarriesCurrentCapabilities() async {
+        let runtime = MockSTTRuntime()
+        await runtime.setCurrentSelection(
+            SpeechEngineSelection(engine: .whisper, language: "ko"),
+            capabilities: SpeechEngineCapabilityRegistry.capabilities(for: .whisper(.largeV3Turbo632MB))
+        )
+        let scheduler = STTScheduler(runtimeProvider: runtime, meetingLiveChunkBacklogLimit: 8)
+
+        let lease = await scheduler.beginSpeechEngineSession()
+
+        XCTAssertEqual(lease.selection, SpeechEngineSelection(engine: .whisper, language: "ko"))
+        XCTAssertEqual(lease.capabilities?.key, .whisper(.largeV3Turbo632MB))
+        await scheduler.endSpeechEngineSession(lease)
     }
 
     func testLiveDictationFinalizationIgnoresConcurrentCancel() async throws {
@@ -1354,6 +1393,7 @@ private actor MockSTTRuntime: STTRuntimeProtocol {
     private(set) var parakeetModelVariantSwitches: [ParakeetModelVariant] = []
     private(set) var nemotronModelVariantSwitches: [NemotronModelVariant] = []
     private var selection = SpeechEngineSelection(engine: .parakeet)
+    private var capabilities = SpeechEngineCapabilityRegistry.capabilities(for: .parakeet(.v3))
     private var ready = false
     private var shouldBlockNextSpeechEngineSwitch = false
     private var shouldBlockNextClearModelCache = false
@@ -1596,7 +1636,7 @@ private actor MockSTTRuntime: STTRuntimeProtocol {
             }
             try Task.checkCancellation()
         }
-        selection = SpeechEngineSelection(engine: preference)
+        updateSelection(SpeechEngineSelection(engine: preference))
         ready = false
     }
 
@@ -1626,7 +1666,10 @@ private actor MockSTTRuntime: STTRuntimeProtocol {
             }
             try Task.checkCancellation()
         }
-        selection = SpeechEngineSelection(engine: .parakeet)
+        updateSelection(
+            SpeechEngineSelection(engine: .parakeet),
+            capabilities: SpeechEngineCapabilityRegistry.capabilities(for: .parakeet(variant))
+        )
     }
 
     func setNemotronModelVariant(
@@ -1646,7 +1689,10 @@ private actor MockSTTRuntime: STTRuntimeProtocol {
             }
             try Task.checkCancellation()
         }
-        selection = SpeechEngineSelection(engine: .nemotron)
+        updateSelection(
+            SpeechEngineSelection(engine: .nemotron),
+            capabilities: SpeechEngineCapabilityRegistry.capabilities(for: .nemotron(variant))
+        )
     }
 
     func currentSpeechEngineSelection() async -> SpeechEngineSelection {
@@ -1660,8 +1706,27 @@ private actor MockSTTRuntime: STTRuntimeProtocol {
         return selection
     }
 
-    func setCurrentSelection(_ selection: SpeechEngineSelection) {
+    func currentSpeechEngineCapabilities() async -> SpeechEngineCapabilities {
+        capabilities
+    }
+
+    func setCurrentSelection(
+        _ selection: SpeechEngineSelection,
+        capabilities: SpeechEngineCapabilities? = nil
+    ) {
+        updateSelection(selection, capabilities: capabilities)
+    }
+
+    private func updateSelection(
+        _ selection: SpeechEngineSelection,
+        capabilities: SpeechEngineCapabilities? = nil
+    ) {
         self.selection = selection
+        self.capabilities = capabilities ?? Self.defaultCapabilities(for: selection.engine)
+    }
+
+    private static func defaultCapabilities(for engine: SpeechEnginePreference) -> SpeechEngineCapabilities {
+        SpeechEngineCapabilityRegistry.capabilities(for: engine)!
     }
 
     func blockNextSelectionRead() {

--- a/Tests/MacParakeetTests/Services/Dictation/DictationServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/Dictation/DictationServiceTests.swift
@@ -62,6 +62,16 @@ final class DictationServiceTests: XCTestCase {
         super.tearDown()
     }
 
+    private static func previewSpeechEngine(
+        _ key: SpeechEngineVariantKey,
+        language: String? = nil
+    ) -> SpeechEngineCapabilitySelection {
+        SpeechEngineCapabilitySelection(
+            selection: SpeechEngineSelection(engine: key.engine, language: language),
+            capabilities: SpeechEngineCapabilityRegistry.capabilities(for: key)
+        )
+    }
+
     func testInitialStateIsIdle() async {
         let state = await service.state
         if case .idle = state {} else {
@@ -681,7 +691,7 @@ final class DictationServiceTests: XCTestCase {
             audioProcessor: mockAudio,
             sttTranscriber: mockSTT,
             dictationRepo: dictationRepo,
-            dictationPreviewSpeechEngine: { SpeechEngineSelection(engine: .parakeet) },
+            dictationPreviewSpeechEngine: { Self.previewSpeechEngine(.parakeet(.v3)) },
             dictationPreviewInterval: .zero
         )
         await mockSTT.configure(result: STTResult(text: "file final", words: [], engine: .parakeet))
@@ -756,7 +766,7 @@ final class DictationServiceTests: XCTestCase {
             sttTranscriber: mockSTT,
             dictationRepo: dictationRepo,
             shouldShowDictationPreview: { true },
-            dictationPreviewSpeechEngine: { SpeechEngineSelection(engine: .cohere, language: "ja") },
+            dictationPreviewSpeechEngine: { Self.previewSpeechEngine(.cohere, language: "ja") },
             dictationPreviewInterval: .zero
         )
         await mockSTT.configure(result: STTResult(text: "cohere final", words: [], engine: .cohere))
@@ -787,7 +797,7 @@ final class DictationServiceTests: XCTestCase {
             sttTranscriber: mockSTT,
             dictationRepo: dictationRepo,
             shouldShowDictationPreview: { false },
-            dictationPreviewSpeechEngine: { SpeechEngineSelection(engine: .parakeet) },
+            dictationPreviewSpeechEngine: { Self.previewSpeechEngine(.parakeet(.v3)) },
             dictationPreviewInterval: .zero
         )
         await mockSTT.configure(result: STTResult(text: "file final", words: [], engine: .parakeet))
@@ -816,7 +826,7 @@ final class DictationServiceTests: XCTestCase {
             audioProcessor: mockAudio,
             sttTranscriber: mockSTT,
             dictationRepo: dictationRepo,
-            dictationPreviewSpeechEngine: { SpeechEngineSelection(engine: .parakeet) },
+            dictationPreviewSpeechEngine: { Self.previewSpeechEngine(.parakeet(.v3)) },
             dictationPreviewInterval: .zero,
             dictationPreviewWindowSeconds: 3.0 / 16_000.0
         )
@@ -847,7 +857,7 @@ final class DictationServiceTests: XCTestCase {
             audioProcessor: mockAudio,
             sttTranscriber: mockSTT,
             dictationRepo: dictationRepo,
-            dictationPreviewSpeechEngine: { SpeechEngineSelection(engine: .parakeet) },
+            dictationPreviewSpeechEngine: { Self.previewSpeechEngine(.parakeet(.v3)) },
             dictationPreviewInterval: .zero
         )
         await mockSTT.configure(result: STTResult(text: "file final", words: [], engine: .parakeet))
@@ -875,7 +885,7 @@ final class DictationServiceTests: XCTestCase {
             audioProcessor: mockAudio,
             sttTranscriber: mockSTT,
             dictationRepo: dictationRepo,
-            dictationPreviewSpeechEngine: { SpeechEngineSelection(engine: .parakeet) },
+            dictationPreviewSpeechEngine: { Self.previewSpeechEngine(.parakeet(.v3)) },
             dictationPreviewInterval: .zero,
             dictationPreviewCancellationTimeout: .milliseconds(50)
         )
@@ -906,7 +916,7 @@ final class DictationServiceTests: XCTestCase {
             audioProcessor: mockAudio,
             sttTranscriber: mockSTT,
             dictationRepo: dictationRepo,
-            dictationPreviewSpeechEngine: { SpeechEngineSelection(engine: .parakeet) },
+            dictationPreviewSpeechEngine: { Self.previewSpeechEngine(.parakeet(.v3)) },
             dictationPreviewInterval: .zero
         )
         await mockSTT.configure(result: STTResult(text: "file final", words: [], engine: .parakeet))

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingServiceTests.swift
@@ -2984,7 +2984,7 @@ private actor LeasingMeetingSTTClient: STTClientProtocol, SpeechEngineRoutedTran
         capabilities: SpeechEngineCapabilities? = nil
     ) {
         self.selection = selection
-        self.capabilities = capabilities
+        self.capabilities = capabilities ?? SpeechEngineCapabilityRegistry.capabilities(for: selection.engine)
     }
 
     var activeLeaseCount: Int {

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingServiceTests.swift
@@ -885,6 +885,36 @@ final class MeetingRecordingServiceTests: XCTestCase {
         XCTAssertEqual(output.speechEngine, SpeechEngineSelection(engine: .cohere, language: "ja"))
     }
 
+    func testMeetingLivePreviewUsesLeaseCapabilities() async throws {
+        let captureService = MockMeetingAudioCaptureService()
+        let audioConverter = MockMeetingAudioFileConverter()
+        let sttClient = LeasingMeetingSTTClient(
+            selection: SpeechEngineSelection(engine: .parakeet),
+            capabilities: SpeechEngineCapabilityRegistry.capabilities(for: .parakeet(.unified))
+        )
+        let service = MeetingRecordingService(
+            audioCaptureService: captureService,
+            audioConverter: audioConverter,
+            sttTranscriber: sttClient
+        )
+
+        try await service.startRecording()
+
+        let microphoneBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 80_000, sampleValue: 0.25))
+        await captureService.yield(.microphoneBuffer(
+            microphoneBuffer,
+            AVAudioTime(hostTime: AVAudioTime.hostTime(forSeconds: 100.0))
+        ))
+        try await Task.sleep(for: .milliseconds(100))
+
+        let routedSelections = await sttClient.routedSelections
+        XCTAssertEqual(routedSelections, [])
+
+        let output = try await service.stopRecording()
+        defer { try? FileManager.default.removeItem(at: output.folderURL) }
+        XCTAssertEqual(output.speechEngine, SpeechEngineSelection(engine: .parakeet))
+    }
+
     func testStaleChunkFailureFromPreviousSessionDoesNotPoisonNextSession() async throws {
         let captureService = MockMeetingAudioCaptureService()
         let audioConverter = MockMeetingAudioFileConverter()
@@ -2945,11 +2975,16 @@ private actor StopOutputCapture {
 
 private actor LeasingMeetingSTTClient: STTClientProtocol, SpeechEngineRoutedTranscribing, SpeechEngineSessionManaging {
     private let selection: SpeechEngineSelection
+    private let capabilities: SpeechEngineCapabilities?
     private var activeLeases: Set<UUID> = []
     private(set) var routedSelections: [SpeechEngineSelection] = []
 
-    init(selection: SpeechEngineSelection) {
+    init(
+        selection: SpeechEngineSelection,
+        capabilities: SpeechEngineCapabilities? = nil
+    ) {
         self.selection = selection
+        self.capabilities = capabilities
     }
 
     var activeLeaseCount: Int {
@@ -2957,7 +2992,7 @@ private actor LeasingMeetingSTTClient: STTClientProtocol, SpeechEngineRoutedTran
     }
 
     func beginSpeechEngineSession() async -> SpeechEngineLease {
-        let lease = SpeechEngineLease(selection: selection)
+        let lease = SpeechEngineLease(selection: selection, capabilities: capabilities)
         activeLeases.insert(lease.id)
         return lease
     }


### PR DESCRIPTION
Implements Phase A item 3 from plans/active/2026-07-03-stt-capability-registry.md: migrate runtime/service capability read sites to the registry in a small mechanical batch.

Summary:
- Resolve active SpeechEngineCapabilities from the registry for runtime preview/live/readiness/telemetry/default-language reads.
- Carry capability snapshots through scheduler leases and dictation preview wiring so service gates do not infer from bare engine families.
- Move AppEnvironment live/preview gates, DictationService preview gating, and MeetingRecordingService live-chunk gating onto registry-backed capability rows.

Plan boundary / deviations:
- Settings and CLI read-site migrations are intentionally left for the next sequential PR.
- Scheduler slot mechanics, Cohere single-flight admission, ANEInferenceGate usage, and runtime dispatch remain unchanged.
- Display preview remains Parakeet-only at the AppEnvironment product-policy layer; the registry only answers whether the selected Parakeet variant supports tail preview.
- Full swift test is deferred to the final Phase A gate per the brief's at-most-once instruction.

Verification:
- swift test --filter 'SpeechEngineCapabilitiesTests|SpeechEnginePreferenceTests|STTSchedulerTests|DictationServiceTests|MeetingRecordingServiceTests|AppEnvironmentTests'
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrate STT runtime and service read sites to the capability registry so live dictation, display preview, readiness, telemetry identity, and default language share one source of truth. Capabilities now flow through scheduler leases and dictation preview; meeting live-chunk gating uses capability rows and stays conservative if a lease lacks a capability snapshot.

- **Refactors**
  - Runtime resolves SpeechEngineCapabilities for preview/live gating, readiness (explicit variant-key switches), telemetry identity, and default language.
  - Added currentSpeechEngineCapabilities() to STTRuntimeProtocol; STTScheduler gates live dictation on supportsNativeLiveDictation; SpeechEngineLease now carries capability snapshots.
  - AppEnvironment, DictationService, and MeetingRecordingService now read registry-backed capability rows; meeting live chunks check providesWordTimestamps and block when a lease lacks capabilities; no-lease default stays Parakeet(.v3).
  - Capability registry adds variantKey(for:) and engine-based capabilities(for:) helpers.

- **Migration**
  - Scope limited to runtime/services/UI; settings and CLI read-site migrations will follow.
  - No changes to scheduler slot mechanics, Cohere single-flight admission, ANEInferenceGate, or dispatch.
  - Display preview remains Parakeet-only at the product-policy layer; the registry verifies variant support.

<sup>Written for commit 0ea38a0ee79699e3a6c502611c7dae9d2f113849. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/711?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

