### PR TITLE
Integrate Parakeet custom vocabulary boosting

### DIFF
--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -125,6 +125,13 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
 
 ### Changed
 
+- `transcribe` / `retranscribe` now apply local recognition-time custom
+  vocabulary boosting when the selected engine is Parakeet TDT (`v3` or `v2`)
+  and enabled `vocab words` entries have no replacement text. Unsupported
+  engines and empty vocabularies keep the previous unboosted path.
+- Human-readable `vocab words list` output now reports whether the current
+  app-default engine supports recognition-time vocabulary boosting. `--json`
+  output is unchanged.
 - `meetings export --format md --stdout` now uses the same shared Markdown
   renderer as `meeting.md`, including YAML frontmatter, notes, transcript,
   prompt-result index, artifact paths, and `speakerLabelsIncluded` metadata.

--- a/Sources/CLI/Commands/RetranscribeCommand.swift
+++ b/Sources/CLI/Commands/RetranscribeCommand.swift
@@ -239,7 +239,8 @@ struct RetranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding 
                 parakeetModelVariant: parakeetVariant,
                 speechEngine: speechEngine.engine,
                 nemotronModelVariant: nemotronVariant,
-                defaults: defaults
+                defaults: defaults,
+                customWordRepository: customWordRepo
             )
             sttClient = client
 

--- a/Sources/CLI/Commands/SpecCommand.swift
+++ b/Sources/CLI/Commands/SpecCommand.swift
@@ -739,7 +739,7 @@ private extension CLISpecCommand {
                 CLISpecParameter.option("--source", valueName: "all|manual|learned", summary: "Filter by source."),
                 databaseOption,
             ],
