### PR TITLE
Harden in-process local LLM lifecycle

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,7 @@ let packageDependencies: [Package.Dependency] = [
     .package(url: "https://github.com/ml-explore/mlx-swift-lm", exact: "3.31.4"),
     .package(url: "https://github.com/ml-explore/mlx-swift", exact: "0.31.4"),
     .package(url: "https://github.com/huggingface/swift-huggingface", from: "0.9.0"),
-    .package(url: "https://github.com/huggingface/swift-transformers", from: "1.3.0"),
+    .package(url: "https://github.com/huggingface/swift-transformers", .upToNextMinor(from: "1.1.6")),
 ] : [])
 
 let coreDependencies: [Target.Dependency] = [
@@ -101,7 +101,8 @@ let package = Package(
             name: "MacParakeet",
             dependencies: appDependencies,
             path: "Sources/MacParakeet",
-            resources: [.process("Resources")]
+            resources: [.process("Resources")],
+            swiftSettings: mlxLocalLLMSwiftSettings
         ),
         // macparakeet-cli — versioned public surface (semver, Sources/CLI/CHANGELOG.md).
         // Consumed by the macOS app, scripted callers, and downstream agent skills

--- a/Sources/MacParakeet/App/AppEnvironment.swift
+++ b/Sources/MacParakeet/App/AppEnvironment.swift
@@ -1,5 +1,8 @@
 import Foundation
 import MacParakeetCore
+#if MACPARAKEET_HAS_MLX_LOCAL_LLM
+import MacParakeetLocalLLM
+#endif
 import MacParakeetViewModels
 import OSLog
 
@@ -271,7 +274,7 @@ final class AppEnvironment {
             )
         }
 
-        llmClient = RoutingLLMClient()
+        llmClient = Self.makeLLMClient()
         self.llmConfigStore = llmConfigStore
         llmService = LLMService(
             client: llmClient,
@@ -435,5 +438,15 @@ final class AppEnvironment {
                 defaults.set(false, forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledForDictationKey)
             }
         }
+    }
+
+    private nonisolated static func makeLLMClient() -> RoutingLLMClient {
+        #if MACPARAKEET_HAS_MLX_LOCAL_LLM
+        return RoutingLLMClient(
+            inProcessClient: InProcessLLMClient(runtime: MLXLocalLLMRuntime())
+        )
+        #else
+        return RoutingLLMClient()
+        #endif
     }
 }

