### PR TITLE
Fix speaker rename accessibility

### DIFF
--- a/Sources/MacParakeet/Views/Transcription/SpeakerRenameAccessibility.swift
+++ b/Sources/MacParakeet/Views/Transcription/SpeakerRenameAccessibility.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+enum SpeakerRenameAccessibility {
+    static let overviewToggleIdentifier = "transcript.speakerOverview.toggle"
+    static let overviewToggleHint = "Shows speaker labels and rename controls."
+    static let speakerNameFieldLabel = "Speaker name"
+    static let speakerNameFieldHint = "Press Return or move focus away to save. Press Escape to cancel."
+    static let renameButtonHint = "Edits this speaker label for this meeting only."
+
+    static func overviewToggleLabel(isExpanded: Bool) -> String {
+        isExpanded ? "Collapse speaker overview" : "Expand speaker overview"
+    }
+
+    static func renameButtonLabel(for speakerLabel: String) -> String {
+        "Rename \(speakerLabel)"
+    }
+
+    static func renameButtonIdentifier(for speakerID: String) -> String {
+        "transcript.speaker.rename.\(speakerID)"
+    }
+
+    static func speakerNameFieldIdentifier(for speakerID: String) -> String {
+        "transcript.speaker.name.\(speakerID)"
+    }
+
+    static func overviewRenameContextIdentifier(for speakerID: String) -> String {
+        "overview:\(speakerID)"
+    }
+
+    static func turnRenameContextIdentifier(
+        speakerID: String,
+        firstStartMs: Int?,
+        duplicateOrdinal: Int
+    ) -> String {
+        let start = firstStartMs.map(String.init) ?? "none"
+        return "turn:\(speakerID):\(start):\(duplicateOrdinal)"
+    }
+}

--- a/Sources/MacParakeet/Views/Transcription/SpeakerRenameAccessibility.swift
+++ b/Sources/MacParakeet/Views/Transcription/SpeakerRenameAccessibility.swift
@@ -15,12 +15,12 @@ enum SpeakerRenameAccessibility {
         "Rename \(speakerLabel)"
     }
 
