### PR TITLE
Signal meeting capture failures from the service

### DIFF
--- a/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
@@ -86,6 +86,7 @@ final class MeetingRecordingFlowCoordinator {
     private var autoDismissTask: Task<Void, Never>?
     private var pillPollingTask: Task<Void, Never>?
     private var pillGlowPollingTask: Task<Void, Never>?
+    private var captureFailureObservationTask: Task<Void, Never>?
     private var transcriptObservationTask: Task<Void, Never>?
     private var speechWarmUpObservationTask: Task<Void, Never>?
     // Saved-completion celebration (Metatron bloom → checkmark). The flow returns
@@ -199,7 +200,7 @@ final class MeetingRecordingFlowCoordinator {
 
     /// Pause / resume the in-flight recording. The state flip happens AFTER
     /// the service confirms — an optimistic flip before the await would race
-    /// with the 150ms polling reconciler (which reads `captureMode` from the
+    /// with the 1s polling reconciler (which reads `captureMode` from the
     /// actor and could see `.full` while the spawned pause Task is still
     /// queued, then flip the pill back to `.recording`).
     ///
@@ -643,6 +644,7 @@ final class MeetingRecordingFlowCoordinator {
                         break
                     }
                     self.sendEvent(.recordingStarted(generation: gen))
+                    self.startCaptureFailureObservation(generation: gen)
                     Telemetry.send(.meetingRecordingStarted(trigger: trigger))
                     self.onRecordingBegan()
                 } catch {
@@ -1051,28 +1053,6 @@ final class MeetingRecordingFlowCoordinator {
                     pillViewModel.state = .recording
                 }
                 panelViewModel?.isPaused = serviceIsPaused
-                if captureMode == .stopped,
-                    stateMachine.state == .recording,
-                    pillViewModel.state == .recording || pillViewModel.state == .paused
-                {
-                    // Audio capture stopped while the state machine still
-                    // expects a live recording — typically because
-                    // `MeetingRecordingService.failCapture` ran (mic unplug,
-                    // writer error, OS audio routing change). Could also
-                    // fire while paused if a USB mic is unplugged mid-pause.
-                    // Without this signal the pill keeps showing the paused
-                    // glyph or "recording" with a ticking timer while no
-                    // audio is actually being captured. Surface it through
-                    // the state machine so the existing stop+transcribe
-                    // path saves whatever made it to disk.
-                    pillViewModel.micLevel = 0
-                    pillViewModel.systemLevel = 0
-                    panelViewModel?.micLevel = 0
-                    panelViewModel?.systemLevel = 0
-                    sendEvent(.captureFailed(generation: stateMachine.generation))
-                    break
-                }
-
                 try? await Task.sleep(for: .seconds(1))
             }
         }
@@ -1126,9 +1106,33 @@ final class MeetingRecordingFlowCoordinator {
         pillGlowPollingTask = nil
     }
 
+    private func startCaptureFailureObservation(generation: Int) {
+        captureFailureObservationTask?.cancel()
+        captureFailureObservationTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            let stream = await meetingRecordingService.captureFailureSignalForCurrentSession()
+            for await _ in stream {
+                guard !Task.isCancelled else { break }
+                guard stateMachine.generation == generation, stateMachine.state == .recording else { break }
+                pillViewModel.micLevel = 0
+                pillViewModel.systemLevel = 0
+                panelViewModel?.micLevel = 0
+                panelViewModel?.systemLevel = 0
+                sendEvent(.captureFailed(generation: generation))
+                break
+            }
+        }
+    }
+
+    private func stopCaptureFailureObservation() {
+        captureFailureObservationTask?.cancel()
+        captureFailureObservationTask = nil
+    }
+
     private func stopPillPolling() {
         pillPollingTask?.cancel()
         pillPollingTask = nil
+        stopCaptureFailureObservation()
         stopPillGlowPolling()
     }
 
