### PR TITLE
fix: refresh meeting markdown after prompt-result writes

### DIFF
--- a/Sources/CLI/Commands/PromptsCommand.swift
+++ b/Sources/CLI/Commands/PromptsCommand.swift
@@ -480,6 +480,10 @@ extension PromptsCommand {
                         userNotesSnapshot: transcript.userNotes
                     )
                     try resultRepo.save(result)
+                    await refreshMeetingArtifactBestEffort(
+                        transcription: transcript,
+                        resultRepo: resultRepo
+                    )
                     // Status messages on stderr so stdout stays grep-able as the prompt output.
                     FileHandle.standardError.write(Data("\nSaved PromptResult \(result.id.uuidString.prefix(8))\n".utf8))
                 }
@@ -489,6 +493,23 @@ extension PromptsCommand {
                 }
             }
         }
+    }
+}
+
+private func refreshMeetingArtifactBestEffort(
+    transcription: Transcription,
+    resultRepo: PromptResultRepositoryProtocol
+) async {
+    guard transcription.sourceType == .meeting else { return }
+
+    do {
+        let promptResults = try resultRepo.fetchAll(transcriptionId: transcription.id)
+        _ = try await MeetingArtifactStore().materialize(
+            transcription: transcription,
+            promptResults: promptResults
+        )
+    } catch {
+        printErr("Warning: meeting artifact refresh failed: \(error.localizedDescription)")
     }
 }
 

--- a/Sources/CLI/Commands/PromptsCommand.swift
+++ b/Sources/CLI/Commands/PromptsCommand.swift
@@ -480,7 +480,7 @@ extension PromptsCommand {
                         userNotesSnapshot: transcript.userNotes
                     )
                     try resultRepo.save(result)
-                    await refreshMeetingArtifactBestEffort(
+                    await refreshMeetingArtifacts(
                         transcription: transcript,
                         resultRepo: resultRepo
                     )
@@ -496,7 +496,8 @@ extension PromptsCommand {
     }
 }
 
