### PR TITLE
fix: sync speaker rename segments and harden voiceprint tools

### DIFF
--- a/Sources/MacParakeetCore/Database/TranscriptionRepository.swift
+++ b/Sources/MacParakeetCore/Database/TranscriptionRepository.swift
@@ -434,6 +434,10 @@ public final class TranscriptionRepository: TranscriptionRepositoryProtocol, @un
         try dbQueue.write { db in
             guard var transcription = try Transcription.fetchOne(db, key: id) else { return }
             transcription.speakers = speakers
+            transcription.transcriptSegments = TranscriptSegmentRecord.updatingSpeakerLabels(
+                in: transcription.transcriptSegments,
+                using: speakers
+            )
             transcription.updatedAt = Date()
             try transcription.update(db)
         }

--- a/Sources/MacParakeetCore/Models/Transcription.swift
+++ b/Sources/MacParakeetCore/Models/Transcription.swift
@@ -249,6 +249,31 @@ public struct TranscriptSegmentRecord: Codable, Sendable, Equatable, Identifiabl
         self.text = text
         self.wordRange = wordRange
     }
+
+    public static func updatingSpeakerLabels(
+        in segments: [TranscriptSegmentRecord]?,
+        using speakers: [SpeakerInfo]?
+    ) -> [TranscriptSegmentRecord]? {
+        guard var segments,
+              let speakers,
+              !speakers.isEmpty
+        else {
+            return segments
+        }
+
+        var labelsBySpeakerID: [String: String] = [:]
+        for speaker in speakers {
+            labelsBySpeakerID[speaker.id] = speaker.label
+        }
+
+        for index in segments.indices {
+            guard let speakerId = segments[index].speakerId,
+                  let label = labelsBySpeakerID[speakerId]
+            else { continue }
+            segments[index].speakerLabel = label
+        }
+        return segments
+    }
 }
 
 extension Transcription: FetchableRecord, PersistableRecord {

--- a/Sources/MacParakeetCore/Models/Transcription.swift
+++ b/Sources/MacParakeetCore/Models/Transcription.swift
@@ -255,6 +255,7 @@ public struct TranscriptSegmentRecord: Codable, Sendable, Equatable, Identifiabl
         using speakers: [SpeakerInfo]?
     ) -> [TranscriptSegmentRecord]? {
         guard var segments,
+              !segments.isEmpty,
               let speakers,
               !speakers.isEmpty
         else {

--- a/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
@@ -1246,19 +1246,36 @@ public final class TranscriptionViewModel {
         let trimmed = newLabel.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty, speakers[index].label != trimmed else { return }
         let previousCurrentSpeakers = speakers
+        let previousCurrentSegments = transcription.transcriptSegments
         let transcriptionIndex = transcriptions.firstIndex(where: { $0.id == transcription.id })
         let previousListSpeakers = transcriptionIndex.flatMap { transcriptions[$0].speakers }
+        let previousListSegments = transcriptionIndex.flatMap { transcriptions[$0].transcriptSegments }
         let renameGeneration = (speakerRenameGenerations[transcription.id] ?? 0) + 1
         speakerRenameGenerations[transcription.id] = renameGeneration
         speakers[index].label = trimmed
         transcription.speakers = speakers
+        transcription.transcriptSegments = TranscriptSegmentRecord.updatingSpeakerLabels(
+            in: transcription.transcriptSegments,
+            using: speakers
+        )
         currentTranscription = transcription
         if let transcriptionIndex {
             transcriptions[transcriptionIndex].speakers = speakers
+            transcriptions[transcriptionIndex].transcriptSegments = transcription.transcriptSegments
         }
         guard let transcriptionRepo else { return }
         let transcriptionID = transcription.id
-        Task { [weak self, transcriptionRepo, transcriptionID, speakers, previousCurrentSpeakers, previousListSpeakers, renameGeneration] in
+        Task { [
+            weak self,
+            transcriptionRepo,
+            transcriptionID,
+            speakers,
+            previousCurrentSpeakers,
+            previousCurrentSegments,
+            previousListSpeakers,
+            previousListSegments,
+            renameGeneration
+        ] in
             do {
                 try await Task.detached(priority: .utility) {
                     try transcriptionRepo.updateSpeakers(id: transcriptionID, speakers: speakers)
@@ -1269,7 +1286,9 @@ public final class TranscriptionViewModel {
                     transcriptionID: transcriptionID,
                     generation: renameGeneration,
                     previousCurrentSpeakers: previousCurrentSpeakers,
+                    previousCurrentSegments: previousCurrentSegments,
                     previousListSpeakers: previousListSpeakers,
+                    previousListSegments: previousListSegments,
                     errorType: errorType
                 )
             }
@@ -1280,16 +1299,20 @@ public final class TranscriptionViewModel {
         transcriptionID: UUID,
         generation: Int,
         previousCurrentSpeakers: [SpeakerInfo],
+        previousCurrentSegments: [TranscriptSegmentRecord]?,
         previousListSpeakers: [SpeakerInfo]?,
+        previousListSegments: [TranscriptSegmentRecord]?,
         errorType: String
     ) {
         guard speakerRenameGenerations[transcriptionID] == generation else { return }
         if var currentTranscription, currentTranscription.id == transcriptionID {
             currentTranscription.speakers = previousCurrentSpeakers
+            currentTranscription.transcriptSegments = previousCurrentSegments
             self.currentTranscription = currentTranscription
         }
         if let index = transcriptions.firstIndex(where: { $0.id == transcriptionID }) {
             transcriptions[index].speakers = previousListSpeakers
+            transcriptions[index].transcriptSegments = previousListSegments
         }
         setError(message: "Failed to save speaker rename. The previous label was restored.")
         logger.error("Failed to persist speaker rename error_type=\(errorType, privacy: .public)")

--- a/Tests/MacParakeetTests/Database/TranscriptionRepositoryTests.swift
+++ b/Tests/MacParakeetTests/Database/TranscriptionRepositoryTests.swift
@@ -884,6 +884,60 @@ final class TranscriptionRepositoryTests: XCTestCase {
         XCTAssertEqual(fetched?.speakers?[1].label, "Bob")
     }
 
+    func testUpdateSpeakersRefreshesMatchingTranscriptSegmentLabels() throws {
+        let transcription = Transcription(
+            fileName: "meeting.wav",
+            speakers: [
+                SpeakerInfo(id: "S1", label: "Speaker 1"),
+                SpeakerInfo(id: "S2", label: "Speaker 2"),
+            ],
+            transcriptSegments: [
+                TranscriptSegmentRecord(
+                    startMs: 0,
+                    endMs: 500,
+                    speakerId: "S1",
+                    speakerLabel: "Speaker 1",
+                    text: "Hello",
+                    wordRange: TranscriptSegmentWordRange(startIndex: 0, endIndexExclusive: 1)
+                ),
+                TranscriptSegmentRecord(
+                    startMs: 500,
+                    endMs: 900,
+                    speakerId: "S2",
+                    speakerLabel: "Speaker 2",
+                    text: "there",
+                    wordRange: TranscriptSegmentWordRange(startIndex: 1, endIndexExclusive: 2)
+                ),
+                TranscriptSegmentRecord(
+                    startMs: 900,
+                    endMs: 1100,
+                    speakerId: "S3",
+                    speakerLabel: "Unmapped speaker",
+                    text: "aside",
+                    wordRange: TranscriptSegmentWordRange(startIndex: 2, endIndexExclusive: 3)
+                ),
+            ],
+            status: .completed,
+            sourceType: .meeting
+        )
+        try repo.save(transcription)
+
+        try repo.updateSpeakers(
+            id: transcription.id,
+            speakers: [
+                SpeakerInfo(id: "S1", label: "Sarah"),
+                SpeakerInfo(id: "S2", label: "Riley"),
+            ]
+        )
+
+        let fetched = try XCTUnwrap(repo.fetch(id: transcription.id))
+        XCTAssertEqual(fetched.speakers?[0].label, "Sarah")
+        XCTAssertEqual(fetched.speakers?[1].label, "Riley")
+        XCTAssertEqual(fetched.transcriptSegments?[0].speakerLabel, "Sarah")
+        XCTAssertEqual(fetched.transcriptSegments?[1].speakerLabel, "Riley")
+        XCTAssertEqual(fetched.transcriptSegments?[2].speakerLabel, "Unmapped speaker")
+    }
+
     func testUpdateSpeakersToNil() throws {
         let speakers = [SpeakerInfo(id: "S1", label: "Speaker 1")]
         let transcription = Transcription(fileName: "test.mp3", speakers: speakers, status: .completed)

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
@@ -1333,6 +1333,59 @@ final class TranscriptionViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.currentTranscription?.speakers?[1].label, "Speaker 2")
     }
 
+    func testRenameSpeakerUpdatesTranscriptSegmentLabels() {
+        let speakers = [
+            SpeakerInfo(id: "S1", label: "Speaker 1"),
+            SpeakerInfo(id: "S2", label: "Speaker 2")
+        ]
+        let t = Transcription(
+            fileName: "meeting.wav",
+            speakers: speakers,
+            transcriptSegments: [
+                TranscriptSegmentRecord(
+                    startMs: 0,
+                    endMs: 500,
+                    speakerId: "S1",
+                    speakerLabel: "Speaker 1",
+                    text: "Hello",
+                    wordRange: TranscriptSegmentWordRange(startIndex: 0, endIndexExclusive: 1)
+                ),
+                TranscriptSegmentRecord(
+                    startMs: 500,
+                    endMs: 900,
+                    speakerId: "S2",
+                    speakerLabel: "Speaker 2",
+                    text: "there",
+                    wordRange: TranscriptSegmentWordRange(startIndex: 1, endIndexExclusive: 2)
+                ),
+                TranscriptSegmentRecord(
+                    startMs: 900,
+                    endMs: 1100,
+                    speakerId: nil,
+                    speakerLabel: "Narrator",
+                    text: "aside",
+                    wordRange: TranscriptSegmentWordRange(startIndex: 2, endIndexExclusive: 3)
+                ),
+            ],
+            status: .completed
+        )
+        mockRepo.transcriptions = [t]
+
+        viewModel.configure(transcriptionService: mockService, transcriptionRepo: mockRepo)
+        viewModel.currentTranscription = t
+
+        viewModel.renameSpeaker(id: "S1", to: "Sarah")
+
+        XCTAssertEqual(viewModel.currentTranscription?.transcriptSegments?[0].speakerLabel, "Sarah")
+        XCTAssertEqual(viewModel.currentTranscription?.transcriptSegments?[1].speakerLabel, "Speaker 2")
+        XCTAssertEqual(viewModel.currentTranscription?.transcriptSegments?[2].speakerLabel, "Narrator")
+
+        let updated = viewModel.transcriptions.first { $0.id == t.id }
+        XCTAssertEqual(updated?.transcriptSegments?[0].speakerLabel, "Sarah")
+        XCTAssertEqual(updated?.transcriptSegments?[1].speakerLabel, "Speaker 2")
+        XCTAssertEqual(updated?.transcriptSegments?[2].speakerLabel, "Narrator")
+    }
+
     func testRenameSpeakerUpdatesMatchingTranscriptionsRow() {
         let speakers = [
             SpeakerInfo(id: "S1", label: "Speaker 1"),
@@ -1364,7 +1417,21 @@ final class TranscriptionViewModelTests: XCTestCase {
             SpeakerInfo(id: "S1", label: "Speaker 1"),
             SpeakerInfo(id: "S2", label: "Speaker 2")
         ]
-        let t = Transcription(fileName: "meeting.wav", speakers: speakers, status: .completed)
+        let t = Transcription(
+            fileName: "meeting.wav",
+            speakers: speakers,
+            transcriptSegments: [
+                TranscriptSegmentRecord(
+                    startMs: 0,
+                    endMs: 500,
+                    speakerId: "S1",
+                    speakerLabel: "Speaker 1",
+                    text: "Hello",
+                    wordRange: TranscriptSegmentWordRange(startIndex: 0, endIndexExclusive: 1)
+                ),
+            ],
+            status: .completed
+        )
         let other = Transcription(
             fileName: "other.wav",
             speakers: [SpeakerInfo(id: "S1", label: "Other speaker")],
@@ -1382,10 +1449,12 @@ final class TranscriptionViewModelTests: XCTestCase {
             self.viewModel.currentTranscription?.speakers?[0].label == "Speaker 1"
         }
         XCTAssertEqual(viewModel.currentTranscription?.speakers?[1].label, "Speaker 2")
+        XCTAssertEqual(viewModel.currentTranscription?.transcriptSegments?[0].speakerLabel, "Speaker 1")
 
         let reverted = viewModel.transcriptions.first { $0.id == t.id }
         XCTAssertEqual(reverted?.speakers?[0].label, "Speaker 1")
         XCTAssertEqual(reverted?.speakers?[1].label, "Speaker 2")
+        XCTAssertEqual(reverted?.transcriptSegments?[0].speakerLabel, "Speaker 1")
 
         let unchanged = viewModel.transcriptions.first { $0.id == other.id }
         XCTAssertEqual(unchanged?.speakers?[0].label, "Other speaker")

--- a/Tests/MacParakeetTests/ViewModels/ViewModelMocks.swift
+++ b/Tests/MacParakeetTests/ViewModels/ViewModelMocks.swift
@@ -222,6 +222,10 @@ final class MockTranscriptionRepository: TranscriptionRepositoryProtocol, @unche
         }
         if let idx = transcriptions.firstIndex(where: { $0.id == id }) {
             transcriptions[idx].speakers = speakers
+            transcriptions[idx].transcriptSegments = TranscriptSegmentRecord.updatingSpeakerLabels(
+                in: transcriptions[idx].transcriptSegments,
+                using: speakers
+            )
             transcriptions[idx].updatedAt = Date()
         }
     }

--- a/docs/research/2026-07-04-voiceprints-phase0/harness/Sources/VoiceprintHarness/main.swift
+++ b/docs/research/2026-07-04-voiceprints-phase0/harness/Sources/VoiceprintHarness/main.swift
@@ -452,21 +452,18 @@ enum VoiceprintHarness {
         process.executableURL = URL(fileURLWithPath: executable)
         process.arguments = arguments
 
-        let stdout = Pipe()
-        let stderr = Pipe()
-        process.standardOutput = stdout
-        process.standardError = stderr
+        let outputPipe = Pipe()
+        process.standardOutput = outputPipe
+        process.standardError = outputPipe
 
         try process.run()
+        let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
         process.waitUntilExit()
 
-        let outData = stdout.fileHandleForReading.readDataToEndOfFile()
-        let errData = stderr.fileHandleForReading.readDataToEndOfFile()
-        let out = String(data: outData, encoding: .utf8) ?? ""
-        let err = String(data: errData, encoding: .utf8) ?? ""
+        let output = String(data: outputData, encoding: .utf8) ?? ""
         guard process.terminationStatus == 0 else {
-            throw HarnessError(description: "\(URL(fileURLWithPath: executable).lastPathComponent) failed: \(err)")
+            throw HarnessError(description: "\(URL(fileURLWithPath: executable).lastPathComponent) failed: \(output)")
         }
-        return out
+        return output
     }
 }

--- a/docs/research/2026-07-04-voiceprints-phase0/harness/Sources/VoiceprintHarness/main.swift
+++ b/docs/research/2026-07-04-voiceprints-phase0/harness/Sources/VoiceprintHarness/main.swift
@@ -452,18 +452,31 @@ enum VoiceprintHarness {
         process.executableURL = URL(fileURLWithPath: executable)
         process.arguments = arguments
 
-        let outputPipe = Pipe()
-        process.standardOutput = outputPipe
-        process.standardError = outputPipe
+        let stdout = Pipe()
+        let stderrURL = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "voiceprint-harness-\(UUID().uuidString).stderr"
+        )
+        _ = FileManager.default.createFile(atPath: stderrURL.path, contents: nil)
+        let stderrHandle = try FileHandle(forWritingTo: stderrURL)
+        defer {
+            try? stderrHandle.close()
+            try? FileManager.default.removeItem(at: stderrURL)
+        }
+        process.standardOutput = stdout
+        process.standardError = stderrHandle
 
         try process.run()
-        let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
+        let outData = try stdout.fileHandleForReading.readToEnd() ?? Data()
         process.waitUntilExit()
+        try? stderrHandle.close()
 
-        let output = String(data: outputData, encoding: .utf8) ?? ""
+        let errData = (try? Data(contentsOf: stderrURL)) ?? Data()
+        let out = String(data: outData, encoding: .utf8) ?? ""
+        let err = String(data: errData, encoding: .utf8) ?? ""
         guard process.terminationStatus == 0 else {
-            throw HarnessError(description: "\(URL(fileURLWithPath: executable).lastPathComponent) failed: \(output)")
+            let detail = err.isEmpty ? out : err
+            throw HarnessError(description: "\(URL(fileURLWithPath: executable).lastPathComponent) failed: \(detail)")
         }
-        return output
+        return out
     }
 }

--- a/docs/research/2026-07-04-voiceprints-phase0/harness/analyze_voiceprints.py
+++ b/docs/research/2026-07-04-voiceprints-phase0/harness/analyze_voiceprints.py
@@ -400,6 +400,11 @@ def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--data-dir", type=Path, required=True)
     parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument(
+        "--include-population-pairs",
+        action="store_true",
+        help="Include linkable per-session/per-speaker pair records. Keep this local.",
+    )
     args = parser.parse_args()
 
     full = load_full(args.data_dir)
@@ -418,15 +423,18 @@ def main() -> None:
         "overlap": overlap(populations),
         "pairwiseTauSweep": pairwise_sweep(populations),
         "marginProxyTauSweep": margin_proxy_sweep(full),
-        "populationPairs": {
-            name: records for name, records in populations.items()
-        },
         "notes": [
             "Microphone clusters are treated as same-speaker because the microphone channel is the app-user ground truth, despite diarizer over-clustering.",
             "System split-half same-speaker pairs use greedy nearest-neighbor matching across halves because no participant labels are available.",
             "Margin proxy sweep is a user-profile proxy, not a fully labeled multi-profile speaker-identification evaluation.",
+            "Detailed populationPairs records are omitted by default because they are linkable "
+            "biometric meeting metadata; pass --include-population-pairs only for local analysis.",
         ],
     }
+    if args.include_population_pairs:
+        output["populationPairs"] = {
+            name: records for name, records in populations.items()
+        }
 
     args.output.write_text(json.dumps(output, indent=2, sort_keys=True) + "\n")
     print(json.dumps({k: output[k] for k in ["generatedAt", "populationStats", "overlap"]}, indent=2))


### PR DESCRIPTION
## Summary

Speaker renames now update the cached transcript segment labels that leave the app through meeting JSON, so CLI consumers do not see stale speaker names after an in-app rename succeeds. The same remap runs in the optimistic view-model state and in `TranscriptionRepository.updateSpeakers`, preserving the existing rollback behavior on persistence failure.

The voiceprint Phase 0 tooling now drains subprocess output before waiting, avoiding a deadlock if `ffmpeg` or `ffprobe` fills an output pipe. Detailed `populationPairs` records are also omitted by default and require `--include-population-pairs`, keeping linkable per-session/per-speaker data local unless explicitly requested.

## Validation

- `swift test --filter TranscriptionViewModelTests/testRenameSpeaker`
- `swift test --filter TranscriptionRepositoryTests/testUpdateSpeakers`
- `swift test --filter MeetingsCommandTests/testMeetingJSONSurfacesExposeTranscriptSegments`
- `python3 -m py_compile docs/research/2026-07-04-voiceprints-phase0/harness/analyze_voiceprints.py`
- Temp analyzer fixture verifying default output omits `populationPairs` and `--include-population-pairs` includes it
- `(cd docs/research/2026-07-04-voiceprints-phase0/harness && swift build)`
- `git diff --check`

`no-mistakes axi run --intent ...` was attempted, but the local daemon failed before starting a run for this branch with `no previous run for branch fix/review-followups-speaker-voiceprints-v2`; manual validation above was used instead.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speaker renames now update transcript segment speaker labels across the view model and repository, so meeting JSON and CLI consumers don’t see stale names. Voiceprint tools avoid subprocess deadlocks and make linkable records opt-in.

- **Bug Fixes**
  - Keep transcript segment `speakerLabel` in sync when speakers are renamed (optimistic UI and `TranscriptionRepository.updateSpeakers`), with rollback on failure; skip remapping when there are no segments.
  - Drain stdout before waiting in the voiceprint harness to prevent deadlocks and keep stderr separate from parsed stdout; errors surface stderr when available.

- **New Features**
  - `analyze_voiceprints.py` omits `populationPairs` by default; include them with `--include-population-pairs`.

<sup>Written for commit c1855359d5d7d21fa55fa8ffd3df733d8e439653. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/714?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

