### PR TITLE
docs: restore spec/11 content reverted by #724's dirty-checkout doc copy

### DIFF
--- a/spec/11-llm-integration.md
+++ b/spec/11-llm-integration.md
@@ -381,11 +381,14 @@ defaults before calling `LLMService`:
 The smart-default tier is user-controllable through
 `AIFormatterSmartDefaultsPolicy` (UserDefaults-backed, no schema change): a
 master "Smart defaults" switch plus per-category switches in Settings, where
-each built-in prompt is also readable before it ever runs. With the master
-switch off (or a category switched off), resolution skips that tier entirely,
-so a user who tuned the fallback prompt gets byte-for-byte pre-profiles
-behavior wherever no custom profile matches. Profile-fetch failures degrade to
-the fallback prompt and are logged via OSLog (`AIFormatter` category).
+each built-in prompt is also readable before it ever runs. The prompt preview
+remains readable when the master switch is off; the grid dims and per-category
+switches are disabled until the master switch is turned back on. With the
+master switch off (or a category switched off), resolution skips that tier
+entirely, so a user who tuned the fallback prompt gets byte-for-byte
+pre-profiles behavior wherever no custom profile matches. Profile-fetch
+failures degrade to the fallback prompt and are logged via OSLog
+(`AIFormatter` category).
 
 Saved dictation rows surface their routing provenance in History: rows
 formatted by an app or category profile (custom or smart default) show a small


### PR DESCRIPTION
## What / why

The doc half of the #724 fast-follow. #724's doc commit was built by copying four spec/plan files from a checkout whose uncommitted state sat on a stale base, which reverted newer main content when it merged.

## Forensic result (all claims from git, whitespace-insensitive diffs)

Classified every pre-#724 line missing from current main by whether the cp source's committed base (`bb3ffd953`) contained it (deliberate edit) or not (accidental revert):

| File | Verdict |
|------|---------|
| `spec/11-llm-integration.md` | **One real loss — restored here**: the master-switch prompt-preview sentences (preview stays readable when off; grid dims; per-category switches disabled) |
| `spec/adr/011` | No semantic loss; churn was rewrap. No trailing-whitespace/CRLF damage. The "accepted current architecture" wording + Future Reconsideration + 2026-07-04 amendment are the author's intended edits — kept |
| `plans/.../on-device-local-llm.md` | No loss — flagged lines (base candidate, RAM tiers, Build/CI, success criteria) were all deliberately rewritten richer (e.g. Build/CI is now "CONFIRMED BLOCKING" with the §6 mitigation) |
| `plans/.../phase0-eval.md` | No loss — GO criteria deliberately recast as GO-TO-OFFER / GO-TO-RECOMMEND, which subsumes the old parity lines |

Net: the earlier "~185 lines clobbered" estimate was rewrap noise plus content the author had already re-improved; the true regression was 3 sentences.

The code half of the fast-follow (races/wiring in #724's new runtime) is a separate PR in progress.

## Spec alignment

Docs-only, restores `spec/11` to accurately describe shipped `AIFormatterSmartDefaultsPolicy` UI behavior. No product or ADR decisions changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores missing spec text in `spec/11-llm-integration.md` that was accidentally reverted, so the doc matches the shipped `AIFormatterSmartDefaultsPolicy` behavior.

- **Bug Fixes**
  - Re-added the UI details: prompt preview remains readable when the master "Smart defaults" switch is off; the grid dims; per-category switches are disabled until the master switch is turned back on.

<sup>Written for commit 688afc4642082e3a9965fd0d0f1aaf783d386688. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/735?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

