### PR TITLE
fix: preserve release export contracts

### DIFF
--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -137,6 +137,13 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
 - Plain-text `retranscribe` validation/misuse failures now use exit code `2`,
   matching the JSON envelope path and the public exit-code contract.
 
+### Fixed
+
+- `transcribe --format json` now shields native STT diagnostics emitted
+  directly to stdout during inference and teardown, then restores stdout before
+  printing the payload. This keeps CoreML/E5RT runtime warnings from corrupting
+  JSON pipelines.
+
 ## [2.11.0] -- 2026-06-28
 
 ### Added

--- a/Sources/CLI/Commands/StandardOutputRedirection.swift
+++ b/Sources/CLI/Commands/StandardOutputRedirection.swift
@@ -10,11 +10,26 @@ import Foundation
 final class StandardOutputRedirection {
     private var savedStdout: Int32?
 
+    var savedStdoutFileDescriptorForTesting: Int32? {
+        savedStdout
+    }
+
     init(to targetFileDescriptor: Int32 = STDERR_FILENO) throws {
         fflush(stdout)
         let saved = dup(STDOUT_FILENO)
         guard saved >= 0 else {
             throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
+        }
+        let savedFlags = fcntl(saved, F_GETFD)
+        guard savedFlags >= 0 else {
+            let errorNumber = errno
+            close(saved)
+            throw NSError(domain: NSPOSIXErrorDomain, code: Int(errorNumber))
+        }
+        guard fcntl(saved, F_SETFD, savedFlags | FD_CLOEXEC) >= 0 else {
+            let errorNumber = errno
+            close(saved)
+            throw NSError(domain: NSPOSIXErrorDomain, code: Int(errorNumber))
         }
         guard dup2(targetFileDescriptor, STDOUT_FILENO) >= 0 else {
             let errorNumber = errno

--- a/Sources/CLI/Commands/StandardOutputRedirection.swift
+++ b/Sources/CLI/Commands/StandardOutputRedirection.swift
@@ -1,0 +1,46 @@
+import Darwin
+import Foundation
+
+/// Temporarily route process stdout to stderr.
+///
+/// Some native inference stacks write diagnostics directly to file descriptor 1,
+/// bypassing Swift logging and `printErr`. CLI commands with stdout payload
+/// contracts can use this while doing native work, then restore stdout before
+/// emitting the actual payload.
+final class StandardOutputRedirection {
+    private var savedStdout: Int32?
+
+    init(to targetFileDescriptor: Int32 = STDERR_FILENO) throws {
+        fflush(stdout)
+        let saved = dup(STDOUT_FILENO)
+        guard saved >= 0 else {
+            throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
+        }
+        guard dup2(targetFileDescriptor, STDOUT_FILENO) >= 0 else {
+            let errorNumber = errno
+            close(saved)
+            throw NSError(domain: NSPOSIXErrorDomain, code: Int(errorNumber))
+        }
+        savedStdout = saved
+    }
+
+    func restore() throws {
+        guard let saved = savedStdout else { return }
+        fflush(stdout)
+        guard dup2(saved, STDOUT_FILENO) >= 0 else {
+            let errorNumber = errno
+            close(saved)
+            savedStdout = nil
+            throw NSError(domain: NSPOSIXErrorDomain, code: Int(errorNumber))
+        }
+        close(saved)
+        savedStdout = nil
+    }
+
+    deinit {
+        guard let saved = savedStdout else { return }
+        fflush(stdout)
+        _ = dup2(saved, STDOUT_FILENO)
+        close(saved)
+    }
+}

--- a/Sources/CLI/Commands/TranscribeCommand.swift
+++ b/Sources/CLI/Commands/TranscribeCommand.swift
@@ -627,7 +627,10 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
         try await emitJSONOrRethrow(json: format == .json) {
             let emission = try Self.outputEmissionAfterNativeTeardown(
                 runResult: runResult,
-                restoreResult: restoreResult
+                restoreResult: restoreResult,
+                warnOnIgnoredRestoreFailure: { error in
+                    printErr("Warning: failed to restore stdout after transcribe failure: \(error.localizedDescription)")
+                }
             )
             try await emitStdout(emission)
         }
@@ -635,11 +638,20 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
 
     static func outputEmissionAfterNativeTeardown<Emission>(
         runResult: Result<Emission, Error>,
-        restoreResult: Result<Void, Error>
+        restoreResult: Result<Void, Error>,
+        warnOnIgnoredRestoreFailure: ((Error) -> Void)? = nil
     ) throws -> Emission {
-        let emission = try runResult.get()
-        try restoreResult.get()
-        return emission
+        switch (runResult, restoreResult) {
+        case (.success(let emission), .success):
+            return emission
+        case (.success, .failure(let restoreError)):
+            throw restoreError
+        case (.failure(let runError), .success):
+            throw runError
+        case (.failure(let runError), .failure(let restoreError)):
+            warnOnIgnoredRestoreFailure?(restoreError)
+            throw runError
+        }
     }
 
     private func emitStdout(_ emission: TranscribeStdoutEmission) async throws {

--- a/Sources/CLI/Commands/TranscribeCommand.swift
+++ b/Sources/CLI/Commands/TranscribeCommand.swift
@@ -61,6 +61,11 @@ struct ResolvedSpeakerDetection: Equatable, Sendable {
     let constraint: SpeakerDiarizationConstraint?
 }
 
+private enum TranscribeStdoutEmission {
+    case none
+    case transcription(Transcription, TranscribeOutputFormat)
+}
+
 struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
     static let configuration = CommandConfiguration(
         commandName: "transcribe",
@@ -441,13 +446,15 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
         )
         let writeToFiles = podcastQuery == nil && (resolvedInputs.count > 1 || outputDir != nil)
 
+        var stdoutRedirection: StandardOutputRedirection?
         var sttClient: STTClient?
         var nemotronEngine: NemotronEngine?
         var nemotronEnglishEngine: NemotronEnglishEngine?
         var whisperEngine: WhisperEngine?
         var cohereEngine: CohereTranscribeEngine?
-        let runResult: Result<Void, Error>
+        let runResult: Result<TranscribeStdoutEmission, Error>
         do {
+            stdoutRedirection = try StandardOutputRedirection()
             guard podcastQuery != nil || !resolvedInputs.isEmpty else {
                 throw ValidationError("No transcribable inputs found — pass a file/URL, or use --podcast \"<search query>\".")
             }
@@ -570,6 +577,7 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
                 diarizationService: diarizationService
             )
 
+            var stdoutEmission: TranscribeStdoutEmission = .none
             if let podcastQuery {
                 let result = try await withStandardOutputRedirectedToStandardError {
                     try await transcribePodcastQuery(
@@ -582,14 +590,7 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
                     let url = try await Self.writeOutput(result, to: dir, format: format)
                     printErr("  \u{2192} \(url.path)")
                 } else {
-                    switch format {
-                    case .json: try printJSON(result)
-                    case .transcript: printTranscript(result)
-                    case .text: printText(result)
-                    case .srt, .vtt:
-                        print(await Self.subtitleString(for: result, format: format), terminator: "")
-                    }
-                    printSaveHintIfSaved(result, format: format)
+                    stdoutEmission = .transcription(result, format)
                 }
             } else if writeToFiles {
                 try await withStandardOutputRedirectedToStandardError {
@@ -607,19 +608,9 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
                         speechEngine: speechEngine
                     )
                 }
-                switch format {
-                case .json:
-                    try printJSON(result)
-                case .transcript:
-                    printTranscript(result)
-                case .text:
-                    printText(result)
-                case .srt, .vtt:
-                    print(await Self.subtitleString(for: result, format: format), terminator: "")
-                }
-                printSaveHintIfSaved(result, format: format)
+                stdoutEmission = .transcription(result, format)
             }
-            runResult = .success(())
+            runResult = .success(stdoutEmission)
         } catch {
             runResult = .failure(error)
         }
@@ -629,8 +620,44 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
         await nemotronEnglishEngine?.unload()
         await whisperEngine?.unload()
         await cohereEngine?.unload()
-        try emitJSONOrRethrow(json: format == .json) {
-            try runResult.get()
+
+        let restoreResult: Result<Void, Error> = Result {
+            try stdoutRedirection?.restore()
+        }
+        try await emitJSONOrRethrow(json: format == .json) {
+            let emission = try Self.outputEmissionAfterNativeTeardown(
+                runResult: runResult,
+                restoreResult: restoreResult
+            )
+            try await emitStdout(emission)
+        }
+    }
+
+    static func outputEmissionAfterNativeTeardown<Emission>(
+        runResult: Result<Emission, Error>,
+        restoreResult: Result<Void, Error>
+    ) throws -> Emission {
+        let emission = try runResult.get()
+        try restoreResult.get()
+        return emission
+    }
+
+    private func emitStdout(_ emission: TranscribeStdoutEmission) async throws {
+        switch emission {
+        case .none:
+            return
+        case .transcription(let result, let outputFormat):
+            switch outputFormat {
+            case .json:
+                try printJSON(result)
+            case .transcript:
+                printTranscript(result)
+            case .text:
+                printText(result)
+            case .srt, .vtt:
+                print(await Self.subtitleString(for: result, format: outputFormat), terminator: "")
+            }
+            printSaveHintIfSaved(result, format: outputFormat)
         }
     }
 

--- a/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
@@ -212,6 +212,7 @@ public final class TranscriptionViewModel {
     private static let configurationError = "Transcription services are unavailable. Please try again."
     private let logger = Logger(subsystem: "com.macparakeet.viewmodels", category: "TranscriptionViewModel")
     private let defaults: UserDefaults
+    private let meetingArtifactStore: MeetingArtifactStoring
     private let isWhisperModelDownloaded: () -> Bool
     private let isNemotronModelDownloaded: () -> Bool
     private let isCohereModelDownloaded: () -> Bool
@@ -219,11 +220,13 @@ public final class TranscriptionViewModel {
 
     public init(
         defaults: UserDefaults = .standard,
+        meetingArtifactStore: MeetingArtifactStoring = MeetingArtifactStore(),
         isWhisperModelDownloaded: (() -> Bool)? = nil,
         isNemotronModelDownloaded: (() -> Bool)? = nil,
         isCohereModelDownloaded: (() -> Bool)? = nil
     ) {
         self.defaults = defaults
+        self.meetingArtifactStore = meetingArtifactStore
         self.isWhisperModelDownloaded = isWhisperModelDownloaded ?? {
             WhisperEngine.isModelDownloaded(
                 model: SpeechEnginePreference.whisperModelVariant(defaults: defaults)
@@ -1247,9 +1250,11 @@ public final class TranscriptionViewModel {
         guard !trimmed.isEmpty, speakers[index].label != trimmed else { return }
         let previousCurrentSpeakers = speakers
         let previousCurrentSegments = transcription.transcriptSegments
+        let previousCurrentUpdatedAt = transcription.updatedAt
         let transcriptionIndex = transcriptions.firstIndex(where: { $0.id == transcription.id })
         let previousListSpeakers = transcriptionIndex.flatMap { transcriptions[$0].speakers }
         let previousListSegments = transcriptionIndex.flatMap { transcriptions[$0].transcriptSegments }
+        let previousListUpdatedAt = transcriptionIndex.map { transcriptions[$0].updatedAt }
         let renameGeneration = (speakerRenameGenerations[transcription.id] ?? 0) + 1
         speakerRenameGenerations[transcription.id] = renameGeneration
         speakers[index].label = trimmed
@@ -1258,10 +1263,12 @@ public final class TranscriptionViewModel {
             in: transcription.transcriptSegments,
             using: speakers
         )
+        transcription.updatedAt = Date()
         currentTranscription = transcription
         if let transcriptionIndex {
             transcriptions[transcriptionIndex].speakers = speakers
             transcriptions[transcriptionIndex].transcriptSegments = transcription.transcriptSegments
+            transcriptions[transcriptionIndex].updatedAt = transcription.updatedAt
         }
         guard let transcriptionRepo else { return }
         let transcriptionID = transcription.id
@@ -1269,17 +1276,21 @@ public final class TranscriptionViewModel {
             weak self,
             transcriptionRepo,
             transcriptionID,
+            transcription,
             speakers,
             previousCurrentSpeakers,
             previousCurrentSegments,
+            previousCurrentUpdatedAt,
             previousListSpeakers,
             previousListSegments,
+            previousListUpdatedAt,
             renameGeneration
         ] in
             do {
                 try await Task.detached(priority: .utility) {
                     try transcriptionRepo.updateSpeakers(id: transcriptionID, speakers: speakers)
                 }.value
+                self?.refreshMeetingArtifactBestEffort(for: transcription)
             } catch {
                 let errorType = TelemetryErrorClassifier.classify(error)
                 self?.handleSpeakerRenamePersistenceFailure(
@@ -1287,8 +1298,10 @@ public final class TranscriptionViewModel {
                     generation: renameGeneration,
                     previousCurrentSpeakers: previousCurrentSpeakers,
                     previousCurrentSegments: previousCurrentSegments,
+                    previousCurrentUpdatedAt: previousCurrentUpdatedAt,
                     previousListSpeakers: previousListSpeakers,
                     previousListSegments: previousListSegments,
+                    previousListUpdatedAt: previousListUpdatedAt,
                     errorType: errorType
                 )
             }
@@ -1300,22 +1313,52 @@ public final class TranscriptionViewModel {
         generation: Int,
         previousCurrentSpeakers: [SpeakerInfo],
         previousCurrentSegments: [TranscriptSegmentRecord]?,
+        previousCurrentUpdatedAt: Date,
         previousListSpeakers: [SpeakerInfo]?,
         previousListSegments: [TranscriptSegmentRecord]?,
+        previousListUpdatedAt: Date?,
         errorType: String
     ) {
         guard speakerRenameGenerations[transcriptionID] == generation else { return }
         if var currentTranscription, currentTranscription.id == transcriptionID {
             currentTranscription.speakers = previousCurrentSpeakers
             currentTranscription.transcriptSegments = previousCurrentSegments
+            currentTranscription.updatedAt = previousCurrentUpdatedAt
             self.currentTranscription = currentTranscription
         }
         if let index = transcriptions.firstIndex(where: { $0.id == transcriptionID }) {
             transcriptions[index].speakers = previousListSpeakers
             transcriptions[index].transcriptSegments = previousListSegments
+            if let previousListUpdatedAt {
+                transcriptions[index].updatedAt = previousListUpdatedAt
+            }
         }
         setError(message: "Failed to save speaker rename. The previous label was restored.")
         logger.error("Failed to persist speaker rename error_type=\(errorType, privacy: .public)")
+    }
+
+    private func refreshMeetingArtifactBestEffort(for transcription: Transcription) {
+        guard transcription.sourceType == .meeting,
+              MeetingArtifactStore.sessionFolderURL(for: transcription) != nil
+        else {
+            return
+        }
+
+        let artifactStore = meetingArtifactStore
+        let promptResultRepo = promptResultRepo
+        let logger = logger
+        Task.detached(priority: .utility) {
+            do {
+                let promptResults = try promptResultRepo?.fetchAll(transcriptionId: transcription.id) ?? []
+                _ = try await artifactStore.materialize(
+                    transcription: transcription,
+                    promptResults: promptResults
+                )
+            } catch {
+                let errorType = TelemetryErrorClassifier.classify(error)
+                logger.error("speaker_rename_artifact_refresh_failed error_type=\(errorType, privacy: .public)")
+            }
+        }
     }
 
     public func renameCurrentTranscription(to newFileName: String) {

--- a/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
@@ -209,6 +209,8 @@ public final class TranscriptionViewModel {
     private var speakerRenameGenerations: [UUID: Int] = [:]
     private var speakerRenameArtifactRefreshTasks: [UUID: Task<Void, Never>] = [:]
     private var speakerRenameArtifactRefreshTokens: [UUID: UUID] = [:]
+    private var speakerRenameArtifactRefreshRequestedGenerations: [UUID: Int] = [:]
+    private var speakerRenameArtifactRefreshCompletedGenerations: [UUID: Int] = [:]
     private var dropPendingCount = 0
     private var dropCollectedURLs: [URL] = []
     private static let configurationError = "Transcription services are unavailable. Please try again."
@@ -1355,40 +1357,62 @@ public final class TranscriptionViewModel {
         let previousTask = speakerRenameArtifactRefreshTasks[transcriptionID]
         let token = UUID()
         speakerRenameArtifactRefreshTokens[transcriptionID] = token
+        speakerRenameArtifactRefreshRequestedGenerations[transcriptionID] = max(
+            speakerRenameArtifactRefreshRequestedGenerations[transcriptionID] ?? 0,
+            generation
+        )
 
         let artifactStore = meetingArtifactStore
         let promptResultRepo = promptResultRepo
         let logger = logger
         let task = Task.detached(priority: .utility) { [weak self, previousTask, transcriptionRepo, promptResultRepo, artifactStore, logger] in
             await previousTask?.value
-            let isCurrentGeneration = await MainActor.run { [weak self] in
-                self?.speakerRenameGenerations[transcriptionID] == generation
+            let shouldMaterialize = await MainActor.run { [weak self] in
+                guard let self else { return false }
+                let requestedGeneration = self.speakerRenameArtifactRefreshRequestedGenerations[transcriptionID] ?? 0
+                let completedGeneration = self.speakerRenameArtifactRefreshCompletedGenerations[transcriptionID] ?? 0
+                return requestedGeneration >= generation && completedGeneration < generation
             }
-            guard isCurrentGeneration else {
+            guard shouldMaterialize else {
                 await MainActor.run { [weak self] in
                     self?.finishSpeakerRenameArtifactRefresh(transcriptionID: transcriptionID, token: token)
                 }
                 return
             }
 
-            do {
-                guard let persisted = try transcriptionRepo.fetch(id: transcriptionID),
-                      persisted.sourceType == .meeting,
-                      MeetingArtifactStore.sessionFolderURL(for: persisted) != nil
-                else {
-                    await MainActor.run { [weak self] in
-                        self?.finishSpeakerRenameArtifactRefresh(transcriptionID: transcriptionID, token: token)
+            var materializedGeneration = generation
+            while true {
+                do {
+                    guard let persisted = try transcriptionRepo.fetch(id: transcriptionID),
+                          persisted.sourceType == .meeting,
+                          MeetingArtifactStore.sessionFolderURL(for: persisted) != nil
+                    else {
+                        break
                     }
-                    return
+                    let promptResults = try promptResultRepo?.fetchAll(transcriptionId: transcriptionID) ?? []
+                    _ = try await artifactStore.materialize(
+                        transcription: persisted,
+                        promptResults: promptResults
+                    )
+                } catch {
+                    let errorType = TelemetryErrorClassifier.classify(error)
+                    logger.error("speaker_rename_artifact_refresh_failed error_type=\(errorType, privacy: .public)")
+                    break
                 }
-                let promptResults = try promptResultRepo?.fetchAll(transcriptionId: transcriptionID) ?? []
-                _ = try await artifactStore.materialize(
-                    transcription: persisted,
-                    promptResults: promptResults
-                )
-            } catch {
-                let errorType = TelemetryErrorClassifier.classify(error)
-                logger.error("speaker_rename_artifact_refresh_failed error_type=\(errorType, privacy: .public)")
+
+                let completedTargetGeneration = materializedGeneration
+                let nextGeneration = await MainActor.run { [weak self] () -> Int? in
+                    guard let self else { return nil }
+                    let completedGeneration = self.speakerRenameArtifactRefreshCompletedGenerations[transcriptionID] ?? 0
+                    self.speakerRenameArtifactRefreshCompletedGenerations[transcriptionID] = max(
+                        completedGeneration,
+                        completedTargetGeneration
+                    )
+                    let requestedGeneration = self.speakerRenameArtifactRefreshRequestedGenerations[transcriptionID] ?? completedTargetGeneration
+                    return requestedGeneration > completedTargetGeneration ? requestedGeneration : nil
+                }
+                guard let nextGeneration else { break }
+                materializedGeneration = nextGeneration
             }
             await MainActor.run { [weak self] in
                 self?.finishSpeakerRenameArtifactRefresh(transcriptionID: transcriptionID, token: token)
@@ -1401,6 +1425,8 @@ public final class TranscriptionViewModel {
         guard speakerRenameArtifactRefreshTokens[transcriptionID] == token else { return }
         speakerRenameArtifactRefreshTokens[transcriptionID] = nil
         speakerRenameArtifactRefreshTasks[transcriptionID] = nil
+        speakerRenameArtifactRefreshRequestedGenerations[transcriptionID] = nil
+        speakerRenameArtifactRefreshCompletedGenerations[transcriptionID] = nil
     }
 
     public func renameCurrentTranscription(to newFileName: String) {

--- a/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
@@ -1290,7 +1290,12 @@ public final class TranscriptionViewModel {
                 try await Task.detached(priority: .utility) {
                     try transcriptionRepo.updateSpeakers(id: transcriptionID, speakers: speakers)
                 }.value
-                self?.refreshMeetingArtifactBestEffort(for: transcription)
+                if self?.speakerRenameGenerations[transcriptionID] == renameGeneration {
+                    self?.refreshMeetingArtifactBestEffort(
+                        for: transcription,
+                        generation: renameGeneration
+                    )
+                }
             } catch {
                 let errorType = TelemetryErrorClassifier.classify(error)
                 self?.handleSpeakerRenamePersistenceFailure(
@@ -1337,8 +1342,9 @@ public final class TranscriptionViewModel {
         logger.error("Failed to persist speaker rename error_type=\(errorType, privacy: .public)")
     }
 
-    private func refreshMeetingArtifactBestEffort(for transcription: Transcription) {
+    private func refreshMeetingArtifactBestEffort(for transcription: Transcription, generation: Int) {
         guard transcription.sourceType == .meeting,
+              speakerRenameGenerations[transcription.id] == generation,
               MeetingArtifactStore.sessionFolderURL(for: transcription) != nil
         else {
             return
@@ -1347,13 +1353,39 @@ public final class TranscriptionViewModel {
         let artifactStore = meetingArtifactStore
         let promptResultRepo = promptResultRepo
         let logger = logger
-        Task.detached(priority: .utility) {
+        Task.detached(priority: .utility) { [weak self] in
             do {
                 let promptResults = try promptResultRepo?.fetchAll(transcriptionId: transcription.id) ?? []
+                let shouldMaterialize = await MainActor.run { [weak self] in
+                    guard let self else { return false }
+                    return self.speakerRenameGenerations[transcription.id] == generation
+                        && self.currentTranscription?.id == transcription.id
+                        && self.currentTranscription?.updatedAt == transcription.updatedAt
+                }
+                guard shouldMaterialize else { return }
                 _ = try await artifactStore.materialize(
                     transcription: transcription,
                     promptResults: promptResults
                 )
+                let latestRefresh = await MainActor.run { [weak self] () -> (Transcription, Int)? in
+                    guard let self,
+                          self.speakerRenameGenerations[transcription.id] != generation,
+                          let currentTranscription = self.currentTranscription,
+                          currentTranscription.id == transcription.id,
+                          let latestGeneration = self.speakerRenameGenerations[transcription.id]
+                    else {
+                        return nil
+                    }
+                    return (currentTranscription, latestGeneration)
+                }
+                if let latestRefresh {
+                    await MainActor.run { [weak self] in
+                        self?.refreshMeetingArtifactBestEffort(
+                            for: latestRefresh.0,
+                            generation: latestRefresh.1
+                        )
+                    }
+                }
             } catch {
                 let errorType = TelemetryErrorClassifier.classify(error)
                 logger.error("speaker_rename_artifact_refresh_failed error_type=\(errorType, privacy: .public)")

--- a/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
@@ -207,6 +207,8 @@ public final class TranscriptionViewModel {
     private var activeProgressNemotronVariant: NemotronModelVariant?
     private var activeDropRequestID: UUID?
     private var speakerRenameGenerations: [UUID: Int] = [:]
+    private var speakerRenameArtifactRefreshTasks: [UUID: Task<Void, Never>] = [:]
+    private var speakerRenameArtifactRefreshTokens: [UUID: UUID] = [:]
     private var dropPendingCount = 0
     private var dropCollectedURLs: [URL] = []
     private static let configurationError = "Transcription services are unavailable. Please try again."
@@ -1276,7 +1278,6 @@ public final class TranscriptionViewModel {
             weak self,
             transcriptionRepo,
             transcriptionID,
-            transcription,
             speakers,
             previousCurrentSpeakers,
             previousCurrentSegments,
@@ -1290,12 +1291,10 @@ public final class TranscriptionViewModel {
                 try await Task.detached(priority: .utility) {
                     try transcriptionRepo.updateSpeakers(id: transcriptionID, speakers: speakers)
                 }.value
-                if self?.speakerRenameGenerations[transcriptionID] == renameGeneration {
-                    self?.refreshMeetingArtifactBestEffort(
-                        for: transcription,
-                        generation: renameGeneration
-                    )
-                }
+                self?.enqueueMeetingArtifactRefresh(
+                    transcriptionID: transcriptionID,
+                    generation: renameGeneration
+                )
             } catch {
                 let errorType = TelemetryErrorClassifier.classify(error)
                 self?.handleSpeakerRenamePersistenceFailure(
@@ -1308,6 +1307,10 @@ public final class TranscriptionViewModel {
                     previousListSegments: previousListSegments,
                     previousListUpdatedAt: previousListUpdatedAt,
                     errorType: errorType
+                )
+                self?.enqueueMeetingArtifactRefresh(
+                    transcriptionID: transcriptionID,
+                    generation: renameGeneration
                 )
             }
         }
@@ -1342,55 +1345,62 @@ public final class TranscriptionViewModel {
         logger.error("Failed to persist speaker rename error_type=\(errorType, privacy: .public)")
     }
 
-    private func refreshMeetingArtifactBestEffort(for transcription: Transcription, generation: Int) {
-        guard transcription.sourceType == .meeting,
-              speakerRenameGenerations[transcription.id] == generation,
-              MeetingArtifactStore.sessionFolderURL(for: transcription) != nil
+    private func enqueueMeetingArtifactRefresh(transcriptionID: UUID, generation: Int) {
+        guard speakerRenameGenerations[transcriptionID] == generation,
+              let transcriptionRepo
         else {
             return
         }
 
+        let previousTask = speakerRenameArtifactRefreshTasks[transcriptionID]
+        let token = UUID()
+        speakerRenameArtifactRefreshTokens[transcriptionID] = token
+
         let artifactStore = meetingArtifactStore
         let promptResultRepo = promptResultRepo
         let logger = logger
-        Task.detached(priority: .utility) { [weak self] in
-            do {
-                let promptResults = try promptResultRepo?.fetchAll(transcriptionId: transcription.id) ?? []
-                let shouldMaterialize = await MainActor.run { [weak self] in
-                    guard let self else { return false }
-                    return self.speakerRenameGenerations[transcription.id] == generation
-                        && self.currentTranscription?.id == transcription.id
-                        && self.currentTranscription?.updatedAt == transcription.updatedAt
+        let task = Task.detached(priority: .utility) { [weak self, previousTask, transcriptionRepo, promptResultRepo, artifactStore, logger] in
+            await previousTask?.value
+            let isCurrentGeneration = await MainActor.run { [weak self] in
+                self?.speakerRenameGenerations[transcriptionID] == generation
+            }
+            guard isCurrentGeneration else {
+                await MainActor.run { [weak self] in
+                    self?.finishSpeakerRenameArtifactRefresh(transcriptionID: transcriptionID, token: token)
                 }
-                guard shouldMaterialize else { return }
+                return
+            }
+
+            do {
+                guard let persisted = try transcriptionRepo.fetch(id: transcriptionID),
+                      persisted.sourceType == .meeting,
+                      MeetingArtifactStore.sessionFolderURL(for: persisted) != nil
+                else {
+                    await MainActor.run { [weak self] in
+                        self?.finishSpeakerRenameArtifactRefresh(transcriptionID: transcriptionID, token: token)
+                    }
+                    return
+                }
+                let promptResults = try promptResultRepo?.fetchAll(transcriptionId: transcriptionID) ?? []
                 _ = try await artifactStore.materialize(
-                    transcription: transcription,
+                    transcription: persisted,
                     promptResults: promptResults
                 )
-                let latestRefresh = await MainActor.run { [weak self] () -> (Transcription, Int)? in
-                    guard let self,
-                          self.speakerRenameGenerations[transcription.id] != generation,
-                          let currentTranscription = self.currentTranscription,
-                          currentTranscription.id == transcription.id,
-                          let latestGeneration = self.speakerRenameGenerations[transcription.id]
-                    else {
-                        return nil
-                    }
-                    return (currentTranscription, latestGeneration)
-                }
-                if let latestRefresh {
-                    await MainActor.run { [weak self] in
-                        self?.refreshMeetingArtifactBestEffort(
-                            for: latestRefresh.0,
-                            generation: latestRefresh.1
-                        )
-                    }
-                }
             } catch {
                 let errorType = TelemetryErrorClassifier.classify(error)
                 logger.error("speaker_rename_artifact_refresh_failed error_type=\(errorType, privacy: .public)")
             }
+            await MainActor.run { [weak self] in
+                self?.finishSpeakerRenameArtifactRefresh(transcriptionID: transcriptionID, token: token)
+            }
         }
+        speakerRenameArtifactRefreshTasks[transcriptionID] = task
+    }
+
+    private func finishSpeakerRenameArtifactRefresh(transcriptionID: UUID, token: UUID) {
+        guard speakerRenameArtifactRefreshTokens[transcriptionID] == token else { return }
+        speakerRenameArtifactRefreshTokens[transcriptionID] = nil
+        speakerRenameArtifactRefreshTasks[transcriptionID] = nil
     }
 
     public func renameCurrentTranscription(to newFileName: String) {

--- a/Tests/CLITests/CLIHelpersTests.swift
+++ b/Tests/CLITests/CLIHelpersTests.swift
@@ -5,6 +5,21 @@ import XCTest
 
 final class CLIHelpersTests: XCTestCase {
 
+    func testStandardOutputRedirectionRestoresStdoutPayload() throws {
+        let nullFileDescriptor = open("/dev/null", O_WRONLY)
+        XCTAssertGreaterThanOrEqual(nullFileDescriptor, 0)
+        defer { close(nullFileDescriptor) }
+
+        let output = try captureStandardOutput {
+            let redirection = try StandardOutputRedirection(to: nullFileDescriptor)
+            print("native-noise")
+            try redirection.restore()
+            print("payload")
+        }
+
+        XCTAssertEqual(output, "payload\n")
+    }
+
     // MARK: - findTranscription
 
     func testFindTranscriptionByExactUUID() throws {

--- a/Tests/CLITests/CLIHelpersTests.swift
+++ b/Tests/CLITests/CLIHelpersTests.swift
@@ -20,6 +20,20 @@ final class CLIHelpersTests: XCTestCase {
         XCTAssertEqual(output, "payload\n")
     }
 
+    func testStandardOutputRedirectionSavedDescriptorClosesOnExec() throws {
+        let nullFileDescriptor = open("/dev/null", O_WRONLY)
+        XCTAssertGreaterThanOrEqual(nullFileDescriptor, 0)
+        defer { close(nullFileDescriptor) }
+
+        let redirection = try StandardOutputRedirection(to: nullFileDescriptor)
+        let savedStdout = try XCTUnwrap(redirection.savedStdoutFileDescriptorForTesting)
+        let flags = fcntl(savedStdout, F_GETFD)
+        XCTAssertGreaterThanOrEqual(flags, 0)
+        XCTAssertNotEqual(flags & FD_CLOEXEC, 0)
+
+        try redirection.restore()
+    }
+
     // MARK: - findTranscription
 
     func testFindTranscriptionByExactUUID() throws {

--- a/Tests/CLITests/MeetingsCommandTests.swift
+++ b/Tests/CLITests/MeetingsCommandTests.swift
@@ -236,6 +236,53 @@ final class MeetingsCommandTests: XCTestCase {
         XCTAssertTrue(markdownExportOutput.contains("promptResultCount: 1"))
     }
 
+    func testMarkdownExportUsesCurrentSpeakerLabels() async throws {
+        let dbURL = temporaryDatabaseURL()
+        defer { try? FileManager.default.removeItem(at: dbURL) }
+        let db = try DatabaseManager(path: dbURL.path)
+        let transcriptionRepo = TranscriptionRepository(dbQueue: db.dbQueue)
+        let meeting = Transcription(
+            fileName: "Speaker Review",
+            rawTranscript: "Stored plain transcript.",
+            wordTimestamps: [
+                WordTimestamp(
+                    word: "Hello",
+                    startMs: 0,
+                    endMs: 300,
+                    confidence: 0.99,
+                    speakerId: "S1"
+                ),
+                WordTimestamp(
+                    word: "there.",
+                    startMs: 320,
+                    endMs: 600,
+                    confidence: 0.98,
+                    speakerId: "S1"
+                ),
+            ],
+            speakers: [SpeakerInfo(id: "S1", label: "Alice")],
+            status: .completed,
+            sourceType: .meeting
+        )
+        try transcriptionRepo.save(meeting)
+
+        let exportCommand = try MeetingsCommand.ExportSubcommand.parse([
+            meeting.id.uuidString,
+            "--format", "md",
+            "--stdout",
+            "--database", dbURL.path,
+        ])
+        let output = try await captureStandardOutput {
+            try await exportCommand.run()
+        }
+
+        XCTAssertTrue(output.contains("## Transcript"))
+        XCTAssertTrue(output.contains("speakerLabelsIncluded: true"))
+        XCTAssertTrue(output.contains("**Alice**"))
+        XCTAssertTrue(output.contains("Hello there."))
+        XCTAssertFalse(output.contains("Stored plain transcript."))
+    }
+
     func testMeetingJSONSurfacesExposeTranscriptSegments() async throws {
         let dbURL = temporaryDatabaseURL()
         defer { try? FileManager.default.removeItem(at: dbURL) }

--- a/Tests/CLITests/TranscribeCommandTests.swift
+++ b/Tests/CLITests/TranscribeCommandTests.swift
@@ -10,25 +10,39 @@ final class TranscribeCommandTests: XCTestCase {
     }
 
     func testOutputEmissionAfterNativeTeardownSurfacesRunErrorBeforeRestoreError() {
+        var ignoredRestoreErrors: [OutputTeardownError] = []
         XCTAssertThrowsError(
             try TranscribeCommand.outputEmissionAfterNativeTeardown(
                 runResult: Result<String, Error>.failure(OutputTeardownError.run),
-                restoreResult: .failure(OutputTeardownError.restore)
+                restoreResult: .failure(OutputTeardownError.restore),
+                warnOnIgnoredRestoreFailure: { error in
+                    if let error = error as? OutputTeardownError {
+                        ignoredRestoreErrors.append(error)
+                    }
+                }
             )
         ) { error in
             XCTAssertEqual(error as? OutputTeardownError, .run)
         }
+        XCTAssertEqual(ignoredRestoreErrors, [.restore])
     }
 
     func testOutputEmissionAfterNativeTeardownSurfacesRestoreErrorWhenRunSucceeds() {
+        var ignoredRestoreErrors: [OutputTeardownError] = []
         XCTAssertThrowsError(
             try TranscribeCommand.outputEmissionAfterNativeTeardown(
                 runResult: Result<String, Error>.success("payload"),
-                restoreResult: .failure(OutputTeardownError.restore)
+                restoreResult: .failure(OutputTeardownError.restore),
+                warnOnIgnoredRestoreFailure: { error in
+                    if let error = error as? OutputTeardownError {
+                        ignoredRestoreErrors.append(error)
+                    }
+                }
             )
         ) { error in
             XCTAssertEqual(error as? OutputTeardownError, .restore)
         }
+        XCTAssertTrue(ignoredRestoreErrors.isEmpty)
     }
 
     func testResolveProcessingModeUsesRawForAppDefaultWhenUnset() {

--- a/Tests/CLITests/TranscribeCommandTests.swift
+++ b/Tests/CLITests/TranscribeCommandTests.swift
@@ -4,6 +4,33 @@ import XCTest
 @testable import MacParakeetCore
 
 final class TranscribeCommandTests: XCTestCase {
+    private enum OutputTeardownError: Error, Equatable {
+        case run
+        case restore
+    }
+
+    func testOutputEmissionAfterNativeTeardownSurfacesRunErrorBeforeRestoreError() {
+        XCTAssertThrowsError(
+            try TranscribeCommand.outputEmissionAfterNativeTeardown(
+                runResult: Result<String, Error>.failure(OutputTeardownError.run),
+                restoreResult: .failure(OutputTeardownError.restore)
+            )
+        ) { error in
+            XCTAssertEqual(error as? OutputTeardownError, .run)
+        }
+    }
+
+    func testOutputEmissionAfterNativeTeardownSurfacesRestoreErrorWhenRunSucceeds() {
+        XCTAssertThrowsError(
+            try TranscribeCommand.outputEmissionAfterNativeTeardown(
+                runResult: Result<String, Error>.success("payload"),
+                restoreResult: .failure(OutputTeardownError.restore)
+            )
+        ) { error in
+            XCTAssertEqual(error as? OutputTeardownError, .restore)
+        }
+    }
+
     func testResolveProcessingModeUsesRawForAppDefaultWhenUnset() {
         let mode = TranscribeCommand.resolveProcessingMode(.appDefault, storedMode: nil)
         XCTAssertEqual(mode, .raw)

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
@@ -69,6 +69,22 @@ private final class SlowFirstSpeakerUpdateSuccess: @unchecked Sendable {
     }
 }
 
+private final class FailSecondSpeakerUpdate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var updateCount = 0
+
+    func handleUpdate() throws {
+        lock.lock()
+        updateCount += 1
+        let callNumber = updateCount
+        lock.unlock()
+
+        if callNumber == 2 {
+            throw NSError(domain: "TranscriptionViewModelTests", code: 1)
+        }
+    }
+}
+
 @MainActor
 final class TranscriptionViewModelTests: XCTestCase {
     var viewModel: TranscriptionViewModel!
@@ -1770,6 +1786,122 @@ final class TranscriptionViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.currentTranscription?.speakers?.first?.label, "Bob")
     }
 
+    func testRenameSpeakerRefreshesMeetingArtifactAfterNavigatingAway() async throws {
+        let artifactStore = RecordingMeetingArtifactStore()
+        viewModel = TranscriptionViewModel(meetingArtifactStore: artifactStore)
+
+        let fixture = try makeMeetingArtifactFixture(namePrefix: "speaker-rename-artifact-navigation")
+        defer { try? FileManager.default.removeItem(at: fixture.folderURL) }
+        let meeting = fixture.meeting
+        let other = Transcription(
+            fileName: "other.wav",
+            speakers: [SpeakerInfo(id: "S1", label: "Other speaker")],
+            status: .completed
+        )
+        mockRepo.transcriptions = [meeting, other]
+
+        viewModel.configure(
+            transcriptionService: mockService,
+            transcriptionRepo: mockRepo,
+            promptResultRepo: mockPromptResultRepo
+        )
+        viewModel.currentTranscription = meeting
+
+        viewModel.renameSpeaker(id: "S1", to: "Alice")
+        viewModel.currentTranscription = other
+
+        try await waitUntilAsync { await artifactStore.materializeCallCount == 1 }
+        let calls = await artifactStore.materializeCalls
+        XCTAssertEqual(calls.first?.transcription.id, meeting.id)
+        XCTAssertEqual(calls.first?.transcription.speakers?.first?.label, "Alice")
+        XCTAssertEqual(viewModel.currentTranscription?.id, other.id)
+    }
+
+    func testRenameSpeakerSerializesOverlappingArtifactRefreshes() async throws {
+        let artifactStore = RecordingMeetingArtifactStore(materializeDelay: .milliseconds(200))
+        viewModel = TranscriptionViewModel(meetingArtifactStore: artifactStore)
+
+        let fixture = try makeMeetingArtifactFixture(namePrefix: "speaker-rename-artifact-serialized")
+        defer { try? FileManager.default.removeItem(at: fixture.folderURL) }
+        let meeting = fixture.meeting
+        mockRepo.transcriptions = [meeting]
+
+        viewModel.configure(
+            transcriptionService: mockService,
+            transcriptionRepo: mockRepo,
+            promptResultRepo: mockPromptResultRepo
+        )
+        viewModel.currentTranscription = meeting
+
+        viewModel.renameSpeaker(id: "S1", to: "Alice")
+        try await waitUntilAsync { await artifactStore.startedMaterializeCount == 1 }
+
+        viewModel.renameSpeaker(id: "S1", to: "Bob")
+
+        try await waitUntilAsync(timeout: .seconds(2)) { await artifactStore.materializeCallCount == 2 }
+        let calls = await artifactStore.materializeCalls
+        let maxConcurrentMaterializeCount = await artifactStore.maxConcurrentMaterializeCount
+        XCTAssertEqual(maxConcurrentMaterializeCount, 1)
+        XCTAssertEqual(calls.last?.transcription.speakers?.first?.label, "Bob")
+    }
+
+    func testRenameSpeakerRefreshesArtifactFromPersistedStateWhenNewerRenameFails() async throws {
+        let artifactStore = RecordingMeetingArtifactStore()
+        viewModel = TranscriptionViewModel(meetingArtifactStore: artifactStore)
+
+        let fixture = try makeMeetingArtifactFixture(namePrefix: "speaker-rename-artifact-failed-rename")
+        defer { try? FileManager.default.removeItem(at: fixture.folderURL) }
+        let meeting = fixture.meeting
+        let probe = FailSecondSpeakerUpdate()
+        mockRepo.transcriptions = [meeting]
+        mockRepo.updateSpeakersHandler = { _, _ in
+            try probe.handleUpdate()
+        }
+
+        viewModel.configure(
+            transcriptionService: mockService,
+            transcriptionRepo: mockRepo,
+            promptResultRepo: mockPromptResultRepo
+        )
+        viewModel.currentTranscription = meeting
+
+        viewModel.renameSpeaker(id: "S1", to: "Alice")
+        viewModel.renameSpeaker(id: "S1", to: "Bob")
+
+        try await waitUntilAsync { await artifactStore.materializeCallCount == 1 }
+        let calls = await artifactStore.materializeCalls
+        XCTAssertEqual(calls.count, 1)
+        XCTAssertEqual(calls.first?.transcription.speakers?.first?.label, "Alice")
+        XCTAssertEqual(viewModel.currentTranscription?.speakers?.first?.label, "Alice")
+        XCTAssertNotNil(viewModel.errorMessage)
+    }
+
+    private func makeMeetingArtifactFixture(namePrefix: String) throws -> (meeting: Transcription, folderURL: URL) {
+        let folderURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(namePrefix)-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: folderURL, withIntermediateDirectories: true)
+        let audioURL = folderURL.appendingPathComponent("meeting.m4a")
+        FileManager.default.createFile(atPath: audioURL.path, contents: Data([0]))
+        let meeting = Transcription(
+            fileName: "Design Review",
+            filePath: audioURL.path,
+            rawTranscript: "Hello there.",
+            wordTimestamps: [
+                WordTimestamp(
+                    word: "Hello",
+                    startMs: 0,
+                    endMs: 300,
+                    confidence: 0.99,
+                    speakerId: "S1"
+                ),
+            ],
+            speakers: [SpeakerInfo(id: "S1", label: "Speaker 1")],
+            status: .completed,
+            sourceType: .meeting
+        )
+        return (meeting: meeting, folderURL: folderURL)
+    }
+
     func testRenameCurrentTranscriptionUpdatesStateAndRepo() {
         let t = Transcription(
             fileName: "Meeting Apr 5",
@@ -3094,7 +3226,15 @@ private struct MaterializeCall: Sendable {
 }
 
 private actor RecordingMeetingArtifactStore: MeetingArtifactStoring {
+    private let materializeDelay: Duration?
     private var calls: [MaterializeCall] = []
+    private var activeMaterializeCount = 0
+    private(set) var startedMaterializeCount = 0
+    private(set) var maxConcurrentMaterializeCount = 0
+
+    init(materializeDelay: Duration? = nil) {
+        self.materializeDelay = materializeDelay
+    }
 
     var materializeCalls: [MaterializeCall] {
         calls
@@ -3108,6 +3248,13 @@ private actor RecordingMeetingArtifactStore: MeetingArtifactStoring {
         transcription: Transcription,
         promptResults: [PromptResult]
     ) async throws -> MeetingArtifactSnapshot {
+        startedMaterializeCount += 1
+        activeMaterializeCount += 1
+        maxConcurrentMaterializeCount = max(maxConcurrentMaterializeCount, activeMaterializeCount)
+        if let materializeDelay {
+            try? await Task.sleep(for: materializeDelay)
+        }
+        activeMaterializeCount -= 1
         calls.append(MaterializeCall(transcription: transcription, promptResults: promptResults))
 
         let folderPath = MeetingArtifactStore.sessionFolderURL(for: transcription)?

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
@@ -61,6 +61,24 @@ final class TranscriptionViewModelTests: XCTestCase {
         }
     }
 
+    private func waitUntilAsync(
+        timeout: Duration = .seconds(1),
+        pollInterval: Duration = .milliseconds(10),
+        file: StaticString = #filePath,
+        line: UInt = #line,
+        _ condition: () async -> Bool
+    ) async throws {
+        let clock = ContinuousClock()
+        let deadline = clock.now + timeout
+        while !(await condition()) {
+            if clock.now >= deadline {
+                XCTFail("Timed out waiting for condition", file: file, line: line)
+                return
+            }
+            try await Task.sleep(for: pollInterval)
+        }
+    }
+
     override func setUp() {
         mockService = MockTranscriptionService()
         mockRepo = MockTranscriptionRepository()
@@ -1392,12 +1410,14 @@ final class TranscriptionViewModelTests: XCTestCase {
             SpeakerInfo(id: "S2", label: "Speaker 2")
         ]
         let t = Transcription(fileName: "meeting.wav", speakers: speakers, status: .completed)
+        var listRow = t
+        listRow.fileName = "library-row-title.wav"
         let other = Transcription(
             fileName: "other.wav",
             speakers: [SpeakerInfo(id: "S1", label: "Other speaker")],
             status: .completed
         )
-        mockRepo.transcriptions = [t, other]
+        mockRepo.transcriptions = [listRow, other]
 
         viewModel.configure(transcriptionService: mockService, transcriptionRepo: mockRepo)
         viewModel.currentTranscription = t
@@ -1407,6 +1427,7 @@ final class TranscriptionViewModelTests: XCTestCase {
         let updated = viewModel.transcriptions.first { $0.id == t.id }
         XCTAssertEqual(updated?.speakers?[0].label, "Sarah")
         XCTAssertEqual(updated?.speakers?[1].label, "Speaker 2")
+        XCTAssertEqual(updated?.fileName, "library-row-title.wav")
 
         let unchanged = viewModel.transcriptions.first { $0.id == other.id }
         XCTAssertEqual(unchanged?.speakers?[0].label, "Other speaker")
@@ -1417,7 +1438,7 @@ final class TranscriptionViewModelTests: XCTestCase {
             SpeakerInfo(id: "S1", label: "Speaker 1"),
             SpeakerInfo(id: "S2", label: "Speaker 2")
         ]
-        let t = Transcription(
+        var t = Transcription(
             fileName: "meeting.wav",
             speakers: speakers,
             transcriptSegments: [
@@ -1432,6 +1453,8 @@ final class TranscriptionViewModelTests: XCTestCase {
             ],
             status: .completed
         )
+        let originalUpdatedAt = Date(timeIntervalSince1970: 1_234)
+        t.updatedAt = originalUpdatedAt
         let other = Transcription(
             fileName: "other.wav",
             speakers: [SpeakerInfo(id: "S1", label: "Other speaker")],
@@ -1450,11 +1473,13 @@ final class TranscriptionViewModelTests: XCTestCase {
         }
         XCTAssertEqual(viewModel.currentTranscription?.speakers?[1].label, "Speaker 2")
         XCTAssertEqual(viewModel.currentTranscription?.transcriptSegments?[0].speakerLabel, "Speaker 1")
+        XCTAssertEqual(viewModel.currentTranscription?.updatedAt, originalUpdatedAt)
 
         let reverted = viewModel.transcriptions.first { $0.id == t.id }
         XCTAssertEqual(reverted?.speakers?[0].label, "Speaker 1")
         XCTAssertEqual(reverted?.speakers?[1].label, "Speaker 2")
         XCTAssertEqual(reverted?.transcriptSegments?[0].speakerLabel, "Speaker 1")
+        XCTAssertEqual(reverted?.updatedAt, originalUpdatedAt)
 
         let unchanged = viewModel.transcriptions.first { $0.id == other.id }
         XCTAssertEqual(unchanged?.speakers?[0].label, "Other speaker")
@@ -1589,6 +1614,69 @@ final class TranscriptionViewModelTests: XCTestCase {
         viewModel.renameSpeaker(id: "S1", to: "  Alice  ")
 
         XCTAssertEqual(viewModel.currentTranscription?.speakers?[0].label, "Alice")
+    }
+
+    func testRenameSpeakerRefreshesMeetingArtifactWithUpdatedLabels() async throws {
+        let artifactStore = RecordingMeetingArtifactStore()
+        viewModel = TranscriptionViewModel(meetingArtifactStore: artifactStore)
+
+        let folderURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("speaker-rename-artifact-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: folderURL) }
+        try FileManager.default.createDirectory(at: folderURL, withIntermediateDirectories: true)
+        let audioURL = folderURL.appendingPathComponent("meeting.m4a")
+        FileManager.default.createFile(atPath: audioURL.path, contents: Data([0]))
+
+        let speakers = [SpeakerInfo(id: "S1", label: "Speaker 1")]
+        let meeting = Transcription(
+            fileName: "Design Review",
+            filePath: audioURL.path,
+            rawTranscript: "Hello there.",
+            wordTimestamps: [
+                WordTimestamp(
+                    word: "Hello",
+                    startMs: 0,
+                    endMs: 300,
+                    confidence: 0.99,
+                    speakerId: "S1"
+                ),
+                WordTimestamp(
+                    word: "there.",
+                    startMs: 320,
+                    endMs: 600,
+                    confidence: 0.98,
+                    speakerId: "S1"
+                ),
+            ],
+            speakers: speakers,
+            status: .completed,
+            sourceType: .meeting
+        )
+        mockRepo.transcriptions = [meeting]
+        mockPromptResultRepo.promptResults = [
+            PromptResult(
+                transcriptionId: meeting.id,
+                promptName: "Summary",
+                promptContent: "Summarize.",
+                content: "Ship it."
+            )
+        ]
+
+        viewModel.configure(
+            transcriptionService: mockService,
+            transcriptionRepo: mockRepo,
+            promptResultRepo: mockPromptResultRepo
+        )
+        viewModel.currentTranscription = meeting
+
+        viewModel.renameSpeaker(id: "S1", to: "Alice")
+
+        try await waitUntilAsync { await artifactStore.materializeCallCount == 1 }
+        let calls = await artifactStore.materializeCalls
+        let call = try XCTUnwrap(calls.first)
+        XCTAssertEqual(call.transcription.speakers?.first?.label, "Alice")
+        XCTAssertEqual(call.promptResults.count, 1)
+        XCTAssertEqual(viewModel.transcriptions.first?.speakers?.first?.label, "Alice")
     }
 
     func testRenameCurrentTranscriptionUpdatesStateAndRepo() {
@@ -2906,5 +2994,47 @@ final class TranscriptionViewModelTests: XCTestCase {
         }
 
         return (folderURL: folderURL, mixedURL: mixedURL)
+    }
+}
+
+private struct MaterializeCall: Sendable {
+    let transcription: Transcription
+    let promptResults: [PromptResult]
+}
+
+private actor RecordingMeetingArtifactStore: MeetingArtifactStoring {
+    private var calls: [MaterializeCall] = []
+
+    var materializeCalls: [MaterializeCall] {
+        calls
+    }
+
+    var materializeCallCount: Int {
+        calls.count
+    }
+
+    func materialize(
+        transcription: Transcription,
+        promptResults: [PromptResult]
+    ) async throws -> MeetingArtifactSnapshot {
+        calls.append(MaterializeCall(transcription: transcription, promptResults: promptResults))
+
+        let folderPath = MeetingArtifactStore.sessionFolderURL(for: transcription)?
+            .standardizedFileURL.path
+            ?? FileManager.default.temporaryDirectory.path
+        return MeetingArtifactSnapshot(
+            generatedAt: Date(),
+            meetingID: transcription.id,
+            title: transcription.fileName,
+            folderPath: folderPath,
+            manifestPath: "\(folderPath)/\(MeetingArtifactStore.manifestFileName)",
+            markdownPath: "\(folderPath)/\(MeetingArtifactStore.markdownFileName)",
+            transcriptPath: "\(folderPath)/\(MeetingArtifactStore.transcriptFileName)",
+            notesPath: nil,
+            promptResultsPath: "\(folderPath)/\(MeetingArtifactStore.promptResultsFileName)",
+            promptResultsDirectoryPath: "\(folderPath)/\(MeetingArtifactStore.promptResultsDirectoryName)",
+            promptResultCount: promptResults.count,
+            calendarEventSnapshot: transcription.calendarEventSnapshot
+        )
     }
 }

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
@@ -36,6 +36,39 @@ private final class SlowFirstSpeakerUpdateFailure: @unchecked Sendable {
     }
 }
 
+private final class SlowFirstSpeakerUpdateSuccess: @unchecked Sendable {
+    private let lock = NSLock()
+    private var startedFirstUpdate = false
+    private var updateCount = 0
+
+    var firstUpdateStarted: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return startedFirstUpdate
+    }
+
+    var count: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return updateCount
+    }
+
+    func handleUpdate(id _: UUID, speakers _: [SpeakerInfo]?) {
+        let callNumber: Int
+        lock.lock()
+        updateCount += 1
+        callNumber = updateCount
+        if callNumber == 1 {
+            startedFirstUpdate = true
+        }
+        lock.unlock()
+
+        if callNumber == 1 {
+            Thread.sleep(forTimeInterval: 0.2)
+        }
+    }
+}
+
 @MainActor
 final class TranscriptionViewModelTests: XCTestCase {
     var viewModel: TranscriptionViewModel!
@@ -1677,6 +1710,64 @@ final class TranscriptionViewModelTests: XCTestCase {
         XCTAssertEqual(call.transcription.speakers?.first?.label, "Alice")
         XCTAssertEqual(call.promptResults.count, 1)
         XCTAssertEqual(viewModel.transcriptions.first?.speakers?.first?.label, "Alice")
+    }
+
+    func testRenameSpeakerSkipsStaleArtifactRefreshAfterNewerRename() async throws {
+        let artifactStore = RecordingMeetingArtifactStore()
+        viewModel = TranscriptionViewModel(meetingArtifactStore: artifactStore)
+
+        let folderURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("speaker-rename-artifact-stale-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: folderURL) }
+        try FileManager.default.createDirectory(at: folderURL, withIntermediateDirectories: true)
+        let audioURL = folderURL.appendingPathComponent("meeting.m4a")
+        FileManager.default.createFile(atPath: audioURL.path, contents: Data([0]))
+
+        let speakers = [SpeakerInfo(id: "S1", label: "Speaker 1")]
+        let meeting = Transcription(
+            fileName: "Design Review",
+            filePath: audioURL.path,
+            rawTranscript: "Hello there.",
+            wordTimestamps: [
+                WordTimestamp(
+                    word: "Hello",
+                    startMs: 0,
+                    endMs: 300,
+                    confidence: 0.99,
+                    speakerId: "S1"
+                ),
+            ],
+            speakers: speakers,
+            status: .completed,
+            sourceType: .meeting
+        )
+        let probe = SlowFirstSpeakerUpdateSuccess()
+        mockRepo.transcriptions = [meeting]
+        mockRepo.updateSpeakersHandler = { id, speakers in
+            probe.handleUpdate(id: id, speakers: speakers)
+        }
+
+        viewModel.configure(
+            transcriptionService: mockService,
+            transcriptionRepo: mockRepo,
+            promptResultRepo: mockPromptResultRepo
+        )
+        viewModel.currentTranscription = meeting
+
+        viewModel.renameSpeaker(id: "S1", to: "Alice")
+        try await waitUntil {
+            probe.firstUpdateStarted
+        }
+
+        viewModel.renameSpeaker(id: "S1", to: "Bob")
+
+        try await waitUntilAsync { await artifactStore.materializeCallCount == 1 }
+        try await Task.sleep(for: .milliseconds(300))
+
+        let calls = await artifactStore.materializeCalls
+        XCTAssertEqual(calls.count, 1)
+        XCTAssertEqual(calls.first?.transcription.speakers?.first?.label, "Bob")
+        XCTAssertEqual(viewModel.currentTranscription?.speakers?.first?.label, "Bob")
     }
 
     func testRenameCurrentTranscriptionUpdatesStateAndRepo() {


### PR DESCRIPTION
## Summary

CLI JSON transcription output now stays parseable even when native STT/CoreML stacks write diagnostics directly to stdout. The command keeps native work quarantined away from stdout, restores stdout before emitting the real payload, and preserves the original transcribe error if cleanup also fails.

Speaker renames now refresh durable meeting artifacts from the persisted transcription row, so Markdown artifacts and CLI exports pick up the current label instead of stale speaker text. The optimistic rename path stays narrow: rollback restores labels, transcript segment labels, and `updatedAt`; stale failures cannot clobber later renames; artifact refreshes are serialized per transcription; and in-flight refreshes write the latest persisted generation before finishing.

## Scope

- No live diarization work.
- No new speaker rename UI beyond keeping main's existing UX consistent with artifacts and exports.
- No persistence schema changes.

## Validation

- `swift test --filter 'CLIHelpersTests|TranscribeCommandTests|TranscriptionViewModelTests/testRenameSpeaker|MeetingsCommandTests/testMarkdownExportUsesCurrentSpeakerLabels'` — 118 tests, 0 failures on `8f660922f`.
- `git diff --check` — passed on `8f660922f`.
- GitHub CI is the full exact-head gate for the PR.
- Release bundle/smoke passed earlier on this patch family before final rebases: `VERSION=0.6.25 BUILD_SOURCE=release-readiness-audit REQUIRE_MEETING_ECHO_ASSETS=1 scripts/dist/build_app_bundle.sh`, then `scripts/dev/release_demo_smoke.sh --cli dist/MacParakeet.app/Contents/MacOS/macparakeet-cli`.

## Gate Notes

`no-mistakes` was attempted repeatedly. It surfaced useful findings that were fixed manually: speaker-rename rollback restores `updatedAt`, transcribe errors take precedence over stdout-restore errors, list-row rename updates no longer replace unrelated row fields, navigation-away artifact refreshes use persisted state, and overlapping artifact writes are serialized.

The no-mistakes auto-fix round for the artifact-refresh findings produced a hanging generated test candidate, so I aborted it and applied the fix manually with focused coverage. A later fresh no-mistakes run on the manual fix was killed during review by the local Claude connector/auth configuration (`ANTHROPIC_API_KEY` taking precedence), so this PR does not claim a no-mistakes pass; it relies on the explicit local focused tests, GitHub CI, and hosted AI review gates.

Greptile and Gemini found the original stale artifact-refresh race; the final branch addresses it with persisted-state refresh, generation checks, token-guarded cleanup, serialized writes, catch-up refresh before task completion, and regression tests.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/Codex-000000)
