### PR TITLE
Hide meeting health UI behind default-off flag

### DIFF
--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingRecordingPanelView.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingRecordingPanelView.swift
@@ -252,8 +252,8 @@ struct MeetingRecordingPanelView: View {
                 }
             }
 
-            if viewModel.showsSourceHealthChips {
-                MeetingSourceHealthChips(chips: viewModel.sourceHealthChips)
+            if !visibleSourceHealthChips.isEmpty {
+                MeetingSourceHealthChips(chips: visibleSourceHealthChips)
             }
 
             if viewModel.showsLaggingIndicator {
@@ -265,6 +265,10 @@ struct MeetingRecordingPanelView: View {
         }
         .padding(.horizontal, DesignSystem.Spacing.md)
         .padding(.vertical, DesignSystem.Spacing.sm)
+    }
+
+    var visibleSourceHealthChips: [MeetingSourceHealthChip] {
+        AppFeatures.meetingSourceHealthUIEnabled ? viewModel.sourceHealthChips : []
     }
 
     @ViewBuilder

--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingRecordingPillView.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingRecordingPillView.swift
@@ -157,7 +157,7 @@ struct MeetingRecordingPillView: View {
 
     private var sacredRecordingPill: some View {
         let isPaused = viewModel.isPaused
-        let healthWarning = viewModel.mirroredSourceHealthWarning
+        let healthWarning = visibleSourceHealthWarning
         return VStack(spacing: 0) {
             ZStack {
                 MerkabaPillIcon(
@@ -270,6 +270,10 @@ struct MeetingRecordingPillView: View {
         .accessibilityAction(named: Text("End and transcribe")) {
             viewModel.onStop?()
         }
+    }
+
+    var visibleSourceHealthWarning: MeetingSourceHealthChip? {
+        AppFeatures.meetingSourceHealthUIEnabled ? viewModel.mirroredSourceHealthWarning : nil
     }
 
     private var pillBackground: some View {

--- a/Sources/MacParakeet/Views/Transcription/MeetingRecordingTile.swift
+++ b/Sources/MacParakeet/Views/Transcription/MeetingRecordingTile.swift
@@ -210,7 +210,7 @@ struct MeetingRecordingTile: View {
                         .font(.system(size: 15, weight: .semibold).monospacedDigit())
                         .foregroundStyle(DesignSystem.Colors.textSecondary)
 
-                    if let warning = viewModel.mirroredSourceHealthWarning {
+                    if let warning = visibleSourceHealthWarning {
                         MeetingSourceHealthInlineBadge(chip: warning)
                     }
                 }
@@ -376,7 +376,11 @@ struct MeetingRecordingTile: View {
     }
 
     private var sourceHealthAccessibilitySuffix: String {
-        viewModel.mirroredSourceHealthWarning.map { ", \($0.label)" } ?? ""
+        visibleSourceHealthWarning.map { ", \($0.label)" } ?? ""
+    }
+
+    var visibleSourceHealthWarning: MeetingSourceHealthChip? {
+        AppFeatures.meetingSourceHealthUIEnabled ? viewModel.mirroredSourceHealthWarning : nil
     }
 }
 

--- a/Sources/MacParakeetCore/AppFeatures.swift
+++ b/Sources/MacParakeetCore/AppFeatures.swift
@@ -40,6 +40,13 @@ public enum AppFeatures {
     /// phases are still being validated.
     public static let meetingCaptureReliabilityEnabled: Bool = true
 
+    /// Meeting source health presentation. When `false`, the Core health model,
+    /// service plumbing, view-model state, and tests remain intact, but the
+    /// panel chips, floating pill degraded glyph, and transcription-tile health
+    /// mirror are hidden. Default-off after 2026-07-04 product review because
+    /// quiet-but-normal recordings made the amber warning chips feel alarmist.
+    public static let meetingSourceHealthUIEnabled: Bool = false
+
     /// Activity-based meeting detection (ADR-024). When `false`, Settings hides
     /// the meeting-activity detection mode, the app does not construct the
     /// coordinator, and no CoreAudio/CoreMediaIO collectors are started. Pure

--- a/Tests/MacParakeetTests/Views/MeetingRecordingTileTests.swift
+++ b/Tests/MacParakeetTests/Views/MeetingRecordingTileTests.swift
@@ -1,7 +1,9 @@
 import XCTest
 import MacParakeetCore
+import MacParakeetViewModels
 @testable import MacParakeet
 
+@MainActor
 final class MeetingRecordingTileTests: XCTestCase {
     func testPermissionStateReadyWhenRequiredPermissionsGranted() {
         let state = MeetingRecordingTile.PermissionState(
@@ -55,5 +57,28 @@ final class MeetingRecordingTileTests: XCTestCase {
         XCTAssertEqual(microphoneAndSystem, .missing(microphone: false, screenRecording: true))
         XCTAssertEqual(microphoneOnly, .ready(sourceMode: .microphoneOnly))
         XCTAssertEqual(systemOnly, .missing(microphone: false, screenRecording: true))
+    }
+
+    func testDefaultOffHealthUIFlagHidesPresentationWhileKeepingViewModelHealthState() {
+        let captureHealth = MeetingCaptureHealthSummary(
+            sourceMode: .microphoneAndSystem,
+            microphone: MeetingSourceHealth(source: .microphone, status: .live, level: 0.5),
+            system: MeetingSourceHealth(source: .system, status: .interrupted)
+        )
+
+        let panelViewModel = MeetingRecordingPanelViewModel()
+        panelViewModel.state = .recording
+        panelViewModel.captureHealth = captureHealth
+        XCTAssertFalse(panelViewModel.sourceHealthChips.isEmpty)
+
+        let pillViewModel = MeetingRecordingPillViewModel()
+        pillViewModel.state = .recording
+        pillViewModel.captureHealth = captureHealth
+        XCTAssertNotNil(pillViewModel.mirroredSourceHealthWarning)
+
+        XCTAssertFalse(AppFeatures.meetingSourceHealthUIEnabled)
+        XCTAssertTrue(MeetingRecordingPanelView(viewModel: panelViewModel).visibleSourceHealthChips.isEmpty)
+        XCTAssertNil(MeetingRecordingPillView(viewModel: pillViewModel).visibleSourceHealthWarning)
+        XCTAssertNil(MeetingRecordingTile(viewModel: pillViewModel, onTap: {}).visibleSourceHealthWarning)
     }
 }

--- a/plans/active/2026-07-04-meeting-health-artifacts-speaker-rename.md
+++ b/plans/active/2026-07-04-meeting-health-artifacts-speaker-rename.md
@@ -3,8 +3,9 @@
 > **Status:** IMPLEMENTED 2026-07-04 — shipped as PR #707 (source health
 > model + UI), PR #708 (meeting.md artifact + shared renderer + CLI/contract
 > promotion), and PR #710 (speaker rename UX + rollback guard). Remaining:
-> manual dual-source QA of the live health chips (mute/unmute, system
-> interruption) before release framing.
+> health UI hidden behind default-off flag per product decision 2026-07-04
+> (chips read as warnings during normal quiet capture); model/plumbing
+> retained; future direction = invisible-until-confirmed-actionable surface.
 > **Date:** 2026-07-04
 > **Priority:** P1 for visible source health, P2 for artifact/CLI promotion and
 > speaker rename polish


### PR DESCRIPTION
## Summary
- Add internal `AppFeatures.meetingSourceHealthUIEnabled`, defaulting off with no Settings UI.
- Gate the presentational health surfaces: panel health chips, floating pill degraded glyph, and transcription-tile health mirror/accessibility suffix.
- Keep the Core health model, service plumbing, view-model state, and existing health tests intact.
- Add a focused view-logic regression proving view-model health state still exists while the default-off flag hides the UI surfaces.
- Update the active meeting-health plan with Daniel's 2026-07-04 product decision.

## Product rationale
Daniel's live review found the health chips too alarmist for normal quiet recordings, especially the common case where amber "may be silent" chips appear while nothing is wrong. This keeps the health facts and plumbing available, but makes the visible surface invisible until a future confirmed-actionable design is ready.

## Tests
- `swift test --filter MeetingRecordingPanelViewModelTests`
- `swift test --filter MeetingRecordingPillViewModelTests`
- `swift test --filter MeetingRecordingServiceTests`
- `swift test --filter MeetingRecordingTileTests`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hides the meeting source health UI behind a default-off feature flag to avoid noisy warnings during normal quiet recordings, while keeping the health model and state intact.

- **New Features**
  - Add `AppFeatures.meetingSourceHealthUIEnabled` (default false).
  - Gate panel chips, pill warning glyph, and transcription tile badge + accessibility suffix.
  - Add a focused view test confirming UI is hidden but view-model health state persists.
  - Update active plan with the 2026-07-04 product decision.

<sup>Written for commit 4873422a3e6e43926786df730a1ace59c66ca264. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/713?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

