### PR TITLE
fix(cli): quarantine model stdout diagnostics

### DIFF
--- a/Sources/CLI/Commands/CLIHelpers.swift
+++ b/Sources/CLI/Commands/CLIHelpers.swift
@@ -1,4 +1,5 @@
 import ArgumentParser
+import Darwin
 import Foundation
 import MacParakeetCore
 
@@ -239,6 +240,63 @@ func printJSON<T: Encodable>(_ value: T) throws {
 /// Append a trailing newline.
 func printErr(_ s: String) {
     try? FileHandle.standardError.write(contentsOf: Data((s + "\n").utf8))
+}
+
+/// Some native model runtimes write diagnostics directly to the process stdout
+/// file descriptor, bypassing Swift logging. Keep those diagnostics off the
+/// CLI payload channel while long-running model work executes.
+///
+/// - Important: This helper redirects process-wide `STDOUT_FILENO` and is not
+///   thread-safe. Only wrap work that does not intentionally write stdout
+///   payloads; emit machine-readable CLI output after this helper returns.
+func withStandardOutputRedirectedToStandardError<T>(
+    _ operation: () async throws -> T
+) async throws -> T {
+    fflush(stdout)
+    let originalStdout = dup(STDOUT_FILENO)
+    guard originalStdout >= 0 else {
+        throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
+    }
+    let fdFlags = fcntl(originalStdout, F_GETFD)
+    guard fdFlags >= 0, fcntl(originalStdout, F_SETFD, fdFlags | FD_CLOEXEC) >= 0 else {
+        let cloexecErrno = errno
+        close(originalStdout)
+        throw NSError(domain: NSPOSIXErrorDomain, code: Int(cloexecErrno))
+    }
+
+    var restored = false
+    func restoreStdout() throws {
+        guard !restored else { return }
+        restored = true
+        fflush(stdout)
+        defer { close(originalStdout) }
+        guard dup2(originalStdout, STDOUT_FILENO) >= 0 else {
+            let restoreErrno = errno
+            throw NSError(domain: NSPOSIXErrorDomain, code: Int(restoreErrno))
+        }
+    }
+
+    guard dup2(STDERR_FILENO, STDOUT_FILENO) >= 0 else {
+        let redirectErrno = errno
+        close(originalStdout)
+        throw NSError(domain: NSPOSIXErrorDomain, code: Int(redirectErrno))
+    }
+
+    do {
+        let result = try await operation()
+        try restoreStdout()
+        return result
+    } catch {
+        // Prefer the operation error if restoration also fails; callers need
+        // the underlying command failure.
+        do {
+            try restoreStdout()
+        } catch let restoreError {
+            let message = "Warning: stdout restoration failed: \(restoreError.localizedDescription)"
+            printErr(message)
+        }
+        throw error
+    }
 }
 
 // MARK: - Failure envelope (--json contract)

--- a/Sources/CLI/Commands/HealthCommand.swift
+++ b/Sources/CLI/Commands/HealthCommand.swift
@@ -148,13 +148,20 @@ struct HealthCommand: AsyncParsableCommand {
         if let repairAttempts = validatedRepairAttempts {
             if !json { print(); print("Speech-stack repair requested...") }
             do {
-                try await prepareSpeechStack(
-                    attempts: repairAttempts,
-                    sttClient: sttClient,
-                    diarizationService: diarizationService,
-                    defaults: defaults,
-                    log: { message in if !self.json { print("  \(message)") } }
-                )
+                let repairOperation = {
+                    try await prepareSpeechStack(
+                        attempts: repairAttempts,
+                        sttClient: sttClient,
+                        diarizationService: diarizationService,
+                        defaults: defaults,
+                        log: { message in if !self.json { print("  \(message)") } }
+                    )
+                }
+                if json {
+                    try await withStandardOutputRedirectedToStandardError(repairOperation)
+                } else {
+                    try await repairOperation()
+                }
                 report.repair = HealthReport.Repair(attempted: true, completed: true, error: nil)
                 if !json { print("Speech-stack repair completed.") }
             } catch {

--- a/Sources/CLI/Commands/RetranscribeCommand.swift
+++ b/Sources/CLI/Commands/RetranscribeCommand.swift
@@ -241,43 +241,43 @@ struct RetranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding 
             )
             sttClient = client
 
-            switch target {
-            case .dictation(let dictation):
-                let result = try await retranscribeDictation(
-                    dictation,
-                    sttClient: client,
-                    speechEngine: speechEngine,
-                    dictationRepo: dictationRepo,
-                    customWordRepo: customWordRepo,
-                    snippetRepo: snippetRepo,
-                    defaults: defaults
-                )
-                runResult = .success(result)
-            case .transcription(let transcription):
-                let result = try await retranscribeTranscription(
-                    transcription,
-                    speechEngine: speechEngine,
-                    transcriptionRepo: transcriptionRepo,
-                    promptResultRepo: promptResultRepo,
-                    customWordRepo: customWordRepo,
-                    snippetRepo: snippetRepo,
-                    defaults: defaults,
-                    sttTranscriber: client
-                )
-                runResult = .success(result)
-            case .meeting(let transcription):
-                let result = try await retranscribeMeeting(
-                    transcription,
-                    speechEngine: speechEngine,
-                    transcriptionRepo: transcriptionRepo,
-                    promptResultRepo: promptResultRepo,
-                    customWordRepo: customWordRepo,
-                    snippetRepo: snippetRepo,
-                    defaults: defaults,
-                    sttTranscriber: client
-                )
-                runResult = .success(result)
+            let result = try await withStandardOutputRedirectedToStandardError {
+                switch target {
+                case .dictation(let dictation):
+                    return try await retranscribeDictation(
+                        dictation,
+                        sttClient: client,
+                        speechEngine: speechEngine,
+                        dictationRepo: dictationRepo,
+                        customWordRepo: customWordRepo,
+                        snippetRepo: snippetRepo,
+                        defaults: defaults
+                    )
+                case .transcription(let transcription):
+                    return try await retranscribeTranscription(
+                        transcription,
+                        speechEngine: speechEngine,
+                        transcriptionRepo: transcriptionRepo,
+                        promptResultRepo: promptResultRepo,
+                        customWordRepo: customWordRepo,
+                        snippetRepo: snippetRepo,
+                        defaults: defaults,
+                        sttTranscriber: client
+                    )
+                case .meeting(let transcription):
+                    return try await retranscribeMeeting(
+                        transcription,
+                        speechEngine: speechEngine,
+                        transcriptionRepo: transcriptionRepo,
+                        promptResultRepo: promptResultRepo,
+                        customWordRepo: customWordRepo,
+                        snippetRepo: snippetRepo,
+                        defaults: defaults,
+                        sttTranscriber: client
+                    )
+                }
             }
+            runResult = .success(result)
         } catch {
             runResult = .failure(error)
         }

--- a/Sources/CLI/Commands/TranscribeCommand.swift
+++ b/Sources/CLI/Commands/TranscribeCommand.swift
@@ -563,10 +563,12 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
             )
 
             if let podcastQuery {
-                let result = try await transcribePodcastQuery(
-                    query: podcastQuery,
-                    service: service
-                )
+                let result = try await withStandardOutputRedirectedToStandardError {
+                    try await transcribePodcastQuery(
+                        query: podcastQuery,
+                        service: service
+                    )
+                }
                 if let outputDir {
                     let dir = try Self.prepareOutputDir(outputDir)
                     let url = try await Self.writeOutput(result, to: dir, format: format)
@@ -582,17 +584,21 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
                     printSaveHintIfSaved(result, format: format)
                 }
             } else if writeToFiles {
-                try await runBatch(
-                    inputs: resolvedInputs,
-                    service: service,
-                    speechEngine: speechEngine
-                )
+                try await withStandardOutputRedirectedToStandardError {
+                    try await runBatch(
+                        inputs: resolvedInputs,
+                        service: service,
+                        speechEngine: speechEngine
+                    )
+                }
             } else {
-                let result = try await transcribeOne(
-                    input: resolvedInputs[0],
-                    service: service,
-                    speechEngine: speechEngine
-                )
+                let result = try await withStandardOutputRedirectedToStandardError {
+                    try await transcribeOne(
+                        input: resolvedInputs[0],
+                        service: service,
+                        speechEngine: speechEngine
+                    )
+                }
                 switch format {
                 case .json:
                     try printJSON(result)

--- a/Tests/CLITests/CLIHelpersTests.swift
+++ b/Tests/CLITests/CLIHelpersTests.swift
@@ -1,3 +1,4 @@
+import Darwin
 import XCTest
 @testable import CLI
 @testable import MacParakeetCore
@@ -313,5 +314,21 @@ final class CLIHelpersTests: XCTestCase {
         let path = resolvedDatabasePath("~/macparakeet-test.db")
         XCTAssertFalse(path.hasPrefix("~"))
         XCTAssertTrue(path.hasSuffix("/macparakeet-test.db"))
+    }
+
+    // MARK: - stdout quarantine
+
+    func testRedirectStandardOutputToStandardErrorKeepsNativeNoiseOutOfStdout() async throws {
+        let output = try await captureStandardOutput {
+            let value = try await withStandardOutputRedirectedToStandardError {
+                fputs("native runtime diagnostic\n", stdout)
+                fflush(stdout)
+                return "payload"
+            }
+            try printJSON(["result": value])
+        }
+
+        XCTAssertFalse(output.contains("native runtime diagnostic"))
+        XCTAssertTrue(output.contains(#""result" : "payload""#), output)
     }
 }


### PR DESCRIPTION
## Summary

Automation-facing CLI JSON output now remains parseable while the Parakeet/CoreML runtime is active. A real `transcribe --format json` smoke reproduced native E5RT diagnostics before the JSON payload on stdout, which broke `jq`; model work for `transcribe`, saved-record `retranscribe`, and `health --json --repair-models` now runs with stdout temporarily routed to stderr and restores stdout before final JSON is emitted.

Human-mode output stays unchanged, and the quarantine is limited to the model/native runtime paths that can leak process-level stdout. The helper also documents the process-wide stdout constraint, marks the saved fd close-on-exec, and warns on stderr if restoration ever fails after an operation error.

## Validation

- Final head `01e95a344`: `MACPARAKEET_SKIP_WHISPERKIT=1 swift test --filter 'CLIHelpersTests|TranscribeCommandTests|RetranscribeCommandTests|ModelLifecycleCommandTests'` — 142 tests passed
- Earlier branch head before final helper-hardening follow-up: `MACPARAKEET_SKIP_WHISPERKIT=1 swift test` — 4,438 tests passed, 15 skipped, 0 failures
- `git diff --check`
- `xcrun swift-format lint --recursive --configuration .swift-format Sources Tests` — exited 0; repo-wide pre-existing formatter warnings remain
- Real Parakeet runtime smokes with `jq` parsing and `0` E5RT matches on stdout:
  - `transcribe ... --format json`
  - `retranscribe ... --json`
  - `health --json --repair-models`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/Codex-GPT--5-000000)
