### PR TITLE
Add gated in-process local LLM foundation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,7 @@ import PackageDescription
 import Foundation
 
 let skipWhisperKit = ProcessInfo.processInfo.environment["MACPARAKEET_SKIP_WHISPERKIT"] == "1"
+let enableMLXLocalLLM = ProcessInfo.processInfo.environment["MACPARAKEET_ENABLE_MLX_LOCAL_LLM"] == "1"
 
 let packageDependencies: [Package.Dependency] = [
     // GRDB for SQLite (dictation history + transcription records)
@@ -21,7 +22,14 @@ let packageDependencies: [Package.Dependency] = [
     // as a target dependency for the first-party Swift 6 syntax/concurrency
     // compile check without removing its lockfile pins.
     .package(url: "https://github.com/argmaxinc/argmax-oss-swift", exact: "0.18.0")
-]
+] + (enableMLXLocalLLM ? [
+    // Opt-in only. mlx-swift-lm currently needs Swift tools 6.1 and Xcode-built
+    // Metal shaders, so plain `swift build` / `swift test` / CI must not resolve it.
+    .package(url: "https://github.com/ml-explore/mlx-swift-lm", exact: "3.31.4"),
+    .package(url: "https://github.com/ml-explore/mlx-swift", exact: "0.31.4"),
+    .package(url: "https://github.com/huggingface/swift-huggingface", from: "0.9.0"),
+    .package(url: "https://github.com/huggingface/swift-transformers", from: "1.3.0"),
+] : [])
 
 let coreDependencies: [Target.Dependency] = [
     .product(name: "GRDB", package: "GRDB.swift"),
@@ -35,6 +43,43 @@ let coreDependencies: [Target.Dependency] = [
 let whisperKitSwiftSettings: [SwiftSetting] = skipWhisperKit ? [] : [
     .define("MACPARAKEET_HAS_WHISPERKIT")
 ]
+
+let mlxLocalLLMSwiftSettings: [SwiftSetting] = enableMLXLocalLLM ? [
+    .define("MACPARAKEET_HAS_MLX_LOCAL_LLM")
+] : []
+
+let appDependencies: [Target.Dependency] = [
+    "MacParakeetCore",
+    "MacParakeetViewModels",
+    .product(name: "Sparkle", package: "Sparkle")
+] + (enableMLXLocalLLM ? [
+    "MacParakeetLocalLLM"
+] : [])
+
+let appTestDependencies: [Target.Dependency] = [
+    "MacParakeet",
+    "MacParakeetCore",
+    "MacParakeetViewModels",
+    "MacParakeetObjCShims"
+] + (enableMLXLocalLLM ? [
+    "MacParakeetLocalLLM"
+] : [])
+
+let mlxLocalLLMTargets: [Target] = enableMLXLocalLLM ? [
+    .target(
+        name: "MacParakeetLocalLLM",
+        dependencies: [
+            "MacParakeetCore",
+            .product(name: "MLXLLM", package: "mlx-swift-lm"),
+            .product(name: "MLXLMCommon", package: "mlx-swift-lm"),
+            .product(name: "MLXHuggingFace", package: "mlx-swift-lm"),
+            .product(name: "HuggingFace", package: "swift-huggingface"),
+            .product(name: "Tokenizers", package: "swift-transformers"),
+        ],
+        path: "Sources/MacParakeetLocalLLM",
+        swiftSettings: mlxLocalLLMSwiftSettings
+    )
+] : []
 
 let package = Package(
     name: "MacParakeet",
@@ -54,11 +99,7 @@ let package = Package(
         // Main GUI app
         .executableTarget(
             name: "MacParakeet",
-            dependencies: [
-                "MacParakeetCore",
-                "MacParakeetViewModels",
-                .product(name: "Sparkle", package: "Sparkle")
-            ],
+            dependencies: appDependencies,
             path: "Sources/MacParakeet",
             resources: [.process("Resources")]
         ),
@@ -108,14 +149,14 @@ let package = Package(
         // Tests
         .testTarget(
             name: "MacParakeetTests",
-            dependencies: ["MacParakeet", "MacParakeetCore", "MacParakeetViewModels", "MacParakeetObjCShims"],
+            dependencies: appTestDependencies,
             path: "Tests/MacParakeetTests",
-            swiftSettings: whisperKitSwiftSettings
+            swiftSettings: whisperKitSwiftSettings + mlxLocalLLMSwiftSettings
         ),
         .testTarget(
             name: "CLITests",
             dependencies: ["CLI", "MacParakeetCore"],
             path: "Tests/CLITests"
         )
-    ]
+    ] + mlxLocalLLMTargets
 )

--- a/Sources/CLI/Commands/LLMInlineConfig.swift
+++ b/Sources/CLI/Commands/LLMInlineConfig.swift
@@ -110,6 +110,9 @@ struct LLMInlineOptions: ParsableArguments {
                 "Unknown provider '\(provider)'. Options: anthropic, openai, openaiCompatible, gemini, openrouter, ollama, lmstudio, cli"
             )
         }
+        if providerID == .inProcessLocal {
+            throw ValidationError("The in-process local provider is not exposed through inline CLI configuration yet.")
+        }
         return providerID
     }
 
