### PR TITLE
Read retranscription timestamps from capabilities

### DIFF
--- a/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
@@ -9,6 +9,7 @@ public final class TranscriptionViewModel {
     public struct RetranscriptionEngineOption: Equatable, Sendable {
         public struct Choice: Identifiable, Equatable, Sendable {
             public let selection: SpeechEngineSelection
+            public let capabilities: SpeechEngineCapabilities
             public let isPrimary: Bool
             public let isAvailable: Bool
             public let unavailableReason: String?
@@ -43,19 +44,14 @@ public final class TranscriptionViewModel {
 
         public var firstTimestampCapableChoice: Choice? {
             choices.first { choice in
-                choice.isAvailable && producesWordTimestamps(choice.selection)
+                choice.isAvailable && choice.capabilities.providesWordTimestamps
             }
         }
 
         public func producesWordTimestamps(_ selection: SpeechEngineSelection) -> Bool {
-            switch selection.engine {
-            case .parakeet:
-                !parakeetVariant.usesUnifiedEngine
-            case .nemotron, .whisper:
-                true
-            case .cohere:
-                false
-            }
+            choices
+                .first { $0.selection.engine == selection.engine }?
+                .capabilities.providesWordTimestamps ?? false
         }
     }
 
@@ -492,14 +488,27 @@ public final class TranscriptionViewModel {
             primaryReflectsTranscriptEngine = false
         }
 
+        let parakeetVariant = SpeechEnginePreference.parakeetModelVariant(defaults: defaults)
+        let nemotronVariant = SpeechEnginePreference.nemotronModelVariant(defaults: defaults)
+        let whisperVariant = SpeechEnginePreference.whisperModelVariant(defaults: defaults)
+
         let choices = retranscriptionEngineOrder(primary: primaryEngine.engine).map { engine in
             let selection = SpeechEngineSelection(
                 engine: engine,
                 language: Self.retranscriptionLanguage(for: engine, defaults: defaults)
             )
+            guard let capabilities = SpeechEngineCapabilityRegistry.capabilities(
+                for: engine,
+                parakeetModelVariant: parakeetVariant,
+                nemotronModelVariant: nemotronVariant,
+                whisperModelVariant: whisperVariant
+            ) else {
+                preconditionFailure("Missing SpeechEngineCapabilities row for \(engine.rawValue)")
+            }
             let unavailableReason = retranscriptionUnavailableReason(for: engine)
             return RetranscriptionEngineOption.Choice(
                 selection: engine == primaryEngine.engine ? primaryEngine : selection,
+                capabilities: capabilities,
                 isPrimary: engine == primaryEngine.engine,
                 isAvailable: unavailableReason == nil,
                 unavailableReason: unavailableReason,
@@ -510,8 +519,8 @@ public final class TranscriptionViewModel {
         return RetranscriptionEngineOption(
             primaryEngine: primaryEngine,
             choices: choices,
-            nemotronVariant: SpeechEnginePreference.nemotronModelVariant(defaults: defaults),
-            parakeetVariant: SpeechEnginePreference.parakeetModelVariant(defaults: defaults),
+            nemotronVariant: nemotronVariant,
+            parakeetVariant: parakeetVariant,
             primaryReflectsTranscriptEngine: primaryReflectsTranscriptEngine
         )
     }

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
@@ -2510,6 +2510,14 @@ final class TranscriptionViewModelTests: XCTestCase {
         )
 
         let option = try XCTUnwrap(viewModel.retranscriptionEngineOption(for: original))
+        let parakeet = try retranscriptionChoice(.parakeet, in: option)
+        let expectedParakeet = SpeechEngineCapabilityRegistry.capabilities(for: .parakeet(.v3))
+
+        XCTAssertEqual(parakeet.capabilities, expectedParakeet)
+        XCTAssertEqual(
+            option.producesWordTimestamps(parakeet.selection),
+            expectedParakeet.providesWordTimestamps
+        )
 
         XCTAssertEqual(
             option.firstTimestampCapableChoice?.selection,
@@ -2546,11 +2554,109 @@ final class TranscriptionViewModelTests: XCTestCase {
         )
 
         let option = try XCTUnwrap(viewModel.retranscriptionEngineOption(for: original))
+        let parakeet = try retranscriptionChoice(.parakeet, in: option)
+        let whisper = try retranscriptionChoice(.whisper, in: option)
+        let whisperVariant = try XCTUnwrap(
+            WhisperModelVariant.normalize(SpeechEnginePreference.defaultWhisperModelVariant)
+        )
+        let expectedParakeet = SpeechEngineCapabilityRegistry.capabilities(for: .parakeet(.unified))
+        let expectedWhisper = SpeechEngineCapabilityRegistry.capabilities(for: .whisper(whisperVariant))
 
-        XCTAssertFalse(option.producesWordTimestamps(SpeechEngineSelection(engine: .parakeet)))
+        XCTAssertEqual(parakeet.capabilities, expectedParakeet)
+        XCTAssertEqual(whisper.capabilities, expectedWhisper)
+        XCTAssertEqual(
+            option.producesWordTimestamps(parakeet.selection),
+            expectedParakeet.providesWordTimestamps
+        )
+        XCTAssertEqual(
+            option.producesWordTimestamps(whisper.selection),
+            expectedWhisper.providesWordTimestamps
+        )
+        XCTAssertFalse(expectedParakeet.providesWordTimestamps)
+        XCTAssertTrue(expectedWhisper.providesWordTimestamps)
         XCTAssertEqual(
             option.firstTimestampCapableChoice?.selection,
             SpeechEngineSelection(engine: .whisper)
+        )
+    }
+
+    func testRetranscriptionEngineOptionChoicesCarryRegistryTimestampCapabilities() throws {
+        let suiteName = "TranscriptionViewModelTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        SpeechEnginePreference.saveParakeetModelVariant(.unified, defaults: defaults)
+        SpeechEnginePreference.saveNemotronModelVariant(.english1120, defaults: defaults)
+        SpeechEnginePreference.saveWhisperModelVariant(
+            SpeechEnginePreference.defaultWhisperModelVariant,
+            defaults: defaults
+        )
+        viewModel = TranscriptionViewModel(
+            defaults: defaults,
+            isWhisperModelDownloaded: { true },
+            isNemotronModelDownloaded: { true },
+            isCohereModelDownloaded: { true }
+        )
+
+        let tmpFile = FileManager.default.temporaryDirectory
+            .appendingPathComponent("retranscribe-timestamps-registry-\(UUID().uuidString).mp3")
+        FileManager.default.createFile(atPath: tmpFile.path, contents: Data([0]))
+        defer { try? FileManager.default.removeItem(at: tmpFile) }
+
+        let original = Transcription(
+            id: UUID(),
+            fileName: "Cohere Meeting",
+            filePath: tmpFile.path,
+            durationMs: 2_000,
+            rawTranscript: "Old transcript",
+            status: .completed,
+            sourceType: .meeting,
+            engine: SpeechEnginePreference.cohere.rawValue
+        )
+
+        let option = try XCTUnwrap(viewModel.retranscriptionEngineOption(for: original))
+        let parakeet = try retranscriptionChoice(.parakeet, in: option)
+        let nemotron = try retranscriptionChoice(.nemotron, in: option)
+        let whisper = try retranscriptionChoice(.whisper, in: option)
+        let cohere = try retranscriptionChoice(.cohere, in: option)
+        let whisperVariant = try XCTUnwrap(
+            WhisperModelVariant.normalize(SpeechEnginePreference.defaultWhisperModelVariant)
+        )
+
+        XCTAssertEqual(
+            parakeet.capabilities,
+            SpeechEngineCapabilityRegistry.capabilities(for: .parakeet(.unified))
+        )
+        XCTAssertEqual(
+            nemotron.capabilities,
+            SpeechEngineCapabilityRegistry.capabilities(for: .nemotron(.english1120))
+        )
+        XCTAssertEqual(
+            whisper.capabilities,
+            SpeechEngineCapabilityRegistry.capabilities(for: .whisper(whisperVariant))
+        )
+        XCTAssertEqual(
+            cohere.capabilities,
+            SpeechEngineCapabilityRegistry.capabilities(for: .cohere)
+        )
+        XCTAssertEqual(
+            option.producesWordTimestamps(parakeet.selection),
+            parakeet.capabilities.providesWordTimestamps
+        )
+        XCTAssertEqual(
+            option.producesWordTimestamps(nemotron.selection),
+            nemotron.capabilities.providesWordTimestamps
+        )
+        XCTAssertEqual(
+            option.producesWordTimestamps(whisper.selection),
+            whisper.capabilities.providesWordTimestamps
+        )
+        XCTAssertEqual(
+            option.producesWordTimestamps(cohere.selection),
+            cohere.capabilities.providesWordTimestamps
+        )
+        XCTAssertEqual(
+            option.firstTimestampCapableChoice?.selection.engine,
+            .nemotron
         )
     }
 
@@ -2583,6 +2689,19 @@ final class TranscriptionViewModelTests: XCTestCase {
         )
 
         let option = try XCTUnwrap(viewModel.retranscriptionEngineOption(for: original))
+        let parakeet = try retranscriptionChoice(.parakeet, in: option)
+        let cohere = try retranscriptionChoice(.cohere, in: option)
+
+        XCTAssertEqual(
+            parakeet.capabilities,
+            SpeechEngineCapabilityRegistry.capabilities(for: .parakeet(.unified))
+        )
+        XCTAssertEqual(
+            cohere.capabilities,
+            SpeechEngineCapabilityRegistry.capabilities(for: .cohere)
+        )
+        XCTAssertFalse(parakeet.capabilities.providesWordTimestamps)
+        XCTAssertFalse(cohere.capabilities.providesWordTimestamps)
 
         XCTAssertNil(option.firstTimestampCapableChoice)
     }


### PR DESCRIPTION
## Summary
Retranscription engine options now carry the `SpeechEngineCapabilities` row resolved for each displayed engine using the persisted Parakeet, Nemotron, and Whisper variants. This removes the last local word-timestamp switch from `TranscriptionViewModel`; timestamp-capable choice selection now reads `providesWordTimestamps` from the registry.

## Design
Before: retranscription options derived timestamp support by switching on engine and Parakeet variant inside the view model.

After: option building resolves one registry row per choice via `SpeechEngineCapabilityRegistry.capabilities(for:parakeetModelVariant:nemotronModelVariant:whisperModelVariant:)`, and `producesWordTimestamps` / `firstTimestampCapableChoice` read the attached capability row. Model-download availability, Whisper cold-start advisory, and display ordering remain in the view model as environment/UI policy.

Spec alignment: this PR implements item R2-1 of PR #725 (docs: architecture deepening round 2). The diff matches that spec exactly; no deviations.

## Risk surface
The diff is limited to retranscription option metadata and its view-model tests. Review hardest whether recorded/current engine selection still uses the existing choice order and persisted variants. `STTRuntime`, `STTScheduler`, `CustomVocabularyBoosting`, Settings, CLI commands, and engine lifecycle code are intentionally out of scope.

## Test evidence
- `git diff --check` passed.
- `swift test --filter TranscriptionViewModelTests` initially failed once while developing the new registry test because the test asserted Nemotron language instead of the timestamp-capability concern; the assertion was narrowed to the first timestamp-capable engine.
- `swift test --filter TranscriptionViewModelTests` passed: 118 tests, 0 failures.
- `swift test --filter SpeechEngineCapabilitiesTests` passed: 8 tests, 0 failures.

## Author's Notes
`swift-format` is not installed in this shell, so formatting was kept manual and scoped to the edited assertions.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retranscription engine choices now carry resolved `SpeechEngineCapabilities`, and timestamp checks read `providesWordTimestamps` from the registry. This removes the last local word-timestamp switch from `TranscriptionViewModel` and keeps the UI consistent with the capability table.

- **Refactors**
  - Added `capabilities` to each retranscription choice, resolved via persisted Parakeet, Nemotron, and Whisper variants.
  - `firstTimestampCapableChoice` and `producesWordTimestamps` now use `providesWordTimestamps` from the attached capability row.
  - Kept option ordering, model-download availability, and Whisper cold-start advisory in the view model.
  - Updated tests to assert registry-derived capabilities for Parakeet, Nemotron, Whisper, and Cohere.

<sup>Written for commit 14c46084e8eb89919de5c3508fa2036e54cac512. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/727?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