-private func refreshMeetingArtifactBestEffort(
+/// Refreshes meeting artifacts; failures are logged and never surfaced or thrown, and refresh never blocks or fails the triggering user action.
+private func refreshMeetingArtifacts(
     transcription: Transcription,
     resultRepo: PromptResultRepositoryProtocol
 ) async {

--- a/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
+++ b/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
@@ -105,6 +105,7 @@ final class AppEnvironmentConfigurer {
             transcriptionRepo: env.transcriptionRepo,
             llmService: hasLLMConfig ? env.llmService : nil,
             promptResultRepo: env.promptResultRepo,
+            meetingArtifactStore: MeetingArtifactStore(),
             promptResultsViewModel: promptResultsViewModel
         )
         historyViewModel.configure(dictationRepo: env.dictationRepo)
@@ -202,6 +203,7 @@ final class AppEnvironmentConfigurer {
             // user-defined prompt that references it, and feed `nil` userNotes
             // into the chat path that ADR-020's 2026-05-02 amendment relies on.
             transcriptionRepo: env.transcriptionRepo,
+            meetingArtifactStore: MeetingArtifactStore(),
             configStore: env.llmConfigStore,
             llmClient: env.llmClient
         )

--- a/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
+++ b/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
@@ -105,7 +105,6 @@ final class AppEnvironmentConfigurer {
             transcriptionRepo: env.transcriptionRepo,
             llmService: hasLLMConfig ? env.llmService : nil,
             promptResultRepo: env.promptResultRepo,
-            meetingArtifactStore: MeetingArtifactStore(),
             promptResultsViewModel: promptResultsViewModel
         )
         historyViewModel.configure(dictationRepo: env.dictationRepo)

--- a/Sources/MacParakeetViewModels/PromptResultsViewModel.swift
+++ b/Sources/MacParakeetViewModels/PromptResultsViewModel.swift
@@ -308,7 +308,7 @@ public final class PromptResultsViewModel {
             onDeletedPromptResult?(promptResult.id)
             let transcriptionID = promptResult.transcriptionId
             Task { [weak self] in
-                await self?.refreshMeetingArtifactBestEffort(transcriptionId: transcriptionID)
+                await self?.refreshMeetingArtifacts(transcriptionId: transcriptionID)
             }
             errorMessage = nil
         } catch {
@@ -518,7 +518,7 @@ public final class PromptResultsViewModel {
             promptResults.insert(promptResult, at: 0)
         }
 
-        await refreshMeetingArtifactBestEffort(transcriptionId: generation.transcriptionId)
+        await refreshMeetingArtifacts(transcriptionId: generation.transcriptionId)
 
         onPromptResultsChanged?(generation.transcriptionId, true)
         onGenerationCompleted?(generation.id, promptResult.id)
@@ -615,7 +615,8 @@ public final class PromptResultsViewModel {
         }
     }
 
-    private func refreshMeetingArtifactBestEffort(transcriptionId: UUID) async {
+    /// Refreshes meeting artifacts; failures are logged and never surfaced or thrown, and refresh never blocks or fails the triggering user action.
+    private func refreshMeetingArtifacts(transcriptionId: UUID) async {
         guard let meetingArtifactStore,
               let transcriptionRepo,
               let promptResultRepo

--- a/Sources/MacParakeetViewModels/PromptResultsViewModel.swift
+++ b/Sources/MacParakeetViewModels/PromptResultsViewModel.swift
@@ -92,6 +92,7 @@ public final class PromptResultsViewModel {
     /// (ADR-020 §4, §6). The legacy `updateSummary` write-back path that
     /// also lived through this property was removed in v0.7.6.
     private var transcriptionRepo: TranscriptionRepositoryProtocol?
+    private var meetingArtifactStore: MeetingArtifactStoring?
     private var configStore: LLMConfigStoreProtocol?
     private var cliConfigStore: LocalCLIConfigStore?
     private var llmClient: LLMClientProtocol?
@@ -162,6 +163,7 @@ public final class PromptResultsViewModel {
         promptRepo: PromptRepositoryProtocol?,
         promptResultRepo: PromptResultRepositoryProtocol?,
         transcriptionRepo: TranscriptionRepositoryProtocol? = nil,
+        meetingArtifactStore: MeetingArtifactStoring? = nil,
         configStore: LLMConfigStoreProtocol? = nil,
         llmClient: LLMClientProtocol? = nil,
         cliConfigStore: LocalCLIConfigStore = LocalCLIConfigStore()
@@ -170,6 +172,7 @@ public final class PromptResultsViewModel {
         self.promptRepo = promptRepo
         self.promptResultRepo = promptResultRepo
         self.transcriptionRepo = transcriptionRepo
+        self.meetingArtifactStore = meetingArtifactStore
         self.configStore = configStore
         self.llmClient = llmClient
         self.cliConfigStore = cliConfigStore
@@ -303,6 +306,10 @@ public final class PromptResultsViewModel {
                 onPromptResultsChanged?(transcriptionID, !promptResults.isEmpty)
             }
             onDeletedPromptResult?(promptResult.id)
+            let transcriptionID = promptResult.transcriptionId
+            Task { [weak self] in
+                await self?.refreshMeetingArtifactBestEffort(transcriptionId: transcriptionID)
+            }
             errorMessage = nil
         } catch {
             errorMessage = error.localizedDescription
@@ -455,7 +462,7 @@ public final class PromptResultsViewModel {
                     finishCancelledGeneration(id: generationID)
                     return
                 }
-                try finishGeneration(id: generationID)
+                try await finishGeneration(id: generationID)
             } catch is CancellationError {
                 finishCancelledGeneration(id: generationID)
             } catch {
@@ -469,7 +476,7 @@ public final class PromptResultsViewModel {
         pendingGenerations[index].content += token
     }
 
-    private func finishGeneration(id generationID: UUID) throws {
+    private func finishGeneration(id generationID: UUID) async throws {
         guard let index = pendingGenerations.firstIndex(where: { $0.id == generationID }) else {
             streamingTask = nil
             processNextQueuedGeneration()
@@ -510,6 +517,8 @@ public final class PromptResultsViewModel {
             }
             promptResults.insert(promptResult, at: 0)
         }
+
+        await refreshMeetingArtifactBestEffort(transcriptionId: generation.transcriptionId)
 
         onPromptResultsChanged?(generation.transcriptionId, true)
         onGenerationCompleted?(generation.id, promptResult.id)
@@ -603,6 +612,28 @@ public final class PromptResultsViewModel {
         } catch {
             logger.warning("Failed to fetch userNotes for transcription \(transcriptionId.uuidString, privacy: .public): \(error.localizedDescription, privacy: .public)")
             return nil
+        }
+    }
+
+    private func refreshMeetingArtifactBestEffort(transcriptionId: UUID) async {
+        guard let meetingArtifactStore,
+              let transcriptionRepo,
+              let promptResultRepo
+        else { return }
+
+        do {
+            guard let transcription = try transcriptionRepo.fetch(id: transcriptionId),
+                  transcription.sourceType == .meeting
+            else { return }
+            let promptResults = try promptResultRepo.fetchAll(transcriptionId: transcriptionId)
+            _ = try await Task.detached(priority: .utility) {
+                try await meetingArtifactStore.materialize(
+                    transcription: transcription,
+                    promptResults: promptResults
+                )
+            }.value
+        } catch {
+            logger.warning("Failed to refresh meeting artifact for prompt results \(transcriptionId.uuidString, privacy: .public): \(error.localizedDescription, privacy: .public)")
         }
     }
 

--- a/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
@@ -1349,7 +1349,8 @@ public final class TranscriptionViewModel {
 
     private func enqueueMeetingArtifactRefresh(transcriptionID: UUID, generation: Int) {
         guard speakerRenameGenerations[transcriptionID] == generation,
-              let transcriptionRepo
+              let transcriptionRepo,
+              let promptResultRepo
         else {
             return
         }
@@ -1389,7 +1390,7 @@ public final class TranscriptionViewModel {
                     else {
                         break
                     }
-                    let promptResults = try promptResultRepo?.fetchAll(transcriptionId: transcriptionID) ?? []
+                    let promptResults = try promptResultRepo.fetchAll(transcriptionId: transcriptionID)
                     _ = try await artifactStore.materialize(
                         transcription: persisted,
                         promptResults: promptResults
@@ -1439,9 +1440,13 @@ public final class TranscriptionViewModel {
         currentTranscription = transcription
         do {
             try transcriptionRepo?.updateFileName(id: transcription.id, fileName: trimmed)
+            let persistedTranscription = (try transcriptionRepo?.fetch(id: transcription.id)) ?? transcription
+            currentTranscription = persistedTranscription
             if let index = transcriptions.firstIndex(where: { $0.id == transcription.id }) {
-                transcriptions[index].fileName = trimmed
-                transcriptions[index].derivedTitle = trimmed
+                transcriptions[index] = persistedTranscription
+            }
+            Task { [weak self, persistedTranscription] in
+                await self?.refreshMeetingArtifacts(transcription: persistedTranscription)
             }
         } catch {
             logger.error("Failed to persist transcription rename error_type=\(TelemetryErrorClassifier.classify(error), privacy: .public)")
@@ -1459,6 +1464,25 @@ public final class TranscriptionViewModel {
         } catch {
             logger.error("Failed to query prompt results error_type=\(TelemetryErrorClassifier.classify(error), privacy: .public)")
             hasPromptResultTabs = false
+        }
+    }
+
+    /// Refreshes meeting artifacts; failures are logged and never surfaced or thrown, and refresh never blocks or fails the triggering user action.
+    private func refreshMeetingArtifacts(transcription: Transcription) async {
+        guard let promptResultRepo,
+              transcription.sourceType == .meeting
+        else { return }
+
+        do {
+            let promptResults = try promptResultRepo.fetchAll(transcriptionId: transcription.id)
+            _ = try await Task.detached(priority: .utility) {
+                try await meetingArtifactStore.materialize(
+                    transcription: transcription,
+                    promptResults: promptResults
+                )
+            }.value
+        } catch {
+            logger.warning("Failed to refresh meeting artifact for transcription \(transcription.id.uuidString, privacy: .public): \(error.localizedDescription, privacy: .public)")
         }
     }
 }

--- a/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
@@ -1364,7 +1364,6 @@ public final class TranscriptionViewModel {
         )
 
         let artifactStore = meetingArtifactStore
-        let promptResultRepo = promptResultRepo
         let logger = logger
         let task = Task.detached(priority: .utility) { [weak self, previousTask, transcriptionRepo, promptResultRepo, artifactStore, logger] in
             await previousTask?.value
@@ -1475,8 +1474,9 @@ public final class TranscriptionViewModel {
 
         do {
             let promptResults = try promptResultRepo.fetchAll(transcriptionId: transcription.id)
+            let artifactStore = meetingArtifactStore
             _ = try await Task.detached(priority: .utility) {
-                try await meetingArtifactStore.materialize(
+                try await artifactStore.materialize(
                     transcription: transcription,
                     promptResults: promptResults
                 )

--- a/Tests/CLITests/MeetingsCommandTests.swift
+++ b/Tests/CLITests/MeetingsCommandTests.swift
@@ -538,6 +538,60 @@ final class MeetingsCommandTests: XCTestCase {
         XCTAssertTrue(exportedMarkdown.contains("**Speaker 1**"))
     }
 
+    func testPromptResultAddRefreshesMaterializedMarkdownAndExportParity() async throws {
+        let dbURL = temporaryDatabaseURL()
+        let folderURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("macparakeet-cli-meeting-result-refresh-\(UUID().uuidString)")
+        defer {
+            try? FileManager.default.removeItem(at: dbURL)
+            try? FileManager.default.removeItem(at: folderURL)
+        }
+        try FileManager.default.createDirectory(at: folderURL, withIntermediateDirectories: true)
+        try Data("audio".utf8).write(to: folderURL.appendingPathComponent("meeting.m4a"))
+
+        let db = try DatabaseManager(path: dbURL.path)
+        let transcriptionRepo = TranscriptionRepository(dbQueue: db.dbQueue)
+        let meeting = Transcription(
+            createdAt: Date(timeIntervalSince1970: 1_720_000_000),
+            fileName: "Result Refresh Review",
+            filePath: folderURL.appendingPathComponent("meeting.m4a").path,
+            rawTranscript: "Refresh the artifact.",
+            status: .completed,
+            sourceType: .meeting,
+            userNotes: "Decision: refresh artifacts",
+            updatedAt: Date(timeIntervalSince1970: 1_720_000_001)
+        )
+        try transcriptionRepo.save(meeting)
+
+        _ = try await MeetingArtifactStore().materialize(
+            transcription: meeting,
+            promptResults: []
+        )
+        let markdownURL = folderURL.appendingPathComponent(MeetingArtifactStore.markdownFileName)
+        let staleMarkdown = try String(contentsOf: markdownURL, encoding: .utf8)
+        XCTAssertTrue(staleMarkdown.contains("promptResultCount: 0"))
+        XCTAssertFalse(staleMarkdown.contains("## Prompt Results"))
+
+        let addCommand = try MeetingsCommand.ResultsSubcommand.AddSubcommand.parse([
+            meeting.id.uuidString,
+            "--name", "QA Summary",
+            "--content", "The prompt result is saved.",
+            "--prompt-content", "Summarize the QA result.",
+            "--database", dbURL.path,
+        ])
+        _ = try await captureStandardOutput {
+            try await addCommand.run()
+        }
+
+        let materializedMarkdown = try String(contentsOf: markdownURL, encoding: .utf8)
+        let exportedMarkdown = try await markdownExport(for: meeting.id, database: dbURL)
+
+        XCTAssertEqual(exportedMarkdown, materializedMarkdown)
+        XCTAssertTrue(materializedMarkdown.contains("promptResultCount: 1"))
+        XCTAssertTrue(materializedMarkdown.contains("## Prompt Results"))
+        XCTAssertTrue(materializedMarkdown.contains("- 1. QA Summary"))
+    }
+
     func testMarkdownExportReflectsSpeakerRenameAndEditedTranscriptFallback() async throws {
         let dbURL = temporaryDatabaseURL()
         let folderURL = FileManager.default.temporaryDirectory

--- a/Tests/MacParakeetTests/ViewModels/PromptResultsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/PromptResultsViewModelTests.swift
@@ -19,6 +19,24 @@ final class PromptResultsViewModelTests: XCTestCase {
         promptRepo.prompts = Prompt.builtInPrompts()
     }
 
+    private func waitUntil(
+        timeout: Duration = .seconds(1),
+        pollInterval: Duration = .milliseconds(10),
+        file: StaticString = #filePath,
+        line: UInt = #line,
+        _ condition: () -> Bool
+    ) async throws {
+        let clock = ContinuousClock()
+        let deadline = clock.now + timeout
+        while !condition() {
+            if clock.now >= deadline {
+                XCTFail("Timed out waiting for condition", file: file, line: line)
+                return
+            }
+            try await Task.sleep(for: pollInterval)
+        }
+    }
+
     func testGenerationCapabilityIsFalseBeforeAIConfigured() {
         XCTAssertFalse(viewModel.hasPromptResultGenerationCapability)
         XCTAssertFalse(viewModel.canGeneratePromptResult)
@@ -100,6 +118,82 @@ final class PromptResultsViewModelTests: XCTestCase {
             "Extract action items only.\n\nReturn terse bullet points."
         )
         XCTAssertEqual(viewModel.promptResults.first?.content, "Task one")
+    }
+
+    func testGeneratePromptResultRefreshesMaterializedMeetingMarkdown() async throws {
+        let folderURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("PromptResultsViewModelTests-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: folderURL) }
+        try FileManager.default.createDirectory(at: folderURL, withIntermediateDirectories: true)
+        try Data("audio".utf8).write(to: folderURL.appendingPathComponent("meeting.m4a"))
+
+        let transcriptionID = UUID()
+        let transcription = Transcription(
+            id: transcriptionID,
+            fileName: "Design Review",
+            filePath: folderURL.appendingPathComponent("meeting.m4a").path,
+            rawTranscript: "Alice will send the draft tomorrow.",
+            status: .completed,
+            sourceType: .meeting,
+            userNotes: "Decision: ship"
+        )
+        try transcriptionRepo.save(transcription)
+
+        let prompt = Prompt(
+            name: "Action Items",
+            content: "Extract action items only.",
+            category: .result,
+            isBuiltIn: false,
+            sortOrder: 99
+        )
+        promptRepo.prompts = [prompt]
+
+        viewModel.configure(
+            llmService: llm,
+            promptRepo: promptRepo,
+            promptResultRepo: promptResultRepo,
+            transcriptionRepo: transcriptionRepo,
+            meetingArtifactStore: MeetingArtifactStore()
+        )
+        viewModel.selectedPrompt = prompt
+        llm.streamTokens = ["Task ", "one"]
+
+        viewModel.generatePromptResult(
+            transcript: "Alice will send the draft tomorrow.",
+            transcriptionId: transcriptionID
+        )
+
+        let markdownURL = folderURL.appendingPathComponent(MeetingArtifactStore.markdownFileName)
+        try await waitUntil {
+            (try? String(contentsOf: markdownURL, encoding: .utf8))
+                .map { $0.contains("promptResultCount: 1") && $0.contains("## Prompt Results") }
+                ?? false
+        }
+
+        let markdown = try String(contentsOf: markdownURL, encoding: .utf8)
+        XCTAssertTrue(markdown.contains("promptResultCount: 1"))
+        XCTAssertTrue(markdown.contains("## Prompt Results"))
+        XCTAssertTrue(markdown.contains("- 1. Action Items"))
+
+        let promptResults = try promptResultRepo.fetchAll(transcriptionId: transcriptionID)
+        let resultMarkdownURL = try XCTUnwrap(
+            MeetingMarkdownArtifactPaths.resolve(
+                transcription: transcription,
+                promptResults: promptResults
+            ).promptResultFiles.first?.path.map(URL.init(fileURLWithPath:))
+        )
+        let resultMarkdown = try String(contentsOf: resultMarkdownURL, encoding: .utf8)
+        XCTAssertTrue(resultMarkdown.contains("Task one"))
+
+        let expectedMarkdown = MeetingMarkdownRenderer().render(
+            transcription: transcription,
+            promptResults: promptResults,
+            artifactPaths: MeetingMarkdownArtifactPaths.resolve(
+                transcription: transcription,
+                promptResults: promptResults
+            )
+        )
+        XCTAssertEqual(markdown, expectedMarkdown)
     }
 
     func testGeneratePromptResultDoesNotPersistEmptyStream() async throws {

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
@@ -1668,6 +1668,7 @@ final class TranscriptionViewModelTests: XCTestCase {
     func testRenameSpeakerRefreshesMeetingArtifactWithUpdatedLabels() async throws {
         let artifactStore = RecordingMeetingArtifactStore()
         viewModel = TranscriptionViewModel(meetingArtifactStore: artifactStore)
+        let oldUpdatedAt = Date(timeIntervalSince1970: 1_000)
 
         let folderURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("speaker-rename-artifact-\(UUID().uuidString)", isDirectory: true)
@@ -1699,7 +1700,8 @@ final class TranscriptionViewModelTests: XCTestCase {
             ],
             speakers: speakers,
             status: .completed,
-            sourceType: .meeting
+            sourceType: .meeting,
+            updatedAt: oldUpdatedAt
         )
         mockRepo.transcriptions = [meeting]
         mockPromptResultRepo.promptResults = [
@@ -1724,6 +1726,7 @@ final class TranscriptionViewModelTests: XCTestCase {
         let calls = await artifactStore.materializeCalls
         let call = try XCTUnwrap(calls.first)
         XCTAssertEqual(call.transcription.speakers?.first?.label, "Alice")
+        XCTAssertGreaterThan(call.transcription.updatedAt, oldUpdatedAt)
         XCTAssertEqual(call.promptResults.count, 1)
         XCTAssertEqual(viewModel.transcriptions.first?.speakers?.first?.label, "Alice")
     }
@@ -1922,6 +1925,99 @@ final class TranscriptionViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.transcriptions.first?.derivedTitle, "Design Review")
         XCTAssertEqual(mockRepo.updateFileNameCalls.count, 1)
         XCTAssertEqual(mockRepo.updateFileNameCalls[0].fileName, "Design Review")
+    }
+
+    func testRenameCurrentTranscriptionRefreshesMeetingArtifact() async throws {
+        let artifactStore = RecordingMeetingArtifactStore()
+        viewModel = TranscriptionViewModel(meetingArtifactStore: artifactStore)
+        let oldUpdatedAt = Date(timeIntervalSince1970: 1_000)
+        let t = Transcription(
+            fileName: "Meeting Apr 5",
+            status: .completed,
+            sourceType: .meeting,
+            derivedTitle: "Auto Derived Title",
+            updatedAt: oldUpdatedAt
+        )
+        let promptResult = PromptResult(
+            transcriptionId: t.id,
+            promptName: "Summary",
+            promptContent: "Summarize",
+            content: "Ship it."
+        )
+        mockRepo.transcriptions = [t]
+        mockPromptResultRepo.promptResults = [promptResult]
+
+        viewModel.configure(
+            transcriptionService: mockService,
+            transcriptionRepo: mockRepo,
+            promptResultRepo: mockPromptResultRepo
+        )
+        viewModel.currentTranscription = t
+
+        viewModel.renameCurrentTranscription(to: "Design Review")
+
+        try await waitUntilAsync { await artifactStore.materializeCallCount == 1 }
+        let calls = await artifactStore.materializeCalls
+        let call = try XCTUnwrap(calls.first)
+        XCTAssertEqual(call.transcription.fileName, "Design Review")
+        XCTAssertEqual(call.transcription.derivedTitle, "Design Review")
+        XCTAssertGreaterThan(call.transcription.updatedAt, oldUpdatedAt)
+        XCTAssertEqual(call.promptResults.map(\.id), [promptResult.id])
+    }
+
+    func testRenameCurrentTranscriptionSkipsArtifactRefreshWithoutPromptResultRepo() async throws {
+        viewModel = TranscriptionViewModel(meetingArtifactStore: MeetingArtifactStore())
+        let folderURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TranscriptionViewModelTests-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: folderURL) }
+        try FileManager.default.createDirectory(at: folderURL, withIntermediateDirectories: true)
+        let audioURL = folderURL.appendingPathComponent("meeting.m4a")
+        try Data("audio".utf8).write(to: audioURL)
+
+        let t = Transcription(
+            fileName: "Meeting Apr 5",
+            filePath: audioURL.path,
+            rawTranscript: "Keep the prompt results.",
+            status: .completed,
+            sourceType: .meeting
+        )
+        let promptResult = PromptResult(
+            transcriptionId: t.id,
+            promptName: "Summary",
+            promptContent: "Summarize",
+            content: "This result must stay materialized."
+        )
+        _ = try await MeetingArtifactStore().materialize(
+            transcription: t,
+            promptResults: [promptResult]
+        )
+
+        let markdownURL = folderURL.appendingPathComponent(MeetingArtifactStore.markdownFileName)
+        let resultMarkdownURL = folderURL
+            .appendingPathComponent(MeetingArtifactStore.promptResultsDirectoryName)
+            .appendingPathComponent("01-Summary.md")
+        let beforeMarkdown = try String(contentsOf: markdownURL, encoding: .utf8)
+        let beforeResultMarkdown = try String(contentsOf: resultMarkdownURL, encoding: .utf8)
+        XCTAssertTrue(beforeMarkdown.contains("promptResultCount: 1"))
+        XCTAssertTrue(beforeMarkdown.contains("## Prompt Results"))
+        XCTAssertTrue(beforeResultMarkdown.contains("This result must stay materialized."))
+
+        mockRepo.transcriptions = [t]
+        viewModel.configure(
+            transcriptionService: mockService,
+            transcriptionRepo: mockRepo
+        )
+        viewModel.currentTranscription = t
+
+        viewModel.renameCurrentTranscription(to: "Design Review")
+        try await Task.sleep(for: .milliseconds(100))
+
+        let afterMarkdown = try String(contentsOf: markdownURL, encoding: .utf8)
+        let afterResultMarkdown = try String(contentsOf: resultMarkdownURL, encoding: .utf8)
+        XCTAssertEqual(afterMarkdown, beforeMarkdown)
+        XCTAssertEqual(afterResultMarkdown, beforeResultMarkdown)
+        XCTAssertTrue(afterMarkdown.contains("promptResultCount: 1"))
+        XCTAssertTrue(afterMarkdown.contains("## Prompt Results"))
     }
 
     func testRenameCurrentTranscriptionTrimsWhitespace() {

--- a/Tests/MacParakeetTests/ViewModels/ViewModelMocks.swift
+++ b/Tests/MacParakeetTests/ViewModels/ViewModelMocks.swift
@@ -200,6 +200,7 @@ final class MockTranscriptionRepository: TranscriptionRepositoryProtocol, @unche
         updateFileNameCalls.append((id: id, fileName: fileName))
         if let idx = transcriptions.firstIndex(where: { $0.id == id }) {
             transcriptions[idx].fileName = fileName
+            transcriptions[idx].derivedTitle = fileName
             transcriptions[idx].updatedAt = Date()
         }
     }


### PR DESCRIPTION
## Summary
Materialized `meeting.md` now refreshes when prompt results are saved through the app prompt-generation path, through generic `prompts run` saves, and through `meetings results add`. This fixes the QA-observed mismatch where CLI markdown export reflected current prompt results but the on-disk `meeting.md` still showed `promptResultCount: 0` with no Prompt Results section.

Related: QA evidence `journal/2026-07-04-health-chips-qa/report.md` item 8.

## Design
The app view models now receive `MeetingArtifactStore` as an injected dependency and re-materialize meeting artifacts after the relevant persisted mutations. Prompt-result refreshes fetch the current full result set before writing artifacts, so `meeting.md`, `prompt-results.json`, per-result markdown files, and the manifest publish from one current snapshot.

R16 trigger audit:
- Prompt-result writes: app prompt generation was missing; now wired. `meetings results add` was already wired and has a new parity regression. Generic `prompts run` meeting saves were missing; now wired.
- Note writes: `meetings notes set/append/clear` were already wired to fetch the updated row and refresh artifacts with current prompt results. I found no separate app post-completion note-write path.
- Meeting title edits: app rename was missing; now refreshes after the DB rename succeeds.
- Speaker rename: app rename was missing; now refreshes after speaker persistence succeeds, with the existing rename generation guard preventing stale refreshes.

## Risk surface
This is intentionally best-effort artifact refresh behavior: DB writes remain canonical, and artifact refresh failures are logged or sent to stderr without rolling back the saved user data. The main risk is async ordering around speaker renames; the refresh uses the existing rename generation guard to avoid publishing stale speaker labels.

## Test evidence
- `git diff --check`
- `swift test --filter MeetingArtifactStoreTests`
- `swift test --filter PromptResultsViewModelTests`
- `swift test --filter MeetingsCommandTests`
- `swift test --filter PromptsCommandTests` (SwiftPM also matched `QuickPromptsCommandTests`)
- `swift test --filter TranscriptionViewModelTests/testRenameCurrentTranscriptionRefreshesMeetingArtifact`
- `swift test --filter TranscriptionViewModelTests/testRenameSpeakerRefreshesMeetingArtifactAfterPersistence`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5 Codex](https://img.shields.io/badge/GPT--5_Codex-000000)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes meeting artifacts after prompt results are generated, added, or deleted, and after meeting title or speaker edits. Keeps meeting.md, per-result markdown, and CLI exports in sync while avoiding destructive publishes.

- Bug Fixes
  - Re-materialize after app prompt-result generation/delete, CLI `prompts run` saves, and `meetings results add`; exported markdown now matches materialized files.
  - On title/speaker edits, re-fetch the persisted transcription, then rebuild from the current prompt-result snapshot; skip refresh if prompt results can’t be fetched; failures are logged and non-blocking.

- Refactors
  - Injected `MeetingArtifactStore` into the app view model and renamed helpers to `refreshMeetingArtifacts`; refresh runs in a detached background task and never blocks user actions.

<sup>Written for commit 8fe5c301293adf01b55fba2de7b92e5c1ac423ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/718?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