-            output: "Array of CustomWord objects."
+            output: "Array of CustomWord objects for --json; human output also reports recognition-boosting support for the current app-default engine."
         ),
         CLISpecCommand(
             ["vocab", "words", "add"],
@@ -748,7 +748,7 @@ private extension CLISpecCommand {
             jsonMode: "none",
             arguments: [
                 .argument("word", summary: "Word or phrase to match."),
-                .argument("replacement", required: false, summary: "Replacement text; omit for vocabulary anchor."),
+                .argument("replacement", required: false, summary: "Replacement text; omit for a vocabulary anchor that can boost supported Parakeet TDT recognition."),
             ],
             options: [databaseOption],
             output: "Human-readable add confirmation."

--- a/Sources/CLI/Commands/TranscribeCommand.swift
+++ b/Sources/CLI/Commands/TranscribeCommand.swift
@@ -501,7 +501,8 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
                 )
                 let createdSTTClient = STTClient(
                     parakeetModelVariant: parakeetVariant,
-                    defaults: defaults
+                    defaults: defaults,
+                    customWordRepository: customWordRepo
                 )
                 sttClient = createdSTTClient
                 sttTranscriber = createdSTTClient

--- a/Sources/CLI/Commands/VocabWordsCommand.swift
+++ b/Sources/CLI/Commands/VocabWordsCommand.swift
@@ -15,6 +15,19 @@ struct VocabWordsCommand: AsyncParsableCommand {
         defaultSubcommand: ListWords.self
     )
 
+    static func recognitionBoostingStatusLine(
+        defaults: UserDefaults = macParakeetAppDefaults()
+    ) -> String {
+        let capabilities = SpeechEngineCapabilityRegistry.capabilities(
+            for: SpeechEnginePreference.current(defaults: defaults),
+            parakeetModelVariant: SpeechEnginePreference.parakeetModelVariant(defaults: defaults),
+            nemotronModelVariant: SpeechEnginePreference.nemotronModelVariant(defaults: defaults),
+            whisperModelVariant: SpeechEnginePreference.whisperModelVariant(defaults: defaults)
+        )
+        let status = CustomVocabularyBoostingPresentation.status(for: capabilities)
+        return "Custom vocabulary: \(status.title) - \(status.detail)"
+    }
+
     struct ListWords: AsyncParsableCommand {
         static let configuration = CommandConfiguration(
             commandName: "list",
@@ -54,18 +67,21 @@ struct VocabWordsCommand: AsyncParsableCommand {
 
                 if words.isEmpty {
                     print("No custom words configured.")
+                    print(VocabWordsCommand.recognitionBoostingStatusLine())
                     return
                 }
 
                 for word in words {
                     let status = word.isEnabled ? "+" : "-"
-                    if let replacement = word.replacement {
+                    if let replacement = word.replacement?.trimmingCharacters(in: .whitespacesAndNewlines),
+                       !replacement.isEmpty {
                         print("[\(status)] \(word.word) -> \(replacement)  [\(word.source.rawValue)]  (\(word.id.uuidString.prefix(8)))")
                     } else {
                         print("[\(status)] \(word.word) (anchor)  [\(word.source.rawValue)]  (\(word.id.uuidString.prefix(8)))")
                     }
                 }
                 print("\n\(words.count) word(s)")
+                print(VocabWordsCommand.recognitionBoostingStatusLine())
             }
         }
     }

--- a/Sources/MacParakeet/App/AppEnvironment.swift
+++ b/Sources/MacParakeet/App/AppEnvironment.swift
@@ -86,7 +86,8 @@ final class AppEnvironment {
             parakeetModelVariant: SpeechEnginePreference.parakeetModelVariant(),
             speechEngine: SpeechEnginePreference.current(),
             nemotronModelVariant: SpeechEnginePreference.nemotronModelVariant(),
-            whisperModelVariant: SpeechEnginePreference.whisperModelVariant()
+            whisperModelVariant: SpeechEnginePreference.whisperModelVariant(),
+            customVocabularyProvider: RepositoryCustomVocabularyBoostingTermProvider(repository: customWordRepo)
         )
         sttScheduler = STTScheduler(runtime: sttRuntime)
         // Ship raw meeting mic capture by default. VPIO remains available for

--- a/Sources/MacParakeet/Views/Vocabulary/CustomWordsView.swift
+++ b/Sources/MacParakeet/Views/Vocabulary/CustomWordsView.swift
@@ -4,6 +4,8 @@ import MacParakeetViewModels
 
 struct CustomWordsView: View {
     @Bindable var viewModel: CustomWordsViewModel
+    var recognitionStatus: CustomVocabularyBoostingSupportPresentation =
+        CustomVocabularyBoostingPresentation.status(for: .parakeet(.v3))
     @Environment(\.dismiss) private var dismiss
     @State private var hoveredWordID: UUID?
     @FocusState private var wordFieldFocused: Bool
@@ -16,7 +18,7 @@ struct CustomWordsView: View {
 
             VocabSheetHeader(
                 title: "Custom Words",
-                subtitle: "Teach MacParakeet how you say things.",
+                subtitle: recognitionStatus.detail,
                 onDone: { dismiss() }
             )
 
@@ -159,7 +161,10 @@ struct CustomWordsView: View {
 
     private func wordRow(_ word: CustomWord) -> some View {
         let isHovered = hoveredWordID == word.id
-        let toggleHint: String = word.replacement.map { "Replaces with \($0)" } ?? "Enforces exact spelling"
+        let trimmedReplacement = word.replacement?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let toggleHint: String = trimmedReplacement.isEmpty
+            ? "Enforces exact spelling"
+            : "Replaces with \(trimmedReplacement)"
         return HStack(spacing: DesignSystem.Spacing.md) {
             Toggle("", isOn: Binding(
                 get: { word.isEnabled },
@@ -176,8 +181,8 @@ struct CustomWordsView: View {
                     .font(DesignSystem.Typography.body)
                     .opacity(word.isEnabled ? 1.0 : 0.55)
 
-                if let replacement = word.replacement {
-                    Text("Replaces with: \(replacement)")
+                if !trimmedReplacement.isEmpty {
+                    Text("Replaces with: \(trimmedReplacement)")
                         .font(DesignSystem.Typography.caption)
                         .foregroundStyle(.secondary)
                 } else {

--- a/Sources/MacParakeet/Views/Vocabulary/CustomWordsView.swift
+++ b/Sources/MacParakeet/Views/Vocabulary/CustomWordsView.swift
@@ -4,8 +4,7 @@ import MacParakeetViewModels
 
 struct CustomWordsView: View {
     @Bindable var viewModel: CustomWordsViewModel
-    var recognitionStatus: CustomVocabularyBoostingSupportPresentation =
-        CustomVocabularyBoostingPresentation.status(for: .parakeet(.v3))
+    var recognitionStatus: CustomVocabularyBoostingSupportPresentation
     @Environment(\.dismiss) private var dismiss
     @State private var hoveredWordID: UUID?
     @FocusState private var wordFieldFocused: Bool

--- a/Sources/MacParakeet/Views/Vocabulary/VocabularyView.swift
+++ b/Sources/MacParakeet/Views/Vocabulary/VocabularyView.swift
@@ -44,7 +44,10 @@ struct VocabularyView: View {
         .sheet(isPresented: $showCustomWords) {
             settingsViewModel.refreshStats()
         } content: {
-            CustomWordsView(viewModel: customWordsViewModel)
+            CustomWordsView(
+                viewModel: customWordsViewModel,
+                recognitionStatus: settingsViewModel.customVocabularyRecognitionStatus
+            )
                 .frame(width: 640, height: 560)
         }
         .sheet(isPresented: $showTextSnippets) {
@@ -134,7 +137,7 @@ struct VocabularyView: View {
                 pipelineStep(
                     number: 2,
                     title: "Fix words",
-                    detail: "\(settingsViewModel.customWordCount) custom correction\(settingsViewModel.customWordCount == 1 ? "" : "s")",
+                    detail: "\(customWordCountLabel) · \(settingsViewModel.customVocabularyRecognitionStatus.title)",
                     actionTitle: "Manage words",
                     action: {
                         customWordsViewModel.loadWords()
@@ -167,6 +170,10 @@ struct VocabularyView: View {
             }
             .padding(.top, 2)
         }
+    }
+
+    private var customWordCountLabel: String {
+        "\(settingsViewModel.customWordCount) custom correction\(settingsViewModel.customWordCount == 1 ? "" : "s")"
     }
 
     private var insertionStyleRow: some View {

--- a/Sources/MacParakeetCore/STT/CustomVocabularyBoosting.swift
+++ b/Sources/MacParakeetCore/STT/CustomVocabularyBoosting.swift
@@ -1,0 +1,353 @@
+import FluidAudio
+import Foundation
+import os
+
+public enum CustomVocabularyBoostingConfiguration {
+    /// Phase 0 showed this stricter gate kept OOV recall at 74% while keeping
+    /// LibriSpeech `test-clean` WER within +0.102 pt; see
+    /// `docs/research/2026-07-04-custom-vocab-phase0.md`.
+    public static let minSimilarity: Float = 0.65
+    public static let minTermLength: Int = 3
+    /// Product v1 avoids loading multi-hour file/meeting audio into RAM for the
+    /// sidecar. Longer jobs keep FluidAudio's URL-backed TDT path and skip
+    /// boosting until chunked sidecar rescoring lands.
+    public static let maxSidecarAudioSeconds: Double = 5 * 60
+
+    static var maxSidecarSampleCount: Int {
+        Int(maxSidecarAudioSeconds * Double(ASRConstants.sampleRate))
+    }
+}
+
+public struct CustomVocabularyBoostingSupportPresentation: Equatable, Sendable {
+    public let title: String
+    public let detail: String
+
+    public init(title: String, detail: String) {
+        self.title = title
+        self.detail = detail
+    }
+}
+
+public enum CustomVocabularyBoostingPresentation {
+    public static func status(for capabilities: SpeechEngineCapabilities?)
+        -> CustomVocabularyBoostingSupportPresentation
+    {
+        guard let capabilities else {
+            return CustomVocabularyBoostingSupportPresentation(
+                title: "Clean corrections only",
+                detail:
+                    "This engine does not support recognition-time vocabulary boosting; enabled rules still run after transcription."
+            )
+        }
+        return status(for: capabilities)
+    }
+
+    public static func status(for capabilities: SpeechEngineCapabilities) -> CustomVocabularyBoostingSupportPresentation
+    {
+        if capabilities.supportsCustomVocabulary {
+            return CustomVocabularyBoostingSupportPresentation(
+                title: "Recognition boosting on",
+                detail:
+                    "Enabled anchors boost Parakeet TDT recognition; replacement rules still run after transcription."
+            )
+        }
+
+        return CustomVocabularyBoostingSupportPresentation(
+            title: "Clean corrections only",
+            detail:
+                "\(displayName(for: capabilities.key)) does not support recognition-time vocabulary boosting; enabled rules still run after transcription."
+        )
+    }
+
+    public static func status(for key: SpeechEngineVariantKey) -> CustomVocabularyBoostingSupportPresentation {
+        status(for: SpeechEngineCapabilityRegistry.capabilities(for: key))
+    }
+
+    private static func displayName(for key: SpeechEngineVariantKey) -> String {
+        switch key {
+        case .parakeet(let variant):
+            "Parakeet \(variant.displayName)"
+        case .nemotron(let variant):
+            "Nemotron \(variant.displayName)"
+        case .whisper(let variant):
+            "Whisper \(variant.displayName)"
+        case .cohere:
+            "Cohere"
+        }
+    }
+}
+
+public struct CustomVocabularyBoostingVocabulary: Equatable, Sendable {
+    public static let empty = CustomVocabularyBoostingVocabulary(terms: [])
+
+    public let terms: [String]
+    public let contentHash: String
+
+    public var isEmpty: Bool { terms.isEmpty }
+
+    public init(terms: [String]) {
+        self.terms = Self.canonicalTerms(terms)
+        self.contentHash = Self.contentHash(for: self.terms)
+    }
+
+    public static func mapping(
+        from words: [CustomWord],
+        minTermLength: Int = CustomVocabularyBoostingConfiguration.minTermLength
+    ) -> CustomVocabularyBoostingVocabulary {
+        CustomVocabularyBoostingVocabulary(
+            terms: words.compactMap { word in
+                guard word.isEnabled else { return nil }
+                if let replacement = word.replacement,
+                    !replacement.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                {
+                    return nil
+                }
+
+                let term = word.word.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard term.count >= minTermLength else { return nil }
+                return term
+            }
+        )
+    }
+
+    private static func canonicalTerms(_ terms: [String]) -> [String] {
+        struct Entry {
+            let key: String
+            let text: String
+        }
+
+        var byKey: [String: String] = [:]
+        for rawTerm in terms {
+            let term = rawTerm.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !term.isEmpty else { continue }
+            let key = term.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: nil)
+            if byKey[key] == nil {
+                byKey[key] = term
+            }
+        }
+        return
+            byKey
+            .map { Entry(key: $0.key, text: $0.value) }
+            .sorted { $0.key < $1.key }
+            .map(\.text)
+    }
+
+    private static func contentHash(for terms: [String]) -> String {
+        var hash: UInt64 = 0xcbf29ce484222325
+        for term in terms {
+            for byte in term.utf8 {
+                hash ^= UInt64(byte)
+                hash &*= 0x100000001b3
+            }
+            hash ^= 0xff
+            hash &*= 0x100000001b3
+        }
+        return String(format: "%016llx", hash)
+    }
+}
+
+public protocol CustomVocabularyBoostingTermProviding: Sendable {
+    func currentVocabulary() async -> CustomVocabularyBoostingVocabulary
+}
+
+public struct CustomVocabularyRescoringRequest: Sendable {
+    public let transcript: String
+    public let tokenTimings: [TokenTiming]?
+    public let audioSamples: [Float]
+    public let vocabulary: CustomVocabularyBoostingVocabulary
+
+    public init(
+        transcript: String,
+        tokenTimings: [TokenTiming]?,
+        audioSamples: [Float],
+        vocabulary: CustomVocabularyBoostingVocabulary
+    ) {
+        self.transcript = transcript
+        self.tokenTimings = tokenTimings
+        self.audioSamples = audioSamples
+        self.vocabulary = vocabulary
+    }
+}
+
+public struct CustomVocabularyRescoringResult: Sendable {
+    public let text: String
+    public let detectedTerms: [String]
+    public let appliedTerms: [String]
+    public let replacementCount: Int
+
+    public init(
+        text: String,
+        detectedTerms: [String],
+        appliedTerms: [String],
+        replacementCount: Int
+    ) {
+        self.text = text
+        self.detectedTerms = detectedTerms
+        self.appliedTerms = appliedTerms
+        self.replacementCount = replacementCount
+    }
+}
+
+public protocol CustomVocabularyRescoring: Sendable {
+    func rescore(_ request: CustomVocabularyRescoringRequest) async throws -> CustomVocabularyRescoringResult
+}
+
+public struct RepositoryCustomVocabularyBoostingTermProvider: CustomVocabularyBoostingTermProviding {
+    private let repository: any CustomWordRepositoryProtocol
+    private let logger = Logger(subsystem: "com.macparakeet.core", category: "CustomVocabulary")
+
+    public init(repository: any CustomWordRepositoryProtocol) {
+        self.repository = repository
+    }
+
+    public func currentVocabulary() async -> CustomVocabularyBoostingVocabulary {
+        do {
+            return CustomVocabularyBoostingVocabulary.mapping(from: try repository.fetchEnabled())
+        } catch {
+            logger.warning(
+                "custom_vocabulary_fetch_failed error_type=\(String(describing: type(of: error)), privacy: .public)"
+            )
+            return .empty
+        }
+    }
+}
+
+public actor FluidAudioCustomVocabularyRescorer: CustomVocabularyRescoring {
+    private struct CachedVocabulary: Sendable {
+        let hash: String
+        let context: CustomVocabularyContext
+        let spotter: CtcKeywordSpotter
+        let rescorer: VocabularyRescorer
+        let cbw: Float
+        let marginSeconds: Double
+    }
+
+    private let logger = Logger(subsystem: "com.macparakeet.core", category: "CustomVocabulary")
+    private var cachedVocabulary: CachedVocabulary?
+
+    public init() {}
+
+    public func rescore(_ request: CustomVocabularyRescoringRequest) async throws -> CustomVocabularyRescoringResult {
+        guard !request.vocabulary.isEmpty,
+            !request.audioSamples.isEmpty,
+            let tokenTimings = request.tokenTimings,
+            !tokenTimings.isEmpty
+        else {
+            return CustomVocabularyRescoringResult(
+                text: request.transcript,
+                detectedTerms: [],
+                appliedTerms: [],
+                replacementCount: 0
+            )
+        }
+
+        let components = try await components(for: request.vocabulary)
+        guard !components.context.terms.isEmpty else {
+            return CustomVocabularyRescoringResult(
+                text: request.transcript,
+                detectedTerms: [],
+                appliedTerms: [],
+                replacementCount: 0
+            )
+        }
+
+        let spotResult = try await components.spotter.spotKeywordsWithLogProbs(
+            audioSamples: request.audioSamples,
+            customVocabulary: components.context,
+            minScore: nil
+        )
+
+        guard !spotResult.logProbs.isEmpty else {
+            return CustomVocabularyRescoringResult(
+                text: request.transcript,
+                detectedTerms: [],
+                appliedTerms: [],
+                replacementCount: 0
+            )
+        }
+
+        let output = components.rescorer.ctcTokenRescore(
+            transcript: request.transcript,
+            tokenTimings: tokenTimings,
+            logProbs: spotResult.logProbs,
+            frameDuration: spotResult.frameDuration,
+            cbw: components.cbw,
+            marginSeconds: components.marginSeconds,
+            minSimilarity: CustomVocabularyBoostingConfiguration.minSimilarity
+        )
+        let detected = Self.uniquePreservingOrder(spotResult.detections.map { $0.term.text })
+        let applied = Self.uniquePreservingOrder(
+            output.replacements.compactMap { replacement in
+                replacement.shouldReplace ? replacement.replacementWord : nil
+            }
+        )
+
+        if output.wasModified {
+            logger.info(
+                "custom_vocabulary_boost_applied terms=\(request.vocabulary.terms.count, privacy: .public) replacements=\(applied.count, privacy: .public)"
+            )
+        }
+
+        return CustomVocabularyRescoringResult(
+            text: output.text,
+            detectedTerms: detected,
+            appliedTerms: applied,
+            replacementCount: output.replacements.filter(\.shouldReplace).count
+        )
+    }
+
+    private func components(for vocabulary: CustomVocabularyBoostingVocabulary) async throws -> CachedVocabulary {
+        if let cachedVocabulary, cachedVocabulary.hash == vocabulary.contentHash {
+            return cachedVocabulary
+        }
+
+        let ctcModels = try await CtcModels.downloadAndLoad(variant: .ctc110m)
+        let ctcModelDirectory = CtcModels.defaultCacheDirectory(for: ctcModels.variant)
+        let tokenizer = try await CtcTokenizer.load(from: ctcModelDirectory)
+        let tokenizedTerms = vocabulary.terms.compactMap { term -> CustomVocabularyTerm? in
+            let tokenIds = tokenizer.encode(term)
+            guard !tokenIds.isEmpty else { return nil }
+            return CustomVocabularyTerm(
+                text: term,
+                weight: 10.0,
+                aliases: nil,
+                tokenIds: nil,
+                ctcTokenIds: tokenIds
+            )
+        }
+
+        let context = CustomVocabularyContext(
+            terms: tokenizedTerms,
+            minSimilarity: CustomVocabularyBoostingConfiguration.minSimilarity,
+            minTermLength: CustomVocabularyBoostingConfiguration.minTermLength
+        )
+        let spotter = CtcKeywordSpotter(models: ctcModels, blankId: ctcModels.vocabulary.count)
+        let rescorer = try await VocabularyRescorer.create(
+            spotter: spotter,
+            vocabulary: context,
+            config: .default,
+            ctcModelDirectory: ctcModelDirectory
+        )
+        let sizeConfig = ContextBiasingConstants.rescorerConfig(forVocabSize: context.terms.count)
+        let cached = CachedVocabulary(
+            hash: vocabulary.contentHash,
+            context: context,
+            spotter: spotter,
+            rescorer: rescorer,
+            cbw: sizeConfig.cbw,
+            marginSeconds: ContextBiasingConstants.defaultMarginSeconds
+        )
+        cachedVocabulary = cached
+        logger.info("custom_vocabulary_boost_loaded terms=\(context.terms.count, privacy: .public)")
+        return cached
+    }
+
+    private static func uniquePreservingOrder(_ values: [String]) -> [String] {
+        var seen = Set<String>()
+        var result: [String] = []
+        for value in values where seen.insert(value).inserted {
+            result.append(value)
+        }
+        return result
+    }
+}

--- a/Sources/MacParakeetCore/STT/CustomVocabularyBoosting.swift
+++ b/Sources/MacParakeetCore/STT/CustomVocabularyBoosting.swift
@@ -299,10 +299,11 @@ public actor FluidAudioCustomVocabularyRescorer: CustomVocabularyRescoring {
                 replacement.shouldReplace ? replacement.replacementWord : nil
             }
         )
+        let replacementCount = output.replacements.filter(\.shouldReplace).count
 
         if output.wasModified {
             logger.info(
-                "custom_vocabulary_boost_applied terms=\(request.vocabulary.terms.count, privacy: .public) replacements=\(applied.count, privacy: .public)"
+                "custom_vocabulary_boost_applied terms=\(request.vocabulary.terms.count, privacy: .public) replacements=\(replacementCount, privacy: .public)"
             )
         }
 
@@ -310,7 +311,7 @@ public actor FluidAudioCustomVocabularyRescorer: CustomVocabularyRescoring {
             text: output.text,
             detectedTerms: detected,
             appliedTerms: applied,
-            replacementCount: output.replacements.filter(\.shouldReplace).count
+            replacementCount: replacementCount
         )
     }
 

--- a/Sources/MacParakeetCore/STT/CustomVocabularyBoosting.swift
+++ b/Sources/MacParakeetCore/STT/CustomVocabularyBoosting.swift
@@ -116,20 +116,25 @@ public struct CustomVocabularyBoostingVocabulary: Equatable, Sendable {
             let text: String
         }
 
-        var byKey: [String: String] = [:]
-        for rawTerm in terms {
-            let term = rawTerm.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !term.isEmpty else { continue }
-            let key = term.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: nil)
-            if byKey[key] == nil {
-                byKey[key] = term
-            }
-        }
+        var seenKeys: Set<String> = []
         return
-            byKey
-            .map { Entry(key: $0.key, text: $0.value) }
-            .sorted { $0.key < $1.key }
-            .map(\.text)
+            terms
+            .compactMap { rawTerm -> Entry? in
+                let term = rawTerm.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !term.isEmpty else { return nil }
+                let key = term.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: nil)
+                return Entry(key: key, text: term)
+            }
+            .sorted {
+                if $0.key != $1.key {
+                    return $0.key < $1.key
+                }
+                return $0.text < $1.text
+            }
+            .compactMap { entry in
+                guard seenKeys.insert(entry.key).inserted else { return nil }
+                return entry.text
+            }
     }
 
     private static func contentHash(for terms: [String]) -> String {
@@ -189,7 +194,16 @@ public struct CustomVocabularyRescoringResult: Sendable {
 }
 
 public protocol CustomVocabularyRescoring: Sendable {
+    func prepare(vocabulary: CustomVocabularyBoostingVocabulary) async throws
     func rescore(_ request: CustomVocabularyRescoringRequest) async throws -> CustomVocabularyRescoringResult
+}
+
+public extension CustomVocabularyRescoring {
+    func prepare(vocabulary: CustomVocabularyBoostingVocabulary) async throws {}
+}
+
+public enum CustomVocabularyBoostingError: Error, Sendable {
+    case emptyTokenizedVocabulary
 }
 
 public struct RepositoryCustomVocabularyBoostingTermProvider: CustomVocabularyBoostingTermProviding {
@@ -223,9 +237,14 @@ public actor FluidAudioCustomVocabularyRescorer: CustomVocabularyRescoring {
     }
 
     private let logger = Logger(subsystem: "com.macparakeet.core", category: "CustomVocabulary")
-    private var cachedVocabulary: CachedVocabulary?
+    private var cachedVocabularies: [String: CachedVocabulary] = [:]
 
     public init() {}
+
+    public func prepare(vocabulary: CustomVocabularyBoostingVocabulary) async throws {
+        guard !vocabulary.isEmpty else { return }
+        _ = try await components(for: vocabulary)
+    }
 
     public func rescore(_ request: CustomVocabularyRescoringRequest) async throws -> CustomVocabularyRescoringResult {
         guard !request.vocabulary.isEmpty,
@@ -242,15 +261,6 @@ public actor FluidAudioCustomVocabularyRescorer: CustomVocabularyRescoring {
         }
 
         let components = try await components(for: request.vocabulary)
-        guard !components.context.terms.isEmpty else {
-            return CustomVocabularyRescoringResult(
-                text: request.transcript,
-                detectedTerms: [],
-                appliedTerms: [],
-                replacementCount: 0
-            )
-        }
-
         let spotResult = try await components.spotter.spotKeywordsWithLogProbs(
             audioSamples: request.audioSamples,
             customVocabulary: components.context,
@@ -297,7 +307,7 @@ public actor FluidAudioCustomVocabularyRescorer: CustomVocabularyRescoring {
     }
 
     private func components(for vocabulary: CustomVocabularyBoostingVocabulary) async throws -> CachedVocabulary {
-        if let cachedVocabulary, cachedVocabulary.hash == vocabulary.contentHash {
+        if let cachedVocabulary = cachedVocabularies[vocabulary.contentHash] {
             return cachedVocabulary
         }
 
@@ -314,6 +324,9 @@ public actor FluidAudioCustomVocabularyRescorer: CustomVocabularyRescoring {
                 tokenIds: nil,
                 ctcTokenIds: tokenIds
             )
+        }
+        guard !tokenizedTerms.isEmpty else {
+            throw CustomVocabularyBoostingError.emptyTokenizedVocabulary
         }
 
         let context = CustomVocabularyContext(
@@ -337,7 +350,7 @@ public actor FluidAudioCustomVocabularyRescorer: CustomVocabularyRescoring {
             cbw: sizeConfig.cbw,
             marginSeconds: ContextBiasingConstants.defaultMarginSeconds
         )
-        cachedVocabulary = cached
+        cachedVocabularies[vocabulary.contentHash] = cached
         logger.info("custom_vocabulary_boost_loaded terms=\(context.terms.count, privacy: .public)")
         return cached
     }

--- a/Sources/MacParakeetCore/STT/CustomVocabularyBoosting.swift
+++ b/Sources/MacParakeetCore/STT/CustomVocabularyBoosting.swift
@@ -196,11 +196,13 @@ public struct CustomVocabularyRescoringResult: Sendable {
 }
 
 public protocol CustomVocabularyRescoring: Sendable {
+    func isPrepared(vocabulary: CustomVocabularyBoostingVocabulary) async -> Bool
     func prepare(vocabulary: CustomVocabularyBoostingVocabulary) async throws
     func rescore(_ request: CustomVocabularyRescoringRequest) async throws -> CustomVocabularyRescoringResult
 }
 
 public extension CustomVocabularyRescoring {
+    func isPrepared(vocabulary: CustomVocabularyBoostingVocabulary) async -> Bool { true }
     func prepare(vocabulary: CustomVocabularyBoostingVocabulary) async throws {}
 }
 
@@ -257,6 +259,10 @@ public actor FluidAudioCustomVocabularyRescorer: CustomVocabularyRescoring {
     public func prepare(vocabulary: CustomVocabularyBoostingVocabulary) async throws {
         guard !vocabulary.isEmpty else { return }
         _ = try await components(for: vocabulary)
+    }
+
+    public func isPrepared(vocabulary: CustomVocabularyBoostingVocabulary) async -> Bool {
+        vocabulary.isEmpty || cachedVocabularies[vocabulary.contentHash] != nil
     }
 
     public func rescore(_ request: CustomVocabularyRescoringRequest) async throws -> CustomVocabularyRescoringResult {

--- a/Sources/MacParakeetCore/STT/CustomVocabularyBoosting.swift
+++ b/Sources/MacParakeetCore/STT/CustomVocabularyBoosting.swift
@@ -247,7 +247,9 @@ public actor FluidAudioCustomVocabularyRescorer: CustomVocabularyRescoring {
 
     private let logger = Logger(subsystem: "com.macparakeet.core", category: "CustomVocabulary")
     private var cachedResources: CtcResources?
+    private var resourceLoadTask: Task<CtcResources, Error>?
     private var cachedVocabularies: [String: CachedVocabulary] = [:]
+    private var cachedVocabularyLoadTasks: [String: Task<CachedVocabulary, Error>] = [:]
     private var cachedVocabularyOrder: [String] = []
 
     public init() {}
@@ -327,8 +329,83 @@ public actor FluidAudioCustomVocabularyRescorer: CustomVocabularyRescoring {
             return cachedVocabulary
         }
 
+        let hash = vocabulary.contentHash
+        if let loadTask = cachedVocabularyLoadTasks[hash] {
+            let cachedVocabulary = try await loadTask.value
+            rememberCachedVocabularyHash(hash)
+            return cachedVocabulary
+        }
+
         try Task.checkCancellation()
-        let resources = try await ctcResources()
+        let loadTask = Task {
+            let resources = try await self.ctcResources()
+            return try await Self.makeCachedVocabulary(
+                vocabulary: vocabulary,
+                resources: resources
+            )
+        }
+        cachedVocabularyLoadTasks[hash] = loadTask
+
+        do {
+            let cachedVocabulary = try await loadTask.value
+            cachedVocabularyLoadTasks.removeValue(forKey: hash)
+            cachedVocabularies[hash] = cachedVocabulary
+            rememberCachedVocabularyHash(hash)
+            evictStaleCachedVocabularies()
+            logger.info(
+                "custom_vocabulary_boost_loaded terms=\(cachedVocabulary.context.terms.count, privacy: .public)"
+            )
+            return cachedVocabulary
+        } catch {
+            cachedVocabularyLoadTasks.removeValue(forKey: hash)
+            throw error
+        }
+    }
+
+    private func ctcResources() async throws -> CtcResources {
+        if let cachedResources {
+            return cachedResources
+        }
+
+        if let resourceLoadTask {
+            return try await resourceLoadTask.value
+        }
+
+        let loadTask = Task {
+            try await Self.loadCtcResources()
+        }
+        resourceLoadTask = loadTask
+
+        do {
+            let resources = try await loadTask.value
+            cachedResources = resources
+            resourceLoadTask = nil
+            return resources
+        } catch {
+            resourceLoadTask = nil
+            throw error
+        }
+    }
+
+    private static func loadCtcResources() async throws -> CtcResources {
+        try Task.checkCancellation()
+        let models = try await CtcModels.downloadAndLoad(variant: .ctc110m)
+        try Task.checkCancellation()
+        let modelDirectory = CtcModels.defaultCacheDirectory(for: models.variant)
+        let tokenizer = try await CtcTokenizer.load(from: modelDirectory)
+        try Task.checkCancellation()
+        let resources = CtcResources(
+            models: models,
+            modelDirectory: modelDirectory,
+            tokenizer: tokenizer
+        )
+        return resources
+    }
+
+    private static func makeCachedVocabulary(
+        vocabulary: CustomVocabularyBoostingVocabulary,
+        resources: CtcResources
+    ) async throws -> CachedVocabulary {
         try Task.checkCancellation()
         let tokenizedTerms = vocabulary.terms.compactMap { term -> CustomVocabularyTerm? in
             let tokenIds = resources.tokenizer.encode(term)
@@ -359,7 +436,7 @@ public actor FluidAudioCustomVocabularyRescorer: CustomVocabularyRescoring {
         )
         try Task.checkCancellation()
         let sizeConfig = ContextBiasingConstants.rescorerConfig(forVocabSize: context.terms.count)
-        let cached = CachedVocabulary(
+        return CachedVocabulary(
             hash: vocabulary.contentHash,
             context: context,
             spotter: spotter,
@@ -367,31 +444,6 @@ public actor FluidAudioCustomVocabularyRescorer: CustomVocabularyRescoring {
             cbw: sizeConfig.cbw,
             marginSeconds: ContextBiasingConstants.defaultMarginSeconds
         )
-        cachedVocabularies[vocabulary.contentHash] = cached
-        rememberCachedVocabularyHash(vocabulary.contentHash)
-        evictStaleCachedVocabularies()
-        logger.info("custom_vocabulary_boost_loaded terms=\(context.terms.count, privacy: .public)")
-        return cached
-    }
-
-    private func ctcResources() async throws -> CtcResources {
-        if let cachedResources {
-            return cachedResources
-        }
-
-        try Task.checkCancellation()
-        let models = try await CtcModels.downloadAndLoad(variant: .ctc110m)
-        try Task.checkCancellation()
-        let modelDirectory = CtcModels.defaultCacheDirectory(for: models.variant)
-        let tokenizer = try await CtcTokenizer.load(from: modelDirectory)
-        try Task.checkCancellation()
-        let resources = CtcResources(
-            models: models,
-            modelDirectory: modelDirectory,
-            tokenizer: tokenizer
-        )
-        cachedResources = resources
-        return resources
     }
 
     private func rememberCachedVocabularyHash(_ hash: String) {

--- a/Sources/MacParakeetCore/STT/CustomVocabularyBoosting.swift
+++ b/Sources/MacParakeetCore/STT/CustomVocabularyBoosting.swift
@@ -13,7 +13,6 @@ public enum CustomVocabularyBoostingConfiguration {
     /// boosting until chunked sidecar rescoring lands.
     public static let maxSidecarAudioSeconds: Double = 5 * 60
     public static let termWeight: Float = 10.0
-    public static let maxBoundaryChangingTimingWordCount: Int = 8
     public static let maxCachedVocabularyEntries: Int = 3
 
     static var maxSidecarSampleCount: Int {
@@ -231,6 +230,12 @@ public struct RepositoryCustomVocabularyBoostingTermProvider: CustomVocabularyBo
 }
 
 public actor FluidAudioCustomVocabularyRescorer: CustomVocabularyRescoring {
+    private struct CtcResources: Sendable {
+        let models: CtcModels
+        let modelDirectory: URL
+        let tokenizer: CtcTokenizer
+    }
+
     private struct CachedVocabulary: Sendable {
         let hash: String
         let context: CustomVocabularyContext
@@ -241,6 +246,7 @@ public actor FluidAudioCustomVocabularyRescorer: CustomVocabularyRescoring {
     }
 
     private let logger = Logger(subsystem: "com.macparakeet.core", category: "CustomVocabulary")
+    private var cachedResources: CtcResources?
     private var cachedVocabularies: [String: CachedVocabulary] = [:]
     private var cachedVocabularyOrder: [String] = []
 
@@ -322,13 +328,10 @@ public actor FluidAudioCustomVocabularyRescorer: CustomVocabularyRescoring {
         }
 
         try Task.checkCancellation()
-        let ctcModels = try await CtcModels.downloadAndLoad(variant: .ctc110m)
-        try Task.checkCancellation()
-        let ctcModelDirectory = CtcModels.defaultCacheDirectory(for: ctcModels.variant)
-        let tokenizer = try await CtcTokenizer.load(from: ctcModelDirectory)
+        let resources = try await ctcResources()
         try Task.checkCancellation()
         let tokenizedTerms = vocabulary.terms.compactMap { term -> CustomVocabularyTerm? in
-            let tokenIds = tokenizer.encode(term)
+            let tokenIds = resources.tokenizer.encode(term)
             guard !tokenIds.isEmpty else { return nil }
             return CustomVocabularyTerm(
                 text: term,
@@ -347,12 +350,12 @@ public actor FluidAudioCustomVocabularyRescorer: CustomVocabularyRescoring {
             minSimilarity: CustomVocabularyBoostingConfiguration.minSimilarity,
             minTermLength: CustomVocabularyBoostingConfiguration.minTermLength
         )
-        let spotter = CtcKeywordSpotter(models: ctcModels, blankId: ctcModels.vocabulary.count)
+        let spotter = CtcKeywordSpotter(models: resources.models, blankId: resources.models.vocabulary.count)
         let rescorer = try await VocabularyRescorer.create(
             spotter: spotter,
             vocabulary: context,
             config: .default,
-            ctcModelDirectory: ctcModelDirectory
+            ctcModelDirectory: resources.modelDirectory
         )
         try Task.checkCancellation()
         let sizeConfig = ContextBiasingConstants.rescorerConfig(forVocabSize: context.terms.count)
@@ -369,6 +372,26 @@ public actor FluidAudioCustomVocabularyRescorer: CustomVocabularyRescoring {
         evictStaleCachedVocabularies()
         logger.info("custom_vocabulary_boost_loaded terms=\(context.terms.count, privacy: .public)")
         return cached
+    }
+
+    private func ctcResources() async throws -> CtcResources {
+        if let cachedResources {
+            return cachedResources
+        }
+
+        try Task.checkCancellation()
+        let models = try await CtcModels.downloadAndLoad(variant: .ctc110m)
+        try Task.checkCancellation()
+        let modelDirectory = CtcModels.defaultCacheDirectory(for: models.variant)
+        let tokenizer = try await CtcTokenizer.load(from: modelDirectory)
+        try Task.checkCancellation()
+        let resources = CtcResources(
+            models: models,
+            modelDirectory: modelDirectory,
+            tokenizer: tokenizer
+        )
+        cachedResources = resources
+        return resources
     }
 
     private func rememberCachedVocabularyHash(_ hash: String) {

--- a/Sources/MacParakeetCore/STT/CustomVocabularyBoosting.swift
+++ b/Sources/MacParakeetCore/STT/CustomVocabularyBoosting.swift
@@ -12,6 +12,8 @@ public enum CustomVocabularyBoostingConfiguration {
     /// sidecar. Longer jobs keep FluidAudio's URL-backed TDT path and skip
     /// boosting until chunked sidecar rescoring lands.
     public static let maxSidecarAudioSeconds: Double = 5 * 60
+    public static let termWeight: Float = 10.0
+    public static let maxBoundaryChangingTimingWordCount: Int = 8
 
     static var maxSidecarSampleCount: Int {
         Int(maxSidecarAudioSeconds * Double(ASRConstants.sampleRate))
@@ -204,6 +206,7 @@ public extension CustomVocabularyRescoring {
 
 public enum CustomVocabularyBoostingError: Error, Sendable {
     case emptyTokenizedVocabulary
+    case unpreparedVocabulary
 }
 
 public struct RepositoryCustomVocabularyBoostingTermProvider: CustomVocabularyBoostingTermProviding {
@@ -237,7 +240,7 @@ public actor FluidAudioCustomVocabularyRescorer: CustomVocabularyRescoring {
     }
 
     private let logger = Logger(subsystem: "com.macparakeet.core", category: "CustomVocabulary")
-    private var cachedVocabularies: [String: CachedVocabulary] = [:]
+    private var cachedVocabulary: CachedVocabulary?
 
     public init() {}
 
@@ -260,7 +263,12 @@ public actor FluidAudioCustomVocabularyRescorer: CustomVocabularyRescoring {
             )
         }
 
-        let components = try await components(for: request.vocabulary)
+        guard let components = cachedVocabulary,
+              components.hash == request.vocabulary.contentHash
+        else {
+            throw CustomVocabularyBoostingError.unpreparedVocabulary
+        }
+
         let spotResult = try await components.spotter.spotKeywordsWithLogProbs(
             audioSamples: request.audioSamples,
             customVocabulary: components.context,
@@ -307,7 +315,9 @@ public actor FluidAudioCustomVocabularyRescorer: CustomVocabularyRescoring {
     }
 
     private func components(for vocabulary: CustomVocabularyBoostingVocabulary) async throws -> CachedVocabulary {
-        if let cachedVocabulary = cachedVocabularies[vocabulary.contentHash] {
+        if let cachedVocabulary,
+           cachedVocabulary.hash == vocabulary.contentHash
+        {
             return cachedVocabulary
         }
 
@@ -319,7 +329,7 @@ public actor FluidAudioCustomVocabularyRescorer: CustomVocabularyRescoring {
             guard !tokenIds.isEmpty else { return nil }
             return CustomVocabularyTerm(
                 text: term,
-                weight: 10.0,
+                weight: CustomVocabularyBoostingConfiguration.termWeight,
                 aliases: nil,
                 tokenIds: nil,
                 ctcTokenIds: tokenIds
@@ -350,7 +360,7 @@ public actor FluidAudioCustomVocabularyRescorer: CustomVocabularyRescoring {
             cbw: sizeConfig.cbw,
             marginSeconds: ContextBiasingConstants.defaultMarginSeconds
         )
-        cachedVocabularies[vocabulary.contentHash] = cached
+        cachedVocabulary = cached
         logger.info("custom_vocabulary_boost_loaded terms=\(context.terms.count, privacy: .public)")
         return cached
     }

--- a/Sources/MacParakeetCore/STT/CustomVocabularyBoosting.swift
+++ b/Sources/MacParakeetCore/STT/CustomVocabularyBoosting.swift
@@ -337,13 +337,21 @@ public actor FluidAudioCustomVocabularyRescorer: CustomVocabularyRescoring {
 
         let hash = vocabulary.contentHash
         if let loadTask = cachedVocabularyLoadTasks[hash] {
-            let cachedVocabulary = try await loadTask.value
-            rememberCachedVocabularyHash(hash)
+            let cachedVocabulary: CachedVocabulary
+            do {
+                cachedVocabulary = try await loadTask.value
+            } catch {
+                if !(error is CancellationError) {
+                    cachedVocabularyLoadTasks.removeValue(forKey: hash)
+                }
+                throw error
+            }
+            storeCachedVocabulary(cachedVocabulary)
             return cachedVocabulary
         }
 
         try Task.checkCancellation()
-        let loadTask = Task {
+        let loadTask = Task.detached { [self, vocabulary] in
             let resources = try await self.ctcResources()
             return try await Self.makeCachedVocabulary(
                 vocabulary: vocabulary,
@@ -354,16 +362,18 @@ public actor FluidAudioCustomVocabularyRescorer: CustomVocabularyRescoring {
 
         do {
             let cachedVocabulary = try await loadTask.value
-            cachedVocabularyLoadTasks.removeValue(forKey: hash)
-            cachedVocabularies[hash] = cachedVocabulary
-            rememberCachedVocabularyHash(hash)
-            evictStaleCachedVocabularies()
-            logger.info(
-                "custom_vocabulary_boost_loaded terms=\(cachedVocabulary.context.terms.count, privacy: .public)"
-            )
+            let shouldLogLoad = cachedVocabularies[hash] == nil
+            storeCachedVocabulary(cachedVocabulary)
+            if shouldLogLoad {
+                logger.info(
+                    "custom_vocabulary_boost_loaded terms=\(cachedVocabulary.context.terms.count, privacy: .public)"
+                )
+            }
             return cachedVocabulary
         } catch {
-            cachedVocabularyLoadTasks.removeValue(forKey: hash)
+            if !(error is CancellationError) {
+                cachedVocabularyLoadTasks.removeValue(forKey: hash)
+            }
             throw error
         }
     }
@@ -374,10 +384,20 @@ public actor FluidAudioCustomVocabularyRescorer: CustomVocabularyRescoring {
         }
 
         if let resourceLoadTask {
-            return try await resourceLoadTask.value
+            do {
+                let resources = try await resourceLoadTask.value
+                cachedResources = resources
+                self.resourceLoadTask = nil
+                return resources
+            } catch {
+                if !(error is CancellationError) {
+                    self.resourceLoadTask = nil
+                }
+                throw error
+            }
         }
 
-        let loadTask = Task {
+        let loadTask = Task.detached {
             try await Self.loadCtcResources()
         }
         resourceLoadTask = loadTask
@@ -388,7 +408,9 @@ public actor FluidAudioCustomVocabularyRescorer: CustomVocabularyRescoring {
             resourceLoadTask = nil
             return resources
         } catch {
-            resourceLoadTask = nil
+            if !(error is CancellationError) {
+                resourceLoadTask = nil
+            }
             throw error
         }
     }
@@ -462,6 +484,14 @@ public actor FluidAudioCustomVocabularyRescorer: CustomVocabularyRescoring {
             let removed = cachedVocabularyOrder.removeFirst()
             cachedVocabularies.removeValue(forKey: removed)
         }
+    }
+
+    private func storeCachedVocabulary(_ cachedVocabulary: CachedVocabulary) {
+        let hash = cachedVocabulary.hash
+        cachedVocabularyLoadTasks.removeValue(forKey: hash)
+        cachedVocabularies[hash] = cachedVocabulary
+        rememberCachedVocabularyHash(hash)
+        evictStaleCachedVocabularies()
     }
 
     private static func uniquePreservingOrder(_ values: [String]) -> [String] {

--- a/Sources/MacParakeetCore/STT/CustomVocabularyBoosting.swift
+++ b/Sources/MacParakeetCore/STT/CustomVocabularyBoosting.swift
@@ -14,6 +14,7 @@ public enum CustomVocabularyBoostingConfiguration {
     public static let maxSidecarAudioSeconds: Double = 5 * 60
     public static let termWeight: Float = 10.0
     public static let maxBoundaryChangingTimingWordCount: Int = 8
+    public static let maxCachedVocabularyEntries: Int = 3
 
     static var maxSidecarSampleCount: Int {
         Int(maxSidecarAudioSeconds * Double(ASRConstants.sampleRate))
@@ -240,7 +241,8 @@ public actor FluidAudioCustomVocabularyRescorer: CustomVocabularyRescoring {
     }
 
     private let logger = Logger(subsystem: "com.macparakeet.core", category: "CustomVocabulary")
-    private var cachedVocabulary: CachedVocabulary?
+    private var cachedVocabularies: [String: CachedVocabulary] = [:]
+    private var cachedVocabularyOrder: [String] = []
 
     public init() {}
 
@@ -263,9 +265,7 @@ public actor FluidAudioCustomVocabularyRescorer: CustomVocabularyRescoring {
             )
         }
 
-        guard let components = cachedVocabulary,
-              components.hash == request.vocabulary.contentHash
-        else {
+        guard let components = cachedVocabularies[request.vocabulary.contentHash] else {
             throw CustomVocabularyBoostingError.unpreparedVocabulary
         }
 
@@ -316,15 +316,17 @@ public actor FluidAudioCustomVocabularyRescorer: CustomVocabularyRescoring {
     }
 
     private func components(for vocabulary: CustomVocabularyBoostingVocabulary) async throws -> CachedVocabulary {
-        if let cachedVocabulary,
-           cachedVocabulary.hash == vocabulary.contentHash
-        {
+        if let cachedVocabulary = cachedVocabularies[vocabulary.contentHash] {
+            rememberCachedVocabularyHash(vocabulary.contentHash)
             return cachedVocabulary
         }
 
+        try Task.checkCancellation()
         let ctcModels = try await CtcModels.downloadAndLoad(variant: .ctc110m)
+        try Task.checkCancellation()
         let ctcModelDirectory = CtcModels.defaultCacheDirectory(for: ctcModels.variant)
         let tokenizer = try await CtcTokenizer.load(from: ctcModelDirectory)
+        try Task.checkCancellation()
         let tokenizedTerms = vocabulary.terms.compactMap { term -> CustomVocabularyTerm? in
             let tokenIds = tokenizer.encode(term)
             guard !tokenIds.isEmpty else { return nil }
@@ -352,6 +354,7 @@ public actor FluidAudioCustomVocabularyRescorer: CustomVocabularyRescoring {
             config: .default,
             ctcModelDirectory: ctcModelDirectory
         )
+        try Task.checkCancellation()
         let sizeConfig = ContextBiasingConstants.rescorerConfig(forVocabSize: context.terms.count)
         let cached = CachedVocabulary(
             hash: vocabulary.contentHash,
@@ -361,9 +364,23 @@ public actor FluidAudioCustomVocabularyRescorer: CustomVocabularyRescoring {
             cbw: sizeConfig.cbw,
             marginSeconds: ContextBiasingConstants.defaultMarginSeconds
         )
-        cachedVocabulary = cached
+        cachedVocabularies[vocabulary.contentHash] = cached
+        rememberCachedVocabularyHash(vocabulary.contentHash)
+        evictStaleCachedVocabularies()
         logger.info("custom_vocabulary_boost_loaded terms=\(context.terms.count, privacy: .public)")
         return cached
+    }
+
+    private func rememberCachedVocabularyHash(_ hash: String) {
+        cachedVocabularyOrder.removeAll { $0 == hash }
+        cachedVocabularyOrder.append(hash)
+    }
+
+    private func evictStaleCachedVocabularies() {
+        while cachedVocabularyOrder.count > CustomVocabularyBoostingConfiguration.maxCachedVocabularyEntries {
+            let removed = cachedVocabularyOrder.removeFirst()
+            cachedVocabularies.removeValue(forKey: removed)
+        }
     }
 
     private static func uniquePreservingOrder(_ values: [String]) -> [String] {

--- a/Sources/MacParakeetCore/STT/STTClient.swift
+++ b/Sources/MacParakeetCore/STT/STTClient.swift
@@ -15,14 +15,21 @@ public actor STTClient: STTManaging, STTDictationPreviewTranscribing, SpeechEngi
         speechEngine: SpeechEnginePreference = .parakeet,
         nemotronModelVariant: NemotronModelVariant = SpeechEnginePreference.defaultNemotronModelVariant,
         whisperModelVariant: String = SpeechEnginePreference.defaultWhisperModelVariant,
-        defaults: UserDefaults = .standard
+        defaults: UserDefaults = .standard,
+        customWordRepository: (any CustomWordRepositoryProtocol)? = nil,
+        customVocabularyRescorer: (any CustomVocabularyRescoring)? = nil
     ) {
+        let customVocabularyProvider = customWordRepository.map {
+            RepositoryCustomVocabularyBoostingTermProvider(repository: $0)
+        }
         let runtime = STTRuntime(
             parakeetModelVariant: parakeetModelVariant,
             speechEngine: speechEngine,
             nemotronModelVariant: nemotronModelVariant,
             whisperModelVariant: whisperModelVariant,
-            defaults: defaults
+            defaults: defaults,
+            customVocabularyProvider: customVocabularyProvider,
+            customVocabularyRescorer: customVocabularyRescorer
         )
         self.scheduler = STTScheduler(runtime: runtime)
     }

--- a/Sources/MacParakeetCore/STT/STTRuntime.swift
+++ b/Sources/MacParakeetCore/STT/STTRuntime.swift
@@ -520,7 +520,7 @@ public actor STTRuntime: STTRuntimeProtocol {
                         try await manager.transcribe(paddedSamples, decoderState: &decoderState)
                     }
                     try Task.checkCancellation()
-                    let boostedResult = await applyCustomVocabularyBoostingIfAvailable(
+                    let boostedResult = try await applyCustomVocabularyBoostingIfAvailable(
                         to: result,
                         audioSamples: paddedSamples
                     )
@@ -575,9 +575,9 @@ public actor STTRuntime: STTRuntimeProtocol {
                 try await manager.transcribe(audioURL, decoderState: &decoderState)
             }
             try Task.checkCancellation()
-            let sidecarSamples = Self.customVocabularySidecarSamples(audioPath: audioPath)
+            let sidecarSamples = try Self.customVocabularySidecarSamples(audioPath: audioPath)
             try Task.checkCancellation()
-            let boostedResult = await applyCustomVocabularyBoostingIfAvailable(
+            let boostedResult = try await applyCustomVocabularyBoostingIfAvailable(
                 to: result,
                 audioSamples: sidecarSamples
             )
@@ -660,7 +660,17 @@ public actor STTRuntime: STTRuntimeProtocol {
     /// loaded into memory (the caller keeps FluidAudio's disk-backed URL path).
     /// Dictation clips are short, so a qualifying file is read in one buffer.
     static func loadShortDictationSamples16k(path: String, maxSamples: Int) -> [Float]? {
+        loadShortDictationSamples16k(path: path, maxSamples: maxSamples, checkCancellation: {})
+    }
+
+    static func loadShortDictationSamples16k(
+        path: String,
+        maxSamples: Int,
+        checkCancellation: () throws -> Void
+    ) rethrows -> [Float]? {
+        try checkCancellation()
         guard let file = try? AVAudioFile(forReading: URL(fileURLWithPath: path)) else { return nil }
+        try checkCancellation()
         let sourceRate = file.processingFormat.sampleRate
         guard
             sourceRate > 0,
@@ -669,36 +679,44 @@ public actor STTRuntime: STTRuntimeProtocol {
         else {
             return nil
         }
+        try checkCancellation()
         // Dictation WAVs are written at 16 kHz mono; estimate the 16 kHz length
         // so the guard holds even if that capture format ever changes.
         let estimated16kSamples = Int(
             (Double(file.length) * Double(ASRConstants.sampleRate) / sourceRate).rounded(.up)
         )
+        guard estimated16kSamples <= maxSamples else { return nil }
+        try checkCancellation()
         guard
-            estimated16kSamples <= maxSamples,
             let buffer = AVAudioPCMBuffer(pcmFormat: file.processingFormat, frameCapacity: frameCount),
             (try? file.read(into: buffer)) != nil
         else {
             return nil
         }
+        try checkCancellation()
         return AudioChunker.extractAndResample(from: buffer)
     }
 
-    static func customVocabularySidecarSamples(audioPath: String) -> [Float] {
-        loadShortDictationSamples16k(
+    static func customVocabularySidecarSamples(audioPath: String) throws -> [Float] {
+        try loadShortDictationSamples16k(
             path: audioPath,
-            maxSamples: CustomVocabularyBoostingConfiguration.maxSidecarSampleCount
+            maxSamples: CustomVocabularyBoostingConfiguration.maxSidecarSampleCount,
+            checkCancellation: {
+                try Task.checkCancellation()
+            }
         ) ?? []
     }
 
     private func applyCustomVocabularyBoostingIfAvailable(
         to result: ASRResult,
         audioSamples: [Float]
-    ) async -> ASRResult {
+    ) async throws -> ASRResult {
         guard let customVocabularyProvider else { return result }
+        try Task.checkCancellation()
         let capabilities = SpeechEngineCapabilityRegistry.capabilities(for: .parakeet(currentParakeetVariant))
         let vocabulary = await customVocabularyProvider.currentVocabulary()
-        return await Self.applyCustomVocabularyBoosting(
+        try Task.checkCancellation()
+        return try await Self.applyCustomVocabularyBoosting(
             to: result,
             audioSamples: audioSamples,
             capabilities: capabilities,
@@ -717,7 +735,7 @@ public actor STTRuntime: STTRuntimeProtocol {
         rescorer: any CustomVocabularyRescoring,
         inferenceGate: ANEInferenceGate,
         logger: Logger? = nil
-    ) async -> ASRResult {
+    ) async throws -> ASRResult {
         guard !Task.isCancelled,
               capabilities.supportsCustomVocabulary,
               !vocabulary.isEmpty,
@@ -750,7 +768,7 @@ public actor STTRuntime: STTRuntimeProtocol {
                 logger: logger
             )
         } catch is CancellationError {
-            return result
+            throw CancellationError()
         } catch {
             logger?.warning(
                 "custom_vocabulary_boost_failed error_type=\(String(describing: type(of: error)), privacy: .public)"
@@ -853,7 +871,7 @@ public actor STTRuntime: STTRuntimeProtocol {
         vocabulary: CustomVocabularyBoostingVocabulary,
         rescorer: any CustomVocabularyRescoring,
         inferenceGate: ANEInferenceGate = ANEInferenceGate(serializationRequired: false)
-    ) async -> ASRResult {
+    ) async throws -> ASRResult {
         let result = ASRResult(
             text: transcript,
             confidence: 1,
@@ -861,7 +879,7 @@ public actor STTRuntime: STTRuntimeProtocol {
             processingTime: 0,
             tokenTimings: tokenTimings
         )
-        return await applyCustomVocabularyBoosting(
+        return try await applyCustomVocabularyBoosting(
             to: result,
             audioSamples: audioSamples,
             capabilities: capabilities,

--- a/Sources/MacParakeetCore/STT/STTRuntime.swift
+++ b/Sources/MacParakeetCore/STT/STTRuntime.swift
@@ -767,11 +767,13 @@ public actor STTRuntime: STTRuntimeProtocol {
                 try await rescorer.prepare(vocabulary: vocabulary)
             case .backgroundIfNeeded:
                 guard await rescorer.isPrepared(vocabulary: vocabulary) else {
+                    try Task.checkCancellation()
                     startBackgroundCustomVocabularyPreparation(
                         vocabulary: vocabulary,
                         rescorer: rescorer,
                         logger: logger
                     )
+                    try Task.checkCancellation()
                     return result
                 }
             }

--- a/Sources/MacParakeetCore/STT/STTRuntime.swift
+++ b/Sources/MacParakeetCore/STT/STTRuntime.swift
@@ -522,7 +522,7 @@ public actor STTRuntime: STTRuntimeProtocol {
                     try Task.checkCancellation()
                     let boostedResult = try await applyCustomVocabularyBoostingIfAvailable(
                         to: result,
-                        audioSamples: paddedSamples
+                        loadAudioSamples: { paddedSamples }
                     )
                     onProgress?(100, 100)
                     return STTResult(
@@ -575,12 +575,11 @@ public actor STTRuntime: STTRuntimeProtocol {
                 try await manager.transcribe(audioURL, decoderState: &decoderState)
             }
             try Task.checkCancellation()
-            let sidecarSamples = try Self.customVocabularySidecarSamples(audioPath: audioPath)
-            try Task.checkCancellation()
             let boostedResult = try await applyCustomVocabularyBoostingIfAvailable(
-                to: result,
-                audioSamples: sidecarSamples
-            )
+                to: result
+            ) {
+                try Self.customVocabularySidecarSamples(audioPath: audioPath)
+            }
             let words = STTWordTimingBuilder.words(from: boostedResult.tokenTimings)
             onProgress?(100, 100)
             // Telemetry `language` is attributed "en": MacParakeet positions
@@ -709,12 +708,16 @@ public actor STTRuntime: STTRuntimeProtocol {
 
     private func applyCustomVocabularyBoostingIfAvailable(
         to result: ASRResult,
-        audioSamples: [Float]
+        loadAudioSamples: () throws -> [Float]
     ) async throws -> ASRResult {
         guard let customVocabularyProvider else { return result }
         try Task.checkCancellation()
         let capabilities = SpeechEngineCapabilityRegistry.capabilities(for: .parakeet(currentParakeetVariant))
+        guard capabilities.supportsCustomVocabulary else { return result }
         let vocabulary = await customVocabularyProvider.currentVocabulary()
+        try Task.checkCancellation()
+        guard !vocabulary.isEmpty else { return result }
+        let audioSamples = try loadAudioSamples()
         try Task.checkCancellation()
         return try await Self.applyCustomVocabularyBoosting(
             to: result,
@@ -839,6 +842,10 @@ public actor STTRuntime: STTRuntimeProtocol {
                     confidence: Float(timing.confidence)
                 )
             }
+        }
+
+        guard originalWords.count <= CustomVocabularyBoostingConfiguration.maxBoundaryChangingTimingWordCount else {
+            return nil
         }
 
         let startTime = Double(firstWord.startMs) / 1_000

--- a/Sources/MacParakeetCore/STT/STTRuntime.swift
+++ b/Sources/MacParakeetCore/STT/STTRuntime.swift
@@ -768,12 +768,17 @@ public actor STTRuntime: STTRuntimeProtocol {
             case .backgroundIfNeeded:
                 guard await rescorer.isPrepared(vocabulary: vocabulary) else {
                     try Task.checkCancellation()
-                    startBackgroundCustomVocabularyPreparation(
+                    let preparationTask = startBackgroundCustomVocabularyPreparation(
                         vocabulary: vocabulary,
                         rescorer: rescorer,
                         logger: logger
                     )
-                    try Task.checkCancellation()
+                    do {
+                        try Task.checkCancellation()
+                    } catch is CancellationError {
+                        preparationTask.cancel()
+                        throw CancellationError()
+                    }
                     return result
                 }
             }
@@ -809,7 +814,7 @@ public actor STTRuntime: STTRuntimeProtocol {
         vocabulary: CustomVocabularyBoostingVocabulary,
         rescorer: any CustomVocabularyRescoring,
         logger: Logger?
-    ) {
+    ) -> Task<Void, Never> {
         // Dictation finalize must not wait on the first-use CTC download/load.
         // This deliberate fire-and-forget exception protects interactive paste
         // latency; a later utterance uses the prepared cache once this finishes.

--- a/Sources/MacParakeetCore/STT/STTRuntime.swift
+++ b/Sources/MacParakeetCore/STT/STTRuntime.swift
@@ -717,6 +717,7 @@ public actor STTRuntime: STTRuntimeProtocol {
         let vocabulary = await customVocabularyProvider.currentVocabulary()
         try Task.checkCancellation()
         guard !vocabulary.isEmpty else { return result }
+        guard let tokenTimings = result.tokenTimings, !tokenTimings.isEmpty else { return result }
         let audioSamples = try loadAudioSamples()
         try Task.checkCancellation()
         return try await Self.applyCustomVocabularyBoosting(
@@ -844,29 +845,128 @@ public actor STTRuntime: STTRuntimeProtocol {
             }
         }
 
-        guard originalWords.count <= CustomVocabularyBoostingConfiguration.maxBoundaryChangingTimingWordCount else {
+        let matches = wordTimingAlignmentMatches(
+            originalWords: originalWords,
+            rescoredWords: rescoredWords
+        )
+        var synthesized: [TokenTiming] = []
+        var originalCursor = 0
+        var rescoredCursor = 0
+        var syntheticTokenIndex = 0
+
+        func appendTiming(word: String, startMs: Int, endMs: Int, confidence: Float) {
+            synthesized.append(
+                TokenTiming(
+                    token: "▁\(word)",
+                    tokenId: -1 - syntheticTokenIndex,
+                    startTime: Double(startMs) / 1_000,
+                    endTime: Double(endMs) / 1_000,
+                    confidence: confidence
+                )
+            )
+            syntheticTokenIndex += 1
+        }
+
+        func appendSyntheticSegment(originalRange: Range<Int>, rescoredRange: Range<Int>) {
+            guard !rescoredRange.isEmpty else { return }
+
+            let segmentStartMs: Int
+            let segmentEndMs: Int
+            if !originalRange.isEmpty {
+                segmentStartMs = originalWords[originalRange.lowerBound].startMs
+                segmentEndMs = originalWords[originalRange.upperBound - 1].endMs
+            } else {
+                segmentStartMs =
+                    originalRange.lowerBound > 0
+                    ? originalWords[originalRange.lowerBound - 1].endMs
+                    : firstWord.startMs
+                segmentEndMs =
+                    originalRange.lowerBound < originalWords.count
+                    ? originalWords[originalRange.lowerBound].startMs
+                    : lastWord.endMs
+            }
+
+            guard segmentEndMs >= segmentStartMs else { return }
+            let durationPerWord = Double(segmentEndMs - segmentStartMs) / Double(rescoredRange.count)
+            for (offset, wordIndex) in rescoredRange.enumerated() {
+                let wordStartMs = segmentStartMs + Int((durationPerWord * Double(offset)).rounded())
+                let wordEndMs =
+                    offset == rescoredRange.count - 1
+                    ? segmentEndMs
+                    : segmentStartMs + Int((durationPerWord * Double(offset + 1)).rounded())
+                appendTiming(
+                    word: rescoredWords[wordIndex],
+                    startMs: wordStartMs,
+                    endMs: wordEndMs,
+                    confidence: 0
+                )
+            }
+        }
+
+        for match in matches {
+            appendSyntheticSegment(
+                originalRange: originalCursor..<match.originalIndex,
+                rescoredRange: rescoredCursor..<match.rescoredIndex
+            )
+
+            let timing = originalWords[match.originalIndex]
+            appendTiming(
+                word: rescoredWords[match.rescoredIndex],
+                startMs: timing.startMs,
+                endMs: timing.endMs,
+                confidence: Float(timing.confidence)
+            )
+
+            originalCursor = match.originalIndex + 1
+            rescoredCursor = match.rescoredIndex + 1
+        }
+
+        appendSyntheticSegment(
+            originalRange: originalCursor..<originalWords.count,
+            rescoredRange: rescoredCursor..<rescoredWords.count
+        )
+
+        guard !synthesized.isEmpty else {
             return nil
         }
 
-        let startTime = Double(firstWord.startMs) / 1_000
-        let endTime = Double(lastWord.endMs) / 1_000
-        guard endTime >= startTime else { return nil }
+        return synthesized
+    }
 
-        let durationPerWord = (endTime - startTime) / Double(rescoredWords.count)
-        return rescoredWords.enumerated().map { index, word in
-            let wordStart = startTime + (durationPerWord * Double(index))
-            let wordEnd =
-                index == rescoredWords.count - 1
-                ? endTime
-                : startTime + (durationPerWord * Double(index + 1))
-            return TokenTiming(
-                token: "▁\(word)",
-                tokenId: -1 - index,
-                startTime: wordStart,
-                endTime: wordEnd,
-                confidence: 0
-            )
+    private static func wordTimingAlignmentMatches(
+        originalWords: [TimestampedWord],
+        rescoredWords: [String]
+    ) -> [(originalIndex: Int, rescoredIndex: Int)] {
+        let normalizedOriginalWords = originalWords.map { normalizedTimingWord($0.word) }
+        let normalizedRescoredWords = rescoredWords.map(normalizedTimingWord)
+        var matches: [(originalIndex: Int, rescoredIndex: Int)] = []
+        var originalSearchStart = 0
+
+        for (rescoredIndex, normalizedRescoredWord) in normalizedRescoredWords.enumerated() {
+            guard !normalizedRescoredWord.isEmpty else { continue }
+            var originalIndex = originalSearchStart
+            while originalIndex < normalizedOriginalWords.count {
+                if normalizedOriginalWords[originalIndex] == normalizedRescoredWord {
+                    matches.append((originalIndex: originalIndex, rescoredIndex: rescoredIndex))
+                    originalSearchStart = originalIndex + 1
+                    break
+                }
+                originalIndex += 1
+            }
         }
+
+        return matches
+    }
+
+    private static func normalizedTimingWord(_ word: String) -> String {
+        word
+            .unicodeScalars
+            .filter {
+                CharacterSet.alphanumerics.contains($0)
+            }
+            .map(String.init)
+            .joined()
+            .folding(options: [.caseInsensitive, .diacriticInsensitive], locale: nil)
     }
 
     #if DEBUG

--- a/Sources/MacParakeetCore/STT/STTRuntime.swift
+++ b/Sources/MacParakeetCore/STT/STTRuntime.swift
@@ -886,13 +886,13 @@ public actor STTRuntime: STTRuntimeProtocol {
                     : lastWord.endMs
             }
 
-            guard segmentEndMs >= segmentStartMs else { return }
-            let durationPerWord = Double(segmentEndMs - segmentStartMs) / Double(rescoredRange.count)
+            let boundedSegmentEndMs = max(segmentEndMs, segmentStartMs)
+            let durationPerWord = Double(boundedSegmentEndMs - segmentStartMs) / Double(rescoredRange.count)
             for (offset, wordIndex) in rescoredRange.enumerated() {
                 let wordStartMs = segmentStartMs + Int((durationPerWord * Double(offset)).rounded())
                 let wordEndMs =
                     offset == rescoredRange.count - 1
-                    ? segmentEndMs
+                    ? boundedSegmentEndMs
                     : segmentStartMs + Int((durationPerWord * Double(offset + 1)).rounded())
                 appendTiming(
                     word: rescoredWords[wordIndex],

--- a/Sources/MacParakeetCore/STT/STTRuntime.swift
+++ b/Sources/MacParakeetCore/STT/STTRuntime.swift
@@ -739,8 +739,8 @@ public actor STTRuntime: STTRuntimeProtocol {
         inferenceGate: ANEInferenceGate,
         logger: Logger? = nil
     ) async throws -> ASRResult {
-        guard !Task.isCancelled,
-              capabilities.supportsCustomVocabulary,
+        try Task.checkCancellation()
+        guard capabilities.supportsCustomVocabulary,
               !vocabulary.isEmpty,
               !audioSamples.isEmpty,
               let tokenTimings = result.tokenTimings,

--- a/Sources/MacParakeetCore/STT/STTRuntime.swift
+++ b/Sources/MacParakeetCore/STT/STTRuntime.swift
@@ -69,6 +69,8 @@ private final class BackgroundCustomVocabularyPreparationCancellation: @unchecke
     private let lock = NSLock()
     private var task: Task<Void, Never>?
     private var cancelled = false
+    private var startAllowed = false
+    private var startWaiter: CheckedContinuation<Void, Never>?
 
     func setTask(_ task: Task<Void, Never>) throws {
         lock.lock()
@@ -88,8 +90,11 @@ private final class BackgroundCustomVocabularyPreparationCancellation: @unchecke
         lock.lock()
         cancelled = true
         let task = task
+        let startWaiter = startWaiter
+        self.startWaiter = nil
         lock.unlock()
 
+        startWaiter?.resume()
         task?.cancel()
     }
 
@@ -101,6 +106,42 @@ private final class BackgroundCustomVocabularyPreparationCancellation: @unchecke
         if shouldCancel {
             throw CancellationError()
         }
+    }
+
+    func allowStart() throws {
+        lock.lock()
+        let shouldCancel = cancelled
+        let startWaiter = startWaiter
+        startAllowed = true
+        self.startWaiter = nil
+        lock.unlock()
+
+        startWaiter?.resume()
+
+        if shouldCancel {
+            throw CancellationError()
+        }
+    }
+
+    func waitUntilStartAllowed() async throws {
+        try checkCancellation()
+        await withCheckedContinuation { continuation in
+            var shouldResume = false
+
+            lock.lock()
+            if startAllowed || cancelled {
+                shouldResume = true
+            } else {
+                startWaiter = continuation
+            }
+            lock.unlock()
+
+            if shouldResume {
+                continuation.resume()
+            }
+        }
+        try Task.checkCancellation()
+        try checkCancellation()
     }
 }
 
@@ -787,7 +828,8 @@ public actor STTRuntime: STTRuntimeProtocol {
         rescorer: any CustomVocabularyRescoring,
         inferenceGate: ANEInferenceGate,
         preparationMode: CustomVocabularyBoostingPreparationMode = .awaitPreparation,
-        logger: Logger? = nil
+        logger: Logger? = nil,
+        backgroundPreparationTaskRegistered: (@Sendable () async -> Void)? = nil
     ) async throws -> ASRResult {
         try Task.checkCancellation()
         guard capabilities.supportsCustomVocabulary,
@@ -812,11 +854,15 @@ public actor STTRuntime: STTRuntimeProtocol {
                         let preparationTask = startBackgroundCustomVocabularyPreparation(
                             vocabulary: vocabulary,
                             rescorer: rescorer,
+                            cancellation: cancellation,
                             logger: logger
                         )
                         try cancellation.setTask(preparationTask)
+                        if let backgroundPreparationTaskRegistered {
+                            await backgroundPreparationTaskRegistered()
+                        }
                         try Task.checkCancellation()
-                        try cancellation.checkCancellation()
+                        try cancellation.allowStart()
                         return result
                     } onCancel: {
                         cancellation.cancel()
@@ -854,6 +900,7 @@ public actor STTRuntime: STTRuntimeProtocol {
     private static func startBackgroundCustomVocabularyPreparation(
         vocabulary: CustomVocabularyBoostingVocabulary,
         rescorer: any CustomVocabularyRescoring,
+        cancellation: BackgroundCustomVocabularyPreparationCancellation,
         logger: Logger?
     ) -> Task<Void, Never> {
         // Dictation finalize must not wait on the first-use CTC download/load.
@@ -861,9 +908,11 @@ public actor STTRuntime: STTRuntimeProtocol {
         // latency; a later utterance uses the prepared cache once this finishes.
         Task.detached {
             do {
+                try await cancellation.waitUntilStartAllowed()
                 try await rescorer.prepare(vocabulary: vocabulary)
             } catch is CancellationError {
-                // The caller already returned the unboosted dictation result.
+                // The caller either cancelled before release or already returned
+                // the unboosted dictation result.
             } catch {
                 logger?.warning(
                     "custom_vocabulary_prepare_background_failed error_type=\(String(describing: type(of: error)), privacy: .public)"
@@ -1069,7 +1118,8 @@ public actor STTRuntime: STTRuntimeProtocol {
         vocabulary: CustomVocabularyBoostingVocabulary,
         rescorer: any CustomVocabularyRescoring,
         inferenceGate: ANEInferenceGate = ANEInferenceGate(serializationRequired: false),
-        preparationMode: CustomVocabularyBoostingPreparationMode = .awaitPreparation
+        preparationMode: CustomVocabularyBoostingPreparationMode = .awaitPreparation,
+        backgroundPreparationTaskRegistered: (@Sendable () async -> Void)? = nil
     ) async throws -> ASRResult {
         let result = ASRResult(
             text: transcript,
@@ -1085,7 +1135,8 @@ public actor STTRuntime: STTRuntimeProtocol {
             vocabulary: vocabulary,
             rescorer: rescorer,
             inferenceGate: inferenceGate,
-            preparationMode: preparationMode
+            preparationMode: preparationMode,
+            backgroundPreparationTaskRegistered: backgroundPreparationTaskRegistered
         )
     }
     #endif

--- a/Sources/MacParakeetCore/STT/STTRuntime.swift
+++ b/Sources/MacParakeetCore/STT/STTRuntime.swift
@@ -60,6 +60,11 @@ extension STTRuntimeProtocol {
     }
 }
 
+enum CustomVocabularyBoostingPreparationMode {
+    case awaitPreparation
+    case backgroundIfNeeded
+}
+
 /// Sole owner of the shared local speech-engine lifecycle.
 ///
 /// The runtime stays process-wide and singular at the app boundary, but it keeps
@@ -522,6 +527,7 @@ public actor STTRuntime: STTRuntimeProtocol {
                     try Task.checkCancellation()
                     let boostedResult = try await applyCustomVocabularyBoostingIfAvailable(
                         to: result,
+                        preparationMode: .backgroundIfNeeded,
                         loadAudioSamples: { paddedSamples }
                     )
                     onProgress?(100, 100)
@@ -576,7 +582,8 @@ public actor STTRuntime: STTRuntimeProtocol {
             }
             try Task.checkCancellation()
             let boostedResult = try await applyCustomVocabularyBoostingIfAvailable(
-                to: result
+                to: result,
+                preparationMode: .awaitPreparation
             ) {
                 try Self.customVocabularySidecarSamples(audioPath: audioPath)
             }
@@ -708,6 +715,7 @@ public actor STTRuntime: STTRuntimeProtocol {
 
     private func applyCustomVocabularyBoostingIfAvailable(
         to result: ASRResult,
+        preparationMode: CustomVocabularyBoostingPreparationMode,
         loadAudioSamples: () throws -> [Float]
     ) async throws -> ASRResult {
         guard let customVocabularyProvider else { return result }
@@ -727,6 +735,7 @@ public actor STTRuntime: STTRuntimeProtocol {
             vocabulary: vocabulary,
             rescorer: customVocabularyRescorer,
             inferenceGate: inferenceGate,
+            preparationMode: preparationMode,
             logger: logger
         )
     }
@@ -738,6 +747,7 @@ public actor STTRuntime: STTRuntimeProtocol {
         vocabulary: CustomVocabularyBoostingVocabulary,
         rescorer: any CustomVocabularyRescoring,
         inferenceGate: ANEInferenceGate,
+        preparationMode: CustomVocabularyBoostingPreparationMode = .awaitPreparation,
         logger: Logger? = nil
     ) async throws -> ASRResult {
         try Task.checkCancellation()
@@ -752,7 +762,19 @@ public actor STTRuntime: STTRuntimeProtocol {
 
         do {
             try Task.checkCancellation()
-            try await rescorer.prepare(vocabulary: vocabulary)
+            switch preparationMode {
+            case .awaitPreparation:
+                try await rescorer.prepare(vocabulary: vocabulary)
+            case .backgroundIfNeeded:
+                guard await rescorer.isPrepared(vocabulary: vocabulary) else {
+                    startBackgroundCustomVocabularyPreparation(
+                        vocabulary: vocabulary,
+                        rescorer: rescorer,
+                        logger: logger
+                    )
+                    return result
+                }
+            }
             try Task.checkCancellation()
             let rescored = try await inferenceGate.withExclusiveAccess {
                 try await rescorer.rescore(
@@ -778,6 +800,27 @@ public actor STTRuntime: STTRuntimeProtocol {
                 "custom_vocabulary_boost_failed error_type=\(String(describing: type(of: error)), privacy: .public)"
             )
             return result
+        }
+    }
+
+    private static func startBackgroundCustomVocabularyPreparation(
+        vocabulary: CustomVocabularyBoostingVocabulary,
+        rescorer: any CustomVocabularyRescoring,
+        logger: Logger?
+    ) {
+        // Dictation finalize must not wait on the first-use CTC download/load.
+        // This deliberate fire-and-forget exception protects interactive paste
+        // latency; a later utterance uses the prepared cache once this finishes.
+        Task.detached {
+            do {
+                try await rescorer.prepare(vocabulary: vocabulary)
+            } catch is CancellationError {
+                // The caller already returned the unboosted dictation result.
+            } catch {
+                logger?.warning(
+                    "custom_vocabulary_prepare_background_failed error_type=\(String(describing: type(of: error)), privacy: .public)"
+                )
+            }
         }
     }
 
@@ -977,7 +1020,8 @@ public actor STTRuntime: STTRuntimeProtocol {
         capabilities: SpeechEngineCapabilities,
         vocabulary: CustomVocabularyBoostingVocabulary,
         rescorer: any CustomVocabularyRescoring,
-        inferenceGate: ANEInferenceGate = ANEInferenceGate(serializationRequired: false)
+        inferenceGate: ANEInferenceGate = ANEInferenceGate(serializationRequired: false),
+        preparationMode: CustomVocabularyBoostingPreparationMode = .awaitPreparation
     ) async throws -> ASRResult {
         let result = ASRResult(
             text: transcript,
@@ -992,7 +1036,8 @@ public actor STTRuntime: STTRuntimeProtocol {
             capabilities: capabilities,
             vocabulary: vocabulary,
             rescorer: rescorer,
-            inferenceGate: inferenceGate
+            inferenceGate: inferenceGate,
+            preparationMode: preparationMode
         )
     }
     #endif

--- a/Sources/MacParakeetCore/STT/STTRuntime.swift
+++ b/Sources/MacParakeetCore/STT/STTRuntime.swift
@@ -65,6 +65,45 @@ enum CustomVocabularyBoostingPreparationMode {
     case backgroundIfNeeded
 }
 
+private final class BackgroundCustomVocabularyPreparationCancellation: @unchecked Sendable {
+    private let lock = NSLock()
+    private var task: Task<Void, Never>?
+    private var cancelled = false
+
+    func setTask(_ task: Task<Void, Never>) throws {
+        lock.lock()
+        let shouldCancel = cancelled
+        if !shouldCancel {
+            self.task = task
+        }
+        lock.unlock()
+
+        if shouldCancel {
+            task.cancel()
+            throw CancellationError()
+        }
+    }
+
+    func cancel() {
+        lock.lock()
+        cancelled = true
+        let task = task
+        lock.unlock()
+
+        task?.cancel()
+    }
+
+    func checkCancellation() throws {
+        lock.lock()
+        let shouldCancel = cancelled
+        lock.unlock()
+
+        if shouldCancel {
+            throw CancellationError()
+        }
+    }
+}
+
 /// Sole owner of the shared local speech-engine lifecycle.
 ///
 /// The runtime stays process-wide and singular at the app boundary, but it keeps
@@ -767,19 +806,21 @@ public actor STTRuntime: STTRuntimeProtocol {
                 try await rescorer.prepare(vocabulary: vocabulary)
             case .backgroundIfNeeded:
                 guard await rescorer.isPrepared(vocabulary: vocabulary) else {
-                    try Task.checkCancellation()
-                    let preparationTask = startBackgroundCustomVocabularyPreparation(
-                        vocabulary: vocabulary,
-                        rescorer: rescorer,
-                        logger: logger
-                    )
-                    do {
+                    let cancellation = BackgroundCustomVocabularyPreparationCancellation()
+                    return try await withTaskCancellationHandler {
                         try Task.checkCancellation()
-                    } catch is CancellationError {
-                        preparationTask.cancel()
-                        throw CancellationError()
+                        let preparationTask = startBackgroundCustomVocabularyPreparation(
+                            vocabulary: vocabulary,
+                            rescorer: rescorer,
+                            logger: logger
+                        )
+                        try cancellation.setTask(preparationTask)
+                        try Task.checkCancellation()
+                        try cancellation.checkCancellation()
+                        return result
+                    } onCancel: {
+                        cancellation.cancel()
                     }
-                    return result
                 }
             }
             try Task.checkCancellation()

--- a/Sources/MacParakeetCore/STT/STTRuntime.swift
+++ b/Sources/MacParakeetCore/STT/STTRuntime.swift
@@ -80,6 +80,8 @@ public actor STTRuntime: STTRuntimeProtocol {
     /// every STT engine and lane contends on one Neural Engine mutex in
     /// production.
     private let inferenceGate: ANEInferenceGate
+    private let customVocabularyProvider: (any CustomVocabularyBoostingTermProviding)?
+    private let customVocabularyRescorer: any CustomVocabularyRescoring
 
     private var interactiveManager: AsrManager?
     private var backgroundManager: AsrManager?
@@ -148,7 +150,9 @@ public actor STTRuntime: STTRuntimeProtocol {
         nemotronModelVariant: NemotronModelVariant = SpeechEnginePreference.defaultNemotronModelVariant,
         whisperModelVariant: String = SpeechEnginePreference.defaultWhisperModelVariant,
         defaults: UserDefaults = .standard,
-        inferenceGate: ANEInferenceGate = .shared
+        inferenceGate: ANEInferenceGate = .shared,
+        customVocabularyProvider: (any CustomVocabularyBoostingTermProviding)? = nil,
+        customVocabularyRescorer: (any CustomVocabularyRescoring)? = nil
     ) {
         self.currentParakeetVariant = parakeetModelVariant
         // `.unified` has no TDT version; the TDT path is never taken for it, so a
@@ -160,6 +164,8 @@ public actor STTRuntime: STTRuntimeProtocol {
         self.whisperModelVariant = WhisperEngine.normalizeModelVariant(whisperModelVariant)
         self.defaults = defaults
         self.inferenceGate = inferenceGate
+        self.customVocabularyProvider = customVocabularyProvider
+        self.customVocabularyRescorer = customVocabularyRescorer ?? FluidAudioCustomVocabularyRescorer()
     }
 
     #if DEBUG
@@ -513,10 +519,14 @@ public actor STTRuntime: STTRuntimeProtocol {
                     let result = try await inferenceGate.withExclusiveAccess {
                         try await manager.transcribe(paddedSamples, decoderState: &decoderState)
                     }
+                    let boostedResult = await applyCustomVocabularyBoostingIfAvailable(
+                        to: result,
+                        audioSamples: paddedSamples
+                    )
                     onProgress?(100, 100)
                     return STTResult(
-                        text: result.text,
-                        words: STTWordTimingBuilder.words(from: result.tokenTimings),
+                        text: boostedResult.text,
+                        words: STTWordTimingBuilder.words(from: boostedResult.tokenTimings),
                         language: "en",
                         engine: .parakeet,
                         engineVariant: ParakeetModelVariant(asrModelVersion: modelVersion).rawValue
@@ -563,7 +573,11 @@ public actor STTRuntime: STTRuntimeProtocol {
             let result = try await inferenceGate.withExclusiveAccess {
                 try await manager.transcribe(audioURL, decoderState: &decoderState)
             }
-            let words = STTWordTimingBuilder.words(from: result.tokenTimings)
+            let boostedResult = await applyCustomVocabularyBoostingIfAvailable(
+                to: result,
+                audioSamples: Self.customVocabularySidecarSamples(audioPath: audioPath)
+            )
+            let words = STTWordTimingBuilder.words(from: boostedResult.tokenTimings)
             onProgress?(100, 100)
             // Telemetry `language` is attributed "en": MacParakeet positions
             // Parakeet as English-first (v2 is English-only; v3 multilingual is
@@ -572,7 +586,7 @@ public actor STTRuntime: STTRuntimeProtocol {
             // `engineVariant` carries the active build (v2/v3) so adoption and
             // impact can be measured without exposing transcript content.
             return STTResult(
-                text: result.text,
+                text: boostedResult.text,
                 words: words,
                 language: "en",
                 engine: .parakeet,
@@ -665,6 +679,101 @@ public actor STTRuntime: STTRuntimeProtocol {
         }
         return AudioChunker.extractAndResample(from: buffer)
     }
+
+    static func customVocabularySidecarSamples(audioPath: String) -> [Float] {
+        loadShortDictationSamples16k(
+            path: audioPath,
+            maxSamples: CustomVocabularyBoostingConfiguration.maxSidecarSampleCount
+        ) ?? []
+    }
+
+    private func applyCustomVocabularyBoostingIfAvailable(
+        to result: ASRResult,
+        audioSamples: [Float]
+    ) async -> ASRResult {
+        guard let customVocabularyProvider else { return result }
+        let capabilities = SpeechEngineCapabilityRegistry.capabilities(for: .parakeet(currentParakeetVariant))
+        let vocabulary = await customVocabularyProvider.currentVocabulary()
+        return await Self.applyCustomVocabularyBoosting(
+            to: result,
+            audioSamples: audioSamples,
+            capabilities: capabilities,
+            vocabulary: vocabulary,
+            rescorer: customVocabularyRescorer,
+            inferenceGate: inferenceGate,
+            logger: logger
+        )
+    }
+
+    static func applyCustomVocabularyBoosting(
+        to result: ASRResult,
+        audioSamples: [Float],
+        capabilities: SpeechEngineCapabilities,
+        vocabulary: CustomVocabularyBoostingVocabulary,
+        rescorer: any CustomVocabularyRescoring,
+        inferenceGate: ANEInferenceGate,
+        logger: Logger? = nil
+    ) async -> ASRResult {
+        guard capabilities.supportsCustomVocabulary,
+              !vocabulary.isEmpty,
+              !audioSamples.isEmpty,
+              let tokenTimings = result.tokenTimings,
+              !tokenTimings.isEmpty
+        else {
+            return result
+        }
+
+        do {
+            let rescored = try await inferenceGate.withExclusiveAccess {
+                try await rescorer.rescore(
+                    CustomVocabularyRescoringRequest(
+                        transcript: result.text,
+                        tokenTimings: tokenTimings,
+                        audioSamples: audioSamples,
+                        vocabulary: vocabulary
+                    )
+                )
+            }
+            return result.withRescoring(
+                text: rescored.text,
+                detected: rescored.detectedTerms,
+                applied: rescored.appliedTerms
+            )
+        } catch {
+            logger?.warning(
+                "custom_vocabulary_boost_failed error_type=\(String(describing: type(of: error)), privacy: .public)"
+            )
+            return result
+        }
+    }
+
+    #if DEBUG
+    static func applyCustomVocabularyBoostingForTesting(
+        transcript: String,
+        tokenTimings: [TokenTiming]?,
+        audioSamples: [Float],
+        capabilities: SpeechEngineCapabilities,
+        vocabulary: CustomVocabularyBoostingVocabulary,
+        rescorer: any CustomVocabularyRescoring,
+        inferenceGate: ANEInferenceGate = ANEInferenceGate(serializationRequired: false)
+    ) async -> ASRResult {
+        let result = ASRResult(
+            text: transcript,
+            confidence: 1,
+            duration: 0,
+            processingTime: 0,
+            tokenTimings: tokenTimings
+        )
+        return await applyCustomVocabularyBoosting(
+            to: result,
+            audioSamples: audioSamples,
+            capabilities: capabilities,
+            vocabulary: vocabulary,
+            rescorer: rescorer,
+            inferenceGate: inferenceGate
+        )
+    }
+    #endif
 
     private func transcribeParakeetPreview(samples: [Float]) async throws -> STTResult {
         // Parakeet Unified drives live dictation through its native streaming

--- a/Sources/MacParakeetCore/STT/STTRuntime.swift
+++ b/Sources/MacParakeetCore/STT/STTRuntime.swift
@@ -519,6 +519,7 @@ public actor STTRuntime: STTRuntimeProtocol {
                     let result = try await inferenceGate.withExclusiveAccess {
                         try await manager.transcribe(paddedSamples, decoderState: &decoderState)
                     }
+                    try Task.checkCancellation()
                     let boostedResult = await applyCustomVocabularyBoostingIfAvailable(
                         to: result,
                         audioSamples: paddedSamples
@@ -573,9 +574,12 @@ public actor STTRuntime: STTRuntimeProtocol {
             let result = try await inferenceGate.withExclusiveAccess {
                 try await manager.transcribe(audioURL, decoderState: &decoderState)
             }
+            try Task.checkCancellation()
+            let sidecarSamples = Self.customVocabularySidecarSamples(audioPath: audioPath)
+            try Task.checkCancellation()
             let boostedResult = await applyCustomVocabularyBoostingIfAvailable(
                 to: result,
-                audioSamples: Self.customVocabularySidecarSamples(audioPath: audioPath)
+                audioSamples: sidecarSamples
             )
             let words = STTWordTimingBuilder.words(from: boostedResult.tokenTimings)
             onProgress?(100, 100)
@@ -714,7 +718,8 @@ public actor STTRuntime: STTRuntimeProtocol {
         inferenceGate: ANEInferenceGate,
         logger: Logger? = nil
     ) async -> ASRResult {
-        guard capabilities.supportsCustomVocabulary,
+        guard !Task.isCancelled,
+              capabilities.supportsCustomVocabulary,
               !vocabulary.isEmpty,
               !audioSamples.isEmpty,
               let tokenTimings = result.tokenTimings,
@@ -724,6 +729,9 @@ public actor STTRuntime: STTRuntimeProtocol {
         }
 
         do {
+            try Task.checkCancellation()
+            try await rescorer.prepare(vocabulary: vocabulary)
+            try Task.checkCancellation()
             let rescored = try await inferenceGate.withExclusiveAccess {
                 try await rescorer.rescore(
                     CustomVocabularyRescoringRequest(
@@ -734,16 +742,105 @@ public actor STTRuntime: STTRuntimeProtocol {
                     )
                 )
             }
-            return result.withRescoring(
-                text: rescored.text,
-                detected: rescored.detectedTerms,
-                applied: rescored.appliedTerms
+            try Task.checkCancellation()
+            return Self.resultByApplyingCustomVocabularyRescoring(
+                rescored,
+                to: result,
+                originalTokenTimings: tokenTimings,
+                logger: logger
             )
+        } catch is CancellationError {
+            return result
         } catch {
             logger?.warning(
                 "custom_vocabulary_boost_failed error_type=\(String(describing: type(of: error)), privacy: .public)"
             )
             return result
+        }
+    }
+
+    private static func resultByApplyingCustomVocabularyRescoring(
+        _ rescored: CustomVocabularyRescoringResult,
+        to result: ASRResult,
+        originalTokenTimings: [TokenTiming],
+        logger: Logger?
+    ) -> ASRResult {
+        guard rescored.text != result.text else {
+            return result.withRescoring(
+                text: rescored.text,
+                detected: rescored.detectedTerms,
+                applied: rescored.appliedTerms
+            )
+        }
+
+        guard
+            let tokenTimings = synthesizedTokenTimings(
+                for: rescored.text,
+                replacing: originalTokenTimings
+            )
+        else {
+            logger?.warning(
+                "custom_vocabulary_boost_skipped reason=timing_synthesis_failed"
+            )
+            return result
+        }
+
+        return ASRResult(
+            text: rescored.text,
+            confidence: result.confidence,
+            duration: result.duration,
+            processingTime: result.processingTime,
+            tokenTimings: tokenTimings,
+            performanceMetrics: result.performanceMetrics,
+            ctcDetectedTerms: rescored.detectedTerms,
+            ctcAppliedTerms: rescored.appliedTerms
+        )
+    }
+
+    private static func synthesizedTokenTimings(
+        for rescoredText: String,
+        replacing originalTokenTimings: [TokenTiming]
+    ) -> [TokenTiming]? {
+        let rescoredWords = rescoredText.split(whereSeparator: \.isWhitespace).map(String.init)
+        let originalWords = STTWordTimingBuilder.words(from: originalTokenTimings)
+        guard !rescoredWords.isEmpty,
+              let firstWord = originalWords.first,
+              let lastWord = originalWords.last
+        else {
+            return nil
+        }
+
+        if rescoredWords.count == originalWords.count {
+            return zip(rescoredWords, originalWords).enumerated().map { index, pair in
+                let (word, timing) = pair
+                return TokenTiming(
+                    token: "▁\(word)",
+                    tokenId: -1 - index,
+                    startTime: Double(timing.startMs) / 1_000,
+                    endTime: Double(timing.endMs) / 1_000,
+                    confidence: Float(timing.confidence)
+                )
+            }
+        }
+
+        let startTime = Double(firstWord.startMs) / 1_000
+        let endTime = Double(lastWord.endMs) / 1_000
+        guard endTime >= startTime else { return nil }
+
+        let durationPerWord = (endTime - startTime) / Double(rescoredWords.count)
+        return rescoredWords.enumerated().map { index, word in
+            let wordStart = startTime + (durationPerWord * Double(index))
+            let wordEnd =
+                index == rescoredWords.count - 1
+                ? endTime
+                : startTime + (durationPerWord * Double(index + 1))
+            return TokenTiming(
+                token: "▁\(word)",
+                tokenId: -1 - index,
+                startTime: wordStart,
+                endTime: wordEnd,
+                confidence: 0
+            )
         }
     }
 

--- a/Sources/MacParakeetCore/STT/SpeechEngineCapabilities.swift
+++ b/Sources/MacParakeetCore/STT/SpeechEngineCapabilities.swift
@@ -194,7 +194,7 @@ public enum SpeechEngineCapabilityRegistry {
                 supportsTailPreview: !variant.usesUnifiedEngine,
                 providesWordTimestamps: !variant.usesUnifiedEngine,
                 supportedLanguages: variant.isEnglishOnly ? .fixed("en") : .automatic(),
-                supportsCustomVocabulary: false,
+                supportsCustomVocabulary: !variant.usesUnifiedEngine,
                 modelLifecycle: SpeechEngineModelLifecycle(
                     modelName: variant.modelName,
                     variantID: variant.rawValue,

--- a/Sources/MacParakeetCore/TextProcessing/CustomWordReplacer.swift
+++ b/Sources/MacParakeetCore/TextProcessing/CustomWordReplacer.swift
@@ -15,8 +15,8 @@ import Foundation
 /// - whole-word (`\b…\b`), case-insensitive matching,
 /// - rules apply in array order, so a later rule can act on an earlier rule's
 ///   output,
-/// - `replacement == nil` (a vocabulary anchor) substitutes the word with
-///   itself,
+/// - `replacement == nil` or blank (a vocabulary anchor) substitutes the word
+///   with itself,
 /// - a word whose pattern fails to compile is skipped silently.
 struct CustomWordReplacer: Sendable {
     private struct Rule: Sendable {
@@ -29,12 +29,18 @@ struct CustomWordReplacer: Sendable {
     init(words: [CustomWord]) {
         rules = words.compactMap { word in
             guard word.isEnabled else { return nil }
-            let replacement = word.replacement ?? word.word
+            let replacement = word.replacement?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            let template = if let replacement, !replacement.isEmpty {
+                replacement
+            } else {
+                word.word
+            }
             let pattern = "\\b\(NSRegularExpression.escapedPattern(for: word.word))\\b"
             guard let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive) else {
                 return nil
             }
-            return Rule(regex: regex, template: NSRegularExpression.escapedTemplate(for: replacement))
+            return Rule(regex: regex, template: NSRegularExpression.escapedTemplate(for: template))
         }
     }
 

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -371,6 +371,14 @@ public final class SettingsViewModel {
     }
     public var customWordCount: Int = 0
     public var snippetCount: Int = 0
+    public var customVocabularyRecognitionStatus: CustomVocabularyBoostingSupportPresentation {
+        CustomVocabularyBoostingPresentation.status(for: SpeechEngineCapabilityRegistry.capabilities(
+            for: engine.speechEnginePreference,
+            parakeetModelVariant: engine.parakeetModelVariant,
+            nemotronModelVariant: engine.nemotronModelVariant,
+            whisperModelVariant: engine.whisperModelVariant.rawValue
+        ))
+    }
 
     // Storage
     public var saveDictationHistory: Bool {

--- a/Tests/CLITests/VocabCommandTests.swift
+++ b/Tests/CLITests/VocabCommandTests.swift
@@ -97,6 +97,48 @@ final class VocabCommandTests: XCTestCase {
         XCTAssertTrue(schema.json)
     }
 
+    func testVocabWordsRecognitionBoostingStatusLineUsesCapabilityRegistry() {
+        let suiteName = "macparakeet-vocab-cli-defaults-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        SpeechEnginePreference.parakeet.save(to: defaults)
+        SpeechEnginePreference.saveParakeetModelVariant(.v3, defaults: defaults)
+        XCTAssertTrue(
+            VocabWordsCommand.recognitionBoostingStatusLine(defaults: defaults)
+                .contains("Recognition boosting on")
+        )
+
+        SpeechEnginePreference.saveParakeetModelVariant(.unified, defaults: defaults)
+        let unifiedLine = VocabWordsCommand.recognitionBoostingStatusLine(defaults: defaults)
+        XCTAssertTrue(unifiedLine.contains("Clean corrections only"))
+        XCTAssertTrue(unifiedLine.contains("Parakeet English (Unified)"))
+
+        SpeechEnginePreference.cohere.save(to: defaults)
+        let cohereLine = VocabWordsCommand.recognitionBoostingStatusLine(defaults: defaults)
+        XCTAssertTrue(cohereLine.contains("Clean corrections only"))
+        XCTAssertTrue(cohereLine.contains("Cohere"))
+    }
+
+    func testVocabWordsListDisplaysBlankReplacementAsAnchor() async throws {
+        let manager = try DatabaseManager(path: dbPath)
+        let repo = CustomWordRepository(dbQueue: manager.dbQueue)
+        let word = CustomWord(word: "MacParakeet", replacement: "  ")
+        try repo.save(word)
+
+        let cmd = try VocabWordsCommand.ListWords.parse([
+            "--database", dbPath,
+        ])
+        let output = try await capturingStdout {
+            try await cmd.run()
+        }
+
+        XCTAssertTrue(output.contains("[+] MacParakeet (anchor)"))
+        XCTAssertFalse(output.contains("MacParakeet ->"))
+    }
+
     func testVocabWordsSetTogglesEnabledState() async throws {
         let manager = try DatabaseManager(path: dbPath)
         let repo = CustomWordRepository(dbQueue: manager.dbQueue)

--- a/Tests/MacParakeetTests/STT/CustomVocabularyBoostingTests.swift
+++ b/Tests/MacParakeetTests/STT/CustomVocabularyBoostingTests.swift
@@ -103,21 +103,23 @@ final class CustomVocabularyBoostingTests: XCTestCase {
         XCTAssertEqual(requests[0].vocabulary.terms, ["MacParakeet"])
     }
 
-    func testBoundaryChangingBoostSkipsLongTranscriptTimingSynthesis() async throws {
-        let rescorer = FakeCustomVocabularyRescorer(text: "MacParakeet")
-        let longTimings = (0..<(CustomVocabularyBoostingConfiguration.maxBoundaryChangingTimingWordCount + 1))
-            .map { index in
-                TokenTiming(
-                    token: "▁word\(index)",
-                    tokenId: index,
-                    startTime: Double(index),
-                    endTime: Double(index + 1),
-                    confidence: 0.9
-                )
-            }
+    func testBoundaryChangingBoostPreservesLongTranscriptWithSynthesizedChangedSpan() async throws {
+        let rescorer = FakeCustomVocabularyRescorer(
+            text: "please open MacParakeet now and save this note"
+        )
+        let words = ["please", "open", "mac", "parakeet", "now", "and", "save", "this", "note"]
+        let longTimings = words.enumerated().map { index, word in
+            TokenTiming(
+                token: "▁\(word)",
+                tokenId: index,
+                startTime: Double(index),
+                endTime: Double(index + 1),
+                confidence: 0.9
+            )
+        }
 
         let result = try await STTRuntime.applyCustomVocabularyBoostingForTesting(
-            transcript: longTimings.map(\.token).joined(separator: " ").replacingOccurrences(of: "▁", with: ""),
+            transcript: words.joined(separator: " "),
             tokenTimings: longTimings,
             audioSamples: [0.1, 0.2, 0.3],
             capabilities: SpeechEngineCapabilityRegistry.capabilities(for: .parakeet(.v3)),
@@ -125,8 +127,15 @@ final class CustomVocabularyBoostingTests: XCTestCase {
             rescorer: rescorer
         )
 
-        XCTAssertNotEqual(result.text, "MacParakeet")
-        XCTAssertEqual(STTWordTimingBuilder.words(from: result.tokenTimings).count, longTimings.count)
+        let resultWords = STTWordTimingBuilder.words(from: result.tokenTimings)
+        XCTAssertEqual(result.text, "please open MacParakeet now and save this note")
+        XCTAssertEqual(resultWords.map(\.word), ["please", "open", "MacParakeet", "now", "and", "save", "this", "note"])
+        XCTAssertEqual(resultWords[0].startMs, 0)
+        XCTAssertEqual(resultWords[0].endMs, 1000)
+        XCTAssertEqual(resultWords[2].startMs, 2000)
+        XCTAssertEqual(resultWords[2].endMs, 4000)
+        XCTAssertEqual(resultWords[3].startMs, 4000)
+        XCTAssertEqual(resultWords[3].endMs, 5000)
     }
 
     func testSidecarFailureFallsBackToUnboostedTranscript() async throws {

--- a/Tests/MacParakeetTests/STT/CustomVocabularyBoostingTests.swift
+++ b/Tests/MacParakeetTests/STT/CustomVocabularyBoostingTests.swift
@@ -169,6 +169,40 @@ final class CustomVocabularyBoostingTests: XCTestCase {
         }
     }
 
+    func testDictationBackgroundPreparationCancelsBeforeSharedWarmupStarts() async throws {
+        let rescorer = FakeCustomVocabularyRescorer(text: "MacParakeet", isPrepared: false)
+        let registrationProbe = BackgroundPreparationRegistrationProbe()
+        let task = Task {
+            try await STTRuntime.applyCustomVocabularyBoostingForTesting(
+                transcript: "MAC Parakeet",
+                tokenTimings: Self.tokenTimings,
+                audioSamples: [0.1, 0.2, 0.3],
+                capabilities: SpeechEngineCapabilityRegistry.capabilities(for: .parakeet(.v3)),
+                vocabulary: CustomVocabularyBoostingVocabulary(terms: ["MacParakeet"]),
+                rescorer: rescorer,
+                preparationMode: .backgroundIfNeeded,
+                backgroundPreparationTaskRegistered: {
+                    await registrationProbe.holdUntilReleased()
+                }
+            )
+        }
+
+        await registrationProbe.waitUntilRegistered()
+        task.cancel()
+        await registrationProbe.release()
+
+        do {
+            _ = try await task.value
+            XCTFail("Expected cancellation to escape before background preparation starts")
+        } catch is CancellationError {
+            await Task.yield()
+            let prepareCount = await rescorer.prepareCount()
+            let requestCount = await rescorer.requestCount()
+            XCTAssertEqual(prepareCount, 0)
+            XCTAssertEqual(requestCount, 0)
+        }
+    }
+
     func testSupportedEngineInvokesSidecarWithOriginalSamples() async throws {
         let rescorer = FakeCustomVocabularyRescorer(text: "MacParakeet")
         let samples: [Float] = [0.1, 0.2, 0.3, 0.0, 0.0]
@@ -303,6 +337,43 @@ final class CustomVocabularyBoostingTests: XCTestCase {
         }
         let count = await rescorer.prepareCount()
         XCTAssertEqual(count, expectedCount, file: file, line: line)
+    }
+}
+
+private actor BackgroundPreparationRegistrationProbe {
+    private var registered = false
+    private var released = false
+    private var registrationWaiters: [CheckedContinuation<Void, Never>] = []
+    private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
+
+    func holdUntilReleased() async {
+        registered = true
+        let waiters = registrationWaiters
+        registrationWaiters.removeAll()
+        for waiter in waiters {
+            waiter.resume()
+        }
+
+        guard !released else { return }
+        await withCheckedContinuation { continuation in
+            releaseWaiters.append(continuation)
+        }
+    }
+
+    func waitUntilRegistered() async {
+        guard !registered else { return }
+        await withCheckedContinuation { continuation in
+            registrationWaiters.append(continuation)
+        }
+    }
+
+    func release() {
+        released = true
+        let waiters = releaseWaiters
+        releaseWaiters.removeAll()
+        for waiter in waiters {
+            waiter.resume()
+        }
     }
 }
 

--- a/Tests/MacParakeetTests/STT/CustomVocabularyBoostingTests.swift
+++ b/Tests/MacParakeetTests/STT/CustomVocabularyBoostingTests.swift
@@ -103,6 +103,32 @@ final class CustomVocabularyBoostingTests: XCTestCase {
         XCTAssertEqual(requests[0].vocabulary.terms, ["MacParakeet"])
     }
 
+    func testBoundaryChangingBoostSkipsLongTranscriptTimingSynthesis() async throws {
+        let rescorer = FakeCustomVocabularyRescorer(text: "MacParakeet")
+        let longTimings = (0..<(CustomVocabularyBoostingConfiguration.maxBoundaryChangingTimingWordCount + 1))
+            .map { index in
+                TokenTiming(
+                    token: "▁word\(index)",
+                    tokenId: index,
+                    startTime: Double(index),
+                    endTime: Double(index + 1),
+                    confidence: 0.9
+                )
+            }
+
+        let result = try await STTRuntime.applyCustomVocabularyBoostingForTesting(
+            transcript: longTimings.map(\.token).joined(separator: " ").replacingOccurrences(of: "▁", with: ""),
+            tokenTimings: longTimings,
+            audioSamples: [0.1, 0.2, 0.3],
+            capabilities: SpeechEngineCapabilityRegistry.capabilities(for: .parakeet(.v3)),
+            vocabulary: CustomVocabularyBoostingVocabulary(terms: ["MacParakeet"]),
+            rescorer: rescorer
+        )
+
+        XCTAssertNotEqual(result.text, "MacParakeet")
+        XCTAssertEqual(STTWordTimingBuilder.words(from: result.tokenTimings).count, longTimings.count)
+    }
+
     func testSidecarFailureFallsBackToUnboostedTranscript() async throws {
         let rescorer = FakeCustomVocabularyRescorer(error: TestError.expected)
         let result = try await STTRuntime.applyCustomVocabularyBoostingForTesting(

--- a/Tests/MacParakeetTests/STT/CustomVocabularyBoostingTests.swift
+++ b/Tests/MacParakeetTests/STT/CustomVocabularyBoostingTests.swift
@@ -81,6 +81,62 @@ final class CustomVocabularyBoostingTests: XCTestCase {
         XCTAssertEqual(requestCount, 0)
     }
 
+    func testDictationUnpreparedVocabularyReturnsUnboostedAndStartsBackgroundPreparation() async throws {
+        let rescorer = FakeCustomVocabularyRescorer(text: "MacParakeet", isPrepared: false)
+        let result = try await STTRuntime.applyCustomVocabularyBoostingForTesting(
+            transcript: "MAC Parakeet",
+            tokenTimings: Self.tokenTimings,
+            audioSamples: [0.1, 0.2, 0.3],
+            capabilities: SpeechEngineCapabilityRegistry.capabilities(for: .parakeet(.v3)),
+            vocabulary: CustomVocabularyBoostingVocabulary(terms: ["MacParakeet"]),
+            rescorer: rescorer,
+            preparationMode: .backgroundIfNeeded
+        )
+
+        XCTAssertEqual(result.text, "MAC Parakeet")
+        let requestCount = await rescorer.requestCount()
+        XCTAssertEqual(requestCount, 0)
+        try await waitForPrepareCount(1, rescorer: rescorer)
+    }
+
+    func testDictationPreparedVocabularyBoostsWithoutPreparing() async throws {
+        let rescorer = FakeCustomVocabularyRescorer(text: "MacParakeet", isPrepared: true)
+        let result = try await STTRuntime.applyCustomVocabularyBoostingForTesting(
+            transcript: "MAC Parakeet",
+            tokenTimings: Self.tokenTimings,
+            audioSamples: [0.1, 0.2, 0.3],
+            capabilities: SpeechEngineCapabilityRegistry.capabilities(for: .parakeet(.v3)),
+            vocabulary: CustomVocabularyBoostingVocabulary(terms: ["MacParakeet"]),
+            rescorer: rescorer,
+            preparationMode: .backgroundIfNeeded
+        )
+
+        XCTAssertEqual(result.text, "MacParakeet")
+        let prepareCount = await rescorer.prepareCount()
+        let requestCount = await rescorer.requestCount()
+        XCTAssertEqual(prepareCount, 0)
+        XCTAssertEqual(requestCount, 1)
+    }
+
+    func testFileMeetingModeAwaitsPreparationBeforeBoosting() async throws {
+        let rescorer = FakeCustomVocabularyRescorer(text: "MacParakeet", isPrepared: false)
+        let result = try await STTRuntime.applyCustomVocabularyBoostingForTesting(
+            transcript: "MAC Parakeet",
+            tokenTimings: Self.tokenTimings,
+            audioSamples: [0.1, 0.2, 0.3],
+            capabilities: SpeechEngineCapabilityRegistry.capabilities(for: .parakeet(.v3)),
+            vocabulary: CustomVocabularyBoostingVocabulary(terms: ["MacParakeet"]),
+            rescorer: rescorer,
+            preparationMode: .awaitPreparation
+        )
+
+        XCTAssertEqual(result.text, "MacParakeet")
+        let prepareCount = await rescorer.prepareCount()
+        let requestCount = await rescorer.requestCount()
+        XCTAssertEqual(prepareCount, 1)
+        XCTAssertEqual(requestCount, 1)
+    }
+
     func testSupportedEngineInvokesSidecarWithOriginalSamples() async throws {
         let rescorer = FakeCustomVocabularyRescorer(text: "MacParakeet")
         let samples: [Float] = [0.1, 0.2, 0.3, 0.0, 0.0]
@@ -200,16 +256,44 @@ final class CustomVocabularyBoostingTests: XCTestCase {
         TokenTiming(token: "▁MAC", tokenId: 1, startTime: 0.0, endTime: 0.2, confidence: 0.9),
         TokenTiming(token: "▁Parakeet", tokenId: 2, startTime: 0.2, endTime: 0.6, confidence: 0.9),
     ]
+
+    private func waitForPrepareCount(
+        _ expectedCount: Int,
+        rescorer: FakeCustomVocabularyRescorer,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws {
+        for _ in 0..<50 {
+            if await rescorer.prepareCount() == expectedCount {
+                return
+            }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        let count = await rescorer.prepareCount()
+        XCTAssertEqual(count, expectedCount, file: file, line: line)
+    }
 }
 
 private actor FakeCustomVocabularyRescorer: CustomVocabularyRescoring {
     private(set) var requests: [CustomVocabularyRescoringRequest] = []
+    private var prepared: Bool
+    private var prepareCalls = 0
     private let text: String
     private let error: Error?
 
-    init(text: String = "boosted", error: Error? = nil) {
+    init(text: String = "boosted", error: Error? = nil, isPrepared: Bool = true) {
         self.text = text
         self.error = error
+        self.prepared = isPrepared
+    }
+
+    func isPrepared(vocabulary: CustomVocabularyBoostingVocabulary) async -> Bool {
+        prepared
+    }
+
+    func prepare(vocabulary: CustomVocabularyBoostingVocabulary) async throws {
+        prepareCalls += 1
+        prepared = true
     }
 
     func rescore(_ request: CustomVocabularyRescoringRequest) async throws -> CustomVocabularyRescoringResult {
@@ -227,6 +311,10 @@ private actor FakeCustomVocabularyRescorer: CustomVocabularyRescoring {
 
     func requestCount() -> Int {
         requests.count
+    }
+
+    func prepareCount() -> Int {
+        prepareCalls
     }
 }
 

--- a/Tests/MacParakeetTests/STT/CustomVocabularyBoostingTests.swift
+++ b/Tests/MacParakeetTests/STT/CustomVocabularyBoostingTests.swift
@@ -51,7 +51,7 @@ final class CustomVocabularyBoostingTests: XCTestCase {
 
     func testUnsupportedEngineSkipsSidecarInvocation() async throws {
         let rescorer = FakeCustomVocabularyRescorer()
-        let result = await STTRuntime.applyCustomVocabularyBoostingForTesting(
+        let result = try await STTRuntime.applyCustomVocabularyBoostingForTesting(
             transcript: "MAC Parakeet",
             tokenTimings: Self.tokenTimings,
             audioSamples: [0.1, 0.2, 0.3],
@@ -67,7 +67,7 @@ final class CustomVocabularyBoostingTests: XCTestCase {
 
     func testEmptyVocabularySkipsSidecarInvocation() async throws {
         let rescorer = FakeCustomVocabularyRescorer()
-        let result = await STTRuntime.applyCustomVocabularyBoostingForTesting(
+        let result = try await STTRuntime.applyCustomVocabularyBoostingForTesting(
             transcript: "MAC Parakeet",
             tokenTimings: Self.tokenTimings,
             audioSamples: [0.1, 0.2, 0.3],
@@ -84,7 +84,7 @@ final class CustomVocabularyBoostingTests: XCTestCase {
     func testSupportedEngineInvokesSidecarWithOriginalSamples() async throws {
         let rescorer = FakeCustomVocabularyRescorer(text: "MacParakeet")
         let samples: [Float] = [0.1, 0.2, 0.3, 0.0, 0.0]
-        let result = await STTRuntime.applyCustomVocabularyBoostingForTesting(
+        let result = try await STTRuntime.applyCustomVocabularyBoostingForTesting(
             transcript: "MAC Parakeet",
             tokenTimings: Self.tokenTimings,
             audioSamples: samples,
@@ -105,7 +105,7 @@ final class CustomVocabularyBoostingTests: XCTestCase {
 
     func testSidecarFailureFallsBackToUnboostedTranscript() async throws {
         let rescorer = FakeCustomVocabularyRescorer(error: TestError.expected)
-        let result = await STTRuntime.applyCustomVocabularyBoostingForTesting(
+        let result = try await STTRuntime.applyCustomVocabularyBoostingForTesting(
             transcript: "MAC Parakeet",
             tokenTimings: Self.tokenTimings,
             audioSamples: [0.1, 0.2, 0.3],
@@ -117,6 +117,25 @@ final class CustomVocabularyBoostingTests: XCTestCase {
         XCTAssertEqual(result.text, "MAC Parakeet")
         let requestCount = await rescorer.requestCount()
         XCTAssertEqual(requestCount, 1)
+    }
+
+    func testCancellationEscapesSidecarBoosting() async throws {
+        let rescorer = FakeCustomVocabularyRescorer(error: CancellationError())
+
+        do {
+            _ = try await STTRuntime.applyCustomVocabularyBoostingForTesting(
+                transcript: "MAC Parakeet",
+                tokenTimings: Self.tokenTimings,
+                audioSamples: [0.1, 0.2, 0.3],
+                capabilities: SpeechEngineCapabilityRegistry.capabilities(for: .parakeet(.v3)),
+                vocabulary: CustomVocabularyBoostingVocabulary(terms: ["MacParakeet"]),
+                rescorer: rescorer
+            )
+            XCTFail("Expected cancellation to escape vocabulary boosting")
+        } catch is CancellationError {
+            let requestCount = await rescorer.requestCount()
+            XCTAssertEqual(requestCount, 1)
+        }
     }
 
     private static let tokenTimings = [

--- a/Tests/MacParakeetTests/STT/CustomVocabularyBoostingTests.swift
+++ b/Tests/MacParakeetTests/STT/CustomVocabularyBoostingTests.swift
@@ -37,6 +37,18 @@ final class CustomVocabularyBoostingTests: XCTestCase {
         XCTAssertNotEqual(first.contentHash, changed.contentHash)
     }
 
+    func testMapperCanonicalizesDuplicateCasingDeterministically() {
+        let first = CustomVocabularyBoostingVocabulary(
+            terms: ["MacParakeet", "macparakeet", "FluidAudio"]
+        )
+        let reversed = CustomVocabularyBoostingVocabulary(
+            terms: ["FluidAudio", "macparakeet", "MacParakeet"]
+        )
+
+        XCTAssertEqual(first.terms, reversed.terms)
+        XCTAssertEqual(first.contentHash, reversed.contentHash)
+    }
+
     func testUnsupportedEngineSkipsSidecarInvocation() async throws {
         let rescorer = FakeCustomVocabularyRescorer()
         let result = await STTRuntime.applyCustomVocabularyBoostingForTesting(
@@ -82,6 +94,9 @@ final class CustomVocabularyBoostingTests: XCTestCase {
         )
 
         XCTAssertEqual(result.text, "MacParakeet")
+        XCTAssertEqual(STTWordTimingBuilder.words(from: result.tokenTimings).map(\.word), ["MacParakeet"])
+        XCTAssertEqual(STTWordTimingBuilder.words(from: result.tokenTimings).first?.startMs, 0)
+        XCTAssertEqual(STTWordTimingBuilder.words(from: result.tokenTimings).first?.endMs, 600)
         let requests = await rescorer.requests
         XCTAssertEqual(requests.count, 1)
         XCTAssertEqual(requests[0].audioSamples, samples)

--- a/Tests/MacParakeetTests/STT/CustomVocabularyBoostingTests.swift
+++ b/Tests/MacParakeetTests/STT/CustomVocabularyBoostingTests.swift
@@ -1,0 +1,143 @@
+import FluidAudio
+@testable import MacParakeetCore
+import XCTest
+
+final class CustomVocabularyBoostingTests: XCTestCase {
+    func testMapperUsesEnabledBlankReplacementWordsOnly() {
+        let vocabulary = CustomVocabularyBoostingVocabulary.mapping(
+            from: [
+                CustomWord(word: "MacParakeet", replacement: nil),
+                CustomWord(word: "FluidAudio", replacement: ""),
+                CustomWord(word: "aye pee eye", replacement: "API"),
+                CustomWord(word: "disabled", replacement: nil, isEnabled: false),
+                CustomWord(word: "go", replacement: nil),
+            ],
+            minTermLength: 3
+        )
+
+        XCTAssertEqual(vocabulary.terms, ["FluidAudio", "MacParakeet"])
+        XCTAssertFalse(vocabulary.isEmpty)
+    }
+
+    func testMapperContentHashChangesWhenVocabularyContentChanges() {
+        let first = CustomVocabularyBoostingVocabulary.mapping(
+            from: [CustomWord(word: "MacParakeet"), CustomWord(word: "FluidAudio")],
+            minTermLength: 3
+        )
+        let reordered = CustomVocabularyBoostingVocabulary.mapping(
+            from: [CustomWord(word: "FluidAudio"), CustomWord(word: "MacParakeet")],
+            minTermLength: 3
+        )
+        let changed = CustomVocabularyBoostingVocabulary.mapping(
+            from: [CustomWord(word: "MacParakeet"), CustomWord(word: "Fluid Audio")],
+            minTermLength: 3
+        )
+
+        XCTAssertEqual(first.contentHash, reordered.contentHash)
+        XCTAssertNotEqual(first.contentHash, changed.contentHash)
+    }
+
+    func testUnsupportedEngineSkipsSidecarInvocation() async throws {
+        let rescorer = FakeCustomVocabularyRescorer()
+        let result = await STTRuntime.applyCustomVocabularyBoostingForTesting(
+            transcript: "MAC Parakeet",
+            tokenTimings: Self.tokenTimings,
+            audioSamples: [0.1, 0.2, 0.3],
+            capabilities: SpeechEngineCapabilityRegistry.capabilities(for: .parakeet(.unified)),
+            vocabulary: CustomVocabularyBoostingVocabulary(terms: ["MacParakeet"]),
+            rescorer: rescorer
+        )
+
+        XCTAssertEqual(result.text, "MAC Parakeet")
+        let requestCount = await rescorer.requestCount()
+        XCTAssertEqual(requestCount, 0)
+    }
+
+    func testEmptyVocabularySkipsSidecarInvocation() async throws {
+        let rescorer = FakeCustomVocabularyRescorer()
+        let result = await STTRuntime.applyCustomVocabularyBoostingForTesting(
+            transcript: "MAC Parakeet",
+            tokenTimings: Self.tokenTimings,
+            audioSamples: [0.1, 0.2, 0.3],
+            capabilities: SpeechEngineCapabilityRegistry.capabilities(for: .parakeet(.v3)),
+            vocabulary: .empty,
+            rescorer: rescorer
+        )
+
+        XCTAssertEqual(result.text, "MAC Parakeet")
+        let requestCount = await rescorer.requestCount()
+        XCTAssertEqual(requestCount, 0)
+    }
+
+    func testSupportedEngineInvokesSidecarWithOriginalSamples() async throws {
+        let rescorer = FakeCustomVocabularyRescorer(text: "MacParakeet")
+        let samples: [Float] = [0.1, 0.2, 0.3, 0.0, 0.0]
+        let result = await STTRuntime.applyCustomVocabularyBoostingForTesting(
+            transcript: "MAC Parakeet",
+            tokenTimings: Self.tokenTimings,
+            audioSamples: samples,
+            capabilities: SpeechEngineCapabilityRegistry.capabilities(for: .parakeet(.v3)),
+            vocabulary: CustomVocabularyBoostingVocabulary(terms: ["MacParakeet"]),
+            rescorer: rescorer
+        )
+
+        XCTAssertEqual(result.text, "MacParakeet")
+        let requests = await rescorer.requests
+        XCTAssertEqual(requests.count, 1)
+        XCTAssertEqual(requests[0].audioSamples, samples)
+        XCTAssertEqual(requests[0].vocabulary.terms, ["MacParakeet"])
+    }
+
+    func testSidecarFailureFallsBackToUnboostedTranscript() async throws {
+        let rescorer = FakeCustomVocabularyRescorer(error: TestError.expected)
+        let result = await STTRuntime.applyCustomVocabularyBoostingForTesting(
+            transcript: "MAC Parakeet",
+            tokenTimings: Self.tokenTimings,
+            audioSamples: [0.1, 0.2, 0.3],
+            capabilities: SpeechEngineCapabilityRegistry.capabilities(for: .parakeet(.v3)),
+            vocabulary: CustomVocabularyBoostingVocabulary(terms: ["MacParakeet"]),
+            rescorer: rescorer
+        )
+
+        XCTAssertEqual(result.text, "MAC Parakeet")
+        let requestCount = await rescorer.requestCount()
+        XCTAssertEqual(requestCount, 1)
+    }
+
+    private static let tokenTimings = [
+        TokenTiming(token: "▁MAC", tokenId: 1, startTime: 0.0, endTime: 0.2, confidence: 0.9),
+        TokenTiming(token: "▁Parakeet", tokenId: 2, startTime: 0.2, endTime: 0.6, confidence: 0.9),
+    ]
+}
+
+private actor FakeCustomVocabularyRescorer: CustomVocabularyRescoring {
+    private(set) var requests: [CustomVocabularyRescoringRequest] = []
+    private let text: String
+    private let error: Error?
+
+    init(text: String = "boosted", error: Error? = nil) {
+        self.text = text
+        self.error = error
+    }
+
+    func rescore(_ request: CustomVocabularyRescoringRequest) async throws -> CustomVocabularyRescoringResult {
+        requests.append(request)
+        if let error {
+            throw error
+        }
+        return CustomVocabularyRescoringResult(
+            text: text,
+            detectedTerms: request.vocabulary.terms,
+            appliedTerms: request.vocabulary.terms,
+            replacementCount: request.vocabulary.terms.count
+        )
+    }
+
+    func requestCount() -> Int {
+        requests.count
+    }
+}
+
+private enum TestError: Error {
+    case expected
+}

--- a/Tests/MacParakeetTests/STT/CustomVocabularyBoostingTests.swift
+++ b/Tests/MacParakeetTests/STT/CustomVocabularyBoostingTests.swift
@@ -137,6 +137,38 @@ final class CustomVocabularyBoostingTests: XCTestCase {
         XCTAssertEqual(requestCount, 1)
     }
 
+    func testDictationBackgroundPreparationPropagatesCancellationAfterReadinessProbe() async throws {
+        let rescorer = FakeCustomVocabularyRescorer(
+            text: "MacParakeet",
+            isPrepared: false,
+            isPreparedDelayNanoseconds: 50_000_000
+        )
+        let task = Task {
+            try await STTRuntime.applyCustomVocabularyBoostingForTesting(
+                transcript: "MAC Parakeet",
+                tokenTimings: Self.tokenTimings,
+                audioSamples: [0.1, 0.2, 0.3],
+                capabilities: SpeechEngineCapabilityRegistry.capabilities(for: .parakeet(.v3)),
+                vocabulary: CustomVocabularyBoostingVocabulary(terms: ["MacParakeet"]),
+                rescorer: rescorer,
+                preparationMode: .backgroundIfNeeded
+            )
+        }
+
+        try await Task.sleep(nanoseconds: 10_000_000)
+        task.cancel()
+
+        do {
+            _ = try await task.value
+            XCTFail("Expected cancellation to escape cold dictation boosting")
+        } catch is CancellationError {
+            let prepareCount = await rescorer.prepareCount()
+            let requestCount = await rescorer.requestCount()
+            XCTAssertEqual(prepareCount, 0)
+            XCTAssertEqual(requestCount, 0)
+        }
+    }
+
     func testSupportedEngineInvokesSidecarWithOriginalSamples() async throws {
         let rescorer = FakeCustomVocabularyRescorer(text: "MacParakeet")
         let samples: [Float] = [0.1, 0.2, 0.3, 0.0, 0.0]
@@ -280,15 +312,25 @@ private actor FakeCustomVocabularyRescorer: CustomVocabularyRescoring {
     private var prepareCalls = 0
     private let text: String
     private let error: Error?
+    private let isPreparedDelayNanoseconds: UInt64
 
-    init(text: String = "boosted", error: Error? = nil, isPrepared: Bool = true) {
+    init(
+        text: String = "boosted",
+        error: Error? = nil,
+        isPrepared: Bool = true,
+        isPreparedDelayNanoseconds: UInt64 = 0
+    ) {
         self.text = text
         self.error = error
         self.prepared = isPrepared
+        self.isPreparedDelayNanoseconds = isPreparedDelayNanoseconds
     }
 
     func isPrepared(vocabulary: CustomVocabularyBoostingVocabulary) async -> Bool {
-        prepared
+        if isPreparedDelayNanoseconds > 0 {
+            try? await Task.sleep(nanoseconds: isPreparedDelayNanoseconds)
+        }
+        return prepared
     }
 
     func prepare(vocabulary: CustomVocabularyBoostingVocabulary) async throws {

--- a/Tests/MacParakeetTests/STT/CustomVocabularyBoostingTests.swift
+++ b/Tests/MacParakeetTests/STT/CustomVocabularyBoostingTests.swift
@@ -138,6 +138,29 @@ final class CustomVocabularyBoostingTests: XCTestCase {
         XCTAssertEqual(resultWords[3].endMs, 5000)
     }
 
+    func testBoundaryChangingBoostKeepsInsertedWordWhenOriginalTimingsOverlap() async throws {
+        let rescorer = FakeCustomVocabularyRescorer(text: "alpha inserted beta")
+        let overlappingTimings = [
+            TokenTiming(token: "▁alpha", tokenId: 1, startTime: 0.0, endTime: 1.0, confidence: 0.9),
+            TokenTiming(token: "▁beta", tokenId: 2, startTime: 0.9, endTime: 1.5, confidence: 0.9),
+        ]
+
+        let result = try await STTRuntime.applyCustomVocabularyBoostingForTesting(
+            transcript: "alpha beta",
+            tokenTimings: overlappingTimings,
+            audioSamples: [0.1, 0.2, 0.3],
+            capabilities: SpeechEngineCapabilityRegistry.capabilities(for: .parakeet(.v3)),
+            vocabulary: CustomVocabularyBoostingVocabulary(terms: ["inserted"]),
+            rescorer: rescorer
+        )
+
+        let resultWords = STTWordTimingBuilder.words(from: result.tokenTimings)
+        XCTAssertEqual(result.text, "alpha inserted beta")
+        XCTAssertEqual(resultWords.map(\.word), ["alpha", "inserted", "beta"])
+        XCTAssertEqual(resultWords[1].startMs, 1000)
+        XCTAssertEqual(resultWords[1].endMs, 1000)
+    }
+
     func testSidecarFailureFallsBackToUnboostedTranscript() async throws {
         let rescorer = FakeCustomVocabularyRescorer(error: TestError.expected)
         let result = try await STTRuntime.applyCustomVocabularyBoostingForTesting(

--- a/Tests/MacParakeetTests/STT/STTRuntimeDictationPadTests.swift
+++ b/Tests/MacParakeetTests/STT/STTRuntimeDictationPadTests.swift
@@ -72,7 +72,7 @@ final class STTRuntimeDictationPadTests: XCTestCase {
 
         let padded = STTRuntime.paddedDictationSamples(audioPath: url.path)
         let rescorer = DictationPadCustomVocabularyRescorer(text: "MacParakeet")
-        let result = await STTRuntime.applyCustomVocabularyBoostingForTesting(
+        let result = try await STTRuntime.applyCustomVocabularyBoostingForTesting(
             transcript: "MAC Parakeet",
             tokenTimings: [
                 TokenTiming(token: "▁MAC", tokenId: 1, startTime: 0.0, endTime: 0.2, confidence: 0.9),
@@ -113,6 +113,27 @@ final class STTRuntimeDictationPadTests: XCTestCase {
             maxSamples: ASRConstants.maxModelSamples - padSamples
         ))
         XCTAssertTrue(STTRuntime.paddedDictationSamples(audioPath: url.path).isEmpty)
+    }
+
+    func testShortSampleLoaderPropagatesCancellation() throws {
+        let url = try writeMonoFloatWav(
+            sampleCount: 1_000,
+            sampleRate: 16_000,
+            valueAt: { _ in 0.1 }
+        )
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        XCTAssertThrowsError(
+            try STTRuntime.loadShortDictationSamples16k(
+                path: url.path,
+                maxSamples: ASRConstants.maxModelSamples,
+                checkCancellation: {
+                    throw CancellationError()
+                }
+            )
+        ) { error in
+            XCTAssertTrue(error is CancellationError)
+        }
     }
 
     func testPaddedDictationSamplesIsEmptyForMissingFile() {

--- a/Tests/MacParakeetTests/STT/STTRuntimeDictationPadTests.swift
+++ b/Tests/MacParakeetTests/STT/STTRuntimeDictationPadTests.swift
@@ -61,6 +61,39 @@ final class STTRuntimeDictationPadTests: XCTestCase {
         XCTAssertFalse(padded.prefix(realSampleCount).allSatisfy { $0 == 0 })
     }
 
+    func testCustomVocabularySidecarReceivesPaddedDictationSamples() async throws {
+        let realSampleCount = 4_800  // 0.3 s at 16 kHz
+        let url = try writeMonoFloatWav(
+            sampleCount: realSampleCount,
+            sampleRate: 16_000,
+            valueAt: { Float(sin(Double($0) * 0.05)) }
+        )
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let padded = STTRuntime.paddedDictationSamples(audioPath: url.path)
+        let rescorer = DictationPadCustomVocabularyRescorer(text: "MacParakeet")
+        let result = await STTRuntime.applyCustomVocabularyBoostingForTesting(
+            transcript: "MAC Parakeet",
+            tokenTimings: [
+                TokenTiming(token: "▁MAC", tokenId: 1, startTime: 0.0, endTime: 0.2, confidence: 0.9),
+                TokenTiming(token: "▁Parakeet", tokenId: 2, startTime: 0.2, endTime: 0.6, confidence: 0.9),
+            ],
+            audioSamples: padded,
+            capabilities: SpeechEngineCapabilityRegistry.capabilities(for: .parakeet(.v3)),
+            vocabulary: CustomVocabularyBoostingVocabulary(terms: ["MacParakeet"]),
+            rescorer: rescorer
+        )
+
+        XCTAssertEqual(result.text, "MacParakeet")
+        let requests = await rescorer.recordedRequests()
+        XCTAssertEqual(requests.count, 1)
+        let requestSamples = requests[0].audioSamples
+        let expectedPad = Int(STTRuntime.dictationTrailingSilenceSeconds * Double(ASRConstants.sampleRate))
+        XCTAssertEqual(requestSamples.count, realSampleCount + expectedPad)
+        XCTAssertEqual(requestSamples, padded)
+        XCTAssertTrue(requestSamples.suffix(expectedPad).allSatisfy { $0 == 0 })
+    }
+
     func testPaddedDictationSamplesFallsThroughWhenPadWouldExceedSingleWindow() throws {
         // A clip whose padded length would cross the single-window limit must
         // stay on FluidAudio's URL path instead of being loaded and padded in
@@ -115,5 +148,28 @@ final class STTRuntimeDictationPadTests: XCTestCase {
         }
         try file.write(from: buffer)
         return url
+    }
+}
+
+private actor DictationPadCustomVocabularyRescorer: CustomVocabularyRescoring {
+    private var requests: [CustomVocabularyRescoringRequest] = []
+    private let text: String
+
+    init(text: String) {
+        self.text = text
+    }
+
+    func rescore(_ request: CustomVocabularyRescoringRequest) async throws -> CustomVocabularyRescoringResult {
+        requests.append(request)
+        return CustomVocabularyRescoringResult(
+            text: text,
+            detectedTerms: request.vocabulary.terms,
+            appliedTerms: request.vocabulary.terms,
+            replacementCount: request.vocabulary.terms.count
+        )
+    }
+
+    func recordedRequests() -> [CustomVocabularyRescoringRequest] {
+        requests
     }
 }

--- a/Tests/MacParakeetTests/STT/SpeechEngineCapabilitiesTests.swift
+++ b/Tests/MacParakeetTests/STT/SpeechEngineCapabilitiesTests.swift
@@ -30,10 +30,49 @@ final class SpeechEngineCapabilitiesTests: XCTestCase {
         ]))
     }
 
+    func testCustomVocabularyClaimsMatchParakeetTDTVariants() {
+        let customVocabularyKeys = Set(SpeechEngineVariantKey.allCases.filter {
+            SpeechEngineCapabilityRegistry.capabilities(for: $0).supportsCustomVocabulary
+        })
+
+        XCTAssertEqual(customVocabularyKeys, Set([
+            .parakeet(.v2),
+            .parakeet(.v3),
+        ]))
+    }
+
+    func testCustomVocabularyPresentationReadsCapabilitySupport() {
+        let tdtStatus = CustomVocabularyBoostingPresentation.status(
+            for: SpeechEngineCapabilityRegistry.capabilities(for: .parakeet(.v3))
+        )
+        XCTAssertEqual(tdtStatus.title, "Recognition boosting on")
+        XCTAssertTrue(tdtStatus.detail.contains("Parakeet TDT"))
+
+        let unifiedStatus = CustomVocabularyBoostingPresentation.status(
+            for: SpeechEngineCapabilityRegistry.capabilities(for: .parakeet(.unified))
+        )
+        XCTAssertEqual(unifiedStatus.title, "Clean corrections only")
+        XCTAssertTrue(unifiedStatus.detail.contains("Parakeet English (Unified)"))
+
+        let cohereStatus = CustomVocabularyBoostingPresentation.status(
+            for: SpeechEngineCapabilityRegistry.capabilities(for: .cohere)
+        )
+        XCTAssertEqual(cohereStatus.title, "Clean corrections only")
+        XCTAssertTrue(cohereStatus.detail.contains("Cohere"))
+    }
+
+    func testCustomVocabularyPresentationFallsBackToUnsupportedWhenCapabilitiesAreMissing() {
+        let status = CustomVocabularyBoostingPresentation.status(for: Optional<SpeechEngineCapabilities>.none)
+
+        XCTAssertEqual(status.title, "Clean corrections only")
+        XCTAssertTrue(status.detail.contains("does not support recognition-time vocabulary boosting"))
+    }
+
     func testCapabilityFactsPreserveCurrentEngineContracts() {
         let parakeetV3 = SpeechEngineCapabilityRegistry.capabilities(for: .parakeet(.v3))
         XCTAssertTrue(parakeetV3.supportsTailPreview)
         XCTAssertTrue(parakeetV3.providesWordTimestamps)
+        XCTAssertTrue(parakeetV3.supportsCustomVocabulary)
         XCTAssertEqual(parakeetV3.supportedLanguages.mode, .automatic)
         XCTAssertEqual(parakeetV3.telemetryIdentity.modelKind, .parakeetSTT)
         XCTAssertEqual(parakeetV3.telemetryIdentity.engineVariant, .fixed("v3"))
@@ -41,11 +80,13 @@ final class SpeechEngineCapabilitiesTests: XCTestCase {
         let parakeetUnified = SpeechEngineCapabilityRegistry.capabilities(for: .parakeet(.unified))
         XCTAssertFalse(parakeetUnified.supportsTailPreview)
         XCTAssertFalse(parakeetUnified.providesWordTimestamps)
+        XCTAssertFalse(parakeetUnified.supportsCustomVocabulary)
         XCTAssertEqual(parakeetUnified.supportedLanguages, .fixed("en"))
 
         let whisper = SpeechEngineCapabilityRegistry.capabilities(for: .whisper(.largeV3Turbo632MB))
         XCTAssertTrue(whisper.supportsTailPreview)
         XCTAssertTrue(whisper.providesWordTimestamps)
+        XCTAssertFalse(whisper.supportsCustomVocabulary)
         XCTAssertEqual(whisper.supportedLanguages.mode, .selectable)
         XCTAssertEqual(whisper.supportedLanguages.defaultLanguage, WhisperLanguageCatalog.autoCode)
         XCTAssertEqual(whisper.supportedLanguages.supportedLanguageCodes?.first, WhisperLanguageCatalog.autoCode)
@@ -54,6 +95,7 @@ final class SpeechEngineCapabilitiesTests: XCTestCase {
         let cohere = SpeechEngineCapabilityRegistry.capabilities(for: .cohere)
         XCTAssertFalse(cohere.supportsTailPreview)
         XCTAssertFalse(cohere.providesWordTimestamps)
+        XCTAssertFalse(cohere.supportsCustomVocabulary)
         XCTAssertEqual(cohere.supportedLanguages.mode, .selectable)
         XCTAssertEqual(cohere.modelLifecycle.minimumMemoryBytes, 16 * 1024 * 1024 * 1024)
         XCTAssertEqual(cohere.telemetryIdentity.engineVariant, .cohereComputePolicy)

--- a/Tests/MacParakeetTests/TextProcessing/CustomWordReplacerTests.swift
+++ b/Tests/MacParakeetTests/TextProcessing/CustomWordReplacerTests.swift
@@ -57,6 +57,11 @@ final class CustomWordReplacerTests: XCTestCase {
         XCTAssertEqual(replacer.apply(to: "i love swift and SWIFT"), "i love Swift and Swift")
     }
 
+    func testBlankReplacementAnchorNormalizesToStoredCasing() {
+        let replacer = CustomWordReplacer(words: [CustomWord(word: "MacParakeet", replacement: "  ")])
+        XCTAssertEqual(replacer.apply(to: "macparakeet and MACPARAKEET"), "MacParakeet and MacParakeet")
+    }
+
     func testReplacementTemplateIsLiteral() {
         // Replacement text containing regex template metacharacters ("$1") must
         // be inserted literally, not interpreted as a capture reference.
@@ -72,12 +77,14 @@ final class CustomWordReplacerTests: XCTestCase {
             CustomWord(word: "acme", replacement: "ACME Corp"),
             CustomWord(word: "disabled", replacement: "SHOULD-NOT-APPEAR", isEnabled: false),
             CustomWord(word: "anchor", replacement: nil),
+            CustomWord(word: "MacParakeet", replacement: " "),
         ]
         let pipeline = TextProcessingPipeline()
         let samples = [
             "deploy k8s for acme",
             "ACME and Acme and acme",
             "anchor stays anchored",
+            "macparakeet",
             "disabled words do nothing",
             "",
             "no custom words here",

--- a/spec/06-stt-engine.md
+++ b/spec/06-stt-engine.md
@@ -145,26 +145,56 @@ For meeting recording specifically, this has an important consequence: the saved
 
 ### Custom Vocabulary Boosting (v0.11.0+)
 
-FluidAudio's CTC-based keyword boosting maps to MacParakeet's `CustomWord` model:
+MacParakeet Phase 1 uses FluidAudio's 110M CTC encoder as a post-TDT
+recognition sidecar, not as a replacement ASR runtime. The normal Parakeet TDT
+decode runs first and returns transcript text plus token timings; when
+recognition boosting is supported and there are enabled vocabulary anchors,
+MacParakeet runs the CTC sidecar over the same audio samples and uses
+`VocabularyRescorer` to produce the final transcript text.
 
-```swift
-let vocabulary = CustomVocabularyContext(terms: [
-    CustomVocabularyTerm(text: "MacParakeet"),
-    CustomVocabularyTerm(
-        text: "macOS",
-        aliases: ["Mac OS", "Macos"]  // recognized variants → canonical form
-    ),
-])
+Source of truth:
 
-let result = try await asrManager.transcribe(
-    audioSamples,
-    customVocabulary: vocabulary
-)
-// result.ctcDetectedTerms — vocabulary terms spotted
-// result.ctcAppliedTerms — terms applied to transcription
-```
+- Enabled `CustomWord` rows with `replacement == nil` or blank replacement
+  become recognition-time vocabulary anchors.
+- Enabled rows with nonblank `replacement` remain deterministic
+  post-transcription corrections/backstops.
+- Disabled rows and terms shorter than `minTermLength` (`3`) are ignored by
+  recognition boosting.
 
-This runs a secondary CTC encoder (110M params) alongside the primary TDT encoder. Memory doubles from ~66MB to ~130MB when active. Optimal at 1-50 terms.
+Support matrix:
+
+| Engine / variant | Recognition boosting |
+|------------------|----------------------|
+| Parakeet TDT `v3` | Yes |
+| Parakeet TDT `v2` | Yes |
+| Parakeet Unified | No |
+| Nemotron | No |
+| WhisperKit | No |
+| Cohere Transcribe | No |
+
+Runtime behavior:
+
+- Empty vocabulary or unsupported engine variants take the byte-for-byte
+  previous path: no CTC model download/load and no added latency.
+- The CTC model is lazy-loaded from FluidAudio's Application Support model
+  cache only when boosting is needed; download/load/rescoring failures degrade
+  to the unboosted transcript and log only content-free diagnostics.
+- Vocabulary tokenization is cached by stable content hash and refreshed when
+  the effective anchor set changes.
+- Product constants live in `CustomVocabularyBoostingConfiguration`:
+  `minSimilarity = 0.65`, `minTermLength = 3`, and FluidAudio's size-aware
+  rescoring defaults otherwise.
+- Dictation sidecar audio uses the same 16 kHz samples sent to TDT, including
+  the 0.5 second trailing-silence pad from issue #562. File and meeting
+  finalization keep the URL/disk-backed TDT path; Phase 1 only sidecars short
+  audio that can be loaded under the configured sidecar sample bound, and skips
+  boosting for longer jobs until chunked sidecar rescoring lands.
+- Vocabulary contents are user data. MacParakeet does not log or emit telemetry
+  with the term strings.
+
+When active, peak working RAM is approximately the Parakeet TDT slot plus the
+CTC sidecar (~130 MB total). The intended term count remains small user
+vocabularies rather than full dictionaries.
 
 ### Additional Capabilities (via FluidAudio)
 
@@ -174,7 +204,7 @@ This runs a secondary CTC encoder (110M params) alongside the primary TDT encode
 | Speaker diarization (offline) | Pyannote community-1 + WeSpeaker v2 + VBx clustering | ~15% DER (VoxConverse, CoreML), ~130 MB models, unlimited speakers. See ADR-010. |
 | Speaker diarization (streaming) | Sortformer (NVIDIA) | ~32% DER, 4 speaker max. Not used — see ADR-010 for rationale. |
 | Voice activity detection | Silero | 96% accuracy, 1220x RTF |
-| Custom vocabulary | CTC/TDT keyword boosting | 99.3% recall, 110M secondary encoder |
+| Custom vocabulary | CTC/TDT keyword boosting | 110M sidecar for Parakeet TDT v2/v3 enabled anchors |
 
 **Note:** ASR (Parakeet TDT) and diarization (pyannote/WeSpeaker) are entirely separate model pipelines. Parakeet does NOT include diarization. Both are bundled in the FluidAudio SDK — no additional dependencies needed.
 

--- a/spec/adr/026-asr-engine-strategy.md
+++ b/spec/adr/026-asr-engine-strategy.md
@@ -79,9 +79,10 @@ models join as variants within an existing family (as Parakeet
 v2/v3/Unified already do). Near-term roadmap, all within FluidAudio,
 in priority order:
 
-1. **Custom-vocabulary Parakeet CTC** — names/jargon accuracy is the
-   canonical dictation complaint and the clearest moat against Apple's
-   free engine.
+1. **Custom-vocabulary Parakeet CTC** — Phase 1 ships this as a
+   recognition-time CTC sidecar for Parakeet TDT v2/v3 enabled anchors.
+   Future work is chunked long-audio sidecar rescoring and any support
+   FluidAudio exposes for non-TDT engines.
 2. **CJK coverage: Parakeet Japanese + SenseVoiceSmall** — closes the
    gap that currently forces Korean/Japanese/Chinese users onto Whisper
    (and that Parakeet v3 fails outright, per the ADR-001 amendment).

--- a/spec/contracts/cli-json-v1.md
+++ b/spec/contracts/cli-json-v1.md
@@ -69,6 +69,12 @@ with human progress/status kept off stdout.
 - `meetings export --format md --stdout` emits the same Markdown shape as the
   materialized `meeting.md`; use `--stdout --format json` when the caller needs
   parseable JSON on stdout.
+- Recognition-time custom vocabulary boosting does not add JSON fields in v1.
+  For Parakeet TDT `v3` and `v2`, enabled `vocab words` entries with no
+  replacement text may improve the returned transcript text before downstream
+  processing. Unsupported engines and empty vocabularies keep the previous
+  unboosted path; human `vocab words list` support text is not a JSON
+  contract.
 
 ## Failure Envelope
 


### PR DESCRIPTION
## Summary

Implements Custom Vocabulary Phase 1 for the default Parakeet TDT path. Enabled custom-word rows with blank or nil replacement now act as recognition-time spelling anchors through a FluidAudio CTC 110M sidecar rescorer, while explicit replacements remain in the existing post-hoc text correction pipeline.

The sidecar runs only when the active engine advertises custom vocabulary support, the vocabulary is non-empty, audio/timings are available, and the caller's injected `ANEInferenceGate` can serialize the extra CTC inference. Unsupported engines and empty vocabularies preserve today's path with no CTC model load and no added latency.

## Design

- One store: uses existing enabled `CustomWord` rows. Blank/nil replacement means "anchor this spelling"; non-blank replacement stays post-hoc correction only.
- Seam: keep existing Parakeet TDT decode, then rescore the final transcript + token timings with the CTC sidecar. This intentionally does not adopt `SlidingWindowAsrManager`.
- Dictation invariant: rescoring receives the exact padded dictation samples that TDT decoded, including the issue-562 trailing silence pad.
- File/meeting invariant: the main decode remains URL/disk-backed. This PR sidecar-rescores only when bounded 16 kHz sample loading succeeds; the bound is 5 minutes. Longer/unreadable media degrade to the original TDT output.
- Capability honesty: registry support is true only for Parakeet TDT variants. Unified, Nemotron, Whisper, and Cohere show unsupported copy in UI/CLI.
- Privacy: no vocabulary content telemetry. Logs carry counts/error types only.
- Contracts: CLI JSON shape is unchanged; human CLI/status/spec copy now documents recognition-time boosting.

## How It Works

```mermaid
flowchart LR
    A[Enabled CustomWord rows] --> B{nil/blank replacement?}
    B -- yes --> C[Trim + minTermLength guard]
    B -- no --> D[Existing post-hoc replacer]
    C --> E[Stable vocab hash]
    E --> F[Cached CTC tokenized terms]
    G[Parakeet TDT final text + token timings] --> H{Engine supports custom vocabulary?}
    H -- no --> I[Original TDT result]
    H -- yes --> J{Vocab + audio + timings available?}
    J -- no --> I
    J -- yes --> K[ANEInferenceGate]
    K --> L[CTC sidecar rescore]
    L --> M[Boosted final text + timings]
```

## Evidence

Product config: `minSimilarity=0.65`, `minTermLength=3`, FluidAudio size-aware defaults, Parakeet TDT v3.

| Guard | No vocab | Product config | Result |
|---|---:|---:|---|
| OOV recall, 50 generated anchors | 11/50 = 22% | 37/50 = 74% | PASS, >= 70% |
| LibriSpeech first-200 WER | 3.3369% | 3.4652% | PASS, +0.1283 pt <= +0.3 pt |
| Warm short-utterance latency | mean 60.37 ms, median 57.81 ms | mean 168.75 ms, median 166.44 ms | +108.38 ms mean, +109.47 ms median |

False replacements observed:

- OOV product: 2 (`oov-041 core ML -> CoreML`, `oov-050 telemetry -> OpenTelemetry`)
- Libri first-200 product: 5 (`lines -> Linear` twice, `wine alone? -> Pinecone`, `vinegar, -> Linear`, `similitude, -> Amplitude`)

Latency caveat: measured as warm probe processing time with models/scorer already loaded. In the app, dictation will not wait on a cold CTC model/vocabulary prepare: the first unprepared utterance returns the original unboosted result and starts preparation in the background, then later utterances boost once the cache is ready. File/meeting transcription still awaits preparation so non-interactive jobs can receive boosting on first use.

Replay commands:

```bash
python3 benchmarks/asr/custom-vocab-phase0/scripts/librispeech_manifest.py --split-dir /Users/dmoon/asr-bench/LibriSpeech/test-clean --limit 200 --output /tmp/codex-vocab1/generated/librispeech-test-clean-first200.jsonl
python3 benchmarks/asr/custom-vocab-phase0/scripts/generate_oov_say.py --output /tmp/codex-vocab1/generated/oov_manifest.jsonl --audio-dir /tmp/codex-vocab1/generated/oov-audio
swift build -c release --package-path benchmarks/asr/custom-vocab-phase0/probe --product custom-vocab-phase0-probe
swift run -c release --package-path benchmarks/asr/custom-vocab-phase0/probe custom-vocab-phase0-probe --engine tdt-v3 --manifest /tmp/codex-vocab1/generated/oov_manifest.jsonl --output /tmp/codex-vocab1/results/oov_tdt-v3_no-vocab.jsonl --append-silence-seconds 0.5
swift run -c release --package-path benchmarks/asr/custom-vocab-phase0/probe custom-vocab-phase0-probe --engine tdt-v3 --manifest /tmp/codex-vocab1/generated/oov_manifest.jsonl --vocab benchmarks/asr/custom-vocab-phase0/vocab_terms.txt --output /tmp/codex-vocab1/results/oov_tdt-v3_vocab_product.jsonl --append-silence-seconds 0.5 --min-similarity 0.65
swift run -c release --package-path benchmarks/asr/custom-vocab-phase0/probe custom-vocab-phase0-probe --engine tdt-v3 --manifest /tmp/codex-vocab1/generated/librispeech-test-clean-first200.jsonl --dataset librispeech-test-clean --output /tmp/codex-vocab1/results/librispeech-first200_tdt-v3_no-vocab.jsonl
swift run -c release --package-path benchmarks/asr/custom-vocab-phase0/probe custom-vocab-phase0-probe --engine tdt-v3 --manifest /tmp/codex-vocab1/generated/librispeech-test-clean-first200.jsonl --dataset librispeech-test-clean --vocab benchmarks/asr/custom-vocab-phase0/vocab_terms.txt --output /tmp/codex-vocab1/results/librispeech-first200_tdt-v3_vocab_product.jsonl --min-similarity 0.65
/tmp/codex-vocab1/venv314/bin/python benchmarks/asr/score.py --input /tmp/codex-vocab1/results/librispeech-first200_tdt-v3_no-vocab.jsonl --output /tmp/codex-vocab1/results/librispeech-first200_tdt-v3_no-vocab_score.json
/tmp/codex-vocab1/venv314/bin/python benchmarks/asr/score.py --input /tmp/codex-vocab1/results/librispeech-first200_tdt-v3_vocab_product.jsonl --output /tmp/codex-vocab1/results/librispeech-first200_tdt-v3_vocab_product_score.json
```

## Test Evidence

```bash
git diff --check
swift test --filter CustomVocabularyBoostingTests --filter SpeechEngineCapabilitiesTests --filter STTRuntimeDictationPadTests --filter VocabCommandTests --filter SpecCommandTests --filter CustomWordReplacerTests --filter RetranscribeCommandTests
swift test
```

Results:

- Focused suite on latest head (`a54cb10b8`): 90 selected tests, 0 failures.
- Full `swift test` on the first implementation commit: 4,495 XCTest tests + 17 Swift Testing tests, 15 skipped, 0 failures.
- After review-fix commits `793cc6648`, `ae68b30b1`, `c22e61996`, `4fbe848e6`, `1f7688dad`, `3d9d8ee2e`, `3492b9798`, `0a6f39fc`, `4f9f5fd1`, `7f6c46b2`, `fcebcafd`, `75c1d78a6`, and `a54cb10b8`, local full suite was not rerun because the brief caps local full-suite execution at one run; hosted CI is the full-suite gate for the final head.
- `git diff --check`: clean.

## Risk Surface

- Recognition quality: product config passed the WER guard, but the observed false replacements show this can still over-bias phonetically similar common words.
- Latency: warm short-utterance added latency is about 108 ms mean. Cold first-use dictation deliberately returns unboosted immediately and warms the CTC sidecar in the background; cold file/meeting transcription still blocks while preparing because it is non-interactive.
- Long media: file/meeting sidecar is intentionally skipped above the 5 minute bounded decode limit. Chunked rescoring is out of scope for Phase 1.
- Model/runtime failure: CTC load/rescore errors fall back to unboosted output and log count/error-type only.
- Privacy: review should check that vocabulary terms never enter telemetry/logs.

## Post-Deploy Monitoring & Validation

Watch logs for:

- `custom_vocabulary_fetch_failed`
- `custom_vocabulary_boost_loaded`
- `custom_vocabulary_boost_applied`
- `custom_vocabulary_boost_failed`

Healthy rollout signals:

- No spike in boost failure logs or STT failures.
- No increase in dictation-stop latency complaints.
- Users on unsupported engines see honest unsupported status.
- Reports of custom anchors improve without a matching rise in incorrect replacements.

Rollback/follow-up triggers:

- Repeated false replacements on common words.
- CTC model load failures or ANE contention affecting dictation reliability.
- Noticeable stop-latency regressions on real short dictations.
- Long-media users expecting anchors beyond the 5 minute bound; follow-up is chunked sidecar rescoring.

## Author's Notes

`scripts/dev/format.sh` was run, but it rewrote hundreds of unrelated files. I reverted that formatter churn and kept this PR scoped to the feature diff; `git diff --check` is the final formatting hygiene gate here.

Greptile/Gemini review follow-up:

- `793cc6648`: added post-decode cancellation checks, moved model/vocabulary preparation before the ANE gate, made duplicate casing canonicalization deterministic, and synthesized rescored token timings so displayed text and timestamped words stay coherent when boosting changes word boundaries.
- `ae68b30b1`: made cancellation escape the sidecar helper instead of returning a successful fallback transcript, and made the bounded sidecar sample loader cancellation-aware before/during synchronous file reads.
- `c22e61996`: made file/meeting sidecar audio loading lazy behind provider/capability/non-empty-vocabulary gates, returned to a single prepared-vocabulary cache, removed the default "boosting on" sheet status, and prevented unsafe long-transcript timing flattening pending a better synthesis path.
- `4fbe848e6`: moved cancellation checking before the final boost-skip guard and changed the applied log count from unique terms to total replacements.
- `1f7688dad`: bounded the prepared-vocabulary cache by vocabulary hash and added cancellation checkpoints inside FluidAudio model/scorer preparation.
- `3d9d8ee2e`: reused one loaded CTC model/tokenizer resource set across prepared vocabularies, applies long boundary-changing boosts with changed-span timing synthesis, and skips sidecar sample decoding when token timings are absent.
- `3492b9798`: memoized in-flight CTC resource and same-vocabulary preparation tasks, and preserved inserted rescored words at zero-duration boundaries when original timings overlap.
- `0a6f39fc`: protected interactive dictation latency by probing prepared vocabulary state first, returning an unboosted result while background-warming cold CTC resources, and keeping file/meeting transcription on the awaited preparation path.
- `4f9f5fd1`: preserved cancellation semantics in the cold dictation preparation branch, so cancelled first-use dictation cannot return a successful unboosted transcript or start background preparation.
- `7f6c46b2`: made the background CTC warmup task cancelable when cancellation is observed after it starts but before the dictation branch returns.
- `fcebcafd`: wrapped the cold dictation warmup start in a cancellation handler so cancellation during the return window cancels the background task and propagates.
- `75c1d78a6`: detached shared CTC resource and vocabulary preparation from individual waiters, preserves in-flight handles when a waiter is cancelled, and promotes completed shared tasks into the actor cache for later waiters.
- `a54cb10b8`: gated background warmup startup so a cancelled first-use dictation cannot release into shared CTC preparation before the cancellation path exits, with a regression test for the registered-but-not-started window.


