### PR TITLE
Fix onboarding re-run and permission state bugs

### DIFF
--- a/Sources/MacParakeet/App/OnboardingCoordinator.swift
+++ b/Sources/MacParakeet/App/OnboardingCoordinator.swift
@@ -44,7 +44,8 @@ final class OnboardingCoordinator {
                 permissionService: environment.permissionService,
                 sttClient: environment.sttScheduler,
                 diarizationService: environment.diarizationService,
-                entitlementsService: environment.entitlementsService
+                entitlementsService: environment.entitlementsService,
+                restartExistingRun: false
             )
         }
     }
@@ -55,7 +56,8 @@ final class OnboardingCoordinator {
             permissionService: environment.permissionService,
             sttClient: environment.sttScheduler,
             diarizationService: environment.diarizationService,
-            entitlementsService: environment.entitlementsService
+            entitlementsService: environment.entitlementsService,
+            restartExistingRun: true
         )
     }
 
@@ -68,7 +70,8 @@ final class OnboardingCoordinator {
         permissionService: PermissionServiceProtocol,
         sttClient: STTClientProtocol,
         diarizationService: DiarizationServiceProtocol?,
-        entitlementsService: EntitlementsService
+        entitlementsService: EntitlementsService,
+        restartExistingRun: Bool
     ) {
         onboardingWindowController.show(
             permissionService: permissionService,
@@ -82,6 +85,7 @@ final class OnboardingCoordinator {
                     await entitlementsService.bootstrapTrialIfNeeded()
                 }
             },
+            restartExistingRun: restartExistingRun,
             onHotkeyPreviewArm: { [weak self] in self?.onHotkeyPreviewArm() },
             onHotkeyPreviewDisarm: { [weak self] in self?.onHotkeyPreviewDisarm() },
             onOpenMainApp: { [weak self] in

--- a/Sources/MacParakeet/Onboarding/OnboardingWindowController.swift
+++ b/Sources/MacParakeet/Onboarding/OnboardingWindowController.swift
@@ -17,6 +17,7 @@ final class OnboardingWindowController: NSObject, NSWindowDelegate {
         sttClient: STTClientProtocol,
         diarizationService: DiarizationServiceProtocol? = nil,
         onFinish: @escaping () -> Void,
+        restartExistingRun: Bool = false,
         onHotkeyPreviewArm: @escaping () -> Void = {},
         onHotkeyPreviewDisarm: @escaping () -> Void = {},
         onOpenMainApp: @escaping () -> Void,
@@ -24,6 +25,10 @@ final class OnboardingWindowController: NSObject, NSWindowDelegate {
         onIncompleteDismiss: @escaping () -> Void
     ) {
         if let window {
+            if restartExistingRun {
+                viewModel?.startNewCurrentRun()
+                viewModel?.markOnboardingShown()
+            }
             window.makeKeyAndOrderFront(nil)
             NSApp.activate(ignoringOtherApps: true)
             return

--- a/Sources/MacParakeet/Views/Onboarding/OnboardingFlowView.swift
+++ b/Sources/MacParakeet/Views/Onboarding/OnboardingFlowView.swift
@@ -77,7 +77,7 @@ struct OnboardingFlowView: View {
             // Whisper fork is already decided (whisperRecommendation resolves in
             // the VM init), and startEngineWarmUp() is idempotent — the engine
             // step's .onAppear call below is a fallback, and any failure before
-            // the engine step is suppressed until that step is shown (§5.1–5.3).
+            // the engine step is preserved but rendered only there (§5.1–5.3).
             viewModel.startEngineWarmUp()
         }
         .onDisappear {
@@ -222,7 +222,7 @@ struct OnboardingFlowView: View {
             if case .ready = viewModel.engineState { return true }
             return false
         case .done:
-            return viewModel.hasCompletedOnboarding
+            return viewModel.hasCompletedCurrentRun
         }
     }
 
@@ -538,6 +538,7 @@ struct OnboardingFlowView: View {
                 .foregroundStyle(.secondary)
         }
         .onAppear {
+            viewModel.refreshAccessibilityPermission()
             startAnimations()
             onHotkeyPreviewArm()
         }

--- a/Sources/MacParakeetViewModels/OnboardingViewModel.swift
+++ b/Sources/MacParakeetViewModels/OnboardingViewModel.swift
@@ -207,10 +207,18 @@ public final class OnboardingViewModel {
         sendStepTelemetry(step: step, action: .dismissed)
     }
 
+    public func startNewCurrentRun() {
+        resetCurrentRunState()
+    }
+
     public func resetOnboarding() {
         defaults.removeObject(forKey: Self.onboardingCompletedKey)
-        step = .welcome
+        resetCurrentRunState()
         engineState = .idle
+    }
+
+    private func resetCurrentRunState() {
+        step = .welcome
         startedAt = now()
         didEmitInitialStep = false
         completionForCurrentRun = nil

--- a/Sources/MacParakeetViewModels/OnboardingViewModel.swift
+++ b/Sources/MacParakeetViewModels/OnboardingViewModel.swift
@@ -97,6 +97,9 @@ public final class OnboardingViewModel {
     private let warmUpStallTimeout: Duration
     private var didEmitInitialStep = false
     private var completionForCurrentRun: Completion?
+    private var accessibilityPromptedInCurrentRun = false
+    private var accessibilityGrantedTelemetrySent = false
+    private var accessibilityDeniedTelemetrySent = false
     private var engineGeneration: Int = 0
     private var refreshTask: Task<Void, Never>?
     private var permissionPollingTask: Task<Void, Never>?
@@ -166,6 +169,14 @@ public final class OnboardingViewModel {
         defaults.string(forKey: Self.onboardingCompletedKey) != nil
     }
 
+    /// Completion for the onboarding window currently on screen. This is
+    /// intentionally separate from the persisted completion key so Settings'
+    /// "Run setup again" can show fresh progress without treating an abandoned
+    /// re-run as a first-run user.
+    public var hasCompletedCurrentRun: Bool {
+        completionForCurrentRun != nil
+    }
+
     public func markOnboardingCompleted() -> Completion {
         if let completionForCurrentRun {
             return completionForCurrentRun
@@ -189,6 +200,10 @@ public final class OnboardingViewModel {
     }
 
     public func markOnboardingDismissed() {
+        if step == .accessibility {
+            refreshAccessibilityPermission()
+        }
+        emitAccessibilityDeniedIfNeeded()
         sendStepTelemetry(step: step, action: .dismissed)
     }
 
@@ -199,6 +214,9 @@ public final class OnboardingViewModel {
         startedAt = now()
         didEmitInitialStep = false
         completionForCurrentRun = nil
+        accessibilityPromptedInCurrentRun = false
+        accessibilityGrantedTelemetrySent = false
+        accessibilityDeniedTelemetrySent = false
     }
 
     public func refresh() {
@@ -210,9 +228,16 @@ public final class OnboardingViewModel {
             // The class is @MainActor, so this Task already runs on the main
             // actor — assign directly rather than hopping through MainActor.run.
             self.micStatus = mic
-            self.accessibilityGranted = ax
+            self.applyAccessibilityPermission(ax)
             self.refreshTask = nil
         }
+    }
+
+    @discardableResult
+    public func refreshAccessibilityPermission() -> Bool {
+        let granted = permissionService.checkAccessibilityPermission()
+        applyAccessibilityPermission(granted)
+        return granted
     }
 
     /// Steps the user actually sees in the dictation-first onboarding flow.
@@ -224,6 +249,7 @@ public final class OnboardingViewModel {
         let visible = Self.visibleSteps
         let currentRaw = step.rawValue
         guard let next = visible.first(where: { $0.rawValue > currentRaw }) else { return }
+        emitAccessibilityDeniedIfLeavingAccessibility(for: next)
         step = next
         sendStepTelemetry(step: next, action: .forward)
         refresh()
@@ -233,12 +259,14 @@ public final class OnboardingViewModel {
         let visible = Self.visibleSteps
         let currentRaw = step.rawValue
         guard let prev = visible.last(where: { $0.rawValue < currentRaw }) else { return }
+        emitAccessibilityDeniedIfLeavingAccessibility(for: prev)
         step = prev
         sendStepTelemetry(step: prev, action: .back)
         refresh()
     }
 
     public func jump(to target: Step) {
+        emitAccessibilityDeniedIfLeavingAccessibility(for: target)
         step = target
         sendStepTelemetry(step: target, action: .jump)
         refresh()
@@ -289,15 +317,42 @@ public final class OnboardingViewModel {
     public func requestAccessibilityAccess(prompt: Bool = true) {
         isBusy = true
         Telemetry.send(.permissionPrompted(permission: .accessibility))
+        accessibilityPromptedInCurrentRun = true
         _ = permissionService.requestAccessibilityPermission(prompt: prompt)
-        accessibilityGranted = permissionService.checkAccessibilityPermission()
+        refreshAccessibilityPermission()
         isBusy = false
-        // Only emit granted — accessibility check is synchronous and returns false
-        // immediately after prompting (user hasn't clicked yet in System Settings).
-        // Emitting permissionDenied here would fire for nearly every new user.
-        if accessibilityGranted {
-            Telemetry.send(.permissionGranted(permission: .accessibility))
+    }
+
+    private func applyAccessibilityPermission(_ granted: Bool) {
+        accessibilityGranted = granted
+        if granted {
+            emitAccessibilityGrantedIfNeeded()
         }
+    }
+
+    private func emitAccessibilityGrantedIfNeeded() {
+        guard accessibilityPromptedInCurrentRun,
+              !accessibilityGrantedTelemetrySent
+        else { return }
+
+        Telemetry.send(.permissionGranted(permission: .accessibility))
+        accessibilityGrantedTelemetrySent = true
+    }
+
+    private func emitAccessibilityDeniedIfLeavingAccessibility(for nextStep: Step) {
+        guard step == .accessibility, nextStep != .accessibility else { return }
+        refreshAccessibilityPermission()
+        emitAccessibilityDeniedIfNeeded()
+    }
+
+    private func emitAccessibilityDeniedIfNeeded() {
+        guard accessibilityPromptedInCurrentRun,
+              !accessibilityGranted,
+              !accessibilityDeniedTelemetrySent
+        else { return }
+
+        Telemetry.send(.permissionDenied(permission: .accessibility))
+        accessibilityDeniedTelemetrySent = true
     }
 
     public func startPermissionPolling() {
@@ -318,17 +373,16 @@ public final class OnboardingViewModel {
         permissionPollingTask = nil
     }
 
-    /// Apply a warm-up failure to `engineState`, surfacing the terminal
-    /// `.failed` **only** once the user is on the Speech Model step. Part B kicks
-    /// the warm-up off at onboarding open, so a failure can land while the user
-    /// is still granting permissions — showing a failed card on those steps (or
-    /// flashing one the instant the engine step appears) would be wrong. Before
-    /// the engine step we reset to `.idle`; the engine step's `.onAppear` then
-    /// retries `startEngineWarmUp()` cleanly. Always clears `engineBusy`.
+    /// Apply a warm-up failure to `engineState`. Part B kicks the warm-up off at
+    /// onboarding open, so a failure can land while the user is still granting
+    /// permissions. The terminal `.failed` state is preserved, but only the
+    /// Speech Model step renders failure UI; earlier steps keep their normal
+    /// permission/hotkey surfaces and the engine step can show Retry immediately.
+    /// Always clears `engineBusy`.
     /// See plans/active/2026-05-dictation-first-onboarding.md §5.3.
     private func applyEngineWarmUpFailure(_ message: String) {
         engineBusy = false
-        engineState = (step == .engine) ? .failed(message: message) : .idle
+        engineState = .failed(message: message)
         if step == .engine {
             sendStepTelemetry(step: .engine, action: .engineFailed, engineState: "failed")
         }

--- a/Tests/MacParakeetTests/ViewModels/OnboardingViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/OnboardingViewModelTests.swift
@@ -116,6 +116,42 @@ private final class PollingPermissionService: PermissionServiceProtocol, @unchec
     }
 }
 
+private final class DelayedMicrophonePermissionService: PermissionServiceProtocol, @unchecked Sendable {
+    var microphonePermission: PermissionStatus = .granted
+    var accessibilityPermission = false
+    var microphoneDelay: Duration = .milliseconds(200)
+
+    func checkMicrophonePermission() async -> PermissionStatus {
+        try? await Task.sleep(for: microphoneDelay)
+        return microphonePermission
+    }
+
+    func requestMicrophonePermission() async -> Bool {
+        microphonePermission = .granted
+        return true
+    }
+
+    func checkScreenRecordingPermission() -> Bool {
+        true
+    }
+
+    func requestScreenRecordingPermission() -> Bool {
+        true
+    }
+
+    func openMicrophoneSettings() {}
+
+    func openScreenRecordingSettings() {}
+
+    func checkAccessibilityPermission() -> Bool {
+        accessibilityPermission
+    }
+
+    func requestAccessibilityPermission(prompt _: Bool) -> Bool {
+        accessibilityPermission
+    }
+}
+
 @MainActor
 final class OnboardingViewModelTests: XCTestCase {
     private func waitUntil(
@@ -212,6 +248,117 @@ final class OnboardingViewModelTests: XCTestCase {
         vm.refresh()
         try await Task.sleep(for: .milliseconds(50))
         XCTAssertTrue(vm.canContinueFromCurrentStep())
+    }
+
+    func testAccessibilityDeniedTelemetryEmitsWhenPromptedUserDismissesStillUngranted() {
+        let telemetry = OnboardingTelemetrySpy()
+        Telemetry.configure(telemetry)
+        defer { Telemetry.configure(NoOpTelemetryService()) }
+
+        let perms = MockPermissionService()
+        perms.accessibilityPermission = false
+        perms.requestAccessibilityResult = false
+        let stt = MockSTTClient()
+        let defaults = UserDefaults(suiteName: "com.macparakeet.tests.\(UUID().uuidString)")!
+
+        let vm = makeViewModel(permissionService: perms, sttClient: stt, defaults: defaults)
+        vm.jump(to: .accessibility)
+        vm.requestAccessibilityAccess()
+
+        XCTAssertFalse(vm.accessibilityGranted)
+        XCTAssertTrue(telemetry.snapshot().contains {
+            if case .permissionPrompted(let permission) = $0 { return permission == .accessibility }
+            return false
+        })
+        XCTAssertFalse(telemetry.snapshot().contains {
+            if case .permissionDenied = $0 { return true }
+            return false
+        }, "Accessibility should not emit denied immediately after prompting")
+
+        vm.markOnboardingDismissed()
+        vm.markOnboardingDismissed()
+
+        let deniedPermissions = telemetry.snapshot().compactMap { event -> TelemetryPermission? in
+            guard case .permissionDenied(let permission) = event else { return nil }
+            return permission
+        }
+        XCTAssertEqual(deniedPermissions, [.accessibility])
+    }
+
+    func testAccessibilityGrantTelemetryCanArriveOnRefreshAfterPrompt() {
+        let telemetry = OnboardingTelemetrySpy()
+        Telemetry.configure(telemetry)
+        defer { Telemetry.configure(NoOpTelemetryService()) }
+
+        let perms = MockPermissionService()
+        perms.accessibilityPermission = false
+        perms.requestAccessibilityResult = false
+        let stt = MockSTTClient()
+        let defaults = UserDefaults(suiteName: "com.macparakeet.tests.\(UUID().uuidString)")!
+
+        let vm = makeViewModel(permissionService: perms, sttClient: stt, defaults: defaults)
+        vm.jump(to: .accessibility)
+        vm.requestAccessibilityAccess()
+
+        perms.accessibilityPermission = true
+        vm.refreshAccessibilityPermission()
+
+        let grantedPermissions = telemetry.snapshot().compactMap { event -> TelemetryPermission? in
+            guard case .permissionGranted(let permission) = event else { return nil }
+            return permission
+        }
+        XCTAssertEqual(grantedPermissions, [.accessibility])
+        XCTAssertFalse(telemetry.snapshot().contains {
+            if case .permissionDenied = $0 { return true }
+            return false
+        })
+    }
+
+    func testAccessibilityDismissRechecksBeforeDeniedTelemetry() {
+        let telemetry = OnboardingTelemetrySpy()
+        Telemetry.configure(telemetry)
+        defer { Telemetry.configure(NoOpTelemetryService()) }
+
+        let perms = MockPermissionService()
+        perms.accessibilityPermission = false
+        perms.requestAccessibilityResult = false
+        let stt = MockSTTClient()
+        let defaults = UserDefaults(suiteName: "com.macparakeet.tests.\(UUID().uuidString)")!
+
+        let vm = makeViewModel(permissionService: perms, sttClient: stt, defaults: defaults)
+        vm.jump(to: .accessibility)
+        vm.requestAccessibilityAccess()
+
+        perms.accessibilityPermission = true
+        vm.markOnboardingDismissed()
+
+        let grantedPermissions = telemetry.snapshot().compactMap { event -> TelemetryPermission? in
+            guard case .permissionGranted(let permission) = event else { return nil }
+            return permission
+        }
+        XCTAssertEqual(grantedPermissions, [.accessibility])
+        XCTAssertFalse(telemetry.snapshot().contains {
+            if case .permissionDenied = $0 { return true }
+            return false
+        })
+    }
+
+    func testHotkeyRefreshChecksAccessibilityBeforePendingFullRefreshCompletes() async throws {
+        let perms = DelayedMicrophonePermissionService()
+        perms.accessibilityPermission = false
+        let stt = MockSTTClient()
+        let defaults = UserDefaults(suiteName: "com.macparakeet.tests.\(UUID().uuidString)")!
+
+        let vm = makeViewModel(permissionService: perms, sttClient: stt, defaults: defaults)
+        vm.refresh()
+
+        perms.accessibilityPermission = true
+        XCTAssertFalse(vm.accessibilityGranted)
+        XCTAssertTrue(vm.refreshAccessibilityPermission())
+        XCTAssertTrue(vm.accessibilityGranted)
+
+        try await Task.sleep(for: .milliseconds(250))
+        XCTAssertTrue(vm.accessibilityGranted)
     }
 
     func testStepOrdering() {
@@ -320,6 +467,26 @@ final class OnboardingViewModelTests: XCTestCase {
 
         let vm = makeViewModel(permissionService: perms, sttClient: stt, defaults: defaults)
         XCTAssertTrue(vm.hasCompletedOnboarding)
+    }
+
+    func testPersistedCompletionDoesNotCompleteCurrentRunProgress() {
+        let perms = MockPermissionService()
+        let stt = MockSTTClient()
+        let suite = "com.macparakeet.tests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        defaults.set("2026-01-01T00:00:00Z", forKey: OnboardingViewModel.onboardingCompletedKey)
+
+        let vm = makeViewModel(permissionService: perms, sttClient: stt, defaults: defaults)
+
+        XCTAssertTrue(vm.hasCompletedOnboarding)
+        XCTAssertFalse(vm.hasCompletedCurrentRun)
+
+        _ = vm.markOnboardingCompleted()
+
+        XCTAssertTrue(vm.hasCompletedOnboarding)
+        XCTAssertTrue(vm.hasCompletedCurrentRun)
+        XCTAssertNotNil(defaults.string(forKey: OnboardingViewModel.onboardingCompletedKey))
     }
 
     func testNoMeetingRecordingOrCalendarStepsInFlow() {
@@ -601,10 +768,10 @@ final class OnboardingViewModelTests: XCTestCase {
     }
 
     /// Guard 3 (§5.3): a warm-up failure that lands before the user reaches the
-    /// Speech Model step must NOT surface a terminal `.failed`; it resets to
-    /// `.idle` so the engine step can retry. Once on the engine step, the failure
-    /// is allowed to surface.
-    func testWarmUpFailureBeforeEngineStepIsSuppressedUntilEngineStep() async throws {
+    /// Speech Model step must be preserved so the engine step can immediately
+    /// show the existing error + Retry UI. Earlier steps do not render
+    /// `engineState`, so preserving `.failed` does not add failure UI there.
+    func testWarmUpFailureBeforeEngineStepIsPreservedForEngineStep() async throws {
         let perms = MockPermissionService()
         let stt = MockSTTClient()
         await stt.configureWarmUp(error: STTError.engineStartFailed("boom"))
@@ -621,22 +788,23 @@ final class OnboardingViewModelTests: XCTestCase {
             try await Task.sleep(for: .milliseconds(10))
         }
 
-        if case .failed = vm.engineState {
-            XCTFail("a warm-up failure before the engine step must not surface as .failed")
+        guard case .failed(let message) = vm.engineState else {
+            return XCTFail("expected the head-start failure to be preserved, got \(vm.engineState)")
         }
-        XCTAssertEqual(vm.engineState, .idle, "suppressed failure resets to .idle so the engine step can retry")
+        XCTAssertTrue(message.contains("boom"), "preserved failure should retain the original error")
         XCTAssertFalse(vm.engineBusy)
+        XCTAssertTrue(vm.canContinueFromCurrentStep(), "early-step navigation must not be blocked by hidden engine failure UI")
+        let backgroundWarmUpCount = await stt.backgroundWarmUpCallCountSnapshot()
 
-        // Reaching the engine step retries; now the failure is allowed to surface.
+        // Reaching the engine step must not silently retry over the preserved
+        // failure; Retry is the explicit restart path.
         vm.jump(to: .engine)
         vm.startEngineWarmUp()
-        try await waitUntil(timeout: .seconds(2)) {
-            if case .failed = vm.engineState { return true }
-            return false
-        }
-        guard case .failed = vm.engineState else {
-            return XCTFail("the engine-step retry should surface the failure, got \(vm.engineState)")
-        }
+        try await Task.sleep(for: .milliseconds(50))
+
+        let backgroundWarmUpCountAfterEngineAppear = await stt.backgroundWarmUpCallCountSnapshot()
+        XCTAssertEqual(backgroundWarmUpCountAfterEngineAppear, backgroundWarmUpCount)
+        guard case .failed = vm.engineState else { return XCTFail("engine step should still surface the preserved failure") }
     }
 
     /// Guard 2 (§5.2): the head-start must honor the Whisper fork for a CJK

--- a/Tests/MacParakeetTests/ViewModels/OnboardingViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/OnboardingViewModelTests.swift
@@ -489,6 +489,32 @@ final class OnboardingViewModelTests: XCTestCase {
         XCTAssertNotNil(defaults.string(forKey: OnboardingViewModel.onboardingCompletedKey))
     }
 
+    func testStartNewCurrentRunClearsCurrentProgressButKeepsPersistedCompletion() {
+        let perms = MockPermissionService()
+        let stt = MockSTTClient()
+        let suite = "com.macparakeet.tests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let clock = OnboardingTestClock(Date(timeIntervalSince1970: 100))
+
+        let vm = makeViewModel(
+            permissionService: perms,
+            sttClient: stt,
+            defaults: defaults,
+            now: { clock.now() }
+        )
+        _ = vm.markOnboardingCompleted()
+        vm.jump(to: .done)
+
+        clock.set(Date(timeIntervalSince1970: 200))
+        vm.startNewCurrentRun()
+
+        XCTAssertEqual(vm.step, .welcome)
+        XCTAssertTrue(vm.hasCompletedOnboarding)
+        XCTAssertFalse(vm.hasCompletedCurrentRun)
+        XCTAssertNotNil(defaults.string(forKey: OnboardingViewModel.onboardingCompletedKey))
+    }
+
     func testNoMeetingRecordingOrCalendarStepsInFlow() {
         let steps = OnboardingViewModel.visibleSteps
         let allCases = OnboardingViewModel.Step.allCases

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -465,6 +465,8 @@ does not use `auto_stop` because auto-stop only affects the stop/finalize path.
 | `permission_granted` | `permission` | Grant rate |
 | `permission_denied` | `permission` | Denial rate — is something confusing? |
 
+Accessibility note: macOS does not provide a direct denial callback for Accessibility. During onboarding, `permission_denied` with `permission=accessibility` is emitted only after the user was prompted and then leaves or dismisses the Accessibility step while it is still ungranted; later System Settings grants are reported via the existing `permission_granted` event on refresh.
+
 ### 9. Errors — "What's breaking?"
 
 | Event | Props | Question It Answers |

--- a/spec/adr/005-onboarding-first-run.md
+++ b/spec/adr/005-onboarding-first-run.md
@@ -76,5 +76,5 @@ Accessibility is still granted during onboarding for all users, which also cover
 - The warm-up tracks its own `engineBusy` flag, separate from the permission `isBusy`, so the head-start download never disables the Microphone/Accessibility grant buttons.
 - `startEngineWarmUp()` is idempotent (generation + observation-token guards): the early trigger starts it; the Speech Model step's `.onAppear` call is a no-op fallback. No second download.
 - The Parakeet-vs-Whisper fork is preserved for CJK locales — `whisperRecommendation` resolves synchronously in `init`, before any trigger.
-- A warm-up failure that occurs before the user reaches the Speech Model step is suppressed (state resets to `.idle`); the terminal `.failed` only surfaces once that step is shown, so an early/transient failure never flashes a failed card on an earlier step.
+- A warm-up failure that occurs before the user reaches the Speech Model step is preserved as `.failed`, but only the Speech Model step renders failure UI. Earlier steps continue to show their permission/hotkey surfaces, and the user sees the existing error + Retry affordance immediately on reaching Speech Model.
 - `modelDownloadStarted` now fires at onboarding open; the start→ready duration still measures real download time (the background download is independent of the user's step).


### PR DESCRIPTION
## Summary
Fixes four onboarding bugs from the July 4 onboarding bug brief: stale setup re-run progress, hidden head-start model failures, missing Accessibility denied telemetry, and stale Hotkey rehearsal state after granting Accessibility in System Settings. The six-step onboarding flow stays intact; this is state/telemetry plumbing, not a UX rewrite.

## Design
| Bug from brief | Before | After |
|---|---|---|
| 1. Stale completed state on Settings re-run | The Ready sidebar row read persisted `onboarding.completedAtISO`, so completed users saw old progress on a fresh setup run. | The UI now uses current-run completion (`hasCompletedCurrentRun`) for the Ready checkmark while `hasCompletedOnboarding` still owns auto-reopen behavior. |
| 2. Early model-download failure suppressed | Head-start failures before Speech Model reset `engineState` to `.idle`, so users reached Speech Model without seeing the first failure. | The failure is preserved as `.failed`; earlier steps do not render engine UI, and Speech Model immediately shows the existing Needs attention/error/Retry state. |
| 3. Accessibility missing denied telemetry | Accessibility sent prompted and sometimes granted, but never denied. | Reuses the existing `permission_denied` event with `permission=accessibility`; no new event name or website allowlist change needed. |
| 4. Hotkey preview can render stale | The Hotkey step could read stale `accessibilityGranted` while the async full permission refresh was still behind the microphone check. | Hotkey `onAppear` performs a synchronous Accessibility re-check before rendering/arming the live rehearsal state. |

Bug 1 design choice: this PR fixes display state instead of resetting persisted onboarding. A completed user who re-runs setup and abandons it remains onboarded because `onboarding.completedAtISO` is not cleared and `hasCompletedOnboarding` still drives auto-reopen decisions.

Bug 3 denial signal: macOS has no Accessibility denial callback, so this PR records `permission_denied/accessibility` only after the app has prompted and the user leaves or dismisses the Accessibility step while it is still ungranted. Before emitting denial on dismiss, the view model re-checks Accessibility so a just-granted System Settings change is counted as granted, not denied. `docs/telemetry.md` documents that semantic.

Spec alignment: this matches the July 4 onboarding bug brief inline: keep Welcome -> Microphone -> Accessibility -> Hotkey -> Speech Model -> Ready, no step restructuring, no copy rewrite, and no new telemetry event name. ADR-005 is updated because the warm-up failure contract changed from "reset to idle" to "preserve failed state but render it only on Speech Model." The scratchpad brief itself is not committed because the journal/scratchpad path is outside the repo and gitignored.

## Risk surface
The main risk is telemetry timing: Accessibility denial is a pragmatic stuck/leave signal, not a native macOS denial callback. The second risk is preserving early `.failed` state while users are still on earlier steps; the UI only reads failure details on Speech Model, and tests assert early-step continuation remains unaffected.

## Test evidence
- `swift test --filter OnboardingViewModelTests` - passed, 49 tests, 0 failures.
- `git diff --check` - passed.

Full `swift test` was intentionally not run per the brief's focused-tests-only instruction; CI/review pipeline can run the broader gate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes four onboarding flow bugs to show correct rerun progress, surface early model failures at the right time, record Accessibility denials, and avoid stale Hotkey state. No UX changes; state handling and telemetry only.

- **Bug Fixes**
  - Rerun progress: split persisted completion from current-run; Ready uses `hasCompletedCurrentRun`. When Settings reruns setup on an already-visible window, reset only the current-run and return to Welcome while keeping users onboarded.
  - Model warm-up failures: preserve `.failed` from early downloads and render it only on the Speech Model step so users see error + Retry immediately.
  - Accessibility telemetry: reuse `permission_denied` with `permission=accessibility`; emit only after a prompt when leaving/dismissing still ungranted, with a final re-check to avoid false denials; send granted on refresh once detected.
  - Hotkey step: perform a synchronous Accessibility re-check on appear to prevent stale rehearsal state while async refresh completes.

<sup>Written for commit 54d0cae29cb319a19d232deeee60d04715f50b16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/722?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

