### PR TITLE
Migrate Settings and CLI capability read sites

### DIFF
--- a/Sources/CLI/Commands/ModelsCommand.swift
+++ b/Sources/CLI/Commands/ModelsCommand.swift
@@ -139,7 +139,8 @@ extension ModelsCommand {
         func run() async throws {
             let lowered = variant.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
             if let parakeetVariant = parakeetDownloadVariant(from: lowered) {
-                print("Parakeet: downloading \(parakeetVariant.modelName)...")
+                let modelName = speechModelLifecycle(for: .parakeet(parakeetVariant)).modelName
+                print("Parakeet: downloading \(modelName)...")
                 let lastMessage = OSAllocatedUnfairLock(initialState: "")
                 try await downloadParakeetVariant(parakeetVariant) { message in
                     let shouldPrint = lastMessage.withLock { last in
@@ -149,13 +150,14 @@ extension ModelsCommand {
                     }
                     if shouldPrint { print("Parakeet: \(message)") }
                 }
-                print("Parakeet: ready (\(parakeetVariant.modelName))")
+                print("Parakeet: ready (\(modelName))")
                 return
             }
 
             if let nemotronVariant = nemotronDownloadVariant(from: lowered) {
                 let language = SpeechEnginePreference.nemotronDefaultLanguage(defaults: macParakeetAppDefaults())
-                print("Nemotron: downloading \(nemotronVariant.modelName)...")
+                let modelName = speechModelLifecycle(for: .nemotron(nemotronVariant)).modelName
+                print("Nemotron: downloading \(modelName)...")
                 let lastMessage = OSAllocatedUnfairLock(initialState: "")
                 try await STTRuntime.downloadNemotronModel(modelVariant: nemotronVariant, language: language) { message in
                     let shouldPrint = lastMessage.withLock { last in
@@ -165,12 +167,12 @@ extension ModelsCommand {
                     }
                     if shouldPrint { print("Nemotron: \(message)") }
                 }
-                print("Nemotron: ready (\(nemotronVariant.modelName))")
+                print("Nemotron: ready (\(modelName))")
                 return
             }
 
             if isCohereModelID(lowered) {
-                print("Cohere: downloading Cohere Transcribe...")
+                print("Cohere: downloading \(cohereModelName)...")
                 let lastMessage = OSAllocatedUnfairLock(initialState: "")
                 _ = try await CohereTranscribeEngine.downloadModel { message in
                     let shouldPrint = lastMessage.withLock { last in
@@ -180,7 +182,7 @@ extension ModelsCommand {
                     }
                     if shouldPrint { print("Cohere: \(message)") }
                 }
-                print("Cohere: ready (Cohere Transcribe)")
+                print("Cohere: ready (\(cohereModelName))")
                 return
             }
 
@@ -306,22 +308,26 @@ extension ModelsCommand {
 
             switch target.kind {
             case .parakeet(let variant):
+                let lifecycle = speechModelLifecycle(for: .parakeet(variant))
                 guard isParakeetVariantCached(variant) else {
-                    print("\(variant.modelName) is not downloaded — nothing to delete.")
+                    print("\(lifecycle.modelName) is not downloaded — nothing to delete.")
                     return
                 }
                 let removed = deleteParakeetVariant(variant)
                 guard removed else {
-                    throw ModelDeletionError.deleteFailed("Could not delete \(variant.modelName). It may be missing or in use by another process.")
+                    throw ModelDeletionError.deleteFailed("Could not delete \(lifecycle.modelName). It may be missing or in use by another process.")
                 }
-                print("Deleted \(target.displayName) · freed \(variant.approximateDownloadSize).")
+                let size = lifecycle.approximateDownloadSize ?? variant.approximateDownloadSize
+                print("Deleted \(target.displayName) · freed \(size).")
             case .nemotron(let variant):
+                let lifecycle = speechModelLifecycle(for: .nemotron(variant))
                 let removed = STTRuntime.deleteNemotronModel(modelVariant: variant, language: nil)
                 guard removed else {
-                    print("\(variant.modelName) is not downloaded — nothing to delete.")
+                    print("\(lifecycle.modelName) is not downloaded — nothing to delete.")
                     return
                 }
-                print("Deleted \(target.displayName) · freed \(variant.approximateDownloadSize).")
+                let size = lifecycle.approximateDownloadSize ?? variant.approximateDownloadSize
+                print("Deleted \(target.displayName) · freed \(size).")
             case .whisper(let variant):
                 guard WhisperEngine.isModelDownloaded(model: variant) else {
                     print("Whisper \(SpeechEnginePreference.friendlyVariantName(variant)) is not downloaded — nothing to delete.")
@@ -335,12 +341,12 @@ extension ModelsCommand {
                 print("Deleted \(target.displayName)\(freed).")
             case .cohere:
                 guard CohereTranscribeEngine.hasModelCacheDirectory() else {
-                    print("Cohere Transcribe is not downloaded — nothing to delete.")
+                    print("\(cohereModelName) is not downloaded — nothing to delete.")
                     return
                 }
                 let removed = CohereTranscribeEngine.deleteModel()
                 guard removed else {
-                    throw ModelDeletionError.deleteFailed("Could not delete Cohere Transcribe. It may be missing or in use by another process.")
+                    throw ModelDeletionError.deleteFailed("Could not delete \(cohereModelName). It may be missing or in use by another process.")
                 }
                 print("Deleted \(target.displayName) · freed \(cohereModelSize).")
             }
@@ -421,8 +427,30 @@ func nemotronDownloadVariant(
 }
 
 private let cohereModelID = "cohere-transcribe"
-private let cohereModelName = "Cohere Transcribe"
-private let cohereModelSize = "~2.1 GB"
+
+private func speechModelLifecycle(for key: SpeechEngineVariantKey) -> SpeechEngineModelLifecycle {
+    SpeechEngineCapabilityRegistry.capabilities(for: key).modelLifecycle
+}
+
+private let cohereModelLifecycle = speechModelLifecycle(for: .cohere)
+
+private let cohereModelName = cohereModelLifecycle.modelName
+
+private let cohereModelSize = cohereModelLifecycle.approximateDownloadSize ?? "~2.1 GB"
+
+private func selectableModelLanguage(
+    for policy: SpeechEngineLanguagePolicy,
+    selectedLanguage: String?
+) -> String? {
+    switch policy.mode {
+    case .automatic:
+        selectedLanguage
+    case .fixed:
+        policy.defaultLanguage
+    case .selectable:
+        selectedLanguage ?? policy.defaultLanguage
+    }
+}
 
 func isCohereModelID(_ lowered: String) -> Bool {
     lowered == SpeechEnginePreference.cohere.rawValue
@@ -657,55 +685,75 @@ func loadSelectableSpeechModels(
     let cohereLanguage = SpeechEnginePreference.cohereDefaultLanguage(defaults: defaults) ?? "en"
 
     let parakeetModels = ParakeetModelVariant.allCases.map { variant in
-        SelectableSpeechModel(
+        let capabilities = SpeechEngineCapabilityRegistry.capabilities(for: .parakeet(variant))
+        let lifecycle = capabilities.modelLifecycle
+        return SelectableSpeechModel(
             id: parakeetModelID(for: variant),
-            name: "\(variant.modelName) (\(variant.displayName))",
+            name: "\(lifecycle.modelName) (\(variant.displayName))",
             engine: SpeechEnginePreference.parakeet.rawValue,
-            variant: variant.rawValue,
-            size: variant.approximateDownloadSize,
+            variant: lifecycle.variantID ?? variant.rawValue,
+            size: lifecycle.approximateDownloadSize,
             installed: checkParakeetModelCached(variant),
             selected: currentEngine == .parakeet && currentParakeetVariant == variant,
-            language: variant.isEnglishOnly ? "en" : nil
+            language: selectableModelLanguage(
+                for: capabilities.supportedLanguages,
+                selectedLanguage: nil
+            )
         )
     }
 
     let currentNemotronVariant = SpeechEnginePreference.nemotronModelVariant(defaults: defaults)
     let nemotronModels = NemotronModelVariant.allCases.map { variant in
-        SelectableSpeechModel(
+        let capabilities = SpeechEngineCapabilityRegistry.capabilities(for: .nemotron(variant))
+        let lifecycle = capabilities.modelLifecycle
+        return SelectableSpeechModel(
             id: nemotronModelID(for: variant),
-            name: "\(variant.modelName) (\(variant.displayName))",
+            name: "\(lifecycle.modelName) (\(variant.displayName))",
             engine: SpeechEnginePreference.nemotron.rawValue,
-            variant: variant.rawValue,
-            size: variant.approximateDownloadSize,
+            variant: lifecycle.variantID ?? variant.rawValue,
+            size: lifecycle.approximateDownloadSize,
             installed: checkNemotronModelDownloaded(variant),
             selected: currentEngine == .nemotron && currentNemotronVariant == variant,
-            language: variant.isEnglishOnly ? "en" : (nemotronLanguage ?? "auto")
+            language: selectableModelLanguage(
+                for: capabilities.supportedLanguages,
+                selectedLanguage: nemotronLanguage ?? "auto"
+            )
         )
     }
 
     let whisperModels = WhisperModelVariant.allCases.map { variant in
-        SelectableSpeechModel(
+        let capabilities = SpeechEngineCapabilityRegistry.capabilities(for: .whisper(variant))
+        let lifecycle = capabilities.modelLifecycle
+        return SelectableSpeechModel(
             id: variant.modelID,
-            name: variant.modelName,
+            name: lifecycle.modelName,
             engine: SpeechEnginePreference.whisper.rawValue,
-            variant: variant.rawValue,
-            size: variant.approximateDownloadSize,
+            variant: lifecycle.variantID ?? variant.rawValue,
+            size: lifecycle.approximateDownloadSize,
             installed: checkWhisperModelDownloaded(variant.rawValue),
             selected: currentEngine == .whisper && whisperVariant == variant,
-            language: whisperLanguage ?? WhisperLanguageCatalog.autoCode
+            language: selectableModelLanguage(
+                for: capabilities.supportedLanguages,
+                selectedLanguage: whisperLanguage ?? WhisperLanguageCatalog.autoCode
+            )
         )
     }
 
+    let cohereCapabilities = SpeechEngineCapabilityRegistry.capabilities(for: .cohere)
+    let cohereLifecycle = cohereCapabilities.modelLifecycle
     return parakeetModels + nemotronModels + [
         SelectableSpeechModel(
             id: cohereModelID,
-            name: cohereModelName,
+            name: cohereLifecycle.modelName,
             engine: SpeechEnginePreference.cohere.rawValue,
-            variant: nil,
+            variant: cohereLifecycle.variantID,
             size: cohereModelSize,
             installed: checkCohereModelDownloaded(),
             selected: currentEngine == .cohere,
-            language: cohereLanguage
+            language: selectableModelLanguage(
+                for: cohereCapabilities.supportedLanguages,
+                selectedLanguage: cohereLanguage
+            )
         )
     ] + whisperModels
 }
@@ -822,7 +870,7 @@ func validateSelectableSpeechModelDownload(
         let downloaded = (isCohereModelDownloaded ?? { CohereTranscribeEngine.isModelCached() })()
         guard downloaded else {
             throw ValidationError(
-                "Cohere Transcribe is not downloaded. Run `macparakeet-cli models download \(cohereModelID)` first."
+                "\(cohereModelName) is not downloaded. Run `macparakeet-cli models download \(cohereModelID)` first."
             )
         }
     }
@@ -864,15 +912,17 @@ func resolveModelDeletionTarget(
 ) throws -> ModelDeletionTarget {
     let selection = try resolveSelectableSpeechModel(id, defaults: defaults)
     if let parakeetVariant = selection.parakeetVariant {
+        let lifecycle = speechModelLifecycle(for: .parakeet(parakeetVariant))
         return ModelDeletionTarget(
             kind: .parakeet(parakeetVariant),
-            displayName: "\(parakeetVariant.modelName) (\(parakeetVariant.displayName))"
+            displayName: "\(lifecycle.modelName) (\(parakeetVariant.displayName))"
         )
     }
     if let nemotronVariant = selection.nemotronVariant {
+        let lifecycle = speechModelLifecycle(for: .nemotron(nemotronVariant))
         return ModelDeletionTarget(
             kind: .nemotron(nemotronVariant),
-            displayName: "\(nemotronVariant.modelName) (\(nemotronVariant.displayName))"
+            displayName: "\(lifecycle.modelName) (\(nemotronVariant.displayName))"
         )
     }
     if let whisperVariant = selection.whisperVariant {
@@ -979,7 +1029,7 @@ func whisperModelID(for variant: String) -> String {
 
 func whisperModelSizeLabel(for variant: String) -> String? {
     if let whisperVariant = WhisperModelVariant.normalize(variant) {
-        return whisperVariant.approximateDownloadSize
+        return speechModelLifecycle(for: .whisper(whisperVariant)).approximateDownloadSize
     }
     let tokens = variant.split(separator: "_")
     guard let last = tokens.last else { return nil }

--- a/Sources/CLI/Commands/RetranscribeCommand.swift
+++ b/Sources/CLI/Commands/RetranscribeCommand.swift
@@ -229,7 +229,9 @@ struct RetranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding 
                 nemotronModel,
                 storedVariant: SpeechEnginePreference.nemotronModelVariant(defaults: defaults)
             )
-            if speechEngine.engine == .nemotron, nemotronVariant.isEnglishOnly, language != nil {
+            if speechEngine.engine == .nemotron,
+               TranscribeCommand.nemotronIgnoresLanguageOverride(nemotronVariant),
+               language != nil {
                 printErr("Note: --language is ignored by the English-only Nemotron build.")
             }
 

--- a/Sources/CLI/Commands/TranscribeCommand.swift
+++ b/Sources/CLI/Commands/TranscribeCommand.swift
@@ -248,13 +248,21 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
         speechEngine: SpeechEngineSelection
     ) throws {
         guard speechEngine.engine == .cohere, let explicitLanguage else { return }
-        guard SpeechEnginePreference.normalizeCohereLanguage(explicitLanguage) != nil else {
-            let supported = CohereTranscribeEngine.supportedLanguages.map(\.code).joined(separator: ", ")
+        let languagePolicy = SpeechEngineCapabilityRegistry.capabilities(for: .cohere).supportedLanguages
+        let supportedLanguageCodes = languagePolicy.supportedLanguageCodes ?? []
+        guard let normalizedLanguage = SpeechEnginePreference.normalizeCohereLanguage(explicitLanguage),
+              supportedLanguageCodes.contains(normalizedLanguage) else {
+            let supported = supportedLanguageCodes.joined(separator: ", ")
             throw ValidationError(
                 "Invalid value for --language with Cohere: '\(explicitLanguage)'. "
                     + "Cohere has no auto-detect; use one of: \(supported)."
             )
         }
+    }
+
+    static func nemotronIgnoresLanguageOverride(_ variant: NemotronModelVariant) -> Bool {
+        SpeechEngineCapabilityRegistry.capabilities(for: .nemotron(variant))
+            .supportedLanguages.mode == .fixed
     }
 
     static func resolveParakeetModelVariant(
@@ -502,7 +510,7 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
                     self.nemotronModel,
                     storedVariant: SpeechEnginePreference.nemotronModelVariant(defaults: defaults)
                 )
-                if nemotronVariant.isEnglishOnly {
+                if Self.nemotronIgnoresLanguageOverride(nemotronVariant) {
                     if language != nil {
                         printErr("Note: --language is ignored by the English-only Nemotron build.")
                     }

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -522,14 +522,68 @@ struct SettingsView: View {
         var id: String { retention.configurationValue }
     }
 
+    private func modelLifecycle(for key: SpeechEngineVariantKey) -> SpeechEngineModelLifecycle {
+        SpeechEngineCapabilityRegistry.capabilities(for: key).modelLifecycle
+    }
+
+    private func parakeetModelLifecycle(for variant: ParakeetModelVariant) -> SpeechEngineModelLifecycle {
+        modelLifecycle(for: .parakeet(variant))
+    }
+
+    private func nemotronModelLifecycle(for variant: NemotronModelVariant) -> SpeechEngineModelLifecycle {
+        modelLifecycle(for: .nemotron(variant))
+    }
+
+    private func nemotronUsesFixedLanguage(_ variant: NemotronModelVariant) -> Bool {
+        SpeechEngineCapabilityRegistry.capabilities(for: .nemotron(variant))
+            .supportedLanguages.mode == .fixed
+    }
+
+    private var whisperModelLifecycle: SpeechEngineModelLifecycle {
+        modelLifecycle(for: .whisper(viewModel.engine.whisperModelVariant))
+    }
+
+    private var cohereModelLifecycle: SpeechEngineModelLifecycle {
+        modelLifecycle(for: .cohere)
+    }
+
+    private func approximateDownloadSize(
+        for lifecycle: SpeechEngineModelLifecycle,
+        fallback: String
+    ) -> String {
+        lifecycle.approximateDownloadSize ?? fallback
+    }
+
+    private func sentenceDownloadSize(
+        for lifecycle: SpeechEngineModelLifecycle,
+        fallback: String
+    ) -> String {
+        guard let size = lifecycle.approximateDownloadSize else {
+            return fallback
+        }
+        if size.hasPrefix("~") {
+            return "about \(size.dropFirst())"
+        }
+        return size
+    }
+
+    private func sentenceStartDownloadSize(
+        for lifecycle: SpeechEngineModelLifecycle,
+        fallback: String
+    ) -> String {
+        let size = sentenceDownloadSize(for: lifecycle, fallback: fallback)
+        guard let first = size.first else { return size }
+        return first.uppercased() + String(size.dropFirst())
+    }
+
     /// Names the model in the alert title; falls back to a generic title once
     /// the alert is dismissed and `pendingModelDeletion` is nil.
     private var modelDeletionAlertTitle: String {
         switch pendingModelDeletion {
-        case .parakeet(let variant): "Delete \(variant.modelName)?"
-        case .nemotron(let variant): "Delete \(variant.modelName)?"
+        case .parakeet(let variant): "Delete \(parakeetModelLifecycle(for: variant).modelName)?"
+        case .nemotron(let variant): "Delete \(nemotronModelLifecycle(for: variant).modelName)?"
         case .whisper: "Delete the Whisper model?"
-        case .cohere: "Delete Cohere Transcribe?"
+        case .cohere: "Delete \(cohereModelLifecycle.modelName)?"
         case nil: "Delete this model?"
         }
     }
@@ -537,13 +591,19 @@ struct SettingsView: View {
     private func modelDeletionMessage(for deletion: PendingModelDeletion) -> String {
         switch deletion {
         case .parakeet(let variant):
-            return "This frees \(variant.approximateDownloadSize). You can download \(variant.modelName) again at any time."
+            let lifecycle = parakeetModelLifecycle(for: variant)
+            let size = approximateDownloadSize(for: lifecycle, fallback: variant.approximateDownloadSize)
+            return "This frees \(size). You can download \(lifecycle.modelName) again at any time."
         case .nemotron(let variant):
-            return "This frees \(variant.approximateDownloadSize). You can download \(variant.modelName) again at any time."
+            let lifecycle = nemotronModelLifecycle(for: variant)
+            let size = approximateDownloadSize(for: lifecycle, fallback: variant.approximateDownloadSize)
+            return "This frees \(size). You can download \(lifecycle.modelName) again at any time."
         case .whisper:
             return "This removes the configured Whisper model download from this Mac. You can download it again at any time."
         case .cohere:
-            return "This frees about 2.1 GB. You can download Cohere Transcribe again at any time."
+            let lifecycle = cohereModelLifecycle
+            let size = sentenceDownloadSize(for: lifecycle, fallback: "about 2.1 GB")
+            return "This frees \(size). You can download \(lifecycle.modelName) again at any time."
         }
     }
 
@@ -2285,7 +2345,7 @@ struct SettingsView: View {
 
                 if let banner = nemotronDownloadBannerState {
                     EngineDownloadBanner(
-                        title: viewModel.engine.nemotronModelVariant.isEnglishOnly
+                        title: nemotronUsesFixedLanguage(viewModel.engine.nemotronModelVariant)
                             ? "Nemotron Speech EN Beta"
                             : "Nemotron 3.5 Beta",
                         subtitle: banner.subtitle,
@@ -2305,7 +2365,7 @@ struct SettingsView: View {
 
                 if let banner = cohereDownloadBannerState {
                     EngineDownloadBanner(
-                        title: "Cohere Transcribe",
+                        title: cohereModelLifecycle.modelName,
                         subtitle: banner.subtitle,
                         mode: banner.mode,
                         action: { viewModel.engine.downloadCohereModel() }
@@ -2353,9 +2413,12 @@ struct SettingsView: View {
     private func parakeetModelOptionRow(_ variant: ParakeetModelVariant) -> some View {
         let isSelected = viewModel.engine.parakeetModelVariant == variant
         let isDownloaded = viewModel.engine.downloadedParakeetVariants.contains(variant)
+        let lifecycle = parakeetModelLifecycle(for: variant)
+        let modelName = lifecycle.modelName
+        let downloadSize = approximateDownloadSize(for: lifecycle, fallback: variant.approximateDownloadSize)
         let downloadStatusLabel = isDownloaded
             ? "Downloaded."
-            : "\(variant.approximateDownloadSize), downloads on first use."
+            : "\(downloadSize), downloads on first use."
         // The selected build is the one Parakeet loads, so it's protected; only
         // the other, already-downloaded build can be removed from here.
         let canDelete = isDownloaded && !isSelected
@@ -2373,10 +2436,10 @@ struct SettingsView: View {
 
                     VStack(alignment: .leading, spacing: 3) {
                         HStack(spacing: DesignSystem.Spacing.sm) {
-                            Text(variant.modelName)
+                            Text(modelName)
                                 .font(DesignSystem.Typography.body.weight(.medium))
                                 .foregroundStyle(DesignSystem.Colors.textPrimary)
-                            modelVariantStatusBadge(isDownloaded: isDownloaded, size: variant.approximateDownloadSize)
+                            modelVariantStatusBadge(isDownloaded: isDownloaded, size: downloadSize)
                         }
                         Text(variant.coverageSummary)
                             .font(DesignSystem.Typography.caption)
@@ -2391,15 +2454,15 @@ struct SettingsView: View {
             .buttonStyle(.plain)
             .disabled(viewModel.engine.speechEngineSwitching)
             .accessibilityElement(children: .combine)
-            .accessibilityLabel("\(variant.modelName). \(variant.displayName). \(variant.coverageSummary) \(downloadStatusLabel)")
+            .accessibilityLabel("\(modelName). \(variant.displayName). \(variant.coverageSummary) \(downloadStatusLabel)")
             // `.combine` can drop the wrapping Button's role, so assert it explicitly
             // alongside the selected state for VoiceOver.
             .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : [.isButton])
 
             if canDelete {
                 ModelDeleteIconButton(
-                    helpText: "Remove this Parakeet build to free \(variant.approximateDownloadSize).",
-                    accessibilityLabel: "Delete \(variant.modelName) download"
+                    helpText: "Remove this Parakeet build to free \(downloadSize).",
+                    accessibilityLabel: "Delete \(modelName) download"
                 ) {
                     pendingModelDeletion = .parakeet(variant)
                 }
@@ -2473,9 +2536,12 @@ struct SettingsView: View {
     private func nemotronModelOptionRow(_ variant: NemotronModelVariant) -> some View {
         let isSelected = viewModel.engine.nemotronModelVariant == variant
         let isDownloaded = viewModel.engine.downloadedNemotronVariants.contains(variant)
+        let lifecycle = nemotronModelLifecycle(for: variant)
+        let modelName = lifecycle.modelName
+        let downloadSize = approximateDownloadSize(for: lifecycle, fallback: variant.approximateDownloadSize)
         let downloadStatusLabel = isDownloaded
             ? "Downloaded."
-            : "\(variant.approximateDownloadSize), downloads on first use."
+            : "\(downloadSize), downloads on first use."
         // The selected build is the one Nemotron loads, so it's protected; only
         // the other, already-downloaded build can be removed from here.
         let canDelete = isDownloaded && !isSelected
@@ -2493,10 +2559,10 @@ struct SettingsView: View {
 
                     VStack(alignment: .leading, spacing: 3) {
                         HStack(spacing: DesignSystem.Spacing.sm) {
-                            Text(variant.modelName)
+                            Text(modelName)
                                 .font(DesignSystem.Typography.body.weight(.medium))
                                 .foregroundStyle(DesignSystem.Colors.textPrimary)
-                            modelVariantStatusBadge(isDownloaded: isDownloaded, size: variant.approximateDownloadSize)
+                            modelVariantStatusBadge(isDownloaded: isDownloaded, size: downloadSize)
                         }
                         Text(variant.coverageSummary)
                             .font(DesignSystem.Typography.caption)
@@ -2511,15 +2577,15 @@ struct SettingsView: View {
             .buttonStyle(.plain)
             .disabled(viewModel.engine.speechEngineSwitching)
             .accessibilityElement(children: .combine)
-            .accessibilityLabel("\(variant.modelName). \(variant.displayName). \(variant.coverageSummary) \(downloadStatusLabel)")
+            .accessibilityLabel("\(modelName). \(variant.displayName). \(variant.coverageSummary) \(downloadStatusLabel)")
             // `.combine` can drop the wrapping Button's role, so assert it explicitly
             // alongside the selected state for VoiceOver.
             .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : [.isButton])
 
             if canDelete {
                 ModelDeleteIconButton(
-                    helpText: "Remove this Nemotron build to free \(variant.approximateDownloadSize).",
-                    accessibilityLabel: "Delete \(variant.modelName) download"
+                    helpText: "Remove this Nemotron build to free \(downloadSize).",
+                    accessibilityLabel: "Delete \(modelName) download"
                 ) {
                     pendingModelDeletion = .nemotron(variant)
                 }
@@ -2925,7 +2991,8 @@ struct SettingsView: View {
         }
         switch viewModel.engine.whisperModelStatus {
         case .notDownloaded:
-            return (.download, "632 MB · broad-language file and retranscription fallback")
+            let size = approximateDownloadSize(for: whisperModelLifecycle, fallback: "632 MB")
+            return (.download, "\(size) · broad-language file and retranscription fallback")
         case .repairing:
             return (.downloading, viewModel.engine.whisperModelStatusDetail)
         case .failed:
@@ -2942,10 +3009,15 @@ struct SettingsView: View {
         }
         switch viewModel.engine.nemotronModelStatus {
         case .notDownloaded:
-            let qualityNote = viewModel.engine.nemotronModelVariant.isEnglishOnly
+            let lifecycle = nemotronModelLifecycle(for: viewModel.engine.nemotronModelVariant)
+            let size = approximateDownloadSize(
+                for: lifecycle,
+                fallback: viewModel.engine.nemotronModelVariant.approximateDownloadSize
+            )
+            let qualityNote = nemotronUsesFixedLanguage(viewModel.engine.nemotronModelVariant)
                 ? "quality still being validated"
                 : "quality varies by language"
-            return (.download, "\(viewModel.engine.nemotronModelVariant.approximateDownloadSize) · Beta streaming model, \(qualityNote)")
+            return (.download, "\(size) · Beta streaming model, \(qualityNote)")
         case .repairing:
             return (.downloading, viewModel.engine.nemotronModelStatusDetail)
         case .failed:
@@ -2964,7 +3036,8 @@ struct SettingsView: View {
         }
         switch viewModel.engine.cohereModelStatus {
         case .notDownloaded:
-            return (.download, "About 2.1 GB · local batch transcripts, no preview or timestamps")
+            let size = sentenceStartDownloadSize(for: cohereModelLifecycle, fallback: "About 2.1 GB")
+            return (.download, "\(size) · local batch transcripts, no preview or timestamps")
         case .repairing:
             return (.downloading, viewModel.engine.cohereModelStatusDetail)
         case .failed:

--- a/Sources/MacParakeetViewModels/EngineSettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/EngineSettingsViewModel.swift
@@ -111,11 +111,19 @@ public final class EngineSettingsViewModel {
     /// it risks an OS jetsam kill mid-transcription that no `catch` can recover.
     /// Selecting Cohere or downloading its model is gated to machines with at
     /// least ``cohereMinimumMemoryBytes`` of RAM.
-    public static let cohereMinimumMemoryBytes: UInt64 = 16 * 1024 * 1024 * 1024
+    public static let cohereMinimumMemoryBytes: UInt64 = {
+        SpeechEngineCapabilityRegistry.capabilities(for: .cohere)
+            .modelLifecycle.minimumMemoryBytes
+            ?? SpeechEngineCapabilityRegistry.cohereMinimumMemoryBytes
+    }()
     public static let cohereInsufficientMemoryMessage =
         "Cohere Transcribe needs 16 GB of memory or more — this Mac has less."
     public var cohereMeetsMemoryRequirement: Bool {
         physicalMemoryBytes() >= Self.cohereMinimumMemoryBytes
+    }
+    public var whisperModelVariant: WhisperModelVariant {
+        WhisperModelVariant.normalize(SpeechEnginePreference.whisperModelVariant(defaults: defaults))
+            ?? .largeV3Turbo632MB
     }
     private var shouldBlockCohereSwitchForModelStatus: Bool {
         if cohereDeleting { return true }
@@ -1340,7 +1348,7 @@ public final class EngineSettingsViewModel {
         case .parakeet:
             "Loading Parakeet with Core ML..."
         case .nemotron:
-            nemotronVariant.isEnglishOnly
+            nemotronUsesFixedLanguage(nemotronVariant)
                 ? "Loading Nemotron Speech EN Beta with Core ML..."
                 : "Loading Nemotron 3.5 Beta with Core ML..."
         case .whisper:
@@ -1348,6 +1356,11 @@ public final class EngineSettingsViewModel {
         case .cohere:
             "Loading Cohere with Core ML..."
         }
+    }
+
+    private static func nemotronUsesFixedLanguage(_ variant: NemotronModelVariant) -> Bool {
+        SpeechEngineCapabilityRegistry.capabilities(for: .nemotron(variant))
+            .supportedLanguages.mode == .fixed
     }
 
     private func runWithRetry(

--- a/Tests/CLITests/ModelLifecycleCommandTests.swift
+++ b/Tests/CLITests/ModelLifecycleCommandTests.swift
@@ -130,6 +130,46 @@ final class ModelLifecycleCommandTests: XCTestCase {
         ))
     }
 
+    func testLoadSelectableSpeechModelsReadsDisplayMetadataFromCapabilityRegistry() throws {
+        let suiteName = "com.macparakeet.tests.cli.models-registry.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let models = loadSelectableSpeechModels(defaults: defaults)
+        let modelsByID = Dictionary(uniqueKeysWithValues: models.map { ($0.id, $0) })
+
+        for variant in ParakeetModelVariant.allCases {
+            let lifecycle = SpeechEngineCapabilityRegistry.capabilities(for: .parakeet(variant)).modelLifecycle
+            let model = try XCTUnwrap(modelsByID[parakeetModelID(for: variant)])
+            XCTAssertEqual(model.name, "\(lifecycle.modelName) (\(variant.displayName))")
+            XCTAssertEqual(model.variant, lifecycle.variantID)
+            XCTAssertEqual(model.size, lifecycle.approximateDownloadSize)
+        }
+
+        for variant in NemotronModelVariant.allCases {
+            let lifecycle = SpeechEngineCapabilityRegistry.capabilities(for: .nemotron(variant)).modelLifecycle
+            let model = try XCTUnwrap(modelsByID[nemotronModelID(for: variant)])
+            XCTAssertEqual(model.name, "\(lifecycle.modelName) (\(variant.displayName))")
+            XCTAssertEqual(model.variant, lifecycle.variantID)
+            XCTAssertEqual(model.size, lifecycle.approximateDownloadSize)
+        }
+
+        for variant in WhisperModelVariant.allCases {
+            let lifecycle = SpeechEngineCapabilityRegistry.capabilities(for: .whisper(variant)).modelLifecycle
+            let model = try XCTUnwrap(modelsByID[variant.modelID])
+            XCTAssertEqual(model.name, lifecycle.modelName)
+            XCTAssertEqual(model.variant, lifecycle.variantID)
+            XCTAssertEqual(model.size, lifecycle.approximateDownloadSize)
+        }
+
+        let cohereLifecycle = SpeechEngineCapabilityRegistry.capabilities(for: .cohere).modelLifecycle
+        let cohere = try XCTUnwrap(modelsByID["cohere-transcribe"])
+        XCTAssertEqual(cohere.name, cohereLifecycle.modelName)
+        XCTAssertEqual(cohere.variant, cohereLifecycle.variantID)
+        XCTAssertEqual(cohere.size, cohereLifecycle.approximateDownloadSize)
+    }
+
     func testLoadSelectableSpeechModelsMarksSelectedParakeetVariant() throws {
         let suiteName = "com.macparakeet.tests.cli.model-list-parakeet.\(UUID().uuidString)"
         let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))

--- a/Tests/CLITests/TranscribeCommandTests.swift
+++ b/Tests/CLITests/TranscribeCommandTests.swift
@@ -238,7 +238,12 @@ final class TranscribeCommandTests: XCTestCase {
 
         XCTAssertThrowsError(try TranscribeCommand.validateCohereLanguageOverride("auto", speechEngine: selection)) { error in
             let message = String(describing: error)
+            let supportedCodes = SpeechEngineCapabilityRegistry.capabilities(for: .cohere)
+                .supportedLanguages.supportedLanguageCodes ?? []
+            let supported = supportedCodes.joined(separator: ", ")
             XCTAssertTrue(message.contains("Cohere has no auto-detect"), message)
+            XCTAssertFalse(supportedCodes.isEmpty)
+            XCTAssertTrue(message.contains(supported), message)
         }
     }
 
@@ -253,6 +258,11 @@ final class TranscribeCommandTests: XCTestCase {
 
         try TranscribeCommand.validateCohereLanguageOverride("zh_CN", speechEngine: selection)
         XCTAssertEqual(selection.language, "zh")
+    }
+
+    func testNemotronLanguageOverridePolicyReadsCapabilityRegistry() {
+        XCTAssertTrue(TranscribeCommand.nemotronIgnoresLanguageOverride(.english1120))
+        XCTAssertFalse(TranscribeCommand.nemotronIgnoresLanguageOverride(.multilingual1120))
     }
 
     func testResolveSpeechEngineExplicitNemotronUsesExplicitLanguage() {

--- a/Tests/MacParakeetTests/ViewModels/EngineSettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/EngineSettingsViewModelTests.swift
@@ -283,6 +283,17 @@ final class EngineSettingsViewModelTests: XCTestCase {
 
     // MARK: - Cohere memory gate
 
+    func testCohereMemoryThresholdMatchesCapabilityRegistry() throws {
+        let registryMinimumMemoryBytes = try XCTUnwrap(
+            SpeechEngineCapabilityRegistry.capabilities(for: .cohere)
+                .modelLifecycle.minimumMemoryBytes
+        )
+        XCTAssertEqual(
+            EngineSettingsViewModel.cohereMinimumMemoryBytes,
+            registryMinimumMemoryBytes
+        )
+    }
+
     func testCohereMeetsMemoryRequirementReflectsInstalledMemory() {
         let gib: UInt64 = 1024 * 1024 * 1024
         XCTAssertFalse(makeViewModel(physicalMemoryBytes: { 8 * gib }).cohereMeetsMemoryRequirement)


### PR DESCRIPTION
## Summary
- Implements the Phase A read-site migration batch for Settings availability/copy plus CLI models/transcribe capability checks.
- Routes Settings model names, sizes, banners, fixed-language copy, and the Cohere memory threshold through SpeechEngineCapabilityRegistry.
- Routes CLI models list/download/delete metadata and transcribe language capability checks through the same registry while preserving model IDs and defaults.

## Plan section
- plans/active/2026-07-03-stt-capability-registry.md: Phase A PR 2..N read-site migration for Settings availability/copy and CLI models/transcribe capability checks.

## Deviations
- No semantic behavior changes intended; user-visible model IDs and copy are preserved.
- Full swift test not run for this PR; per brief, that gate is reserved for the final Phase A pass.

## Verification
- swift test --filter 'EngineSettingsViewModelTests|SettingsStatusRulesTests|ModelLifecycleCommandTests|TranscribeCommandTests|RetranscribeCommandTests' (178 selected tests, 0 failures)
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated Settings and CLI to read STT model metadata, language policy, and memory thresholds from `SpeechEngineCapabilityRegistry` for consistent names, sizes, language handling, and copy. Preserves model IDs and defaults; no behavioral changes intended.

- **Refactors**
  - Settings: registry-driven model names/sizes across Parakeet/Nemotron/Whisper/Cohere; banners, deletion titles/messages, help text, and size labels read the registry; Nemotron fixed-language checks use policy; Cohere titles use registry name.
  - CLI models list/download/delete: use registry modelLifecycle (names, sizes, variant IDs); logs, deletion messages, and size labels use registry values; Whisper size label reads lifecycle.
  - CLI language: selection respects registry language policy (automatic/fixed/selectable); Cohere --language validated against registry-supported codes; Nemotron ignores --language when policy is fixed.
  - EngineSettingsViewModel: Cohere minimum memory bytes read from the registry (with fallback); adds normalized Whisper variant helper.
  - Tests: assert registry-driven names, variant IDs, sizes, language policies, and the Cohere memory threshold.

<sup>Written for commit 09567aa436529e0b9c9acf0eba9b6842264b49af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/715?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

