### PR TITLE
Verify default meeting echo model checksum

### DIFF
--- a/Tests/MacParakeetTests/Services/Capture/MeetingEchoSuppressionRuntimeTests.swift
+++ b/Tests/MacParakeetTests/Services/Capture/MeetingEchoSuppressionRuntimeTests.swift
@@ -328,6 +328,32 @@ final class MeetingEchoSuppressionRuntimeTests: XCTestCase {
         XCTAssertTrue(result.output.contains("Meeting echo assets verified"))
     }
 
+    func testDistributionVerifierAcceptsDefaultModelWithExplicitMatchingChecksum() throws {
+        let appURL = try Self.makeEchoAssetAppBundle(
+            modelName: MeetingEchoSuppressionFactory.defaultModelName,
+            modelData: Data("model".utf8),
+            includeLibrary: true
+        )
+        defer { try? FileManager.default.removeItem(at: appURL.deletingLastPathComponent()) }
+        let modelURL = appURL.appendingPathComponent(
+            "Contents/Resources/MeetingEchoSuppression/" +
+                MeetingEchoSuppressionFactory.defaultModelName
+        )
+
+        let result = try Self.runVerifier(
+            appURL: appURL,
+            environment: [
+                "REQUIRE_MEETING_ECHO_ASSETS": "1",
+                "MACPARAKEET_MEETING_ECHO_MODEL_SHA256": try MeetingEchoSuppressionFactory.sha256Hex(
+                    for: modelURL
+                ),
+            ]
+        )
+
+        XCTAssertEqual(result.status, 0, result.output)
+        XCTAssertTrue(result.output.contains("Meeting echo assets verified"))
+    }
+
     func testDistributionVerifierFailsWhenRequiredAssetsAreMissing() throws {
         let appURL = try Self.makeEmptyAppBundle()
         defer { try? FileManager.default.removeItem(at: appURL.deletingLastPathComponent()) }
@@ -381,7 +407,20 @@ final class MeetingEchoSuppressionRuntimeTests: XCTestCase {
         XCTAssertTrue(result.output.contains("exactly one meeting echo model must be bundled"))
     }
 
-    func testDistributionVerifierRejectsChecksumMismatch() throws {
+    func testDistributionVerifierRejectsDefaultModelChecksumMismatchWithoutEnv() throws {
+        let appURL = try Self.makeEchoAssetAppBundle(
+            modelName: MeetingEchoSuppressionFactory.defaultModelName,
+            modelData: Data("model".utf8),
+            includeLibrary: true
+        )
+        defer { try? FileManager.default.removeItem(at: appURL.deletingLastPathComponent()) }
+        let result = try Self.runVerifier(appURL: appURL)
+
+        XCTAssertNotEqual(result.status, 0)
+        XCTAssertTrue(result.output.contains("SHA256 mismatch"))
+    }
+
+    func testDistributionVerifierRejectsExplicitChecksumMismatch() throws {
         let appURL = try Self.makeEchoAssetAppBundle(
             modelName: MeetingEchoSuppressionFactory.defaultModelName,
             modelData: Data("model".utf8),
@@ -398,6 +437,25 @@ final class MeetingEchoSuppressionRuntimeTests: XCTestCase {
 
         XCTAssertNotEqual(result.status, 0)
         XCTAssertTrue(result.output.contains("SHA256 mismatch"))
+    }
+
+    func testDistributionVerifierRejectsStrictCustomModelWithoutChecksum() throws {
+        let appURL = try Self.makeEchoAssetAppBundle(
+            modelName: "custom-aec-model.gguf",
+            modelData: Data("model".utf8),
+            includeLibrary: true
+        )
+        defer { try? FileManager.default.removeItem(at: appURL.deletingLastPathComponent()) }
+        let result = try Self.runVerifier(
+            appURL: appURL,
+            environment: ["REQUIRE_MEETING_ECHO_ASSETS": "1"]
+        )
+
+        XCTAssertNotEqual(result.status, 0)
+        XCTAssertTrue(
+            result.output.contains("requires MACPARAKEET_MEETING_ECHO_MODEL_SHA256"),
+            result.output
+        )
     }
 
     func testDistributionVerifierRejectsRuntimeMissingRequiredSymbols() throws {
@@ -425,9 +483,17 @@ final class MeetingEchoSuppressionRuntimeTests: XCTestCase {
             universalLibrary: true
         )
         defer { try? FileManager.default.removeItem(at: appURL.deletingLastPathComponent()) }
+        let modelURL = appURL.appendingPathComponent(
+            "Contents/Resources/MeetingEchoSuppression/localvqe-v1.4-aec-200K-f32.gguf"
+        )
         let result = try Self.runVerifier(
             appURL: appURL,
-            environment: ["REQUIRE_MEETING_ECHO_ASSETS": "1"]
+            environment: [
+                "REQUIRE_MEETING_ECHO_ASSETS": "1",
+                "MACPARAKEET_MEETING_ECHO_MODEL_SHA256": try MeetingEchoSuppressionFactory.sha256Hex(
+                    for: modelURL
+                ),
+            ]
         )
 
         XCTAssertEqual(result.status, 0, result.output)

--- a/Tests/MacParakeetTests/Services/Capture/MeetingEchoSuppressionRuntimeTests.swift
+++ b/Tests/MacParakeetTests/Services/Capture/MeetingEchoSuppressionRuntimeTests.swift
@@ -420,6 +420,19 @@ final class MeetingEchoSuppressionRuntimeTests: XCTestCase {
         XCTAssertTrue(result.output.contains("SHA256 mismatch"))
     }
 
+    func testDistributionVerifierRejectsCaseVariantDefaultModelChecksumMismatchWithoutEnv() throws {
+        let appURL = try Self.makeEchoAssetAppBundle(
+            modelName: "LocalVQE-v1.4-aec-200K-f32.gguf",
+            modelData: Data("model".utf8),
+            includeLibrary: true
+        )
+        defer { try? FileManager.default.removeItem(at: appURL.deletingLastPathComponent()) }
+        let result = try Self.runVerifier(appURL: appURL)
+
+        XCTAssertNotEqual(result.status, 0)
+        XCTAssertTrue(result.output.contains("SHA256 mismatch"))
+    }
+
     func testDistributionVerifierRejectsExplicitChecksumMismatch() throws {
         let appURL = try Self.makeEchoAssetAppBundle(
             modelName: MeetingEchoSuppressionFactory.defaultModelName,

--- a/scripts/dist/verify_meeting_echo_assets.sh
+++ b/scripts/dist/verify_meeting_echo_assets.sh
@@ -113,7 +113,9 @@ fi
 expected_model_sha="${MACPARAKEET_MEETING_ECHO_MODEL_SHA256:-}"
 if [[ -z "$expected_model_sha" ]]; then
   bundled_model_name="$(basename "$MODEL_PATH")"
-  if [[ "$bundled_model_name" == "$DEFAULT_MEETING_ECHO_MODEL_NAME" ]]; then
+  bundled_model_name_lc="$(printf '%s' "$bundled_model_name" | tr '[:upper:]' '[:lower:]')"
+  default_model_name_lc="$(printf '%s' "$DEFAULT_MEETING_ECHO_MODEL_NAME" | tr '[:upper:]' '[:lower:]')"
+  if [[ "$bundled_model_name_lc" == "$default_model_name_lc" ]]; then
     expected_model_sha="$DEFAULT_MEETING_ECHO_MODEL_SHA256"
   elif [[ "$STRICT_MEETING_ECHO_ASSETS" == "1" ]]; then
     echo "Error: strict meeting echo asset verification requires MACPARAKEET_MEETING_ECHO_MODEL_SHA256 for non-default models." >&2

--- a/scripts/dist/verify_meeting_echo_assets.sh
+++ b/scripts/dist/verify_meeting_echo_assets.sh
@@ -2,6 +2,9 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+. "$ROOT_DIR/scripts/dist/meeting_echo_asset_defaults.sh"
+
 APP_PATH="${1:-${APP_PATH:-$ROOT_DIR/dist/MacParakeet.app}}"
 REQUIRE_MEETING_ECHO_ASSETS="${REQUIRE_MEETING_ECHO_ASSETS:-0}"
 VERIFY_CODE_SIGNATURES="${VERIFY_CODE_SIGNATURES:-0}"
@@ -107,12 +110,26 @@ else
   missing_tool "nm" "meeting echo runtime LocalVQE symbols"
 fi
 
-if [[ -n "${MACPARAKEET_MEETING_ECHO_MODEL_SHA256:-}" ]]; then
+expected_model_sha="${MACPARAKEET_MEETING_ECHO_MODEL_SHA256:-}"
+if [[ -z "$expected_model_sha" ]]; then
+  bundled_model_name="$(basename "$MODEL_PATH")"
+  if [[ "$bundled_model_name" == "$DEFAULT_MEETING_ECHO_MODEL_NAME" ]]; then
+    expected_model_sha="$DEFAULT_MEETING_ECHO_MODEL_SHA256"
+  elif [[ "$STRICT_MEETING_ECHO_ASSETS" == "1" ]]; then
+    echo "Error: strict meeting echo asset verification requires MACPARAKEET_MEETING_ECHO_MODEL_SHA256 for non-default models." >&2
+    echo "  Bundled model: $bundled_model_name" >&2
+    echo "  Default model: $DEFAULT_MEETING_ECHO_MODEL_NAME" >&2
+    echo "  Set MACPARAKEET_MEETING_ECHO_MODEL_SHA256 to the expected SHA256 for this model." >&2
+    exit 1
+  fi
+fi
+
+if [[ -n "$expected_model_sha" ]]; then
   actual_sha="$(shasum -a 256 "$MODEL_PATH" | awk '{print $1}')"
-  expected_sha_lc="$(printf '%s' "$MACPARAKEET_MEETING_ECHO_MODEL_SHA256" | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')"
+  expected_sha_lc="$(printf '%s' "$expected_model_sha" | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')"
   if [[ "$actual_sha" != "$expected_sha_lc" ]]; then
     echo "Error: bundled meeting echo model SHA256 mismatch." >&2
-    echo "  Expected: $MACPARAKEET_MEETING_ECHO_MODEL_SHA256" >&2
+    echo "  Expected: $expected_model_sha" >&2
     echo "  Actual:   $actual_sha" >&2
     exit 1
   fi


### PR DESCRIPTION
## Summary
The meeting echo asset verifier now enforces the pinned default model SHA even when `MACPARAKEET_MEETING_ECHO_MODEL_SHA256` is not set. This closes the release/notarization gap where the default bundled LocalVQE model could be present but unverified, while preserving explicit SHA behavior for custom model workflows.

## Design
This PR implements item R2-3 of PR #725 (docs: architecture deepening round 2). The diff matches that spec exactly: `verify_meeting_echo_assets.sh` sources `meeting_echo_asset_defaults.sh`, uses `DEFAULT_MEETING_ECHO_MODEL_SHA256` when the bundled basename is `DEFAULT_MEETING_ECHO_MODEL_NAME`, treats an explicit `MACPARAKEET_MEETING_ECHO_MODEL_SHA256` as authoritative, and fails strict verification for non-default models without a SHA.

No `docs/distribution.md` edit was needed because its release-gate wording already promises checksum mismatch failure, which is the behavior restored here.

## Behavior
| Scenario | Before | After |
|---|---|---|
| Default bundled model, no SHA env | Checksum skipped | Default SHA is verified |
| Default bundled model, explicit SHA env | Explicit SHA verified | Explicit SHA still wins |
| Custom bundled model, strict mode, no SHA env | Checksum skipped | Fails with an actionable SHA env message |
| Custom bundled model, explicit SHA env | Explicit SHA verified | Explicit SHA still wins |

## Risk surface
The change is limited to the distribution verifier and its focused runtime-verifier tests. The main risk is stricter release packaging behavior: strict custom model bundles now need `MACPARAKEET_MEETING_ECHO_MODEL_SHA256`, which is intentional for release-grade verification. No Swift runtime loading behavior, build bundle assembly, asset preparation, or manifest format changes are included.

## Test evidence
```bash
bash -n scripts/dist/verify_meeting_echo_assets.sh scripts/dist/build_app_bundle.sh scripts/dist/prepare_meeting_echo_assets.sh scripts/dist/sign_notarize.sh
# passed (exit 0)
```

```bash
swift test --filter MeetingEchoSuppressionRuntimeTests
# passed: 24 tests executed, 1 skipped, 0 failures
```

```bash
git diff --check
# passed (exit 0)
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces SHA256 verification for the default meeting echo model during release/notarization even when no checksum env is set, including case-variant default filenames. Keeps explicit checksum overrides and tightens strict mode for custom models.

- **Bug Fixes**
  - Source `scripts/dist/meeting_echo_asset_defaults.sh` and verify the default model against `DEFAULT_MEETING_ECHO_MODEL_SHA256` when `MACPARAKEET_MEETING_ECHO_MODEL_SHA256` is unset; compare the bundled name to the default name case-insensitively; explicit env still wins.
  - In strict mode (`STRICT_MEETING_ECHO_ASSETS=1`), fail for non-default models without a checksum. Added focused tests for default no-env mismatch (normal and case-variant), explicit match/mismatch, and strict custom no-SHA failure.

- **Migration**
  - If you bundle a custom model and enable strict verification, set `MACPARAKEET_MEETING_ECHO_MODEL_SHA256` to the expected SHA256.

<sup>Written for commit 35babbd60c756d47a2b507edce05d464ff4f01d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/726?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