@@ -1392,6 +1396,18 @@ extension MeetingRecordingFlowCoordinator {
 
     func testHook_waitForActionTask() async {
         await actionTask?.value
+    }
+
+    func testHook_startCaptureFailureObservation(generation: Int) {
+        startCaptureFailureObservation(generation: generation)
+    }
+
+    func testHook_waitForCaptureFailureObservationTask() async {
+        await captureFailureObservationTask?.value
+    }
+
+    var testHook_generation: Int {
+        stateMachine.generation
     }
 
     func testHook_waitForMeetingTranscriptionQueue() async {

--- a/Sources/MacParakeetCore/MeetingRecordingFlow/MeetingRecordingFlowStateMachine.swift
+++ b/Sources/MacParakeetCore/MeetingRecordingFlow/MeetingRecordingFlowStateMachine.swift
@@ -26,12 +26,13 @@ public enum MeetingRecordingFlowEvent: Equatable, Sendable {
     case startFailed(generation: Int, message: String)
     case stopRequested
     case cancelRequested
-    /// Emitted by the pill polling task when it detects that audio capture
-    /// has stopped unexpectedly while the state machine still believes a
-    /// recording is in progress (e.g., a USB mic was unplugged mid-meeting,
-    /// `MeetingRecordingService.failCapture` ran). Routes through the same
-    /// stop+transcribe path as `.stopRequested` so whatever audio was
-    /// captured before the failure still becomes a saved Transcription.
+    /// Emitted from `MeetingRecordingService`'s terminal capture-failure
+    /// signal when audio capture stops unexpectedly while the state machine
+    /// still believes a recording is in progress (e.g., a USB mic was
+    /// unplugged mid-meeting, `MeetingRecordingService.failCapture` ran).
+    /// Routes through the same stop+transcribe path as `.stopRequested` so
+    /// whatever audio was captured before the failure still becomes a saved
+    /// Transcription.
     case captureFailed(generation: Int)
     case recordingQueued(generation: Int, transcriptionID: UUID)
     case transcriptionFailed(generation: Int, message: String)

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
@@ -1177,9 +1177,9 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
     }
 
     private func removeCaptureFailureObserver(sessionID: UUID, observerID: UUID) {
-        captureFailureObserverContinuations[sessionID]?[observerID] = nil
+        captureFailureObserverContinuations[sessionID]?.removeValue(forKey: observerID)
         if captureFailureObserverContinuations[sessionID]?.isEmpty == true {
-            captureFailureObserverContinuations[sessionID] = nil
+            captureFailureObserverContinuations.removeValue(forKey: sessionID)
         }
     }
 

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
@@ -32,6 +32,14 @@ public struct MeetingMicrophoneMuteState: Sendable, Equatable {
     }
 }
 
+public struct MeetingCaptureFailureSignal: Sendable, Equatable {
+    public let sessionID: UUID
+
+    public init(sessionID: UUID) {
+        self.sessionID = sessionID
+    }
+}
+
 public protocol MeetingRecordingServiceProtocol: Sendable {
     /// `title` lets callers (e.g., the calendar auto-start path) pre-name
     /// the recording. `nil` or whitespace-only falls back to the default
@@ -75,6 +83,10 @@ public protocol MeetingRecordingServiceProtocol: Sendable {
     var microphoneMuteState: MeetingMicrophoneMuteState { get async }
     var captureHealth: MeetingCaptureHealthSummary { get async }
     var transcriptUpdates: AsyncStream<MeetingTranscriptUpdate> { get async }
+    /// One terminal capture-failure signal for the currently active session.
+    /// If that session has already failed, the returned stream yields once and
+    /// finishes; if no session is active, it finishes without yielding.
+    func captureFailureSignalForCurrentSession() async -> AsyncStream<MeetingCaptureFailureSignal>
 }
 
 public extension MeetingRecordingServiceProtocol {
@@ -99,6 +111,12 @@ public extension MeetingRecordingServiceProtocol {
 
     var captureHealth: MeetingCaptureHealthSummary {
         get async { .notRecording }
+    }
+
+    func captureFailureSignalForCurrentSession() async -> AsyncStream<MeetingCaptureFailureSignal> {
+        AsyncStream { continuation in
+            continuation.finish()
+        }
     }
 }
 
@@ -266,6 +284,9 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
 
     private var transcriptContinuation: AsyncStream<MeetingTranscriptUpdate>.Continuation?
     private var cachedTranscriptUpdates: AsyncStream<MeetingTranscriptUpdate>?
+    private var captureFailureObserverContinuations:
+        [UUID: [UUID: AsyncStream<MeetingCaptureFailureSignal>.Continuation]] = [:]
+    private var captureFailureSignaledSessionIDs: Set<UUID> = []
 
     private static let rmsEmaAlpha: Float = 0.3
     private static let processedRmsHealthLevelScale: Float = 10
@@ -472,6 +493,35 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         return stream
     }
 
+    public func captureFailureSignalForCurrentSession() async -> AsyncStream<MeetingCaptureFailureSignal> {
+        guard let sessionID = currentSession?.id else {
+            return AsyncStream { continuation in
+                continuation.finish()
+            }
+        }
+
+        var continuation: AsyncStream<MeetingCaptureFailureSignal>.Continuation?
+        let stream = AsyncStream<MeetingCaptureFailureSignal>(bufferingPolicy: .bufferingOldest(1)) {
+            continuation = $0
+        }
+        guard let continuation else { return stream }
+
+        if captureFailureSignaledSessionIDs.contains(sessionID) || captureFailed {
+            continuation.yield(MeetingCaptureFailureSignal(sessionID: sessionID))
+            continuation.finish()
+            return stream
+        }
+
+        let observerID = UUID()
+        captureFailureObserverContinuations[sessionID, default: [:]][observerID] = continuation
+        continuation.onTermination = { [weak self] _ in
+            Task {
+                await self?.removeCaptureFailureObserver(sessionID: sessionID, observerID: observerID)
+            }
+        }
+        return stream
+    }
+
     public func startRecording(
         title: String? = nil,
         sourceMode: MeetingAudioSourceMode? = nil,
@@ -553,6 +603,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
             transcriptAssembler.reset()
             isTranscriptionLagging = false
             captureFailed = false
+            captureFailureSignaledSessionIDs.remove(session.id)
             interruptedSources = []
             sourceCaptureMetrics = [:]
             captureHealthMetrics = CaptureHealthMetrics()
@@ -1086,6 +1137,11 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
     }
 
     private func failCapture(_ error: Error) async {
+        guard let sessionID = currentSession?.id,
+              !captureFailureSignaledSessionIDs.contains(sessionID)
+        else { return }
+
+        captureFailureSignaledSessionIDs.insert(sessionID)
         captureFailed = true
         latestLevels = MeetingAudioLevels()
         recentMicrophoneRms = 0
@@ -1096,7 +1152,35 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         microphoneMutedHostTime = nil
         completedMicrophoneMuteHostTimeRanges = []
         logger.error("meeting_capture_failed error_type=\(AudioCaptureDiagnostics.errorType(error), privacy: .public) error_detail=\(error.localizedDescription, privacy: .private)")
+        emitCaptureFailureSignal(for: sessionID)
         await audioCaptureService.stop()
+    }
+
+    private func emitCaptureFailureSignal(for sessionID: UUID) {
+        guard let continuations = captureFailureObserverContinuations.removeValue(forKey: sessionID) else {
+            return
+        }
+        let signal = MeetingCaptureFailureSignal(sessionID: sessionID)
+        for continuation in continuations.values {
+            continuation.yield(signal)
+            continuation.finish()
+        }
+    }
+
+    private func finishCaptureFailureSignal(for sessionID: UUID) {
+        if let continuations = captureFailureObserverContinuations.removeValue(forKey: sessionID) {
+            for continuation in continuations.values {
+                continuation.finish()
+            }
+        }
+        captureFailureSignaledSessionIDs.remove(sessionID)
+    }
+
+    private func removeCaptureFailureObserver(sessionID: UUID, observerID: UUID) {
+        captureFailureObserverContinuations[sessionID]?[observerID] = nil
+        if captureFailureObserverContinuations[sessionID]?.isEmpty == true {
+            captureFailureObserverContinuations[sessionID] = nil
+        }
     }
 
     /// Pick the live-preview chunking strategy for this session and install it
@@ -1664,6 +1748,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
     }
 
     private func cleanupState() {
+        let finishedSessionID = currentSession?.id
         currentSession = nil
         currentNotes = nil
         currentLockFile = nil
@@ -1696,6 +1781,9 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         transcriptContinuation?.finish()
         transcriptContinuation = nil
         cachedTranscriptUpdates = nil
+        if let finishedSessionID {
+            finishCaptureFailureSignal(for: finishedSessionID)
+        }
     }
 
     private static func resolveDisplayName(title: String?, fallbackDate: Date) -> String {

--- a/Tests/MacParakeetTests/MeetingRecordingFlow/MeetingRecordingFlowCoordinatorTests.swift
+++ b/Tests/MacParakeetTests/MeetingRecordingFlow/MeetingRecordingFlowCoordinatorTests.swift
@@ -90,6 +90,104 @@ final class MeetingRecordingFlowCoordinatorTests: XCTestCase {
         XCTAssertEqual(operation.systemTrackPresent, true)
     }
 
+    func testCaptureFailureSignalUsesStopTranscribeFlowExactlyOnce() async throws {
+        let output = makeRecordingOutput()
+        let recordingService = MeetingRecordingServiceSpy(output: output)
+        let transcriptionService = MockTranscriptionService()
+        let settlementHarness = await makeSettlementHarness(transcriptionService: transcriptionService)
+        let coordinator = MeetingRecordingFlowCoordinator(
+            meetingRecordingService: recordingService,
+            transcriptionService: transcriptionService,
+            permissionService: MockPermissionService(),
+            transcriptionRepo: settlementHarness.transcriptionRepo,
+            conversationRepo: MockChatConversationRepository(),
+            quickPromptRepo: NoOpQuickPromptRepository(),
+            configStore: NoOpLLMConfigStore(),
+            llmService: nil,
+            pillViewModel: MeetingRecordingPillViewModel(),
+            meetingRecordingSettlement: settlementHarness.settlement,
+            onMenuBarIconUpdate: { _ in },
+            onTranscriptionReady: { _ in }
+        )
+
+        XCTAssertNotNil(coordinator.startRecording(trigger: .manual))
+        try await waitForStartCall(on: recordingService, coordinator: coordinator)
+
+        await recordingService.emitCaptureFailure()
+        await recordingService.emitCaptureFailure()
+        try await waitForStopCall(on: recordingService, coordinator: coordinator)
+
+        let recordingSnapshot = await recordingService.snapshot()
+        let transcriptionSnapshot = await transcriptionService.meetingFlowSnapshot()
+        XCTAssertEqual(coordinator.testHook_state, .idle)
+        XCTAssertEqual(recordingSnapshot.stopCallCount, 1)
+        XCTAssertEqual(transcriptionSnapshot.prepareMeetingCallCount, 1)
+    }
+
+    func testCaptureFailureSignalWhilePausedUsesStopTranscribeFlow() async throws {
+        let output = makeRecordingOutput()
+        let recordingService = MeetingRecordingServiceSpy(output: output)
+        let transcriptionService = MockTranscriptionService()
+        let settlementHarness = await makeSettlementHarness(transcriptionService: transcriptionService)
+        let pillViewModel = MeetingRecordingPillViewModel()
+        let coordinator = MeetingRecordingFlowCoordinator(
+            meetingRecordingService: recordingService,
+            transcriptionService: transcriptionService,
+            permissionService: MockPermissionService(),
+            transcriptionRepo: settlementHarness.transcriptionRepo,
+            conversationRepo: MockChatConversationRepository(),
+            quickPromptRepo: NoOpQuickPromptRepository(),
+            configStore: NoOpLLMConfigStore(),
+            llmService: nil,
+            pillViewModel: pillViewModel,
+            meetingRecordingSettlement: settlementHarness.settlement,
+            onMenuBarIconUpdate: { _ in },
+            onTranscriptionReady: { _ in }
+        )
+
+        XCTAssertNotNil(coordinator.startRecording(trigger: .manual))
+        try await waitForStartCall(on: recordingService, coordinator: coordinator)
+        coordinator.togglePause()
+        try await waitForPillState(pillViewModel, .paused)
+
+        await recordingService.emitCaptureFailure()
+        try await waitForStopCall(on: recordingService, coordinator: coordinator)
+
+        let recordingSnapshot = await recordingService.snapshot()
+        let transcriptionSnapshot = await transcriptionService.meetingFlowSnapshot()
+        XCTAssertEqual(coordinator.testHook_state, .idle)
+        XCTAssertEqual(recordingSnapshot.stopCallCount, 1)
+        XCTAssertEqual(transcriptionSnapshot.prepareMeetingCallCount, 1)
+    }
+
+    func testStaleGenerationCaptureFailureSignalIsIgnored() async throws {
+        let recordingService = MeetingRecordingServiceSpy(output: makeRecordingOutput())
+        let coordinator = MeetingRecordingFlowCoordinator(
+            meetingRecordingService: recordingService,
+            transcriptionService: MockTranscriptionService(),
+            permissionService: MockPermissionService(),
+            transcriptionRepo: MockTranscriptionRepository(),
+            conversationRepo: MockChatConversationRepository(),
+            quickPromptRepo: NoOpQuickPromptRepository(),
+            configStore: NoOpLLMConfigStore(),
+            llmService: nil,
+            pillViewModel: MeetingRecordingPillViewModel(),
+            meetingRecordingSettlement: makeSettlement(),
+            onMenuBarIconUpdate: { _ in },
+            onTranscriptionReady: { _ in }
+        )
+        coordinator.testHook_enterRecording()
+        let staleGeneration = coordinator.testHook_generation - 1
+
+        coordinator.testHook_startCaptureFailureObservation(generation: staleGeneration)
+        await recordingService.emitCaptureFailure()
+        await coordinator.testHook_waitForCaptureFailureObservationTask()
+
+        let recordingSnapshot = await recordingService.snapshot()
+        XCTAssertEqual(coordinator.testHook_state, .recording)
+        XCTAssertEqual(recordingSnapshot.stopCallCount, 0)
+    }
+
     func testCanStartNextRecordingWhilePreviousFinalizeIsQueued() async throws {
         let output = makeRecordingOutput()
         let recordingService = MeetingRecordingServiceSpy(output: output)
@@ -586,6 +684,40 @@ final class MeetingRecordingFlowCoordinatorTests: XCTestCase {
         XCTFail("Expected recording service to receive startRecording.")
     }
 
+    private func waitForStopCall(
+        on service: MeetingRecordingServiceSpy,
+        coordinator: MeetingRecordingFlowCoordinator,
+        expectedCount: Int = 1
+    ) async throws {
+        let startedAt = ContinuousClock.now
+        while true {
+            await coordinator.testHook_waitForActionTask()
+            let snapshot = await service.snapshot()
+            if snapshot.stopCallCount >= expectedCount {
+                return
+            }
+            if startedAt.duration(to: .now) > .seconds(1) {
+                XCTFail("Expected recording service to receive stopRecording.")
+                return
+            }
+            try await Task.sleep(for: .milliseconds(20))
+        }
+    }
+
+    private func waitForPillState(
+        _ pillViewModel: MeetingRecordingPillViewModel,
+        _ expectedState: MeetingRecordingPillViewModel.PillState
+    ) async throws {
+        let startedAt = ContinuousClock.now
+        while pillViewModel.state != expectedState {
+            if startedAt.duration(to: .now) > .seconds(1) {
+                XCTFail("Timed out waiting for pill state \(expectedState); latest state: \(pillViewModel.state)")
+                return
+            }
+            try await Task.sleep(for: .milliseconds(20))
+        }
+    }
+
     private func makeRecordingOutput() -> MeetingRecordingOutput {
         let folder = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -649,6 +781,10 @@ private actor MeetingRecordingServiceSpy: MeetingRecordingServiceProtocol {
     var stopCallCount = 0
     var startTitles: [String?] = []
     var calendarEventSnapshots: [MeetingCalendarSnapshot?] = []
+    private var paused = false
+    private var captureFailureSessionID = UUID()
+    private var captureFailureSignaled = false
+    private var captureFailureContinuations: [UUID: AsyncStream<MeetingCaptureFailureSignal>.Continuation] = [:]
 
     init(output: MeetingRecordingOutput) {
         self.output = output
@@ -669,18 +805,31 @@ private actor MeetingRecordingServiceSpy: MeetingRecordingServiceProtocol {
         ))
         startTitles.append(title)
         calendarEventSnapshots.append(calendarEventSnapshot)
+        paused = false
+        finishCaptureFailureContinuations()
+        captureFailureSessionID = UUID()
+        captureFailureSignaled = false
     }
 
     func stopRecording() async throws -> MeetingRecordingOutput {
         stopCallCount += 1
+        paused = false
+        finishCaptureFailureContinuations()
         return output
     }
 
-    func cancelRecording() async {}
+    func cancelRecording() async {
+        paused = false
+        finishCaptureFailureContinuations()
+    }
 
-    func pauseRecording() async {}
+    func pauseRecording() async {
+        paused = true
+    }
 
-    func resumeRecording() async {}
+    func resumeRecording() async {
+        paused = false
+    }
 
     func setMicrophoneMuted(_ muted: Bool) async -> MeetingMicrophoneMuteState {
         MeetingMicrophoneMuteState(isMuted: muted, canMute: true)
@@ -690,7 +839,7 @@ private actor MeetingRecordingServiceSpy: MeetingRecordingServiceProtocol {
 
     var isRecording: Bool { true }
 
-    var isPaused: Bool { false }
+    var isPaused: Bool { paused }
 
     var micLevel: Float { 0 }
 
@@ -698,7 +847,7 @@ private actor MeetingRecordingServiceSpy: MeetingRecordingServiceProtocol {
 
     var elapsedSeconds: Int { 0 }
 
-    var captureMode: CaptureMode { .full }
+    var captureMode: CaptureMode { paused ? .paused : .full }
 
     var isMicrophoneMuted: Bool { false }
 
@@ -712,6 +861,53 @@ private actor MeetingRecordingServiceSpy: MeetingRecordingServiceProtocol {
         AsyncStream { continuation in
             continuation.finish()
         }
+    }
+
+    func captureFailureSignalForCurrentSession() async -> AsyncStream<MeetingCaptureFailureSignal> {
+        var continuation: AsyncStream<MeetingCaptureFailureSignal>.Continuation?
+        let stream = AsyncStream<MeetingCaptureFailureSignal>(bufferingPolicy: .bufferingOldest(1)) {
+            continuation = $0
+        }
+        guard let continuation else { return stream }
+
+        if captureFailureSignaled {
+            continuation.yield(MeetingCaptureFailureSignal(sessionID: captureFailureSessionID))
+            continuation.finish()
+            return stream
+        }
+
+        let continuationID = UUID()
+        captureFailureContinuations[continuationID] = continuation
+        continuation.onTermination = { [weak self] _ in
+            Task {
+                await self?.removeCaptureFailureContinuation(id: continuationID)
+            }
+        }
+        return stream
+    }
+
+    func emitCaptureFailure() {
+        guard !captureFailureSignaled else { return }
+        captureFailureSignaled = true
+        let continuations = captureFailureContinuations
+        captureFailureContinuations.removeAll()
+        let signal = MeetingCaptureFailureSignal(sessionID: captureFailureSessionID)
+        for continuation in continuations.values {
+            continuation.yield(signal)
+            continuation.finish()
+        }
+    }
+
+    private func finishCaptureFailureContinuations() {
+        let continuations = captureFailureContinuations
+        captureFailureContinuations.removeAll()
+        for continuation in continuations.values {
+            continuation.finish()
+        }
+    }
+
+    private func removeCaptureFailureContinuation(id: UUID) {
+        captureFailureContinuations[id] = nil
     }
 
     func snapshot() -> (

--- a/Tests/MacParakeetTests/MeetingRecordingFlow/MeetingRecordingFlowCoordinatorTests.swift
+++ b/Tests/MacParakeetTests/MeetingRecordingFlow/MeetingRecordingFlowCoordinatorTests.swift
@@ -806,21 +806,19 @@ private actor MeetingRecordingServiceSpy: MeetingRecordingServiceProtocol {
         startTitles.append(title)
         calendarEventSnapshots.append(calendarEventSnapshot)
         paused = false
-        finishCaptureFailureContinuations()
-        captureFailureSessionID = UUID()
-        captureFailureSignaled = false
+        resetCaptureFailureObservationState()
     }
 
     func stopRecording() async throws -> MeetingRecordingOutput {
         stopCallCount += 1
         paused = false
-        finishCaptureFailureContinuations()
+        resetCaptureFailureObservationState()
         return output
     }
 
     func cancelRecording() async {
         paused = false
-        finishCaptureFailureContinuations()
+        resetCaptureFailureObservationState()
     }
 
     func pauseRecording() async {
@@ -904,6 +902,12 @@ private actor MeetingRecordingServiceSpy: MeetingRecordingServiceProtocol {
         for continuation in continuations.values {
             continuation.finish()
         }
+    }
+
+    private func resetCaptureFailureObservationState() {
+        finishCaptureFailureContinuations()
+        captureFailureSessionID = UUID()
+        captureFailureSignaled = false
     }
 
     private func removeCaptureFailureContinuation(id: UUID) {

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingServiceTests.swift
@@ -594,6 +594,78 @@ final class MeetingRecordingServiceTests: XCTestCase {
         await service.cancelRecording()
     }
 
+    func testCaptureFailureSignalYieldsOnceForRuntimeError() async throws {
+        let captureService = MockMeetingAudioCaptureService()
+        let service = MeetingRecordingService(
+            audioCaptureService: captureService,
+            audioConverter: MockMeetingAudioFileConverter(),
+            sttTranscriber: CountingMeetingSTTClient()
+        )
+
+        try await service.startRecording()
+        let stream = await service.captureFailureSignalForCurrentSession()
+        let signalTask = Task { await collectCaptureFailureSignals(from: stream) }
+
+        await captureService.yield(.error(.captureRuntimeFailure("simulated runtime failure")))
+
+        let signals = try await value(
+            of: signalTask,
+            timeoutMessage: "Timed out waiting for capture-failure signal"
+        )
+        XCTAssertEqual(signals.count, 1)
+
+        await service.cancelRecording()
+    }
+
+    func testCaptureFailureSignalYieldsToLateObserverForFailedSession() async throws {
+        let captureService = MockMeetingAudioCaptureService()
+        let service = MeetingRecordingService(
+            audioCaptureService: captureService,
+            audioConverter: MockMeetingAudioFileConverter(),
+            sttTranscriber: CountingMeetingSTTClient()
+        )
+
+        try await service.startRecording()
+        await captureService.yield(.error(.captureRuntimeFailure("simulated runtime failure")))
+        try await waitForCaptureMode(service) { $0 == .stopped }
+
+        let stream = await service.captureFailureSignalForCurrentSession()
+        let signalTask = Task { await collectCaptureFailureSignals(from: stream) }
+        let signals = try await value(
+            of: signalTask,
+            timeoutMessage: "Timed out waiting for late capture-failure signal"
+        )
+        XCTAssertEqual(signals.count, 1)
+
+        await service.cancelRecording()
+    }
+
+    func testDuplicateCaptureFailuresEmitOneSignal() async throws {
+        let captureService = MockMeetingAudioCaptureService()
+        let service = MeetingRecordingService(
+            audioCaptureService: captureService,
+            audioConverter: MockMeetingAudioFileConverter(),
+            sttTranscriber: CountingMeetingSTTClient()
+        )
+
+        try await service.startRecording()
+        let stream = await service.captureFailureSignalForCurrentSession()
+        let signalTask = Task { await collectCaptureFailureSignals(from: stream) }
+
+        await captureService.yield(.error(.captureRuntimeFailure("first runtime failure")))
+        await captureService.yield(.error(.captureRuntimeFailure("duplicate runtime failure")))
+
+        let signals = try await value(
+            of: signalTask,
+            timeoutMessage: "Timed out waiting for duplicate capture-failure signal"
+        )
+        let stopCallCount = await captureService.stopCallCount
+        XCTAssertEqual(signals.count, 1)
+        XCTAssertEqual(stopCallCount, 1)
+
+        await service.cancelRecording()
+    }
+
     func testSystemSourceInterruptionKeepsMicrophoneRecordingAlive() async throws {
         let captureService = MockMeetingAudioCaptureService()
         let audioConverter = MockMeetingAudioFileConverter()
@@ -1781,6 +1853,21 @@ final class MeetingRecordingServiceTests: XCTestCase {
         }
     }
 
+    private func waitForCaptureMode(
+        _ service: MeetingRecordingService,
+        timeout: Duration = .seconds(1),
+        _ predicate: @escaping (CaptureMode) -> Bool
+    ) async throws {
+        let startedAt = ContinuousClock.now
+        while !predicate(await service.captureMode) {
+            if startedAt.duration(to: .now) > timeout {
+                XCTFail("Timed out waiting for capture mode predicate")
+                return
+            }
+            try await Task.sleep(for: .milliseconds(20))
+        }
+    }
+
     private func waitForCaptureHealth(
         _ service: MeetingRecordingService,
         timeout: Duration = .seconds(1),
@@ -1797,6 +1884,37 @@ final class MeetingRecordingServiceTests: XCTestCase {
                 return health
             }
             try await Task.sleep(for: .milliseconds(20))
+        }
+    }
+
+    private func collectCaptureFailureSignals(
+        from stream: AsyncStream<MeetingCaptureFailureSignal>
+    ) async -> [MeetingCaptureFailureSignal] {
+        var signals: [MeetingCaptureFailureSignal] = []
+        for await signal in stream {
+            signals.append(signal)
+        }
+        return signals
+    }
+
+    private func value<T>(
+        of task: Task<T, Never>,
+        timeout: Duration = .seconds(1),
+        timeoutMessage: String
+    ) async throws -> T {
+        try await withThrowingTaskGroup(of: T.self) { group in
+            group.addTask {
+                await task.value
+            }
+            group.addTask {
+                try await Task.sleep(for: timeout)
+                throw TestError.timedOut(timeoutMessage)
+            }
+            guard let value = try await group.next() else {
+                throw TestError.timedOut(timeoutMessage)
+            }
+            group.cancelAll()
+            return value
         }
     }
 
@@ -2920,6 +3038,7 @@ private actor BlockingStartMeetingAudioCaptureService: MeetingAudioCapturing {
 
 private enum TestError: Error {
     case lockWriteFailed
+    case timedOut(String)
 }
 
 private final class RecordingLockFileStore: MeetingRecordingLockFileStoring, @unchecked Sendable {


### PR DESCRIPTION
## Summary
Capture failures now move from `MeetingRecordingService` to the meeting flow through a direct terminal signal instead of being inferred by the coordinator's 1s pill poll. The service emits exactly one failure signal for the active session, including late-observer delivery for an already-failed session, so the coordinator can enter the existing stop-and-transcribe path without waiting for the next poll tick.

Before this PR, `failCapture(_:)` only flipped service-local state and the UI reconstructed failure by sampling `captureMode == .stopped`. After this PR, failure is pushed from the service; the poll remains only for levels, elapsed time, mute/health, and pause reconciliation.

## Design
This implements item R2-2 of PR #725, docs: architecture deepening round 2.

The diff matches that spec exactly. No deviations.

Key decisions:
- `MeetingRecordingServiceProtocol` now exposes `captureFailureSignalForCurrentSession()`, an `AsyncStream` with a single terminal `MeetingCaptureFailureSignal` for the currently active session.
- `MeetingRecordingService.failCapture(_:)` marks the current session as signaled before awaiting capture stop, making duplicate failure paths idempotent even with actor reentrancy.
- The signal is session-keyed by service session UUID. Observers registered after the active session has already failed still receive the terminal signal, while cleanup finishes stale observers for ended sessions.
- `MeetingRecordingFlowCoordinator` starts a dedicated failure observation task only after `.recordingStarted` has moved the flow into `.recording`, then generation-guards before sending `.captureFailed`.
- The former `captureMode == .stopped` synthesized-failure branch was removed from `startPillPolling`; the rest of the 1s poll survives unchanged.

## How it works
```mermaid
sequenceDiagram
    participant Capture as Capture callbacks
    participant Service as MeetingRecordingService
    participant Coordinator as Flow coordinator
    participant Machine as Flow state machine

    Capture->>Service: error / mic interruption / writer failure
    Service->>Service: mark session failure signaled once
    Service-->>Coordinator: MeetingCaptureFailureSignal
    Coordinator->>Coordinator: guard captured generation is current
    Coordinator->>Machine: .captureFailed(generation)
    Machine-->>Coordinator: show transcribing + stopRecordingAndTranscribe
```

## Risk surface
The main risk is async lifecycle ordering: a failure can happen before the coordinator starts observing, while paused, or through more than one failure path. The service tests cover observer-before-failure, late observer after failure, and duplicate failures; coordinator tests cover current-generation routing, paused routing, and stale-generation ignore.

Deliberately out of scope: paused/resumed/stopped event streams, state-machine transition changes, level polling redesign, ADR-014/019 stop-boundary or recovery semantics, and `MeetingCleanedMicrophoneReadiness`.

## Test evidence
Replayable commands run from `/tmp/wt-r2-2`:

```bash
swift test --filter MeetingRecordingServiceTests
# passed: 80 tests, 0 failures

swift test --filter MeetingRecordingFlowCoordinatorTests
# passed: 16 tests, 0 failures

git diff --check
# passed
```

The full `swift test` suite was not run, per the R2-2 instruction that the orchestrator gates that separately.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Push a terminal capture-failure signal from the recording service so the flow stops and transcribes immediately and exactly once, replacing the old 1s poll inference. Implements R2-2 from the architecture deepening spec.

- **New Features**
  - Added a session-scoped `captureFailureSignalForCurrentSession()` `AsyncStream` that yields once per failed session and delivers to late observers.
  - Made `failCapture(_:)` idempotent by marking the session as signaled before stopping capture, preventing duplicate emissions.
  - The coordinator starts a failure observation task after `.recordingStarted` and emits `.captureFailed` only for the current generation; removed the poll-based `captureMode == .stopped` inference while keeping the poll for levels, elapsed time, mute/health, and pause reconciliation.

- **Refactors**
  - Clarified capture-failure observer cleanup by using explicit `removeValue(forKey:)` at both dictionary levels and finishing streams at session end.
  - Reset the `MeetingRecordingServiceSpy` failure latch and session token on stop/cancel to mirror the production session boundary.

<sup>Written for commit 09b634f0a9b77f6192f1e22801a17ade123ba0d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/730?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

