### PR TITLE
Close out STT capability registry Phase A

### DIFF
--- a/Tests/MacParakeetTests/STT/STTSchedulerTests.swift
+++ b/Tests/MacParakeetTests/STT/STTSchedulerTests.swift
@@ -1297,6 +1297,7 @@ final class STTSchedulerTests: XCTestCase {
             try await Task.sleep(for: .milliseconds(20))
         }
     }
+
 }
 
 private final class STTRuntimeUnhealthySpy: TelemetryServiceProtocol, @unchecked Sendable {

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingServiceTests.swift
@@ -1199,6 +1199,36 @@ final class MeetingRecordingServiceTests: XCTestCase {
         XCTAssertEqual(output.speechEngine, SpeechEngineSelection(engine: .cohere, language: "ja"))
     }
 
+    func testMeetingLivePreviewDryRunUsesInjectedCapabilitiesForNextVariant() async throws {
+        let captureService = MockMeetingAudioCaptureService()
+        let audioConverter = MockMeetingAudioFileConverter()
+        let sttClient = LeasingMeetingSTTClient(
+            selection: SpeechEngineSelection(engine: .cohere, language: "ja"),
+            capabilities: Self.dryRunNextVariantCapabilities(base: .cohere)
+        )
+        let service = MeetingRecordingService(
+            audioCaptureService: captureService,
+            audioConverter: audioConverter,
+            sttTranscriber: sttClient
+        )
+
+        try await service.startRecording()
+
+        let microphoneBuffer = try XCTUnwrap(makeMonoFloatBuffer(frameCount: 80_000, sampleValue: 0.25))
+        await captureService.yield(.microphoneBuffer(
+            microphoneBuffer,
+            AVAudioTime(hostTime: AVAudioTime.hostTime(forSeconds: 100.0))
+        ))
+        try await waitForRoutedLiveChunkSelection(sttClient)
+
+        let routedSelections = await sttClient.routedSelections
+        XCTAssertEqual(routedSelections, [SpeechEngineSelection(engine: .cohere, language: "ja")])
+
+        let output = try await service.stopRecording()
+        defer { try? FileManager.default.removeItem(at: output.folderURL) }
+        XCTAssertEqual(output.speechEngine, SpeechEngineSelection(engine: .cohere, language: "ja"))
+    }
+
     func testMeetingLivePreviewUsesLeaseCapabilities() async throws {
         let captureService = MockMeetingAudioCaptureService()
         let audioConverter = MockMeetingAudioFileConverter()
@@ -1645,6 +1675,30 @@ final class MeetingRecordingServiceTests: XCTestCase {
             }
             try await Task.sleep(for: .milliseconds(20))
         }
+    }
+
+    private static func dryRunNextVariantCapabilities(base key: SpeechEngineVariantKey) -> SpeechEngineCapabilities {
+        let base = SpeechEngineCapabilityRegistry.capabilities(for: key)
+        return SpeechEngineCapabilities(
+            key: key,
+            supportsNativeLiveDictation: base.supportsNativeLiveDictation,
+            supportsTailPreview: base.supportsTailPreview,
+            providesWordTimestamps: true,
+            supportedLanguages: base.supportedLanguages,
+            supportsCustomVocabulary: base.supportsCustomVocabulary,
+            modelLifecycle: SpeechEngineModelLifecycle(
+                modelName: "Dry Run Next Variant",
+                variantID: "dry-run-next-variant",
+                selectableVariantIDs: base.modelLifecycle.selectableVariantIDs + ["dry-run-next-variant"],
+                approximateDownloadSize: base.modelLifecycle.approximateDownloadSize,
+                isUserDeletable: base.modelLifecycle.isUserDeletable,
+                minimumMemoryBytes: base.modelLifecycle.minimumMemoryBytes
+            ),
+            telemetryIdentity: SpeechEngineTelemetryIdentity(
+                modelKind: base.telemetryIdentity.modelKind,
+                engineVariant: .fixed("dry-run-next-variant")
+            )
+        )
     }
 
     private func waitForMeetingSTTCall(

--- a/plans/active/2026-07-03-stt-capability-registry.md
+++ b/plans/active/2026-07-03-stt-capability-registry.md
@@ -1,7 +1,6 @@
 # STT capability registry + optional-engine adapters
 
-> Status: **TODO** (Phase A executor-ready after a short design grilling;
-> Phases B/C gated as described)
+> Status: **DONE** (Phase A complete; Phases B/C gated as described)
 > Date: 2026-07-03
 > Governing decision: [ADR-026 §4](../../spec/adr/026-asr-engine-strategy.md)
 > Design source: [`docs/research/2026-06-28-architecture-deepening-opportunities.md`](../../docs/research/2026-06-28-architecture-deepening-opportunities.md)
@@ -53,10 +52,12 @@ wave is the cheap ordering.
 
 ### Phase A — capability registry, read-only adoption (the bulk of the win)
 
-1. Define `EngineCapabilities` — field set DECIDED 2026-07-04 (design
-   grilling). Admission test: a field earns a row only if it is a stable
-   fact about the engine/variant consulted by existing call sites — not a
-   policy, not a mechanism, not speculation. Two-part structure:
+1. Define `SpeechEngineCapabilities` — field set DECIDED 2026-07-04
+   (design grilling; renamed from the original `EngineCapabilities` draft
+   to align with the `SpeechEnginePreference` naming family). Admission
+   test: a field earns a row only if it is a stable fact about the
+   engine/variant consulted by existing call sites — not a policy, not a
+   mechanism, not speculation. Two-part structure:
    - **Behavioral capabilities** (each kills existing switch sites):
      `supportsNativeLiveDictation` (backed by the NativeLiveDictating
      conformance invariant), `supportsTailPreview`,
@@ -97,6 +98,30 @@ dry run (add a fake variant in a test) touches registry + adapter only
 lifecycle helpers stay enum-backed for now and still enumerate cases;
 collapsing those is a later variant-model abstraction, not Phase A. No
 behavior change (characterization suites green).
+
+Phase A completion evidence (2026-07-04):
+
+- Capability source: `Sources/MacParakeetCore/STT/SpeechEngineCapabilities.swift`
+  declares the registry, rows, language policy, model lifecycle, and telemetry
+  identity; `Tests/MacParakeetTests/STT/SpeechEngineCapabilitiesTests.swift`
+  covers totality and core invariants.
+- Read-only adoption: runtime live/preview/readiness/telemetry/default-language
+  gates, scheduler live admission and leases, DictationService preview gating,
+  MeetingRecordingService live-chunk gating, Settings model/copy surfaces, and
+  CLI model/transcribe checks now read `SpeechEngineCapabilityRegistry`.
+- New-variant dry run: `MeetingRecordingServiceTests.testMeetingLivePreviewDryRunUsesInjectedCapabilitiesForNextVariant`
+  injects a synthetic `dry-run-next-variant` capability payload into the
+  meeting live-chunk read site and routes that chunk through the lease
+  selection. This intentionally leaves persisted variant enums, defaults
+  bridging, and model-lifecycle enumeration unchanged; a real persisted
+  variant still updates those enum-backed surfaces outside this read-site dry
+  run.
+- Characterization coverage: `SpeechEngineCapabilitiesTests`,
+  `SpeechEnginePreferenceTests`, `STTSchedulerTests`, `DictationServiceTests`,
+  `MeetingRecordingServiceTests`, `AppEnvironmentTests`,
+  `EngineSettingsViewModelTests`, `SettingsStatusRulesTests`,
+  `ModelLifecycleCommandTests`, `TranscribeCommandTests`, and
+  `RetranscribeCommandTests`.
 
 ### Phase B — wrap the optional engines as full adapters
 


### PR DESCRIPTION
## Summary
- Marks `plans/active/2026-07-03-stt-capability-registry.md` Phase A as done and updates the planned type name to `SpeechEngineCapabilities` after the design-review rename.
- Adds Phase A exit-criteria evidence for registry source, read-site adoption, characterization coverage, and the synthetic next-variant dry run.
- Adds `MeetingRecordingServiceTests.testMeetingLivePreviewDryRunUsesInjectedCapabilitiesForNextVariant` to prove a new-variant-style capability payload can drive a meeting live-chunk read site through lease capabilities without changing persisted variant enums/defaults/model-lifecycle enumeration.

## Plan Section
Implements the final PR from `plans/active/2026-07-03-stt-capability-registry.md`: Phase A status -> done, with exit-criteria evidence and the new-variant dry-run test.

## Deviations
None.

## Verification
- `swift test --filter 'MeetingRecordingServiceTests/testMeetingLivePreviewDryRunUsesInjectedCapabilitiesForNextVariant|MeetingRecordingServiceTests/testCohereMeetingDoesNotRouteLivePreviewChunks|MeetingRecordingServiceTests/testMeetingLivePreviewUsesLeaseCapabilities'`
- `swift test --filter 'SpeechEngineCapabilitiesTests|SpeechEnginePreferenceTests|STTSchedulerTests|DictationServiceTests|MeetingRecordingServiceTests|AppEnvironmentTests|EngineSettingsViewModelTests|SettingsStatusRulesTests|ModelLifecycleCommandTests|TranscribeCommandTests|RetranscribeCommandTests'`
- `swift test` (run before review-fix amend as the one local full-suite Phase A gate; amended head is covered by GitHub `swift-test` checks)
- `git diff --check`
