### PR TITLE
fix(llm): harden local LLM runtime lifetimes and generation lifecycle

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,8 +27,7 @@ let packageDependencies: [Package.Dependency] = [
     // Metal shaders, so plain `swift build` / `swift test` / CI must not resolve it.
     .package(url: "https://github.com/ml-explore/mlx-swift-lm", exact: "3.31.4"),
     .package(url: "https://github.com/ml-explore/mlx-swift", exact: "0.31.4"),
-    .package(url: "https://github.com/huggingface/swift-huggingface", from: "0.9.0"),
-    .package(url: "https://github.com/huggingface/swift-transformers", .upToNextMinor(from: "1.1.6")),
+    .package(url: "https://github.com/huggingface/swift-transformers", "1.1.6" ..< "1.2.0"),
 ] : [])
 
 let coreDependencies: [Target.Dependency] = [
@@ -73,7 +72,6 @@ let mlxLocalLLMTargets: [Target] = enableMLXLocalLLM ? [
             .product(name: "MLXLLM", package: "mlx-swift-lm"),
             .product(name: "MLXLMCommon", package: "mlx-swift-lm"),
             .product(name: "MLXHuggingFace", package: "mlx-swift-lm"),
-            .product(name: "HuggingFace", package: "swift-huggingface"),
             .product(name: "Tokenizers", package: "swift-transformers"),
         ],
         path: "Sources/MacParakeetLocalLLM",

--- a/Package.swift
+++ b/Package.swift
@@ -27,6 +27,9 @@ let packageDependencies: [Package.Dependency] = [
     // Metal shaders, so plain `swift build` / `swift test` / CI must not resolve it.
     .package(url: "https://github.com/ml-explore/mlx-swift-lm", exact: "3.31.4"),
     .package(url: "https://github.com/ml-explore/mlx-swift", exact: "0.31.4"),
+    // Only the Tokenizers product is used (local-directory tokenizer loading).
+    // Held to 1.1.x because argmax-oss-swift (WhisperKit) cannot resolve
+    // alongside swift-transformers 1.3 in the gated dependency graph.
     .package(url: "https://github.com/huggingface/swift-transformers", "1.1.6" ..< "1.2.0"),
 ] : [])
 

--- a/Sources/MacParakeet/App/AppEnvironment.swift
+++ b/Sources/MacParakeet/App/AppEnvironment.swift
@@ -183,7 +183,8 @@ final class AppEnvironment {
         let checkoutURLString =
             (Bundle.main.object(forInfoDictionaryKey: "MacParakeetCheckoutURL") as? String)
             ?? ProcessInfo.processInfo.environment["MACPARAKEET_CHECKOUT_URL"]
-        checkoutURL = checkoutURLString
+        checkoutURL =
+            checkoutURLString
             .flatMap { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
             .flatMap { $0.isEmpty ? nil : $0 }
             .flatMap(URL.init(string:))
@@ -265,7 +266,9 @@ final class AppEnvironment {
                     // design; log it so a corrupted DB doesn't silently route
                     // every dictation past the user's profiles.
                     Logger(subsystem: "com.macparakeet.app", category: "AIFormatter")
-                        .error("Formatter profile fetch failed; using fallback prompt error=\(error.localizedDescription, privacy: .public)")
+                        .error(
+                            "Formatter profile fetch failed; using fallback prompt error=\(error.localizedDescription, privacy: .public)"
+                        )
                 }
             )
         } else {
@@ -324,9 +327,10 @@ final class AppEnvironment {
                     .string(forKey: OnboardingViewModel.onboardingCompletedKey)
                     .flatMap { ISO8601DateFormatter().date(from: $0) }
                     .map { Date().timeIntervalSince($0) }
-                Telemetry.send(.firstDictationCompleted(
-                    activationWindow: TelemetryActivationWindow(secondsSinceOnboarding: secondsSinceOnboarding)
-                ))
+                Telemetry.send(
+                    .firstDictationCompleted(
+                        activationWindow: TelemetryActivationWindow(secondsSinceOnboarding: secondsSinceOnboarding)
+                    ))
             }
         )
 
