### PR TITLE
Fix meeting health silent recovery and mute AX

### DIFF
--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingRecordingStopButton.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingRecordingStopButton.swift
@@ -122,6 +122,10 @@ struct MeetingMicrophoneMuteButton: View {
         isMuted ? DesignSystem.Colors.errorRed : DesignSystem.Colors.accent
     }
 
+    var accessibilityLabelText: String {
+        isMuted ? "Unmute microphone" : "Mute microphone"
+    }
+
     var body: some View {
         Button(action: onToggle) {
             Image(systemName: isMuted ? "mic.slash.fill" : "mic.fill")
@@ -161,10 +165,13 @@ struct MeetingMicrophoneMuteButton: View {
         }
         .buttonStyle(.plain)
         .frame(height: Self.trackHeight)
-        .accessibilityLabel(isMuted ? "Unmute meeting microphone" : "Mute meeting microphone")
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityLabelText)
+        .accessibilityIdentifier("meeting-microphone-mute-button")
+        .accessibilityAddTraits(.isButton)
         .help(
             isMuted
-                ? "Unmute meeting microphone"
+                ? "Unmute microphone"
                 : "Mute your microphone in this recording — system audio keeps recording"
         )
         .onHover { hovering in

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
@@ -268,6 +268,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
     private var cachedTranscriptUpdates: AsyncStream<MeetingTranscriptUpdate>?
 
     private static let rmsEmaAlpha: Float = 0.3
+    private static let processedRmsHealthLevelScale: Float = 10
     private static let systemDominanceRatio: Float = 10.0
     private static let systemActiveFloor: Float = 0.02
     private static let systemSignalFreshnessWindow: Duration = .milliseconds(750)
@@ -399,8 +400,8 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         }
         return MeetingCaptureHealthSummary.reduce(
             sourceMode: sourceMode,
-            microphoneLevel: microphoneCaptureHealthRms,
-            systemLevel: recentSystemRms,
+            microphoneLevel: microphoneCaptureHealthLevel,
+            systemLevel: systemCaptureHealthLevel,
             lastBufferAt: sourceHealthLastBufferAt,
             isMicrophoneMuted: microphoneMuteState.isMuted,
             microphoneStarted: captureHealthMetrics.microphoneStarted,
@@ -1555,8 +1556,21 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         return size.uint64Value
     }
 
-    private var microphoneCaptureHealthRms: Float {
-        recentProcessedMicRms > 0 ? recentProcessedMicRms : recentMicrophoneRms
+    private var microphoneCaptureHealthLevel: Float {
+        max(latestLevels.microphone, recentMicrophoneRms, processedMicrophoneCaptureHealthLevel)
+    }
+
+    private var systemCaptureHealthLevel: Float {
+        max(latestLevels.system, recentSystemRms)
+    }
+
+    private var processedMicrophoneCaptureHealthLevel: Float {
+        guard recentProcessedMicRms > 0 else { return 0 }
+        return Self.captureHealthLevel(fromRawRms: recentProcessedMicRms)
+    }
+
+    private static func captureHealthLevel(fromRawRms rms: Float) -> Float {
+        min(1, max(0, rms * processedRmsHealthLevelScale))
     }
 
     private func updateMicrophoneRms(with bufferRms: Float) {

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingServiceTests.swift
@@ -679,6 +679,56 @@ final class MeetingRecordingServiceTests: XCTestCase {
         await service.cancelRecording()
     }
 
+    func testCaptureHealthRecoversSilentSourcesOnRealisticSpeechLevelBuffers() async throws {
+        let captureService = MockMeetingAudioCaptureService()
+        let service = MeetingRecordingService(
+            audioCaptureService: captureService,
+            audioConverter: MockMeetingAudioFileConverter(),
+            sttTranscriber: CountingMeetingSTTClient(),
+            micConditionerFactory: {
+                PassthroughMicConditioner()
+            }
+        )
+
+        try await service.startRecording()
+        let quietMicrophoneBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 4_800, sampleValue: 0.0005))
+        let quietSystemBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 4_800, sampleValue: 0.0005))
+        await captureService.yield(.microphoneBuffer(
+            quietMicrophoneBuffer,
+            AVAudioTime(hostTime: AVAudioTime.hostTime(forSeconds: 100.0))
+        ))
+        await captureService.yield(.systemBuffer(
+            quietSystemBuffer,
+            AVAudioTime(hostTime: AVAudioTime.hostTime(forSeconds: 100.1))
+        ))
+
+        let silentHealth = try await waitForCaptureHealth(service) {
+            $0.microphone.status == .silent && $0.system.status == .silent
+        }
+        XCTAssertLessThan(silentHealth.microphone.level, AudioCaptureHealth.silentInputMaximumLevel)
+        XCTAssertLessThan(silentHealth.system.level, AudioCaptureHealth.silentInputMaximumLevel)
+
+        let speechMicrophoneBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 4_800, sampleValue: 0.005))
+        let speechSystemBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 4_800, sampleValue: 0.005))
+        await captureService.yield(.microphoneBuffer(
+            speechMicrophoneBuffer,
+            AVAudioTime(hostTime: AVAudioTime.hostTime(forSeconds: 101.0))
+        ))
+        await captureService.yield(.systemBuffer(
+            speechSystemBuffer,
+            AVAudioTime(hostTime: AVAudioTime.hostTime(forSeconds: 101.1))
+        ))
+
+        let recoveredHealth = try await waitForCaptureHealth(service) {
+            $0.microphone.status == .live && $0.system.status == .live
+        }
+        XCTAssertGreaterThanOrEqual(recoveredHealth.microphone.level, AudioCaptureHealth.silentInputMaximumLevel)
+        XCTAssertGreaterThanOrEqual(recoveredHealth.system.level, AudioCaptureHealth.silentInputMaximumLevel)
+        XCTAssertNil(recoveredHealth.primaryMessage)
+
+        await service.cancelRecording()
+    }
+
     func testCaptureHealthMarksSystemNotSelectedForMicrophoneOnly() async throws {
         let captureService = MockMeetingAudioCaptureService(
             startReport: MeetingAudioCaptureStartReport(

--- a/Tests/MacParakeetTests/Views/MeetingRecordingTileTests.swift
+++ b/Tests/MacParakeetTests/Views/MeetingRecordingTileTests.swift
@@ -81,4 +81,15 @@ final class MeetingRecordingTileTests: XCTestCase {
         XCTAssertNil(MeetingRecordingPillView(viewModel: pillViewModel).visibleSourceHealthWarning)
         XCTAssertNil(MeetingRecordingTile(viewModel: pillViewModel, onTap: {}).visibleSourceHealthWarning)
     }
+
+    func testMicrophoneMuteButtonAccessibilityLabelReflectsAction() {
+        XCTAssertEqual(
+            MeetingMicrophoneMuteButton(isMuted: false, onToggle: {}).accessibilityLabelText,
+            "Mute microphone"
+        )
+        XCTAssertEqual(
+            MeetingMicrophoneMuteButton(isMuted: true, onToggle: {}).accessibilityLabelText,
+            "Unmute microphone"
+        )
+    }
 }


### PR DESCRIPTION
## Summary
- Fixes QA report item 1 from `journal/2026-07-04-health-chips-qa/report.md`: source health now recovers from `.silent` to `.live` as soon as a realistic live buffer arrives, using current capture-buffer activity plus the EMA instead of only the smoothed value.
- Fixes QA report item 4: the meeting panel microphone mute control now exposes action-oriented accessibility labels (`Mute microphone` / `Unmute microphone`), a stable AX identifier, and the button trait.
- Keeps the hidden-by-default health UI policy from PR #713 unchanged; this only corrects the retained model and the always-visible mute control.

## Root Cause
- The reducer classifies source health by comparing its input level to `AudioCaptureHealth.silentInputMaximumLevel`.
- Meeting capture events already compute a current capture-buffer level for mic/system buffers, but the health path relied only on smoothed values. For microphone health, the processed-mic RMS from the conditioner could shadow the direct capture level; for both sources, low-but-real speech after silence could remain below the threshold for the current evaluation because the EMA had not caught up.
- The fix feeds the reducer a capture-health level built from the latest buffer level plus the EMA, with processed microphone RMS scaled only as an additional signal.

## Tests
- `swift test --filter MeetingRecordingServiceTests`
- `swift test --filter MeetingRecordingPanelViewModelTests`
- `swift test --filter MeetingRecordingTileTests.testMicrophoneMuteButtonAccessibilityLabelReflectsAction`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes meeting source health getting stuck on “silent” by using current capture-buffer activity plus EMA, so mic and system recover to “live” as soon as speech-level buffers arrive. Also improves the meeting panel mute button accessibility with action labels, a stable identifier, and button traits.

- **Bug Fixes**
  - Health: use latest buffer levels + EMA (and scaled processed mic RMS) for classification; immediate recovery from silent when speech-level buffers arrive; health UI policy unchanged.
  - Accessibility: mute button now says “Mute microphone”/“Unmute microphone,” adds a stable accessibility identifier, button trait, and updates tooltip copy.

<sup>Written for commit 9547447637150036d8bfd8be80bb6a525724c654. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/719?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