-    static func renameButtonIdentifier(for speakerID: String) -> String {
-        "transcript.speaker.rename.\(speakerID)"
+    static func renameButtonIdentifier(contextID: String) -> String {
+        "transcript.speaker.rename.\(contextID)"
     }
 
-    static func speakerNameFieldIdentifier(for speakerID: String) -> String {
-        "transcript.speaker.name.\(speakerID)"
+    static func speakerNameFieldIdentifier(contextID: String) -> String {
+        "transcript.speaker.name.\(contextID)"
     }
 
     static func renameButtonOpacity(isVisuallyRevealed: Bool) -> Double {

--- a/Sources/MacParakeet/Views/Transcription/SpeakerRenameAccessibility.swift
+++ b/Sources/MacParakeet/Views/Transcription/SpeakerRenameAccessibility.swift
@@ -23,6 +23,10 @@ enum SpeakerRenameAccessibility {
         "transcript.speaker.name.\(speakerID)"
     }
 
+    static func renameButtonOpacity(isVisuallyRevealed: Bool) -> Double {
+        isVisuallyRevealed ? 1 : 0
+    }
+
     static func overviewRenameContextIdentifier(for speakerID: String) -> String {
         "overview:\(speakerID)"
     }

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
@@ -2850,12 +2850,15 @@ struct TranscriptResultView: View {
             segments: cachedSegments,
             speakerColorMap: cachedSpeakerColorMap,
             speakerLabelForID: { cachedSpeakerLabelMap[$0] ?? "Unknown" },
-            speakerLabelContent: { speakerID, speakerLabel, speakerColor, renameContextID in
+            speakerLabelContent: { speakerID, speakerLabel, speakerColor, renameContextID, isRenameButtonVisuallyRevealed in
                 speakerLabelView(
                     speaker: SpeakerInfo(id: speakerID, label: speakerLabel),
                     color: speakerColor,
                     contextID: renameContextID,
-                    font: DesignSystem.Typography.body.weight(.semibold)
+                    font: DesignSystem.Typography.body.weight(.semibold),
+                    renameButtonOpacity: SpeakerRenameAccessibility.renameButtonOpacity(
+                        isVisuallyRevealed: isRenameButtonVisuallyRevealed
+                    )
                 )
             },
             isSegmentActive: isSegmentActiveBinarySearch(segmentIndex:),
@@ -2970,7 +2973,8 @@ struct TranscriptResultView: View {
         speaker: SpeakerInfo,
         color: Color,
         contextID: String,
-        font: Font = DesignSystem.Typography.caption.weight(.semibold)
+        font: Font = DesignSystem.Typography.caption.weight(.semibold),
+        renameButtonOpacity: Double = SpeakerRenameAccessibility.renameButtonOpacity(isVisuallyRevealed: true)
     ) -> some View {
         if editingSpeakerId == speaker.id, editingSpeakerContextID == contextID {
             TextField("Name", text: $editingSpeakerLabel)
@@ -3018,6 +3022,7 @@ struct TranscriptResultView: View {
                 .accessibilityLabel(SpeakerRenameAccessibility.renameButtonLabel(for: speaker.label))
                 .accessibilityHint(SpeakerRenameAccessibility.renameButtonHint)
                 .accessibilityIdentifier(SpeakerRenameAccessibility.renameButtonIdentifier(for: speaker.id))
+                .opacity(renameButtonOpacity)
             }
             .accessibilityElement(children: .contain)
         }

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
@@ -2997,7 +2997,7 @@ struct TranscriptResultView: View {
                 }
                 .accessibilityLabel(SpeakerRenameAccessibility.speakerNameFieldLabel)
                 .accessibilityHint(SpeakerRenameAccessibility.speakerNameFieldHint)
-                .accessibilityIdentifier(SpeakerRenameAccessibility.speakerNameFieldIdentifier(for: speaker.id))
+                .accessibilityIdentifier(SpeakerRenameAccessibility.speakerNameFieldIdentifier(contextID: contextID))
         } else {
             HStack(spacing: 6) {
                 Text(speaker.label)
@@ -3021,7 +3021,7 @@ struct TranscriptResultView: View {
                 .accessibilityElement(children: .ignore)
                 .accessibilityLabel(SpeakerRenameAccessibility.renameButtonLabel(for: speaker.label))
                 .accessibilityHint(SpeakerRenameAccessibility.renameButtonHint)
-                .accessibilityIdentifier(SpeakerRenameAccessibility.renameButtonIdentifier(for: speaker.id))
+                .accessibilityIdentifier(SpeakerRenameAccessibility.renameButtonIdentifier(contextID: contextID))
                 .opacity(renameButtonOpacity)
             }
             .accessibilityElement(children: .contain)

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
@@ -91,7 +91,7 @@ struct TranscriptResultView: View {
 
     @State private var backHovered = false
     @State private var headerExpanded = false
-    @State private var speakerOverviewExpanded = false
+    @State private var speakerOverviewExpanded = true
     @State private var copied = false
     @State private var copiedResultID: UUID?
     @State private var copiedButtonResultID: UUID?
@@ -137,6 +137,7 @@ struct TranscriptResultView: View {
     /// manual-scroll pause when find never navigated.
     @State private var findPausedAutoScroll = false
     @State private var editingSpeakerId: String?
+    @State private var editingSpeakerContextID: String?
     @State private var editingSpeakerLabel: String = ""
     @State private var showConversationPopover = false
     @State private var hoveredConversationId: UUID?
@@ -226,7 +227,7 @@ struct TranscriptResultView: View {
             }
             rebuildSegmentCache()
             headerExpanded = false
-            speakerOverviewExpanded = false
+            speakerOverviewExpanded = true
             editingMeetingTitle = false
             meetingTitleDraft = ""
             editingTranscript = false
@@ -2849,6 +2850,14 @@ struct TranscriptResultView: View {
             segments: cachedSegments,
             speakerColorMap: cachedSpeakerColorMap,
             speakerLabelForID: { cachedSpeakerLabelMap[$0] ?? "Unknown" },
+            speakerLabelContent: { speakerID, speakerLabel, speakerColor, renameContextID in
+                speakerLabelView(
+                    speaker: SpeakerInfo(id: speakerID, label: speakerLabel),
+                    color: speakerColor,
+                    contextID: renameContextID,
+                    font: DesignSystem.Typography.body.weight(.semibold)
+                )
+            },
             isSegmentActive: isSegmentActiveBinarySearch(segmentIndex:),
             timestampLabel: { formatTimestamp(ms: $0) },
             isTimestampSeekable: playerViewModel.playerState == .ready,
@@ -2877,68 +2886,77 @@ struct TranscriptResultView: View {
         )
 
         VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
-            // Collapsible header row
-            HStack {
-                Text("Speaker overview")
-                    .font(DesignSystem.Typography.body.weight(.semibold))
-                    .foregroundStyle(DesignSystem.Colors.textPrimary)
-
-                if !speakerOverviewExpanded {
-                    // Compact inline speaker dots when collapsed
-                    HStack(spacing: 4) {
-                        ForEach(speakers.prefix(6), id: \.id) { speaker in
-                            Circle()
-                                .fill(colorMap[speaker.id] ?? DesignSystem.Colors.textTertiary)
-                                .frame(width: 8, height: 8)
-                        }
-                    }
-                }
-
-                Spacer()
-
-                Image(systemName: "chevron.down")
-                    .font(.system(size: 9, weight: .semibold))
-                    .foregroundStyle(DesignSystem.Colors.textTertiary)
-                    .rotationEffect(.degrees(speakerOverviewExpanded ? 180 : 0))
-            }
-            .contentShape(Rectangle())
-            .onTapGesture {
+            Button {
                 withAnimation(.easeInOut(duration: 0.2)) {
                     speakerOverviewExpanded.toggle()
                 }
-            }
+            } label: {
+                HStack {
+                    Text("Speaker overview")
+                        .font(DesignSystem.Typography.body.weight(.semibold))
+                        .foregroundStyle(DesignSystem.Colors.textPrimary)
 
-            if speakerOverviewExpanded {
-            ForEach(speakers, id: \.id) { speaker in
-                let stats = speakerStats[speaker.id]
-                HStack(spacing: DesignSystem.Spacing.md) {
-                    Circle()
-                        .fill(colorMap[speaker.id] ?? DesignSystem.Colors.textTertiary)
-                        .frame(width: 10, height: 10)
-
-                    VStack(alignment: .leading, spacing: 6) {
-                        speakerLabelView(speaker: speaker, color: colorMap[speaker.id] ?? DesignSystem.Colors.textSecondary)
-
-                        if let stats {
-                            HStack(spacing: DesignSystem.Spacing.sm) {
-                                metadataChip(icon: "clock", text: formatSpeakingTime(ms: stats.speakingTimeMs), tint: DesignSystem.Colors.textSecondary)
-                                metadataChip(icon: "text.word.spacing", text: "\(stats.wordCount.formatted()) words", tint: DesignSystem.Colors.textSecondary)
+                    if !speakerOverviewExpanded {
+                        // Compact inline speaker dots when collapsed
+                        HStack(spacing: 4) {
+                            ForEach(speakers.prefix(6), id: \.id) { speaker in
+                                Circle()
+                                    .fill(colorMap[speaker.id] ?? DesignSystem.Colors.textTertiary)
+                                    .frame(width: 8, height: 8)
                             }
                         }
                     }
 
                     Spacer()
+
+                    Image(systemName: "chevron.down")
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundStyle(DesignSystem.Colors.textTertiary)
+                        .rotationEffect(.degrees(speakerOverviewExpanded ? 180 : 0))
                 }
-                .padding(DesignSystem.Spacing.md)
-                .background(
-                    RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius)
-                        .fill(DesignSystem.Colors.surfaceElevated.opacity(0.45))
-                )
             }
-            Text("Speaker labels are approximate.")
-                .font(DesignSystem.Typography.caption)
-                .foregroundStyle(DesignSystem.Colors.textTertiary)
-            } // end if speakerOverviewExpanded
+            .buttonStyle(.plain)
+            .contentShape(Rectangle())
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(SpeakerRenameAccessibility.overviewToggleLabel(isExpanded: speakerOverviewExpanded))
+            .accessibilityHint(SpeakerRenameAccessibility.overviewToggleHint)
+            .accessibilityIdentifier(SpeakerRenameAccessibility.overviewToggleIdentifier)
+
+            if speakerOverviewExpanded {
+                ForEach(speakers, id: \.id) { speaker in
+                    let stats = speakerStats[speaker.id]
+                    HStack(spacing: DesignSystem.Spacing.md) {
+                        Circle()
+                            .fill(colorMap[speaker.id] ?? DesignSystem.Colors.textTertiary)
+                            .frame(width: 10, height: 10)
+
+                        VStack(alignment: .leading, spacing: 6) {
+                            speakerLabelView(
+                                speaker: speaker,
+                                color: colorMap[speaker.id] ?? DesignSystem.Colors.textSecondary,
+                                contextID: SpeakerRenameAccessibility.overviewRenameContextIdentifier(for: speaker.id)
+                            )
+
+                            if let stats {
+                                HStack(spacing: DesignSystem.Spacing.sm) {
+                                    metadataChip(icon: "clock", text: formatSpeakingTime(ms: stats.speakingTimeMs), tint: DesignSystem.Colors.textSecondary)
+                                    metadataChip(icon: "text.word.spacing", text: "\(stats.wordCount.formatted()) words", tint: DesignSystem.Colors.textSecondary)
+                                }
+                            }
+                        }
+
+                        Spacer()
+                    }
+                    .padding(DesignSystem.Spacing.md)
+                    .background(
+                        RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius)
+                            .fill(DesignSystem.Colors.surfaceElevated.opacity(0.45))
+                    )
+                }
+                Text("Speaker labels are approximate.")
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundStyle(DesignSystem.Colors.textTertiary)
+            }
         }
         .padding(DesignSystem.Spacing.md)
         .background(
@@ -2948,10 +2966,15 @@ struct TranscriptResultView: View {
     }
 
     @ViewBuilder
-    private func speakerLabelView(speaker: SpeakerInfo, color: Color) -> some View {
-        if editingSpeakerId == speaker.id {
+    private func speakerLabelView(
+        speaker: SpeakerInfo,
+        color: Color,
+        contextID: String,
+        font: Font = DesignSystem.Typography.caption.weight(.semibold)
+    ) -> some View {
+        if editingSpeakerId == speaker.id, editingSpeakerContextID == contextID {
             TextField("Name", text: $editingSpeakerLabel)
-                .font(DesignSystem.Typography.caption.weight(.semibold))
+                .font(font)
                 .foregroundStyle(color)
                 .textFieldStyle(.plain)
                 .frame(minWidth: 60, maxWidth: 200)
@@ -2968,38 +2991,44 @@ struct TranscriptResultView: View {
                         commitSpeakerRename()
                     }
                 }
-                .accessibilityLabel("Speaker name")
-                .accessibilityHint("Press Return or move focus away to save. Press Escape to cancel.")
+                .accessibilityLabel(SpeakerRenameAccessibility.speakerNameFieldLabel)
+                .accessibilityHint(SpeakerRenameAccessibility.speakerNameFieldHint)
+                .accessibilityIdentifier(SpeakerRenameAccessibility.speakerNameFieldIdentifier(for: speaker.id))
         } else {
             HStack(spacing: 6) {
                 Text(speaker.label)
-                    .font(DesignSystem.Typography.caption.weight(.semibold))
+                    .font(font)
                     .foregroundStyle(color)
                     .onTapGesture {
-                        beginSpeakerRename(speaker)
+                        beginSpeakerRename(speaker, contextID: contextID)
                     }
 
                 Button {
-                    beginSpeakerRename(speaker)
+                    beginSpeakerRename(speaker, contextID: contextID)
                 } label: {
-                    Image(systemName: "pencil")
+                    Label(SpeakerRenameAccessibility.renameButtonLabel(for: speaker.label), systemImage: "pencil")
+                        .labelStyle(.iconOnly)
                         .font(.system(size: 11, weight: .semibold))
                         .frame(width: 20, height: 20)
                 }
                 .parakeetAction(.subtle)
                 .controlSize(.small)
-                .help("Rename \(speaker.label)")
-                .accessibilityLabel("Rename \(speaker.label)")
-                .accessibilityHint("Edits this speaker label for this meeting only.")
+                .help(SpeakerRenameAccessibility.renameButtonLabel(for: speaker.label))
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel(SpeakerRenameAccessibility.renameButtonLabel(for: speaker.label))
+                .accessibilityHint(SpeakerRenameAccessibility.renameButtonHint)
+                .accessibilityIdentifier(SpeakerRenameAccessibility.renameButtonIdentifier(for: speaker.id))
             }
+            .accessibilityElement(children: .contain)
         }
     }
 
-    private func beginSpeakerRename(_ speaker: SpeakerInfo) {
-        if editingSpeakerId != nil, editingSpeakerId != speaker.id {
+    private func beginSpeakerRename(_ speaker: SpeakerInfo, contextID: String) {
+        if editingSpeakerId != nil, editingSpeakerId != speaker.id || editingSpeakerContextID != contextID {
             commitSpeakerRename()
         }
         editingSpeakerId = speaker.id
+        editingSpeakerContextID = contextID
         editingSpeakerLabel = speaker.label
     }
 
@@ -3015,6 +3044,7 @@ struct TranscriptResultView: View {
 
     private func cancelSpeakerRename() {
         editingSpeakerId = nil
+        editingSpeakerContextID = nil
         editingSpeakerLabel = ""
         speakerRenameFocused = false
     }

--- a/Sources/MacParakeet/Views/Transcription/TranscriptTimestampedContentView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptTimestampedContentView.swift
@@ -88,12 +88,13 @@ func identifiedSpeakerTurns(_ turns: [SpeakerTurn]) -> [IdentifiedSpeakerTurn] {
     }
 }
 
-struct TranscriptTimestampedContentView: View {
+struct TranscriptTimestampedContentView<SpeakerLabelContent: View>: View {
     let hasSpeakers: Bool
     let identifiedTurns: [IdentifiedSpeakerTurn]
     let segments: [TranscriptSegment]
     let speakerColorMap: [String: Color]
     let speakerLabelForID: (String) -> String
+    let speakerLabelContent: (String, String, Color, String) -> SpeakerLabelContent
     let isSegmentActive: (Int) -> Bool
     let timestampLabel: (Int) -> String
     let isTimestampSeekable: Bool
@@ -110,9 +111,16 @@ struct TranscriptTimestampedContentView: View {
         if hasSpeakers {
             ForEach(identifiedTurns) { identified in
                 let turn = identified.turn
+                let speakerLabel = speakerLabelForID(turn.speakerId)
+                let speakerColor = speakerColorMap[turn.speakerId] ?? DesignSystem.Colors.textTertiary
+                let renameContextID = SpeakerRenameAccessibility.turnRenameContextIdentifier(
+                    speakerID: turn.speakerId,
+                    firstStartMs: identified.identity.firstStartMs,
+                    duplicateOrdinal: identified.identity.duplicateOrdinal
+                )
                 TranscriptTurnCardView(
-                    speakerLabel: speakerLabelForID(turn.speakerId),
-                    speakerColor: speakerColorMap[turn.speakerId] ?? DesignSystem.Colors.textTertiary,
+                    speakerLabelContent: speakerLabelContent(turn.speakerId, speakerLabel, speakerColor, renameContextID),
+                    speakerColor: speakerColor,
                     segments: turn.segments,
                     timestampLabel: timestampLabel,
                     isTimestampSeekable: isTimestampSeekable,
@@ -156,8 +164,8 @@ private func timestampScrollAnchor(startMs: Int) -> some View {
         .accessibilityHidden(true)
 }
 
-private struct TranscriptTurnCardView: View {
-    let speakerLabel: String
+private struct TranscriptTurnCardView<SpeakerLabelContent: View>: View {
+    let speakerLabelContent: SpeakerLabelContent
     let speakerColor: Color
     let segments: [TranscriptSegment]
     let timestampLabel: (Int) -> String
@@ -174,9 +182,7 @@ private struct TranscriptTurnCardView: View {
                     .fill(speakerColor)
                     .frame(width: 10, height: 10)
 
-                Text(speakerLabel)
-                    .font(DesignSystem.Typography.body.weight(.semibold))
-                    .foregroundStyle(speakerColor)
+                speakerLabelContent
 
                 if let firstStart = segments.first?.startMs {
                     transcriptMetadataChip(icon: "clock", text: timestampLabel(firstStart))

--- a/Sources/MacParakeet/Views/Transcription/TranscriptTimestampedContentView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptTimestampedContentView.swift
@@ -94,7 +94,7 @@ struct TranscriptTimestampedContentView<SpeakerLabelContent: View>: View {
     let segments: [TranscriptSegment]
     let speakerColorMap: [String: Color]
     let speakerLabelForID: (String) -> String
-    let speakerLabelContent: (String, String, Color, String) -> SpeakerLabelContent
+    let speakerLabelContent: (String, String, Color, String, Bool) -> SpeakerLabelContent
     let isSegmentActive: (Int) -> Bool
     let timestampLabel: (Int) -> String
     let isTimestampSeekable: Bool
@@ -119,7 +119,10 @@ struct TranscriptTimestampedContentView<SpeakerLabelContent: View>: View {
                     duplicateOrdinal: identified.identity.duplicateOrdinal
                 )
                 TranscriptTurnCardView(
-                    speakerLabelContent: speakerLabelContent(turn.speakerId, speakerLabel, speakerColor, renameContextID),
+                    speakerID: turn.speakerId,
+                    speakerLabel: speakerLabel,
+                    renameContextID: renameContextID,
+                    speakerLabelContent: speakerLabelContent,
                     speakerColor: speakerColor,
                     segments: turn.segments,
                     timestampLabel: timestampLabel,
@@ -165,7 +168,10 @@ private func timestampScrollAnchor(startMs: Int) -> some View {
 }
 
 private struct TranscriptTurnCardView<SpeakerLabelContent: View>: View {
-    let speakerLabelContent: SpeakerLabelContent
+    let speakerID: String
+    let speakerLabel: String
+    let renameContextID: String
+    let speakerLabelContent: (String, String, Color, String, Bool) -> SpeakerLabelContent
     let speakerColor: Color
     let segments: [TranscriptSegment]
     let timestampLabel: (Int) -> String
@@ -175,6 +181,8 @@ private struct TranscriptTurnCardView<SpeakerLabelContent: View>: View {
     var currentHighlight: (id: Int, range: NSRange)?
     let onTimestampTap: (Int) -> Void
 
+    @State private var isHovering = false
+
     var body: some View {
         VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
             HStack(spacing: DesignSystem.Spacing.sm) {
@@ -182,7 +190,7 @@ private struct TranscriptTurnCardView<SpeakerLabelContent: View>: View {
                     .fill(speakerColor)
                     .frame(width: 10, height: 10)
 
-                speakerLabelContent
+                speakerLabelContent(speakerID, speakerLabel, speakerColor, renameContextID, isHovering)
 
                 if let firstStart = segments.first?.startMs {
                     transcriptMetadataChip(icon: "clock", text: timestampLabel(firstStart))
@@ -208,6 +216,11 @@ private struct TranscriptTurnCardView<SpeakerLabelContent: View>: View {
             RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius)
                 .strokeBorder(speakerColor.opacity(0.18), lineWidth: 0.75)
         )
+        .onHover { hovering in
+            withAnimation(DesignSystem.Animation.hoverTransition) {
+                isHovering = hovering
+            }
+        }
     }
 
     @ViewBuilder

--- a/Tests/MacParakeetTests/Views/SpeakerRenameAccessibilityTests.swift
+++ b/Tests/MacParakeetTests/Views/SpeakerRenameAccessibilityTests.swift
@@ -48,6 +48,17 @@ final class SpeakerRenameAccessibilityTests: XCTestCase {
         )
     }
 
+    func testRenameButtonHoverRevealUsesOpacityValues() {
+        XCTAssertEqual(
+            SpeakerRenameAccessibility.renameButtonOpacity(isVisuallyRevealed: false),
+            0
+        )
+        XCTAssertEqual(
+            SpeakerRenameAccessibility.renameButtonOpacity(isVisuallyRevealed: true),
+            1
+        )
+    }
+
     func testRenameContextIdentifiersSeparateOverviewAndRepeatedTimedTurns() {
         XCTAssertEqual(
             SpeakerRenameAccessibility.overviewRenameContextIdentifier(for: "speaker_1"),

--- a/Tests/MacParakeetTests/Views/SpeakerRenameAccessibilityTests.swift
+++ b/Tests/MacParakeetTests/Views/SpeakerRenameAccessibilityTests.swift
@@ -21,14 +21,14 @@ final class SpeakerRenameAccessibilityTests: XCTestCase {
         )
     }
 
-    func testRenameButtonLabelsAndIdentifiersAreSpeakerSpecific() {
+    func testRenameButtonLabelsAreSpeakerSpecificAndIdentifiersAreContextSpecific() {
         XCTAssertEqual(
             SpeakerRenameAccessibility.renameButtonLabel(for: "Others"),
             "Rename Others"
         )
         XCTAssertEqual(
-            SpeakerRenameAccessibility.renameButtonIdentifier(for: "speaker_1"),
-            "transcript.speaker.rename.speaker_1"
+            SpeakerRenameAccessibility.renameButtonIdentifier(contextID: "overview:speaker_1"),
+            "transcript.speaker.rename.overview:speaker_1"
         )
         XCTAssertEqual(
             SpeakerRenameAccessibility.renameButtonHint,
@@ -43,8 +43,8 @@ final class SpeakerRenameAccessibilityTests: XCTestCase {
             "Press Return or move focus away to save. Press Escape to cancel."
         )
         XCTAssertEqual(
-            SpeakerRenameAccessibility.speakerNameFieldIdentifier(for: "speaker_1"),
-            "transcript.speaker.name.speaker_1"
+            SpeakerRenameAccessibility.speakerNameFieldIdentifier(contextID: "turn:speaker_1:1200:0"),
+            "transcript.speaker.name.turn:speaker_1:1200:0"
         )
     }
 
@@ -60,25 +60,34 @@ final class SpeakerRenameAccessibilityTests: XCTestCase {
     }
 
     func testRenameContextIdentifiersSeparateOverviewAndRepeatedTimedTurns() {
-        XCTAssertEqual(
-            SpeakerRenameAccessibility.overviewRenameContextIdentifier(for: "speaker_1"),
-            "overview:speaker_1"
+        let overview = SpeakerRenameAccessibility.overviewRenameContextIdentifier(for: "speaker_1")
+        let firstTurn = SpeakerRenameAccessibility.turnRenameContextIdentifier(
+            speakerID: "speaker_1",
+            firstStartMs: 1200,
+            duplicateOrdinal: 0
         )
-        XCTAssertEqual(
-            SpeakerRenameAccessibility.turnRenameContextIdentifier(
-                speakerID: "speaker_1",
-                firstStartMs: 1200,
-                duplicateOrdinal: 0
-            ),
-            "turn:speaker_1:1200:0"
+        let secondTurn = SpeakerRenameAccessibility.turnRenameContextIdentifier(
+            speakerID: "speaker_1",
+            firstStartMs: 1200,
+            duplicateOrdinal: 1
         )
-        XCTAssertEqual(
-            SpeakerRenameAccessibility.turnRenameContextIdentifier(
-                speakerID: "speaker_1",
-                firstStartMs: 1200,
-                duplicateOrdinal: 1
-            ),
-            "turn:speaker_1:1200:1"
-        )
+
+        XCTAssertEqual(overview, "overview:speaker_1")
+        XCTAssertEqual(firstTurn, "turn:speaker_1:1200:0")
+        XCTAssertEqual(secondTurn, "turn:speaker_1:1200:1")
+
+        let renameButtonIdentifiers = [
+            SpeakerRenameAccessibility.renameButtonIdentifier(contextID: overview),
+            SpeakerRenameAccessibility.renameButtonIdentifier(contextID: firstTurn),
+            SpeakerRenameAccessibility.renameButtonIdentifier(contextID: secondTurn),
+        ]
+        let speakerNameFieldIdentifiers = [
+            SpeakerRenameAccessibility.speakerNameFieldIdentifier(contextID: overview),
+            SpeakerRenameAccessibility.speakerNameFieldIdentifier(contextID: firstTurn),
+            SpeakerRenameAccessibility.speakerNameFieldIdentifier(contextID: secondTurn),
+        ]
+
+        XCTAssertEqual(Set(renameButtonIdentifiers).count, 3)
+        XCTAssertEqual(Set(speakerNameFieldIdentifiers).count, 3)
     }
 }

--- a/Tests/MacParakeetTests/Views/SpeakerRenameAccessibilityTests.swift
+++ b/Tests/MacParakeetTests/Views/SpeakerRenameAccessibilityTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+@testable import MacParakeet
+
+final class SpeakerRenameAccessibilityTests: XCTestCase {
+    func testOverviewToggleLabelsDescribeDisclosureAction() {
+        XCTAssertEqual(
+            SpeakerRenameAccessibility.overviewToggleLabel(isExpanded: true),
+            "Collapse speaker overview"
+        )
+        XCTAssertEqual(
+            SpeakerRenameAccessibility.overviewToggleLabel(isExpanded: false),
+            "Expand speaker overview"
+        )
+        XCTAssertEqual(
+            SpeakerRenameAccessibility.overviewToggleIdentifier,
+            "transcript.speakerOverview.toggle"
+        )
+        XCTAssertEqual(
+            SpeakerRenameAccessibility.overviewToggleHint,
+            "Shows speaker labels and rename controls."
+        )
+    }
+
+    func testRenameButtonLabelsAndIdentifiersAreSpeakerSpecific() {
+        XCTAssertEqual(
+            SpeakerRenameAccessibility.renameButtonLabel(for: "Others"),
+            "Rename Others"
+        )
+        XCTAssertEqual(
+            SpeakerRenameAccessibility.renameButtonIdentifier(for: "speaker_1"),
+            "transcript.speaker.rename.speaker_1"
+        )
+        XCTAssertEqual(
+            SpeakerRenameAccessibility.renameButtonHint,
+            "Edits this speaker label for this meeting only."
+        )
+    }
+
+    func testSpeakerRenameFieldAccessibilityMetadataIsStable() {
+        XCTAssertEqual(SpeakerRenameAccessibility.speakerNameFieldLabel, "Speaker name")
+        XCTAssertEqual(
+            SpeakerRenameAccessibility.speakerNameFieldHint,
+            "Press Return or move focus away to save. Press Escape to cancel."
+        )
+        XCTAssertEqual(
+            SpeakerRenameAccessibility.speakerNameFieldIdentifier(for: "speaker_1"),
+            "transcript.speaker.name.speaker_1"
+        )
+    }
+
+    func testRenameContextIdentifiersSeparateOverviewAndRepeatedTimedTurns() {
+        XCTAssertEqual(
+            SpeakerRenameAccessibility.overviewRenameContextIdentifier(for: "speaker_1"),
+            "overview:speaker_1"
+        )
+        XCTAssertEqual(
+            SpeakerRenameAccessibility.turnRenameContextIdentifier(
+                speakerID: "speaker_1",
+                firstStartMs: 1200,
+                duplicateOrdinal: 0
+            ),
+            "turn:speaker_1:1200:0"
+        )
+        XCTAssertEqual(
+            SpeakerRenameAccessibility.turnRenameContextIdentifier(
+                speakerID: "speaker_1",
+                firstStartMs: 1200,
+                duplicateOrdinal: 1
+            ),
+            "turn:speaker_1:1200:1"
+        )
+    }
+}


### PR DESCRIPTION
## Summary
Fixes QA report item 10 from `journal/2026-07-04-health-chips-qa/report.md`.

The Timed transcript speaker header displayed speaker labels but did not expose a real rename button. The only rename entry point lived in the speaker overview, whose disclosure row was an `HStack` with `onTapGesture`; AX automation could not press it as a control, so the `Rename Others` action and edit text field were not reliably reachable.

This PR:
- Shares the speaker rename control into Timed speaker-turn headers and the speaker overview.
- Gives the rename button an explicit `Rename <speaker label>` accessibility label, hint, and identifier.
- Converts the speaker overview disclosure into a real accessible button and leaves the overview expanded by default.
- Labels the edit text field and keeps Return, Escape, and focus-loss commit/cancel semantics on the existing shared flow.
- Scopes edit state by per-card/per-overview context so repeated Timed turns for the same speaker do not all enter edit mode together.

## Tests
- `swift test --filter SpeakerRenameAccessibilityTests`
- `swift test --filter TranscriptionViewModelTests`
- `swift test --filter SpeakerTurnIdentityTests`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes accessibility for speaker rename in transcripts. VoiceOver and keyboard users can now reliably open and edit speaker names in timed turns and in the speaker overview; timed turns keep a real Rename control that is AX-pressable even when visually hidden.

- **Bug Fixes**
  - Added a pressable Rename button to timed speaker headers and the speaker overview with explicit accessibility label and hint; in timed turns it hover-reveals visually while staying instantiated and AX-pressable.
  - Converted the speaker overview toggle into a real button with accessibility metadata, and left the overview expanded by default.
  - Labeled the rename text field and preserved Return, Escape, and focus-loss commit/cancel behavior.
  - Scoped both edit state and accessibility identifiers by context (overview vs each timed turn) so only the intended label enters edit mode and each instance has a unique AX identifier.

<sup>Written for commit f726c9dd24a0cd3b52fc2e5886095421efc0cbc7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/717?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