@@ -399,12 +403,14 @@ final class AppEnvironment {
         // while this feature rides the live-dictation flag; the registry answers
         // whether the selected Parakeet variant actually has that tail-preview path.
         guard speechEngine == .parakeet else { return nil }
-        guard let capabilities = SpeechEngineCapabilityRegistry.capabilities(
-            for: speechEngine,
-            parakeetModelVariant: parakeetModelVariant,
-            nemotronModelVariant: nemotronModelVariant,
-            whisperModelVariant: whisperModelVariant
-        ) else {
+        guard
+            let capabilities = SpeechEngineCapabilityRegistry.capabilities(
+                for: speechEngine,
+                parakeetModelVariant: parakeetModelVariant,
+                nemotronModelVariant: nemotronModelVariant,
+                whisperModelVariant: whisperModelVariant
+            )
+        else {
             return nil
         }
         guard capabilities.supportsTailPreview else { return nil }
@@ -424,13 +430,15 @@ final class AppEnvironment {
         } catch {
             return
         }
-        let hasDictationRoutingPreference = defaults.object(
-            forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledForDictationKey
-        ) != nil
+        let hasDictationRoutingPreference =
+            defaults.object(
+                forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledForDictationKey
+            ) != nil
         if config != nil {
-            let legacyFormatterWasEnabled = defaults.object(
-                forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledKey
-            ) as? Bool == true
+            let legacyFormatterWasEnabled =
+                defaults.object(
+                    forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledKey
+                ) as? Bool == true
             if !hasDictationRoutingPreference {
                 defaults.set(
                     legacyFormatterWasEnabled,

--- a/Sources/MacParakeet/App/AppEnvironment.swift
+++ b/Sources/MacParakeet/App/AppEnvironment.swift
@@ -274,7 +274,13 @@ final class AppEnvironment {
             )
         }
 
-        llmClient = Self.makeLLMClient()
+        #if MACPARAKEET_HAS_MLX_LOCAL_LLM
+        llmClient = RoutingLLMClient(
+            inProcessClient: InProcessLLMClient(runtime: MLXLocalLLMRuntime())
+        )
+        #else
+        llmClient = RoutingLLMClient()
+        #endif
         self.llmConfigStore = llmConfigStore
         llmService = LLMService(
             client: llmClient,
@@ -438,15 +444,5 @@ final class AppEnvironment {
                 defaults.set(false, forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledForDictationKey)
             }
         }
-    }
-
-    private nonisolated static func makeLLMClient() -> RoutingLLMClient {
-        #if MACPARAKEET_HAS_MLX_LOCAL_LLM
-        return RoutingLLMClient(
-            inProcessClient: InProcessLLMClient(runtime: MLXLocalLLMRuntime())
-        )
-        #else
-        return RoutingLLMClient()
-        #endif
     }
 }

--- a/Sources/MacParakeetCore/Services/LLM/InProcessLLMClient.swift
+++ b/Sources/MacParakeetCore/Services/LLM/InProcessLLMClient.swift
@@ -94,7 +94,8 @@ public final class InProcessLLMClient: LLMClientProtocol, Sendable {
 
     public static func environmentModelDirectory(for config: LLMProviderConfig) throws -> URL {
         guard let rawPath = ProcessInfo.processInfo.environment[modelDirectoryEnvironmentVariable],
-              !rawPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            !rawPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else {
             throw LLMError.modelNotFound(
                 "Set \(modelDirectoryEnvironmentVariable) to a local MLX model directory for \(config.modelName)."
             )
@@ -279,7 +280,8 @@ public final class InProcessLLMClient: LLMClientProtocol, Sendable {
     }
 
     private static func splitForMapReduce(_ messages: [ChatMessage], maxCharacters: Int) -> [String] {
-        let joined = messages
+        let joined =
+            messages
             .map { "\($0.role.rawValue.uppercased()): \($0.modelContent)" }
             .joined(separator: "\n\n")
         return split(joined, maxCharacters: maxCharacters)
@@ -314,15 +316,15 @@ public final class InProcessLLMClient: LLMClientProtocol, Sendable {
             ChatMessage(
                 role: .user,
                 content: """
-                Process chunk \(index) of \(total) for the user's request. Preserve facts exactly and do not infer missing details.
+                    Process chunk \(index) of \(total) for the user's request. Preserve facts exactly and do not infer missing details.
 
-                Original conversation context, including user and assistant turns:
-                \(originalConversationContext)
+                    Original conversation context, including user and assistant turns:
+                    \(originalConversationContext)
 
-                Chunk:
-                \(chunk)
-                """
-            ),
+                    Chunk:
+                    \(chunk)
+                    """
+            )
         ]
     }
 
@@ -345,15 +347,15 @@ public final class InProcessLLMClient: LLMClientProtocol, Sendable {
             ChatMessage(
                 role: .user,
                 content: """
-                Combine the chunk results into one final answer for the original request. Preserve source facts exactly, remove duplication, and do not add unstated details.
+                    Combine the chunk results into one final answer for the original request. Preserve source facts exactly, remove duplication, and do not add unstated details.
 
-                Original conversation context, including user and assistant turns:
-                \(originalConversationContext)
+                    Original conversation context, including user and assistant turns:
+                    \(originalConversationContext)
 
-                Chunk results:
-                \(boundedCombined)
-                """
-            ),
+                    Chunk results:
+                    \(boundedCombined)
+                    """
+            )
         ]
     }
 
@@ -361,7 +363,8 @@ public final class InProcessLLMClient: LLMClientProtocol, Sendable {
         _ messages: [ChatMessage],
         maxCharacters: Int = 6_000
     ) -> String {
-        let context = messages
+        let context =
+            messages
             .filter { $0.role != .system }
             .map { "\($0.role.rawValue.uppercased()): \($0.modelContent)" }
             .joined(separator: "\n\n")
@@ -443,9 +446,10 @@ private actor LocalLLMLifetimeCoordinator {
         if activeGenerationID != nil {
             let lease = LocalLLMGenerationLease(id: UUID())
             return try await withTaskCancellationHandler {
-                try await withCheckedThrowingContinuation { (
-                    continuation: CheckedContinuation<LocalLLMGenerationLease, Error>
-                ) in
+                try await withCheckedThrowingContinuation {
+                    (
+                        continuation: CheckedContinuation<LocalLLMGenerationLease, Error>
+                    ) in
                     waitingGenerations.append(
                         WaitingGeneration(lease: lease, continuation: continuation)
                     )
@@ -519,8 +523,9 @@ private actor LocalLLMLifetimeCoordinator {
         runtime: any LocalLLMRuntime
     ) async {
         guard scheduledUnloadID == id,
-              activeGenerationID == nil,
-              waitingGenerations.isEmpty else {
+            activeGenerationID == nil,
+            waitingGenerations.isEmpty
+        else {
             return
         }
 

--- a/Sources/MacParakeetCore/Services/LLM/InProcessLLMClient.swift
+++ b/Sources/MacParakeetCore/Services/LLM/InProcessLLMClient.swift
@@ -16,10 +16,10 @@ public final class InProcessLLMClient: LLMClientProtocol, Sendable {
     private let chunkCharacterThreshold: Int
     private let chunkCharacterLimit: Int
     private let idleUnloadDelayNanoseconds: UInt64
-    private let lifetimeCoordinator: LocalLLMLifetimeCoordinator
+    private let lifetimeCoordinator = LocalLLMLifetimeCoordinator()
     private let logger = Logger(subsystem: "com.macparakeet.core", category: "InProcessLLMClient")
 
-    public convenience init(
+    public init(
         runtime: any LocalLLMRuntime = UnavailableLocalLLMRuntime(),
         modelDirectoryResolver: @escaping LocalLLMModelDirectoryResolver = {
             try InProcessLLMClient.environmentModelDirectory(for: $0)
@@ -28,33 +28,12 @@ public final class InProcessLLMClient: LLMClientProtocol, Sendable {
         chunkCharacterLimit: Int = InProcessLLMClient.defaultChunkCharacterLimit,
         idleUnloadDelaySeconds: TimeInterval = InProcessLLMClient.defaultIdleUnloadDelaySeconds
     ) {
-        self.init(
-            runtime: runtime,
-            modelDirectoryResolver: modelDirectoryResolver,
-            chunkCharacterThreshold: chunkCharacterThreshold,
-            chunkCharacterLimit: chunkCharacterLimit,
-            idleUnloadDelaySeconds: idleUnloadDelaySeconds,
-            lifetimeCoordinator: LocalLLMLifetimeCoordinator()
-        )
-    }
-
-    init(
-        runtime: any LocalLLMRuntime = UnavailableLocalLLMRuntime(),
-        modelDirectoryResolver: @escaping LocalLLMModelDirectoryResolver = {
-            try InProcessLLMClient.environmentModelDirectory(for: $0)
-        },
-        chunkCharacterThreshold: Int = InProcessLLMClient.defaultChunkCharacterThreshold,
-        chunkCharacterLimit: Int = InProcessLLMClient.defaultChunkCharacterLimit,
-        idleUnloadDelaySeconds: TimeInterval = InProcessLLMClient.defaultIdleUnloadDelaySeconds,
-        lifetimeCoordinator: LocalLLMLifetimeCoordinator
-    ) {
         self.runtime = runtime
         self.modelDirectoryResolver = modelDirectoryResolver
         self.chunkCharacterThreshold = max(1, chunkCharacterThreshold)
         self.chunkCharacterLimit = max(1, chunkCharacterLimit)
         let boundedDelay = max(0, idleUnloadDelaySeconds)
         self.idleUnloadDelayNanoseconds = UInt64(boundedDelay * 1_000_000_000)
-        self.lifetimeCoordinator = lifetimeCoordinator
     }
 
     public func chatCompletion(
@@ -103,23 +82,9 @@ public final class InProcessLLMClient: LLMClientProtocol, Sendable {
     }
 
     public func testConnection(context: LLMExecutionContext) async throws {
-        try Task.checkCancellation()
-        let lease = try await lifetimeCoordinator.beginGeneration()
-        do {
+        try await withGenerationLease(delayNanoseconds: 0) {
             try Task.checkCancellation()
             try await loadRuntime(for: context.providerConfig)
-            await lifetimeCoordinator.endGeneration(
-                lease,
-                runtime: runtime,
-                delayNanoseconds: 0
-            )
-        } catch {
-            await lifetimeCoordinator.endGeneration(
-                lease,
-                runtime: runtime,
-                delayNanoseconds: 0
-            )
-            throw error
         }
     }
 
@@ -149,10 +114,7 @@ public final class InProcessLLMClient: LLMClientProtocol, Sendable {
             throw LLMError.providerError("InProcessLLMClient received \(context.providerConfig.id.rawValue).")
         }
 
-        try Task.checkCancellation()
-        let lease = try await lifetimeCoordinator.beginGeneration()
-
-        do {
+        return try await withGenerationLease(delayNanoseconds: idleUnloadDelayNanoseconds) {
             try Task.checkCancellation()
             try await loadRuntime(for: context.providerConfig)
 
@@ -172,17 +134,29 @@ public final class InProcessLLMClient: LLMClientProtocol, Sendable {
             }
 
             log(metrics: response.metrics, inputCharacters: Self.inputCharacterCount(messages))
+            return response
+        }
+    }
+
+    private func withGenerationLease<T: Sendable>(
+        delayNanoseconds: UInt64,
+        _ operation: @Sendable () async throws -> T
+    ) async throws -> T {
+        try Task.checkCancellation()
+        let lease = try await lifetimeCoordinator.beginGeneration()
+        do {
+            let result = try await operation()
             await lifetimeCoordinator.endGeneration(
                 lease,
                 runtime: runtime,
-                delayNanoseconds: idleUnloadDelayNanoseconds
+                delayNanoseconds: delayNanoseconds
             )
-            return response
+            return result
         } catch {
             await lifetimeCoordinator.endGeneration(
                 lease,
                 runtime: runtime,
-                delayNanoseconds: idleUnloadDelayNanoseconds
+                delayNanoseconds: delayNanoseconds
             )
             throw error
         }
@@ -451,43 +425,30 @@ private struct LocalLLMPromptBudget: Sendable {
     let partialResultCharacters: Int
 }
 
-typealias LocalLLMLifetimeHook = @Sendable () async -> Void
-
-actor LocalLLMLifetimeCoordinator {
+private actor LocalLLMLifetimeCoordinator {
     private var unloadTask: Task<Void, Never>?
-    private var activeGenerationID: UUID?
-    private var idleUnloadGeneration: UInt64 = 0
+    private var scheduledUnloadID: UUID?
     private var unloadInProgress = false
+    private var activeGenerationID: UUID?
     private var waitingGenerations: [WaitingGeneration] = []
-    private let beforeWaitContinuationHook: LocalLLMLifetimeHook?
-    private let beforeIdleUnloadHook: LocalLLMLifetimeHook?
-
-    init(
-        beforeWaitContinuationHook: LocalLLMLifetimeHook? = nil,
-        beforeIdleUnloadHook: LocalLLMLifetimeHook? = nil
-    ) {
-        self.beforeWaitContinuationHook = beforeWaitContinuationHook
-        self.beforeIdleUnloadHook = beforeIdleUnloadHook
-    }
 
     func beginGeneration() async throws -> LocalLLMGenerationLease {
         try Task.checkCancellation()
-        if activeGenerationID != nil || unloadInProgress {
+        if unloadInProgress {
+            let task = unloadTask
+            await task?.value
+            return try await beginGeneration()
+        }
+
+        if activeGenerationID != nil {
             let lease = LocalLLMGenerationLease(id: UUID())
             return try await withTaskCancellationHandler {
-                if let beforeWaitContinuationHook {
-                    await beforeWaitContinuationHook()
-                }
-                return try await withCheckedThrowingContinuation { (
+                try await withCheckedThrowingContinuation { (
                     continuation: CheckedContinuation<LocalLLMGenerationLease, Error>
                 ) in
-                    if Task.isCancelled {
-                        continuation.resume(throwing: CancellationError())
-                    } else {
-                        waitingGenerations.append(
-                            WaitingGeneration(lease: lease, continuation: continuation)
-                        )
-                    }
+                    waitingGenerations.append(
+                        WaitingGeneration(lease: lease, continuation: continuation)
+                    )
                 }
             } onCancel: {
                 Task {
@@ -509,7 +470,10 @@ actor LocalLLMLifetimeCoordinator {
     ) {
         guard activeGenerationID == lease.id else { return }
 
-        if resumeNextWaitingGeneration() {
+        if !waitingGenerations.isEmpty {
+            let next = waitingGenerations.removeFirst()
+            activeGenerationID = next.lease.id
+            next.continuation.resume(returning: next.lease)
             return
         }
 
@@ -525,34 +489,23 @@ actor LocalLLMLifetimeCoordinator {
     }
 
     private func cancelPendingUnload() {
-        idleUnloadGeneration &+= 1
         unloadTask?.cancel()
         unloadTask = nil
+        scheduledUnloadID = nil
     }
 
     private func scheduleUnload(runtime: any LocalLLMRuntime, delayNanoseconds: UInt64) {
-        cancelPendingUnload()
-        let generation = idleUnloadGeneration
+        unloadTask?.cancel()
+        let unloadID = UUID()
+        scheduledUnloadID = unloadID
         unloadTask = Task {
-            guard delayNanoseconds > 0 else {
-                if let beforeIdleUnloadHook {
-                    await beforeIdleUnloadHook()
-                }
-                await self.unloadIfStillIdle(
-                    generation: generation,
-                    runtime: runtime
-                )
-                return
-            }
-
             do {
-                try await Task.sleep(nanoseconds: delayNanoseconds)
-                try Task.checkCancellation()
-                if let beforeIdleUnloadHook {
-                    await beforeIdleUnloadHook()
+                if delayNanoseconds > 0 {
+                    try await Task.sleep(nanoseconds: delayNanoseconds)
                 }
-                await self.unloadIfStillIdle(
-                    generation: generation,
+                try Task.checkCancellation()
+                await self.unloadIfStillScheduled(
+                    id: unloadID,
                     runtime: runtime
                 )
             } catch {
@@ -561,45 +514,25 @@ actor LocalLLMLifetimeCoordinator {
         }
     }
 
-    private func unloadIfStillIdle(
-        generation: UInt64,
+    private func unloadIfStillScheduled(
+        id: UUID,
         runtime: any LocalLLMRuntime
     ) async {
-        guard generation == idleUnloadGeneration,
+        guard scheduledUnloadID == id,
               activeGenerationID == nil,
-              waitingGenerations.isEmpty,
-              !unloadInProgress else {
+              waitingGenerations.isEmpty else {
             return
         }
 
-        unloadTask = nil
+        scheduledUnloadID = nil
         unloadInProgress = true
         await runtime.unload()
-        finishIdleUnload(generation: generation)
-    }
-
-    private func finishIdleUnload(generation: UInt64) {
-        guard unloadInProgress else { return }
         unloadInProgress = false
-
-        if generation == idleUnloadGeneration {
-            unloadTask = nil
-        }
-
-        _ = resumeNextWaitingGeneration()
-    }
-
-    private func resumeNextWaitingGeneration() -> Bool {
-        guard !waitingGenerations.isEmpty else { return false }
-
-        let next = waitingGenerations.removeFirst()
-        activeGenerationID = next.lease.id
-        next.continuation.resume(returning: next.lease)
-        return true
+        unloadTask = nil
     }
 }
 
-struct LocalLLMGenerationLease: Sendable {
+private struct LocalLLMGenerationLease: Sendable {
     let id: UUID
 }
 

--- a/Sources/MacParakeetLocalLLM/MLXLocalLLMRuntime.swift
+++ b/Sources/MacParakeetLocalLLM/MLXLocalLLMRuntime.swift
@@ -13,8 +13,8 @@ public actor MLXLocalLLMRuntime: LocalLLMRuntime {
     private var modelContainer: ModelContainer?
     private var loadedModel: LocalLLMModelReference?
     private var latestMetrics: LLMGenerationMetrics?
-    private var generationInProgress = false
     private var generationTask: Task<Void, Never>?
+    private var generationInProgress: Bool { generationTask != nil }
     private var unloadAfterGeneration = false
 
     public init() {}
@@ -68,7 +68,6 @@ public actor MLXLocalLLMRuntime: LocalLLMRuntime {
             throw LLMError.modelNotFound("Local MLX model is not loaded.")
         }
 
-        generationInProgress = true
         unloadAfterGeneration = false
         let streamPair = AsyncThrowingStream<LocalLLMRuntimeEvent, Error>.makeStream()
         let task = Task {
@@ -149,7 +148,6 @@ public actor MLXLocalLLMRuntime: LocalLLMRuntime {
     }
 
     private func finishGeneration() {
-        generationInProgress = false
         generationTask = nil
         guard unloadAfterGeneration else { return }
 

--- a/Sources/MacParakeetLocalLLM/MLXLocalLLMRuntime.swift
+++ b/Sources/MacParakeetLocalLLM/MLXLocalLLMRuntime.swift
@@ -14,12 +14,16 @@ public actor MLXLocalLLMRuntime: LocalLLMRuntime {
     private var loadedModel: LocalLLMModelReference?
     private var latestMetrics: LLMGenerationMetrics?
     private var generationInProgress = false
+    private var generationTask: Task<Void, Never>?
     private var unloadAfterGeneration = false
 
     public init() {}
 
     public func load(model: LocalLLMModelReference) async throws {
         try Task.checkCancellation()
+        await drainGenerationIfNeeded()
+        try Task.checkCancellation()
+
         if generationInProgress {
             guard loadedModel == model, modelContainer != nil else {
                 throw LLMError.providerError("Cannot switch local MLX models while generation is in progress.")
@@ -56,27 +60,29 @@ public actor MLXLocalLLMRuntime: LocalLLMRuntime {
         messages: [ChatMessage],
         options: ChatCompletionOptions
     ) async throws -> AsyncThrowingStream<LocalLLMRuntimeEvent, Error> {
+        try Task.checkCancellation()
+        await drainGenerationIfNeeded()
+        try Task.checkCancellation()
+
         guard modelContainer != nil else {
             throw LLMError.modelNotFound("Local MLX model is not loaded.")
-        }
-        guard !generationInProgress else {
-            throw LLMError.providerError("Local MLX generation is already in progress.")
         }
 
         generationInProgress = true
         unloadAfterGeneration = false
-        return AsyncThrowingStream { continuation in
-            let task = Task {
-                await self.generate(
-                    messages: messages,
-                    options: options,
-                    continuation: continuation
-                )
-            }
-            continuation.onTermination = { _ in
-                task.cancel()
-            }
+        let streamPair = AsyncThrowingStream<LocalLLMRuntimeEvent, Error>.makeStream()
+        let task = Task {
+            await self.generate(
+                messages: messages,
+                options: options,
+                continuation: streamPair.continuation
+            )
         }
+        generationTask = task
+        streamPair.continuation.onTermination = { _ in
+            task.cancel()
+        }
+        return streamPair.stream
     }
 
     public func instrumentation() async -> LLMGenerationMetrics? {
@@ -98,21 +104,27 @@ public actor MLXLocalLLMRuntime: LocalLLMRuntime {
             }
 
             try Task.checkCancellation()
+            let parameters = GenerateParameters(
+                maxTokens: options.maxTokens,
+                kvBits: 4,
+                temperature: Float(options.temperature ?? 0.2)
+            )
+            let input = Self.chatInput(from: messages)
             let session = ChatSession(
                 modelContainer,
-                generateParameters: GenerateParameters(
-                    maxTokens: options.maxTokens,
-                    kvBits: 4,
-                    temperature: Float(options.temperature ?? 0.2)
-                )
+                instructions: input.instructions,
+                history: input.history,
+                generateParameters: parameters
             )
-            let prompt = Self.prompt(from: messages)
 
             let start = Date()
             var firstTokenDate: Date?
             var tokenCount = 0
 
-            for try await token in session.streamResponse(to: prompt) {
+            for try await token in session.streamResponse(
+                to: input.prompt,
+                role: input.role
+            ) {
                 try Task.checkCancellation()
                 if firstTokenDate == nil {
                     firstTokenDate = Date()
@@ -138,11 +150,18 @@ public actor MLXLocalLLMRuntime: LocalLLMRuntime {
 
     private func finishGeneration() {
         generationInProgress = false
+        generationTask = nil
         guard unloadAfterGeneration else { return }
 
         unloadAfterGeneration = false
         clearLoadedState()
         logger.info("Unloaded local MLX model")
+    }
+
+    private func drainGenerationIfNeeded() async {
+        while let generationTask {
+            await generationTask.value
+        }
     }
 
     private func clearLoadedState() {
@@ -151,19 +170,45 @@ public actor MLXLocalLLMRuntime: LocalLLMRuntime {
         latestMetrics = nil
     }
 
-    private static func prompt(from messages: [ChatMessage]) -> String {
-        messages.map { message in
+    private static func chatInput(from messages: [ChatMessage]) -> MLXChatInput {
+        let instructions = messages
+            .filter { $0.role == .system }
+            .map(\.content)
+            .joined(separator: "\n\n")
+        let conversationalMessages = messages.compactMap { message -> Chat.Message? in
             switch message.role {
             case .system:
-                return "System: \(message.content)"
+                return nil
             case .user:
-                return "User: \(message.modelContent)"
+                return .user(message.modelContent)
             case .assistant:
-                return "Assistant: \(message.content)"
+                return .assistant(message.content)
             }
         }
-        .joined(separator: "\n\n")
+
+        guard let finalMessage = conversationalMessages.last else {
+            return MLXChatInput(
+                instructions: instructions.isEmpty ? nil : instructions,
+                history: [],
+                prompt: "",
+                role: .user
+            )
+        }
+
+        return MLXChatInput(
+            instructions: instructions.isEmpty ? nil : instructions,
+            history: Array(conversationalMessages.dropLast()),
+            prompt: finalMessage.content,
+            role: finalMessage.role
+        )
     }
+}
+
+private struct MLXChatInput {
+    let instructions: String?
+    let history: [Chat.Message]
+    let prompt: String
+    let role: Chat.Message.Role
 }
 
 #endif

--- a/Sources/MacParakeetLocalLLM/MLXLocalLLMRuntime.swift
+++ b/Sources/MacParakeetLocalLLM/MLXLocalLLMRuntime.swift
@@ -37,7 +37,7 @@ public actor MLXLocalLLMRuntime: LocalLLMRuntime {
 
         clearLoadedState()
 
-        modelContainer = try await loadModelContainer(
+        modelContainer = try await LLMModelFactory.shared.loadContainer(
             from: model.directory,
             using: #huggingFaceTokenizerLoader()
         )

--- a/Sources/MacParakeetLocalLLM/MLXLocalLLMRuntime.swift
+++ b/Sources/MacParakeetLocalLLM/MLXLocalLLMRuntime.swift
@@ -169,7 +169,8 @@ public actor MLXLocalLLMRuntime: LocalLLMRuntime {
     }
 
     private static func chatInput(from messages: [ChatMessage]) -> MLXChatInput {
-        let instructions = messages
+        let instructions =
+            messages
             .filter { $0.role == .system }
             .map(\.content)
             .joined(separator: "\n\n")

--- a/Tests/MacParakeetTests/Services/LLM/InProcessLLMClientTests.swift
+++ b/Tests/MacParakeetTests/Services/LLM/InProcessLLMClientTests.swift
@@ -176,12 +176,12 @@ final class InProcessLLMClientTests: XCTestCase {
 
     func testQueuedGenerationDoesNotUnloadRuntimeBetweenRequests() async throws {
         let modelDirectory = temporaryModelDirectory()
+        let firstGenerationGate = AsyncGate()
         let runtime = FakeLocalLLMRuntime(
             eventPlans: [
-                [.text("first")],
+                [.wait(firstGenerationGate), .text("first")],
                 [.text("second")],
-            ],
-            delayNanoseconds: 50_000_000
+            ]
         )
         let client = InProcessLLMClient(
             runtime: runtime,
@@ -194,18 +194,22 @@ final class InProcessLLMClientTests: XCTestCase {
             context: LLMExecutionContext(providerConfig: .inProcessLocal(model: "queued-test")),
             options: .default
         )
-        try await Task.sleep(nanoseconds: 10_000_000)
+        await runtime.waitForRequestCount(1)
         async let second = client.chatCompletion(
             messages: [ChatMessage(role: .user, content: "Second")],
             context: LLMExecutionContext(providerConfig: .inProcessLocal(model: "queued-test")),
             options: .default
         )
+        await Task.yield()
+        await firstGenerationGate.open()
 
         let firstResponse = try await first
         let secondResponse = try await second
         XCTAssertEqual([firstResponse.content, secondResponse.content], ["first", "second"])
 
-        try await Task.sleep(nanoseconds: 50_000_000)
+        try await withTimeout {
+            await runtime.waitForUnloadCount(1)
+        }
         let requestContents = await runtime.requestContents()
         let unloadCount = await runtime.unloadCallCount()
         XCTAssertEqual(requestContents, ["First", "Second"])
@@ -214,12 +218,12 @@ final class InProcessLLMClientTests: XCTestCase {
 
     func testQueuedGenerationCancellationReturnsBeforeActiveGenerationFinishes() async throws {
         let modelDirectory = temporaryModelDirectory()
+        let firstGenerationGate = AsyncGate()
         let runtime = FakeLocalLLMRuntime(
             eventPlans: [
-                [.text("first")],
+                [.wait(firstGenerationGate), .text("first")],
                 [.text("second")],
-            ],
-            delayNanoseconds: 700_000_000
+            ]
         )
         let client = InProcessLLMClient(
             runtime: runtime,
@@ -235,7 +239,7 @@ final class InProcessLLMClientTests: XCTestCase {
             )
         }
 
-        try await Task.sleep(nanoseconds: 50_000_000)
+        await runtime.waitForRequestCount(1)
         let queuedTask = Task {
             try await client.chatCompletion(
                 messages: [ChatMessage(role: .user, content: "Second")],
@@ -244,7 +248,7 @@ final class InProcessLLMClientTests: XCTestCase {
             )
         }
 
-        try await Task.sleep(nanoseconds: 50_000_000)
+        await Task.yield()
         let cancellationStart = Date()
         queuedTask.cancel()
 
@@ -257,67 +261,12 @@ final class InProcessLLMClientTests: XCTestCase {
             XCTFail("Expected CancellationError, got \(error)")
         }
 
+        await firstGenerationGate.open()
         let firstResponse = try await firstTask.value
         XCTAssertEqual(firstResponse.content, "first")
 
         let requestContents = await runtime.requestContents()
         XCTAssertEqual(requestContents, ["First"])
-    }
-
-    func testQueuedGenerationCancellationBeforeWaitRegistrationReturnsPromptly() async throws {
-        let modelDirectory = temporaryModelDirectory()
-        let signal = StateSignal<String>()
-        let runtime = CoordinatedLocalLLMRuntime(signal: signal)
-        let coordinator = LocalLLMLifetimeCoordinator(
-            beforeWaitContinuationHook: {
-                await signal.emit("before-wait-registration")
-                _ = await signal.wait(for: "release-wait-registration")
-            }
-        )
-        let client = InProcessLLMClient(
-            runtime: runtime,
-            modelDirectoryResolver: { _ in modelDirectory },
-            idleUnloadDelaySeconds: 60,
-            lifetimeCoordinator: coordinator
-        )
-
-        let firstTask = Task {
-            try await client.chatCompletion(
-                messages: [ChatMessage(role: .user, content: "First")],
-                context: LLMExecutionContext(providerConfig: .inProcessLocal(model: "queued-cancel-race-test")),
-                options: .default
-            )
-        }
-        let didStartFirstStream = await signal.wait(for: "stream-started-First")
-        XCTAssertTrue(didStartFirstStream)
-
-        let queuedTask = Task {
-            try await client.chatCompletion(
-                messages: [ChatMessage(role: .user, content: "Second")],
-                context: LLMExecutionContext(providerConfig: .inProcessLocal(model: "queued-cancel-race-test")),
-                options: .default
-            )
-        }
-        let didReachWaitRegistration = await signal.wait(for: "before-wait-registration")
-        XCTAssertTrue(didReachWaitRegistration)
-
-        queuedTask.cancel()
-        await signal.emit("release-wait-registration")
-
-        do {
-            _ = try await queuedTask.value
-            XCTFail("Expected queued local generation to throw CancellationError")
-        } catch is CancellationError {
-            // Expected.
-        } catch {
-            XCTFail("Expected CancellationError, got \(error)")
-        }
-
-        let requestContents = await runtime.requestContents()
-        XCTAssertEqual(requestContents, ["First"])
-        await signal.emit("finish-First")
-        let firstResponse = try await firstTask.value
-        XCTAssertEqual(firstResponse.content, "response-First")
     }
 
     func testStreamingYieldsRuntimeChunks() async throws {
@@ -386,61 +335,77 @@ final class InProcessLLMClientTests: XCTestCase {
             options: .default
         )
 
-        try await Task.sleep(nanoseconds: 80_000_000)
+        try await withTimeout {
+            await runtime.waitForUnloadCount(1)
+        }
         let unloadCount = await runtime.unloadCallCount()
         XCTAssertEqual(unloadCount, 1)
     }
 
-    func testStaleIdleUnloadDoesNotUnloadDuringNextGeneration() async throws {
+    func testGenerationWaitsForInProgressImmediateUnloadToDrain() async throws {
         let modelDirectory = temporaryModelDirectory()
-        let signal = StateSignal<String>()
-        let runtime = CoordinatedLocalLLMRuntime(signal: signal)
-        let coordinator = LocalLLMLifetimeCoordinator(
-            beforeIdleUnloadHook: {
-                await signal.emit("idle-unload-ready")
-                _ = await signal.wait(for: "release-idle-unload")
-            }
+        let unloadGate = AsyncGate()
+        let runtime = FakeLocalLLMRuntime(
+            eventPlans: [
+                [.text("first")],
+                [.text("second")],
+            ],
+            unloadGate: unloadGate
         )
         let client = InProcessLLMClient(
             runtime: runtime,
             modelDirectoryResolver: { _ in modelDirectory },
-            idleUnloadDelaySeconds: 0,
-            lifetimeCoordinator: coordinator
+            idleUnloadDelaySeconds: 0
         )
 
-        let firstTask = Task {
-            try await client.chatCompletion(
-                messages: [ChatMessage(role: .user, content: "First")],
-                context: LLMExecutionContext(providerConfig: .inProcessLocal(model: "idle-unload-race-test")),
-                options: .default
-            )
+        let firstResponse = try await client.chatCompletion(
+            messages: [ChatMessage(role: .user, content: "First")],
+            context: LLMExecutionContext(providerConfig: .inProcessLocal(model: "unload-drain-test")),
+            options: .default
+        )
+        XCTAssertEqual(firstResponse.content, "first")
+        try await withTimeout {
+            await runtime.waitForUnloadCount(1)
         }
-        let didStartFirstStream = await signal.wait(for: "stream-started-First")
-        XCTAssertTrue(didStartFirstStream)
-        await signal.emit("finish-First")
-        let firstResponse = try await firstTask.value
-        XCTAssertEqual(firstResponse.content, "response-First")
-        let didReachIdleUnload = await signal.wait(for: "idle-unload-ready")
-        XCTAssertTrue(didReachIdleUnload)
 
         let secondTask = Task {
             try await client.chatCompletion(
                 messages: [ChatMessage(role: .user, content: "Second")],
-                context: LLMExecutionContext(providerConfig: .inProcessLocal(model: "idle-unload-race-test")),
+                context: LLMExecutionContext(providerConfig: .inProcessLocal(model: "unload-drain-test")),
                 options: .default
             )
         }
-        let didStartSecondStream = await signal.wait(for: "stream-started-Second")
-        XCTAssertTrue(didStartSecondStream)
+        await Task.yield()
+        let requestCountWhileUnloadHeld = await runtime.requestCallCount()
+        XCTAssertEqual(requestCountWhileUnloadHeld, 1)
 
-        await signal.emit("release-idle-unload")
-        try await Task.sleep(nanoseconds: 50_000_000)
-        let didUnloadDuringActiveStream = await runtime.didUnloadDuringActiveStream()
-        XCTAssertFalse(didUnloadDuringActiveStream)
-
-        await signal.emit("finish-Second")
+        await unloadGate.open()
         let secondResponse = try await secondTask.value
-        XCTAssertEqual(secondResponse.content, "response-Second")
+        XCTAssertEqual(secondResponse.content, "second")
+        let requestContents = await runtime.requestContents()
+        XCTAssertEqual(requestContents, ["First", "Second"])
+    }
+
+    func testConnectionReleasesLeaseAndSchedulesImmediateUnload() async throws {
+        let modelDirectory = temporaryModelDirectory()
+        let runtime = FakeLocalLLMRuntime(eventPlans: [])
+        let client = InProcessLLMClient(
+            runtime: runtime,
+            modelDirectoryResolver: { _ in modelDirectory },
+            idleUnloadDelaySeconds: 60
+        )
+
+        try await client.testConnection(
+            context: LLMExecutionContext(providerConfig: .inProcessLocal(model: "probe-test"))
+        )
+
+        try await withTimeout {
+            await runtime.waitForUnloadCount(1)
+        }
+        let loadedModels = await runtime.loadedModels()
+        let unloadCount = await runtime.unloadCallCount()
+        XCTAssertEqual(loadedModels, [LocalLLMModelReference(modelName: "probe-test", directory: modelDirectory)])
+        XCTAssertEqual(unloadCount, 1)
     }
 
     private func temporaryModelDirectory() -> URL {
@@ -452,17 +417,22 @@ final class InProcessLLMClientTests: XCTestCase {
 private actor FakeLocalLLMRuntime: LocalLLMRuntime {
     private var eventPlans: [[FakeRuntimeEvent]]
     private let delayNanoseconds: UInt64
+    private let unloadGate: AsyncGate?
     private var loadCalls: [LocalLLMModelReference] = []
     private var unloadCalls = 0
     private var requests: [[ChatMessage]] = []
     private var latestMetricsValue: LLMGenerationMetrics?
+    private var requestCountWaiters: [CountWaiter] = []
+    private var unloadCountWaiters: [CountWaiter] = []
 
     init(
         eventPlans: [[FakeRuntimeEvent]],
-        delayNanoseconds: UInt64 = 0
+        delayNanoseconds: UInt64 = 0,
+        unloadGate: AsyncGate? = nil
     ) {
         self.eventPlans = eventPlans
         self.delayNanoseconds = delayNanoseconds
+        self.unloadGate = unloadGate
     }
 
     func load(model: LocalLLMModelReference) async throws {
@@ -471,6 +441,10 @@ private actor FakeLocalLLMRuntime: LocalLLMRuntime {
 
     func unload() async {
         unloadCalls += 1
+        resumeSatisfiedWaiters(&unloadCountWaiters, currentCount: unloadCalls)
+        if let unloadGate {
+            await unloadGate.wait()
+        }
     }
 
     func generateStream(
@@ -478,6 +452,7 @@ private actor FakeLocalLLMRuntime: LocalLLMRuntime {
         options: ChatCompletionOptions
     ) async throws -> AsyncThrowingStream<LocalLLMRuntimeEvent, Error> {
         requests.append(messages)
+        resumeSatisfiedWaiters(&requestCountWaiters, currentCount: requests.count)
         let events = eventPlans.isEmpty ? [.text("fallback")] : eventPlans.removeFirst()
         latestMetricsValue = events.compactMap { event in
             if case .metrics(let metrics) = event {
@@ -503,6 +478,8 @@ private actor FakeLocalLLMRuntime: LocalLLMRuntime {
                         case .failure(let error):
                             continuation.finish(throwing: error)
                             return
+                        case .wait(let gate):
+                            await gate.wait()
                         }
                     }
                     continuation.finish()
@@ -526,10 +503,37 @@ private actor FakeLocalLLMRuntime: LocalLLMRuntime {
         unloadCalls
     }
 
+    func requestCallCount() -> Int {
+        requests.count
+    }
+
+    func waitForRequestCount(_ count: Int) async {
+        guard requests.count < count else { return }
+        await withCheckedContinuation { continuation in
+            requestCountWaiters.append(CountWaiter(count: count, continuation: continuation))
+        }
+    }
+
+    func waitForUnloadCount(_ count: Int) async {
+        guard unloadCalls < count else { return }
+        await withCheckedContinuation { continuation in
+            unloadCountWaiters.append(CountWaiter(count: count, continuation: continuation))
+        }
+    }
+
     func requestContents() -> [String] {
         requests.map { request in
             request.map(\.content).joined(separator: "\n\n")
         }
+    }
+
+    private func resumeSatisfiedWaiters(
+        _ waiters: inout [CountWaiter],
+        currentCount: Int
+    ) {
+        let ready = waiters.filter { currentCount >= $0.count }
+        waiters.removeAll { currentCount >= $0.count }
+        ready.forEach { $0.continuation.resume() }
     }
 }
 
@@ -537,68 +541,54 @@ private enum FakeRuntimeEvent: Sendable {
     case text(String)
     case metrics(LLMGenerationMetrics)
     case failure(any Error & Sendable)
+    case wait(AsyncGate)
 }
 
-private actor CoordinatedLocalLLMRuntime: LocalLLMRuntime {
-    private let signal: StateSignal<String>
-    private var loadCalls: [LocalLLMModelReference] = []
-    private var unloadCalls = 0
-    private var requests: [[ChatMessage]] = []
-    private var activeStreamIDs: Set<UUID> = []
-    private var unloadedDuringActiveStream = false
+private actor AsyncGate {
+    private var isOpen = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
 
-    init(signal: StateSignal<String>) {
-        self.signal = signal
-    }
-
-    func load(model: LocalLLMModelReference) async throws {
-        loadCalls.append(model)
-    }
-
-    func unload() async {
-        unloadCalls += 1
-        if !activeStreamIDs.isEmpty {
-            unloadedDuringActiveStream = true
+    func wait() async {
+        guard !isOpen else { return }
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
         }
     }
 
-    func generateStream(
-        messages: [ChatMessage],
-        options: ChatCompletionOptions
-    ) async throws -> AsyncThrowingStream<LocalLLMRuntimeEvent, Error> {
-        requests.append(messages)
-        let requestLabel = messages.map(\.content).joined(separator: "\n\n")
-        let streamID = UUID()
-        activeStreamIDs.insert(streamID)
-        let signal = signal
+    func open() {
+        isOpen = true
+        let ready = waiters
+        waiters.removeAll()
+        ready.forEach { $0.resume() }
+    }
+}
 
-        return AsyncThrowingStream { continuation in
-            let task = Task {
-                await signal.emit("stream-started-\(requestLabel)")
-                _ = await signal.wait(for: "finish-\(requestLabel)")
-                continuation.yield(.text("response-\(requestLabel)"))
-                self.finishStream(id: streamID)
-                continuation.finish()
-            }
-            continuation.onTermination = { _ in task.cancel() }
+private struct CountWaiter {
+    let count: Int
+    let continuation: CheckedContinuation<Void, Never>
+}
+
+private enum TestTimeoutError: Error {
+    case timedOut
+}
+
+private func withTimeout<T: Sendable>(
+    nanoseconds: UInt64 = 1_000_000_000,
+    operation: @escaping @Sendable () async throws -> T
+) async throws -> T {
+    try await withThrowingTaskGroup(of: T.self) { group in
+        group.addTask {
+            try await operation()
         }
-    }
-
-    func instrumentation() async -> LLMGenerationMetrics? {
-        nil
-    }
-
-    func requestContents() -> [String] {
-        requests.map { request in
-            request.map(\.content).joined(separator: "\n\n")
+        group.addTask {
+            try await Task.sleep(nanoseconds: nanoseconds)
+            throw TestTimeoutError.timedOut
         }
-    }
 
-    func didUnloadDuringActiveStream() -> Bool {
-        unloadedDuringActiveStream
-    }
-
-    private func finishStream(id: UUID) {
-        activeStreamIDs.remove(id)
+        guard let result = try await group.next() else {
+            throw TestTimeoutError.timedOut
+        }
+        group.cancelAll()
+        return result
     }
 }

--- a/Tests/MacParakeetTests/Services/LLM/InProcessLLMClientTests.swift
+++ b/Tests/MacParakeetTests/Services/LLM/InProcessLLMClientTests.swift
@@ -10,11 +10,13 @@ final class InProcessLLMClientTests: XCTestCase {
             timeToFirstTokenMs: 25,
             peakRSSBytes: 1_000
         )
-        let runtime = FakeLocalLLMRuntime(eventPlans: [[
-            .text("hello"),
-            .text(" local"),
-            .metrics(metrics),
-        ]])
+        let runtime = FakeLocalLLMRuntime(eventPlans: [
+            [
+                .text("hello"),
+                .text(" local"),
+                .metrics(metrics),
+            ]
+        ])
         let client = InProcessLLMClient(
             runtime: runtime,
             modelDirectoryResolver: { _ in modelDirectory },
@@ -54,7 +56,7 @@ final class InProcessLLMClientTests: XCTestCase {
 
         let response = try await client.chatCompletion(
             messages: [
-                ChatMessage(role: .user, content: String(repeating: "a", count: 100)),
+                ChatMessage(role: .user, content: String(repeating: "a", count: 100))
             ],
             context: LLMExecutionContext(providerConfig: .inProcessLocal(model: "chunk-test")),
             options: .default
@@ -70,7 +72,7 @@ final class InProcessLLMClientTests: XCTestCase {
     func testChunkingBypassesMapReduceWhenSplitProducesOneChunk() async throws {
         let modelDirectory = temporaryModelDirectory()
         let runtime = FakeLocalLLMRuntime(eventPlans: [
-            [.text("single")],
+            [.text("single")]
         ])
         let client = InProcessLLMClient(
             runtime: runtime,
@@ -82,7 +84,7 @@ final class InProcessLLMClientTests: XCTestCase {
 
         let response = try await client.chatCompletion(
             messages: [
-                ChatMessage(role: .user, content: String(repeating: "a", count: 450)),
+                ChatMessage(role: .user, content: String(repeating: "a", count: 450))
             ],
             context: LLMExecutionContext(providerConfig: .inProcessLocal(model: "single-chunk-test")),
             options: .default
@@ -159,7 +161,7 @@ final class InProcessLLMClientTests: XCTestCase {
 
         _ = try await client.chatCompletion(
             messages: [
-                ChatMessage(role: .user, content: String(repeating: "a", count: 500)),
+                ChatMessage(role: .user, content: String(repeating: "a", count: 500))
             ],
             context: LLMExecutionContext(providerConfig: .inProcessLocal(model: "prompt-budget-test")),
             options: .default
@@ -275,10 +277,12 @@ final class InProcessLLMClientTests: XCTestCase {
 
     func testStreamingYieldsRuntimeChunks() async throws {
         let modelDirectory = temporaryModelDirectory()
-        let runtime = FakeLocalLLMRuntime(eventPlans: [[
-            .text("stream"),
-            .text("-chunk"),
-        ]])
+        let runtime = FakeLocalLLMRuntime(eventPlans: [
+            [
+                .text("stream"),
+                .text("-chunk"),
+            ]
+        ])
         let client = InProcessLLMClient(
             runtime: runtime,
             modelDirectoryResolver: { _ in modelDirectory },
@@ -458,12 +462,13 @@ private actor FakeLocalLLMRuntime: LocalLLMRuntime {
         requests.append(messages)
         resumeSatisfiedWaiters(&requestCountWaiters, currentCount: requests.count)
         let events = eventPlans.isEmpty ? [.text("fallback")] : eventPlans.removeFirst()
-        latestMetricsValue = events.compactMap { event in
-            if case .metrics(let metrics) = event {
-                return metrics
-            }
-            return nil
-        }.last
+        latestMetricsValue =
+            events.compactMap { event in
+                if case .metrics(let metrics) = event {
+                    return metrics
+                }
+                return nil
+            }.last
         let delayNanoseconds = delayNanoseconds
 
         return AsyncThrowingStream { continuation in

--- a/Tests/MacParakeetTests/Services/LLM/InProcessLLMClientTests.swift
+++ b/Tests/MacParakeetTests/Services/LLM/InProcessLLMClientTests.swift
@@ -194,7 +194,9 @@ final class InProcessLLMClientTests: XCTestCase {
             context: LLMExecutionContext(providerConfig: .inProcessLocal(model: "queued-test")),
             options: .default
         )
-        await runtime.waitForRequestCount(1)
+        try await withTimeout {
+            await runtime.waitForRequestCount(1)
+        }
         async let second = client.chatCompletion(
             messages: [ChatMessage(role: .user, content: "Second")],
             context: LLMExecutionContext(providerConfig: .inProcessLocal(model: "queued-test")),
@@ -239,7 +241,9 @@ final class InProcessLLMClientTests: XCTestCase {
             )
         }
 
-        await runtime.waitForRequestCount(1)
+        try await withTimeout {
+            await runtime.waitForRequestCount(1)
+        }
         let queuedTask = Task {
             try await client.chatCompletion(
                 messages: [ChatMessage(role: .user, content: "Second")],
@@ -509,15 +513,42 @@ private actor FakeLocalLLMRuntime: LocalLLMRuntime {
 
     func waitForRequestCount(_ count: Int) async {
         guard requests.count < count else { return }
-        await withCheckedContinuation { continuation in
-            requestCountWaiters.append(CountWaiter(count: count, continuation: continuation))
+        let id = UUID()
+        await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                if requests.count >= count || Task.isCancelled {
+                    continuation.resume()
+                    return
+                }
+                requestCountWaiters.append(CountWaiter(id: id, count: count, continuation: continuation))
+            }
+        } onCancel: {
+            Task { await self.resumeCancelledWaiter(id: id) }
         }
     }
 
     func waitForUnloadCount(_ count: Int) async {
         guard unloadCalls < count else { return }
-        await withCheckedContinuation { continuation in
-            unloadCountWaiters.append(CountWaiter(count: count, continuation: continuation))
+        let id = UUID()
+        await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                if unloadCalls >= count || Task.isCancelled {
+                    continuation.resume()
+                    return
+                }
+                unloadCountWaiters.append(CountWaiter(id: id, count: count, continuation: continuation))
+            }
+        } onCancel: {
+            Task { await self.resumeCancelledWaiter(id: id) }
+        }
+    }
+
+    private func resumeCancelledWaiter(id: UUID) {
+        if let index = requestCountWaiters.firstIndex(where: { $0.id == id }) {
+            requestCountWaiters.remove(at: index).continuation.resume()
+        }
+        if let index = unloadCountWaiters.firstIndex(where: { $0.id == id }) {
+            unloadCountWaiters.remove(at: index).continuation.resume()
         }
     }
 
@@ -564,6 +595,7 @@ private actor AsyncGate {
 }
 
 private struct CountWaiter {
+    let id: UUID
     let count: Int
     let continuation: CheckedContinuation<Void, Never>
 }

--- a/spec/README.md
+++ b/spec/README.md
@@ -73,12 +73,14 @@ Current `main` feature gates in `Sources/MacParakeetCore/AppFeatures.swift`:
 | `calendarEnabled` | `true` | Shipping calendar reminders/auto-start; per-user auto-start defaults off |
 | `meetingAutoStopEnabled` | `true` | `main` dogfood flag for ADR-023; per-user setting defaults off and is not yet in a tagged release |
 | `meetingCaptureReliabilityEnabled` | `true` | Default-on kill switch for ADR-025 Phase A mic-health telemetry watchdog |
+| `meetingSourceHealthUIEnabled` | `false` | Source-health model/plumbing stay compiled, but health chips/pill glyph/tile mirror are hidden after the 2026-07-04 product review |
 | `meetingActivityDetectionEnabled` | `false` | ADR-024 collectors/detector are compiled but runtime coordinator/UI remain gated |
 | `transformsEnabled` | `true` | Productized Transforms shipping surface |
 | `cohereEngineEnabled` | `true` | Settings exposes Cohere Transcribe as an opt-in, downloaded, batch-only local engine; no live preview/timestamps |
 | `meetingVadLiveChunkingEnabled` | `true` | VAD-guided meeting live-preview chunking; final post-stop transcript path unchanged |
 | `liveDictationStreamingEnabled` | `true` | Display-only live dictation preview enabled on `main`; final paste remains stop-time transcription |
 | `aiFormatterProfilesEnabled` | `false` | App-aware AI Formatter profiles are code-complete but held out of the current tagged release train |
+| `inProcessLocalLLMEnabled` | `false` | In-process local LLM (MLX) foundation seam is compiled and tested, but provider lists hide the option; the real MLX runtime links only in opt-in `MACPARAKEET_ENABLE_MLX_LOCAL_LLM=1` app builds |
 
 ## Architecture Decision Records (ADRs)
 

--- a/spec/adr/011-llm-cloud-and-local-providers.md
+++ b/spec/adr/011-llm-cloud-and-local-providers.md
@@ -54,15 +54,11 @@ The current branch supports these provider/runtime types through one shared serv
 
 ### Locked Decisions
 
-1. **No bundled LLM runtime in the accepted current architecture.** No mlx-swift-lm, no llama.cpp, no Cactus, no model downloads. Zero GPU/memory impact from LLM.
+1. **No bundled LLM runtime.** No mlx-swift-lm, no llama.cpp, no Cactus, no model downloads. Zero GPU/memory impact from LLM.
 2. **Provider-aware transport behind one shared service boundary.** Runtime choices are external providers, OpenAI-compatible endpoints, local servers, or Local CLI tools. Transport details may vary per provider.
 3. **LLM features are optional.** The app is fully functional without any provider configured. Transcription, dictation, export — all work without LLM.
 4. **No default provider.** User must explicitly choose and configure. No "sign up for our cloud" upsell.
 5. **Transcription stays local.** Audio never leaves the device. The app can remain fully local when users choose only local providers/features. Only transcript text is sent to providers/CLI tools when the user explicitly triggers an LLM feature. This distinction must be clear in the UI.
-
-### Future Reconsideration
-
-This ADR can be superseded only if local LLMs prove good enough for the actual product jobs, not merely because they are convenient to package. The likely first acceptable scope is single-transcript work: cleanup, summarization, or grounded Q&A over one transcript. Cross-meeting / whole-library analysis, agent workflows, and tool calling need materially stronger context handling, intelligence, and structured-output reliability before MacParakeet should make a first-party local model the default path. A future proposal must pass a Phase 0 eval against real transcripts and cloud baselines before adding a runtime or model download to the app.
 
 **Amendment (2026-07-04): direction confirmed, positioning fixed.** Product decision: MacParakeet will offer a first-party local model (Qwen/Gemma-class via MLX) as a dead-simple, one-click *option* aimed at non-technical and privacy-first users, while cloud/frontier providers remain the recommended quality path per surface until the local model demonstrably reaches parity there. The accepted architecture is unchanged for now — the Phase 0 eval in `plans/active/2026-06-27-on-device-local-llm.md` still gates adding any runtime or model download. Shipping bar per surface: fidelity-safe and clearly above the deterministic pipeline to *offer*; cloud parity to *recommend*. Agentic/tool-calling and whole-library analysis stay cloud-first until proven.
 


### PR DESCRIPTION
## Intent

The developer was working in the MacParakeet repo to land the first PR of an in-process local LLM foundation. They asked the agent to read and fully execute a prepared brief (journal/local-llm-pr1-brief.md) on branch feat/local-llm-mlx-foundation, starting by committing four already-modified governing plan/spec/ADR doc files as the first commit before any code. Key constraints were: keep the MLX dependency completely invisible to plain swift build/swift test/CI via opt-in build gating, respect scope fences and memory invariants from the brief, add the specified tests, and follow the required report shape. Process requirements included opening the PR early with gh against main once focused verification passed, following the personal commit-messages and pr-descriptions skills for commit and PR text, iterating only with focused swift test --filter runs, and running the full swift test suite at most once as the final gate. The work culminated in PR 734 with follow-up commits addressing review findings (unload/drain races, prompt flattening via ChatSession, runtime wiring, lease deduplication) and doc audit fixes, with CI green.

## What Changed

- `MLXLocalLLMRuntime` now tracks the live generation `Task` and drains it before `load`/`generateStream` instead of throwing "already in progress", loads models through the explicit `LLMModelFactory` with the MLXHuggingFace tokenizer loader, and builds prompts as structured `ChatSession` input (system instructions, chat history, per-message roles) rather than a flattened `System:/User:` string.
- `InProcessLLMClient` consolidates lease handling into a shared `withGenerationLease` helper, and the lifetime coordinator now uses a scheduled-unload ID plus an unload-in-progress gate so a pending or in-flight unload can never race a newly arriving generation; `AppEnvironment` wires `MLXLocalLLMRuntime` into `RoutingLLMClient` in `MACPARAKEET_HAS_MLX_LOCAL_LLM` builds.
- Dependency and test support: dropped `swift-huggingface` and pinned `swift-transformers` to `1.1.6..<1.2.0` with a comment explaining the WhisperKit (argmax-oss-swift) resolution constraint — verified in the pipeline that plain `swift package resolve` still pulls no MLX packages while the gated graph resolves and builds; `InProcessLLMClientTests` gains deterministic, cancellation-aware count-waiters with bounded timeouts covering the unload/drain races (12/12 passing, stable across a 10x stress loop), and `spec/README.md` + ADR-011 are synced with the current flag state.

## Risk Assessment

✅ Low: All round-1 findings were correctly fixed, the new coordinator/runtime concurrency logic holds up under race analysis, the MLX code path is opt-in gated so plain builds and CI are unaffected, and the only remaining findings are informational.

## Testing

Exercised the hardened lifetime coordinator via the focused InProcessLLMClientTests suite (12 tests, plus a 10x stress loop — all green and deterministic), then proved both sides of the MLX build gate end-to-end: fresh plain dependency resolution pulls zero MLX packages, while the opt-in gated graph resolves with the new swift-transformers 1.1.x pin alongside WhisperKit and the rewritten MLXLocalLLMRuntime compiles cleanly. No UI surface changed, so no screenshot applies; true on-device generation would require a multi-GB model download, so the gated compile plus the fake-runtime lifecycle tests are the deepest available end-to-end evidence. All checks passed and the worktree was restored to clean.

<details>
<summary>Evidence: InProcessLLMClientTests full transcript (12/12 passed)</summary>

```text
warning: 'fluidaudio': found 1 file(s) which are unhandled; explicitly declare them as resources or exclude from the target
    /Users/dmoon/.no-mistakes/worktrees/48a9a45229ed/01KWR8BNNMWQWFKHR3PVMAJKVV/.build/checkouts/FluidAudio/Sources/FluidAudio/ASR/Parakeet/Unified/benchmark.md
[0/1] Planning build
[1/1] Compiling plugin GenerateManual
[2/2] Compiling plugin GenerateDoccReference
Building for debugging...
[2/8] Write swift-version--58304C5D6DBC2206.txt
Build complete! (8.20s)
Test Suite 'Selected tests' started at 2026-07-04 21:59:53.228.
Test Suite 'MacParakeetPackageTests.xctest' started at 2026-07-04 21:59:53.229.
Test Suite 'InProcessLLMClientTests' started at 2026-07-04 21:59:53.229.
Test Case '-[MacParakeetTests.InProcessLLMClientTests testCancellationPropagates]' started.
Test Case '-[MacParakeetTests.InProcessLLMClientTests testCancellationPropagates]' passed (0.001 seconds).
Test Case '-[MacParakeetTests.InProcessLLMClientTests testChatCompletionLoadsRuntimeAndReturnsMetrics]' started.
Test Case '-[MacParakeetTests.InProcessLLMClientTests testChatCompletionLoadsRuntimeAndReturnsMetrics]' passed (0.000 seconds).
Test Case '-[MacParakeetTests.InProcessLLMClientTests testChunkedPromptsBoundContextAndPartialResults]' started.
Test Case '-[MacParakeetTests.InProcessLLMClientTests testChunkedPromptsBoundContextAndPartialResults]' passed (0.000 seconds).
Test Case '-[MacParakeetTests.InProcessLLMClientTests testChunkingBypassesMapReduceWhenSplitProducesOneChunk]' started.
Test Case '-[MacParakeetTests.InProcessLLMClientTests testChunkingBypassesMapReduceWhenSplitProducesOneChunk]' passed (0.000 seconds).
Test Case '-[MacParakeetTests.InProcessLLMClientTests testConnectionReleasesLeaseAndSchedulesImmediateUnload]' started.
Test Case '-[MacParakeetTests.InProcessLLMClientTests testConnectionReleasesLeaseAndSchedulesImmediateUnload]' passed (0.000 seconds).
Test Case '-[MacParakeetTests.InProcessLLMClientTests testGenerationWaitsForInProgressImmediateUnloadToDrain]' started.
Test Case '-[MacParakeetTests.InProcessLLMClientTests testGenerationWaitsForInProgressImmediateUnloadToDrain]' passed (0.000 seconds).
Test Case '-[MacParakeetTests.InProcessLLMClientTests testIdleUnloadRunsAfterGenerationDelay]' started.
Test Case '-[MacParakeetTests.InProcessLLMClientTests testIdleUnloadRunsAfterGenerationDelay]' passed (0.037 seconds).
Test Case '-[MacParakeetTests.InProcessLLMClientTests testLongInputReducePromptPreservesConversationContext]' started.
Test Case '-[MacParakeetTests.InProcessLLMClientTests testLongInputReducePromptPreservesConversationContext]' passed (0.000 seconds).
Test Case '-[MacParakeetTests.InProcessLLMClientTests testLongInputUsesMapReduceChunksBeforeFinalAnswer]' started.
Test Case '-[MacParakeetTests.InProcessLLMClientTests testLongInputUsesMapReduceChunksBeforeFinalAnswer]' passed (0.000 seconds).
Test Case '-[MacParakeetTests.InProcessLLMClientTests testQueuedGenerationCancellationReturnsBeforeActiveGenerationFinishes]' started.
Test Case '-[MacParakeetTests.InProcessLLMClientTests testQueuedGenerationCancellationReturnsBeforeActiveGenerationFinishes]' passed (0.000 seconds).
Test Case '-[MacParakeetTests.InProcessLLMClientTests testQueuedGenerationDoesNotUnloadRuntimeBetweenRequests]' started.
Test Case '-[MacParakeetTests.InProcessLLMClientTests testQueuedGenerationDoesNotUnloadRuntimeBetweenRequests]' passed (0.000 seconds).
Test Case '-[MacParakeetTests.InProcessLLMClientTests testStreamingYieldsRuntimeChunks]' started.
Test Case '-[MacParakeetTests.InProcessLLMClientTests testStreamingYieldsRuntimeChunks]' passed (0.000 seconds).
Test Suite 'InProcessLLMClientTests' passed at 2026-07-04 21:59:53.272.
	 Executed 12 tests, with 0 failures (0 unexpected) in 0.041 (0.042) seconds
Test Suite 'MacParakeetPackageTests.xctest' passed at 2026-07-04 21:59:53.272.
	 Executed 12 tests, with 0 failures (0 unexpected) in 0.041 (0.042) seconds
Test Suite 'Selected tests' passed at 2026-07-04 21:59:53.272.
	 Executed 12 tests, with 0 failures (0 unexpected) in 0.041 (0.043) seconds
◇ Test run started.
↳ Testing Library Version: 1743
↳ Target Platform: arm64e-apple-macos14.0
✔ Test run with 0 tests in 0 suites passed after 0.001 seconds.
```
</details>
<details>
<summary>Evidence: 10x stress loop of lifetime tests (no flakes/deadlocks)</summary>

```text
	 Executed 12 tests, with 0 failures (0 unexpected) in 0.020 (0.021) seconds
	 Executed 12 tests, with 0 failures (0 unexpected) in 0.019 (0.019) seconds
	 Executed 12 tests, with 0 failures (0 unexpected) in 0.068 (0.069) seconds
	 Executed 12 tests, with 0 failures (0 unexpected) in 0.046 (0.047) seconds
	 Executed 12 tests, with 0 failures (0 unexpected) in 0.076 (0.077) seconds
	 Executed 12 tests, with 0 failures (0 unexpected) in 0.093 (0.094) seconds
	 Executed 12 tests, with 0 failures (0 unexpected) in 0.040 (0.041) seconds
	 Executed 12 tests, with 0 failures (0 unexpected) in 0.036 (0.037) seconds
	 Executed 12 tests, with 0 failures (0 unexpected) in 0.064 (0.065) seconds
	 Executed 12 tests, with 0 failures (0 unexpected) in 0.022 (0.023) seconds
```
</details>
<details>
<summary>Evidence: Plain resolve: no MLX packages in default graph</summary>

```text
Working copy of https://github.com/ibireme/yyjson.git resolved at 0.12.0
Creating working copy for https://github.com/argmaxinc/argmax-oss-swift
Working copy of https://github.com/argmaxinc/argmax-oss-swift resolved at 0.18.0
Fetching binary artifact https://github.com/sparkle-project/Sparkle/releases/download/2.9.0/Sparkle-for-Swift-Package-Manager.zip from cache
Fetched https://github.com/sparkle-project/Sparkle/releases/download/2.9.0/Sparkle-for-Swift-Package-Manager.zip from cache (0.71s)
--- checkouts:
FluidAudio
GRDB.swift
Sparkle
argmax-oss-swift
swift-argument-parser
swift-asn1
swift-collections
swift-crypto
swift-jinja
swift-transformers
yyjson
```
</details>
<details>
<summary>Evidence: Gated resolve: MLX + swift-transformers 1.1.9 pin resolves with WhisperKit</summary>

```text
=== MACPARAKEET_ENABLE_MLX_LOCAL_LLM=1 swift package resolve (fresh scratch) ===
Creating working copy for https://github.com/apple/swift-numerics
Working copy of https://github.com/apple/swift-numerics resolved at 1.1.1
Creating working copy for https://github.com/argmaxinc/argmax-oss-swift
Working copy of https://github.com/argmaxinc/argmax-oss-swift resolved at 0.18.0
Creating working copy for https://github.com/apple/swift-crypto.git
Working copy of https://github.com/apple/swift-crypto.git resolved at 4.5.0
Fetching binary artifact https://github.com/sparkle-project/Sparkle/releases/download/2.9.0/Sparkle-for-Swift-Package-Manager.zip from cache
Fetched https://github.com/sparkle-project/Sparkle/releases/download/2.9.0/Sparkle-for-Swift-Package-Manager.zip from cache (0.50s)
=== gated checkouts:
FluidAudio
GRDB.swift
Sparkle
argmax-oss-swift
mlx-swift
mlx-swift-lm
swift-argument-parser
swift-asn1
swift-collections
swift-crypto
swift-jinja
swift-numerics
swift-syntax
swift-transformers
yyjson
=== resolved pins now:
argmax-oss-swift 0.18.0
fluidaudio 0.15.4
grdb.swift 7.10.0
mlx-swift 0.31.4
mlx-swift-lm 3.31.4
sparkle 2.9.0
swift-argument-parser 1.7.1
swift-asn1 1.7.0
swift-collections 1.4.1
swift-crypto 4.5.0
swift-jinja 2.3.5
swift-numerics 1.1.1
swift-syntax 603.0.2
swift-transformers 1.1.9
yyjson 0.12.0
```
</details>
<details>
<summary>Evidence: Gated build: MacParakeetLocalLLM target compiles (Build complete, 48s)</summary>

```text
[1579/1581] Compiling MacParakeetCore MeetingRecordingLockFileStore.swift
[1580/1581] Compiling MacParakeetCore MeetingRecordingMetadata.swift
[1581/1581] Compiling MacParakeetCore MeetingRecordingOutput.swift
[1582/1583] Compiling MacParakeetLocalLLM MLXLocalLLMRuntime.swift
[1583/1583] Emitting module MacParakeetLocalLLM
Build of target: 'MacParakeetLocalLLM' complete! (48.16s)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ⚠️ `Tests/MacParakeetTests/Services/LLM/InProcessLLMClientTests.swift:575` - withTimeout cannot actually time out for its primary use case. When the operation is runtime.waitForUnloadCount(...) and the expected unload never happens, the timeout child throws TestTimeoutError, but withThrowingTaskGroup must await all children before propagating, and the operation child is parked in a non-cancellable withCheckedContinuation (the CountWaiter in FakeLocalLLMRuntime is never resumed and ignores cancellation). The group therefore never returns and the test hangs until the CI job is killed instead of failing with a clear timeout. Fix by making waitForUnloadCount/waitForRequestCount cancellation-aware (withTaskCancellationHandler that removes and resumes the waiter), so group.cancelAll() actually unblocks the stuck child.
- ℹ️ `Tests/MacParakeetTests/Services/LLM/InProcessLLMClientTests.swift:197` - Bare `await runtime.waitForRequestCount(1)` calls (here and at line 242) are not wrapped in withTimeout, so if the first generation never reaches the fake runtime the test hangs indefinitely with no diagnostic. Once the waiters are made cancellation-aware (see the withTimeout finding), wrapping these in withTimeout gives a bounded failure instead of a hang.
- ℹ️ `Sources/MacParakeetLocalLLM/MLXLocalLLMRuntime.swift:16` - `generationInProgress` is now fully redundant with `generationTask != nil`: both are set together in generateStream with no suspension between them and both are cleared together in finishGeneration. Keeping two variables for one lifecycle invites drift in future edits (e.g. a new early-return path updating one but not the other). Collapsing to `generationTask != nil` (or a computed property) would remove that risk.
- ℹ️ `Package.swift:30` - swift-transformers was changed from `from: &#34;1.3.0&#34;` to the narrowed, downgraded range `&#34;1.1.6&#34; ..&lt; &#34;1.2.0&#34;` (alongside dropping swift-huggingface in favor of MLXHuggingFace&#39;s #huggingFaceTokenizerLoader). Because this dependency graph is only resolved in opt-in MACPARAKEET_ENABLE_MLX_LOCAL_LLM builds that CI never runs, an eventual conflict with mlx-swift-lm 3.31.4&#39;s own swift-transformers requirement would surface late and confusingly. A one-line comment stating why 1.1.x is required (presumably tokenizer API compatibility with mlx-swift-lm 3.31.4) would make the pin safe to maintain.

🔧 Fix: Fix test waiter deadlock, collapse redundant flag, document pin
2 infos still open:
- ℹ️ `Sources/MacParakeetLocalLLM/MLXLocalLLMRuntime.swift:27` - MLXLocalLLMRuntime.load&#39;s `if generationInProgress` branch is unreachable: drainGenerationIfNeeded() only returns once generationTask == nil, and there is no suspension point between the drain and the check, so the &#39;Cannot switch local MLX models while generation is in progress&#39; path can never execute. Either delete the branch or replace it with a comment/assert documenting the drained invariant so future readers don&#39;t treat it as live behavior.
- ℹ️ `Tests/MacParakeetTests/Services/LLM/InProcessLLMClientTests.swift:205` - testQueuedGenerationDoesNotUnloadRuntimeBetweenRequests relies on a single `await Task.yield()` to ensure the second async-let request has enqueued as a coordinator waiter before the gate opens. With idleUnloadDelaySeconds: 0, if the child task is starved, the first generation ends with no waiters, an immediate unload fires between requests, and the final XCTAssertEqual(unloadCount, 1) observes 2. Low probability (several actor hops precede first-generation completion) and much better than the removed sleeps, but the assertion is still timing-dependent rather than deterministic.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`swift test --filter InProcessLLMClientTests` — all 12 tests pass, including the new testGenerationWaitsForInProgressImmediateUnloadToDrain and testConnectionReleasesLeaseAndSchedulesImmediateUnload</code>
- <code>10x stress loop of `swift test --filter InProcessLLMClientTests` — 120/120 test executions passed with no hangs, verifying the deadlock fix in the deterministic count-waiters</code>
- <code>Fresh-scratch plain `swift package resolve` — confirmed no mlx-swift, mlx-swift-lm, or swift-huggingface checkouts; plain Package.resolved has no MLX pins (gate invariant for plain build/test/CI)</code>
- <code>`MACPARAKEET_ENABLE_MLX_LOCAL_LLM=1 swift package resolve` — gated graph resolves successfully: mlx-swift 0.31.4 + mlx-swift-lm 3.31.4 coexist with argmax-oss-swift 0.18.0 via swift-transformers 1.1.9 (validates the new 1.1.6..&lt;1.2.0 pin)</code>
- <code>`MACPARAKEET_ENABLE_MLX_LOCAL_LLM=1 swift build --target MacParakeetLocalLLM` — gated compile of the rewritten MLXLocalLLMRuntime (ChatSession-based prompting, explicit LLMModelFactory, tokenizer macro) succeeded</code>
- `Restored Package.resolved and removed gated scratch/build artifacts; worktree left clean`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
