### PR TITLE
Stabilize no-speech load caption test

### DIFF
--- a/Tests/MacParakeetTests/DictationFlow/DictationFlowCoordinatorLoadCaptionTests.swift
+++ b/Tests/MacParakeetTests/DictationFlow/DictationFlowCoordinatorLoadCaptionTests.swift
@@ -151,19 +151,27 @@ final class DictationFlowCoordinatorLoadCaptionTests: XCTestCase {
     }
 
     func testNoSpeechDismissesCaptionWithSnakeCaseOutcome() async throws {
+        let transcribeGate = AsyncGate()
         let harness = try makeHarness(
             isReady: false,
-            transcribeDelayMs: 140,
-            transcribeError: DictationServiceError.emptyTranscript
+            transcribeDelayMs: 0,
+            transcribeError: DictationServiceError.emptyTranscript,
+            transcribeGate: transcribeGate
         )
 
         try await harness.startAndStop()
-        let shown = await harness.captionSignal.wait(for: .preparing)
+        let shown = await harness.captionSignal.wait(for: .preparing, timeout: .seconds(3))
         XCTAssertTrue(shown)
-        let cleared = await waitUntil { harness.coordinator.processingLoadCaptionForTesting == nil }
+        await transcribeGate.release()
+        let cleared = await waitUntil(timeoutMs: 3_000) {
+            harness.coordinator.processingLoadCaptionForTesting == nil
+        }
         XCTAssertTrue(cleared)
 
-        XCTAssertTrue(harness.telemetry.snapshot().containsCaptionDuration(outcome: "no_speech"))
+        let recordedNoSpeech = await waitUntil(timeoutMs: 3_000) {
+            harness.telemetry.snapshot().containsCaptionDuration(outcome: "no_speech")
+        }
+        XCTAssertTrue(recordedNoSpeech)
     }
 
     func testPasteFailureDismissesCaptionWithFailureOutcome() async throws {
@@ -319,7 +327,8 @@ final class DictationFlowCoordinatorLoadCaptionTests: XCTestCase {
         processingMode: Dictation.ProcessingMode = .raw,
         dictationInsertionStyle: DictationInsertionStyle = .sentence,
         engine: SpeechEnginePreference = .parakeet,
-        timing: DictationProcessingLoadCaptionTiming? = nil
+        timing: DictationProcessingLoadCaptionTiming? = nil,
+        transcribeGate: AsyncGate? = nil
     ) throws -> Harness {
         let telemetry = LoadCaptionTelemetrySpy()
         Telemetry.configure(telemetry)
@@ -331,7 +340,8 @@ final class DictationFlowCoordinatorLoadCaptionTests: XCTestCase {
             ready: isReady,
             transcribeDelayMs: transcribeDelayMs,
             transcribeText: transcribeText,
-            transcribeError: transcribeError
+            transcribeError: transcribeError,
+            transcribeGate: transcribeGate
         )
         let repo = DictationRepository(dbQueue: dbManager.dbQueue)
         let preferencesDefaults = UserDefaults(suiteName: "load-caption-\(UUID().uuidString)")!
@@ -478,12 +488,20 @@ private actor DelayedSTTClient: STTClientProtocol, DictationSTTReadinessChecking
     private var transcribeDelayMs: UInt64
     private var transcribeText: String
     private var transcribeError: Error?
+    private let transcribeGate: AsyncGate?
 
-    init(ready: Bool, transcribeDelayMs: UInt64, transcribeText: String, transcribeError: Error?) {
+    init(
+        ready: Bool,
+        transcribeDelayMs: UInt64,
+        transcribeText: String,
+        transcribeError: Error?,
+        transcribeGate: AsyncGate?
+    ) {
         self.ready = ready
         self.transcribeDelayMs = transcribeDelayMs
         self.transcribeText = transcribeText
         self.transcribeError = transcribeError
+        self.transcribeGate = transcribeGate
     }
 
     func setReady(_ ready: Bool) {
@@ -499,6 +517,9 @@ private actor DelayedSTTClient: STTClientProtocol, DictationSTTReadinessChecking
         job: STTJobKind,
         onProgress: (@Sendable (Int, Int) -> Void)?
     ) async throws -> STTResult {
+        if let transcribeGate {
+            try await transcribeGate.wait()
+        }
         if transcribeDelayMs > 0 {
             try await Task.sleep(for: .milliseconds(Int(transcribeDelayMs)))
         }
@@ -547,6 +568,48 @@ private actor DelayedSTTClient: STTClientProtocol, DictationSTTReadinessChecking
     }
 
     func shutdown() async {}
+}
+
+private actor AsyncGate {
+    private struct Waiter {
+        let id: UUID
+        let continuation: CheckedContinuation<Void, Error>
+    }
+
+    private var isReleased = false
+    private var continuations: [Waiter] = []
+
+    func wait() async throws {
+        if isReleased { return }
+        let id = UUID()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                if isReleased {
+                    continuation.resume()
+                } else {
+                    continuations.append(Waiter(id: id, continuation: continuation))
+                }
+            }
+        } onCancel: {
+            Task {
+                await self.cancelWaiter(id: id)
+            }
+        }
+    }
+
+    func release() {
+        guard !isReleased else { return }
+        isReleased = true
+        let pending = continuations
+        continuations.removeAll()
+        pending.forEach { $0.continuation.resume() }
+    }
+
+    private func cancelWaiter(id: UUID) {
+        guard let index = continuations.firstIndex(where: { $0.id == id }) else { return }
+        let waiter = continuations.remove(at: index)
+        waiter.continuation.resume(throwing: CancellationError())
+    }
 }
 
 private final class LoadCaptionTelemetrySpy: TelemetryServiceProtocol, @unchecked Sendable {


### PR DESCRIPTION
## Summary
- make the no-speech load-caption test deterministic by gating the mock STT result until the caption is observed
- wait for the no-speech duration telemetry instead of reading the spy synchronously

## Why
Exact-head release CI on `949d21e860a514d5bd46ed2d3358822b6beeff97` failed in `DictationFlowCoordinatorLoadCaptionTests.testNoSpeechDismissesCaptionWithSnakeCaseOutcome`. The product path passed locally in isolation; the failure was a test race between a short mock transcription delay and the caption grace timer under hosted `swift test --parallel`.

## Verification
- `swift test --filter DictationFlowCoordinatorLoadCaptionTests/testNoSpeechDismissesCaptionWithSnakeCaseOutcome`
- `swift test --parallel --filter DictationFlowCoordinatorLoadCaptionTests`
- `swift test --parallel`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the no-speech load-caption test by blocking mock STT until the `.preparing` caption is shown and waiting for telemetry, removing the parallel CI race. The test is now deterministic and fixes the flake in `testNoSpeechDismissesCaptionWithSnakeCaseOutcome`.

- **Bug Fixes**
  - Added `AsyncGate` with cancellation; gate is released after `.preparing` is observed so STT returns at the right time.
  - `DelayedSTTClient` and the harness accept an optional `transcribeGate` and wait on it before any delay.
  - Replaced immediate checks with 3s timeouts: wait for `.preparing`, wait for coordinator to clear via `waitUntil`, and wait until `"no_speech"` telemetry is recorded.

<sup>Written for commit fff19a5849cdfb6773be22ee65561df821762d22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/737?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved reliability of caption-flow coverage by making speech-to-text timing deterministic.
  * Added a one-time gating mechanism to precisely control when delayed speech-to-text proceeds during the dictation flow.
  * Updated the test harness to support the new gate and strengthened timeout-based assertions for caption loading, completion, and the final no-speech outcome.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->