### PR TITLE
Stabilize StateSignal waits for flaky tests

### DIFF
--- a/Sources/MacParakeet/App/DictationFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/DictationFlowCoordinator.swift
@@ -182,6 +182,7 @@ final class DictationFlowCoordinator {
     private var captionFailureDismissTask: Task<Void, Never>?
     private var captionShownAt: Date?
     private var captionGeneration = 0
+    var testHook_onProcessingLoadCaptionChange: ((DictationOverlayViewModel.ProcessingLoadCaption?) -> Void)?
 
     // MARK: - Flow Context (not state machine concerns)
 
@@ -468,7 +469,7 @@ final class DictationFlowCoordinator {
             vm.recordingMode = mode
             vm.processingMessage = nil
             vm.busyProcessingMessage = nil
-            vm.processingLoadCaption = nil
+            setProcessingLoadCaption(nil)
             vm.liveTranscript = ""
             vm.previewTextSize = runtimePreferences.dictationPreviewTextSize
             vm.state = .recording
@@ -478,7 +479,7 @@ final class DictationFlowCoordinator {
             overlayViewModel?.stopTimer()
             overlayViewModel?.processingMessage = nil
             overlayViewModel?.busyProcessingMessage = nil
-            overlayViewModel?.processingLoadCaption = nil
+            setProcessingLoadCaption(nil)
             overlayViewModel?.liveTranscript = ""
             overlayViewModel?.state = .processing
             armProcessingLoadCaption()
@@ -790,6 +791,11 @@ final class DictationFlowCoordinator {
         stateMachine.state
     }
 
+    private func setProcessingLoadCaption(_ caption: DictationOverlayViewModel.ProcessingLoadCaption?) {
+        overlayViewModel?.processingLoadCaption = caption
+        testHook_onProcessingLoadCaptionChange?(caption)
+    }
+
     private func armProcessingLoadCaption() {
         captionGeneration += 1
         let generation = captionGeneration
@@ -839,7 +845,7 @@ final class DictationFlowCoordinator {
         let extendedCaption: DictationOverlayViewModel.ProcessingLoadCaption =
             isCohere ? .optimizingExtended : .preparingExtended
 
-        overlayViewModel?.processingLoadCaption = baseCaption
+        setProcessingLoadCaption(baseCaption)
         captionShownAt = Date()
         Telemetry.send(.dictationFirstLoadCaptionShown(firstInstall: firstInstall))
 
@@ -848,7 +854,7 @@ final class DictationFlowCoordinator {
             Task { @MainActor in
                 guard self?.captionGeneration == generation else { return }
                 guard self?.overlayViewModel?.processingLoadCaption == baseCaption else { return }
-                self?.overlayViewModel?.processingLoadCaption = extendedCaption
+                self?.setProcessingLoadCaption(extendedCaption)
             }
         }
         captionEscalationTimer = escalation
@@ -875,7 +881,7 @@ final class DictationFlowCoordinator {
             ))
             captionShownAt = nil
         }
-        overlayViewModel?.processingLoadCaption = nil
+        setProcessingLoadCaption(nil)
     }
 
     private func showErrorAfterCaptionFailureIfNeeded(message: String) {
@@ -886,7 +892,7 @@ final class DictationFlowCoordinator {
 
         switch overlayViewModel?.processingLoadCaption {
         case .preparing, .preparingExtended, .optimizing, .optimizingExtended:
-            overlayViewModel?.processingLoadCaption = .failed
+            setProcessingLoadCaption(.failed)
             captionFailureDismissTask?.cancel()
             captionFailureDismissTask = Task { @MainActor [weak self] in
                 guard let self else { return }

--- a/Tests/MacParakeetTests/DictationFlow/DictationFlowCoordinatorLoadCaptionTests.swift
+++ b/Tests/MacParakeetTests/DictationFlow/DictationFlowCoordinatorLoadCaptionTests.swift
@@ -5,6 +5,8 @@ import XCTest
 
 @MainActor
 final class DictationFlowCoordinatorLoadCaptionTests: XCTestCase {
+    private typealias ProcessingLoadCaption = DictationOverlayViewModel.ProcessingLoadCaption
+
     private let timing = DictationProcessingLoadCaptionTiming(
         graceMs: 20,
         escalationMs: 50,
@@ -73,7 +75,7 @@ final class DictationFlowCoordinatorLoadCaptionTests: XCTestCase {
         let harness = try makeHarness(isReady: false, transcribeDelayMs: 90, hasCompletedFirstDictation: false)
 
         try await harness.startAndStop()
-        let shown = await waitUntil { self.isPreparingCaption(harness.coordinator.processingLoadCaptionForTesting) }
+        let shown = await harness.captionSignal.wait(for: .preparing)
         XCTAssertTrue(shown)
         let cleared = await waitUntil { harness.coordinator.processingLoadCaptionForTesting == nil }
         XCTAssertTrue(cleared)
@@ -88,7 +90,7 @@ final class DictationFlowCoordinatorLoadCaptionTests: XCTestCase {
 
         try await harness.startAndStop()
 
-        let escalated = await waitUntil { harness.coordinator.processingLoadCaptionForTesting == .preparingExtended }
+        let escalated = await harness.captionSignal.wait(for: .preparingExtended)
         XCTAssertTrue(escalated)
     }
 
@@ -96,7 +98,7 @@ final class DictationFlowCoordinatorLoadCaptionTests: XCTestCase {
         let harness = try makeHarness(isReady: false, transcribeDelayMs: 140, hasCompletedFirstDictation: true)
 
         try await harness.startAndStop()
-        let shown = await waitUntil { self.isPreparingCaption(harness.coordinator.processingLoadCaptionForTesting) }
+        let shown = await harness.captionSignal.wait(for: .preparing)
         XCTAssertTrue(shown)
         try await Task.sleep(for: .milliseconds(70))
 
@@ -117,9 +119,9 @@ final class DictationFlowCoordinatorLoadCaptionTests: XCTestCase {
 
         try await harness.startAndStop()
 
-        let shown = await waitUntil { harness.coordinator.processingLoadCaptionForTesting == .optimizing }
+        let shown = await harness.captionSignal.wait(for: .optimizing)
         XCTAssertTrue(shown)
-        let escalated = await waitUntil { harness.coordinator.processingLoadCaptionForTesting == .optimizingExtended }
+        let escalated = await harness.captionSignal.wait(for: .optimizingExtended)
         XCTAssertTrue(escalated)
     }
 
@@ -136,11 +138,9 @@ final class DictationFlowCoordinatorLoadCaptionTests: XCTestCase {
         )
 
         try await harness.startAndStop()
-        let preparingCaptionShown = await waitUntil {
-            self.isPreparingCaption(harness.coordinator.processingLoadCaptionForTesting)
-        }
+        let preparingCaptionShown = await harness.captionSignal.wait(for: .preparing)
         XCTAssertTrue(preparingCaptionShown)
-        let failedCaptionShown = await waitUntil { harness.coordinator.processingLoadCaptionForTesting == .failed }
+        let failedCaptionShown = await harness.captionSignal.wait(for: .failed)
         XCTAssertTrue(failedCaptionShown)
         XCTAssertTrue(harness.coordinator.overlayStateForTesting?.isProcessingForTest == true)
 
@@ -158,7 +158,7 @@ final class DictationFlowCoordinatorLoadCaptionTests: XCTestCase {
         )
 
         try await harness.startAndStop()
-        let shown = await waitUntil { self.isPreparingCaption(harness.coordinator.processingLoadCaptionForTesting) }
+        let shown = await harness.captionSignal.wait(for: .preparing)
         XCTAssertTrue(shown)
         let cleared = await waitUntil { harness.coordinator.processingLoadCaptionForTesting == nil }
         XCTAssertTrue(cleared)
@@ -171,7 +171,7 @@ final class DictationFlowCoordinatorLoadCaptionTests: XCTestCase {
         await harness.clipboard.setPasteError(ClipboardServiceError.eventSourceUnavailable)
 
         try await harness.startAndStop()
-        let shown = await waitUntil { self.isPreparingCaption(harness.coordinator.processingLoadCaptionForTesting) }
+        let shown = await harness.captionSignal.wait(for: .preparing)
         XCTAssertTrue(shown)
         let recordedFailure = await waitUntil {
             harness.telemetry.snapshot().containsCaptionDuration(outcome: "failure")
@@ -185,9 +185,7 @@ final class DictationFlowCoordinatorLoadCaptionTests: XCTestCase {
         let harness = try makeHarness(isReady: false, transcribeDelayMs: 2_000)
 
         try await harness.startAndStop()
-        let shown = await waitUntil(timeoutMs: 3_000) {
-            self.isPreparingCaption(harness.coordinator.processingLoadCaptionForTesting)
-        }
+        let shown = await harness.captionSignal.wait(for: .preparing, timeout: .seconds(3))
         XCTAssertTrue(shown)
 
         harness.coordinator.cancelDictation(reason: .escape)
@@ -202,7 +200,7 @@ final class DictationFlowCoordinatorLoadCaptionTests: XCTestCase {
         let harness = try makeHarness(isReady: false, transcribeDelayMs: 80)
 
         try await harness.startAndStop()
-        let firstShown = await waitUntil { self.isPreparingCaption(harness.coordinator.processingLoadCaptionForTesting) }
+        let firstShown = await harness.captionSignal.wait(for: .preparing)
         XCTAssertTrue(firstShown)
         let firstCleared = await waitUntil { harness.coordinator.processingLoadCaptionForTesting == nil }
         XCTAssertTrue(firstCleared)
@@ -325,6 +323,7 @@ final class DictationFlowCoordinatorLoadCaptionTests: XCTestCase {
     ) throws -> Harness {
         let telemetry = LoadCaptionTelemetrySpy()
         Telemetry.configure(telemetry)
+        let captionSignal = StateSignal<ProcessingLoadCaption?>()
 
         let dbManager = try DatabaseManager()
         let audio = MockAudioProcessor()
@@ -383,13 +382,19 @@ final class DictationFlowCoordinatorLoadCaptionTests: XCTestCase {
             onHistoryReload: {},
             onPresentEntitlementsAlert: { _ in }
         )
+        coordinator.testHook_onProcessingLoadCaptionChange = { caption in
+            Task {
+                await captionSignal.emit(caption)
+            }
+        }
 
         return Harness(
             coordinator: coordinator,
             stt: stt,
             telemetry: telemetry,
             clipboard: clipboard,
-            preferencesDefaults: preferencesDefaults
+            preferencesDefaults: preferencesDefaults,
+            captionSignal: captionSignal
         )
     }
 
@@ -417,16 +422,13 @@ final class DictationFlowCoordinatorLoadCaptionTests: XCTestCase {
         return await condition()
     }
 
-    private func isPreparingCaption(_ caption: DictationOverlayViewModel.ProcessingLoadCaption?) -> Bool {
-        caption == .preparing || caption == .preparingExtended
-    }
-
     private struct Harness {
         let coordinator: DictationFlowCoordinator
         let stt: DelayedSTTClient
         let telemetry: LoadCaptionTelemetrySpy
         let clipboard: MockClipboardService
         let preferencesDefaults: UserDefaults
+        let captionSignal: StateSignal<ProcessingLoadCaption?>
 
         @MainActor
         func startAndStop() async throws {

--- a/Tests/MacParakeetTests/TestSupport/StateSignal.swift
+++ b/Tests/MacParakeetTests/TestSupport/StateSignal.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+actor StateSignal<T: Equatable & Sendable> {
+    private struct Waiter {
+        let id: UUID
+        let value: T
+        let continuation: CheckedContinuation<Bool, Never>
+    }
+
+    private var emittedValues: [T] = []
+    private var waiters: [Waiter] = []
+
+    var history: [T] {
+        emittedValues
+    }
+
+    func emit(_ value: T) {
+        emittedValues.append(value)
+
+        let matchingWaiters = waiters.filter { $0.value == value }
+        waiters.removeAll { $0.value == value }
+        matchingWaiters.forEach { $0.continuation.resume(returning: true) }
+    }
+
+    func wait(for value: T, timeout: Duration = .seconds(1)) async -> Bool {
+        if emittedValues.contains(value) {
+            return true
+        }
+
+        let id = UUID()
+        return await withTaskGroup(of: Bool.self) { group in
+            group.addTask {
+                await self.registerWaiter(id: id, value: value)
+            }
+            group.addTask {
+                try? await Task.sleep(for: timeout)
+                return await self.timeOutWaiter(id: id, value: value)
+            }
+
+            let result = await group.next() ?? false
+            group.cancelAll()
+            return result
+        }
+    }
+
+    private func registerWaiter(id: UUID, value: T) async -> Bool {
+        if emittedValues.contains(value) {
+            return true
+        }
+
+        return await withCheckedContinuation { continuation in
+            if emittedValues.contains(value) {
+                continuation.resume(returning: true)
+            } else {
+                waiters.append(Waiter(id: id, value: value, continuation: continuation))
+            }
+        }
+    }
+
+    private func timeOutWaiter(id: UUID, value: T) -> Bool {
+        if emittedValues.contains(value) {
+            return true
+        }
+
+        guard let index = waiters.firstIndex(where: { $0.id == id }) else {
+            return emittedValues.contains(value)
+        }
+        let waiter = waiters.remove(at: index)
+        waiter.continuation.resume(returning: false)
+        return false
+    }
+}

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
@@ -1873,12 +1873,16 @@ final class TranscriptionViewModelTests: XCTestCase {
         viewModel.currentTranscription = meeting
 
         viewModel.renameSpeaker(id: "S1", to: "Alice")
+        let firstRefreshCompleted = await artifactStore.waitForMaterializeCallCount(1)
+        XCTAssertTrue(firstRefreshCompleted)
+
         viewModel.renameSpeaker(id: "S1", to: "Bob")
 
-        try await waitUntilAsync { await artifactStore.materializeCallCount == 1 }
+        let failedRenameRefreshCompleted = await artifactStore.waitForMaterializeCallCount(2)
+        XCTAssertTrue(failedRenameRefreshCompleted)
         let calls = await artifactStore.materializeCalls
-        XCTAssertEqual(calls.count, 1)
-        XCTAssertEqual(calls.first?.transcription.speakers?.first?.label, "Alice")
+        XCTAssertEqual(calls.count, 2)
+        XCTAssertEqual(calls.last?.transcription.speakers?.first?.label, "Alice")
         XCTAssertEqual(viewModel.currentTranscription?.speakers?.first?.label, "Alice")
         XCTAssertNotNil(viewModel.errorMessage)
     }
@@ -3513,6 +3517,7 @@ private struct MaterializeCall: Sendable {
 
 private actor RecordingMeetingArtifactStore: MeetingArtifactStoring {
     private let materializeDelay: Duration?
+    private let materializeCallCountSignal = StateSignal<Int>()
     private var calls: [MaterializeCall] = []
     private var activeMaterializeCount = 0
     private(set) var startedMaterializeCount = 0
@@ -3530,6 +3535,13 @@ private actor RecordingMeetingArtifactStore: MeetingArtifactStoring {
         calls.count
     }
 
+    func waitForMaterializeCallCount(_ count: Int, timeout: Duration = .seconds(1)) async -> Bool {
+        if calls.count >= count {
+            return true
+        }
+        return await materializeCallCountSignal.wait(for: count, timeout: timeout)
+    }
+
     func materialize(
         transcription: Transcription,
         promptResults: [PromptResult]
@@ -3542,6 +3554,7 @@ private actor RecordingMeetingArtifactStore: MeetingArtifactStoring {
         }
         activeMaterializeCount -= 1
         calls.append(MaterializeCall(transcription: transcription, promptResults: promptResults))
+        await materializeCallCountSignal.emit(calls.count)
 
         let folderPath = MeetingArtifactStore.sessionFolderURL(for: transcription)?
             .standardizedFileURL.path


### PR DESCRIPTION
## Summary
CI flakes in the caption tests and issue #732 had the same test-harness smell: the tests were polling live state after short-lived transitions had already moved on. This PR adds a small `StateSignal` test-support actor that records every emitted transition, wires the dictation load-caption tests to it through an internal `testHook_` callback, and makes the #732 rename artifact test wait for the intended refresh completion rather than whichever async refresh happens to finish first.

Closes #732.

## Design
Before:

| Area | Behavior |
|---|---|
| Caption tests | `waitUntil` polled `processingLoadCaption`, so `.failed` / `.preparing` could be missed under scheduler jitter. |
| Rename artifact test | Back-to-back speaker renames let the first artifact refresh win before the newer failed rename restored state. |

After:

| Area | Behavior |
|---|---|
| Caption tests | `StateSignal<ProcessingLoadCaption?>` records each caption assignment; waits succeed if the transition ever occurred. |
| Rename artifact test | The test completes the Alice baseline artifact refresh, performs the failing Bob rename, then waits for the failed-rename refresh before asserting restored persisted state. |

Spec alignment: this implements the supplied StateSignal/#732 task spec. The diff matches that spec's implementation scope: no product behavior change, caption-suite-only adoption, and no sleeps or timeout bumps for #732. Explicit deviation: the PR-body template asked to name an item `<R2-N>` from PR #725, but live PR #725 only lists R2-1 through R2-5 and none covers this StateSignal/#732 fix, so this PR cannot honestly identify a matching PR #725 R2 item.

## Risk surface
The product path change is limited to routing existing caption assignments through a private setter and invoking an internal `testHook_` callback when present. The callback is nil in production construction, so user-facing behavior should be unchanged.

The test-support actor is intentionally narrow: exact-value waits plus full history. It does not convert other repo-wide polling sites yet.

Out of scope follow-ups from the brief: hotkey gesture-timing flake, BT device test, `AudioRecorderFormatChange` test, and the remaining repo-wide `waitUntil` call sites.

## Test evidence
Focused suites:

```bash
swift test --filter DictationFlowCoordinatorLoadCaptionTests
```

Result: 16 tests, 0 failures.

```bash
swift test --filter TranscriptionViewModelTests
```

Result: 121 tests, 0 failures.

Formerly flaky repetition proof:

```bash
tests=(
  'DictationFlowCoordinatorLoadCaptionTests.testFailureShowsFailureCaptionBeforeErrorCard'
  'DictationFlowCoordinatorLoadCaptionTests.testCancelDuringVisibleCaptionClearsCaption'
  'TranscriptionViewModelTests.testRenameSpeakerRefreshesArtifactFromPersistedStateWhenNewerRenameFails'
)
for test_name in "${tests[@]}"; do
  for i in {1..20}; do
    swift test --filter "$test_name" >/tmp/statesignal-${test_name//./-}-$i.log 2>&1
    rc=$?
    if [ $rc -ne 0 ]; then
      echo "FAIL $test_name iteration $i"
      tail -80 /tmp/statesignal-${test_name//./-}-$i.log
      exit $rc
    fi
  done
  echo "PASS $test_name 20/20"
done
```

Result:

```text
PASS DictationFlowCoordinatorLoadCaptionTests.testFailureShowsFailureCaptionBeforeErrorCard 20/20
PASS DictationFlowCoordinatorLoadCaptionTests.testCancelDuringVisibleCaptionClearsCaption 20/20
PASS TranscriptionViewModelTests.testRenameSpeakerRefreshesArtifactFromPersistedStateWhenNewerRenameFails 20/20
```

Also run:

```bash
git diff --check
git diff --cached --check
```

Result: no whitespace errors.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes flaky caption and rename tests by waiting on transition history instead of current state. Addresses #732 by waiting for the failed-rename refresh rather than whichever async refresh finishes first.

- **Bug Fixes**
  - Added a test-only StateSignal that records all emitted values and lets tests wait for specific transitions with timeouts.
  - Routed caption updates through a private setter and a `testHook_onProcessingLoadCaptionChange`, so caption tests reliably wait for .preparing/.optimizing/.failed transitions.
  - Updated TranscriptionViewModelTests to wait for specific materialize call counts, ensuring the Alice refresh completes first and the failed Bob rename refresh completes before assertions (per #732).

<sup>Written for commit bb4bb669f1832d3e70342d5b290e0b3390abc576. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/733?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