@@ -205,6 +208,8 @@ struct LLMInlineOptions: ParsableArguments {
             localCLIConfig = LocalCLIConfig(
                 commandTemplate: rawCommand.trimmingCharacters(in: .whitespacesAndNewlines)
             )
+        case .inProcessLocal:
+            throw ValidationError("The in-process local provider is not exposed through inline CLI configuration yet.")
         }
 
         if local && !providerConfig.isLocal {

--- a/Sources/MacParakeet/Views/Settings/LLMSettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/LLMSettingsView.swift
@@ -26,16 +26,7 @@ struct LLMSettingsView: View {
     @State private var aiFormatterAppIcons: [String: NSImage] = [:]
     @State private var aiFormatterAppIconLoadingIDs: Set<String> = []
 
-    private static let providerOrder: [LLMProviderID] = [
-        .lmstudio,
-        .ollama,
-        .anthropic,
-        .openai,
-        .gemini,
-        .openrouter,
-        .openaiCompatible,
-        .localCLI,
-    ]
+    private static let providerOrder: [LLMProviderID] = LLMProviderID.userSelectableProviderIDs
 
     private static let smartDefaultGridColumns = [
         GridItem(.adaptive(minimum: 168), spacing: DesignSystem.Spacing.sm)

--- a/Sources/MacParakeetCore/AppFeatures.swift
+++ b/Sources/MacParakeetCore/AppFeatures.swift
@@ -117,4 +117,12 @@ public enum AppFeatures {
     /// back to `true` to ship profiles in a later tag (no-data operation — the
     /// profile table/repository migrate regardless of this flag).
     public static let aiFormatterProfilesEnabled: Bool = false
+
+    /// In-process local LLM provider (MLX foundation). When `false`, the
+    /// provider descriptor, config, routing seam, and fake-runtime tests remain
+    /// compiled, but Settings and user-reachable provider lists hide the option.
+    /// The real MLX implementation is a separate opt-in build target gated by
+    /// `MACPARAKEET_ENABLE_MLX_LOCAL_LLM=1`, so normal SwiftPM builds and CI do
+    /// not resolve mlx-swift-lm.
+    public static let inProcessLocalLLMEnabled: Bool = false
 }

--- a/Sources/MacParakeetCore/Models/LLMProvider.swift
+++ b/Sources/MacParakeetCore/Models/LLMProvider.swift
@@ -39,6 +39,7 @@ public enum LLMProviderID: String, Codable, Sendable, CaseIterable {
     case ollama
     case lmstudio
     case localCLI
+    case inProcessLocal
 
     public var descriptor: LLMProviderDescriptor {
         switch self {
@@ -199,7 +200,35 @@ public enum LLMProviderID: String, Codable, Sendable, CaseIterable {
                 defaultModelName: "",
                 fallbackModels: []
             )
+        case .inProcessLocal:
+            return LLMProviderDescriptor(
+                id: self,
+                displayName: "Local MLX",
+                defaultBaseURL: "inprocess://local",
+                isLocal: true,
+                supportsAPIKey: false,
+                requiresAPIKey: false,
+                requiresCustomEndpoint: false,
+                modelListEndpoint: .none,
+                defaultModelName: "mlx-community/Qwen3-4B-Instruct-2507-DDWQ",
+                fallbackModels: [
+                    "mlx-community/Qwen3-4B-Instruct-2507-DDWQ",
+                ]
+            )
         }
+    }
+
+    public static var userSelectableProviderIDs: [LLMProviderID] {
+        [
+            .lmstudio,
+            .ollama,
+            .anthropic,
+            .openai,
+            .gemini,
+            .openrouter,
+            .openaiCompatible,
+            .localCLI,
+        ] + (AppFeatures.inProcessLocalLLMEnabled ? [.inProcessLocal] : [])
     }
 
     public var displayName: String {
@@ -384,6 +413,18 @@ public struct LLMProviderConfig: Codable, Sendable, Equatable {
             apiKey: nil,
             modelName: "cli",
             isLocal: false
+        )
+    }
+
+    public static func inProcessLocal(
+        model: String = LLMProviderID.inProcessLocal.defaultModelName
+    ) -> LLMProviderConfig {
+        LLMProviderConfig(
+            id: .inProcessLocal,
+            baseURL: URL(string: LLMProviderID.inProcessLocal.defaultBaseURL)!,
+            apiKey: nil,
+            modelName: model,
+            isLocal: true
         )
     }
 

--- a/Sources/MacParakeetCore/Models/LLMTypes.swift
+++ b/Sources/MacParakeetCore/Models/LLMTypes.swift
@@ -77,25 +77,58 @@ public struct ChatCompletionOptions: Sendable, Equatable {
 
 // MARK: - Chat Completion Response
 
+public struct LLMGenerationMetrics: Sendable, Equatable, Codable {
+    public let tokensPerSecond: Double?
+    public let promptTokensPerSecond: Double?
+    public let timeToFirstTokenMs: Int?
+    public let peakRSSBytes: UInt64?
+
+    public init(
+        tokensPerSecond: Double? = nil,
+        promptTokensPerSecond: Double? = nil,
+        timeToFirstTokenMs: Int? = nil,
+        peakRSSBytes: UInt64? = nil
+    ) {
+        self.tokensPerSecond = tokensPerSecond
+        self.promptTokensPerSecond = promptTokensPerSecond
+        self.timeToFirstTokenMs = timeToFirstTokenMs
+        self.peakRSSBytes = peakRSSBytes
+    }
+
+    public func withPeakRSS(_ sample: UInt64?) -> LLMGenerationMetrics {
+        guard let sample else { return self }
+        let peak = peakRSSBytes.map { max($0, sample) } ?? sample
+        return LLMGenerationMetrics(
+            tokensPerSecond: tokensPerSecond,
+            promptTokensPerSecond: promptTokensPerSecond,
+            timeToFirstTokenMs: timeToFirstTokenMs,
+            peakRSSBytes: peak
+        )
+    }
+}
+
 public struct ChatCompletionResponse: Sendable {
     public let content: String
     public let reasoningContent: String?
     public let finishReason: String?
     public let model: String
     public let usage: TokenUsage?
+    public let generationMetrics: LLMGenerationMetrics?
 
     public init(
         content: String,
         reasoningContent: String? = nil,
         finishReason: String? = nil,
         model: String,
-        usage: TokenUsage? = nil
+        usage: TokenUsage? = nil,
+        generationMetrics: LLMGenerationMetrics? = nil
     ) {
         self.content = content
         self.reasoningContent = reasoningContent
         self.finishReason = finishReason
         self.model = model
         self.usage = usage
+        self.generationMetrics = generationMetrics
     }
 }
 

--- a/Sources/MacParakeetCore/Services/LLM/InProcessLLMClient.swift
+++ b/Sources/MacParakeetCore/Services/LLM/InProcessLLMClient.swift
@@ -15,7 +15,7 @@ public final class InProcessLLMClient: LLMClientProtocol, Sendable {
     private let chunkCharacterThreshold: Int
     private let chunkCharacterLimit: Int
     private let idleUnloadDelayNanoseconds: UInt64
-    private let idleUnloadScheduler = LocalLLMIdleUnloadScheduler()
+    private let lifetimeCoordinator = LocalLLMLifetimeCoordinator()
     private let logger = Logger(subsystem: "com.macparakeet.core", category: "InProcessLLMClient")
 
     public init(
@@ -82,8 +82,21 @@ public final class InProcessLLMClient: LLMClientProtocol, Sendable {
 
     public func testConnection(context: LLMExecutionContext) async throws {
         try Task.checkCancellation()
-        try await loadRuntime(for: context.providerConfig)
-        await runtime.unload()
+        await lifetimeCoordinator.beginGeneration()
+        do {
+            try Task.checkCancellation()
+            try await loadRuntime(for: context.providerConfig)
+            await lifetimeCoordinator.endGeneration(
+                runtime: runtime,
+                delayNanoseconds: 0
+            )
+        } catch {
+            await lifetimeCoordinator.endGeneration(
+                runtime: runtime,
+                delayNanoseconds: 0
+            )
+            throw error
+        }
     }
 
     public func listModels(context: LLMExecutionContext) async throws -> [String] {
@@ -113,10 +126,12 @@ public final class InProcessLLMClient: LLMClientProtocol, Sendable {
         }
 
         try Task.checkCancellation()
-        await idleUnloadScheduler.cancelPendingUnload()
-        try await loadRuntime(for: context.providerConfig)
+        await lifetimeCoordinator.beginGeneration()
 
         do {
+            try Task.checkCancellation()
+            try await loadRuntime(for: context.providerConfig)
+
             let response: CollectedLocalLLMResponse
             if shouldChunk(messages) {
                 response = try await generateChunked(
@@ -133,13 +148,13 @@ public final class InProcessLLMClient: LLMClientProtocol, Sendable {
             }
 
             log(metrics: response.metrics, inputCharacters: Self.inputCharacterCount(messages))
-            await idleUnloadScheduler.scheduleUnload(
+            await lifetimeCoordinator.endGeneration(
                 runtime: runtime,
                 delayNanoseconds: idleUnloadDelayNanoseconds
             )
             return response
         } catch {
-            await idleUnloadScheduler.scheduleUnload(
+            await lifetimeCoordinator.endGeneration(
                 runtime: runtime,
                 delayNanoseconds: idleUnloadDelayNanoseconds
             )
@@ -295,6 +310,7 @@ public final class InProcessLLMClient: LLMClientProtocol, Sendable {
         partials: [String]
     ) -> [ChatMessage] {
         let systemMessages = originalMessages.filter { $0.role == .system }
+        let originalConversationContext = compactConversationContext(originalMessages)
         let combined = partials.enumerated()
             .map { "Chunk \($0.offset + 1):\n\($0.element)" }
             .joined(separator: "\n\n")
@@ -304,10 +320,44 @@ public final class InProcessLLMClient: LLMClientProtocol, Sendable {
                 content: """
                 Combine the chunk results into one final answer for the original request. Preserve source facts exactly, remove duplication, and do not add unstated details.
 
+                Original conversation context, including user and assistant turns:
+                \(originalConversationContext)
+
+                Chunk results:
                 \(combined)
                 """
             ),
         ]
+    }
+
+    private static func compactConversationContext(
+        _ messages: [ChatMessage],
+        maxCharacters: Int = 6_000
+    ) -> String {
+        let context = messages
+            .filter { $0.role != .system }
+            .map { "\($0.role.rawValue.uppercased()): \($0.modelContent)" }
+            .joined(separator: "\n\n")
+
+        guard !context.isEmpty else { return "(no user or assistant context)" }
+        return middleTruncated(context, maxCharacters: maxCharacters)
+    }
+
+    private static func middleTruncated(_ text: String, maxCharacters: Int) -> String {
+        guard text.count > maxCharacters else { return text }
+
+        let boundedLimit = max(1, maxCharacters)
+        let headCount = boundedLimit / 2
+        let tailCount = boundedLimit - headCount
+        let headEnd = text.index(text.startIndex, offsetBy: headCount)
+        let tailStart = text.index(text.endIndex, offsetBy: -tailCount)
+        return """
+        \(text[..<headEnd])
+
+        [...conversation truncated for local model memory...]
+
+        \(text[tailStart...])
+        """
     }
 
     private static func merge(
@@ -331,15 +381,40 @@ private struct CollectedLocalLLMResponse: Sendable {
     let metrics: LLMGenerationMetrics?
 }
 
-private actor LocalLLMIdleUnloadScheduler {
+private actor LocalLLMLifetimeCoordinator {
     private var unloadTask: Task<Void, Never>?
+    private var generationActive = false
+    private var waitingGenerations: [CheckedContinuation<Void, Never>] = []
 
-    func cancelPendingUnload() {
+    func beginGeneration() async {
+        if generationActive {
+            await withCheckedContinuation { continuation in
+                waitingGenerations.append(continuation)
+            }
+            return
+        }
+
+        generationActive = true
+        cancelPendingUnload()
+    }
+
+    func endGeneration(runtime: any LocalLLMRuntime, delayNanoseconds: UInt64) {
+        if !waitingGenerations.isEmpty {
+            let next = waitingGenerations.removeFirst()
+            next.resume()
+            return
+        }
+
+        generationActive = false
+        scheduleUnload(runtime: runtime, delayNanoseconds: delayNanoseconds)
+    }
+
+    private func cancelPendingUnload() {
         unloadTask?.cancel()
         unloadTask = nil
     }
 
-    func scheduleUnload(runtime: any LocalLLMRuntime, delayNanoseconds: UInt64) {
+    private func scheduleUnload(runtime: any LocalLLMRuntime, delayNanoseconds: UInt64) {
         unloadTask?.cancel()
         unloadTask = Task {
             guard delayNanoseconds > 0 else {

--- a/Sources/MacParakeetCore/Services/LLM/InProcessLLMClient.swift
+++ b/Sources/MacParakeetCore/Services/LLM/InProcessLLMClient.swift
@@ -1,0 +1,379 @@
+import Darwin
+import Foundation
+import OSLog
+
+public typealias LocalLLMModelDirectoryResolver = @Sendable (LLMProviderConfig) throws -> URL
+
+public final class InProcessLLMClient: LLMClientProtocol, Sendable {
+    public static let modelDirectoryEnvironmentVariable = "MACPARAKEET_LOCAL_LLM_MODEL_DIR"
+    public static let defaultChunkCharacterThreshold = 24_000
+    public static let defaultChunkCharacterLimit = 12_000
+    public static let defaultIdleUnloadDelaySeconds: TimeInterval = 300
+
+    private let runtime: any LocalLLMRuntime
+    private let modelDirectoryResolver: LocalLLMModelDirectoryResolver
+    private let chunkCharacterThreshold: Int
+    private let chunkCharacterLimit: Int
+    private let idleUnloadDelayNanoseconds: UInt64
+    private let idleUnloadScheduler = LocalLLMIdleUnloadScheduler()
+    private let logger = Logger(subsystem: "com.macparakeet.core", category: "InProcessLLMClient")
+
+    public init(
+        runtime: any LocalLLMRuntime = UnavailableLocalLLMRuntime(),
+        modelDirectoryResolver: @escaping LocalLLMModelDirectoryResolver = {
+            try InProcessLLMClient.environmentModelDirectory(for: $0)
+        },
+        chunkCharacterThreshold: Int = InProcessLLMClient.defaultChunkCharacterThreshold,
+        chunkCharacterLimit: Int = InProcessLLMClient.defaultChunkCharacterLimit,
+        idleUnloadDelaySeconds: TimeInterval = InProcessLLMClient.defaultIdleUnloadDelaySeconds
+    ) {
+        self.runtime = runtime
+        self.modelDirectoryResolver = modelDirectoryResolver
+        self.chunkCharacterThreshold = max(1, chunkCharacterThreshold)
+        self.chunkCharacterLimit = max(1, chunkCharacterLimit)
+        let boundedDelay = max(0, idleUnloadDelaySeconds)
+        self.idleUnloadDelayNanoseconds = UInt64(boundedDelay * 1_000_000_000)
+    }
+
+    public func chatCompletion(
+        messages: [ChatMessage],
+        context: LLMExecutionContext,
+        options: ChatCompletionOptions
+    ) async throws -> ChatCompletionResponse {
+        let generation = try await generateResponse(
+            messages: messages,
+            context: context,
+            options: options,
+            emit: nil
+        )
+        return ChatCompletionResponse(
+            content: generation.content,
+            finishReason: "stop",
+            model: context.providerConfig.modelName,
+            generationMetrics: generation.metrics
+        )
+    }
+
+    public func chatCompletionStream(
+        messages: [ChatMessage],
+        context: LLMExecutionContext,
+        options: ChatCompletionOptions
+    ) -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { continuation in
+            let task = Task {
+                do {
+                    _ = try await self.generateResponse(
+                        messages: messages,
+                        context: context,
+                        options: options,
+                        emit: { continuation.yield($0) }
+                    )
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+
+            continuation.onTermination = { _ in
+                task.cancel()
+            }
+        }
+    }
+
+    public func testConnection(context: LLMExecutionContext) async throws {
+        try Task.checkCancellation()
+        try await loadRuntime(for: context.providerConfig)
+        await runtime.unload()
+    }
+
+    public func listModels(context: LLMExecutionContext) async throws -> [String] {
+        [context.providerConfig.modelName].filter { !$0.isEmpty }
+    }
+
+    public static func environmentModelDirectory(for config: LLMProviderConfig) throws -> URL {
+        guard let rawPath = ProcessInfo.processInfo.environment[modelDirectoryEnvironmentVariable],
+              !rawPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw LLMError.modelNotFound(
+                "Set \(modelDirectoryEnvironmentVariable) to a local MLX model directory for \(config.modelName)."
+            )
+        }
+        return URL(fileURLWithPath: rawPath, isDirectory: true)
+    }
+
+    // MARK: - Generation
+
+    private func generateResponse(
+        messages: [ChatMessage],
+        context: LLMExecutionContext,
+        options: ChatCompletionOptions,
+        emit: (@Sendable (String) -> Void)?
+    ) async throws -> CollectedLocalLLMResponse {
+        guard context.providerConfig.id == .inProcessLocal else {
+            throw LLMError.providerError("InProcessLLMClient received \(context.providerConfig.id.rawValue).")
+        }
+
+        try Task.checkCancellation()
+        await idleUnloadScheduler.cancelPendingUnload()
+        try await loadRuntime(for: context.providerConfig)
+
+        do {
+            let response: CollectedLocalLLMResponse
+            if shouldChunk(messages) {
+                response = try await generateChunked(
+                    messages: messages,
+                    options: options,
+                    emit: emit
+                )
+            } else {
+                response = try await generateSingle(
+                    messages: messages,
+                    options: options,
+                    emit: emit
+                )
+            }
+
+            log(metrics: response.metrics, inputCharacters: Self.inputCharacterCount(messages))
+            await idleUnloadScheduler.scheduleUnload(
+                runtime: runtime,
+                delayNanoseconds: idleUnloadDelayNanoseconds
+            )
+            return response
+        } catch {
+            await idleUnloadScheduler.scheduleUnload(
+                runtime: runtime,
+                delayNanoseconds: idleUnloadDelayNanoseconds
+            )
+            throw error
+        }
+    }
+
+    private func loadRuntime(for config: LLMProviderConfig) async throws {
+        let directory = try modelDirectoryResolver(config)
+        try await runtime.load(
+            model: LocalLLMModelReference(
+                modelName: config.modelName,
+                directory: directory
+            )
+        )
+    }
+
+    private func generateChunked(
+        messages: [ChatMessage],
+        options: ChatCompletionOptions,
+        emit: (@Sendable (String) -> Void)?
+    ) async throws -> CollectedLocalLLMResponse {
+        let chunks = Self.splitForMapReduce(messages, maxCharacters: chunkCharacterLimit)
+        var partials: [String] = []
+        var mergedMetrics: LLMGenerationMetrics?
+
+        for (offset, chunk) in chunks.enumerated() {
+            try Task.checkCancellation()
+            let mapMessages = Self.mapMessages(
+                originalMessages: messages,
+                chunk: chunk,
+                index: offset + 1,
+                total: chunks.count
+            )
+            let response = try await generateSingle(
+                messages: mapMessages,
+                options: options,
+                emit: nil
+            )
+            partials.append(response.content)
+            mergedMetrics = Self.merge(mergedMetrics, response.metrics)
+        }
+
+        let reduceMessages = Self.reduceMessages(
+            originalMessages: messages,
+            partials: partials
+        )
+        let reduceResponse = try await generateSingle(
+            messages: reduceMessages,
+            options: options,
+            emit: emit
+        )
+        return CollectedLocalLLMResponse(
+            content: reduceResponse.content,
+            metrics: Self.merge(mergedMetrics, reduceResponse.metrics)
+        )
+    }
+
+    private func generateSingle(
+        messages: [ChatMessage],
+        options: ChatCompletionOptions,
+        emit: (@Sendable (String) -> Void)?
+    ) async throws -> CollectedLocalLLMResponse {
+        try Task.checkCancellation()
+        let rssBefore = ProcessRSSSampler.currentResidentSetSizeBytes()
+        let stream = try await runtime.generateStream(messages: messages, options: options)
+
+        var content = ""
+        var metrics: LLMGenerationMetrics?
+        for try await event in stream {
+            try Task.checkCancellation()
+            switch event {
+            case .text(let text):
+                content += text
+                emit?(text)
+            case .metrics(let eventMetrics):
+                metrics = eventMetrics
+            }
+        }
+
+        let runtimeMetrics: LLMGenerationMetrics?
+        if let metrics {
+            runtimeMetrics = metrics
+        } else {
+            runtimeMetrics = await runtime.instrumentation()
+        }
+        let peakRSS = [rssBefore, ProcessRSSSampler.currentResidentSetSizeBytes(), runtimeMetrics?.peakRSSBytes]
+            .compactMap { $0 }
+            .max()
+        return CollectedLocalLLMResponse(
+            content: content,
+            metrics: (runtimeMetrics ?? LLMGenerationMetrics()).withPeakRSS(peakRSS)
+        )
+    }
+
+    private func shouldChunk(_ messages: [ChatMessage]) -> Bool {
+        Self.inputCharacterCount(messages) > chunkCharacterThreshold
+    }
+
+    private func log(metrics: LLMGenerationMetrics?, inputCharacters: Int) {
+        logger.info(
+            "Local LLM generation completed inputCharacters=\(inputCharacters, privacy: .public) tokensPerSecond=\(metrics?.tokensPerSecond ?? -1, privacy: .public) promptTokensPerSecond=\(metrics?.promptTokensPerSecond ?? -1, privacy: .public) ttftMs=\(metrics?.timeToFirstTokenMs ?? -1, privacy: .public) peakRSSBytes=\(metrics?.peakRSSBytes ?? 0, privacy: .public)"
+        )
+    }
+
+    // MARK: - Chunking
+
+    private static func inputCharacterCount(_ messages: [ChatMessage]) -> Int {
+        messages.reduce(0) { $0 + $1.modelContent.count }
+    }
+
+    private static func splitForMapReduce(_ messages: [ChatMessage], maxCharacters: Int) -> [String] {
+        let joined = messages
+            .map { "\($0.role.rawValue.uppercased()): \($0.modelContent)" }
+            .joined(separator: "\n\n")
+        return split(joined, maxCharacters: maxCharacters)
+    }
+
+    private static func split(_ text: String, maxCharacters: Int) -> [String] {
+        guard text.count > maxCharacters else { return [text] }
+
+        var chunks: [String] = []
+        var cursor = text.startIndex
+        while cursor < text.endIndex {
+            let end = text.index(cursor, offsetBy: maxCharacters, limitedBy: text.endIndex) ?? text.endIndex
+            chunks.append(String(text[cursor..<end]))
+            cursor = end
+        }
+        return chunks
+    }
+
+    private static func mapMessages(
+        originalMessages: [ChatMessage],
+        chunk: String,
+        index: Int,
+        total: Int
+    ) -> [ChatMessage] {
+        let systemMessages = originalMessages.filter { $0.role == .system }
+        return systemMessages + [
+            ChatMessage(
+                role: .user,
+                content: """
+                Process chunk \(index) of \(total) for the user's request. Preserve facts exactly and do not infer missing details.
+
+                \(chunk)
+                """
+            ),
+        ]
+    }
+
+    private static func reduceMessages(
+        originalMessages: [ChatMessage],
+        partials: [String]
+    ) -> [ChatMessage] {
+        let systemMessages = originalMessages.filter { $0.role == .system }
+        let combined = partials.enumerated()
+            .map { "Chunk \($0.offset + 1):\n\($0.element)" }
+            .joined(separator: "\n\n")
+        return systemMessages + [
+            ChatMessage(
+                role: .user,
+                content: """
+                Combine the chunk results into one final answer for the original request. Preserve source facts exactly, remove duplication, and do not add unstated details.
+
+                \(combined)
+                """
+            ),
+        ]
+    }
+
+    private static func merge(
+        _ lhs: LLMGenerationMetrics?,
+        _ rhs: LLMGenerationMetrics?
+    ) -> LLMGenerationMetrics? {
+        guard let lhs else { return rhs }
+        guard let rhs else { return lhs }
+
+        return LLMGenerationMetrics(
+            tokensPerSecond: rhs.tokensPerSecond ?? lhs.tokensPerSecond,
+            promptTokensPerSecond: rhs.promptTokensPerSecond ?? lhs.promptTokensPerSecond,
+            timeToFirstTokenMs: rhs.timeToFirstTokenMs ?? lhs.timeToFirstTokenMs,
+            peakRSSBytes: [lhs.peakRSSBytes, rhs.peakRSSBytes].compactMap { $0 }.max()
+        )
+    }
+}
+
+private struct CollectedLocalLLMResponse: Sendable {
+    let content: String
+    let metrics: LLMGenerationMetrics?
+}
+
+private actor LocalLLMIdleUnloadScheduler {
+    private var unloadTask: Task<Void, Never>?
+
+    func cancelPendingUnload() {
+        unloadTask?.cancel()
+        unloadTask = nil
+    }
+
+    func scheduleUnload(runtime: any LocalLLMRuntime, delayNanoseconds: UInt64) {
+        unloadTask?.cancel()
+        unloadTask = Task {
+            guard delayNanoseconds > 0 else {
+                await runtime.unload()
+                return
+            }
+
+            do {
+                try await Task.sleep(nanoseconds: delayNanoseconds)
+                try Task.checkCancellation()
+                await runtime.unload()
+            } catch {
+                return
+            }
+        }
+    }
+}
+
+private enum ProcessRSSSampler {
+    static func currentResidentSetSizeBytes() -> UInt64? {
+        #if os(macOS)
+        var info = mach_task_basic_info_data_t()
+        var count = mach_msg_type_number_t(
+            MemoryLayout<mach_task_basic_info_data_t>.stride / MemoryLayout<natural_t>.stride
+        )
+        let result = withUnsafeMutablePointer(to: &info) {
+            $0.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
+                task_info(mach_task_self_, task_flavor_t(MACH_TASK_BASIC_INFO), $0, &count)
+            }
+        }
+        guard result == KERN_SUCCESS else { return nil }
+        return UInt64(info.resident_size)
+        #else
+        return nil
+        #endif
+    }
+}

--- a/Sources/MacParakeetCore/Services/LLM/InProcessLLMClient.swift
+++ b/Sources/MacParakeetCore/Services/LLM/InProcessLLMClient.swift
@@ -1,5 +1,6 @@
 import Darwin
 import Foundation
+import MacParakeetObjCShims
 import OSLog
 
 public typealias LocalLLMModelDirectoryResolver = @Sendable (LLMProviderConfig) throws -> URL
@@ -439,12 +440,6 @@ private actor LocalLLMLifetimeCoordinator {
 }
 
 private enum ProcessRSSSampler {
-    #if compiler(>=6.2)
-    private static let currentTaskPort: mach_port_t = mach_task_self_
-    #else
-    nonisolated(unsafe) private static let currentTaskPort: mach_port_t = mach_task_self_
-    #endif
-
     static func currentResidentSetSizeBytes() -> UInt64? {
         #if os(macOS)
         var info = mach_task_basic_info_data_t()
@@ -453,7 +448,7 @@ private enum ProcessRSSSampler {
         )
         let result = withUnsafeMutablePointer(to: &info) {
             $0.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
-                task_info(currentTaskPort, task_flavor_t(MACH_TASK_BASIC_INFO), $0, &count)
+                task_info(MPKCurrentTaskPort(), task_flavor_t(MACH_TASK_BASIC_INFO), $0, &count)
             }
         }
         guard result == KERN_SUCCESS else { return nil }

--- a/Sources/MacParakeetCore/Services/LLM/InProcessLLMClient.swift
+++ b/Sources/MacParakeetCore/Services/LLM/InProcessLLMClient.swift
@@ -83,7 +83,7 @@ public final class InProcessLLMClient: LLMClientProtocol, Sendable {
 
     public func testConnection(context: LLMExecutionContext) async throws {
         try Task.checkCancellation()
-        await lifetimeCoordinator.beginGeneration()
+        try await lifetimeCoordinator.beginGeneration()
         do {
             try Task.checkCancellation()
             try await loadRuntime(for: context.providerConfig)
@@ -127,7 +127,7 @@ public final class InProcessLLMClient: LLMClientProtocol, Sendable {
         }
 
         try Task.checkCancellation()
-        await lifetimeCoordinator.beginGeneration()
+        try await lifetimeCoordinator.beginGeneration()
 
         do {
             try Task.checkCancellation()
@@ -178,7 +178,16 @@ public final class InProcessLLMClient: LLMClientProtocol, Sendable {
         options: ChatCompletionOptions,
         emit: (@Sendable (String) -> Void)?
     ) async throws -> CollectedLocalLLMResponse {
-        let chunks = Self.splitForMapReduce(messages, maxCharacters: chunkCharacterLimit)
+        guard Self.inputCharacterCount(messages) > chunkCharacterLimit else {
+            return try await generateSingle(messages: messages, options: options, emit: emit)
+        }
+
+        let promptBudget = Self.promptBudget(maxCharacters: chunkCharacterLimit)
+        let chunks = Self.splitForMapReduce(messages, maxCharacters: promptBudget.chunkCharacters)
+        guard chunks.count > 1 else {
+            return try await generateSingle(messages: messages, options: options, emit: emit)
+        }
+
         var partials: [String] = []
         var mergedMetrics: LLMGenerationMetrics?
 
@@ -188,7 +197,8 @@ public final class InProcessLLMClient: LLMClientProtocol, Sendable {
                 originalMessages: messages,
                 chunk: chunk,
                 index: offset + 1,
-                total: chunks.count
+                total: chunks.count,
+                conversationContextMaxCharacters: promptBudget.contextCharacters
             )
             let response = try await generateSingle(
                 messages: mapMessages,
@@ -201,7 +211,9 @@ public final class InProcessLLMClient: LLMClientProtocol, Sendable {
 
         let reduceMessages = Self.reduceMessages(
             originalMessages: messages,
-            partials: partials
+            partials: partials,
+            conversationContextMaxCharacters: promptBudget.contextCharacters,
+            partialResultsMaxCharacters: promptBudget.partialResultCharacters
         )
         let reduceResponse = try await generateSingle(
             messages: reduceMessages,
@@ -291,10 +303,14 @@ public final class InProcessLLMClient: LLMClientProtocol, Sendable {
         originalMessages: [ChatMessage],
         chunk: String,
         index: Int,
-        total: Int
+        total: Int,
+        conversationContextMaxCharacters: Int
     ) -> [ChatMessage] {
         let systemMessages = originalMessages.filter { $0.role == .system }
-        let originalConversationContext = compactConversationContext(originalMessages)
+        let originalConversationContext = compactConversationContext(
+            originalMessages,
+            maxCharacters: conversationContextMaxCharacters
+        )
         return systemMessages + [
             ChatMessage(
                 role: .user,
@@ -313,13 +329,19 @@ public final class InProcessLLMClient: LLMClientProtocol, Sendable {
 
     private static func reduceMessages(
         originalMessages: [ChatMessage],
-        partials: [String]
+        partials: [String],
+        conversationContextMaxCharacters: Int,
+        partialResultsMaxCharacters: Int
     ) -> [ChatMessage] {
         let systemMessages = originalMessages.filter { $0.role == .system }
-        let originalConversationContext = compactConversationContext(originalMessages)
+        let originalConversationContext = compactConversationContext(
+            originalMessages,
+            maxCharacters: conversationContextMaxCharacters
+        )
         let combined = partials.enumerated()
             .map { "Chunk \($0.offset + 1):\n\($0.element)" }
             .joined(separator: "\n\n")
+        let boundedCombined = middleTruncated(combined, maxCharacters: partialResultsMaxCharacters)
         return systemMessages + [
             ChatMessage(
                 role: .user,
@@ -330,7 +352,7 @@ public final class InProcessLLMClient: LLMClientProtocol, Sendable {
                 \(originalConversationContext)
 
                 Chunk results:
-                \(combined)
+                \(boundedCombined)
                 """
             ),
         ]
@@ -353,17 +375,28 @@ public final class InProcessLLMClient: LLMClientProtocol, Sendable {
         guard text.count > maxCharacters else { return text }
 
         let boundedLimit = max(1, maxCharacters)
-        let headCount = boundedLimit / 2
-        let tailCount = boundedLimit - headCount
+        let marker = "\n\n[...truncated for local model memory...]\n\n"
+        guard boundedLimit > marker.count + 2 else {
+            return String(text.prefix(boundedLimit))
+        }
+
+        let remainingCharacters = boundedLimit - marker.count
+        let headCount = remainingCharacters / 2
+        let tailCount = remainingCharacters - headCount
         let headEnd = text.index(text.startIndex, offsetBy: headCount)
         let tailStart = text.index(text.endIndex, offsetBy: -tailCount)
-        return """
-        \(text[..<headEnd])
+        return "\(text[..<headEnd])\(marker)\(text[tailStart...])"
+    }
 
-        [...conversation truncated for local model memory...]
-
-        \(text[tailStart...])
-        """
+    private static func promptBudget(maxCharacters: Int) -> LocalLLMPromptBudget {
+        let boundedLimit = max(1, maxCharacters)
+        let contextCharacters = max(1, boundedLimit / 3)
+        let payloadCharacters = max(1, boundedLimit - contextCharacters)
+        return LocalLLMPromptBudget(
+            chunkCharacters: payloadCharacters,
+            contextCharacters: contextCharacters,
+            partialResultCharacters: payloadCharacters
+        )
     }
 
     private static func merge(
@@ -387,16 +420,33 @@ private struct CollectedLocalLLMResponse: Sendable {
     let metrics: LLMGenerationMetrics?
 }
 
+private struct LocalLLMPromptBudget: Sendable {
+    let chunkCharacters: Int
+    let contextCharacters: Int
+    let partialResultCharacters: Int
+}
+
 private actor LocalLLMLifetimeCoordinator {
     private var unloadTask: Task<Void, Never>?
     private var generationActive = false
-    private var waitingGenerations: [CheckedContinuation<Void, Never>] = []
+    private var waitingGenerations: [WaitingGeneration] = []
 
-    func beginGeneration() async {
+    func beginGeneration() async throws {
+        try Task.checkCancellation()
         if generationActive {
-            await withCheckedContinuation { continuation in
-                waitingGenerations.append(continuation)
+            let waiterID = UUID()
+            try await withTaskCancellationHandler {
+                try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                    waitingGenerations.append(
+                        WaitingGeneration(id: waiterID, continuation: continuation)
+                    )
+                }
+            } onCancel: {
+                Task {
+                    await self.cancelWaitingGeneration(id: waiterID)
+                }
             }
+            try Task.checkCancellation()
             return
         }
 
@@ -407,12 +457,19 @@ private actor LocalLLMLifetimeCoordinator {
     func endGeneration(runtime: any LocalLLMRuntime, delayNanoseconds: UInt64) {
         if !waitingGenerations.isEmpty {
             let next = waitingGenerations.removeFirst()
-            next.resume()
+            next.continuation.resume()
             return
         }
 
         generationActive = false
         scheduleUnload(runtime: runtime, delayNanoseconds: delayNanoseconds)
+    }
+
+    private func cancelWaitingGeneration(id: UUID) {
+        guard let index = waitingGenerations.firstIndex(where: { $0.id == id }) else { return }
+
+        let waitingGeneration = waitingGenerations.remove(at: index)
+        waitingGeneration.continuation.resume(throwing: CancellationError())
     }
 
     private func cancelPendingUnload() {
@@ -437,6 +494,11 @@ private actor LocalLLMLifetimeCoordinator {
             }
         }
     }
+}
+
+private struct WaitingGeneration {
+    let id: UUID
+    let continuation: CheckedContinuation<Void, Error>
 }
 
 private enum ProcessRSSSampler {

--- a/Sources/MacParakeetCore/Services/LLM/InProcessLLMClient.swift
+++ b/Sources/MacParakeetCore/Services/LLM/InProcessLLMClient.swift
@@ -439,6 +439,12 @@ private actor LocalLLMLifetimeCoordinator {
 }
 
 private enum ProcessRSSSampler {
+    #if compiler(>=6.2)
+    private static let currentTaskPort: mach_port_t = mach_task_self_
+    #else
+    nonisolated(unsafe) private static let currentTaskPort: mach_port_t = mach_task_self_
+    #endif
+
     static func currentResidentSetSizeBytes() -> UInt64? {
         #if os(macOS)
         var info = mach_task_basic_info_data_t()
@@ -447,7 +453,7 @@ private enum ProcessRSSSampler {
         )
         let result = withUnsafeMutablePointer(to: &info) {
             $0.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
-                task_info(mach_task_self_, task_flavor_t(MACH_TASK_BASIC_INFO), $0, &count)
+                task_info(currentTaskPort, task_flavor_t(MACH_TASK_BASIC_INFO), $0, &count)
             }
         }
         guard result == KERN_SUCCESS else { return nil }

--- a/Sources/MacParakeetCore/Services/LLM/InProcessLLMClient.swift
+++ b/Sources/MacParakeetCore/Services/LLM/InProcessLLMClient.swift
@@ -293,12 +293,17 @@ public final class InProcessLLMClient: LLMClientProtocol, Sendable {
         total: Int
     ) -> [ChatMessage] {
         let systemMessages = originalMessages.filter { $0.role == .system }
+        let originalConversationContext = compactConversationContext(originalMessages)
         return systemMessages + [
             ChatMessage(
                 role: .user,
                 content: """
                 Process chunk \(index) of \(total) for the user's request. Preserve facts exactly and do not infer missing details.
 
+                Original conversation context, including user and assistant turns:
+                \(originalConversationContext)
+
+                Chunk:
                 \(chunk)
                 """
             ),

--- a/Sources/MacParakeetCore/Services/LLM/InProcessLLMClient.swift
+++ b/Sources/MacParakeetCore/Services/LLM/InProcessLLMClient.swift
@@ -83,16 +83,18 @@ public final class InProcessLLMClient: LLMClientProtocol, Sendable {
 
     public func testConnection(context: LLMExecutionContext) async throws {
         try Task.checkCancellation()
-        try await lifetimeCoordinator.beginGeneration()
+        let lease = try await lifetimeCoordinator.beginGeneration()
         do {
             try Task.checkCancellation()
             try await loadRuntime(for: context.providerConfig)
             await lifetimeCoordinator.endGeneration(
+                lease,
                 runtime: runtime,
                 delayNanoseconds: 0
             )
         } catch {
             await lifetimeCoordinator.endGeneration(
+                lease,
                 runtime: runtime,
                 delayNanoseconds: 0
             )
@@ -127,7 +129,7 @@ public final class InProcessLLMClient: LLMClientProtocol, Sendable {
         }
 
         try Task.checkCancellation()
-        try await lifetimeCoordinator.beginGeneration()
+        let lease = try await lifetimeCoordinator.beginGeneration()
 
         do {
             try Task.checkCancellation()
@@ -150,12 +152,14 @@ public final class InProcessLLMClient: LLMClientProtocol, Sendable {
 
             log(metrics: response.metrics, inputCharacters: Self.inputCharacterCount(messages))
             await lifetimeCoordinator.endGeneration(
+                lease,
                 runtime: runtime,
                 delayNanoseconds: idleUnloadDelayNanoseconds
             )
             return response
         } catch {
             await lifetimeCoordinator.endGeneration(
+                lease,
                 runtime: runtime,
                 delayNanoseconds: idleUnloadDelayNanoseconds
             )
@@ -428,45 +432,54 @@ private struct LocalLLMPromptBudget: Sendable {
 
 private actor LocalLLMLifetimeCoordinator {
     private var unloadTask: Task<Void, Never>?
-    private var generationActive = false
+    private var activeGenerationID: UUID?
     private var waitingGenerations: [WaitingGeneration] = []
 
-    func beginGeneration() async throws {
+    func beginGeneration() async throws -> LocalLLMGenerationLease {
         try Task.checkCancellation()
-        if generationActive {
-            let waiterID = UUID()
-            try await withTaskCancellationHandler {
-                try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+        if activeGenerationID != nil {
+            let lease = LocalLLMGenerationLease(id: UUID())
+            return try await withTaskCancellationHandler {
+                try await withCheckedThrowingContinuation { (
+                    continuation: CheckedContinuation<LocalLLMGenerationLease, Error>
+                ) in
                     waitingGenerations.append(
-                        WaitingGeneration(id: waiterID, continuation: continuation)
+                        WaitingGeneration(lease: lease, continuation: continuation)
                     )
                 }
             } onCancel: {
                 Task {
-                    await self.cancelWaitingGeneration(id: waiterID)
+                    await self.cancelWaitingGeneration(id: lease.id)
                 }
             }
-            try Task.checkCancellation()
-            return
         }
 
-        generationActive = true
+        let lease = LocalLLMGenerationLease(id: UUID())
+        activeGenerationID = lease.id
         cancelPendingUnload()
+        return lease
     }
 
-    func endGeneration(runtime: any LocalLLMRuntime, delayNanoseconds: UInt64) {
+    func endGeneration(
+        _ lease: LocalLLMGenerationLease,
+        runtime: any LocalLLMRuntime,
+        delayNanoseconds: UInt64
+    ) {
+        guard activeGenerationID == lease.id else { return }
+
         if !waitingGenerations.isEmpty {
             let next = waitingGenerations.removeFirst()
-            next.continuation.resume()
+            activeGenerationID = next.lease.id
+            next.continuation.resume(returning: next.lease)
             return
         }
 
-        generationActive = false
+        activeGenerationID = nil
         scheduleUnload(runtime: runtime, delayNanoseconds: delayNanoseconds)
     }
 
     private func cancelWaitingGeneration(id: UUID) {
-        guard let index = waitingGenerations.firstIndex(where: { $0.id == id }) else { return }
+        guard let index = waitingGenerations.firstIndex(where: { $0.lease.id == id }) else { return }
 
         let waitingGeneration = waitingGenerations.remove(at: index)
         waitingGeneration.continuation.resume(throwing: CancellationError())
@@ -496,9 +509,13 @@ private actor LocalLLMLifetimeCoordinator {
     }
 }
 
-private struct WaitingGeneration {
+private struct LocalLLMGenerationLease: Sendable {
     let id: UUID
-    let continuation: CheckedContinuation<Void, Error>
+}
+
+private struct WaitingGeneration {
+    let lease: LocalLLMGenerationLease
+    let continuation: CheckedContinuation<LocalLLMGenerationLease, Error>
 }
 
 private enum ProcessRSSSampler {

--- a/Sources/MacParakeetCore/Services/LLM/LLMClient.swift
+++ b/Sources/MacParakeetCore/Services/LLM/LLMClient.swift
@@ -838,7 +838,7 @@ public final class LLMClient: LLMClientProtocol, Sendable {
                     return isGeminiTextLLMModelID(entry.id)
                 case .openaiCompatible, .lmstudio, .ollama:
                     return !isClearlyNonTextModelID(entry.id)
-                case .localCLI:
+                case .localCLI, .inProcessLocal:
                     return false
                 }
             }
@@ -1029,7 +1029,7 @@ public final class LLMClient: LLMClientProtocol, Sendable {
         switch id {
         case .openai, .openrouter, .anthropic:
             return true
-        case .openaiCompatible, .gemini, .ollama, .lmstudio, .localCLI:
+        case .openaiCompatible, .gemini, .ollama, .lmstudio, .localCLI, .inProcessLocal:
             return false
         }
     }

--- a/Sources/MacParakeetCore/Services/LLM/LocalLLMRuntime.swift
+++ b/Sources/MacParakeetCore/Services/LLM/LocalLLMRuntime.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+public struct LocalLLMModelReference: Sendable, Equatable {
+    public let modelName: String
+    public let directory: URL
+
+    public init(modelName: String, directory: URL) {
+        self.modelName = modelName
+        self.directory = directory
+    }
+}
+
+public enum LocalLLMRuntimeEvent: Sendable, Equatable {
+    case text(String)
+    case metrics(LLMGenerationMetrics)
+}
+
+public protocol LocalLLMRuntime: Sendable {
+    func load(model: LocalLLMModelReference) async throws
+    func unload() async
+    func generateStream(
+        messages: [ChatMessage],
+        options: ChatCompletionOptions
+    ) async throws -> AsyncThrowingStream<LocalLLMRuntimeEvent, Error>
+    func instrumentation() async -> LLMGenerationMetrics?
+}
+
+public actor UnavailableLocalLLMRuntime: LocalLLMRuntime {
+    public init() {}
+
+    public func load(model: LocalLLMModelReference) async throws {
+        throw LLMError.modelNotFound(
+            "Local MLX runtime is not linked in this build. Enable the gated app build and set \(InProcessLLMClient.modelDirectoryEnvironmentVariable) to a local model directory."
+        )
+    }
+
+    public func unload() async {}
+
+    public func generateStream(
+        messages: [ChatMessage],
+        options: ChatCompletionOptions
+    ) async throws -> AsyncThrowingStream<LocalLLMRuntimeEvent, Error> {
+        throw LLMError.modelNotFound("Local MLX runtime is not linked in this build.")
+    }
+
+    public func instrumentation() async -> LLMGenerationMetrics? {
+        nil
+    }
+}

--- a/Sources/MacParakeetCore/Services/LLM/RoutingLLMClient.swift
+++ b/Sources/MacParakeetCore/Services/LLM/RoutingLLMClient.swift
@@ -1,17 +1,21 @@
 import Foundation
 
 /// Routes LLM requests to the appropriate client based on provider ID.
-/// HTTP-based providers go to `LLMClient`; `.localCLI` goes to `LocalCLILLMClient`.
+/// HTTP-based providers go to `LLMClient`; `.localCLI` goes to
+/// `LocalCLILLMClient`; `.inProcessLocal` goes to `InProcessLLMClient`.
 public final class RoutingLLMClient: LLMClientProtocol, Sendable {
-    private let httpClient: LLMClient
-    private let cliClient: LocalCLILLMClient
+    private let httpClient: any LLMClientProtocol
+    private let cliClient: any LLMClientProtocol
+    private let inProcessClient: any LLMClientProtocol
 
     public init(
-        httpClient: LLMClient = LLMClient(),
-        cliClient: LocalCLILLMClient = LocalCLILLMClient()
+        httpClient: any LLMClientProtocol = LLMClient(),
+        cliClient: any LLMClientProtocol = LocalCLILLMClient(),
+        inProcessClient: any LLMClientProtocol = InProcessLLMClient()
     ) {
         self.httpClient = httpClient
         self.cliClient = cliClient
+        self.inProcessClient = inProcessClient
     }
 
     public func chatCompletion(
@@ -38,7 +42,14 @@ public final class RoutingLLMClient: LLMClientProtocol, Sendable {
         try await client(for: context).listModels(context: context)
     }
 
-    private func client(for context: LLMExecutionContext) -> LLMClientProtocol {
-        context.providerConfig.id == .localCLI ? cliClient : httpClient
+    private func client(for context: LLMExecutionContext) -> any LLMClientProtocol {
+        switch context.providerConfig.id {
+        case .localCLI:
+            return cliClient
+        case .inProcessLocal:
+            return inProcessClient
+        case .anthropic, .openai, .openaiCompatible, .gemini, .openrouter, .ollama, .lmstudio:
+            return httpClient
+        }
     }
 }

--- a/Sources/MacParakeetLocalLLM/MLXLocalLLMRuntime.swift
+++ b/Sources/MacParakeetLocalLLM/MLXLocalLLMRuntime.swift
@@ -9,7 +9,7 @@ import OSLog
 
 public actor MLXLocalLLMRuntime: LocalLLMRuntime {
     private let logger = Logger(subsystem: "com.macparakeet.core", category: "MLXLocalLLMRuntime")
-    private var session: ChatSession?
+    private var modelContainer: ModelContainer?
     private var loadedModel: LocalLLMModelReference?
     private var latestMetrics: LLMGenerationMetrics?
     private var generationInProgress = false
@@ -20,20 +20,19 @@ public actor MLXLocalLLMRuntime: LocalLLMRuntime {
     public func load(model: LocalLLMModelReference) async throws {
         try Task.checkCancellation()
         if generationInProgress {
-            guard loadedModel == model, session != nil else {
+            guard loadedModel == model, modelContainer != nil else {
                 throw LLMError.providerError("Cannot switch local MLX models while generation is in progress.")
             }
             return
         }
 
-        if loadedModel == model, session != nil {
+        if loadedModel == model, modelContainer != nil {
             return
         }
 
         clearLoadedState()
 
-        let container = try await loadModelContainer(from: model.directory)
-        session = ChatSession(container)
+        modelContainer = try await loadModelContainer(from: model.directory)
         loadedModel = model
         unloadAfterGeneration = false
         logger.info("Loaded local MLX model \(model.modelName, privacy: .public)")
@@ -53,7 +52,7 @@ public actor MLXLocalLLMRuntime: LocalLLMRuntime {
         messages: [ChatMessage],
         options: ChatCompletionOptions
     ) async throws -> AsyncThrowingStream<LocalLLMRuntimeEvent, Error> {
-        guard session != nil else {
+        guard modelContainer != nil else {
             throw LLMError.modelNotFound("Local MLX model is not loaded.")
         }
         guard !generationInProgress else {
@@ -90,11 +89,12 @@ public actor MLXLocalLLMRuntime: LocalLLMRuntime {
         }
 
         do {
-            guard let session else {
+            guard let modelContainer else {
                 throw LLMError.modelNotFound("Local MLX model is not loaded.")
             }
 
             try Task.checkCancellation()
+            let session = ChatSession(modelContainer)
             let prompt = Self.prompt(from: messages)
             let parameters = GenerateParameters(
                 temperature: Float(options.temperature ?? 0.2),
@@ -143,7 +143,7 @@ public actor MLXLocalLLMRuntime: LocalLLMRuntime {
     }
 
     private func clearLoadedState() {
-        session = nil
+        modelContainer = nil
         loadedModel = nil
         latestMetrics = nil
     }

--- a/Sources/MacParakeetLocalLLM/MLXLocalLLMRuntime.swift
+++ b/Sources/MacParakeetLocalLLM/MLXLocalLLMRuntime.swift
@@ -1,0 +1,130 @@
+import Foundation
+import MacParakeetCore
+import MLXHuggingFace
+import MLXLLM
+import MLXLMCommon
+import OSLog
+
+#if MACPARAKEET_HAS_MLX_LOCAL_LLM
+
+public actor MLXLocalLLMRuntime: LocalLLMRuntime {
+    private let logger = Logger(subsystem: "com.macparakeet.core", category: "MLXLocalLLMRuntime")
+    private var session: ChatSession?
+    private var loadedModel: LocalLLMModelReference?
+    private var latestMetrics: LLMGenerationMetrics?
+
+    public init() {}
+
+    public func load(model: LocalLLMModelReference) async throws {
+        try Task.checkCancellation()
+        if loadedModel == model, session != nil {
+            return
+        }
+
+        session = nil
+        latestMetrics = nil
+
+        let container = try await loadModelContainer(from: model.directory)
+        session = ChatSession(container)
+        loadedModel = model
+        logger.info("Loaded local MLX model \(model.modelName, privacy: .public)")
+    }
+
+    public func unload() async {
+        session = nil
+        loadedModel = nil
+        latestMetrics = nil
+        logger.info("Unloaded local MLX model")
+    }
+
+    public func generateStream(
+        messages: [ChatMessage],
+        options: ChatCompletionOptions
+    ) async throws -> AsyncThrowingStream<LocalLLMRuntimeEvent, Error> {
+        guard session != nil else {
+            throw LLMError.modelNotFound("Local MLX model is not loaded.")
+        }
+
+        return AsyncThrowingStream { continuation in
+            let task = Task {
+                await self.generate(
+                    messages: messages,
+                    options: options,
+                    continuation: continuation
+                )
+            }
+            continuation.onTermination = { _ in
+                task.cancel()
+            }
+        }
+    }
+
+    public func instrumentation() async -> LLMGenerationMetrics? {
+        latestMetrics
+    }
+
+    private func generate(
+        messages: [ChatMessage],
+        options: ChatCompletionOptions,
+        continuation: AsyncThrowingStream<LocalLLMRuntimeEvent, Error>.Continuation
+    ) async {
+        do {
+            guard let session else {
+                throw LLMError.modelNotFound("Local MLX model is not loaded.")
+            }
+
+            try Task.checkCancellation()
+            let prompt = Self.prompt(from: messages)
+            let parameters = GenerateParameters(
+                temperature: Float(options.temperature ?? 0.2),
+                maxTokens: options.maxTokens,
+                kvBits: 4
+            )
+
+            let start = Date()
+            var firstTokenDate: Date?
+            var tokenCount = 0
+
+            for try await token in session.streamResponse(
+                to: prompt,
+                generateParameters: parameters
+            ) {
+                try Task.checkCancellation()
+                if firstTokenDate == nil {
+                    firstTokenDate = Date()
+                }
+                tokenCount += 1
+                continuation.yield(.text(token))
+            }
+
+            let duration = max(Date().timeIntervalSince(start), 0.001)
+            let metrics = LLMGenerationMetrics(
+                tokensPerSecond: Double(tokenCount) / duration,
+                promptTokensPerSecond: nil,
+                timeToFirstTokenMs: firstTokenDate.map { Int($0.timeIntervalSince(start) * 1_000) },
+                peakRSSBytes: nil
+            )
+            latestMetrics = metrics
+            continuation.yield(.metrics(metrics))
+            continuation.finish()
+        } catch {
+            continuation.finish(throwing: error)
+        }
+    }
+
+    private static func prompt(from messages: [ChatMessage]) -> String {
+        messages.map { message in
+            switch message.role {
+            case .system:
+                return "System: \(message.content)"
+            case .user:
+                return "User: \(message.modelContent)"
+            case .assistant:
+                return "Assistant: \(message.content)"
+            }
+        }
+        .joined(separator: "\n\n")
+    }
+}
+
+#endif

--- a/Sources/MacParakeetLocalLLM/MLXLocalLLMRuntime.swift
+++ b/Sources/MacParakeetLocalLLM/MLXLocalLLMRuntime.swift
@@ -12,28 +12,40 @@ public actor MLXLocalLLMRuntime: LocalLLMRuntime {
     private var session: ChatSession?
     private var loadedModel: LocalLLMModelReference?
     private var latestMetrics: LLMGenerationMetrics?
+    private var generationInProgress = false
+    private var unloadAfterGeneration = false
 
     public init() {}
 
     public func load(model: LocalLLMModelReference) async throws {
         try Task.checkCancellation()
+        if generationInProgress {
+            guard loadedModel == model, session != nil else {
+                throw LLMError.providerError("Cannot switch local MLX models while generation is in progress.")
+            }
+            return
+        }
+
         if loadedModel == model, session != nil {
             return
         }
 
-        session = nil
-        latestMetrics = nil
+        clearLoadedState()
 
         let container = try await loadModelContainer(from: model.directory)
         session = ChatSession(container)
         loadedModel = model
+        unloadAfterGeneration = false
         logger.info("Loaded local MLX model \(model.modelName, privacy: .public)")
     }
 
     public func unload() async {
-        session = nil
-        loadedModel = nil
-        latestMetrics = nil
+        if generationInProgress {
+            unloadAfterGeneration = true
+            return
+        }
+
+        clearLoadedState()
         logger.info("Unloaded local MLX model")
     }
 
@@ -44,7 +56,12 @@ public actor MLXLocalLLMRuntime: LocalLLMRuntime {
         guard session != nil else {
             throw LLMError.modelNotFound("Local MLX model is not loaded.")
         }
+        guard !generationInProgress else {
+            throw LLMError.providerError("Local MLX generation is already in progress.")
+        }
 
+        generationInProgress = true
+        unloadAfterGeneration = false
         return AsyncThrowingStream { continuation in
             let task = Task {
                 await self.generate(
@@ -68,6 +85,10 @@ public actor MLXLocalLLMRuntime: LocalLLMRuntime {
         options: ChatCompletionOptions,
         continuation: AsyncThrowingStream<LocalLLMRuntimeEvent, Error>.Continuation
     ) async {
+        defer {
+            finishGeneration()
+        }
+
         do {
             guard let session else {
                 throw LLMError.modelNotFound("Local MLX model is not loaded.")
@@ -110,6 +131,21 @@ public actor MLXLocalLLMRuntime: LocalLLMRuntime {
         } catch {
             continuation.finish(throwing: error)
         }
+    }
+
+    private func finishGeneration() {
+        generationInProgress = false
+        guard unloadAfterGeneration else { return }
+
+        unloadAfterGeneration = false
+        clearLoadedState()
+        logger.info("Unloaded local MLX model")
+    }
+
+    private func clearLoadedState() {
+        session = nil
+        loadedModel = nil
+        latestMetrics = nil
     }
 
     private static func prompt(from messages: [ChatMessage]) -> String {

--- a/Sources/MacParakeetObjCShims/MPKObjCExceptionCatcher.m
+++ b/Sources/MacParakeetObjCShims/MPKObjCExceptionCatcher.m
@@ -37,3 +37,7 @@ BOOL MPKTryBlock(NS_NOESCAPE void (^block)(void),
         return NO;
     }
 }
+
+mach_port_t MPKCurrentTaskPort(void) {
+    return mach_task_self();
+}

--- a/Sources/MacParakeetObjCShims/include/MPKObjCExceptionCatcher.h
+++ b/Sources/MacParakeetObjCShims/include/MPKObjCExceptionCatcher.h
@@ -1,4 +1,5 @@
 #import <Foundation/Foundation.h>
+#import <mach/mach.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -26,5 +27,9 @@ FOUNDATION_EXPORT NSString *const MPKObjCExceptionCallStackKey;
 /// @return @c YES if @c block returned normally, @c NO if it raised.
 FOUNDATION_EXPORT BOOL MPKTryBlock(NS_NOESCAPE void (^block)(void),
                                    NSError * _Nullable * _Nullable error);
+
+/// Returns the current process task port without exposing Darwin's
+/// mach_task_self_ global to Swift concurrency checking.
+FOUNDATION_EXPORT mach_port_t MPKCurrentTaskPort(void);
 
 NS_ASSUME_NONNULL_END

--- a/Sources/MacParakeetViewModels/LLMSettingsDraft.swift
+++ b/Sources/MacParakeetViewModels/LLMSettingsDraft.swift
@@ -178,6 +178,10 @@ public struct LLMSettingsDraft: Equatable, Sendable {
             return .localCLI()
         }
 
+        if providerID == .inProcessLocal {
+            return .inProcessLocal(model: effectiveModelName)
+        }
+
         let baseURL: URL
         if !trimmedBaseURLOverride.isEmpty {
             guard let override = URL(string: trimmedBaseURLOverride) else {
@@ -274,6 +278,9 @@ public struct LLMSettingsDraft: Equatable, Sendable {
         guard let scheme = url.scheme?.lowercased(),
               url.host != nil else {
             return .invalidBaseURL
+        }
+        if providerID == .inProcessLocal {
+            return scheme == "inprocess" ? nil : .invalidBaseURL
         }
         if scheme == "https" {
             return nil

--- a/Sources/MacParakeetViewModels/LLMSettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/LLMSettingsViewModel.swift
@@ -217,7 +217,7 @@ public final class LLMSettingsViewModel {
             return "Optional API key"
         case .openai:
             return "sk-..."
-        case .ollama, .localCLI, nil:
+        case .ollama, .localCLI, .inProcessLocal, nil:
             return ""
         }
     }

--- a/Tests/MacParakeetTests/Models/LLMProviderDescriptorTests.swift
+++ b/Tests/MacParakeetTests/Models/LLMProviderDescriptorTests.swift
@@ -25,6 +25,7 @@ final class LLMProviderDescriptorTests: XCTestCase {
 
     func testModelListEndpointPolicy() {
         XCTAssertEqual(LLMProviderID.localCLI.modelListEndpoint, .none)
+        XCTAssertEqual(LLMProviderID.inProcessLocal.modelListEndpoint, .none)
         XCTAssertEqual(LLMProviderID.anthropic.modelListEndpoint, .anthropic)
         XCTAssertEqual(LLMProviderID.gemini.modelListEndpoint, .gemini)
         XCTAssertEqual(LLMProviderID.ollama.modelListEndpoint, .ollama)
@@ -38,6 +39,7 @@ final class LLMProviderDescriptorTests: XCTestCase {
         XCTAssertEqual(LLMProviderID.openaiCompatible.fallbackModels, [])
         XCTAssertEqual(LLMProviderID.lmstudio.fallbackModels, [])
         XCTAssertEqual(LLMProviderID.localCLI.fallbackModels, [])
+        XCTAssertEqual(LLMProviderID.inProcessLocal.fallbackModels, ["mlx-community/Qwen3-4B-Instruct-2507-DDWQ"])
         XCTAssertEqual(LLMProviderID.gemini.defaultModelName, "gemini-3.5-flash")
     }
 
@@ -62,5 +64,25 @@ final class LLMProviderDescriptorTests: XCTestCase {
         XCTAssertEqual(LLMProviderConfig.openrouter(apiKey: "key").baseURL.absoluteString, LLMProviderID.openrouter.defaultBaseURL)
         XCTAssertEqual(LLMProviderConfig.ollama().modelName, LLMProviderID.ollama.defaultModelName)
         XCTAssertEqual(LLMProviderConfig.ollama().baseURL.absoluteString, LLMProviderID.ollama.defaultBaseURL)
+        XCTAssertEqual(LLMProviderConfig.inProcessLocal().modelName, LLMProviderID.inProcessLocal.defaultModelName)
+        XCTAssertEqual(LLMProviderConfig.inProcessLocal().baseURL.absoluteString, LLMProviderID.inProcessLocal.defaultBaseURL)
+    }
+
+    func testInProcessLocalProviderIsHiddenWhileFeatureFlagIsOff() {
+        XCTAssertFalse(AppFeatures.inProcessLocalLLMEnabled)
+        XCTAssertEqual(
+            LLMProviderID.userSelectableProviderIDs,
+            [
+                .lmstudio,
+                .ollama,
+                .anthropic,
+                .openai,
+                .gemini,
+                .openrouter,
+                .openaiCompatible,
+                .localCLI,
+            ]
+        )
+        XCTAssertFalse(LLMProviderID.userSelectableProviderIDs.contains(.inProcessLocal))
     }
 }

--- a/Tests/MacParakeetTests/Services/LLM/InProcessLLMClientTests.swift
+++ b/Tests/MacParakeetTests/Services/LLM/InProcessLLMClientTests.swift
@@ -93,6 +93,13 @@ final class InProcessLLMClientTests: XCTestCase {
         )
 
         let requestContents = await runtime.requestContents()
+        let mapPrompts = requestContents.dropLast()
+        XCTAssertFalse(mapPrompts.isEmpty)
+        XCTAssertTrue(mapPrompts.allSatisfy { $0.contains("Original conversation context") })
+        XCTAssertTrue(mapPrompts.allSatisfy { $0.contains("Earlier user asked for Alpha.") })
+        XCTAssertTrue(mapPrompts.allSatisfy { $0.contains("Earlier assistant answered with Alpha.") })
+        XCTAssertTrue(mapPrompts.allSatisfy { $0.contains("Final user asks for Beta.") })
+
         let reducePrompt = try XCTUnwrap(requestContents.last)
         XCTAssertTrue(reducePrompt.contains("Original conversation context"))
         XCTAssertTrue(reducePrompt.contains("Earlier user asked for Alpha."))

--- a/Tests/MacParakeetTests/Services/LLM/InProcessLLMClientTests.swift
+++ b/Tests/MacParakeetTests/Services/LLM/InProcessLLMClientTests.swift
@@ -66,6 +66,78 @@ final class InProcessLLMClientTests: XCTestCase {
         XCTAssertTrue(requestContents.last?.contains("Combine the chunk results") == true)
     }
 
+    func testLongInputReducePromptPreservesConversationContext() async throws {
+        let modelDirectory = temporaryModelDirectory()
+        let runtime = FakeLocalLLMRuntime(eventPlans: [
+            [.text("map-1")],
+            [.text("map-2")],
+            [.text("final")],
+        ])
+        let client = InProcessLLMClient(
+            runtime: runtime,
+            modelDirectoryResolver: { _ in modelDirectory },
+            chunkCharacterThreshold: 10,
+            chunkCharacterLimit: 160,
+            idleUnloadDelaySeconds: 60
+        )
+
+        _ = try await client.chatCompletion(
+            messages: [
+                ChatMessage(role: .system, content: "Be faithful."),
+                ChatMessage(role: .user, content: "Earlier user asked for Alpha."),
+                ChatMessage(role: .assistant, content: "Earlier assistant answered with Alpha."),
+                ChatMessage(role: .user, content: "Final user asks for Beta. " + String(repeating: "b", count: 220)),
+            ],
+            context: LLMExecutionContext(providerConfig: .inProcessLocal(model: "chunk-context-test")),
+            options: .default
+        )
+
+        let requestContents = await runtime.requestContents()
+        let reducePrompt = try XCTUnwrap(requestContents.last)
+        XCTAssertTrue(reducePrompt.contains("Original conversation context"))
+        XCTAssertTrue(reducePrompt.contains("Earlier user asked for Alpha."))
+        XCTAssertTrue(reducePrompt.contains("Earlier assistant answered with Alpha."))
+        XCTAssertTrue(reducePrompt.contains("Final user asks for Beta."))
+    }
+
+    func testQueuedGenerationDoesNotUnloadRuntimeBetweenRequests() async throws {
+        let modelDirectory = temporaryModelDirectory()
+        let runtime = FakeLocalLLMRuntime(
+            eventPlans: [
+                [.text("first")],
+                [.text("second")],
+            ],
+            delayNanoseconds: 50_000_000
+        )
+        let client = InProcessLLMClient(
+            runtime: runtime,
+            modelDirectoryResolver: { _ in modelDirectory },
+            idleUnloadDelaySeconds: 0
+        )
+
+        async let first = client.chatCompletion(
+            messages: [ChatMessage(role: .user, content: "First")],
+            context: LLMExecutionContext(providerConfig: .inProcessLocal(model: "queued-test")),
+            options: .default
+        )
+        try await Task.sleep(nanoseconds: 10_000_000)
+        async let second = client.chatCompletion(
+            messages: [ChatMessage(role: .user, content: "Second")],
+            context: LLMExecutionContext(providerConfig: .inProcessLocal(model: "queued-test")),
+            options: .default
+        )
+
+        let firstResponse = try await first
+        let secondResponse = try await second
+        XCTAssertEqual([firstResponse.content, secondResponse.content], ["first", "second"])
+
+        try await Task.sleep(nanoseconds: 50_000_000)
+        let requestContents = await runtime.requestContents()
+        let unloadCount = await runtime.unloadCallCount()
+        XCTAssertEqual(requestContents, ["First", "Second"])
+        XCTAssertEqual(unloadCount, 1)
+    }
+
     func testStreamingYieldsRuntimeChunks() async throws {
         let modelDirectory = temporaryModelDirectory()
         let runtime = FakeLocalLLMRuntime(eventPlans: [[

--- a/Tests/MacParakeetTests/Services/LLM/InProcessLLMClientTests.swift
+++ b/Tests/MacParakeetTests/Services/LLM/InProcessLLMClientTests.swift
@@ -1,0 +1,234 @@
+import XCTest
+@testable import MacParakeetCore
+
+final class InProcessLLMClientTests: XCTestCase {
+    func testChatCompletionLoadsRuntimeAndReturnsMetrics() async throws {
+        let modelDirectory = temporaryModelDirectory()
+        let metrics = LLMGenerationMetrics(
+            tokensPerSecond: 42,
+            promptTokensPerSecond: 120,
+            timeToFirstTokenMs: 25,
+            peakRSSBytes: 1_000
+        )
+        let runtime = FakeLocalLLMRuntime(eventPlans: [[
+            .text("hello"),
+            .text(" local"),
+            .metrics(metrics),
+        ]])
+        let client = InProcessLLMClient(
+            runtime: runtime,
+            modelDirectoryResolver: { _ in modelDirectory },
+            idleUnloadDelaySeconds: 60
+        )
+
+        let response = try await client.chatCompletion(
+            messages: [ChatMessage(role: .user, content: "Summarize.")],
+            context: LLMExecutionContext(providerConfig: .inProcessLocal(model: "test-model")),
+            options: .default
+        )
+
+        XCTAssertEqual(response.content, "hello local")
+        XCTAssertEqual(response.model, "test-model")
+        XCTAssertEqual(response.generationMetrics?.tokensPerSecond, 42)
+        XCTAssertGreaterThanOrEqual(response.generationMetrics?.peakRSSBytes ?? 0, 1_000)
+
+        let loadedModels = await runtime.loadedModels()
+        XCTAssertEqual(loadedModels, [LocalLLMModelReference(modelName: "test-model", directory: modelDirectory)])
+    }
+
+    func testLongInputUsesMapReduceChunksBeforeFinalAnswer() async throws {
+        let modelDirectory = temporaryModelDirectory()
+        let runtime = FakeLocalLLMRuntime(eventPlans: [
+            [.text("map-1")],
+            [.text("final")],
+        ])
+        let client = InProcessLLMClient(
+            runtime: runtime,
+            modelDirectoryResolver: { _ in modelDirectory },
+            chunkCharacterThreshold: 10,
+            chunkCharacterLimit: 500,
+            idleUnloadDelaySeconds: 60
+        )
+
+        let response = try await client.chatCompletion(
+            messages: [
+                ChatMessage(role: .system, content: "Be faithful."),
+                ChatMessage(role: .user, content: String(repeating: "a", count: 30)),
+            ],
+            context: LLMExecutionContext(providerConfig: .inProcessLocal(model: "chunk-test")),
+            options: .default
+        )
+
+        XCTAssertEqual(response.content, "final")
+        let requestContents = await runtime.requestContents()
+        XCTAssertGreaterThan(requestContents.count, 1)
+        XCTAssertTrue(requestContents.dropLast().allSatisfy { $0.contains("Process chunk") })
+        XCTAssertTrue(requestContents.last?.contains("Combine the chunk results") == true)
+    }
+
+    func testStreamingYieldsRuntimeChunks() async throws {
+        let modelDirectory = temporaryModelDirectory()
+        let runtime = FakeLocalLLMRuntime(eventPlans: [[
+            .text("stream"),
+            .text("-chunk"),
+        ]])
+        let client = InProcessLLMClient(
+            runtime: runtime,
+            modelDirectoryResolver: { _ in modelDirectory },
+            idleUnloadDelaySeconds: 60
+        )
+
+        let stream = client.chatCompletionStream(
+            messages: [ChatMessage(role: .user, content: "Hi")],
+            context: LLMExecutionContext(providerConfig: .inProcessLocal(model: "stream-test")),
+            options: .default
+        )
+
+        var chunks: [String] = []
+        for try await chunk in stream {
+            chunks.append(chunk)
+        }
+
+        XCTAssertEqual(chunks, ["stream", "-chunk"])
+    }
+
+    func testCancellationPropagates() async throws {
+        let modelDirectory = temporaryModelDirectory()
+        let runtime = FakeLocalLLMRuntime(
+            eventPlans: [[.failure(CancellationError())]]
+        )
+        let client = InProcessLLMClient(
+            runtime: runtime,
+            modelDirectoryResolver: { _ in modelDirectory },
+            idleUnloadDelaySeconds: 60
+        )
+
+        do {
+            _ = try await client.chatCompletion(
+                messages: [ChatMessage(role: .user, content: "Cancel me")],
+                context: LLMExecutionContext(providerConfig: .inProcessLocal(model: "cancel-test")),
+                options: .default
+            )
+            XCTFail("Expected CancellationError")
+        } catch is CancellationError {
+            // Expected.
+        } catch {
+            XCTFail("Expected CancellationError, got \(error)")
+        }
+    }
+
+    func testIdleUnloadRunsAfterGenerationDelay() async throws {
+        let modelDirectory = temporaryModelDirectory()
+        let runtime = FakeLocalLLMRuntime(eventPlans: [[.text("done")]])
+        let client = InProcessLLMClient(
+            runtime: runtime,
+            modelDirectoryResolver: { _ in modelDirectory },
+            idleUnloadDelaySeconds: 0.01
+        )
+
+        _ = try await client.chatCompletion(
+            messages: [ChatMessage(role: .user, content: "Hi")],
+            context: LLMExecutionContext(providerConfig: .inProcessLocal(model: "idle-test")),
+            options: .default
+        )
+
+        try await Task.sleep(nanoseconds: 80_000_000)
+        let unloadCount = await runtime.unloadCallCount()
+        XCTAssertEqual(unloadCount, 1)
+    }
+
+    private func temporaryModelDirectory() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+    }
+}
+
+private actor FakeLocalLLMRuntime: LocalLLMRuntime {
+    private var eventPlans: [[FakeRuntimeEvent]]
+    private let delayNanoseconds: UInt64
+    private var loadCalls: [LocalLLMModelReference] = []
+    private var unloadCalls = 0
+    private var requests: [[ChatMessage]] = []
+    private var latestMetricsValue: LLMGenerationMetrics?
+
+    init(
+        eventPlans: [[FakeRuntimeEvent]],
+        delayNanoseconds: UInt64 = 0
+    ) {
+        self.eventPlans = eventPlans
+        self.delayNanoseconds = delayNanoseconds
+    }
+
+    func load(model: LocalLLMModelReference) async throws {
+        loadCalls.append(model)
+    }
+
+    func unload() async {
+        unloadCalls += 1
+    }
+
+    func generateStream(
+        messages: [ChatMessage],
+        options: ChatCompletionOptions
+    ) async throws -> AsyncThrowingStream<LocalLLMRuntimeEvent, Error> {
+        requests.append(messages)
+        let events = eventPlans.isEmpty ? [.text("fallback")] : eventPlans.removeFirst()
+        latestMetricsValue = events.compactMap { event in
+            if case .metrics(let metrics) = event {
+                return metrics
+            }
+            return nil
+        }.last
+        let delayNanoseconds = delayNanoseconds
+
+        return AsyncThrowingStream { continuation in
+            let task = Task {
+                do {
+                    for event in events {
+                        if delayNanoseconds > 0 {
+                            try await Task.sleep(nanoseconds: delayNanoseconds)
+                        }
+                        try Task.checkCancellation()
+                        switch event {
+                        case .text(let text):
+                            continuation.yield(.text(text))
+                        case .metrics(let metrics):
+                            continuation.yield(.metrics(metrics))
+                        case .failure(let error):
+                            continuation.finish(throwing: error)
+                            return
+                        }
+                    }
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+
+    func instrumentation() async -> LLMGenerationMetrics? {
+        latestMetricsValue
+    }
+
+    func loadedModels() -> [LocalLLMModelReference] {
+        loadCalls
+    }
+
+    func unloadCallCount() -> Int {
+        unloadCalls
+    }
+
+    func requestContents() -> [String] {
+        requests.map { request in
+            request.map(\.content).joined(separator: "\n\n")
+        }
+    }
+}
+
+private enum FakeRuntimeEvent: Sendable {
+    case text(String)
+    case metrics(LLMGenerationMetrics)
+    case failure(any Error & Sendable)
+}

--- a/Tests/MacParakeetTests/Services/LLM/InProcessLLMClientTests.swift
+++ b/Tests/MacParakeetTests/Services/LLM/InProcessLLMClientTests.swift
@@ -40,20 +40,21 @@ final class InProcessLLMClientTests: XCTestCase {
         let modelDirectory = temporaryModelDirectory()
         let runtime = FakeLocalLLMRuntime(eventPlans: [
             [.text("map-1")],
+            [.text("map-2")],
+            [.text("map-3")],
             [.text("final")],
         ])
         let client = InProcessLLMClient(
             runtime: runtime,
             modelDirectoryResolver: { _ in modelDirectory },
             chunkCharacterThreshold: 10,
-            chunkCharacterLimit: 500,
+            chunkCharacterLimit: 60,
             idleUnloadDelaySeconds: 60
         )
 
         let response = try await client.chatCompletion(
             messages: [
-                ChatMessage(role: .system, content: "Be faithful."),
-                ChatMessage(role: .user, content: String(repeating: "a", count: 30)),
+                ChatMessage(role: .user, content: String(repeating: "a", count: 100)),
             ],
             context: LLMExecutionContext(providerConfig: .inProcessLocal(model: "chunk-test")),
             options: .default
@@ -66,18 +67,47 @@ final class InProcessLLMClientTests: XCTestCase {
         XCTAssertTrue(requestContents.last?.contains("Combine the chunk results") == true)
     }
 
+    func testChunkingBypassesMapReduceWhenSplitProducesOneChunk() async throws {
+        let modelDirectory = temporaryModelDirectory()
+        let runtime = FakeLocalLLMRuntime(eventPlans: [
+            [.text("single")],
+        ])
+        let client = InProcessLLMClient(
+            runtime: runtime,
+            modelDirectoryResolver: { _ in modelDirectory },
+            chunkCharacterThreshold: 10,
+            chunkCharacterLimit: 500,
+            idleUnloadDelaySeconds: 60
+        )
+
+        let response = try await client.chatCompletion(
+            messages: [
+                ChatMessage(role: .user, content: String(repeating: "a", count: 450)),
+            ],
+            context: LLMExecutionContext(providerConfig: .inProcessLocal(model: "single-chunk-test")),
+            options: .default
+        )
+
+        XCTAssertEqual(response.content, "single")
+        let requestContents = await runtime.requestContents()
+        XCTAssertEqual(requestContents.count, 1)
+        XCTAssertFalse(requestContents[0].contains("Process chunk"))
+        XCTAssertFalse(requestContents[0].contains("Combine the chunk results"))
+    }
+
     func testLongInputReducePromptPreservesConversationContext() async throws {
         let modelDirectory = temporaryModelDirectory()
         let runtime = FakeLocalLLMRuntime(eventPlans: [
             [.text("map-1")],
             [.text("map-2")],
+            [.text("map-3")],
             [.text("final")],
         ])
         let client = InProcessLLMClient(
             runtime: runtime,
             modelDirectoryResolver: { _ in modelDirectory },
             chunkCharacterThreshold: 10,
-            chunkCharacterLimit: 160,
+            chunkCharacterLimit: 900,
             idleUnloadDelaySeconds: 60
         )
 
@@ -86,7 +116,10 @@ final class InProcessLLMClientTests: XCTestCase {
                 ChatMessage(role: .system, content: "Be faithful."),
                 ChatMessage(role: .user, content: "Earlier user asked for Alpha."),
                 ChatMessage(role: .assistant, content: "Earlier assistant answered with Alpha."),
-                ChatMessage(role: .user, content: "Final user asks for Beta. " + String(repeating: "b", count: 220)),
+                ChatMessage(
+                    role: .user,
+                    content: String(repeating: "b", count: 1_400) + " Final user asks for Beta."
+                ),
             ],
             context: LLMExecutionContext(providerConfig: .inProcessLocal(model: "chunk-context-test")),
             options: .default
@@ -105,6 +138,40 @@ final class InProcessLLMClientTests: XCTestCase {
         XCTAssertTrue(reducePrompt.contains("Earlier user asked for Alpha."))
         XCTAssertTrue(reducePrompt.contains("Earlier assistant answered with Alpha."))
         XCTAssertTrue(reducePrompt.contains("Final user asks for Beta."))
+    }
+
+    func testChunkedPromptsBoundContextAndPartialResults() async throws {
+        let modelDirectory = temporaryModelDirectory()
+        let largePartial = String(repeating: "partial ", count: 200)
+        let runtime = FakeLocalLLMRuntime(eventPlans: [
+            [.text(largePartial)],
+            [.text(largePartial)],
+            [.text(largePartial)],
+            [.text("final")],
+        ])
+        let client = InProcessLLMClient(
+            runtime: runtime,
+            modelDirectoryResolver: { _ in modelDirectory },
+            chunkCharacterThreshold: 10,
+            chunkCharacterLimit: 300,
+            idleUnloadDelaySeconds: 60
+        )
+
+        _ = try await client.chatCompletion(
+            messages: [
+                ChatMessage(role: .user, content: String(repeating: "a", count: 500)),
+            ],
+            context: LLMExecutionContext(providerConfig: .inProcessLocal(model: "prompt-budget-test")),
+            options: .default
+        )
+
+        let requestContents = await runtime.requestContents()
+        XCTAssertGreaterThan(requestContents.count, 1)
+        XCTAssertTrue(requestContents.dropLast().allSatisfy { $0.count < 800 })
+
+        let reducePrompt = try XCTUnwrap(requestContents.last)
+        XCTAssertLessThan(reducePrompt.count, 800)
+        XCTAssertTrue(reducePrompt.contains("[...truncated for local model memory...]"))
     }
 
     func testQueuedGenerationDoesNotUnloadRuntimeBetweenRequests() async throws {
@@ -143,6 +210,58 @@ final class InProcessLLMClientTests: XCTestCase {
         let unloadCount = await runtime.unloadCallCount()
         XCTAssertEqual(requestContents, ["First", "Second"])
         XCTAssertEqual(unloadCount, 1)
+    }
+
+    func testQueuedGenerationCancellationReturnsBeforeActiveGenerationFinishes() async throws {
+        let modelDirectory = temporaryModelDirectory()
+        let runtime = FakeLocalLLMRuntime(
+            eventPlans: [
+                [.text("first")],
+                [.text("second")],
+            ],
+            delayNanoseconds: 700_000_000
+        )
+        let client = InProcessLLMClient(
+            runtime: runtime,
+            modelDirectoryResolver: { _ in modelDirectory },
+            idleUnloadDelaySeconds: 60
+        )
+
+        let firstTask = Task {
+            try await client.chatCompletion(
+                messages: [ChatMessage(role: .user, content: "First")],
+                context: LLMExecutionContext(providerConfig: .inProcessLocal(model: "queued-cancel-test")),
+                options: .default
+            )
+        }
+
+        try await Task.sleep(nanoseconds: 50_000_000)
+        let queuedTask = Task {
+            try await client.chatCompletion(
+                messages: [ChatMessage(role: .user, content: "Second")],
+                context: LLMExecutionContext(providerConfig: .inProcessLocal(model: "queued-cancel-test")),
+                options: .default
+            )
+        }
+
+        try await Task.sleep(nanoseconds: 50_000_000)
+        let cancellationStart = Date()
+        queuedTask.cancel()
+
+        do {
+            _ = try await queuedTask.value
+            XCTFail("Expected queued local generation to throw CancellationError")
+        } catch is CancellationError {
+            XCTAssertLessThan(Date().timeIntervalSince(cancellationStart), 0.3)
+        } catch {
+            XCTFail("Expected CancellationError, got \(error)")
+        }
+
+        let firstResponse = try await firstTask.value
+        XCTAssertEqual(firstResponse.content, "first")
+
+        let requestContents = await runtime.requestContents()
+        XCTAssertEqual(requestContents, ["First"])
     }
 
     func testStreamingYieldsRuntimeChunks() async throws {

--- a/Tests/MacParakeetTests/Services/LLM/LLMConfigStoreTests.swift
+++ b/Tests/MacParakeetTests/Services/LLM/LLMConfigStoreTests.swift
@@ -87,6 +87,19 @@ final class LLMConfigStoreTests: XCTestCase {
         XCTAssertEqual(loaded?.apiKey, "lm-token")
     }
 
+    func testInProcessLocalSentinelURLRoundTripsWithoutAPIKey() throws {
+        let config = LLMProviderConfig.inProcessLocal(model: "local-model")
+        try store.saveConfig(config)
+
+        let loaded = try store.loadConfig()
+        XCTAssertEqual(loaded?.id, .inProcessLocal)
+        XCTAssertEqual(loaded?.baseURL.absoluteString, "inprocess://local")
+        XCTAssertEqual(loaded?.modelName, "local-model")
+        XCTAssertEqual(loaded?.isLocal, true)
+        XCTAssertNil(loaded?.apiKey)
+        XCTAssertNil(try keychain.getString("llm_api_key_inProcessLocal"))
+    }
+
     func testOverwriteAPIKey() throws {
         let config1 = LLMProviderConfig.openai(apiKey: "old-key")
         try store.saveConfig(config1)

--- a/Tests/MacParakeetTests/Services/LLM/MLXLocalLLMIntegrationTests.swift
+++ b/Tests/MacParakeetTests/Services/LLM/MLXLocalLLMIntegrationTests.swift
@@ -32,7 +32,10 @@ final class MLXLocalLLMIntegrationTests: XCTestCase {
             options: ChatCompletionOptions(temperature: 0, maxTokens: 16)
         )
 
-        XCTAssertFalse(response.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        XCTAssertTrue(
+            response.content.localizedCaseInsensitiveContains("local mlx"),
+            "Expected the model to follow the zero-temperature instruction, got: \(response.content)"
+        )
         #else
         throw XCTSkip("Run with MACPARAKEET_ENABLE_MLX_LOCAL_LLM=1 so the gated MLX target is linked.")
         #endif

--- a/Tests/MacParakeetTests/Services/LLM/MLXLocalLLMIntegrationTests.swift
+++ b/Tests/MacParakeetTests/Services/LLM/MLXLocalLLMIntegrationTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+@testable import MacParakeetCore
+
+#if MACPARAKEET_HAS_MLX_LOCAL_LLM
+@testable import MacParakeetLocalLLM
+#endif
+
+final class MLXLocalLLMIntegrationTests: XCTestCase {
+    func testRealMLXGenerationWhenGatedBuildAndLocalModelArePresent() async throws {
+        let environment = ProcessInfo.processInfo.environment
+        try XCTSkipUnless(
+            environment["MACPARAKEET_RUN_MLX_LOCAL_LLM_INTEGRATION"] == "1",
+            "Set MACPARAKEET_RUN_MLX_LOCAL_LLM_INTEGRATION=1 to run the real MLX local LLM smoke."
+        )
+        guard let modelPath = environment[InProcessLLMClient.modelDirectoryEnvironmentVariable],
+              !modelPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw XCTSkip("Set \(InProcessLLMClient.modelDirectoryEnvironmentVariable) to a local MLX model directory.")
+        }
+
+        #if MACPARAKEET_HAS_MLX_LOCAL_LLM
+        let modelDirectory = URL(fileURLWithPath: modelPath, isDirectory: true)
+        let runtime = MLXLocalLLMRuntime()
+        let client = InProcessLLMClient(
+            runtime: runtime,
+            modelDirectoryResolver: { _ in modelDirectory },
+            idleUnloadDelaySeconds: 0
+        )
+
+        let response = try await client.chatCompletion(
+            messages: [ChatMessage(role: .user, content: "Reply with exactly: local mlx ok")],
+            context: LLMExecutionContext(providerConfig: .inProcessLocal()),
+            options: ChatCompletionOptions(temperature: 0, maxTokens: 16)
+        )
+
+        XCTAssertFalse(response.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        #else
+        throw XCTSkip("Run with MACPARAKEET_ENABLE_MLX_LOCAL_LLM=1 so the gated MLX target is linked.")
+        #endif
+    }
+}

--- a/Tests/MacParakeetTests/Services/LLM/RoutingLLMClientTests.swift
+++ b/Tests/MacParakeetTests/Services/LLM/RoutingLLMClientTests.swift
@@ -33,4 +33,51 @@ final class RoutingLLMClientTests: XCTestCase {
         let models = try await router.listModels(context: context)
         XCTAssertTrue(models.isEmpty)
     }
+
+    func testInProcessLocalContextRoutesToInjectedClient() async throws {
+        let expected = ChatCompletionResponse(content: "in-process", model: "local-test")
+        let inProcessClient = StubLLMClient(response: expected)
+        let router = RoutingLLMClient(inProcessClient: inProcessClient)
+
+        let response = try await router.chatCompletion(
+            messages: [ChatMessage(role: .user, content: "test")],
+            context: LLMExecutionContext(providerConfig: .inProcessLocal(model: "local-test")),
+            options: .default
+        )
+
+        XCTAssertEqual(response.content, "in-process")
+    }
+}
+
+private final class StubLLMClient: LLMClientProtocol, @unchecked Sendable {
+    private let response: ChatCompletionResponse
+
+    init(response: ChatCompletionResponse) {
+        self.response = response
+    }
+
+    func chatCompletion(
+        messages: [ChatMessage],
+        context: LLMExecutionContext,
+        options: ChatCompletionOptions
+    ) async throws -> ChatCompletionResponse {
+        return response
+    }
+
+    func chatCompletionStream(
+        messages: [ChatMessage],
+        context: LLMExecutionContext,
+        options: ChatCompletionOptions
+    ) -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { continuation in
+            continuation.yield(response.content)
+            continuation.finish()
+        }
+    }
+
+    func testConnection(context: LLMExecutionContext) async throws {}
+
+    func listModels(context: LLMExecutionContext) async throws -> [String] {
+        []
+    }
 }

--- a/plans/active/2026-06-27-on-device-local-llm-phase0-eval.md
+++ b/plans/active/2026-06-27-on-device-local-llm-phase0-eval.md
@@ -14,6 +14,15 @@ Issues: #439 (integrated local cleanup), relates #265, #550, #460, #563, #408
 > Primary focus: **cleanup**. Summary and grounded-QA are covered second, with an
 > evidence-backed argument that for those tasks the long-context *architecture*
 > matters more than the model.
+>
+> Product gate (updated 2026-07-04): the local model ships as an *option*, not the
+> default — cloud/frontier stays the recommended path per surface until local
+> reaches parity there. Phase 0 therefore answers two bars per surface:
+> **OFFER** (fidelity gates pass at a high rate AND quality clearly beats the
+> deterministic floor) and **RECOMMEND** (parity with the cloud baseline).
+> Single-transcript cleanup, summary, or Q&A may pass before broader library
+> intelligence does. Cross-meeting / whole-library analysis and tool-calling are
+> not presumed viable just because a local model can answer one transcript.
 
 ---
 
@@ -48,9 +57,10 @@ corrupted number into a 4/5 and hides the failure that destroys user trust.
 ## 2. What Phase 0 must answer (go / no-go)
 
 - **Q-QUALITY:** On a domain-matched gold set, does an on-device 4B-class model do
-  cleanup that (a) passes the fidelity gates at a high rate and (b) is judged at
-  least at parity with the current cloud-cleanup baseline and clearly above the
-  deterministic no-LLM baseline?
+  cleanup that (a) passes the fidelity gates at a high rate, (b) clearly beats the
+  deterministic no-LLM baseline (the bar to OFFER the local option), and (c)
+  reaches parity with the current cloud-cleanup baseline (the bar to RECOMMEND
+  local for that surface)?
 - **Q-MODEL:** Which model + quant wins the cleanup bake-off?
 - **Q-PREFILL:** Where does prefill latency cross the UX budget as input grows
   (1K → 64K tokens)? This sets the single-shot vs map-reduce threshold.
@@ -60,9 +70,15 @@ corrupted number into a 4/5 and hides the failure that destroys user trust.
   parse-success rate at our schema sizes? Is a custom logits processor worth it?
 - **Q-LONGCTX:** Confirm long-context degradation on our transcripts to justify
   map-reduce + retrieval over "use a bigger model."
+- **Q-SCOPE:** Which product surfaces are actually good enough to ship: cleanup,
+  summary, one-transcript Q&A, selected-text Transforms, cross-meeting/library
+  analysis, and/or tool-calling?
 
-A "go" means: at least one model+quant clears the cleanup quality bar within the
-latency/RAM budget on a mid-tier Mac, with a credible long-transcript path.
+A "go" means: at least one model+quant clears the OFFER bar within the latency/RAM
+budget on a mid-tier Mac, with a credible long-transcript path and a clearly
+bounded product scope; RECOMMEND status per surface additionally requires cloud
+parity. A "partial go" is acceptable — cleanup alone is a shippable scope — while
+cross-library analysis remains a no-go.
 
 ---
 
@@ -181,7 +197,10 @@ few-shot + self-consistency.
 ## 5. Gold set recipe (the highest-leverage Phase 0 item)
 
 No large commercial real-dictation→cleaned corpus exists. The set that matches our
-true distribution is ours — build it.
+true distribution is ours — build it. Build it in two slices (2026-07-04): a
+~50-item core annotated with must-preserve lists only (enough for the Tier-1 gates
+and a directional read alongside the runtime spike), then the full stratified ~200
++ judge calibration only if the go/no-go is borderline.
 
 - **Cleanup: ~200 items.** Stratify by length: ~60 short dictation (<50 words),
   ~80 medium (50–300), ~60 long/meeting (>300, multi-speaker). Spread across ~5–8
@@ -270,13 +289,20 @@ bounds — calibrate on a small meeting set.
 Numbers below are triangulated from measured community benchmarks; the prefill
 curve is the gap to close on our own hardware.
 
+> Role change (2026-07-04): these measurements are **instrumentation, not a
+> shipping gate**. The parent plan's §3 memory invariants (always-chunked long
+> inputs + `kvBits:4` + unload-on-idle) make the OOM/prefill failure modes
+> structurally unreachable, so the §7 numbers are collected from the spike build
+> during dogfood and used to tune the chunking threshold. Go/no-go rests on the
+> quality gates (§3–§5, §9).
+
 ### Model + quant — Qwen3-4B-Instruct-2507 (exact HF sizes, 2026-06-27)
 | Quant | Size | Note |
 |---|---|---|
-| 4-bit | 2.26 GB | baseline |
-| **4-bit DWQ (2510)** | **2.26 GB** | **ship this — same size, distillation-recovered quality** |
-| 6-bit | 3.27 GB | cheap quality upgrade if testing demands |
-| 8-bit | 4.27 GB | effectively lossless |
+| 4-bit | 2.26 GB | `mlx-community/Qwen3-4B-Instruct-2507-4bit` |
+| **4-bit DDWQ** | **2.53 GB** | **ship this — `mlx-community/Qwen3-4B-Instruct-2507-DDWQ` (verified 2026-07-04; repo is named DDWQ, slightly larger than plain 4-bit), distillation-recovered quality** |
+| 6-bit | 3.27 GB | `…-6bit`; cheap quality upgrade if testing demands |
+| 8-bit | 4.27 GB | `…-8bit`; effectively lossless |
 | bf16 | 8.04 GB | reference |
 
 Quant quality consensus: 8-bit ≈ lossless, 6-bit imperceptible, **plain 4-bit is
@@ -378,15 +404,23 @@ didn't say," suppress preamble, preserve speaker/timing tags, skip trivial input
 
 ## 9. Go / no-go criteria
 
-GO if, on the domain-matched gold set:
-- Best model+quant achieves a gate pass-rate competitive with the cloud baseline
-  and clearly above the deterministic floor, AND
-- mean quality among passers ≥ cloud-baseline parity on cleanup, AND
+Two bars per surface (positioning decided 2026-07-04: local ships as an option,
+not the default).
+
+GO-TO-OFFER if, on the domain-matched gold set:
+- Best model+quant achieves a high absolute Tier-1 gate pass-rate (fidelity is
+  trust-critical even for an opt-in path), AND
+- mean quality among passers clearly beats the deterministic no-LLM floor, AND
 - meets the latency budget (short dictation interactive; long-transcript path has a
   workable map-reduce threshold from the prefill curve), AND
 - fits RAM on a 16 GB Mac for the default tier (with `kvBits:4` long-context), AND
 - structured-output reliability is high enough (or fixable via validate-retry) for
-  the v1 scope (cleanup + summary + Ask; tool-calling is Phase 3).
+  the offered scope (tool-calling is Phase 3).
+
+GO-TO-RECOMMEND (per surface, later): additionally, gate pass-rate competitive
+with the cloud baseline AND mean quality among passers at cloud parity. Until a
+surface clears this, setup/recommendation copy keeps pointing at cloud for best
+quality.
 
 NO-GO / re-scope triggers: gates fail too often even at 8-bit (over-edit/
 hallucination intrinsic at 4B) → consider the 30B-A3B tier (parent plan §3 places

--- a/plans/active/2026-06-27-on-device-local-llm.md
+++ b/plans/active/2026-06-27-on-device-local-llm.md
@@ -1,6 +1,6 @@
 # On-Device Local LLM — A Self-Optimized MLX Model for Transcript AI
 
-**Status:** PROPOSED (needs product decisions — see §11)
+**Status:** DIRECTION CONFIRMED (Daniel, 2026-07-04) — ship a local model as a dead-simple *option* while cloud/frontier stays the recommended default until local quality catches up (§1). Phase 0 spike + eval still gates what ships and at what scope (§8, §11).
 **Created:** 2026-06-27
 **Related issues:** #439 (integrated local cleanup/format — the core ask), #265 (custom/specialized cleanup model + full prompt control), #550 (global company context for cleanup), #460 (folder-scoped AI queries / cross-meeting QA), #563 (chat truncation from hardcoded context budgets), #408 (separate dictation/transform AI from meeting AI).
 **Related plans:** [`2026-05-ai-setup-ux.md`](2026-05-ai-setup-ux.md) (where one-click setup lives), [`2026-06-19-meetings-workspace-productization.md`](2026-06-19-meetings-workspace-productization.md) (U6 local index / U7 cross-meeting Ask), [`2026-05-voice-command-agent-mode.md`](2026-05-voice-command-agent-mode.md) (tool-calling / agent mode).
@@ -10,16 +10,18 @@
 
 ## 1. Goal & north star
 
-Give MacParakeet a **first-party, on-device LLM** that powers transcript-based AI — **cleanup, summarization, QA, and (later) tool-calling** — with **no API key, no second app, and nothing leaving the Mac**, set up in **one click**.
+Future direction: give MacParakeet a **first-party, on-device LLM** that powers transcript-based AI — **cleanup, summarization, QA, and eventually tool-calling** — with **no API key, no second app, and nothing leaving the Mac**, set up in **one click**.
 
-**North star: output quality/accuracy of the final result.** We target performant Apple Silicon Macs, so model size (multi-GB download/RAM) is acceptable when it buys reliably better output. Latency is a managed secondary concern.
+**Positioning (decided 2026-07-04): option, not default.** The local model ships as a dead-simple choice alongside the existing providers; cloud/frontier models remain the recommended quality path for every AI surface until the local model demonstrably closes the gap on that surface. This splits the bar: to **offer** local, a surface must be trust-safe (fidelity gates) and clearly better than the deterministic pipeline; to **recommend or default to** local on a surface, it must reach cloud parity there. The option must stay effortless for non-technical users — one click, no key, no terminal — because that audience is exactly who cannot do BYO keys or Ollama.
 
-**Strategy: hyper-focus on one engine and one self-optimized model.** Rather than supporting every runtime and every model format, we commit to **MLX** (Apple's on-device ML framework) and ship a **single model that we optimize specifically for Apple Silicon** — an open, permissively-licensed base that we convert, quantize, and (over time) fine-tune for MacParakeet's transcript tasks, with our own purpose-built model as the endgame. This is the opposite of a sprawling provider matrix: one engine, one tuned model, deeply optimized.
+**North star: output quality/accuracy of the final result.** We should not ship a local model just because it is local or easier for nontechnical users to set up. The feature is only worth adding if Phase 0 proves the model actually works well enough on real MacParakeet transcripts. A local model may be good enough first for one-transcript cleanup, summary, or Q&A; whole-library / cross-meeting analysis is a higher bar and current local LLMs are likely not sufficient without stronger retrieval, context handling, and model intelligence. We target performant Apple Silicon Macs, so model size (multi-GB download/RAM) is acceptable only when it buys reliably better output. Latency is a managed secondary concern.
+
+**Strategy, if the gate passes: hyper-focus on one engine and one self-optimized model.** Rather than supporting every runtime and every model format, we would commit to **MLX** (Apple's on-device ML framework) and ship a **single model that we optimize specifically for Apple Silicon** — an open, permissively-licensed base that we convert, quantize, and (over time) fine-tune for MacParakeet's transcript tasks, with our own purpose-built model as the endgame. This is the opposite of a sprawling provider matrix: one engine, one tuned model, deeply optimized.
 
 This is **not** "bundle a model into the app." The app stays small; the model is an **opt-in, verified download** the user enables with a single action, on top of the BYO flexibility we already have (Ollama / LM Studio / cloud keys / local CLI remain for power users).
 
 ### Why this matters now
-Today every AI feature requires the user to bring a cloud API key **or** stand up Ollama/LM Studio themselves — a real setup cliff and an extra trust boundary for transcript text. Issue #439 captures it: people want a default local refiner that "just works" for "mama + grandma," while power users keep their options. The same on-device model unlocks summary/QA over meeting, YouTube, and file transcripts with no cloud round-trip.
+Today every AI feature requires the user to bring a cloud API key **or** stand up Ollama/LM Studio themselves — a real setup cliff and an extra trust boundary for transcript text. Issue #439 captures it: people want a default local refiner that "just works" for "mama + grandma," while power users keep their options. The open question is whether current local LLMs are good enough to earn that default. If they are, the likely first win is local AI for one transcript at a time; broader cross-library intelligence remains a later capability gate.
 
 ---
 
@@ -29,10 +31,13 @@ Today every AI feature requires the user to bring a cloud API key **or** stand u
 |---|------|---------------|------------------------------------------------------|
 | A | **Transcript / dictation cleanup** (disfluency removal, light formatting, ITN, casing) | Strong instruction-following + faithfulness; low temperature; fast | `TextProcessing/AIFormatter.swift`, `TextProcessing/TranscriptFormatter.swift`; dictation `Services/Dictation/DictationService.swift`, file/URL/meeting `Services/TranscriptionService.swift` |
 | B | **Summarization of long transcripts** (meetings, YouTube, files; 10k–50k+ tokens) | Long context (via chunking/map-reduce); capable model | `PromptResultsViewModel` → `LLMService.generatePromptResultStream`; prompt library |
-| C | **QA over a transcript** (grounded answers; per-transcript, later cross-meeting) | Long context + retrieval; faithfulness | `TranscriptChatViewModel` → `LLMService.chatStream`; live meeting `LiveAskPaneView` |
-| D | **Tool / function calling** (drive app actions, agent mode) | A tool-trained model + tool plumbing we don't have yet | New — enables `2026-05-voice-command-agent-mode.md` |
+| C | **QA over one transcript** (grounded answers; per-transcript first) | Long context + retrieval; faithfulness | `TranscriptChatViewModel` → `LLMService.chatStream`; live meeting `LiveAskPaneView` |
+| D | **Cross-meeting / whole-library analysis** | Local index + retrieval + stronger context handling; likely beyond current small local LLMs until proven | `2026-06-19-meetings-workspace-productization.md` U6/U7; new retrieval layer |
+| E | **Tool / function calling** (drive app actions, agent mode) | A tool-trained model + tool plumbing we don't have yet; structured-output reliability must be proven | New — enables `2026-05-voice-command-agent-mode.md` |
 
-Cleanup, summary, Ask, and Transforms are **already provider-agnostic** (they route through `LLMService` → `RoutingLLMClient`). Adding one local MLX provider makes A/B/C and selected-text Transforms local-by-default with **no call-site changes**. D needs new plumbing (§6).
+Cleanup, summary, Ask, and Transforms are **already provider-agnostic** (they route through `LLMService` → `RoutingLLMClient`). If Phase 0 passes, adding one local MLX provider makes the proven subset of A/B/C and selected-text Transforms available locally with **no call-site changes**. Cross-library analysis and tool-calling need separate gates and new plumbing (§6).
+
+**Underweighted consumer — background/library intelligence jobs (added 2026-07-04):** the strongest structural fit for a local model is not replacing a user-initiated cloud call but the calls nobody makes because of cost/trust: auto-titling, entity/action-item extraction, tagging, and index enrichment for the context engine (see [`2026-07-04-context-engine-agent-tools.md`](2026-07-04-context-engine-agent-tools.md)). These are high-volume, low-entropy background tasks with a lower quality bar than user-facing prose, zero marginal cost locally, and no privacy exposure — where cloud can never compete on economics or trust. Design context-engine indexing jobs as local-model consumers from day one; they may justify the runtime even if only cleanup passes the user-facing gate.
 
 ---
 
@@ -40,12 +45,14 @@ Cleanup, summary, Ask, and Transforms are **already provider-agnostic** (they ro
 
 - **One engine: MLX.** We do not build a multi-runtime hybrid. (Keep a thin `LocalLLMRuntime` protocol as cheap future insurance, but implement only MLX.)
 - **One self-optimized model is the first-party path.** We pick/convert/quantize/fine-tune a single model for Apple Silicon and ship it as the default; depth of optimization over breadth of choice.
+- **No product commitment before proof.** Do not add the runtime, downloader, or default setup path until Phase 0 proves the local model is useful enough for at least one clear user-facing job. "It runs locally" is not sufficient.
 - **Apple Silicon only.** The MLX engine + our model require Apple Silicon (the app is already Apple-Silicon-only). The one-click local path must be hardware-gated/hidden so an unsupported Mac never surfaces a setup that cannot run.
 - **On-device only for the local path.** No transcript text leaves the Mac when the local model is selected; indexing/retrieval for QA stays local.
 - **Do not bundle a multi-GB model into the app binary.** Keep the DMG small; the model is a verified on-demand download into Application Support.
 - **Preserve existing providers.** Cloud keys, Ollama, LM Studio, local CLI remain for power users. "BYO" for the in-process engine means **other MLX-format models**, not arbitrary formats.
 - **Permissive licensing for anything we ship/fine-tune by default** — Apache-2.0 / MIT base only (see §5).
 - **Accuracy beats latency.** When forced to choose for the default, pick the more accurate model/quant.
+- **Structurally bounded memory (added 2026-07-04).** Long inputs are always chunked/map-reduced (small per-call windows) with quantized KV (`kvBits:4`), and the model unloads on idle. These are day-one design invariants, not tuning knobs: they make the in-process OOM scenario unreachable by construction instead of merely unlikely, which is what lets perf be instrumentation rather than a gate (§8).
 - **Graceful fallback.** On model-missing / load failure / OOM, fall back to the deterministic pipeline (and offer raw transcript) — never block dictation, never insert an error string.
 
 ---
@@ -60,6 +67,8 @@ We want an in-process runtime on Apple Silicon, optimizable for a single model, 
 - **Full self-optimization control** — MLX quantization (including DWQ 4-bit ≈ 6–8-bit quality), and a clear path to convert/fine-tune our own model into MLX format. Conversion is a one-time, deliberate step we own, not a per-user chore.
 - **Ships in notarized apps** today (Metal shaders built via Xcode, `.metallib` bundled). Large models on macOS need **no special memory entitlement** (the `com.apple.developer.kernel.increased-memory-limit` entitlement is iOS-only and does not apply on macOS) — fit is managed by RAM-gating model tiers and respecting the Metal wired-memory limit (see §9).
 
+**Pinned facts (live-verified 2026-07-04, Codex web pass):** mlx-swift-lm latest is `3.31.4` — pin **exact** for the spike, plus a direct exact `mlx-swift 0.31.4` pin (the resolver otherwise picks `0.31.6`, which requires Swift tools 6.3). mlx-swift-lm itself requires Swift tools 6.1 (our package is 5.9 — see the build-gating decision in §6). Confirmed as cited: `ChatSession.respond`/`streamResponse`/`streamDetails`; `GenerateParameters` `kvBits`/`kvGroupSize`/`kvScheme`; `savePromptCache`/`loadPromptCache`; `RotatingKVCache.toQuantized()` still a `fatalError`; macOS 14.0 platform floor. Changed since research: `LLMModelFactory.loadContainer` in 3.x needs downloader/tokenizer adapters or the `MLXHuggingFace` macros — don't code against the old bare `loadContainer(configuration:)` shape.
+
 **Runtimes we are NOT using (and why):** llama.cpp/GGUF — its main advantage is universal "load any GGUF" BYO, which we are explicitly *not* prioritizing; not worth the C++ vendoring when we optimize one MLX model. MLC-LLM / Core ML — per-model compile/convert, weaker momentum. Bundled Ollama — a hidden second process. **Apple Foundation Models** — Apple's fixed ~3B model with a ~4096-token window; we can't self-optimize it and it can't summarize long transcripts without heavy chunking. Demoted to an **optional zero-download fallback** for eligible users (the public `FoundationModels` API — `LanguageModelSession` + `@Generable` — on macOS 26+ with Apple Intelligence enabled), never the primary "our model" path.
 
 ### Two tradeoffs MLX carries — and our mitigations (own the model)
@@ -72,9 +81,9 @@ We want an in-process runtime on Apple Silicon, optimizable for a single model, 
 
 We ship **one** first-party model (with optional RAM-tiered variants), built from a permissively-licensed base so we can redistribute and fine-tune freely.
 
-- **Base candidate / starting default: `Qwen3-4B-Instruct-2507`** — Apache-2.0, 256K context, top sub-8B instruction-following, light KV cache, competent tool-calling. Convert to MLX (4-bit DWQ ≈ 2.3 GB) and use the **non-thinking Instruct** checkpoint (cleanup wants determinism). This is the *base we optimize*, not necessarily the final shipped weights.
+- **Base candidate / starting default: `Qwen3-4B-Instruct-2507`** — Apache-2.0, 262K native context, top sub-8B instruction-following, light KV cache, competent tool-calling. Exact MLX weights (verified 2026-07-04): `mlx-community/Qwen3-4B-Instruct-2507-DDWQ` **2.53 GB** (the distillation-recovered quant — note the repo is named DDWQ, not DWQ, and is slightly larger than plain 4-bit); plain 4-bit 2.26 GB; 6-bit 3.27 GB; 8-bit 4.27 GB and use the **non-thinking Instruct** checkpoint (cleanup wants determinism). This is the *base we optimize*, not necessarily the final shipped weights. Phase 0 bakes this off against Apache-licensed **Gemma-4-E4B** (community signal: the Gemma line leans terse/faithful for cleanup, Qwen stronger at summarizing/structuring — eval doc §8); the single-model invariant holds and the bake-off picks the one first-party default.
 - **Self-optimization path:** (1) MLX convert + DWQ quantize and tune generation params; (2) fine-tune on transcript cleanup / summarization / QA style for higher faithfulness and our house formatting; (3) endgame = our own purpose-built MacParakeet model, published as MLX weights the one-click flow fetches.
-- **Optional RAM tiers (same family for consistent prompts):** 16 GB → 4B; 32 GB → Qwen3-30B-A3B-Instruct (MoE, ~18.6 GB, ~3B-speed, near-flagship quality); 64 GB → 30B-A3B Q6/Q8. Start with the single 4B and add tiers only if the spike shows a clear quality gap.
+- **Optional RAM tiers (same family for consistent prompts):** 16 GB → 4B; 32 GB → Qwen3-30B-A3B-Instruct (MoE, ~18.6 GB, ~3B-speed, near-flagship quality); 64 GB → 30B-A3B Q6/Q8. Start with the single 4B and add tiers only if the spike shows a clear quality gap. Note (2026-07-04 review): the user base skews pro hardware, so expect the 30B-A3B tier to be the difference between a tolerable option and a genuinely good one — the 4B is the 16 GB floor, not the pitch. Still Phase 2, not v1.
 - **License rule:** base/fine-tune only from **Apache-2.0 / MIT** (Qwen3, Mistral Apache models, Phi-4/-mini, SmolLM, IBM Granite 4.0, OLMo 2). Avoid Gemma 2/3 (custom terms) and Llama (community license + EU multimodal carve-out) as a base. (Gemma 4 reportedly moved to Apache — re-check if wanted.)
 - **Specialized cleanup model (#265):** don't maintain a second first-party model. Parakeet already emits punctuation/casing, so cleanup *beyond* punctuation (disfluency, ITN, light rewrite) is best done by our tuned general model under a strict source-faithful prompt. #265's "plug in a tiny specialized cleanup model + control the prompt" is satisfied by **BYO (another MLX model) + the editable prompt**.
 
@@ -104,13 +113,15 @@ Our LLM stack is already cleanly abstracted; the change is additive.
 6. **Fix context budgets (#563) — this changes `LLMService` internals** (the `cloud`/`local`/`lmStudio` char budgets + `truncateMiddle` live there): make budgets token-based and per-model (read the model's real context window) instead of hardcoded chars. Provider abstraction and call sites stay unchanged.
 7. **Tool-calling (Phase 3):** extend `ChatMessage`/`ChatCompletionOptions`/`ChatCompletionResponse` with tool definitions + results; implement via a fine-tuned-for-tools model + validate/retry (and/or a logits processor / FM `@Generable`); wire allowlisted typed tools per `2026-05-voice-command-agent-mode.md`.
 
+**Build gating (decided 2026-07-04, from live verification):** MLX **cannot** land as a plain dependency — command-line SwiftPM can't build the Metal shaders (xcodebuild required; Jan's app ships this way, copying `default.metallib`), and mlx-swift-lm needs Swift tools 6.1 vs our tools 5.9 and CI's Xcode 16.1. Therefore: `LocalLLMRuntime` protocol + `InProcessLLMClient` live in `MacParakeetCore` with **no MLX import**; the MLX implementation lives in a separate opt-in target/module wired only into app builds, gated the same way as the existing no-Whisper gate, so `swift build` / `swift test` / CI never resolve or compile MLX. App release builds (xcodebuild, Daniel's machine) turn the gate on.
+
 Build the **chunking / map-reduce / retrieval layer** for long transcripts regardless (summary/QA need it; mitigates MLX long-prefill).
 
 ---
 
 ## 7. One-click setup UX (hard requirement)
 
-Setup must be **a single obvious action**. Lives in the Settings → AI card + onboarding AI step (extends [`2026-05-ai-setup-ux.md`](2026-05-ai-setup-ux.md): `.setUpNeeded` / `.ready` / `.cannotConnect`).
+The local model is presented as an **option alongside the other providers** — recommendation copy keeps pointing at cloud/frontier for best quality until per-surface evidence flips it (§1) — but enabling it must be **a single obvious action**. Lives in the Settings → AI card + onboarding AI step (extends [`2026-05-ai-setup-ux.md`](2026-05-ai-setup-ux.md): `.setUpNeeded` / `.ready` / `.cannotConnect`).
 
 - **Hardware gate (first):** only offer the local path on Apple Silicon (see §3); on unsupported hardware, hide it and fall back to BYO/cloud messaging — never surface a one-click setup that cannot run.
 - **Primary: one "Enable local AI" button** that runs **download our optimized model → verify → select → test → "Ready"**, with a progress bar (reuse speech-model download UI) and recoverable error states (network/disk/corrupt → re-validate; mirror speech-model download hardening). RAM-aware: pick the right tier for the machine, respecting the macOS Metal wired-memory limit.
@@ -122,13 +133,13 @@ Setup must be **a single obvious action**. Lives in the Settings → AI card + o
 
 ## 8. Phasing
 
-**Phase 0 — Spike + evaluation (decision gate).** Stand up a minimal in-process **MLX** path (mlx-swift-lm) with the base candidate (Qwen3-4B-Instruct-2507, DWQ). Evaluate on real MacParakeet transcripts: cleanup faithfulness, summary quality, QA groundedness, and a tool-calling/JSON-reliability probe — **vs the deterministic pipeline and vs a cloud model**. Measure on-device latency (prewarm + prompt-cache) and RAM on 16/32/64 GB, and **explicitly validate the two MLX risks** (structured-output reliability, long-transcript prefill). Output: confirmed base model + quant, the chunking approach, accept/reject thresholds met. *Accuracy is the gating metric.* **Eval methodology — what to measure and how (metric stack, judge protocol, gold-set recipe, perf benchmarks, go/no-go) — is detailed in the companion [Phase 0 Eval Design](./2026-06-27-on-device-local-llm-phase0-eval.md).**
+**Phase 0 — Spike + evaluation (decision gate).** Stand up a minimal in-process **MLX** path (mlx-swift-lm) with the base candidate (Qwen3-4B-Instruct-2507, DWQ). Evaluate on real MacParakeet transcripts: cleanup faithfulness, summary quality, one-transcript QA groundedness, and a tool-calling/JSON-reliability probe — **vs the deterministic pipeline and vs a cloud model**. Also run a deliberately hard cross-meeting / library-analysis probe to decide whether that scope is currently a no-go. Measure on-device latency (prewarm + prompt-cache) and RAM on 16/32/64 GB, and **explicitly validate the two MLX risks** (structured-output reliability, long-transcript prefill). Output: confirmed base model + quant, the chunking approach, which product surfaces are allowed, and accept/reject thresholds met. *Accuracy is the gating metric.* **Eval methodology — what to measure and how (metric stack, judge protocol, gold-set recipe, perf benchmarks, go/no-go) — is detailed in the companion [Phase 0 Eval Design](./2026-06-27-on-device-local-llm-phase0-eval.md).** Sequencing (revised 2026-07-04): **perf is instrumentation, not a gate.** 4B-class viability on M-series is community-settled, and the two real perf risks (long-context KV OOM, prefill stalls) are removed by construction via the §3 memory invariants (chunking + `kvBits:4` + unload-on-idle). Collect the §7 numbers incidentally from the spike build during dogfood — they tune the chunking threshold, they don't decide go/no-go. The gate is **quality only**: (1) Tier-1 deterministic fidelity gates on a ~50-item core plus side-by-side dogfood vs the cloud baseline on real meetings (including one adversarial session: summarize a long meeting on a 16 GB Mac while a recording is live); (2) the full 200-item gold set + judge calibration only if the decision is borderline. Don't let the eval become the project.
 
-**Phase 1 — In-process MLX provider + one-click default.** Add `.inProcessLocal` + `InProcessLLMClient` (MLX) + downloader; ship the optimized default with the one-click card. Cleanup/summary/Ask/Transforms go local-by-default (no call-site changes). Fix #563 (token budgets). Resolves the core of #439, #550.
+**Phase 1 — In-process MLX provider + one-click local *option* for proven tasks only.** Add `.inProcessLocal` + `InProcessLLMClient` (MLX) + downloader; ship the one-click card as an option (cloud stays the recommended default, §1) covering only the surfaces Phase 0 proves. Cleanup alone is a legitimate Phase 1 — do not stretch scope to summary/QA to justify the download if they read as mediocre; visible mediocrity is what killed ADR-008. Fix #563 (token budgets). Resolves the core of #439, and only part of #550.
 
 **Phase 2 — Self-optimization + tiers + fallback.** Fine-tune the model for our tasks (cleanup/summary faithfulness, house style); add RAM tiers if warranted; add the optional Apple Intelligence zero-download fallback; ship the map-reduce/retrieval layer for long transcripts. BYO MLX model for power users (#265).
 
-**Phase 3 — Tool-calling + cross-meeting QA.** Add tool-calling (enables `2026-05-voice-command-agent-mode.md`) via a tools-tuned model + validation (and/or logits processor / FM); leverage the local model for cross-meeting/folder-scoped QA (#460), relaxing the "snippets-only to remote" constraint when inference is local (ties to meetings-workspace U6/U7).
+**Phase 3 — Tool-calling + cross-meeting QA, only if model capability catches up.** Add tool-calling (enables `2026-05-voice-command-agent-mode.md`) via a tools-tuned model + validation (and/or logits processor / FM); leverage the local model for cross-meeting/folder-scoped QA (#460), relaxing the "snippets-only to remote" constraint when inference is local (ties to meetings-workspace U6/U7). This phase should wait until local models demonstrate enough context, reasoning, and structured-output reliability to make whole-library analysis actually useful.
 
 **Phase 4 (endgame) — Our own model.** A purpose-built MacParakeet cleanup/summary model, published as MLX weights the one-click flow fetches.
 
@@ -137,6 +148,7 @@ Setup must be **a single obvious action**. Lives in the Settings → AI card + o
 ## 9. Risks & mitigations
 
 - **Quality bar not met at tolerable size** → Phase 0 gate; accuracy is the metric; deterministic fallback retained.
+- **Local model works only for narrow tasks** → ship only the proven subset; keep cloud/BYO providers as the recommendation for long-context or cross-library work.
 - **MLX structured-output gap (tool-calling/JSON)** → fine-tune for tool output + validate/retry; optional logits processor; FM `@Generable` where available.
 - **MLX long-context prefill** → map-reduce/retrieval + KV/prompt caching; validate in Phase 0.
 - **RAM / macOS Metal wired-memory limit** (≈67% ≤36 GB, ≈75% >36 GB unified memory) → RAM-gate recommendations; cap context/KV; quantize KV for long transcripts; free idle models. (No memory entitlement on macOS — that is iOS-only.)
@@ -145,22 +157,28 @@ Setup must be **a single obvious action**. Lives in the Settings → AI card + o
 - **First-run latency** (model load + shader compile) → prewarm on AI entry; stable-prompt-prefix prompt cache.
 - **Long-transcript truncation (#563)** → token budgets + map-reduce, not silent middle-drop.
 - **License contamination** → automated check that the base/fine-tune is Apache-2.0/MIT.
-- **Build/CI** → MLX Metal shaders need Xcode/`xcodebuild` (not bare `swift build`); ensure CI uses the full toolchain.
+- **Build/CI** → CONFIRMED BLOCKING (2026-07-04): MLX Metal shaders need `xcodebuild`, and mlx-swift-lm needs Swift tools 6.1 (transitive `mlx-swift 0.31.6` even needs 6.3 — pin `0.31.4` directly). Mitigation is the §6 gating decision: CI and `swift build`/`swift test` never compile MLX; only gated app builds do.
 
 ## 10. Success criteria
 
 - Fresh-install user enables capable local AI **in one action**, no key, no extra app; transcript text never leaves the device.
-- Cleanup/summary/Ask quality on real transcripts **meets or beats** the deterministic baseline by Phase 0 thresholds, and is "good enough vs cloud" for everyday use.
+- Cleanup/summary/Ask quality on real single-transcript tasks **meets or beats** the deterministic baseline by Phase 0 thresholds, and is "good enough vs cloud" for everyday use.
 - Summary/QA work on long meeting/YouTube/file transcripts without silent truncation.
+- Cross-meeting / whole-library analysis is either proven useful with retrieval and explicit quality gates, or explicitly excluded from the first local-LLM release.
 - The model is demonstrably **optimized for Apple Silicon** (latency/RAM acceptable on a 16 GB Mac), with a clear path to a fine-tuned MacParakeet model.
 
-## 11. Open decisions for Daniel
+## 11. Decisions & open questions
 
+**Decided (Daniel, 2026-07-04):**
+- Ship the local model as a **dead-simple option, not the default**; cloud/frontier stays the recommended quality path per surface until local reaches parity there (§1).
+- The go/no-go bar splits accordingly: fidelity-safe + clearly above the deterministic floor to *offer*; cloud parity to *recommend* (eval doc §9).
+- v1 scope is whatever subset Phase 0 proves; cleanup alone is acceptable. Cross-library analysis and agentic/MCP-style tool-calling stay cloud-first until local capability is proven (closed-world app tools may qualify earlier than open-ended agents).
+
+**Still open:**
 1. **Confirm MLX as the single engine** (no llama.cpp/multi-runtime), with a thin `LocalLLMRuntime` seam as optional insurance?
-2. **Base model:** Qwen3-4B-Instruct-2507 (Apache) as the starting base to convert/optimize, 30B-A3B tier only if the spike justifies it?
+2. **Base model:** Qwen3-4B-Instruct-2507 vs Gemma-4-E4B (both Apache) — Phase 0 bake-off picks the one first-party default; 30B-A3B tier expected in Phase 2 for 32 GB+ Macs.
 3. **Self-optimization roadmap:** convert+quantize first (Phase 1), fine-tune next (Phase 2), our own model as endgame (Phase 4) — agree on this sequencing?
 4. **Apple Intelligence:** include as an optional zero-download fallback, or skip entirely to stay single-model?
-5. **v1 scope:** cleanup + summary + Ask (Phase 1), tool-calling explicitly Phase 3?
 
 ---
 

--- a/spec/11-llm-integration.md
+++ b/spec/11-llm-integration.md
@@ -18,10 +18,12 @@ This spec defines how MacParakeet integrates LLM-powered features via external p
 
 ## Non-Goals
 
-1. Bundling any LLM runtime or model (no mlx-swift-lm, no llama.cpp, no model downloads).
+1. Bundling any LLM runtime or model today (no mlx-swift-lm, no llama.cpp, no model downloads in the current accepted architecture).
 2. Bundled/default LLM processing in the dictation hot path. The AI formatter is opt-in, runs after deterministic cleanup, and falls back to the deterministic result if the provider fails.
 3. Building a hosted backend or proxy service.
 4. Automatic fallback between providers.
+
+**Future direction (updated 2026-07-04):** A first-party local model (Qwen/Gemma-class via MLX) will be offered as a dead-simple, one-click *option* once Phase 0 evidence shows it is trust-safe and clearly better than the deterministic pipeline for at least one surface (cleanup is the likely first). Cloud/frontier providers remain the recommended quality path per surface until the local model reaches parity there; cross-library / cross-meeting analysis, durable tool calling, and agent workflows stay cloud-first until local capability is proven. See `plans/active/2026-06-27-on-device-local-llm.md`.
 
 ---
 
@@ -379,14 +381,11 @@ defaults before calling `LLMService`:
 The smart-default tier is user-controllable through
 `AIFormatterSmartDefaultsPolicy` (UserDefaults-backed, no schema change): a
 master "Smart defaults" switch plus per-category switches in Settings, where
-each built-in prompt is also readable before it ever runs. The prompt preview
-remains readable when the master switch is off; the grid dims and per-category
-switches are disabled until the master switch is turned back on. With the
-master switch off (or a category switched off), resolution skips that tier
-entirely, so a user who tuned the fallback prompt gets byte-for-byte
-pre-profiles behavior wherever no custom profile matches. Profile-fetch
-failures degrade to the fallback prompt and are logged via OSLog
-(`AIFormatter` category).
+each built-in prompt is also readable before it ever runs. With the master
+switch off (or a category switched off), resolution skips that tier entirely,
+so a user who tuned the fallback prompt gets byte-for-byte pre-profiles
+behavior wherever no custom profile matches. Profile-fetch failures degrade to
+the fallback prompt and are logged via OSLog (`AIFormatter` category).
 
 Saved dictation rows surface their routing provenance in History: rows
 formatted by an app or category profile (custom or smart default) show a small

--- a/spec/adr/011-llm-cloud-and-local-providers.md
+++ b/spec/adr/011-llm-cloud-and-local-providers.md
@@ -54,11 +54,17 @@ The current branch supports these provider/runtime types through one shared serv
 
 ### Locked Decisions
 
-1. **No bundled LLM runtime.** No mlx-swift-lm, no llama.cpp, no Cactus, no model downloads. Zero GPU/memory impact from LLM.
+1. **No bundled LLM runtime in the accepted current architecture.** No mlx-swift-lm, no llama.cpp, no Cactus, no model downloads. Zero GPU/memory impact from LLM.
 2. **Provider-aware transport behind one shared service boundary.** Runtime choices are external providers, OpenAI-compatible endpoints, local servers, or Local CLI tools. Transport details may vary per provider.
 3. **LLM features are optional.** The app is fully functional without any provider configured. Transcription, dictation, export — all work without LLM.
 4. **No default provider.** User must explicitly choose and configure. No "sign up for our cloud" upsell.
 5. **Transcription stays local.** Audio never leaves the device. The app can remain fully local when users choose only local providers/features. Only transcript text is sent to providers/CLI tools when the user explicitly triggers an LLM feature. This distinction must be clear in the UI.
+
+### Future Reconsideration
+
+This ADR can be superseded only if local LLMs prove good enough for the actual product jobs, not merely because they are convenient to package. The likely first acceptable scope is single-transcript work: cleanup, summarization, or grounded Q&A over one transcript. Cross-meeting / whole-library analysis, agent workflows, and tool calling need materially stronger context handling, intelligence, and structured-output reliability before MacParakeet should make a first-party local model the default path. A future proposal must pass a Phase 0 eval against real transcripts and cloud baselines before adding a runtime or model download to the app.
+
+**Amendment (2026-07-04): direction confirmed, positioning fixed.** Product decision: MacParakeet will offer a first-party local model (Qwen/Gemma-class via MLX) as a dead-simple, one-click *option* aimed at non-technical and privacy-first users, while cloud/frontier providers remain the recommended quality path per surface until the local model demonstrably reaches parity there. The accepted architecture is unchanged for now — the Phase 0 eval in `plans/active/2026-06-27-on-device-local-llm.md` still gates adding any runtime or model download. Shipping bar per surface: fidelity-safe and clearly above the deterministic pipeline to *offer*; cloud parity to *recommend*. Agentic/tool-calling and whole-library analysis stay cloud-first until proven.
 
 ### Features Enabled
 


### PR DESCRIPTION
## Summary
Adds PR 1 foundation for a first-party local MLX LLM provider while keeping MLX completely invisible to normal SwiftPM and CI.

- Commits the local LLM plan/spec/ADR updates first.
- Adds the Core-only provider seam: `.inProcessLocal`, sentinel `inprocess://local`, runtime protocol, in-process client, routing, metrics, chunked map/reduce, cancellation, and idle unload.
- Adds gated `MacParakeetLocalLLM` behind `MACPARAKEET_ENABLE_MLX_LOCAL_LLM=1` with exact `mlx-swift-lm 3.31.4` and direct `mlx-swift 0.31.4` pins.
- Keeps the provider hidden from Settings and normal provider lists while `AppFeatures.inProcessLocalLLMEnabled == false`.
- Addresses review and CI findings by serializing local generation ownership, preventing idle unload between queued streams, preserving compact chat context in both map and reduce prompts, deferring gated MLX unload during generation, using a fresh MLX `ChatSession` per generation from the loaded `ModelContainer`, and moving RSS task-port lookup into the existing ObjC shim so Swift 6 language-mode CI does not touch Darwin's `mach_task_self_` global from Swift.

## Design
```mermaid
flowchart LR
  Existing[Existing LLM callers] --> Routing[RoutingLLMClient]
  Routing --> Remote[HTTP and CLI providers]
  Routing --> InProcess[InProcessLLMClient]
  InProcess --> Lifetime[LocalLLMLifetimeCoordinator]
  Lifetime --> Runtime[LocalLLMRuntime protocol]
  Runtime --> Normal[Unavailable runtime in normal builds]
  Runtime --> Gated[MacParakeetLocalLLM / MLX in env-gated builds]
```

Normal `swift build`, `swift test`, and CI do not resolve or compile MLX because `Package.swift` only adds the MLX packages and target when `MACPARAKEET_ENABLE_MLX_LOCAL_LLM=1` is present.

Memory invariants in this PR:
- long inputs are chunked before runtime generation
- map and reduce prompts retain compact role-labeled user and assistant context
- MLX runtime generation uses `kvBits: 4`
- in-process client schedules unload-on-idle only after no queued generation owns the runtime
- gated MLX runtime keeps the model loaded but uses a fresh `ChatSession` per generation
- generation metrics include TTFT, throughput, and peak RSS sample

## Verification
Before opening:
- `swift package describe --type json` - passed; normal path has no MLX packages, products, dependencies, or target
- `swift build` - passed
- `swift test --filter LLM` - passed; 400 tests, 1 skipped, 0 failures
- `git diff --check` - passed

Final full-suite gate, run once per brief:
- `swift test` - passed; XCTest: 4521 tests, 16 skipped, 0 failures; Swift Testing: 17 tests, 0 failures

After review and CI follow-up commits:
- `swift test --filter InProcessLLMClientTests` - passed; 7 tests, 0 failures
- `swift test --filter LLM` - passed; 402 tests, 1 skipped, 0 failures
- `MACPARAKEET_SKIP_WHISPERKIT=1 swift build --build-path .build-swift6-no-whisper -Xswiftc -swift-version -Xswiftc 6` - passed
- `swift package describe --type json` with normal env - passed; MLX still hidden from dependency/product/target graph
- `git diff --check` - passed

Remote checks on head `9676f9ddb35bd88adb22e896653e079cc05731c0`:
- Greptile Review - passed
- Cubic review - passed
- `swift-test` push run - passed
- `swift-test` PR rerun - passed

The first PR `swift-test` run on this head passed Swift 6 but failed once in unrelated `TranscriptionViewModelTests.testRenameSpeakerRefreshesArtifactFromPersistedStateWhenNewerRenameFails`; the push run on the same SHA had already passed, and rerunning the failed PR job passed.

I did not run full `swift test` a second time locally after the follow-ups because the brief capped full-suite runs at one; the follow-up surface is covered by focused LLM tests, the CI-equivalent Swift 6 build, and remote CI.

## Not Included
- no model downloader
- no UI/onboarding exposure
- no cloud recommendation/default change
- no context-budget/#563 fix
- no non-gated MLX dependency

Real MLX generation smoke requires a local model and explicit env:

```bash
MACPARAKEET_ENABLE_MLX_LOCAL_LLM=1 \
MACPARAKEET_RUN_MLX_LOCAL_LLM_INTEGRATION=1 \
MACPARAKEET_LOCAL_LLM_MODEL_DIR=/path/to/mlx-community/Qwen3-4B-Instruct-2507-DDWQ \
swift test --filter MLXLocalLLMIntegrationTests
```