--- a/Sources/MacParakeetCore/Services/LLM/InProcessLLMClient.swift
+++ b/Sources/MacParakeetCore/Services/LLM/InProcessLLMClient.swift
@@ -16,10 +16,10 @@ public final class InProcessLLMClient: LLMClientProtocol, Sendable {
     private let chunkCharacterThreshold: Int
     private let chunkCharacterLimit: Int
     private let idleUnloadDelayNanoseconds: UInt64
-    private let lifetimeCoordinator = LocalLLMLifetimeCoordinator()
+    private let lifetimeCoordinator: LocalLLMLifetimeCoordinator
     private let logger = Logger(subsystem: "com.macparakeet.core", category: "InProcessLLMClient")
 
-    public init(
+    public convenience init(
         runtime: any LocalLLMRuntime = UnavailableLocalLLMRuntime(),
         modelDirectoryResolver: @escaping LocalLLMModelDirectoryResolver = {
             try InProcessLLMClient.environmentModelDirectory(for: $0)
@@ -28,12 +28,33 @@ public final class InProcessLLMClient: LLMClientProtocol, Sendable {
         chunkCharacterLimit: Int = InProcessLLMClient.defaultChunkCharacterLimit,
         idleUnloadDelaySeconds: TimeInterval = InProcessLLMClient.defaultIdleUnloadDelaySeconds
     ) {
+        self.init(
+            runtime: runtime,
+            modelDirectoryResolver: modelDirectoryResolver,
+            chunkCharacterThreshold: chunkCharacterThreshold,
+            chunkCharacterLimit: chunkCharacterLimit,
+            idleUnloadDelaySeconds: idleUnloadDelaySeconds,
+            lifetimeCoordinator: LocalLLMLifetimeCoordinator()
+        )
+    }
+
+    init(
+        runtime: any LocalLLMRuntime = UnavailableLocalLLMRuntime(),
+        modelDirectoryResolver: @escaping LocalLLMModelDirectoryResolver = {
+            try InProcessLLMClient.environmentModelDirectory(for: $0)
+        },
+        chunkCharacterThreshold: Int = InProcessLLMClient.defaultChunkCharacterThreshold,
+        chunkCharacterLimit: Int = InProcessLLMClient.defaultChunkCharacterLimit,
+        idleUnloadDelaySeconds: TimeInterval = InProcessLLMClient.defaultIdleUnloadDelaySeconds,
+        lifetimeCoordinator: LocalLLMLifetimeCoordinator
+    ) {
         self.runtime = runtime
         self.modelDirectoryResolver = modelDirectoryResolver
         self.chunkCharacterThreshold = max(1, chunkCharacterThreshold)
         self.chunkCharacterLimit = max(1, chunkCharacterLimit)
         let boundedDelay = max(0, idleUnloadDelaySeconds)
         self.idleUnloadDelayNanoseconds = UInt64(boundedDelay * 1_000_000_000)
+        self.lifetimeCoordinator = lifetimeCoordinator
     }
 
     public func chatCompletion(
@@ -430,22 +451,43 @@ private struct LocalLLMPromptBudget: Sendable {
     let partialResultCharacters: Int
 }
 
-private actor LocalLLMLifetimeCoordinator {
+typealias LocalLLMLifetimeHook = @Sendable () async -> Void
+
+actor LocalLLMLifetimeCoordinator {
     private var unloadTask: Task<Void, Never>?
     private var activeGenerationID: UUID?
+    private var idleUnloadGeneration: UInt64 = 0
+    private var unloadInProgress = false
     private var waitingGenerations: [WaitingGeneration] = []
+    private let beforeWaitContinuationHook: LocalLLMLifetimeHook?
+    private let beforeIdleUnloadHook: LocalLLMLifetimeHook?
+
+    init(
+        beforeWaitContinuationHook: LocalLLMLifetimeHook? = nil,
+        beforeIdleUnloadHook: LocalLLMLifetimeHook? = nil
+    ) {
+        self.beforeWaitContinuationHook = beforeWaitContinuationHook
+        self.beforeIdleUnloadHook = beforeIdleUnloadHook
+    }
 
     func beginGeneration() async throws -> LocalLLMGenerationLease {
         try Task.checkCancellation()
-        if activeGenerationID != nil {
+        if activeGenerationID != nil || unloadInProgress {
             let lease = LocalLLMGenerationLease(id: UUID())
             return try await withTaskCancellationHandler {
-                try await withCheckedThrowingContinuation { (
+                if let beforeWaitContinuationHook {
+                    await beforeWaitContinuationHook()
+                }
+                return try await withCheckedThrowingContinuation { (
                     continuation: CheckedContinuation<LocalLLMGenerationLease, Error>
                 ) in
-                    waitingGenerations.append(
-                        WaitingGeneration(lease: lease, continuation: continuation)
-                    )
+                    if Task.isCancelled {
+                        continuation.resume(throwing: CancellationError())
+                    } else {
+                        waitingGenerations.append(
+                            WaitingGeneration(lease: lease, continuation: continuation)
+                        )
+                    }
                 }
             } onCancel: {
                 Task {
@@ -467,10 +509,7 @@ private actor LocalLLMLifetimeCoordinator {
     ) {
         guard activeGenerationID == lease.id else { return }
 
-        if !waitingGenerations.isEmpty {
-            let next = waitingGenerations.removeFirst()
-            activeGenerationID = next.lease.id
-            next.continuation.resume(returning: next.lease)
+        if resumeNextWaitingGeneration() {
             return
         }
 
@@ -486,30 +525,81 @@ private actor LocalLLMLifetimeCoordinator {
     }
 
     private func cancelPendingUnload() {
+        idleUnloadGeneration &+= 1
         unloadTask?.cancel()
         unloadTask = nil
     }
 
     private func scheduleUnload(runtime: any LocalLLMRuntime, delayNanoseconds: UInt64) {
-        unloadTask?.cancel()
+        cancelPendingUnload()
+        let generation = idleUnloadGeneration
         unloadTask = Task {
             guard delayNanoseconds > 0 else {
-                await runtime.unload()
+                if let beforeIdleUnloadHook {
+                    await beforeIdleUnloadHook()
+                }
+                await self.unloadIfStillIdle(
+                    generation: generation,
+                    runtime: runtime
+                )
                 return
             }
 
             do {
                 try await Task.sleep(nanoseconds: delayNanoseconds)
                 try Task.checkCancellation()
-                await runtime.unload()
+                if let beforeIdleUnloadHook {
+                    await beforeIdleUnloadHook()
+                }
+                await self.unloadIfStillIdle(
+                    generation: generation,
+                    runtime: runtime
+                )
             } catch {
                 return
             }
         }
     }
+
+    private func unloadIfStillIdle(
+        generation: UInt64,
+        runtime: any LocalLLMRuntime
+    ) async {
+        guard generation == idleUnloadGeneration,
+              activeGenerationID == nil,
+              waitingGenerations.isEmpty,
+              !unloadInProgress else {
+            return
+        }
+
+        unloadTask = nil
+        unloadInProgress = true
+        await runtime.unload()
+        finishIdleUnload(generation: generation)
+    }
+
+    private func finishIdleUnload(generation: UInt64) {
+        guard unloadInProgress else { return }
+        unloadInProgress = false
+
+        if generation == idleUnloadGeneration {
+            unloadTask = nil
+        }
+
+        _ = resumeNextWaitingGeneration()
+    }
+
+    private func resumeNextWaitingGeneration() -> Bool {
+        guard !waitingGenerations.isEmpty else { return false }
+
+        let next = waitingGenerations.removeFirst()
+        activeGenerationID = next.lease.id
+        next.continuation.resume(returning: next.lease)
+        return true
+    }
 }
 
-private struct LocalLLMGenerationLease: Sendable {
+struct LocalLLMGenerationLease: Sendable {
     let id: UUID
 }
 

--- a/Sources/MacParakeetLocalLLM/MLXLocalLLMRuntime.swift
+++ b/Sources/MacParakeetLocalLLM/MLXLocalLLMRuntime.swift
@@ -4,6 +4,7 @@ import MLXHuggingFace
 import MLXLLM
 import MLXLMCommon
 import OSLog
+import Tokenizers
 
 #if MACPARAKEET_HAS_MLX_LOCAL_LLM
 
@@ -32,7 +33,10 @@ public actor MLXLocalLLMRuntime: LocalLLMRuntime {
 
         clearLoadedState()
 
-        modelContainer = try await loadModelContainer(from: model.directory)
+        modelContainer = try await loadModelContainer(
+            from: model.directory,
+            using: #huggingFaceTokenizerLoader()
+        )
         loadedModel = model
         unloadAfterGeneration = false
         logger.info("Loaded local MLX model \(model.modelName, privacy: .public)")
@@ -94,22 +98,21 @@ public actor MLXLocalLLMRuntime: LocalLLMRuntime {
             }
 
             try Task.checkCancellation()
-            let session = ChatSession(modelContainer)
-            let prompt = Self.prompt(from: messages)
-            let parameters = GenerateParameters(
-                temperature: Float(options.temperature ?? 0.2),
-                maxTokens: options.maxTokens,
-                kvBits: 4
+            let session = ChatSession(
+                modelContainer,
+                generateParameters: GenerateParameters(
+                    maxTokens: options.maxTokens,
+                    kvBits: 4,
+                    temperature: Float(options.temperature ?? 0.2)
+                )
             )
+            let prompt = Self.prompt(from: messages)
 
             let start = Date()
             var firstTokenDate: Date?
             var tokenCount = 0
 
-            for try await token in session.streamResponse(
-                to: prompt,
-                generateParameters: parameters
-            ) {
+            for try await token in session.streamResponse(to: prompt) {
                 try Task.checkCancellation()
                 if firstTokenDate == nil {
                     firstTokenDate = Date()

--- a/Tests/MacParakeetTests/Services/LLM/InProcessLLMClientTests.swift
+++ b/Tests/MacParakeetTests/Services/LLM/InProcessLLMClientTests.swift
@@ -264,6 +264,62 @@ final class InProcessLLMClientTests: XCTestCase {
         XCTAssertEqual(requestContents, ["First"])
     }
 
+    func testQueuedGenerationCancellationBeforeWaitRegistrationReturnsPromptly() async throws {
+        let modelDirectory = temporaryModelDirectory()
+        let signal = StateSignal<String>()
+        let runtime = CoordinatedLocalLLMRuntime(signal: signal)
+        let coordinator = LocalLLMLifetimeCoordinator(
+            beforeWaitContinuationHook: {
+                await signal.emit("before-wait-registration")
+                _ = await signal.wait(for: "release-wait-registration")
+            }
+        )
+        let client = InProcessLLMClient(
+            runtime: runtime,
+            modelDirectoryResolver: { _ in modelDirectory },
+            idleUnloadDelaySeconds: 60,
+            lifetimeCoordinator: coordinator
+        )
+
+        let firstTask = Task {
+            try await client.chatCompletion(
+                messages: [ChatMessage(role: .user, content: "First")],
+                context: LLMExecutionContext(providerConfig: .inProcessLocal(model: "queued-cancel-race-test")),
+                options: .default
+            )
+        }
+        let didStartFirstStream = await signal.wait(for: "stream-started-First")
+        XCTAssertTrue(didStartFirstStream)
+
+        let queuedTask = Task {
+            try await client.chatCompletion(
+                messages: [ChatMessage(role: .user, content: "Second")],
+                context: LLMExecutionContext(providerConfig: .inProcessLocal(model: "queued-cancel-race-test")),
+                options: .default
+            )
+        }
+        let didReachWaitRegistration = await signal.wait(for: "before-wait-registration")
+        XCTAssertTrue(didReachWaitRegistration)
+
+        queuedTask.cancel()
+        await signal.emit("release-wait-registration")
+
+        do {
+            _ = try await queuedTask.value
+            XCTFail("Expected queued local generation to throw CancellationError")
+        } catch is CancellationError {
+            // Expected.
+        } catch {
+            XCTFail("Expected CancellationError, got \(error)")
+        }
+
+        let requestContents = await runtime.requestContents()
+        XCTAssertEqual(requestContents, ["First"])
+        await signal.emit("finish-First")
+        let firstResponse = try await firstTask.value
+        XCTAssertEqual(firstResponse.content, "response-First")
+    }
+
     func testStreamingYieldsRuntimeChunks() async throws {
         let modelDirectory = temporaryModelDirectory()
         let runtime = FakeLocalLLMRuntime(eventPlans: [[
@@ -333,6 +389,58 @@ final class InProcessLLMClientTests: XCTestCase {
         try await Task.sleep(nanoseconds: 80_000_000)
         let unloadCount = await runtime.unloadCallCount()
         XCTAssertEqual(unloadCount, 1)
+    }
+
+    func testStaleIdleUnloadDoesNotUnloadDuringNextGeneration() async throws {
+        let modelDirectory = temporaryModelDirectory()
+        let signal = StateSignal<String>()
+        let runtime = CoordinatedLocalLLMRuntime(signal: signal)
+        let coordinator = LocalLLMLifetimeCoordinator(
+            beforeIdleUnloadHook: {
+                await signal.emit("idle-unload-ready")
+                _ = await signal.wait(for: "release-idle-unload")
+            }
+        )
+        let client = InProcessLLMClient(
+            runtime: runtime,
+            modelDirectoryResolver: { _ in modelDirectory },
+            idleUnloadDelaySeconds: 0,
+            lifetimeCoordinator: coordinator
+        )
+
+        let firstTask = Task {
+            try await client.chatCompletion(
+                messages: [ChatMessage(role: .user, content: "First")],
+                context: LLMExecutionContext(providerConfig: .inProcessLocal(model: "idle-unload-race-test")),
+                options: .default
+            )
+        }
+        let didStartFirstStream = await signal.wait(for: "stream-started-First")
+        XCTAssertTrue(didStartFirstStream)
+        await signal.emit("finish-First")
+        let firstResponse = try await firstTask.value
+        XCTAssertEqual(firstResponse.content, "response-First")
+        let didReachIdleUnload = await signal.wait(for: "idle-unload-ready")
+        XCTAssertTrue(didReachIdleUnload)
+
+        let secondTask = Task {
+            try await client.chatCompletion(
+                messages: [ChatMessage(role: .user, content: "Second")],
+                context: LLMExecutionContext(providerConfig: .inProcessLocal(model: "idle-unload-race-test")),
+                options: .default
+            )
+        }
+        let didStartSecondStream = await signal.wait(for: "stream-started-Second")
+        XCTAssertTrue(didStartSecondStream)
+
+        await signal.emit("release-idle-unload")
+        try await Task.sleep(nanoseconds: 50_000_000)
+        let didUnloadDuringActiveStream = await runtime.didUnloadDuringActiveStream()
+        XCTAssertFalse(didUnloadDuringActiveStream)
+
+        await signal.emit("finish-Second")
+        let secondResponse = try await secondTask.value
+        XCTAssertEqual(secondResponse.content, "response-Second")
     }
 
     private func temporaryModelDirectory() -> URL {
@@ -429,4 +537,68 @@ private enum FakeRuntimeEvent: Sendable {
     case text(String)
     case metrics(LLMGenerationMetrics)
     case failure(any Error & Sendable)
+}
+
+private actor CoordinatedLocalLLMRuntime: LocalLLMRuntime {
+    private let signal: StateSignal<String>
+    private var loadCalls: [LocalLLMModelReference] = []
+    private var unloadCalls = 0
+    private var requests: [[ChatMessage]] = []
+    private var activeStreamIDs: Set<UUID> = []
+    private var unloadedDuringActiveStream = false
+
+    init(signal: StateSignal<String>) {
+        self.signal = signal
+    }
+
+    func load(model: LocalLLMModelReference) async throws {
+        loadCalls.append(model)
+    }
+
+    func unload() async {
+        unloadCalls += 1
+        if !activeStreamIDs.isEmpty {
+            unloadedDuringActiveStream = true
+        }
+    }
+
+    func generateStream(
+        messages: [ChatMessage],
+        options: ChatCompletionOptions
+    ) async throws -> AsyncThrowingStream<LocalLLMRuntimeEvent, Error> {
+        requests.append(messages)
+        let requestLabel = messages.map(\.content).joined(separator: "\n\n")
+        let streamID = UUID()
+        activeStreamIDs.insert(streamID)
+        let signal = signal
+
+        return AsyncThrowingStream { continuation in
+            let task = Task {
+                await signal.emit("stream-started-\(requestLabel)")
+                _ = await signal.wait(for: "finish-\(requestLabel)")
+                continuation.yield(.text("response-\(requestLabel)"))
+                self.finishStream(id: streamID)
+                continuation.finish()
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+
+    func instrumentation() async -> LLMGenerationMetrics? {
+        nil
+    }
+
+    func requestContents() -> [String] {
+        requests.map { request in
+            request.map(\.content).joined(separator: "\n\n")
+        }
+    }
+
+    func didUnloadDuringActiveStream() -> Bool {
+        unloadedDuringActiveStream
+    }
+
+    private func finishStream(id: UUID) {
+        activeStreamIDs.remove(id)
+    }
 }


### PR DESCRIPTION
## Summary

This is the code half of the #724 fast-follow. It hardens the in-process local LLM lifecycle and fixes confirmed gated-build wiring problems without touching `spec/`, `plans/`, or `docs/`.

## Findings

### 1. Queued generation cancellation before waiter registration

Verdict: **CONFIRMED-FIXED**

Interleaving:
1. Generation A owns `activeGenerationID`.
2. Generation B enters `beginGeneration()`, sees the active generation, and chooses the waiting path.
3. B is cancelled before its continuation is appended to `waitingGenerations`.
4. The cancellation handler runs `cancelWaitingGeneration`, finds no waiter yet, and returns.
5. The original path appends B anyway, so a cancelled request can later acquire the runtime and run.

Fix: `beginGeneration()` now checks `Task.isCancelled` inside actor-isolated continuation registration before appending the waiter.

Evidence:
- Fix: `Sources/MacParakeetCore/Services/LLM/InProcessLLMClient.swift:473`
- Test: `Tests/MacParakeetTests/Services/LLM/InProcessLLMClientTests.swift:267`

### 2. Stale idle-unload task racing a new generation

Verdict: **CONFIRMED-FIXED**

Interleaving:
1. Generation A ends and schedules an idle unload task.
2. The unload task wakes and is about to call `runtime.unload()`.
3. Generation B starts, cancels the pending unload, and begins generation.
4. The stale task can still reach `runtime.unload()` after cancellation, unloading during B's active stream.

Fix: idle unloads now carry a generation token and re-enter the coordinator actor to validate that the token is current, no generation is active, no waiter exists, and no unload is already in progress. New generations wait behind an in-progress unload instead of racing it.

Evidence:
- Fix: `Sources/MacParakeetCore/Services/LLM/InProcessLLMClient.swift:527`
- Test: `Tests/MacParakeetTests/Services/LLM/InProcessLLMClientTests.swift:394`

### 3. Gated app linked local LLM target but still routed to unavailable runtime

Verdict: **CONFIRMED-FIXED**

Interleaving:
1. `MACPARAKEET_ENABLE_MLX_LOCAL_LLM=1` adds `MacParakeetLocalLLM` to the app dependencies.
2. The app target did not receive `MACPARAKEET_HAS_MLX_LOCAL_LLM`, so app code could not conditionally import or construct `MLXLocalLLMRuntime`.
3. `AppEnvironment` still constructed `RoutingLLMClient()` with the default `InProcessLLMClient()` backed by `UnavailableLocalLLMRuntime`.
4. Selecting `.inProcessLocal` in a gated app would route to the unavailable runtime despite the MLX target being linked.

Fix: the app target now receives the MLX define, and `AppEnvironment` injects `InProcessLLMClient(runtime: MLXLocalLLMRuntime())` only in gated builds.

Evidence:
- Fix: `Package.swift:47`, `Package.swift:100`, `Sources/MacParakeet/App/AppEnvironment.swift:1`, `Sources/MacParakeet/App/AppEnvironment.swift:443`
- Build: `MACPARAKEET_ENABLE_MLX_LOCAL_LLM=1 swift build --target MacParakeet`

### 4. Gated MLX package/runtime surface did not compile

Verdict: **CONFIRMED-FIXED**

Interleaving:
1. Enabling the MLX gate required root `swift-transformers` `1.3.0..<2.0.0`.
2. The existing Argmax dependency requires `swift-transformers` `1.1.6..<1.2.0`, so SwiftPM dependency resolution failed before compiling the gated target.
3. After resolution, `MLXLocalLLMRuntime` also used outdated `mlx-swift-lm` 3.31.4 APIs: missing tokenizer loader, old `GenerateParameters` label order, and obsolete `streamResponse(... generateParameters:)`.

Fix: the tokenizer dependency now aligns with Argmax's 1.1.x range, `Tokenizers` is imported for the Hugging Face tokenizer macro, and the runtime uses the current `loadModelContainer` / `ChatSession` APIs.

Evidence:
- Fix: `Package.swift:31`, `Package.swift:77`, `Sources/MacParakeetLocalLLM/MLXLocalLLMRuntime.swift:7`, `Sources/MacParakeetLocalLLM/MLXLocalLLMRuntime.swift:36`, `Sources/MacParakeetLocalLLM/MLXLocalLLMRuntime.swift:101`
- Build: `MACPARAKEET_ENABLE_MLX_LOCAL_LLM=1 swift build --target MacParakeet`

## Investigated Not A Bug

- `RoutingLLMClient` already routes `.inProcessLocal` to its injected in-process client (`Sources/MacParakeetCore/Services/LLM/RoutingLLMClient.swift:45`).
- Inline CLI intentionally rejects `.inProcessLocal` for now instead of silently routing it through incomplete inline config (`Sources/CLI/Commands/LLMInlineConfig.swift:113`).
- The settings provider list intentionally hides `.inProcessLocal` while the feature flag is off (`Sources/MacParakeetCore/Models/LLMProvider.swift:221`).

## Verification

- `swift test --filter InProcessLLMClientTests` - 12 tests, 0 failures
- `swift test --filter RoutingLLMClientTests` - 3 tests, 0 failures
- `swift test --filter LLMServiceTests` - 63 tests, 0 failures
- `swift test --filter LLMClientTests` - 104 matched tests, 0 failures
- `swift test --filter LLMConfigStoreTests` - 12 tests, 0 failures
- `swift test --filter LLMProviderDescriptorTests` - 6 tests, 0 failures
- `MACPARAKEET_ENABLE_MLX_LOCAL_LLM=1 swift build --target MacParakeet` - passed
- `git diff --check` - clean
- `swift test` - 4,586 XCTest tests, 16 skipped, 0 failures; 17 Swift Testing tests, 0 failures


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the in‑process local LLM lifecycle to stop cancelled queued requests from running and to prevent idle unloads from racing active generations. Also fixed MLX-gated app wiring so gated builds route `.inProcessLocal` to `MLXLocalLLMRuntime`.

- **Bug Fixes**
  - Cancelled queued generations no longer get enqueued; cancellation is checked inside the actor before waiter registration.
  - Idle unloads use a generation token and actor-side revalidation; stale tasks can’t unload during a new stream, and new generations queue behind an in‑progress unload.
  - Gated app now receives `MACPARAKEET_HAS_MLX_LOCAL_LLM` and injects `InProcessLLMClient(runtime: MLXLocalLLMRuntime())` when the gate is enabled.

- **Dependencies**
  - Aligned `swift-transformers` to `1.1.x` to match `Argmax`; added `Tokenizers` for the Hugging Face tokenizer macro.
  - Updated `MLXLocalLLMRuntime` to current `mlx-swift-lm` 3.31.4 APIs (`loadModelContainer(... using:)`, `ChatSession` with `GenerateParameters`, new `streamResponse`).

<sup>Written for commit 2ce7ad9d72d867002f189059ff17babe0a258618. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/736?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

