### PR TITLE
Add dev-gated local AI setup flow

### DIFF
--- a/Sources/MacParakeet/Views/Settings/LLMSettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/LLMSettingsView.swift
@@ -58,8 +58,8 @@ struct LLMSettingsView: View {
                                     ? "Your key is stored securely in the macOS Keychain."
                                     : "Optional. Leave blank for servers that do not require authentication."
                             )
-                                .font(DesignSystem.Typography.caption)
-                                .foregroundStyle(.secondary)
+                            .font(DesignSystem.Typography.caption)
+                            .foregroundStyle(.secondary)
                         }
                         Spacer(minLength: DesignSystem.Spacing.md)
                         SecureField(viewModel.apiKeyPlaceholder, text: $viewModel.apiKeyInput)
@@ -327,7 +327,9 @@ struct LLMSettingsView: View {
             Button {
                 manager.startEnableLocalAI()
             } label: {
-                Label(localAIPrimaryButtonTitle, systemImage: manager.isModelDownloaded ? "checkmark.circle" : "arrow.down.circle")
+                Label(
+                    localAIPrimaryButtonTitle,
+                    systemImage: manager.isModelDownloaded ? "checkmark.circle" : "arrow.down.circle")
             }
             .parakeetAction(.secondary)
             .disabled(!manager.meetsMemoryRequirement || manager.isWorking)
@@ -352,19 +354,23 @@ struct LLMSettingsView: View {
                     .font(.system(size: 11, weight: .semibold))
                     .foregroundStyle(DesignSystem.Colors.textSecondary)
                     .accessibilityHidden(true)
-                Text("Local AI needs \(manager.minimumMemoryDescription). Use a cloud provider above or a local server such as LM Studio/Ollama.")
-                    .font(DesignSystem.Typography.caption)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
+                Text(
+                    "Local AI needs \(manager.minimumMemoryDescription). Use a cloud provider above or a local server such as LM Studio/Ollama."
+                )
+                .font(DesignSystem.Typography.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
         } else {
             switch manager.state {
             case .setUpNeeded:
-                Text("Downloads are never automatic. Enable local AI only on a dev-enabled build when you want to test the on-device option.")
-                    .font(DesignSystem.Typography.caption)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
+                Text(
+                    "Downloads are never automatic. Enable local AI only on a dev-enabled build when you want to test the on-device option."
+                )
+                .font(DesignSystem.Typography.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
             case .downloading(let progress):
                 VStack(alignment: .leading, spacing: 4) {
                     ProgressView(value: progress)
@@ -387,16 +393,22 @@ struct LLMSettingsView: View {
                         .font(.system(size: 12, weight: .semibold))
                         .foregroundStyle(DesignSystem.Colors.successGreen)
                         .accessibilityHidden(true)
-                    Text(manager.isLocalAISelected ? "Local AI is downloaded and selected." : "Local AI is downloaded. The current AI choice can still stay on a cloud or BYO provider.")
-                        .font(DesignSystem.Typography.caption)
-                        .foregroundStyle(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
+                    Text(
+                        manager.isLocalAISelected
+                            ? "Local AI is downloaded and selected."
+                            : "Local AI is downloaded. The current AI choice can still stay on a cloud or BYO provider."
+                    )
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
                 }
             case .failed(let reason, let recoverable):
                 HStack(alignment: .top, spacing: 6) {
                     Image(systemName: recoverable ? "exclamationmark.triangle.fill" : "info.circle.fill")
                         .font(.system(size: 11, weight: .semibold))
-                        .foregroundStyle(recoverable ? DesignSystem.Colors.warningAmber : DesignSystem.Colors.textSecondary)
+                        .foregroundStyle(
+                            recoverable ? DesignSystem.Colors.warningAmber : DesignSystem.Colors.textSecondary
+                        )
                         .accessibilityHidden(true)
                     Text(reason)
                         .font(DesignSystem.Typography.caption)
@@ -480,7 +492,8 @@ struct LLMSettingsView: View {
     private func setupStatusCopy(for status: LLMSettingsViewModel.AISetupStatus) -> String {
         switch status {
         case .setUpNeeded:
-            return "Choose how MacParakeet should run AI features. Transcription, dictation, and meeting recording still work without this."
+            return
+                "Choose how MacParakeet should run AI features. Transcription, dictation, and meeting recording still work without this."
         case .ready(let displayName):
             return "Ready: using \(displayName)."
         case .cannotConnect(let displayName, let message):
@@ -583,10 +596,12 @@ struct LLMSettingsView: View {
                 Image(systemName: "info.circle.fill")
                     .font(.system(size: 11, weight: .semibold))
                     .foregroundStyle(DesignSystem.Colors.textSecondary)
-                Text("When included, speaker labels are a rough reference from audio-source separation and diarization, not a high-accuracy identification of who said each line.")
-                    .font(DesignSystem.Typography.caption)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
+                Text(
+                    "When included, speaker labels are a rough reference from audio-source separation and diarization, not a high-accuracy identification of who said each line."
+                )
+                .font(DesignSystem.Typography.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
         }
@@ -598,10 +613,12 @@ struct LLMSettingsView: View {
             VStack(alignment: .leading, spacing: 3) {
                 Text("Meeting titles")
                     .font(DesignSystem.Typography.body.weight(.semibold))
-                Text("Use the saved AI provider to replace timestamp-only meeting names with short topic titles after transcription.")
-                    .font(DesignSystem.Typography.caption)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
+                Text(
+                    "Use the saved AI provider to replace timestamp-only meeting names with short topic titles after transcription."
+                )
+                .font(DesignSystem.Typography.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
             }
 
             Spacer(minLength: DesignSystem.Spacing.md)
@@ -639,10 +656,12 @@ struct LLMSettingsView: View {
                                         .fill(DesignSystem.Colors.accent.opacity(0.12))
                                 )
                         }
-                        Text("Uses the saved LLM provider after cleanup for file and meeting transcripts. Dictation use can add latency.")
-                            .font(DesignSystem.Typography.caption)
-                            .foregroundStyle(.secondary)
-                            .fixedSize(horizontal: false, vertical: true)
+                        Text(
+                            "Uses the saved LLM provider after cleanup for file and meeting transcripts. Dictation use can add latency."
+                        )
+                        .font(DesignSystem.Typography.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
                     }
 
                     Spacer(minLength: DesignSystem.Spacing.md)
@@ -711,9 +730,9 @@ struct LLMSettingsView: View {
                             ? "Dictation picks a tuned prompt for the kind of app you're in. Click a type to read its prompt."
                             : "Off — dictation uses your fallback prompt wherever no custom profile matches."
                     )
-                        .font(DesignSystem.Typography.caption)
-                        .foregroundStyle(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
                 }
 
                 Spacer(minLength: DesignSystem.Spacing.md)
@@ -737,7 +756,8 @@ struct LLMSettingsView: View {
             // individual category are off, so a prompt can be inspected before
             // deciding to let it run.
             if let selected = selectedSmartDefaultCategory,
-               let categoryDefault = AIFormatterSmartDefaults.categoryDefault(for: selected) {
+                let categoryDefault = AIFormatterSmartDefaults.categoryDefault(for: selected)
+            {
                 smartDefaultPromptPreview(
                     categoryDefault,
                     isMasterEnabled: viewModel.aiFormatterSmartDefaultsEnabled,
@@ -752,11 +772,12 @@ struct LLMSettingsView: View {
         let isMasterEnabled = viewModel.aiFormatterSmartDefaultsEnabled
         let isCategoryEnabled = viewModel.isAIFormatterSmartDefaultCategoryEnabled(categoryDefault.category)
         let isEffectivelyEnabled = isMasterEnabled && isCategoryEnabled
-        let accessibilityValue = isEffectivelyEnabled
+        let accessibilityValue =
+            isEffectivelyEnabled
             ? "Enabled"
             : isCategoryEnabled
-            ? "Enabled, inactive while Smart defaults are off"
-            : "Disabled"
+                ? "Enabled, inactive while Smart defaults are off"
+                : "Disabled"
         let isSelected = selectedSmartDefaultCategory == categoryDefault.category
 
         return HStack(spacing: 6) {
@@ -770,7 +791,9 @@ struct LLMSettingsView: View {
                         .frame(width: 16, height: 16)
                     Text(categoryDefault.name)
                         .font(DesignSystem.Typography.caption.weight(.medium))
-                        .foregroundStyle(isCategoryEnabled ? DesignSystem.Colors.textPrimary : DesignSystem.Colors.textSecondary)
+                        .foregroundStyle(
+                            isCategoryEnabled ? DesignSystem.Colors.textPrimary : DesignSystem.Colors.textSecondary
+                        )
                         .lineLimit(1)
                     Spacer(minLength: 0)
                 }
@@ -858,12 +881,12 @@ struct LLMSettingsView: View {
                 !isMasterEnabled
                     ? "Smart defaults are off — this prompt will not run unless you turn Smart defaults on."
                     : isCategoryEnabled
-                    ? "To format \(categoryDefault.name) apps differently, turn this type off or add a custom profile below — custom profiles always win."
-                    : "This type is off — dictation into \(categoryDefault.name) apps uses your fallback prompt unless a custom profile matches."
+                        ? "To format \(categoryDefault.name) apps differently, turn this type off or add a custom profile below — custom profiles always win."
+                        : "This type is off — dictation into \(categoryDefault.name) apps uses your fallback prompt unless a custom profile matches."
             )
-                .font(DesignSystem.Typography.caption)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
+            .font(DesignSystem.Typography.caption)
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
         }
         .padding(DesignSystem.Spacing.sm)
         .background(
@@ -946,10 +969,12 @@ struct LLMSettingsView: View {
                                 )
                         }
                     }
-                    Text("Set your own prompt for a specific app or an app type. When you finish dictating, the first match wins: app profile, category profile, smart default, then your fallback prompt.")
-                        .font(DesignSystem.Typography.caption)
-                        .foregroundStyle(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
+                    Text(
+                        "Set your own prompt for a specific app or an app type. When you finish dictating, the first match wins: app profile, category profile, smart default, then your fallback prompt."
+                    )
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
                 }
 
                 Spacer(minLength: DesignSystem.Spacing.md)
@@ -1003,10 +1028,12 @@ struct LLMSettingsView: View {
                         aiFormatterProfileRow(profile)
                     }
                 }
-                Text("Disabling a profile falls back to the smart default for its app type, then to your fallback prompt.")
-                    .font(DesignSystem.Typography.caption)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
+                Text(
+                    "Disabling a profile falls back to the smart default for its app type, then to your fallback prompt."
+                )
+                .font(DesignSystem.Typography.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
             }
         }
     }
@@ -1460,7 +1487,7 @@ struct LLMSettingsView: View {
     private func loadAIFormatterAppIconIfNeeded(for app: AIFormatterInstalledApp) {
         let bundleIdentifier = app.bundleIdentifier
         guard aiFormatterAppIcons[bundleIdentifier] == nil,
-              !aiFormatterAppIconLoadingIDs.contains(bundleIdentifier)
+            !aiFormatterAppIconLoadingIDs.contains(bundleIdentifier)
         else { return }
 
         aiFormatterAppIconLoadingIDs.insert(bundleIdentifier)
@@ -1565,35 +1592,39 @@ struct LLMSettingsView: View {
         }
 
         for directory in directories {
-            guard let urls = try? fileManager.contentsOfDirectory(
-                at: directory,
-                includingPropertiesForKeys: [.isDirectoryKey],
-                options: [.skipsHiddenFiles]
-            ) else { continue }
+            guard
+                let urls = try? fileManager.contentsOfDirectory(
+                    at: directory,
+                    includingPropertiesForKeys: [.isDirectoryKey],
+                    options: [.skipsHiddenFiles]
+                )
+            else { continue }
 
             for url in urls where url.pathExtension == "app" {
-                let plistURL = url
+                let plistURL =
+                    url
                     .appendingPathComponent("Contents", isDirectory: true)
                     .appendingPathComponent("Info.plist")
                 guard let plistData = try? Data(contentsOf: plistURL),
-                      let plistObject = try? PropertyListSerialization.propertyList(
-                          from: plistData,
-                          options: [],
-                          format: nil
-                      ),
-                      let plist = plistObject as? [String: Any],
-                      let rawBundleIdentifier = plist["CFBundleIdentifier"] as? String,
-                      let bundleIdentifier = AppPromptContext.normalizedBundleIdentifier(rawBundleIdentifier),
-                      bundleIdentifier != selfBundleIdentifier,
-                      appsByBundleIdentifier[bundleIdentifier] == nil
+                    let plistObject = try? PropertyListSerialization.propertyList(
+                        from: plistData,
+                        options: [],
+                        format: nil
+                    ),
+                    let plist = plistObject as? [String: Any],
+                    let rawBundleIdentifier = plist["CFBundleIdentifier"] as? String,
+                    let bundleIdentifier = AppPromptContext.normalizedBundleIdentifier(rawBundleIdentifier),
+                    bundleIdentifier != selfBundleIdentifier,
+                    appsByBundleIdentifier[bundleIdentifier] == nil
                 else { continue }
 
-                let displayName = AppPromptContext.normalizedDisplayName(
-                    Self.localizedAppName(at: url)
-                        ?? plist["CFBundleDisplayName"] as? String
-                        ?? plist["CFBundleName"] as? String
-                        ?? url.deletingPathExtension().lastPathComponent
-                ) ?? bundleIdentifier
+                let displayName =
+                    AppPromptContext.normalizedDisplayName(
+                        Self.localizedAppName(at: url)
+                            ?? plist["CFBundleDisplayName"] as? String
+                            ?? plist["CFBundleName"] as? String
+                            ?? url.deletingPathExtension().lastPathComponent
+                    ) ?? bundleIdentifier
                 appsByBundleIdentifier[bundleIdentifier] = AIFormatterInstalledApp(
                     bundleIdentifier: bundleIdentifier,
                     displayName: displayName,
@@ -1683,9 +1714,11 @@ struct LLMSettingsView: View {
             VStack(alignment: .leading, spacing: 2) {
                 Text("Command")
                     .font(DesignSystem.Typography.body)
-                Text("Prompt is passed via stdin and environment variables. Presets run from an app-owned working directory.")
-                    .font(DesignSystem.Typography.caption)
-                    .foregroundStyle(.secondary)
+                Text(
+                    "Prompt is passed via stdin and environment variables. Presets run from an app-owned working directory."
+                )
+                .font(DesignSystem.Typography.caption)
+                .foregroundStyle(.secondary)
             }
             Spacer(minLength: DesignSystem.Spacing.md)
             TextField("claude -p", text: $viewModel.commandTemplate)

--- a/Sources/MacParakeet/Views/Settings/LLMSettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/LLMSettingsView.swift
@@ -387,7 +387,7 @@ struct LLMSettingsView: View {
                         .font(.system(size: 12, weight: .semibold))
                         .foregroundStyle(DesignSystem.Colors.successGreen)
                         .accessibilityHidden(true)
-                    Text(manager.isLocalAISelected ? "Local AI is downloaded, verified, and selected." : "Local AI is downloaded and verified. The current AI choice can still stay on a cloud or BYO provider.")
+                    Text(manager.isLocalAISelected ? "Local AI is downloaded and selected." : "Local AI is downloaded. The current AI choice can still stay on a cloud or BYO provider.")
                         .font(DesignSystem.Typography.caption)
                         .foregroundStyle(.secondary)
                         .fixedSize(horizontal: false, vertical: true)

--- a/Sources/MacParakeet/Views/Settings/LLMSettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/LLMSettingsView.swift
@@ -305,11 +305,11 @@ struct LLMSettingsView: View {
     private var localAIActionButtons: some View {
         let manager = viewModel.inProcessModelManager
         HStack(spacing: DesignSystem.Spacing.xs) {
-            if manager.isModelDownloaded {
+            if manager.isModelDownloaded || manager.hasModelArtifacts {
                 Button {
                     Task { await manager.deleteModel() }
                 } label: {
-                    Label("Delete model", systemImage: "trash")
+                    Label(manager.isModelDownloaded ? "Delete model" : "Delete partial download", systemImage: "trash")
                 }
                 .parakeetAction(.secondary)
                 .disabled(manager.isWorking)

--- a/Sources/MacParakeet/Views/Settings/LLMSettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/LLMSettingsView.swift
@@ -26,8 +26,6 @@ struct LLMSettingsView: View {
     @State private var aiFormatterAppIcons: [String: NSImage] = [:]
     @State private var aiFormatterAppIconLoadingIDs: Set<String> = []
 
-    private static let providerOrder: [LLMProviderID] = LLMProviderID.userSelectableProviderIDs
-
     private static let smartDefaultGridColumns = [
         GridItem(.adaptive(minimum: 168), spacing: DesignSystem.Spacing.sm)
     ]
@@ -39,6 +37,12 @@ struct LLMSettingsView: View {
             Divider()
 
             selectedAIOptionSection
+
+            if viewModel.shouldShowInProcessLocalSetup {
+                Divider()
+
+                localAISetupSection
+            }
 
             if viewModel.selectedProviderID != nil {
                 Divider()
@@ -176,6 +180,11 @@ struct LLMSettingsView: View {
 
             aiFormatterSection
         }
+        .task {
+            if viewModel.shouldShowInProcessLocalSetup {
+                await viewModel.inProcessModelManager.refresh()
+            }
+        }
     }
 
     @ViewBuilder
@@ -227,7 +236,7 @@ struct LLMSettingsView: View {
                 Spacer(minLength: DesignSystem.Spacing.md)
                 Picker("AI option", selection: $viewModel.selectedProviderID) {
                     Text("None").tag(LLMProviderID?.none)
-                    ForEach(Self.providerOrder, id: \.self) { provider in
+                    ForEach(providerOrder, id: \.self) { provider in
                         Text(provider.displayName).tag(Optional(provider))
                     }
                 }
@@ -248,6 +257,157 @@ struct LLMSettingsView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
+    }
+
+    private var providerOrder: [LLMProviderID] {
+        LLMProviderID.userSelectableProviderIDs(
+            inProcessLocalLLMVisible: viewModel.shouldShowInProcessLocalSetup
+        )
+    }
+
+    @ViewBuilder
+    private var localAISetupSection: some View {
+        let manager = viewModel.inProcessModelManager
+
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+            HStack(alignment: .top, spacing: DesignSystem.Spacing.md) {
+                VStack(alignment: .leading, spacing: 3) {
+                    HStack(spacing: 7) {
+                        Text("Local AI")
+                            .font(DesignSystem.Typography.body.weight(.semibold))
+                        Text("Experimental")
+                            .font(DesignSystem.Typography.micro.weight(.semibold))
+                            .foregroundStyle(DesignSystem.Colors.textSecondary)
+                            .padding(.horizontal, 7)
+                            .padding(.vertical, 3)
+                            .background(Capsule().fill(DesignSystem.Colors.surfaceElevated))
+                    }
+                    Text("Optional on-device setup. Cloud providers remain recommended for best AI answer quality.")
+                        .font(DesignSystem.Typography.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                    Text("\(manager.modelDisplayName), \(manager.modelSizeDescription) download.")
+                        .font(DesignSystem.Typography.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer(minLength: DesignSystem.Spacing.md)
+
+                localAIActionButtons
+            }
+
+            localAIStateContent
+        }
+        .id("ai.localAI")
+    }
+
+    @ViewBuilder
+    private var localAIActionButtons: some View {
+        let manager = viewModel.inProcessModelManager
+        HStack(spacing: DesignSystem.Spacing.xs) {
+            if manager.isModelDownloaded {
+                Button {
+                    Task { await manager.deleteModel() }
+                } label: {
+                    Label("Delete model", systemImage: "trash")
+                }
+                .parakeetAction(.secondary)
+                .disabled(manager.isWorking)
+            }
+
+            Button {
+                Task { await manager.enableLocalAI() }
+            } label: {
+                Label(localAIPrimaryButtonTitle, systemImage: manager.isModelDownloaded ? "checkmark.circle" : "arrow.down.circle")
+            }
+            .parakeetAction(.secondary)
+            .disabled(!manager.meetsMemoryRequirement || manager.isWorking)
+        }
+        .fixedSize()
+    }
+
+    private var localAIPrimaryButtonTitle: String {
+        let manager = viewModel.inProcessModelManager
+        if manager.isModelDownloaded {
+            return manager.isLocalAISelected ? "Test local AI" : "Use local AI"
+        }
+        return "Enable local AI"
+    }
+
+    @ViewBuilder
+    private var localAIStateContent: some View {
+        let manager = viewModel.inProcessModelManager
+        if !manager.meetsMemoryRequirement {
+            HStack(alignment: .top, spacing: 6) {
+                Image(systemName: "info.circle.fill")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(DesignSystem.Colors.textSecondary)
+                    .accessibilityHidden(true)
+                Text("Local AI needs \(manager.minimumMemoryDescription). Use a cloud provider above or a local server such as LM Studio/Ollama.")
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        } else {
+            switch manager.state {
+            case .setUpNeeded:
+                Text("Downloads are never automatic. Enable local AI only on a dev-enabled build when you want to test the on-device option.")
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            case .downloading(let progress):
+                VStack(alignment: .leading, spacing: 4) {
+                    ProgressView(value: progress)
+                        .frame(maxWidth: 320)
+                    Text(localAIProgressCopy)
+                        .font(DesignSystem.Typography.caption)
+                        .foregroundStyle(.secondary)
+                }
+            case .verifying:
+                HStack(spacing: 8) {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("Verifying files and testing the local runtime.")
+                        .font(DesignSystem.Typography.caption)
+                        .foregroundStyle(.secondary)
+                }
+            case .ready:
+                HStack(alignment: .top, spacing: 6) {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(DesignSystem.Colors.successGreen)
+                        .accessibilityHidden(true)
+                    Text(manager.isLocalAISelected ? "Local AI is downloaded, verified, and selected." : "Local AI is downloaded and verified. The current AI choice can still stay on a cloud or BYO provider.")
+                        .font(DesignSystem.Typography.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            case .failed(let reason, let recoverable):
+                HStack(alignment: .top, spacing: 6) {
+                    Image(systemName: recoverable ? "exclamationmark.triangle.fill" : "info.circle.fill")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(recoverable ? DesignSystem.Colors.warningAmber : DesignSystem.Colors.textSecondary)
+                        .accessibilityHidden(true)
+                    Text(reason)
+                        .font(DesignSystem.Typography.caption)
+                        .foregroundStyle(recoverable ? DesignSystem.Colors.warningAmber : .secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+        }
+    }
+
+    private var localAIProgressCopy: String {
+        guard let progress = viewModel.inProcessModelManager.progress else {
+            return "Preparing download..."
+        }
+        let completed = ByteCountFormatter.string(fromByteCount: Int64(progress.completedBytes), countStyle: .file)
+        let total = ByteCountFormatter.string(fromByteCount: Int64(progress.totalBytes), countStyle: .file)
+        if let currentFile = progress.currentFile {
+            return "\(completed) of \(total) - \(currentFile)"
+        }
+        return "\(completed) of \(total)"
     }
 
     private var localNetworkHTTPSection: some View {

--- a/Sources/MacParakeet/Views/Settings/LLMSettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/LLMSettingsView.swift
@@ -315,8 +315,17 @@ struct LLMSettingsView: View {
                 .disabled(manager.isWorking)
             }
 
+            if manager.isDownloading {
+                Button {
+                    manager.cancelSetup()
+                } label: {
+                    Label("Cancel", systemImage: "xmark.circle")
+                }
+                .parakeetAction(.secondary)
+            }
+
             Button {
-                Task { await manager.enableLocalAI() }
+                manager.startEnableLocalAI()
             } label: {
                 Label(localAIPrimaryButtonTitle, systemImage: manager.isModelDownloaded ? "checkmark.circle" : "arrow.down.circle")
             }

--- a/Sources/MacParakeetCore/AppFeatures.swift
+++ b/Sources/MacParakeetCore/AppFeatures.swift
@@ -125,4 +125,27 @@ public enum AppFeatures {
     /// `MACPARAKEET_ENABLE_MLX_LOCAL_LLM=1`, so normal SwiftPM builds and CI do
     /// not resolve mlx-swift-lm.
     public static let inProcessLocalLLMEnabled: Bool = false
+
+    /// Developer-only escape hatch for exercising the local LLM setup flow
+    /// while the public feature flag above stays off.
+    public static let inProcessLocalLLMDeveloperDefaultsKey = "MacParakeetEnableInProcessLocalLLM"
+    public static let inProcessLocalLLMDeveloperLaunchArgument = "--enable-local-ai"
+
+    public static func inProcessLocalLLMDeveloperOverrideEnabled(
+        defaults: UserDefaults = .standard,
+        arguments: [String] = ProcessInfo.processInfo.arguments
+    ) -> Bool {
+        defaults.bool(forKey: inProcessLocalLLMDeveloperDefaultsKey)
+            || arguments.contains(inProcessLocalLLMDeveloperLaunchArgument)
+    }
+
+    public static func isInProcessLocalLLMVisible(
+        defaults: UserDefaults = .standard,
+        arguments: [String] = ProcessInfo.processInfo.arguments
+    ) -> Bool {
+        inProcessLocalLLMEnabled || inProcessLocalLLMDeveloperOverrideEnabled(
+            defaults: defaults,
+            arguments: arguments
+        )
+    }
 }

--- a/Sources/MacParakeetCore/AppFeatures.swift
+++ b/Sources/MacParakeetCore/AppFeatures.swift
@@ -143,9 +143,10 @@ public enum AppFeatures {
         defaults: UserDefaults = .standard,
         arguments: [String] = ProcessInfo.processInfo.arguments
     ) -> Bool {
-        inProcessLocalLLMEnabled || inProcessLocalLLMDeveloperOverrideEnabled(
-            defaults: defaults,
-            arguments: arguments
-        )
+        inProcessLocalLLMEnabled
+            || inProcessLocalLLMDeveloperOverrideEnabled(
+                defaults: defaults,
+                arguments: arguments
+            )
     }
 }

--- a/Sources/MacParakeetCore/Models/LLMProvider.swift
+++ b/Sources/MacParakeetCore/Models/LLMProvider.swift
@@ -212,7 +212,7 @@ public enum LLMProviderID: String, Codable, Sendable, CaseIterable {
                 modelListEndpoint: .none,
                 defaultModelName: "mlx-community/Qwen3-4B-Instruct-2507-DDWQ",
                 fallbackModels: [
-                    "mlx-community/Qwen3-4B-Instruct-2507-DDWQ",
+                    "mlx-community/Qwen3-4B-Instruct-2507-DDWQ"
                 ]
             )
         }
@@ -312,7 +312,7 @@ public struct LLMProviderConfig: Codable, Sendable, Equatable {
         baseURL = try container.decode(URL.self, forKey: .baseURL)
         modelName = try container.decode(String.self, forKey: .modelName)
         isLocal = try container.decode(Bool.self, forKey: .isLocal)
-        apiKey = nil // Excluded from Codable — hydrated from Keychain separately
+        apiKey = nil  // Excluded from Codable — hydrated from Keychain separately
     }
 
     // MARK: - Factory Methods

--- a/Sources/MacParakeetCore/Models/LLMProvider.swift
+++ b/Sources/MacParakeetCore/Models/LLMProvider.swift
@@ -219,6 +219,12 @@ public enum LLMProviderID: String, Codable, Sendable, CaseIterable {
     }
 
     public static var userSelectableProviderIDs: [LLMProviderID] {
+        userSelectableProviderIDs()
+    }
+
+    public static func userSelectableProviderIDs(
+        inProcessLocalLLMVisible: Bool = AppFeatures.isInProcessLocalLLMVisible()
+    ) -> [LLMProviderID] {
         [
             .lmstudio,
             .ollama,
@@ -228,7 +234,7 @@ public enum LLMProviderID: String, Codable, Sendable, CaseIterable {
             .openrouter,
             .openaiCompatible,
             .localCLI,
-        ] + (AppFeatures.inProcessLocalLLMEnabled ? [.inProcessLocal] : [])
+        ] + (inProcessLocalLLMVisible ? [.inProcessLocal] : [])
     }
 
     public var displayName: String {

--- a/Sources/MacParakeetCore/Services/AppPaths.swift
+++ b/Sources/MacParakeetCore/Services/AppPaths.swift
@@ -19,7 +19,8 @@ public enum AppPaths {
             return override
         }
         #endif
-        let path = FileManager.default
+        let path =
+            FileManager.default
             .urls(for: .applicationSupportDirectory, in: .userDomainMask)
             .first?
             .path
@@ -73,7 +74,8 @@ public enum AppPaths {
         }
         #endif
         if let raw = defaults.string(forKey: meetingArtifactsFolderKey),
-           let path = normalizedMeetingArtifactsFolder(raw) {
+            let path = normalizedMeetingArtifactsFolder(raw)
+        {
             return path
         }
         return defaultMeetingRecordingsDir(environment: environment)
@@ -98,7 +100,8 @@ public enum AppPaths {
             return "\(override)/logs"
         }
         #endif
-        let path = FileManager.default
+        let path =
+            FileManager.default
             .urls(for: .libraryDirectory, in: .userDomainMask)
             .first?
             .path
@@ -152,7 +155,10 @@ public enum AppPaths {
     /// Ensure all required directories exist
     public static func ensureDirectories() throws {
         let fm = FileManager.default
-        for dir in [appSupportDir, dictationsDir, youtubeDownloadsDir, meetingRecordingsDir, binDir, whisperModelsDir, thumbnailsDir, logsDir, tempDir] {
+        for dir in [
+            appSupportDir, dictationsDir, youtubeDownloadsDir, meetingRecordingsDir, binDir, whisperModelsDir,
+            thumbnailsDir, logsDir, tempDir,
+        ] {
             if !fm.fileExists(atPath: dir) {
                 try fm.createDirectory(atPath: dir, withIntermediateDirectories: true)
             }
@@ -169,8 +175,9 @@ public enum AppPaths {
 
     #if DEBUG
     private static func debugAppStateDir(environment: [String: String]) -> String? {
-        guard let raw = environment[debugAppStateDirEnvironmentKey]?
-            .trimmingCharacters(in: .whitespacesAndNewlines),
+        guard
+            let raw = environment[debugAppStateDirEnvironmentKey]?
+                .trimmingCharacters(in: .whitespacesAndNewlines),
             !raw.isEmpty
         else {
             return nil

--- a/Sources/MacParakeetCore/Services/AppPaths.swift
+++ b/Sources/MacParakeetCore/Services/AppPaths.swift
@@ -111,6 +111,11 @@ public enum AppPaths {
         "\(appSupportDir)/bin"
     }
 
+    /// Verified opt-in local LLM model cache.
+    public static var llmModelsDir: String {
+        "\(appSupportDir)/LLMModels"
+    }
+
     /// WhisperKit CoreML model cache base.
     public static var whisperModelsDir: String {
         "\(appSupportDir)/models/stt/whisper"

--- a/Sources/MacParakeetCore/Services/LLM/InProcessLLMClient.swift
+++ b/Sources/MacParakeetCore/Services/LLM/InProcessLLMClient.swift
@@ -105,7 +105,8 @@ public final class InProcessLLMClient: LLMClientProtocol, Sendable {
 
     public static func defaultModelDirectory(for config: LLMProviderConfig) throws -> URL {
         if let rawPath = ProcessInfo.processInfo.environment[modelDirectoryEnvironmentVariable],
-            !rawPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            !rawPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        {
             return URL(fileURLWithPath: rawPath, isDirectory: true)
         }
 
@@ -323,7 +324,8 @@ public final class InProcessLLMClient: LLMClientProtocol, Sendable {
         var cursor = text.startIndex
         while cursor < text.endIndex {
             let hardEnd = text.index(cursor, offsetBy: maxCharacters, limitedBy: text.endIndex) ?? text.endIndex
-            let end = hardEnd == text.endIndex
+            let end =
+                hardEnd == text.endIndex
                 ? hardEnd
                 : preferredChunkBoundary(in: cursor..<hardEnd, text: text) ?? hardEnd
             let chunk = String(text[cursor..<end]).trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/MacParakeetCore/Services/LLM/InProcessLLMClient.swift
+++ b/Sources/MacParakeetCore/Services/LLM/InProcessLLMClient.swift
@@ -109,13 +109,27 @@ public final class InProcessLLMClient: LLMClientProtocol, Sendable {
             return URL(fileURLWithPath: rawPath, isDirectory: true)
         }
 
-        let directory = InProcessLocalModelCatalog.modelDirectory(for: config.modelName)
-        guard FileManager.default.fileExists(atPath: directory.path) else {
+        return try managedModelDirectory(for: config)
+    }
+
+    static func managedModelDirectory(
+        for config: LLMProviderConfig,
+        manifest: InProcessLocalModelManifest = InProcessLocalModelCatalog.defaultManifest,
+        cacheRoot: URL = InProcessLocalModelCatalog.defaultCacheRoot(),
+        fileManager: FileManager = .default
+    ) throws -> URL {
+        do {
+            return try InProcessLocalModelCatalog.verifiedManagedCacheDirectory(
+                for: config.modelName,
+                manifest: manifest,
+                cacheRoot: cacheRoot,
+                fileManager: fileManager
+            )
+        } catch {
             throw LLMError.modelNotFound(
-                "Download the local AI model before using \(config.modelName), or set \(modelDirectoryEnvironmentVariable) to a local MLX model directory."
+                "Download and verify the local AI model before using \(config.modelName), or set \(modelDirectoryEnvironmentVariable) to a local MLX model directory."
             )
         }
-        return directory
     }
 
     // MARK: - Generation

--- a/Sources/MacParakeetCore/Services/LLM/InProcessLLMClient.swift
+++ b/Sources/MacParakeetCore/Services/LLM/InProcessLLMClient.swift
@@ -22,7 +22,7 @@ public final class InProcessLLMClient: LLMClientProtocol, Sendable {
     public init(
         runtime: any LocalLLMRuntime = UnavailableLocalLLMRuntime(),
         modelDirectoryResolver: @escaping LocalLLMModelDirectoryResolver = {
-            try InProcessLLMClient.environmentModelDirectory(for: $0)
+            try InProcessLLMClient.defaultModelDirectory(for: $0)
         },
         chunkCharacterThreshold: Int = InProcessLLMClient.defaultChunkCharacterThreshold,
         chunkCharacterLimit: Int = InProcessLLMClient.defaultChunkCharacterLimit,
@@ -101,6 +101,21 @@ public final class InProcessLLMClient: LLMClientProtocol, Sendable {
             )
         }
         return URL(fileURLWithPath: rawPath, isDirectory: true)
+    }
+
+    public static func defaultModelDirectory(for config: LLMProviderConfig) throws -> URL {
+        if let rawPath = ProcessInfo.processInfo.environment[modelDirectoryEnvironmentVariable],
+            !rawPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return URL(fileURLWithPath: rawPath, isDirectory: true)
+        }
+
+        let directory = InProcessLocalModelCatalog.modelDirectory(for: config.modelName)
+        guard FileManager.default.fileExists(atPath: directory.path) else {
+            throw LLMError.modelNotFound(
+                "Download the local AI model before using \(config.modelName), or set \(modelDirectoryEnvironmentVariable) to a local MLX model directory."
+            )
+        }
+        return directory
     }
 
     // MARK: - Generation
@@ -293,11 +308,51 @@ public final class InProcessLLMClient: LLMClientProtocol, Sendable {
         var chunks: [String] = []
         var cursor = text.startIndex
         while cursor < text.endIndex {
-            let end = text.index(cursor, offsetBy: maxCharacters, limitedBy: text.endIndex) ?? text.endIndex
-            chunks.append(String(text[cursor..<end]))
-            cursor = end
+            let hardEnd = text.index(cursor, offsetBy: maxCharacters, limitedBy: text.endIndex) ?? text.endIndex
+            let end = hardEnd == text.endIndex
+                ? hardEnd
+                : preferredChunkBoundary(in: cursor..<hardEnd, text: text) ?? hardEnd
+            let chunk = String(text[cursor..<end]).trimmingCharacters(in: .whitespacesAndNewlines)
+            if !chunk.isEmpty {
+                chunks.append(chunk)
+            }
+            cursor = skipLeadingWhitespace(from: end, in: text)
         }
         return chunks
+    }
+
+    private static func preferredChunkBoundary(
+        in range: Range<String.Index>,
+        text: String
+    ) -> String.Index? {
+        if let paragraphBreak = text.range(of: "\n\n", options: .backwards, range: range) {
+            return paragraphBreak.upperBound
+        }
+
+        var cursor = range.upperBound
+        while cursor > range.lowerBound {
+            let punctuationIndex = text.index(before: cursor)
+            if isSentenceTerminator(text[punctuationIndex]) {
+                let boundary = text.index(after: punctuationIndex)
+                if boundary == text.endIndex || boundary == range.upperBound || text[boundary].isWhitespace {
+                    return boundary
+                }
+            }
+            cursor = punctuationIndex
+        }
+        return nil
+    }
+
+    private static func isSentenceTerminator(_ character: Character) -> Bool {
+        character == "." || character == "!" || character == "?"
+    }
+
+    private static func skipLeadingWhitespace(from index: String.Index, in text: String) -> String.Index {
+        var cursor = index
+        while cursor < text.endIndex, text[cursor].isWhitespace {
+            cursor = text.index(after: cursor)
+        }
+        return cursor
     }
 
     private static func mapMessages(

--- a/Sources/MacParakeetCore/Services/LLM/InProcessModelDownloader.swift
+++ b/Sources/MacParakeetCore/Services/LLM/InProcessModelDownloader.swift
@@ -526,8 +526,13 @@ private final class StreamingDownloadDelegate: NSObject, URLSessionDataDelegate,
     }
 
     func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
-        fileHandle?.write(data)
-        onBytesReceived(UInt64(data.count))
+        do {
+            try fileHandle?.write(contentsOf: data)
+            onBytesReceived(UInt64(data.count))
+        } catch {
+            finish(throwing: error)
+            dataTask.cancel()
+        }
     }
 
     func urlSession(

--- a/Sources/MacParakeetCore/Services/LLM/InProcessModelDownloader.swift
+++ b/Sources/MacParakeetCore/Services/LLM/InProcessModelDownloader.swift
@@ -1,4 +1,5 @@
 import CryptoKit
+import Darwin
 import Foundation
 
 public struct InProcessLocalModelFile: Sendable, Equatable {
@@ -73,6 +74,12 @@ public enum InProcessModelDownloaderError: LocalizedError, Equatable {
     case sizeMismatch(file: String, expected: UInt64, actual: UInt64)
     case checksumMismatch(file: String, expected: String, actual: String)
     case invalidHTTPStatus(Int)
+    case invalidManifestPath(String)
+    case manifestPathEscapesCache(String)
+    case symlinkedManifestPath(String)
+    case invalidVerificationMarker
+    case disallowedRedirect(String)
+    case fileCreationFailed(path: String, errno: Int32)
 
     public var errorDescription: String? {
         switch self {
@@ -84,11 +91,25 @@ public enum InProcessModelDownloaderError: LocalizedError, Equatable {
             return "Local AI model file \(file) failed checksum verification."
         case .invalidHTTPStatus(let status):
             return "Model download failed with HTTP \(status)."
+        case .invalidManifestPath(let path):
+            return "Local AI model manifest path is not a safe relative path: \(path)"
+        case .manifestPathEscapesCache(let path):
+            return "Local AI model manifest path escapes the model cache: \(path)"
+        case .symlinkedManifestPath(let path):
+            return "Local AI model cache path uses a symbolic link: \(path)"
+        case .invalidVerificationMarker:
+            return "Local AI model verification marker is missing or stale."
+        case .disallowedRedirect(let url):
+            return "Model download redirected to an untrusted URL: \(url)"
+        case .fileCreationFailed(let path, let code):
+            return "Could not create local AI model cache file \(path) (errno \(code))."
         }
     }
 }
 
 public enum InProcessLocalModelCatalog {
+    static let verificationMarkerFileName = ".macparakeet-verified-manifest.json"
+
     public static let defaultManifest = InProcessLocalModelManifest(
         modelID: "mlx-community/Qwen3-4B-Instruct-2507-DDWQ",
         displayName: "Qwen3 4B Instruct (DDWQ)",
@@ -164,6 +185,245 @@ public enum InProcessLocalModelCatalog {
             .replacingOccurrences(of: "/", with: "__")
             .replacingOccurrences(of: ":", with: "_")
     }
+
+    static func verifiedManagedCacheDirectory(
+        for modelID: String,
+        manifest: InProcessLocalModelManifest = defaultManifest,
+        cacheRoot: URL = defaultCacheRoot(),
+        fileManager: FileManager = .default
+    ) throws -> URL {
+        guard modelID == manifest.modelID else {
+            throw LLMError.modelNotFound("Download the supported local AI model before using \(modelID).")
+        }
+        let directory = modelDirectory(for: modelID, cacheRoot: cacheRoot)
+        guard try hasValidVerificationMarker(for: manifest, in: directory, fileManager: fileManager) else {
+            throw LLMError.modelNotFound("Download and verify the local AI model before using \(modelID).")
+        }
+        return directory
+    }
+
+    static func fileURL(
+        for file: InProcessLocalModelFile,
+        in directory: URL,
+        fileManager: FileManager = .default
+    ) throws -> URL {
+        let components = try validatedManifestPathComponents(file.path)
+        let base = directory.standardizedFileURL
+        try assertNotSymlink(base)
+        var candidate = base
+        for component in components {
+            candidate.appendPathComponent(component, isDirectory: false)
+        }
+        let standardized = candidate.standardizedFileURL
+        guard isContained(standardized, in: base) else {
+            throw InProcessModelDownloaderError.manifestPathEscapesCache(file.path)
+        }
+        try rejectSymlinkedExistingComponents(
+            components,
+            base: base,
+            originalPath: file.path,
+            fileManager: fileManager
+        )
+        return standardized
+    }
+
+    static func partialURL(for destination: URL) -> URL {
+        destination.deletingLastPathComponent()
+            .appendingPathComponent(".\(destination.lastPathComponent).part")
+    }
+
+    static func assertNotSymlink(_ url: URL) throws {
+        guard isSymlink(at: url) else { return }
+        throw InProcessModelDownloaderError.symlinkedManifestPath(url.path)
+    }
+
+    static func fileSize(at url: URL, fileManager: FileManager = .default) throws -> UInt64? {
+        if isSymlink(at: url) {
+            throw InProcessModelDownloaderError.symlinkedManifestPath(url.path)
+        }
+        guard let size = try? fileManager.attributesOfItem(atPath: url.path)[.size] as? NSNumber else {
+            return nil
+        }
+        return size.uint64Value
+    }
+
+    static func writeVerificationMarker(
+        for manifest: InProcessLocalModelManifest,
+        in directory: URL,
+        fileManager: FileManager = .default
+    ) throws {
+        let marker = try verificationMarker(for: manifest, in: directory, fileManager: fileManager)
+        let data = try JSONEncoder().encode(marker)
+        try data.write(to: verificationMarkerURL(in: directory), options: .atomic)
+    }
+
+    static func removeVerificationMarker(
+        in directory: URL,
+        fileManager: FileManager = .default
+    ) {
+        try? fileManager.removeItem(at: verificationMarkerURL(in: directory))
+    }
+
+    static func hasValidVerificationMarker(
+        for manifest: InProcessLocalModelManifest,
+        in directory: URL,
+        fileManager: FileManager = .default
+    ) throws -> Bool {
+        let markerURL = verificationMarkerURL(in: directory)
+        guard fileManager.fileExists(atPath: markerURL.path) else { return false }
+        try assertNotSymlink(markerURL)
+        let marker: VerificationMarker
+        do {
+            marker = try JSONDecoder().decode(VerificationMarker.self, from: Data(contentsOf: markerURL))
+        } catch {
+            removeVerificationMarker(in: directory, fileManager: fileManager)
+            return false
+        }
+        let expected = try verificationMarker(for: manifest, in: directory, fileManager: fileManager)
+        let isValid = marker == expected
+        if !isValid {
+            removeVerificationMarker(in: directory, fileManager: fileManager)
+        }
+        return isValid
+    }
+
+    static func manifestFingerprint(_ manifest: InProcessLocalModelManifest) -> String {
+        var hasher = SHA256()
+        update(&hasher, manifest.modelID)
+        update(&hasher, manifest.repositoryID)
+        update(&hasher, manifest.revision)
+        for file in manifest.files.sorted(by: { $0.path < $1.path }) {
+            update(&hasher, file.path)
+            update(&hasher, String(file.sizeBytes))
+            update(&hasher, file.sha256)
+        }
+        return hasher.finalize().map { String(format: "%02x", $0) }.joined()
+    }
+
+    private static func verificationMarkerURL(in directory: URL) -> URL {
+        directory.appendingPathComponent(verificationMarkerFileName, isDirectory: false)
+    }
+
+    private static func verificationMarker(
+        for manifest: InProcessLocalModelManifest,
+        in directory: URL,
+        fileManager: FileManager
+    ) throws -> VerificationMarker {
+        // The marker avoids re-hashing the 2.5 GB default model on every Settings refresh
+        // or runtime load. It is written only after a full SHA-256 pass. The cheap path
+        // trusts stable file metadata; if size, identity, modification time, or status-change
+        // time changes, the marker is invalidated and callers must run full verification again.
+        let files = try manifest.files.sorted(by: { $0.path < $1.path }).map { file in
+            let url = try fileURL(for: file, in: directory, fileManager: fileManager)
+            guard let size = try fileSize(at: url, fileManager: fileManager), size == file.sizeBytes else {
+                throw InProcessModelDownloaderError.invalidVerificationMarker
+            }
+            let metadata = try fileMarkerMetadata(at: url)
+            return VerificationMarker.FileEntry(
+                path: file.path,
+                sizeBytes: file.sizeBytes,
+                sha256: file.sha256,
+                modifiedAt: metadata.modifiedAt,
+                changedAt: metadata.changedAt,
+                deviceID: metadata.deviceID,
+                inode: metadata.inode
+            )
+        }
+        return VerificationMarker(
+            version: 1,
+            manifestFingerprint: manifestFingerprint(manifest),
+            files: files
+        )
+    }
+
+    private static func validatedManifestPathComponents(_ path: String) throws -> [String] {
+        guard !path.isEmpty, !path.hasPrefix("/"), !path.contains("\0") else {
+            throw InProcessModelDownloaderError.invalidManifestPath(path)
+        }
+        let components = path.split(separator: "/", omittingEmptySubsequences: false).map(String.init)
+        guard !components.isEmpty,
+            components.allSatisfy({ !$0.isEmpty && $0 != "." && $0 != ".." })
+        else {
+            throw InProcessModelDownloaderError.invalidManifestPath(path)
+        }
+        return components
+    }
+
+    private static func isContained(_ candidate: URL, in directory: URL) -> Bool {
+        let basePath = directory.standardizedFileURL.path
+        let candidatePath = candidate.standardizedFileURL.path
+        let prefix = basePath.hasSuffix("/") ? basePath : basePath + "/"
+        return candidatePath.hasPrefix(prefix)
+    }
+
+    private static func rejectSymlinkedExistingComponents(
+        _ components: [String],
+        base: URL,
+        originalPath: String,
+        fileManager: FileManager
+    ) throws {
+        var current = base
+        for component in components {
+            current.appendPathComponent(component, isDirectory: false)
+            if isSymlink(at: current) {
+                throw InProcessModelDownloaderError.symlinkedManifestPath(originalPath)
+            }
+            guard fileManager.fileExists(atPath: current.path) else { return }
+        }
+    }
+
+    private static func isSymlink(at url: URL) -> Bool {
+        var info = stat()
+        return lstat(url.path, &info) == 0 && (info.st_mode & S_IFMT) == S_IFLNK
+    }
+
+    private static func fileMarkerMetadata(at url: URL) throws -> FileMarkerMetadata {
+        var info = stat()
+        guard lstat(url.path, &info) == 0 else {
+            throw InProcessModelDownloaderError.invalidVerificationMarker
+        }
+        guard (info.st_mode & S_IFMT) != S_IFLNK else {
+            throw InProcessModelDownloaderError.symlinkedManifestPath(url.path)
+        }
+        return FileMarkerMetadata(
+            modifiedAt: timeInterval(info.st_mtimespec),
+            changedAt: timeInterval(info.st_ctimespec),
+            deviceID: UInt64(info.st_dev),
+            inode: UInt64(info.st_ino)
+        )
+    }
+
+    private static func timeInterval(_ value: timespec) -> TimeInterval {
+        TimeInterval(value.tv_sec) + (TimeInterval(value.tv_nsec) / 1_000_000_000)
+    }
+
+    private static func update(_ hasher: inout SHA256, _ string: String) {
+        hasher.update(data: Data(string.utf8))
+        hasher.update(data: Data([0]))
+    }
+}
+
+private struct VerificationMarker: Codable, Equatable {
+    struct FileEntry: Codable, Equatable {
+        let path: String
+        let sizeBytes: UInt64
+        let sha256: String
+        let modifiedAt: TimeInterval
+        let changedAt: TimeInterval
+        let deviceID: UInt64
+        let inode: UInt64
+    }
+
+    let version: Int
+    let manifestFingerprint: String
+    let files: [FileEntry]
+}
+
+private struct FileMarkerMetadata {
+    let modifiedAt: TimeInterval
+    let changedAt: TimeInterval
+    let deviceID: UInt64
+    let inode: UInt64
 }
 
 public actor InProcessModelDownloader: InProcessModelDownloading {
@@ -193,8 +453,19 @@ public actor InProcessModelDownloader: InProcessModelDownloading {
 
     public func isDefaultModelDownloaded() async -> Bool {
         let directory = modelDirectory()
-        return manifest.files.allSatisfy { file in
-            fileSize(at: directory.appendingPathComponent(file.path)) == file.sizeBytes
+        do {
+            if try InProcessLocalModelCatalog.hasValidVerificationMarker(
+                for: manifest,
+                in: directory,
+                fileManager: fileManager
+            ) {
+                return true
+            }
+            _ = try await verifyDefaultModel()
+            return true
+        } catch {
+            InProcessLocalModelCatalog.removeVerificationMarker(in: directory, fileManager: fileManager)
+            return false
         }
     }
 
@@ -207,10 +478,20 @@ public actor InProcessModelDownloader: InProcessModelDownloading {
     public func verifyDefaultModel() async throws -> URL {
         try Task.checkCancellation()
         let directory = modelDirectory()
-        for file in manifest.files {
-            try verify(file: file, in: directory)
+        do {
+            for file in manifest.files {
+                try verify(file: file, in: directory)
+            }
+            try InProcessLocalModelCatalog.writeVerificationMarker(
+                for: manifest,
+                in: directory,
+                fileManager: fileManager
+            )
+            return directory
+        } catch {
+            InProcessLocalModelCatalog.removeVerificationMarker(in: directory, fileManager: fileManager)
+            throw error
         }
-        return directory
     }
 
     @discardableResult
@@ -235,7 +516,11 @@ public actor InProcessModelDownloader: InProcessModelDownloading {
                 continue
             }
 
-            let destination = directory.appendingPathComponent(file.path)
+            let destination = try InProcessLocalModelCatalog.fileURL(
+                for: file,
+                in: directory,
+                fileManager: fileManager
+            )
             try await download(file: file, to: destination, completedBytesBeforeFile: completedBytes, progress: progress)
             completedBytes += file.sizeBytes
             await progress(progressValue(
@@ -244,6 +529,11 @@ public actor InProcessModelDownloader: InProcessModelDownloading {
             ))
         }
 
+        try InProcessLocalModelCatalog.writeVerificationMarker(
+            for: manifest,
+            in: directory,
+            fileManager: fileManager
+        )
         return directory
     }
 
@@ -269,29 +559,31 @@ public actor InProcessModelDownloader: InProcessModelDownloading {
             at: destination.deletingLastPathComponent(),
             withIntermediateDirectories: true
         )
+        try InProcessLocalModelCatalog.assertNotSymlink(destination.deletingLastPathComponent())
+        try InProcessLocalModelCatalog.assertNotSymlink(destination)
         if fileManager.fileExists(atPath: destination.path) {
             try fileManager.removeItem(at: destination)
         }
 
-        let partial = partialURL(for: destination)
+        let partial = InProcessLocalModelCatalog.partialURL(for: destination)
         var attempts = 0
         while attempts < 2 {
             attempts += 1
             try Task.checkCancellation()
-            let partialSize = fileSize(at: partial) ?? 0
+            let partialSize = try InProcessLocalModelCatalog.fileSize(at: partial, fileManager: fileManager) ?? 0
             if partialSize >= file.sizeBytes {
                 if partialSize == file.sizeBytes, try isVerified(file: file, at: partial) {
+                    try InProcessLocalModelCatalog.assertNotSymlink(destination.deletingLastPathComponent())
+                    try InProcessLocalModelCatalog.assertNotSymlink(destination)
+                    if fileManager.fileExists(atPath: destination.path) {
+                        try fileManager.removeItem(at: destination)
+                    }
                     try fileManager.moveItem(at: partial, to: destination)
                     return
                 }
                 try? fileManager.removeItem(at: partial)
             }
-            let effectiveResumeOffset = fileSize(at: partial) ?? 0
-            await progress(progressValue(
-                completedBytes: completedBytesBeforeFile + effectiveResumeOffset,
-                completedFiles: completedFiles(before: file),
-                currentFile: file.path
-            ))
+            let effectiveResumeOffset = try InProcessLocalModelCatalog.fileSize(at: partial, fileManager: fileManager) ?? 0
 
             let (updates, updatesContinuation) = AsyncStream.makeStream(
                 of: InProcessModelDownloadProgress.self,
@@ -329,6 +621,8 @@ public actor InProcessModelDownloader: InProcessModelDownloading {
 
             do {
                 try verify(file: file, at: partial)
+                try InProcessLocalModelCatalog.assertNotSymlink(destination.deletingLastPathComponent())
+                try InProcessLocalModelCatalog.assertNotSymlink(destination)
                 if fileManager.fileExists(atPath: destination.path) {
                     try fileManager.removeItem(at: destination)
                 }
@@ -346,14 +640,15 @@ public actor InProcessModelDownloader: InProcessModelDownloading {
     }
 
     private func verify(file: InProcessLocalModelFile, in directory: URL) throws {
-        try verify(file: file, at: directory.appendingPathComponent(file.path))
+        let url = try InProcessLocalModelCatalog.fileURL(for: file, in: directory, fileManager: fileManager)
+        try verify(file: file, at: url)
     }
 
     private func verify(file: InProcessLocalModelFile, at url: URL) throws {
         guard fileManager.fileExists(atPath: url.path) else {
             throw InProcessModelDownloaderError.missingFile(file.path)
         }
-        let actualSize = fileSize(at: url) ?? 0
+        let actualSize = try InProcessLocalModelCatalog.fileSize(at: url, fileManager: fileManager) ?? 0
         guard actualSize == file.sizeBytes else {
             throw InProcessModelDownloaderError.sizeMismatch(
                 file: file.path,
@@ -372,7 +667,8 @@ public actor InProcessModelDownloader: InProcessModelDownloading {
     }
 
     private func isFileVerified(_ file: InProcessLocalModelFile, in directory: URL) throws -> Bool {
-        try isVerified(file: file, at: directory.appendingPathComponent(file.path))
+        let url = try InProcessLocalModelCatalog.fileURL(for: file, in: directory, fileManager: fileManager)
+        return try isVerified(file: file, at: url)
     }
 
     private func isVerified(file: InProcessLocalModelFile, at url: URL) throws -> Bool {
@@ -384,18 +680,6 @@ public actor InProcessModelDownloader: InProcessModelDownloading {
         } catch {
             return false
         }
-    }
-
-    private func fileSize(at url: URL) -> UInt64? {
-        guard let size = try? fileManager.attributesOfItem(atPath: url.path)[.size] as? NSNumber else {
-            return nil
-        }
-        return size.uint64Value
-    }
-
-    private func partialURL(for destination: URL) -> URL {
-        destination.deletingLastPathComponent()
-            .appendingPathComponent(".\(destination.lastPathComponent).part")
     }
 
     private func downloadURL(for file: InProcessLocalModelFile) -> URL {
@@ -446,6 +730,20 @@ public final class URLSessionInProcessModelDownloadTransport: NSObject, InProces
     @unchecked Sendable
 {
     public override init() {}
+
+    static func isAllowedRedirectURL(_ url: URL?) -> Bool {
+        guard let url,
+            url.scheme?.lowercased() == "https",
+            let host = url.host?.lowercased()
+        else {
+            return false
+        }
+
+        return host == "huggingface.co"
+            || host.hasSuffix(".huggingface.co")
+            || host == "hf.co"
+            || host.hasSuffix(".hf.co")
+    }
 
     public func download(
         _ request: InProcessModelDownloadRequest,
@@ -535,23 +833,28 @@ private final class StreamingDownloadDelegate: NSObject, URLSessionDataDelegate,
         }
 
         do {
-            if !FileManager.default.fileExists(atPath: destination.path) {
-                FileManager.default.createFile(atPath: destination.path, contents: nil)
-            }
-            let handle = try FileHandle(forWritingTo: destination)
-            if requestedResumeOffset > 0, httpResponse.statusCode == 206 {
-                try handle.seekToEnd()
-                totalBytesWritten = requestedResumeOffset
-            } else {
-                try handle.truncate(atOffset: 0)
-                totalBytesWritten = 0
-            }
+            let handle = try openDestinationFile(for: httpResponse)
             fileHandle = handle
             completionHandler(.allow)
         } catch {
             finish(throwing: error)
             completionHandler(.cancel)
         }
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        willPerformHTTPRedirection response: HTTPURLResponse,
+        newRequest request: URLRequest,
+        completionHandler: @escaping (URLRequest?) -> Void
+    ) {
+        guard URLSessionInProcessModelDownloadTransport.isAllowedRedirectURL(request.url) else {
+            finish(throwing: InProcessModelDownloaderError.disallowedRedirect(request.url?.absoluteString ?? ""))
+            completionHandler(nil)
+            return
+        }
+        completionHandler(request)
     }
 
     func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
@@ -604,5 +907,43 @@ private final class StreamingDownloadDelegate: NSObject, URLSessionDataDelegate,
         lock.unlock()
         try? fileHandle?.close()
         continuation?.resume(throwing: error)
+    }
+
+    private func openDestinationFile(for httpResponse: HTTPURLResponse) throws -> FileHandle {
+        try InProcessLocalModelCatalog.assertNotSymlink(destination.deletingLastPathComponent())
+        try InProcessLocalModelCatalog.assertNotSymlink(destination)
+
+        if requestedResumeOffset > 0, httpResponse.statusCode == 206 {
+            let fileDescriptor = Darwin.open(destination.path, O_WRONLY | O_NOFOLLOW)
+            guard fileDescriptor >= 0 else {
+                throw InProcessModelDownloaderError.fileCreationFailed(path: destination.path, errno: errno)
+            }
+            let handle = FileHandle(fileDescriptor: fileDescriptor, closeOnDealloc: true)
+            let offset = try handle.seekToEnd()
+            guard offset == requestedResumeOffset else {
+                try? handle.close()
+                throw InProcessModelDownloaderError.sizeMismatch(
+                    file: destination.lastPathComponent,
+                    expected: requestedResumeOffset,
+                    actual: offset
+                )
+            }
+            totalBytesWritten = requestedResumeOffset
+            return handle
+        }
+
+        if FileManager.default.fileExists(atPath: destination.path) {
+            try FileManager.default.removeItem(at: destination)
+        }
+        let fileDescriptor = Darwin.open(
+            destination.path,
+            O_WRONLY | O_CREAT | O_EXCL | O_NOFOLLOW,
+            mode_t(0o600)
+        )
+        guard fileDescriptor >= 0 else {
+            throw InProcessModelDownloaderError.fileCreationFailed(path: destination.path, errno: errno)
+        }
+        totalBytesWritten = 0
+        return FileHandle(fileDescriptor: fileDescriptor, closeOnDealloc: true)
     }
 }

--- a/Sources/MacParakeetCore/Services/LLM/InProcessModelDownloader.swift
+++ b/Sources/MacParakeetCore/Services/LLM/InProcessModelDownloader.swift
@@ -92,7 +92,7 @@ public enum InProcessLocalModelCatalog {
         modelID: "mlx-community/Qwen3-4B-Instruct-2507-DDWQ",
         displayName: "Qwen3 4B Instruct (DDWQ)",
         repositoryID: "mlx-community/Qwen3-4B-Instruct-2507-DDWQ",
-        revision: "main",
+        revision: "88033de44951ebedb96e0adb68cc037443aab93a",
         files: [
             InProcessLocalModelFile(
                 path: "added_tokens.json",
@@ -191,7 +191,10 @@ public actor InProcessModelDownloader: InProcessModelDownloading {
     }
 
     public func isDefaultModelDownloaded() async -> Bool {
-        (try? await verifyDefaultModel()) != nil
+        let directory = modelDirectory()
+        return manifest.files.allSatisfy { file in
+            fileSize(at: directory.appendingPathComponent(file.path)) == file.sizeBytes
+        }
     }
 
     @discardableResult
@@ -235,7 +238,7 @@ public actor InProcessModelDownloader: InProcessModelDownloading {
             ))
         }
 
-        return try await verifyDefaultModel()
+        return directory
     }
 
     public func deleteDefaultModel() async throws {
@@ -269,8 +272,12 @@ public actor InProcessModelDownloader: InProcessModelDownloading {
         while attempts < 2 {
             attempts += 1
             try Task.checkCancellation()
-            let resumeOffset = min(fileSize(at: partial) ?? 0, file.sizeBytes)
-            if resumeOffset >= file.sizeBytes {
+            let partialSize = fileSize(at: partial) ?? 0
+            if partialSize >= file.sizeBytes {
+                if partialSize == file.sizeBytes, (try? verify(file: file, at: partial)) != nil {
+                    try fileManager.moveItem(at: partial, to: destination)
+                    return
+                }
                 try? fileManager.removeItem(at: partial)
             }
             let effectiveResumeOffset = fileSize(at: partial) ?? 0
@@ -281,22 +288,38 @@ public actor InProcessModelDownloader: InProcessModelDownloading {
                 currentFile: file.path
             ))
 
-            try await transport.download(
-                InProcessModelDownloadRequest(
-                    url: downloadURL(for: file),
-                    resumeOffset: effectiveResumeOffset
-                ),
-                to: partial
-            ) { delta in
-                let fileBytes = min(accumulator.add(delta), file.sizeBytes)
-                let progressValue = self.progressValue(
-                    completedBytes: completedBytesBeforeFile + fileBytes,
-                    completedFiles: self.completedFiles(before: file),
-                    currentFile: file.path
-                )
-                Task {
-                    await progress(progressValue)
+            let (updates, updatesContinuation) = AsyncStream.makeStream(
+                of: InProcessModelDownloadProgress.self,
+                bufferingPolicy: .bufferingNewest(1)
+            )
+            let progressForwarder = Task {
+                for await value in updates {
+                    await progress(value)
                 }
+            }
+            do {
+                try await transport.download(
+                    InProcessModelDownloadRequest(
+                        url: downloadURL(for: file),
+                        resumeOffset: effectiveResumeOffset
+                    ),
+                    to: partial
+                ) { delta in
+                    let fileBytes = min(accumulator.add(delta), file.sizeBytes)
+                    updatesContinuation.yield(self.progressValue(
+                        completedBytes: completedBytesBeforeFile + fileBytes,
+                        completedFiles: self.completedFiles(before: file),
+                        currentFile: file.path
+                    ))
+                }
+                updatesContinuation.finish()
+                await progressForwarder.value
+            } catch {
+                updatesContinuation.finish()
+                progressForwarder.cancel()
+                await progressForwarder.value
+                try Task.checkCancellation()
+                throw error
             }
 
             do {

--- a/Sources/MacParakeetCore/Services/LLM/InProcessModelDownloader.swift
+++ b/Sources/MacParakeetCore/Services/LLM/InProcessModelDownloader.swift
@@ -1,0 +1,573 @@
+import CryptoKit
+import Foundation
+
+public struct InProcessLocalModelFile: Sendable, Equatable {
+    public let path: String
+    public let sizeBytes: UInt64
+    public let sha256: String
+
+    public init(path: String, sizeBytes: UInt64, sha256: String) {
+        self.path = path
+        self.sizeBytes = sizeBytes
+        self.sha256 = sha256.lowercased()
+    }
+}
+
+public struct InProcessLocalModelManifest: Sendable, Equatable {
+    public let modelID: String
+    public let displayName: String
+    public let repositoryID: String
+    public let revision: String
+    public let files: [InProcessLocalModelFile]
+
+    public var totalBytes: UInt64 {
+        files.reduce(0) { $0 + $1.sizeBytes }
+    }
+}
+
+public struct InProcessModelDownloadProgress: Sendable, Equatable {
+    public let completedBytes: UInt64
+    public let totalBytes: UInt64
+    public let completedFiles: Int
+    public let totalFiles: Int
+    public let currentFile: String?
+
+    public var fractionCompleted: Double {
+        guard totalBytes > 0 else { return 0 }
+        return min(1, Double(completedBytes) / Double(totalBytes))
+    }
+}
+
+public struct InProcessModelDownloadRequest: Sendable, Equatable {
+    public let url: URL
+    public let resumeOffset: UInt64
+
+    public init(url: URL, resumeOffset: UInt64) {
+        self.url = url
+        self.resumeOffset = resumeOffset
+    }
+}
+
+public protocol InProcessModelDownloadTransport: Sendable {
+    func download(
+        _ request: InProcessModelDownloadRequest,
+        to destination: URL,
+        onBytesReceived: @escaping @Sendable (UInt64) -> Void
+    ) async throws
+}
+
+public typealias InProcessModelDownloadProgressHandler =
+    @Sendable (InProcessModelDownloadProgress) async -> Void
+
+public protocol InProcessModelDownloading: Sendable {
+    func defaultModelDirectory() -> URL
+    func isDefaultModelDownloaded() async -> Bool
+    func verifyDefaultModel() async throws -> URL
+    func downloadDefaultModel(progress: @escaping InProcessModelDownloadProgressHandler) async throws -> URL
+    func deleteDefaultModel() async throws
+}
+
+public enum InProcessModelDownloaderError: LocalizedError, Equatable {
+    case missingFile(String)
+    case sizeMismatch(file: String, expected: UInt64, actual: UInt64)
+    case checksumMismatch(file: String, expected: String, actual: String)
+    case invalidHTTPStatus(Int)
+
+    public var errorDescription: String? {
+        switch self {
+        case .missingFile(let file):
+            return "Missing local AI model file: \(file)"
+        case .sizeMismatch(let file, let expected, let actual):
+            return "Local AI model file \(file) has size \(actual), expected \(expected)."
+        case .checksumMismatch(let file, _, _):
+            return "Local AI model file \(file) failed checksum verification."
+        case .invalidHTTPStatus(let status):
+            return "Model download failed with HTTP \(status)."
+        }
+    }
+}
+
+public enum InProcessLocalModelCatalog {
+    public static let defaultManifest = InProcessLocalModelManifest(
+        modelID: "mlx-community/Qwen3-4B-Instruct-2507-DDWQ",
+        displayName: "Qwen3 4B Instruct (DDWQ)",
+        repositoryID: "mlx-community/Qwen3-4B-Instruct-2507-DDWQ",
+        revision: "main",
+        files: [
+            InProcessLocalModelFile(
+                path: "added_tokens.json",
+                sizeBytes: 707,
+                sha256: "c0284b582e14987fbd3d5a2cb2bd139084371ed9acbae488829a1c900833c680"
+            ),
+            InProcessLocalModelFile(
+                path: "config.json",
+                sizeBytes: 54_340,
+                sha256: "d34791eee725047d963633517487093d28e9e0845f48d4f0e89c46fe3ff732dd"
+            ),
+            InProcessLocalModelFile(
+                path: "generation_config.json",
+                sizeBytes: 238,
+                sha256: "835fffe355c9438e7a25be099b3fccaa98350b83451f9fd2d99512e74f1ade48"
+            ),
+            InProcessLocalModelFile(
+                path: "merges.txt",
+                sizeBytes: 1_671_853,
+                sha256: "8831e4f1a044471340f7c0a83d7bd71306a5b867e95fd870f74d0c5308a904d5"
+            ),
+            InProcessLocalModelFile(
+                path: "model.safetensors",
+                sizeBytes: 2_513_288_145,
+                sha256: "93302f8b5d39da32ecc2b175472d5e31f6776ecfa813285833aa7470a24f3e5b"
+            ),
+            InProcessLocalModelFile(
+                path: "model.safetensors.index.json",
+                sizeBytes: 63_964,
+                sha256: "2cd8d29f787f879bcda15972c72179b1d5800191cb957710a75b1cf6cf6c739c"
+            ),
+            InProcessLocalModelFile(
+                path: "special_tokens_map.json",
+                sizeBytes: 613,
+                sha256: "76862e765266b85aa9459767e33cbaf13970f327a0e88d1c65846c2ddd3a1ecd"
+            ),
+            InProcessLocalModelFile(
+                path: "tokenizer.json",
+                sizeBytes: 11_422_654,
+                sha256: "aeb13307a71acd8fe81861d94ad54ab689df773318809eed3cbe794b4492dae4"
+            ),
+            InProcessLocalModelFile(
+                path: "tokenizer_config.json",
+                sizeBytes: 9_627,
+                sha256: "2f8396a75e4ef94389a2738b55a4d4aea47ca444f320c39f92f71c9c0a9c6ee8"
+            ),
+            InProcessLocalModelFile(
+                path: "vocab.json",
+                sizeBytes: 2_776_833,
+                sha256: "ca10d7e9fb3ed18575dd1e277a2579c16d108e32f27439684afa0e10b1440910"
+            ),
+        ]
+    )
+
+    public static func defaultCacheRoot() -> URL {
+        URL(fileURLWithPath: AppPaths.llmModelsDir, isDirectory: true)
+    }
+
+    public static func modelDirectory(
+        for modelID: String,
+        cacheRoot: URL = defaultCacheRoot()
+    ) -> URL {
+        cacheRoot.appendingPathComponent(sanitizedDirectoryName(for: modelID), isDirectory: true)
+    }
+
+    public static func sanitizedDirectoryName(for modelID: String) -> String {
+        modelID
+            .replacingOccurrences(of: "/", with: "__")
+            .replacingOccurrences(of: ":", with: "_")
+    }
+}
+
+public actor InProcessModelDownloader: InProcessModelDownloading {
+    private let manifest: InProcessLocalModelManifest
+    private let cacheRoot: URL
+    private let transport: any InProcessModelDownloadTransport
+    private let fileManager: FileManager
+
+    public init(
+        manifest: InProcessLocalModelManifest = InProcessLocalModelCatalog.defaultManifest,
+        cacheRoot: URL = InProcessLocalModelCatalog.defaultCacheRoot(),
+        transport: any InProcessModelDownloadTransport = URLSessionInProcessModelDownloadTransport(),
+        fileManager: FileManager = .default
+    ) {
+        self.manifest = manifest
+        self.cacheRoot = cacheRoot
+        self.transport = transport
+        self.fileManager = fileManager
+    }
+
+    public nonisolated func defaultModelDirectory() -> URL {
+        InProcessLocalModelCatalog.modelDirectory(
+            for: InProcessLocalModelCatalog.defaultManifest.modelID,
+            cacheRoot: cacheRoot
+        )
+    }
+
+    public func isDefaultModelDownloaded() async -> Bool {
+        (try? await verifyDefaultModel()) != nil
+    }
+
+    @discardableResult
+    public func verifyDefaultModel() async throws -> URL {
+        try Task.checkCancellation()
+        let directory = modelDirectory()
+        for file in manifest.files {
+            try verify(file: file, in: directory)
+        }
+        return directory
+    }
+
+    @discardableResult
+    public func downloadDefaultModel(
+        progress: @escaping InProcessModelDownloadProgressHandler = { _ in }
+    ) async throws -> URL {
+        try Task.checkCancellation()
+        let directory = modelDirectory()
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        var completedBytes: UInt64 = 0
+        await progress(progressValue(completedBytes: completedBytes, completedFiles: 0))
+
+        for (index, file) in manifest.files.enumerated() {
+            try Task.checkCancellation()
+            if isFileVerified(file, in: directory) {
+                completedBytes += file.sizeBytes
+                await progress(progressValue(
+                    completedBytes: min(completedBytes, manifest.totalBytes),
+                    completedFiles: index + 1
+                ))
+                continue
+            }
+
+            let destination = directory.appendingPathComponent(file.path)
+            try await download(file: file, to: destination, completedBytesBeforeFile: completedBytes, progress: progress)
+            completedBytes += file.sizeBytes
+            await progress(progressValue(
+                completedBytes: min(completedBytes, manifest.totalBytes),
+                completedFiles: index + 1
+            ))
+        }
+
+        return try await verifyDefaultModel()
+    }
+
+    public func deleteDefaultModel() async throws {
+        try Task.checkCancellation()
+        let directory = modelDirectory()
+        if fileManager.fileExists(atPath: directory.path) {
+            try fileManager.removeItem(at: directory)
+        }
+    }
+
+    private nonisolated func modelDirectory() -> URL {
+        InProcessLocalModelCatalog.modelDirectory(for: manifest.modelID, cacheRoot: cacheRoot)
+    }
+
+    private func download(
+        file: InProcessLocalModelFile,
+        to destination: URL,
+        completedBytesBeforeFile: UInt64,
+        progress: @escaping InProcessModelDownloadProgressHandler
+    ) async throws {
+        try fileManager.createDirectory(
+            at: destination.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        if fileManager.fileExists(atPath: destination.path) {
+            try fileManager.removeItem(at: destination)
+        }
+
+        let partial = partialURL(for: destination)
+        var attempts = 0
+        while attempts < 2 {
+            attempts += 1
+            try Task.checkCancellation()
+            let resumeOffset = min(fileSize(at: partial) ?? 0, file.sizeBytes)
+            if resumeOffset >= file.sizeBytes {
+                try? fileManager.removeItem(at: partial)
+            }
+            let effectiveResumeOffset = fileSize(at: partial) ?? 0
+            let accumulator = DownloadProgressAccumulator(initialBytes: effectiveResumeOffset)
+            await progress(progressValue(
+                completedBytes: completedBytesBeforeFile + effectiveResumeOffset,
+                completedFiles: completedFiles(before: file),
+                currentFile: file.path
+            ))
+
+            try await transport.download(
+                InProcessModelDownloadRequest(
+                    url: downloadURL(for: file),
+                    resumeOffset: effectiveResumeOffset
+                ),
+                to: partial
+            ) { delta in
+                let fileBytes = min(accumulator.add(delta), file.sizeBytes)
+                let progressValue = self.progressValue(
+                    completedBytes: completedBytesBeforeFile + fileBytes,
+                    completedFiles: self.completedFiles(before: file),
+                    currentFile: file.path
+                )
+                Task {
+                    await progress(progressValue)
+                }
+            }
+
+            do {
+                try verify(file: file, at: partial)
+                if fileManager.fileExists(atPath: destination.path) {
+                    try fileManager.removeItem(at: destination)
+                }
+                try fileManager.moveItem(at: partial, to: destination)
+                return
+            } catch {
+                try? fileManager.removeItem(at: partial)
+                if attempts >= 2 {
+                    throw error
+                }
+            }
+        }
+    }
+
+    private func verify(file: InProcessLocalModelFile, in directory: URL) throws {
+        try verify(file: file, at: directory.appendingPathComponent(file.path))
+    }
+
+    private func verify(file: InProcessLocalModelFile, at url: URL) throws {
+        guard fileManager.fileExists(atPath: url.path) else {
+            throw InProcessModelDownloaderError.missingFile(file.path)
+        }
+        let actualSize = fileSize(at: url) ?? 0
+        guard actualSize == file.sizeBytes else {
+            throw InProcessModelDownloaderError.sizeMismatch(
+                file: file.path,
+                expected: file.sizeBytes,
+                actual: actualSize
+            )
+        }
+        let actualHash = try sha256Hex(for: url)
+        guard actualHash == file.sha256 else {
+            throw InProcessModelDownloaderError.checksumMismatch(
+                file: file.path,
+                expected: file.sha256,
+                actual: actualHash
+            )
+        }
+    }
+
+    private func isFileVerified(_ file: InProcessLocalModelFile, in directory: URL) -> Bool {
+        (try? verify(file: file, in: directory)) != nil
+    }
+
+    private func fileSize(at url: URL) -> UInt64? {
+        guard let size = try? fileManager.attributesOfItem(atPath: url.path)[.size] as? NSNumber else {
+            return nil
+        }
+        return size.uint64Value
+    }
+
+    private func partialURL(for destination: URL) -> URL {
+        destination.deletingLastPathComponent()
+            .appendingPathComponent(".\(destination.lastPathComponent).part")
+    }
+
+    private func downloadURL(for file: InProcessLocalModelFile) -> URL {
+        let path = file.path
+            .split(separator: "/")
+            .map { component in
+                String(component).addingPercentEncoding(withAllowedCharacters: .urlPathAllowed)
+                    ?? String(component)
+            }
+            .joined(separator: "/")
+        return URL(
+            string: "https://huggingface.co/\(manifest.repositoryID)/resolve/\(manifest.revision)/\(path)"
+        )!
+    }
+
+    private nonisolated func completedFiles(before file: InProcessLocalModelFile) -> Int {
+        manifest.files.firstIndex(of: file) ?? 0
+    }
+
+    private nonisolated func progressValue(
+        completedBytes: UInt64,
+        completedFiles: Int,
+        currentFile: String? = nil
+    ) -> InProcessModelDownloadProgress {
+        InProcessModelDownloadProgress(
+            completedBytes: min(completedBytes, manifest.totalBytes),
+            totalBytes: manifest.totalBytes,
+            completedFiles: completedFiles,
+            totalFiles: manifest.files.count,
+            currentFile: currentFile
+        )
+    }
+
+    private func sha256Hex(for url: URL) throws -> String {
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { try? handle.close() }
+
+        var hasher = SHA256()
+        while let data = try handle.read(upToCount: 1024 * 1024), !data.isEmpty {
+            hasher.update(data: data)
+        }
+        return hasher.finalize().map { String(format: "%02x", $0) }.joined()
+    }
+}
+
+public final class URLSessionInProcessModelDownloadTransport: NSObject, InProcessModelDownloadTransport,
+    @unchecked Sendable
+{
+    public override init() {}
+
+    public func download(
+        _ request: InProcessModelDownloadRequest,
+        to destination: URL,
+        onBytesReceived: @escaping @Sendable (UInt64) -> Void
+    ) async throws {
+        var urlRequest = URLRequest(url: request.url)
+        urlRequest.timeoutInterval = 60
+        if request.resumeOffset > 0 {
+            urlRequest.setValue("bytes=\(request.resumeOffset)-", forHTTPHeaderField: "Range")
+        }
+
+        let delegate = StreamingDownloadDelegate(
+            destination: destination,
+            requestedResumeOffset: request.resumeOffset,
+            onBytesReceived: onBytesReceived
+        )
+        let session = URLSession(configuration: .ephemeral, delegate: delegate, delegateQueue: nil)
+        let task = session.dataTask(with: urlRequest)
+        let cancelBox = URLSessionTaskCancelBox(task: task)
+        defer { session.invalidateAndCancel() }
+
+        try await withTaskCancellationHandler {
+            try await delegate.start(task: task)
+        } onCancel: {
+            cancelBox.cancel()
+        }
+    }
+}
+
+private final class DownloadProgressAccumulator: @unchecked Sendable {
+    private let lock = NSLock()
+    private var bytes: UInt64
+
+    init(initialBytes: UInt64) {
+        self.bytes = initialBytes
+    }
+
+    func add(_ delta: UInt64) -> UInt64 {
+        lock.lock()
+        defer { lock.unlock() }
+        bytes += delta
+        return bytes
+    }
+}
+
+private final class URLSessionTaskCancelBox: @unchecked Sendable {
+    private let task: URLSessionTask
+
+    init(task: URLSessionTask) {
+        self.task = task
+    }
+
+    func cancel() {
+        task.cancel()
+    }
+}
+
+private final class StreamingDownloadDelegate: NSObject, URLSessionDataDelegate, @unchecked Sendable {
+    private let destination: URL
+    private let requestedResumeOffset: UInt64
+    private let onBytesReceived: @Sendable (UInt64) -> Void
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<Void, Error>?
+    private var fileHandle: FileHandle?
+    private var isCompleted = false
+
+    init(
+        destination: URL,
+        requestedResumeOffset: UInt64,
+        onBytesReceived: @escaping @Sendable (UInt64) -> Void
+    ) {
+        self.destination = destination
+        self.requestedResumeOffset = requestedResumeOffset
+        self.onBytesReceived = onBytesReceived
+    }
+
+    func start(task: URLSessionDataTask) async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            lock.lock()
+            self.continuation = continuation
+            lock.unlock()
+            task.resume()
+        }
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        dataTask: URLSessionDataTask,
+        didReceive response: URLResponse,
+        completionHandler: @escaping (URLSession.ResponseDisposition) -> Void
+    ) {
+        guard let httpResponse = response as? HTTPURLResponse else {
+            finish(throwing: InProcessModelDownloaderError.invalidHTTPStatus(-1))
+            completionHandler(.cancel)
+            return
+        }
+        guard httpResponse.statusCode == 200 || httpResponse.statusCode == 206 else {
+            finish(throwing: InProcessModelDownloaderError.invalidHTTPStatus(httpResponse.statusCode))
+            completionHandler(.cancel)
+            return
+        }
+
+        do {
+            if !FileManager.default.fileExists(atPath: destination.path) {
+                FileManager.default.createFile(atPath: destination.path, contents: nil)
+            }
+            let handle = try FileHandle(forWritingTo: destination)
+            if requestedResumeOffset > 0, httpResponse.statusCode == 206 {
+                try handle.seekToEnd()
+            } else {
+                try handle.truncate(atOffset: 0)
+            }
+            fileHandle = handle
+            completionHandler(.allow)
+        } catch {
+            finish(throwing: error)
+            completionHandler(.cancel)
+        }
+    }
+
+    func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+        fileHandle?.write(data)
+        onBytesReceived(UInt64(data.count))
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didCompleteWithError error: Error?
+    ) {
+        try? fileHandle?.close()
+        fileHandle = nil
+        if let error {
+            finish(throwing: error)
+        } else {
+            finish(returning: ())
+        }
+    }
+
+    private func finish(returning value: Void) {
+        lock.lock()
+        guard !isCompleted else {
+            lock.unlock()
+            return
+        }
+        isCompleted = true
+        let continuation = continuation
+        self.continuation = nil
+        lock.unlock()
+        continuation?.resume(returning: value)
+    }
+
+    private func finish(throwing error: Error) {
+        lock.lock()
+        guard !isCompleted else {
+            lock.unlock()
+            return
+        }
+        isCompleted = true
+        let continuation = continuation
+        self.continuation = nil
+        lock.unlock()
+        try? fileHandle?.close()
+        continuation?.resume(throwing: error)
+    }
+}

--- a/Sources/MacParakeetCore/Services/LLM/InProcessModelDownloader.swift
+++ b/Sources/MacParakeetCore/Services/LLM/InProcessModelDownloader.swift
@@ -509,10 +509,11 @@ public actor InProcessModelDownloader: InProcessModelDownloading {
             try Task.checkCancellation()
             if try isFileVerified(file, in: directory) {
                 completedBytes += file.sizeBytes
-                await progress(progressValue(
-                    completedBytes: min(completedBytes, manifest.totalBytes),
-                    completedFiles: index + 1
-                ))
+                await progress(
+                    progressValue(
+                        completedBytes: min(completedBytes, manifest.totalBytes),
+                        completedFiles: index + 1
+                    ))
                 continue
             }
 
@@ -521,12 +522,14 @@ public actor InProcessModelDownloader: InProcessModelDownloading {
                 in: directory,
                 fileManager: fileManager
             )
-            try await download(file: file, to: destination, completedBytesBeforeFile: completedBytes, progress: progress)
+            try await download(
+                file: file, to: destination, completedBytesBeforeFile: completedBytes, progress: progress)
             completedBytes += file.sizeBytes
-            await progress(progressValue(
-                completedBytes: min(completedBytes, manifest.totalBytes),
-                completedFiles: index + 1
-            ))
+            await progress(
+                progressValue(
+                    completedBytes: min(completedBytes, manifest.totalBytes),
+                    completedFiles: index + 1
+                ))
         }
 
         try InProcessLocalModelCatalog.writeVerificationMarker(
@@ -583,7 +586,8 @@ public actor InProcessModelDownloader: InProcessModelDownloading {
                 }
                 try? fileManager.removeItem(at: partial)
             }
-            let effectiveResumeOffset = try InProcessLocalModelCatalog.fileSize(at: partial, fileManager: fileManager) ?? 0
+            let effectiveResumeOffset =
+                try InProcessLocalModelCatalog.fileSize(at: partial, fileManager: fileManager) ?? 0
 
             let (updates, updatesContinuation) = AsyncStream.makeStream(
                 of: InProcessModelDownloadProgress.self,
@@ -603,11 +607,12 @@ public actor InProcessModelDownloader: InProcessModelDownloading {
                     to: partial
                 ) { totalBytesWritten in
                     let fileBytes = min(totalBytesWritten, file.sizeBytes)
-                    updatesContinuation.yield(self.progressValue(
-                        completedBytes: completedBytesBeforeFile + fileBytes,
-                        completedFiles: self.completedFiles(before: file),
-                        currentFile: file.path
-                    ))
+                    updatesContinuation.yield(
+                        self.progressValue(
+                            completedBytes: completedBytesBeforeFile + fileBytes,
+                            completedFiles: self.completedFiles(before: file),
+                            currentFile: file.path
+                        ))
                 }
                 updatesContinuation.finish()
                 await progressForwarder.value

--- a/Sources/MacParakeetCore/Services/LLM/InProcessModelDownloader.swift
+++ b/Sources/MacParakeetCore/Services/LLM/InProcessModelDownloader.swift
@@ -52,7 +52,7 @@ public protocol InProcessModelDownloadTransport: Sendable {
     func download(
         _ request: InProcessModelDownloadRequest,
         to destination: URL,
-        onBytesReceived: @escaping @Sendable (UInt64) -> Void
+        onTotalBytesWritten: @escaping @Sendable (UInt64) -> Void
     ) async throws
 }
 
@@ -62,6 +62,7 @@ public typealias InProcessModelDownloadProgressHandler =
 public protocol InProcessModelDownloading: Sendable {
     func defaultModelDirectory() -> URL
     func isDefaultModelDownloaded() async -> Bool
+    func hasDefaultModelArtifacts() async -> Bool
     func verifyDefaultModel() async throws -> URL
     func downloadDefaultModel(progress: @escaping InProcessModelDownloadProgressHandler) async throws -> URL
     func deleteDefaultModel() async throws
@@ -197,6 +198,11 @@ public actor InProcessModelDownloader: InProcessModelDownloading {
         }
     }
 
+    public func hasDefaultModelArtifacts() async -> Bool {
+        let contents = (try? fileManager.contentsOfDirectory(atPath: modelDirectory().path)) ?? []
+        return !contents.isEmpty
+    }
+
     @discardableResult
     public func verifyDefaultModel() async throws -> URL {
         try Task.checkCancellation()
@@ -220,7 +226,7 @@ public actor InProcessModelDownloader: InProcessModelDownloading {
 
         for (index, file) in manifest.files.enumerated() {
             try Task.checkCancellation()
-            if isFileVerified(file, in: directory) {
+            if try isFileVerified(file, in: directory) {
                 completedBytes += file.sizeBytes
                 await progress(progressValue(
                     completedBytes: min(completedBytes, manifest.totalBytes),
@@ -274,14 +280,13 @@ public actor InProcessModelDownloader: InProcessModelDownloading {
             try Task.checkCancellation()
             let partialSize = fileSize(at: partial) ?? 0
             if partialSize >= file.sizeBytes {
-                if partialSize == file.sizeBytes, (try? verify(file: file, at: partial)) != nil {
+                if partialSize == file.sizeBytes, try isVerified(file: file, at: partial) {
                     try fileManager.moveItem(at: partial, to: destination)
                     return
                 }
                 try? fileManager.removeItem(at: partial)
             }
             let effectiveResumeOffset = fileSize(at: partial) ?? 0
-            let accumulator = DownloadProgressAccumulator(initialBytes: effectiveResumeOffset)
             await progress(progressValue(
                 completedBytes: completedBytesBeforeFile + effectiveResumeOffset,
                 completedFiles: completedFiles(before: file),
@@ -304,8 +309,8 @@ public actor InProcessModelDownloader: InProcessModelDownloading {
                         resumeOffset: effectiveResumeOffset
                     ),
                     to: partial
-                ) { delta in
-                    let fileBytes = min(accumulator.add(delta), file.sizeBytes)
+                ) { totalBytesWritten in
+                    let fileBytes = min(totalBytesWritten, file.sizeBytes)
                     updatesContinuation.yield(self.progressValue(
                         completedBytes: completedBytesBeforeFile + fileBytes,
                         completedFiles: self.completedFiles(before: file),
@@ -329,6 +334,8 @@ public actor InProcessModelDownloader: InProcessModelDownloading {
                 }
                 try fileManager.moveItem(at: partial, to: destination)
                 return
+            } catch is CancellationError {
+                throw CancellationError()
             } catch {
                 try? fileManager.removeItem(at: partial)
                 if attempts >= 2 {
@@ -364,8 +371,19 @@ public actor InProcessModelDownloader: InProcessModelDownloading {
         }
     }
 
-    private func isFileVerified(_ file: InProcessLocalModelFile, in directory: URL) -> Bool {
-        (try? verify(file: file, in: directory)) != nil
+    private func isFileVerified(_ file: InProcessLocalModelFile, in directory: URL) throws -> Bool {
+        try isVerified(file: file, at: directory.appendingPathComponent(file.path))
+    }
+
+    private func isVerified(file: InProcessLocalModelFile, at url: URL) throws -> Bool {
+        do {
+            try verify(file: file, at: url)
+            return true
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            return false
+        }
     }
 
     private func fileSize(at url: URL) -> UInt64? {
@@ -417,6 +435,7 @@ public actor InProcessModelDownloader: InProcessModelDownloading {
 
         var hasher = SHA256()
         while let data = try handle.read(upToCount: 1024 * 1024), !data.isEmpty {
+            try Task.checkCancellation()
             hasher.update(data: data)
         }
         return hasher.finalize().map { String(format: "%02x", $0) }.joined()
@@ -431,7 +450,7 @@ public final class URLSessionInProcessModelDownloadTransport: NSObject, InProces
     public func download(
         _ request: InProcessModelDownloadRequest,
         to destination: URL,
-        onBytesReceived: @escaping @Sendable (UInt64) -> Void
+        onTotalBytesWritten: @escaping @Sendable (UInt64) -> Void
     ) async throws {
         var urlRequest = URLRequest(url: request.url)
         urlRequest.timeoutInterval = 60
@@ -442,7 +461,7 @@ public final class URLSessionInProcessModelDownloadTransport: NSObject, InProces
         let delegate = StreamingDownloadDelegate(
             destination: destination,
             requestedResumeOffset: request.resumeOffset,
-            onBytesReceived: onBytesReceived
+            onTotalBytesWritten: onTotalBytesWritten
         )
         let session = URLSession(configuration: .ephemeral, delegate: delegate, delegateQueue: nil)
         let task = session.dataTask(with: urlRequest)
@@ -454,22 +473,6 @@ public final class URLSessionInProcessModelDownloadTransport: NSObject, InProces
         } onCancel: {
             cancelBox.cancel()
         }
-    }
-}
-
-private final class DownloadProgressAccumulator: @unchecked Sendable {
-    private let lock = NSLock()
-    private var bytes: UInt64
-
-    init(initialBytes: UInt64) {
-        self.bytes = initialBytes
-    }
-
-    func add(_ delta: UInt64) -> UInt64 {
-        lock.lock()
-        defer { lock.unlock() }
-        bytes += delta
-        return bytes
     }
 }
 
@@ -488,20 +491,21 @@ private final class URLSessionTaskCancelBox: @unchecked Sendable {
 private final class StreamingDownloadDelegate: NSObject, URLSessionDataDelegate, @unchecked Sendable {
     private let destination: URL
     private let requestedResumeOffset: UInt64
-    private let onBytesReceived: @Sendable (UInt64) -> Void
+    private let onTotalBytesWritten: @Sendable (UInt64) -> Void
     private let lock = NSLock()
     private var continuation: CheckedContinuation<Void, Error>?
     private var fileHandle: FileHandle?
+    private var totalBytesWritten: UInt64 = 0
     private var isCompleted = false
 
     init(
         destination: URL,
         requestedResumeOffset: UInt64,
-        onBytesReceived: @escaping @Sendable (UInt64) -> Void
+        onTotalBytesWritten: @escaping @Sendable (UInt64) -> Void
     ) {
         self.destination = destination
         self.requestedResumeOffset = requestedResumeOffset
-        self.onBytesReceived = onBytesReceived
+        self.onTotalBytesWritten = onTotalBytesWritten
     }
 
     func start(task: URLSessionDataTask) async throws {
@@ -537,8 +541,10 @@ private final class StreamingDownloadDelegate: NSObject, URLSessionDataDelegate,
             let handle = try FileHandle(forWritingTo: destination)
             if requestedResumeOffset > 0, httpResponse.statusCode == 206 {
                 try handle.seekToEnd()
+                totalBytesWritten = requestedResumeOffset
             } else {
                 try handle.truncate(atOffset: 0)
+                totalBytesWritten = 0
             }
             fileHandle = handle
             completionHandler(.allow)
@@ -551,7 +557,8 @@ private final class StreamingDownloadDelegate: NSObject, URLSessionDataDelegate,
     func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
         do {
             try fileHandle?.write(contentsOf: data)
-            onBytesReceived(UInt64(data.count))
+            totalBytesWritten += UInt64(data.count)
+            onTotalBytesWritten(totalBytesWritten)
         } catch {
             finish(throwing: error)
             dataTask.cancel()

--- a/Sources/MacParakeetViewModels/InProcessModelManagerViewModel.swift
+++ b/Sources/MacParakeetViewModels/InProcessModelManagerViewModel.swift
@@ -1,0 +1,164 @@
+import Foundation
+import MacParakeetCore
+
+@MainActor
+@Observable
+public final class InProcessModelManagerViewModel {
+    public enum State: Equatable {
+        case setUpNeeded
+        case downloading(progress: Double)
+        case verifying
+        case ready
+        case failed(reason: String, recoverable: Bool)
+    }
+
+    public static let minimumPhysicalMemoryBytes: UInt64 = 16 * 1024 * 1024 * 1024
+
+    public private(set) var state: State = .setUpNeeded
+    public private(set) var progress: InProcessModelDownloadProgress?
+    public private(set) var isModelDownloaded = false
+    public private(set) var isWorking = false
+
+    private var downloader: (any InProcessModelDownloading)?
+    private var configStore: (any LLMConfigStoreProtocol)?
+    private var llmClient: (any LLMClientProtocol)?
+    private var onConfigurationChanged: (() -> Void)?
+    private var physicalMemoryBytes: UInt64
+
+    public init(physicalMemoryBytes: UInt64 = ProcessInfo.processInfo.physicalMemory) {
+        self.physicalMemoryBytes = physicalMemoryBytes
+    }
+
+    public func configure(
+        downloader: any InProcessModelDownloading = InProcessModelDownloader(),
+        configStore: any LLMConfigStoreProtocol,
+        llmClient: any LLMClientProtocol,
+        physicalMemoryBytes: UInt64 = ProcessInfo.processInfo.physicalMemory,
+        onConfigurationChanged: (() -> Void)? = nil
+    ) {
+        self.downloader = downloader
+        self.configStore = configStore
+        self.llmClient = llmClient
+        self.physicalMemoryBytes = physicalMemoryBytes
+        self.onConfigurationChanged = onConfigurationChanged
+    }
+
+    public var meetsMemoryRequirement: Bool {
+        physicalMemoryBytes >= Self.minimumPhysicalMemoryBytes
+    }
+
+    public var minimumMemoryDescription: String {
+        "16 GB RAM"
+    }
+
+    public var modelDisplayName: String {
+        InProcessLocalModelCatalog.defaultManifest.displayName
+    }
+
+    public var modelSizeDescription: String {
+        ByteCountFormatter.string(
+            fromByteCount: Int64(InProcessLocalModelCatalog.defaultManifest.totalBytes),
+            countStyle: .file
+        )
+    }
+
+    public var isLocalAISelected: Bool {
+        guard let config = try? configStore?.loadConfig() else { return false }
+        return config.id == .inProcessLocal
+    }
+
+    public func refresh() async {
+        guard meetsMemoryRequirement else {
+            isModelDownloaded = false
+            state = .setUpNeeded
+            return
+        }
+        guard let downloader else {
+            state = .setUpNeeded
+            return
+        }
+        isModelDownloaded = await downloader.isDefaultModelDownloaded()
+        state = isModelDownloaded ? .ready : .setUpNeeded
+    }
+
+    public func enableLocalAI() async {
+        guard meetsMemoryRequirement else {
+            state = .failed(
+                reason: "Local AI needs \(minimumMemoryDescription). Use a cloud provider or bring your own local server instead.",
+                recoverable: false
+            )
+            return
+        }
+        guard let downloader, let configStore, let llmClient else {
+            state = .failed(reason: "Local AI setup is not configured yet.", recoverable: true)
+            return
+        }
+
+        isWorking = true
+        defer { isWorking = false }
+
+        do {
+            state = .downloading(progress: 0)
+            progress = nil
+            let progressSink = InProcessModelProgressSink(viewModel: self)
+            _ = try await downloader.downloadDefaultModel { progress in
+                await progressSink.update(progress)
+            }
+
+            state = .verifying
+            _ = try await downloader.verifyDefaultModel()
+            isModelDownloaded = true
+
+            let config = LLMProviderConfig.inProcessLocal(
+                model: InProcessLocalModelCatalog.defaultManifest.modelID
+            )
+            try await llmClient.testConnection(context: LLMExecutionContext(providerConfig: config))
+            try configStore.saveConfig(config)
+
+            state = .ready
+            onConfigurationChanged?()
+        } catch is CancellationError {
+            state = .failed(reason: "Local AI setup was canceled.", recoverable: true)
+        } catch {
+            state = .failed(reason: error.localizedDescription, recoverable: true)
+        }
+    }
+
+    public func deleteModel() async {
+        guard let downloader else { return }
+        isWorking = true
+        defer { isWorking = false }
+
+        do {
+            try await downloader.deleteDefaultModel()
+            isModelDownloaded = false
+            progress = nil
+            if isLocalAISelected {
+                try configStore?.deleteConfig()
+                onConfigurationChanged?()
+            }
+            state = .setUpNeeded
+        } catch {
+            state = .failed(reason: error.localizedDescription, recoverable: true)
+        }
+    }
+
+    fileprivate func updateDownloadProgress(_ progress: InProcessModelDownloadProgress) {
+        guard case .downloading = state else { return }
+        self.progress = progress
+        state = .downloading(progress: progress.fractionCompleted)
+    }
+}
+
+private final class InProcessModelProgressSink: @unchecked Sendable {
+    weak var viewModel: InProcessModelManagerViewModel?
+
+    init(viewModel: InProcessModelManagerViewModel) {
+        self.viewModel = viewModel
+    }
+
+    @MainActor
+    func update(_ progress: InProcessModelDownloadProgress) {
+        viewModel?.updateDownloadProgress(progress)
+    }
+}

--- a/Sources/MacParakeetViewModels/InProcessModelManagerViewModel.swift
+++ b/Sources/MacParakeetViewModels/InProcessModelManagerViewModel.swift
@@ -43,6 +43,7 @@ public final class InProcessModelManagerViewModel {
         self.llmClient = llmClient
         self.physicalMemoryBytes = physicalMemoryBytes
         self.onConfigurationChanged = onConfigurationChanged
+        refreshSelectionState()
     }
 
     public var meetsMemoryRequirement: Bool {
@@ -64,13 +65,16 @@ public final class InProcessModelManagerViewModel {
         )
     }
 
-    public var isLocalAISelected: Bool {
-        guard let config = try? configStore?.loadConfig() else { return false }
-        return config.id == .inProcessLocal
+    public private(set) var isLocalAISelected = false
+
+    public func refreshSelectionState() {
+        let config = try? configStore?.loadConfig()
+        isLocalAISelected = config?.id == .inProcessLocal
     }
 
     public func refresh() async {
         guard setupTask == nil else { return }
+        refreshSelectionState()
         guard let downloader else {
             state = .setUpNeeded
             return
@@ -130,6 +134,7 @@ public final class InProcessModelManagerViewModel {
             )
             try await llmClient.testConnection(context: LLMExecutionContext(providerConfig: config))
             try configStore.saveConfig(config)
+            refreshSelectionState()
 
             state = .ready
             onConfigurationChanged?()
@@ -152,8 +157,10 @@ public final class InProcessModelManagerViewModel {
             isModelDownloaded = false
             hasModelArtifacts = false
             progress = nil
+            refreshSelectionState()
             if isLocalAISelected {
                 try configStore?.deleteConfig()
+                refreshSelectionState()
                 onConfigurationChanged?()
             }
             state = .setUpNeeded

--- a/Sources/MacParakeetViewModels/InProcessModelManagerViewModel.swift
+++ b/Sources/MacParakeetViewModels/InProcessModelManagerViewModel.swift
@@ -24,6 +24,7 @@ public final class InProcessModelManagerViewModel {
     private var llmClient: (any LLMClientProtocol)?
     private var onConfigurationChanged: (() -> Void)?
     private var physicalMemoryBytes: UInt64
+    private var setupTask: Task<Void, Never>?
 
     public init(physicalMemoryBytes: UInt64 = ProcessInfo.processInfo.physicalMemory) {
         self.physicalMemoryBytes = physicalMemoryBytes
@@ -68,17 +69,29 @@ public final class InProcessModelManagerViewModel {
     }
 
     public func refresh() async {
-        guard meetsMemoryRequirement else {
-            isModelDownloaded = false
-            state = .setUpNeeded
-            return
-        }
         guard let downloader else {
             state = .setUpNeeded
             return
         }
         isModelDownloaded = await downloader.isDefaultModelDownloaded()
         state = isModelDownloaded ? .ready : .setUpNeeded
+    }
+
+    public var isDownloading: Bool {
+        if case .downloading = state { return true }
+        return false
+    }
+
+    public func startEnableLocalAI() {
+        guard setupTask == nil else { return }
+        setupTask = Task {
+            await enableLocalAI()
+            setupTask = nil
+        }
+    }
+
+    public func cancelSetup() {
+        setupTask?.cancel()
     }
 
     public func enableLocalAI() async {
@@ -103,10 +116,9 @@ public final class InProcessModelManagerViewModel {
             _ = try await downloader.downloadDefaultModel { [weak self] progress in
                 await self?.updateDownloadProgress(progress)
             }
+            isModelDownloaded = true
 
             state = .verifying
-            _ = try await downloader.verifyDefaultModel()
-            isModelDownloaded = true
 
             let config = LLMProviderConfig.inProcessLocal(
                 model: InProcessLocalModelCatalog.defaultManifest.modelID

--- a/Sources/MacParakeetViewModels/InProcessModelManagerViewModel.swift
+++ b/Sources/MacParakeetViewModels/InProcessModelManagerViewModel.swift
@@ -100,9 +100,8 @@ public final class InProcessModelManagerViewModel {
         do {
             state = .downloading(progress: 0)
             progress = nil
-            let progressSink = InProcessModelProgressSink(viewModel: self)
-            _ = try await downloader.downloadDefaultModel { progress in
-                await progressSink.update(progress)
+            _ = try await downloader.downloadDefaultModel { [weak self] progress in
+                await self?.updateDownloadProgress(progress)
             }
 
             state = .verifying
@@ -147,18 +146,5 @@ public final class InProcessModelManagerViewModel {
         guard case .downloading = state else { return }
         self.progress = progress
         state = .downloading(progress: progress.fractionCompleted)
-    }
-}
-
-private final class InProcessModelProgressSink: @unchecked Sendable {
-    weak var viewModel: InProcessModelManagerViewModel?
-
-    init(viewModel: InProcessModelManagerViewModel) {
-        self.viewModel = viewModel
-    }
-
-    @MainActor
-    func update(_ progress: InProcessModelDownloadProgress) {
-        viewModel?.updateDownloadProgress(progress)
     }
 }

--- a/Sources/MacParakeetViewModels/InProcessModelManagerViewModel.swift
+++ b/Sources/MacParakeetViewModels/InProcessModelManagerViewModel.swift
@@ -105,7 +105,8 @@ public final class InProcessModelManagerViewModel {
     public func enableLocalAI() async {
         guard meetsMemoryRequirement else {
             state = .failed(
-                reason: "Local AI needs \(minimumMemoryDescription). Use a cloud provider or bring your own local server instead.",
+                reason:
+                    "Local AI needs \(minimumMemoryDescription). Use a cloud provider or bring your own local server instead.",
                 recoverable: false
             )
             return

--- a/Sources/MacParakeetViewModels/InProcessModelManagerViewModel.swift
+++ b/Sources/MacParakeetViewModels/InProcessModelManagerViewModel.swift
@@ -17,6 +17,7 @@ public final class InProcessModelManagerViewModel {
     public private(set) var state: State = .setUpNeeded
     public private(set) var progress: InProcessModelDownloadProgress?
     public private(set) var isModelDownloaded = false
+    public private(set) var hasModelArtifacts = false
     public private(set) var isWorking = false
 
     private var downloader: (any InProcessModelDownloading)?
@@ -74,6 +75,7 @@ public final class InProcessModelManagerViewModel {
             return
         }
         isModelDownloaded = await downloader.isDefaultModelDownloaded()
+        hasModelArtifacts = await downloader.hasDefaultModelArtifacts()
         state = isModelDownloaded ? .ready : .setUpNeeded
     }
 
@@ -117,6 +119,7 @@ public final class InProcessModelManagerViewModel {
                 await self?.updateDownloadProgress(progress)
             }
             isModelDownloaded = true
+            hasModelArtifacts = true
 
             state = .verifying
 
@@ -130,8 +133,10 @@ public final class InProcessModelManagerViewModel {
             onConfigurationChanged?()
         } catch is CancellationError {
             state = .failed(reason: "Local AI setup was canceled.", recoverable: true)
+            hasModelArtifacts = await downloader.hasDefaultModelArtifacts()
         } catch {
             state = .failed(reason: error.localizedDescription, recoverable: true)
+            hasModelArtifacts = await downloader.hasDefaultModelArtifacts()
         }
     }
 
@@ -143,6 +148,7 @@ public final class InProcessModelManagerViewModel {
         do {
             try await downloader.deleteDefaultModel()
             isModelDownloaded = false
+            hasModelArtifacts = false
             progress = nil
             if isLocalAISelected {
                 try configStore?.deleteConfig()

--- a/Sources/MacParakeetViewModels/InProcessModelManagerViewModel.swift
+++ b/Sources/MacParakeetViewModels/InProcessModelManagerViewModel.swift
@@ -70,12 +70,14 @@ public final class InProcessModelManagerViewModel {
     }
 
     public func refresh() async {
+        guard setupTask == nil else { return }
         guard let downloader else {
             state = .setUpNeeded
             return
         }
         isModelDownloaded = await downloader.isDefaultModelDownloaded()
         hasModelArtifacts = await downloader.hasDefaultModelArtifacts()
+        guard setupTask == nil else { return }
         state = isModelDownloaded ? .ready : .setUpNeeded
     }
 

--- a/Sources/MacParakeetViewModels/LLMSettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/LLMSettingsViewModel.swift
@@ -103,7 +103,8 @@ public final class LLMSettingsViewModel {
                 return "Name is required."
             }
             if targetKind == .bundle,
-               bundleIdentifier.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                bundleIdentifier.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            {
                 return "Bundle ID is required for app profiles."
             }
             if promptTemplate.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
@@ -347,7 +348,8 @@ public final class LLMSettingsViewModel {
             nextDraft.commandTemplate = newValue
             // Clear template picker when user manually edits the command
             if let template = nextDraft.selectedCLITemplate,
-               newValue != template.defaultCommand {
+                newValue != template.defaultCommand
+            {
                 nextDraft.selectedCLITemplate = nil
             }
             updateDraft(nextDraft)
@@ -487,11 +489,13 @@ public final class LLMSettingsViewModel {
     /// or neither (genuinely custom)?
     public func aiFormatterProfileBadgeText(_ profile: AIFormatterProfile) -> String {
         let promptTemplate = AIFormatter.normalizedPromptTemplate(profile.promptTemplate)
-        let category = profile.appCategory
+        let category =
+            profile.appCategory
             ?? profile.bundleIdentifier.map { TelemetryAppCategory(bundleIdentifier: $0) }
         if let category,
-           let categoryDefault = AIFormatterSmartDefaults.categoryDefault(for: category),
-           promptTemplate == AIFormatter.normalizedPromptTemplate(categoryDefault.promptTemplate) {
+            let categoryDefault = AIFormatterSmartDefaults.categoryDefault(for: category),
+            promptTemplate == AIFormatter.normalizedPromptTemplate(categoryDefault.promptTemplate)
+        {
             return "Smart default"
         }
         if promptTemplate == draft.normalizedAIFormatterPrompt {
@@ -521,7 +525,8 @@ public final class LLMSettingsViewModel {
     private var savedAIOptionDisplayName: String? {
         guard let configStore, let config = try? configStore.loadConfig() else { return nil }
         if config.id == .localCLI {
-            return cliConfigStore
+            return
+                cliConfigStore
                 .flatMap { $0.load() }
                 .map { LocalCLITemplate.displayName(for: $0.commandTemplate) }
                 ?? config.id.displayName
@@ -652,10 +657,11 @@ public final class LLMSettingsViewModel {
             guard let config = try buildConfig(from: snapshot) else { return }
             context = LLMExecutionContext(
                 providerConfig: config,
-                localCLIConfig: snapshot.providerID == .localCLI ? LocalCLIConfig(
-                    commandTemplate: snapshot.trimmedCommandTemplate,
-                    timeoutSeconds: snapshot.cliTimeoutSeconds
-                ) : nil
+                localCLIConfig: snapshot.providerID == .localCLI
+                    ? LocalCLIConfig(
+                        commandTemplate: snapshot.trimmedCommandTemplate,
+                        timeoutSeconds: snapshot.cliTimeoutSeconds
+                    ) : nil
             )
         } catch {
             connectionTestState = .error(error.localizedDescription)
@@ -680,7 +686,8 @@ public final class LLMSettingsViewModel {
         // Use the persisted provider to decide what to delete. The draft may
         // point at an unsaved provider switch in Settings.
         let storedProviderID = (try? configStore.loadConfig())?.id
-        let preservedCLIConfig = draft.providerID == .localCLI && storedProviderID != .localCLI
+        let preservedCLIConfig =
+            draft.providerID == .localCLI && storedProviderID != .localCLI
             ? cliConfigStore?.load()
             : nil
         do {
@@ -753,7 +760,8 @@ public final class LLMSettingsViewModel {
         let promptTemplate: String
         let name: String
         if targetKind == .category,
-           let categoryDefault = AIFormatterSmartDefaults.categoryDefault(for: defaultCategory) {
+            let categoryDefault = AIFormatterSmartDefaults.categoryDefault(for: defaultCategory)
+        {
             name = Self.aiFormatterProfileCategoryName(defaultCategory)
             promptTemplate = categoryDefault.promptTemplate
         } else {
@@ -787,7 +795,8 @@ public final class LLMSettingsViewModel {
         let currentName = draft.name.trimmingCharacters(in: .whitespacesAndNewlines)
         let previousAppDisplayName = AppPromptContext.normalizedDisplayName(draft.appDisplayName)
         let previousBundleIdentifier = AppPromptContext.normalizedBundleIdentifier(draft.bundleIdentifier)
-        let shouldReplaceName = currentName.isEmpty
+        let shouldReplaceName =
+            currentName.isEmpty
             || currentName == "New app profile"
             || currentName == Self.aiFormatterProfileCategoryName(previousCategory)
             || previousAppDisplayName.map { currentName == $0 } == true
@@ -799,7 +808,8 @@ public final class LLMSettingsViewModel {
             draft.name = Self.aiFormatterProfileCategoryName(category)
         }
         if shouldUseSmartDefaultPrompt,
-           let categoryDefault = AIFormatterSmartDefaults.categoryDefault(for: category) {
+            let categoryDefault = AIFormatterSmartDefaults.categoryDefault(for: category)
+        {
             draft.promptTemplate = categoryDefault.promptTemplate
         }
         aiFormatterProfileDraft = draft
@@ -829,7 +839,8 @@ public final class LLMSettingsViewModel {
             let previousSmartDefault = AIFormatterSmartDefaults.categoryDefault(for: previousCategory)
             let normalizedPrompt = AIFormatter.normalizedPromptTemplate(draft.promptTemplate)
             let currentName = draft.name.trimmingCharacters(in: .whitespacesAndNewlines)
-            let shouldReplaceName = currentName.isEmpty
+            let shouldReplaceName =
+                currentName.isEmpty
                 || currentName == Self.aiFormatterProfileCategoryName(previousCategory)
 
             draft.targetKind = .bundle
@@ -865,7 +876,8 @@ public final class LLMSettingsViewModel {
         let currentName = draft.name.trimmingCharacters(in: .whitespacesAndNewlines)
         let previousAppDisplayName = AppPromptContext.normalizedDisplayName(draft.appDisplayName)
         let previousBundleIdentifier = AppPromptContext.normalizedBundleIdentifier(draft.bundleIdentifier)
-        let shouldReplaceName = currentName.isEmpty
+        let shouldReplaceName =
+            currentName.isEmpty
             || currentName == "New app profile"
             || currentName == Self.aiFormatterProfileCategoryName(draft.appCategory)
             || previousAppDisplayName.map { currentName == $0 } == true
@@ -883,7 +895,8 @@ public final class LLMSettingsViewModel {
             draft.name = normalizedDisplayName ?? normalizedBundleIdentifier
         }
         if shouldUseSmartDefaultPrompt,
-           let categoryDefault = AIFormatterSmartDefaults.categoryDefault(for: appCategory) {
+            let categoryDefault = AIFormatterSmartDefaults.categoryDefault(for: appCategory)
+        {
             draft.promptTemplate = categoryDefault.promptTemplate
         } else if shouldUseSmartDefaultPrompt {
             draft.promptTemplate = self.draft.normalizedAIFormatterPrompt
@@ -935,7 +948,8 @@ public final class LLMSettingsViewModel {
         let currentName = draft.name.trimmingCharacters(in: .whitespacesAndNewlines)
         let previousAppDisplayName = AppPromptContext.normalizedDisplayName(draft.appDisplayName)
         let previousBundleIdentifier = AppPromptContext.normalizedBundleIdentifier(draft.bundleIdentifier)
-        let shouldReplaceName = currentName.isEmpty
+        let shouldReplaceName =
+            currentName.isEmpty
             || currentName == "New app profile"
             || currentName == Self.aiFormatterProfileCategoryName(previousCategory)
             || previousAppDisplayName.map { currentName == $0 } == true
@@ -980,7 +994,8 @@ public final class LLMSettingsViewModel {
         previousCategoryDefault: AIFormatterSmartDefaults.CategoryDefault?
     ) -> Bool {
         if let previousCategoryDefault,
-           normalizedPrompt == AIFormatter.normalizedPromptTemplate(previousCategoryDefault.promptTemplate) {
+            normalizedPrompt == AIFormatter.normalizedPromptTemplate(previousCategoryDefault.promptTemplate)
+        {
             return true
         }
         return normalizedPrompt == draft.normalizedAIFormatterPrompt
@@ -1146,10 +1161,12 @@ public final class LLMSettingsViewModel {
 
     private func buildModelListContext(from draft: LLMSettingsDraft) throws -> LLMExecutionContext? {
         guard let providerID = draft.providerID, Self.usesDiscoveredModelList(providerID) else { return nil }
-        guard let config = try draft.buildConfig(
-            defaultBaseURL: Self.defaultBaseURL(for: providerID),
-            allowMissingModelName: true
-        ) else {
+        guard
+            let config = try draft.buildConfig(
+                defaultBaseURL: Self.defaultBaseURL(for: providerID),
+                allowMissingModelName: true
+            )
+        else {
             return nil
         }
         return LLMExecutionContext(providerConfig: config)
@@ -1170,8 +1187,9 @@ public final class LLMSettingsViewModel {
         guard !models.isEmpty else { return }
         guard draft.providerID == snapshot.providerID else { return }
         guard draft.useCustomModel == snapshot.useCustomModel,
-              draft.customModelName == snapshot.customModelName,
-              draft.suggestedModelName == snapshot.suggestedModelName else {
+            draft.customModelName == snapshot.customModelName,
+            draft.suggestedModelName == snapshot.suggestedModelName
+        else {
             return
         }
 
@@ -1300,7 +1318,8 @@ public final class LLMSettingsViewModel {
     }
 
     private static func loadStoredAIFormatterEnabledForTranscriptions(from defaults: UserDefaults) -> Bool {
-        defaults.object(forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledForTranscriptionsKey) as? Bool ?? true
+        defaults.object(forKey: UserDefaultsAppRuntimePreferences.aiFormatterEnabledForTranscriptionsKey) as? Bool
+            ?? true
     }
 
     private static func loadStoredAutoGenerateMeetingTitles(from defaults: UserDefaults) -> Bool {

--- a/Sources/MacParakeetViewModels/LLMSettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/LLMSettingsViewModel.swift
@@ -153,6 +153,7 @@ public final class LLMSettingsViewModel {
     public var aiFormatterProfileDraft: AIFormatterProfileDraft?
     public var aiFormatterProfileError: String?
     public private(set) var aiFormatterSmartDefaultsPolicy: AIFormatterSmartDefaultsPolicy
+    public let inProcessModelManager: InProcessModelManagerViewModel
     private var discoveredModels: [String] = []
 
     public var selectedProviderID: LLMProviderID? {
@@ -328,6 +329,10 @@ public final class LLMSettingsViewModel {
 
     public var usesInsecureLocalNetworkHTTP: Bool {
         draft.usesInsecureLocalNetworkHTTP
+    }
+
+    public var shouldShowInProcessLocalSetup: Bool {
+        AppFeatures.isInProcessLocalLLMVisible(defaults: defaults)
     }
 
     public var validationMessage: String? {
@@ -563,6 +568,7 @@ public final class LLMSettingsViewModel {
 
     public init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
+        self.inProcessModelManager = InProcessModelManagerViewModel()
         self.aiFormatterEnabledForDictation = Self.loadStoredAIFormatterEnabledForDictation(from: defaults)
         self.aiFormatterEnabledForTranscriptions = Self.loadStoredAIFormatterEnabledForTranscriptions(from: defaults)
         self.autoGenerateMeetingTitles = Self.loadStoredAutoGenerateMeetingTitles(from: defaults)
@@ -577,14 +583,29 @@ public final class LLMSettingsViewModel {
         configStore: LLMConfigStoreProtocol,
         llmClient: LLMClientProtocol,
         cliConfigStore: LocalCLIConfigStore = LocalCLIConfigStore(),
-        aiFormatterProfileRepo: AIFormatterProfileRepositoryProtocol? = nil
+        aiFormatterProfileRepo: AIFormatterProfileRepositoryProtocol? = nil,
+        inProcessModelDownloader: any InProcessModelDownloading = InProcessModelDownloader(),
+        physicalMemoryBytes: UInt64 = ProcessInfo.processInfo.physicalMemory
     ) {
         self.configStore = configStore
         self.llmClient = llmClient
         self.cliConfigStore = cliConfigStore
         self.aiFormatterProfileRepo = aiFormatterProfileRepo
+        inProcessModelManager.configure(
+            downloader: inProcessModelDownloader,
+            configStore: configStore,
+            llmClient: llmClient,
+            physicalMemoryBytes: physicalMemoryBytes,
+            onConfigurationChanged: { [weak self] in
+                self?.loadExistingConfig()
+                self?.onConfigurationChanged?()
+            }
+        )
         loadExistingConfig()
         loadAIFormatterProfiles()
+        Task {
+            await inProcessModelManager.refresh()
+        }
     }
 
     public func saveConfiguration() {

--- a/Sources/MacParakeetViewModels/LLMSettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/LLMSettingsViewModel.swift
@@ -636,6 +636,7 @@ public final class LLMSettingsViewModel {
             }
 
             saveState = .saved
+            inProcessModelManager.refreshSelectionState()
             onConfigurationChanged?()
         } catch {
             saveState = .error(error.localizedDescription)
@@ -720,6 +721,7 @@ public final class LLMSettingsViewModel {
         }
         connectionTestState = .idle
         saveState = .idle
+        inProcessModelManager.refreshSelectionState()
         onConfigurationChanged?()
     }
 

--- a/Tests/MacParakeetTests/Models/LLMProviderDescriptorTests.swift
+++ b/Tests/MacParakeetTests/Models/LLMProviderDescriptorTests.swift
@@ -57,15 +57,19 @@ final class LLMProviderDescriptorTests: XCTestCase {
 
     func testFactoryDefaultsComeFromDescriptors() {
         XCTAssertEqual(LLMProviderConfig.openai(apiKey: "sk").modelName, LLMProviderID.openai.defaultModelName)
-        XCTAssertEqual(LLMProviderConfig.openai(apiKey: "sk").baseURL.absoluteString, LLMProviderID.openai.defaultBaseURL)
+        XCTAssertEqual(
+            LLMProviderConfig.openai(apiKey: "sk").baseURL.absoluteString, LLMProviderID.openai.defaultBaseURL)
         XCTAssertEqual(LLMProviderConfig.gemini(apiKey: "key").modelName, LLMProviderID.gemini.defaultModelName)
-        XCTAssertEqual(LLMProviderConfig.gemini(apiKey: "key").baseURL.absoluteString, LLMProviderID.gemini.defaultBaseURL)
+        XCTAssertEqual(
+            LLMProviderConfig.gemini(apiKey: "key").baseURL.absoluteString, LLMProviderID.gemini.defaultBaseURL)
         XCTAssertEqual(LLMProviderConfig.openrouter(apiKey: "key").modelName, LLMProviderID.openrouter.defaultModelName)
-        XCTAssertEqual(LLMProviderConfig.openrouter(apiKey: "key").baseURL.absoluteString, LLMProviderID.openrouter.defaultBaseURL)
+        XCTAssertEqual(
+            LLMProviderConfig.openrouter(apiKey: "key").baseURL.absoluteString, LLMProviderID.openrouter.defaultBaseURL)
         XCTAssertEqual(LLMProviderConfig.ollama().modelName, LLMProviderID.ollama.defaultModelName)
         XCTAssertEqual(LLMProviderConfig.ollama().baseURL.absoluteString, LLMProviderID.ollama.defaultBaseURL)
         XCTAssertEqual(LLMProviderConfig.inProcessLocal().modelName, LLMProviderID.inProcessLocal.defaultModelName)
-        XCTAssertEqual(LLMProviderConfig.inProcessLocal().baseURL.absoluteString, LLMProviderID.inProcessLocal.defaultBaseURL)
+        XCTAssertEqual(
+            LLMProviderConfig.inProcessLocal().baseURL.absoluteString, LLMProviderID.inProcessLocal.defaultBaseURL)
     }
 
     func testInProcessLocalProviderIsHiddenWhileFeatureFlagIsOff() {
@@ -83,7 +87,8 @@ final class LLMProviderDescriptorTests: XCTestCase {
                 .localCLI,
             ]
         )
-        XCTAssertFalse(LLMProviderID.userSelectableProviderIDs(inProcessLocalLLMVisible: false).contains(.inProcessLocal))
+        XCTAssertFalse(
+            LLMProviderID.userSelectableProviderIDs(inProcessLocalLLMVisible: false).contains(.inProcessLocal))
     }
 
     func testDeveloperOverrideCanExposeInProcessLocalProviderWithoutFlippingPublicFlag() {
@@ -105,9 +110,10 @@ final class LLMProviderDescriptorTests: XCTestCase {
         defer { defaults.removePersistentDomain(forName: suiteName) }
 
         XCTAssertFalse(AppFeatures.inProcessLocalLLMEnabled)
-        XCTAssertTrue(AppFeatures.inProcessLocalLLMDeveloperOverrideEnabled(
-            defaults: defaults,
-            arguments: [AppFeatures.inProcessLocalLLMDeveloperLaunchArgument]
-        ))
+        XCTAssertTrue(
+            AppFeatures.inProcessLocalLLMDeveloperOverrideEnabled(
+                defaults: defaults,
+                arguments: [AppFeatures.inProcessLocalLLMDeveloperLaunchArgument]
+            ))
     }
 }

--- a/Tests/MacParakeetTests/Models/LLMProviderDescriptorTests.swift
+++ b/Tests/MacParakeetTests/Models/LLMProviderDescriptorTests.swift
@@ -71,7 +71,7 @@ final class LLMProviderDescriptorTests: XCTestCase {
     func testInProcessLocalProviderIsHiddenWhileFeatureFlagIsOff() {
         XCTAssertFalse(AppFeatures.inProcessLocalLLMEnabled)
         XCTAssertEqual(
-            LLMProviderID.userSelectableProviderIDs,
+            LLMProviderID.userSelectableProviderIDs(inProcessLocalLLMVisible: false),
             [
                 .lmstudio,
                 .ollama,
@@ -83,6 +83,31 @@ final class LLMProviderDescriptorTests: XCTestCase {
                 .localCLI,
             ]
         )
-        XCTAssertFalse(LLMProviderID.userSelectableProviderIDs.contains(.inProcessLocal))
+        XCTAssertFalse(LLMProviderID.userSelectableProviderIDs(inProcessLocalLLMVisible: false).contains(.inProcessLocal))
+    }
+
+    func testDeveloperOverrideCanExposeInProcessLocalProviderWithoutFlippingPublicFlag() {
+        let suiteName = "LLMProviderDescriptorTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set(true, forKey: AppFeatures.inProcessLocalLLMDeveloperDefaultsKey)
+
+        XCTAssertFalse(AppFeatures.inProcessLocalLLMEnabled)
+        XCTAssertTrue(AppFeatures.inProcessLocalLLMDeveloperOverrideEnabled(defaults: defaults, arguments: []))
+        XCTAssertTrue(AppFeatures.isInProcessLocalLLMVisible(defaults: defaults, arguments: []))
+        XCTAssertTrue(LLMProviderID.userSelectableProviderIDs(inProcessLocalLLMVisible: true).contains(.inProcessLocal))
+    }
+
+    func testDeveloperLaunchArgumentCanExposeInProcessLocalProviderWithoutFlippingPublicFlag() {
+        let suiteName = "LLMProviderDescriptorTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        XCTAssertFalse(AppFeatures.inProcessLocalLLMEnabled)
+        XCTAssertTrue(AppFeatures.inProcessLocalLLMDeveloperOverrideEnabled(
+            defaults: defaults,
+            arguments: [AppFeatures.inProcessLocalLLMDeveloperLaunchArgument]
+        ))
     }
 }

--- a/Tests/MacParakeetTests/Services/LLM/InProcessLLMClientTests.swift
+++ b/Tests/MacParakeetTests/Services/LLM/InProcessLLMClientTests.swift
@@ -176,6 +176,105 @@ final class InProcessLLMClientTests: XCTestCase {
         XCTAssertTrue(reducePrompt.contains("[...truncated for local model memory...]"))
     }
 
+    func testChunkingPrefersParagraphBoundaries() async throws {
+        let modelDirectory = temporaryModelDirectory()
+        let runtime = FakeLocalLLMRuntime(eventPlans: [
+            [.text("map-1")],
+            [.text("map-2")],
+            [.text("final")],
+        ])
+        let client = InProcessLLMClient(
+            runtime: runtime,
+            modelDirectoryResolver: { _ in modelDirectory },
+            chunkCharacterThreshold: 10,
+            chunkCharacterLimit: 90,
+            idleUnloadDelaySeconds: 60
+        )
+
+        _ = try await client.chatCompletion(
+            messages: [
+                ChatMessage(
+                    role: .user,
+                    content: """
+                        First paragraph keeps one idea together.
+
+                        Second paragraph should begin the next local chunk.
+                        """
+                )
+            ],
+            context: LLMExecutionContext(providerConfig: .inProcessLocal(model: "paragraph-boundary-test")),
+            options: .default
+        )
+
+        let requestContents = await runtime.requestContents()
+        XCTAssertEqual(requestContents.count, 3)
+        XCTAssertTrue(requestContents[0].contains("First paragraph keeps one idea together."))
+        XCTAssertFalse(requestContents[0].contains("Second paragraph should begin"))
+        XCTAssertTrue(requestContents[1].contains("Second paragraph should begin the next local chunk."))
+    }
+
+    func testChunkingPrefersSentenceBoundaries() async throws {
+        let modelDirectory = temporaryModelDirectory()
+        let runtime = FakeLocalLLMRuntime(eventPlans: [
+            [.text("map-1")],
+            [.text("map-2")],
+            [.text("final")],
+        ])
+        let client = InProcessLLMClient(
+            runtime: runtime,
+            modelDirectoryResolver: { _ in modelDirectory },
+            chunkCharacterThreshold: 10,
+            chunkCharacterLimit: 75,
+            idleUnloadDelaySeconds: 60
+        )
+
+        _ = try await client.chatCompletion(
+            messages: [
+                ChatMessage(
+                    role: .user,
+                    content: "Alpha sentence should stay whole. Beta sentence should start the second chunk."
+                )
+            ],
+            context: LLMExecutionContext(providerConfig: .inProcessLocal(model: "sentence-boundary-test")),
+            options: .default
+        )
+
+        let requestContents = await runtime.requestContents()
+        XCTAssertEqual(requestContents.count, 3)
+        XCTAssertTrue(requestContents[0].contains("Alpha sentence should stay whole."))
+        XCTAssertFalse(requestContents[0].contains("Beta sentence"))
+        XCTAssertTrue(requestContents[1].contains("Beta sentence should start the second chunk."))
+    }
+
+    func testChunkingFallsBackToHardCutForSingleOversizedSentence() async throws {
+        let modelDirectory = temporaryModelDirectory()
+        let runtime = FakeLocalLLMRuntime(eventPlans: [
+            [.text("map-1")],
+            [.text("map-2")],
+            [.text("final")],
+        ])
+        let client = InProcessLLMClient(
+            runtime: runtime,
+            modelDirectoryResolver: { _ in modelDirectory },
+            chunkCharacterThreshold: 10,
+            chunkCharacterLimit: 60,
+            idleUnloadDelaySeconds: 60
+        )
+
+        _ = try await client.chatCompletion(
+            messages: [
+                ChatMessage(role: .user, content: String(repeating: "x", count: 90))
+            ],
+            context: LLMExecutionContext(providerConfig: .inProcessLocal(model: "hard-cut-boundary-test")),
+            options: .default
+        )
+
+        let requestContents = await runtime.requestContents()
+        XCTAssertEqual(requestContents.count, 4)
+        XCTAssertTrue(requestContents.dropLast().allSatisfy { $0.contains("Process chunk") })
+        XCTAssertTrue(requestContents.last?.contains("Combine the chunk results") == true)
+    }
+
     func testQueuedGenerationDoesNotUnloadRuntimeBetweenRequests() async throws {
         let modelDirectory = temporaryModelDirectory()
         let firstGenerationGate = AsyncGate()

--- a/Tests/MacParakeetTests/Services/LLM/InProcessModelDownloaderTests.swift
+++ b/Tests/MacParakeetTests/Services/LLM/InProcessModelDownloaderTests.swift
@@ -104,7 +104,8 @@ final class InProcessModelDownloaderTests: XCTestCase {
 
         let recorded = await recorder.values()
         XCTAssertEqual(recorded, recorded.sorted(), "Progress moved backward: \(recorded)")
-        XCTAssertFalse(recorded.contains(3), "Discarded resume offset should not be emitted before response: \(recorded)")
+        XCTAssertFalse(
+            recorded.contains(3), "Discarded resume offset should not be emitted before response: \(recorded)")
         XCTAssertTrue(recorded.allSatisfy { $0 <= 6 }, "Progress overcounted the file size: \(recorded)")
         XCTAssertEqual(
             try Data(contentsOf: fixture.directory.appendingPathComponent("model.safetensors")),
@@ -178,7 +179,8 @@ final class InProcessModelDownloaderTests: XCTestCase {
         XCTAssertTrue(downloaded)
 
         let corruptFile = fixture.directory.appendingPathComponent("config.json")
-        let originalModifiedAt = try FileManager.default
+        let originalModifiedAt =
+            try FileManager.default
             .attributesOfItem(atPath: corruptFile.path)[.modificationDate] as? Date
         try Data(repeating: 0x78, count: fixture.files["config.json"]!.count).write(to: corruptFile)
         if let originalModifiedAt {
@@ -233,21 +235,26 @@ final class InProcessModelDownloaderTests: XCTestCase {
     }
 
     func testRedirectPolicyAllowsOnlyTrustedHTTPSHosts() {
-        XCTAssertTrue(URLSessionInProcessModelDownloadTransport.isAllowedRedirectURL(
-            URL(string: "https://huggingface.co/example/model")!
-        ))
-        XCTAssertTrue(URLSessionInProcessModelDownloadTransport.isAllowedRedirectURL(
-            URL(string: "https://cdn-lfs.huggingface.co/example/model")!
-        ))
-        XCTAssertTrue(URLSessionInProcessModelDownloadTransport.isAllowedRedirectURL(
-            URL(string: "https://cas-bridge.xethub.hf.co/example/model")!
-        ))
-        XCTAssertFalse(URLSessionInProcessModelDownloadTransport.isAllowedRedirectURL(
-            URL(string: "http://huggingface.co/example/model")!
-        ))
-        XCTAssertFalse(URLSessionInProcessModelDownloadTransport.isAllowedRedirectURL(
-            URL(string: "https://example.com/example/model")!
-        ))
+        XCTAssertTrue(
+            URLSessionInProcessModelDownloadTransport.isAllowedRedirectURL(
+                URL(string: "https://huggingface.co/example/model")!
+            ))
+        XCTAssertTrue(
+            URLSessionInProcessModelDownloadTransport.isAllowedRedirectURL(
+                URL(string: "https://cdn-lfs.huggingface.co/example/model")!
+            ))
+        XCTAssertTrue(
+            URLSessionInProcessModelDownloadTransport.isAllowedRedirectURL(
+                URL(string: "https://cas-bridge.xethub.hf.co/example/model")!
+            ))
+        XCTAssertFalse(
+            URLSessionInProcessModelDownloadTransport.isAllowedRedirectURL(
+                URL(string: "http://huggingface.co/example/model")!
+            ))
+        XCTAssertFalse(
+            URLSessionInProcessModelDownloadTransport.isAllowedRedirectURL(
+                URL(string: "https://example.com/example/model")!
+            ))
     }
 
     func testDeleteRemovesModelDirectory() async throws {

--- a/Tests/MacParakeetTests/Services/LLM/InProcessModelDownloaderTests.swift
+++ b/Tests/MacParakeetTests/Services/LLM/InProcessModelDownloaderTests.swift
@@ -102,12 +102,10 @@ final class InProcessModelDownloaderTests: XCTestCase {
             await recorder.append(progress.completedBytes)
         }
 
-        let validValues: Set<UInt64> = [0, 2, 3, 4, 6]
         let recorded = await recorder.values()
-        XCTAssertTrue(
-            recorded.allSatisfy { validValues.contains($0) },
-            "Progress double-counted the discarded resume offset: \(recorded)"
-        )
+        XCTAssertEqual(recorded, recorded.sorted(), "Progress moved backward: \(recorded)")
+        XCTAssertFalse(recorded.contains(3), "Discarded resume offset should not be emitted before response: \(recorded)")
+        XCTAssertTrue(recorded.allSatisfy { $0 <= 6 }, "Progress overcounted the file size: \(recorded)")
         XCTAssertEqual(
             try Data(contentsOf: fixture.directory.appendingPathComponent("model.safetensors")),
             Data("abcdef".utf8)
@@ -167,7 +165,7 @@ final class InProcessModelDownloaderTests: XCTestCase {
         )
     }
 
-    func testIsDefaultModelDownloadedChecksPresenceAndSize() async throws {
+    func testIsDefaultModelDownloadedRequiresVerificationMarkerAndRejectsSameSizeCorruption() async throws {
         let fixture = try makeFixture()
         try writeFixtureFiles(fixture)
         let downloader = InProcessModelDownloader(
@@ -179,11 +177,77 @@ final class InProcessModelDownloaderTests: XCTestCase {
         let downloaded = await downloader.isDefaultModelDownloaded()
         XCTAssertTrue(downloaded)
 
+        let corruptFile = fixture.directory.appendingPathComponent("config.json")
+        let originalModifiedAt = try FileManager.default
+            .attributesOfItem(atPath: corruptFile.path)[.modificationDate] as? Date
+        try Data(repeating: 0x78, count: fixture.files["config.json"]!.count).write(to: corruptFile)
+        if let originalModifiedAt {
+            try FileManager.default.setAttributes(
+                [.modificationDate: originalModifiedAt],
+                ofItemAtPath: corruptFile.path
+            )
+        }
+        let afterSameSizeCorruption = await downloader.isDefaultModelDownloaded()
+        XCTAssertFalse(afterSameSizeCorruption)
+
+        try writeFixtureFiles(fixture)
+        _ = try await downloader.verifyDefaultModel()
+        let managedDirectory = try InProcessLLMClient.managedModelDirectory(
+            for: .inProcessLocal(model: fixture.manifest.modelID),
+            manifest: fixture.manifest,
+            cacheRoot: fixture.root
+        )
+        XCTAssertEqual(managedDirectory.standardizedFileURL, fixture.directory.standardizedFileURL)
+
         try FileManager.default.removeItem(
             at: fixture.directory.appendingPathComponent("config.json")
         )
         let afterRemoval = await downloader.isDefaultModelDownloaded()
         XCTAssertFalse(afterRemoval)
+        XCTAssertThrowsError(
+            try InProcessLLMClient.managedModelDirectory(
+                for: .inProcessLocal(model: fixture.manifest.modelID),
+                manifest: fixture.manifest,
+                cacheRoot: fixture.root
+            )
+        )
+    }
+
+    func testDownloadRejectsManifestPathEscapingModelDirectory() async throws {
+        let fixture = try makeFixture(files: ["../escape.bin": Data("escape".utf8)])
+        let downloader = InProcessModelDownloader(
+            manifest: fixture.manifest,
+            cacheRoot: fixture.root,
+            transport: fixture.transport
+        )
+
+        do {
+            _ = try await downloader.downloadDefaultModel()
+            XCTFail("Expected manifest path validation to reject directory traversal")
+        } catch InProcessModelDownloaderError.invalidManifestPath("../escape.bin") {
+            // Expected.
+        } catch {
+            XCTFail("Expected invalidManifestPath, got \(error)")
+        }
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fixture.root.appendingPathComponent("escape.bin").path))
+    }
+
+    func testRedirectPolicyAllowsOnlyTrustedHTTPSHosts() {
+        XCTAssertTrue(URLSessionInProcessModelDownloadTransport.isAllowedRedirectURL(
+            URL(string: "https://huggingface.co/example/model")!
+        ))
+        XCTAssertTrue(URLSessionInProcessModelDownloadTransport.isAllowedRedirectURL(
+            URL(string: "https://cdn-lfs.huggingface.co/example/model")!
+        ))
+        XCTAssertTrue(URLSessionInProcessModelDownloadTransport.isAllowedRedirectURL(
+            URL(string: "https://cas-bridge.xethub.hf.co/example/model")!
+        ))
+        XCTAssertFalse(URLSessionInProcessModelDownloadTransport.isAllowedRedirectURL(
+            URL(string: "http://huggingface.co/example/model")!
+        ))
+        XCTAssertFalse(URLSessionInProcessModelDownloadTransport.isAllowedRedirectURL(
+            URL(string: "https://example.com/example/model")!
+        ))
     }
 
     func testDeleteRemovesModelDirectory() async throws {

--- a/Tests/MacParakeetTests/Services/LLM/InProcessModelDownloaderTests.swift
+++ b/Tests/MacParakeetTests/Services/LLM/InProcessModelDownloaderTests.swift
@@ -63,6 +63,47 @@ final class InProcessModelDownloaderTests: XCTestCase {
         )
     }
 
+    func testDownloadPromotesCompleteVerifiedPartialWithoutRedownloading() async throws {
+        let fixture = try makeFixture(files: ["model.safetensors": Data("abcdef".utf8)])
+        try FileManager.default.createDirectory(at: fixture.directory, withIntermediateDirectories: true)
+        let partial = fixture.directory.appendingPathComponent(".model.safetensors.part")
+        try Data("abcdef".utf8).write(to: partial)
+        let downloader = InProcessModelDownloader(
+            manifest: fixture.manifest,
+            cacheRoot: fixture.root,
+            transport: fixture.transport
+        )
+
+        _ = try await downloader.downloadDefaultModel()
+
+        let requests = await fixture.transport.requests()
+        XCTAssertTrue(requests.isEmpty)
+        XCTAssertEqual(
+            try Data(contentsOf: fixture.directory.appendingPathComponent("model.safetensors")),
+            Data("abcdef".utf8)
+        )
+        XCTAssertFalse(FileManager.default.fileExists(atPath: partial.path))
+    }
+
+    func testIsDefaultModelDownloadedChecksPresenceAndSize() async throws {
+        let fixture = try makeFixture()
+        try writeFixtureFiles(fixture)
+        let downloader = InProcessModelDownloader(
+            manifest: fixture.manifest,
+            cacheRoot: fixture.root,
+            transport: fixture.transport
+        )
+
+        let downloaded = await downloader.isDefaultModelDownloaded()
+        XCTAssertTrue(downloaded)
+
+        try FileManager.default.removeItem(
+            at: fixture.directory.appendingPathComponent("config.json")
+        )
+        let afterRemoval = await downloader.isDefaultModelDownloaded()
+        XCTAssertFalse(afterRemoval)
+    }
+
     func testDeleteRemovesModelDirectory() async throws {
         let fixture = try makeFixture()
         try writeFixtureFiles(fixture)

--- a/Tests/MacParakeetTests/Services/LLM/InProcessModelDownloaderTests.swift
+++ b/Tests/MacParakeetTests/Services/LLM/InProcessModelDownloaderTests.swift
@@ -85,6 +85,88 @@ final class InProcessModelDownloaderTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: partial.path))
     }
 
+    func testProgressDoesNotOvercountWhenServerIgnoresResumeOffset() async throws {
+        let fixture = try makeFixture(files: ["model.safetensors": Data("abcdef".utf8)])
+        try FileManager.default.createDirectory(at: fixture.directory, withIntermediateDirectories: true)
+        let partial = fixture.directory.appendingPathComponent(".model.safetensors.part")
+        try Data("abc".utf8).write(to: partial)
+        await fixture.transport.setIgnoresResumeOffset(true)
+        let downloader = InProcessModelDownloader(
+            manifest: fixture.manifest,
+            cacheRoot: fixture.root,
+            transport: fixture.transport
+        )
+        let recorder = ProgressRecorder()
+
+        _ = try await downloader.downloadDefaultModel { progress in
+            await recorder.append(progress.completedBytes)
+        }
+
+        let validValues: Set<UInt64> = [0, 2, 3, 4, 6]
+        let recorded = await recorder.values()
+        XCTAssertTrue(
+            recorded.allSatisfy { validValues.contains($0) },
+            "Progress double-counted the discarded resume offset: \(recorded)"
+        )
+        XCTAssertEqual(
+            try Data(contentsOf: fixture.directory.appendingPathComponent("model.safetensors")),
+            Data("abcdef".utf8)
+        )
+    }
+
+    func testHasDefaultModelArtifactsDetectsPartialFiles() async throws {
+        let fixture = try makeFixture()
+        let downloader = InProcessModelDownloader(
+            manifest: fixture.manifest,
+            cacheRoot: fixture.root,
+            transport: fixture.transport
+        )
+
+        let beforeAnyFiles = await downloader.hasDefaultModelArtifacts()
+        XCTAssertFalse(beforeAnyFiles)
+
+        try FileManager.default.createDirectory(at: fixture.directory, withIntermediateDirectories: true)
+        let partial = fixture.directory.appendingPathComponent(".model.safetensors.part")
+        try Data("abc".utf8).write(to: partial)
+
+        let downloaded = await downloader.isDefaultModelDownloaded()
+        XCTAssertFalse(downloaded)
+        let withPartial = await downloader.hasDefaultModelArtifacts()
+        XCTAssertTrue(withPartial)
+
+        try await downloader.deleteDefaultModel()
+        let afterDelete = await downloader.hasDefaultModelArtifacts()
+        XCTAssertFalse(afterDelete)
+    }
+
+    func testCanceledDownloadThrowsCancellationAndPreservesCompletePartial() async throws {
+        let fixture = try makeFixture(files: ["model.safetensors": Data("abcdef".utf8)])
+        try FileManager.default.createDirectory(at: fixture.directory, withIntermediateDirectories: true)
+        let partial = fixture.directory.appendingPathComponent(".model.safetensors.part")
+        try Data("abcdef".utf8).write(to: partial)
+        let downloader = InProcessModelDownloader(
+            manifest: fixture.manifest,
+            cacheRoot: fixture.root,
+            transport: fixture.transport
+        )
+
+        let task = Task {
+            _ = try await downloader.downloadDefaultModel()
+        }
+        task.cancel()
+
+        do {
+            try await task.value
+        } catch {
+            XCTAssertTrue(error is CancellationError)
+        }
+        let destination = fixture.directory.appendingPathComponent("model.safetensors")
+        XCTAssertTrue(
+            FileManager.default.fileExists(atPath: partial.path)
+                || FileManager.default.fileExists(atPath: destination.path)
+        )
+    }
+
     func testIsDefaultModelDownloadedChecksPresenceAndSize() async throws {
         let fixture = try makeFixture()
         try writeFixtureFiles(fixture)
@@ -167,6 +249,18 @@ final class InProcessModelDownloaderTests: XCTestCase {
     }
 }
 
+private actor ProgressRecorder {
+    private var recorded: [UInt64] = []
+
+    func append(_ value: UInt64) {
+        recorded.append(value)
+    }
+
+    func values() -> [UInt64] {
+        recorded
+    }
+}
+
 private struct DownloaderFixture {
     let root: URL
     let directory: URL
@@ -178,33 +272,45 @@ private struct DownloaderFixture {
 private actor MockInProcessModelDownloadTransport: InProcessModelDownloadTransport {
     private let files: [URL: Data]
     private var capturedRequests: [InProcessModelDownloadRequest] = []
+    private var ignoresResumeOffset = false
 
     init(files: [URL: Data]) {
         self.files = files
     }
 
+    func setIgnoresResumeOffset(_ value: Bool) {
+        ignoresResumeOffset = value
+    }
+
     func download(
         _ request: InProcessModelDownloadRequest,
         to destination: URL,
-        onBytesReceived: @escaping @Sendable (UInt64) -> Void
+        onTotalBytesWritten: @escaping @Sendable (UInt64) -> Void
     ) async throws {
         capturedRequests.append(request)
         guard let data = files[request.url] else {
             throw URLError(.badURL)
         }
-        if !FileManager.default.fileExists(atPath: destination.path) || request.resumeOffset == 0 {
+        let effectiveOffset = ignoresResumeOffset ? 0 : request.resumeOffset
+        if !FileManager.default.fileExists(atPath: destination.path) || effectiveOffset == 0 {
             FileManager.default.createFile(atPath: destination.path, contents: nil)
         }
         let handle = try FileHandle(forWritingTo: destination)
         defer { try? handle.close() }
-        if request.resumeOffset > 0 {
+        if effectiveOffset > 0 {
             try handle.seekToEnd()
         } else {
             try handle.truncate(atOffset: 0)
         }
-        let remaining = data.dropFirst(Int(request.resumeOffset))
-        handle.write(Data(remaining))
-        onBytesReceived(UInt64(remaining.count))
+        var totalBytesWritten = effectiveOffset
+        let remaining = Data(data.dropFirst(Int(effectiveOffset)))
+        for chunkStart in stride(from: 0, to: remaining.count, by: 2) {
+            let chunk = remaining[chunkStart..<min(chunkStart + 2, remaining.count)]
+            try handle.write(contentsOf: chunk)
+            totalBytesWritten += UInt64(chunk.count)
+            onTotalBytesWritten(totalBytesWritten)
+            try await Task.sleep(nanoseconds: 1_000_000)
+        }
     }
 
     func requests() -> [InProcessModelDownloadRequest] {

--- a/Tests/MacParakeetTests/Services/LLM/InProcessModelDownloaderTests.swift
+++ b/Tests/MacParakeetTests/Services/LLM/InProcessModelDownloaderTests.swift
@@ -1,0 +1,172 @@
+import CryptoKit
+import XCTest
+@testable import MacParakeetCore
+
+final class InProcessModelDownloaderTests: XCTestCase {
+    func testVerifyDefaultModelAcceptsCompleteManifestAndRejectsCorruption() async throws {
+        let fixture = try makeFixture()
+        try writeFixtureFiles(fixture)
+        let downloader = InProcessModelDownloader(
+            manifest: fixture.manifest,
+            cacheRoot: fixture.root,
+            transport: fixture.transport
+        )
+
+        _ = try await downloader.verifyDefaultModel()
+
+        let corruptFile = fixture.directory.appendingPathComponent("config.json")
+        try "corrupt".data(using: .utf8)!.write(to: corruptFile)
+
+        do {
+            _ = try await downloader.verifyDefaultModel()
+            XCTFail("Expected checksum or size verification to fail")
+        } catch {
+            XCTAssertTrue(error is InProcessModelDownloaderError)
+        }
+    }
+
+    func testDownloadRepairsCorruptFileAndVerifiesManifest() async throws {
+        let fixture = try makeFixture()
+        try writeFixtureFiles(fixture)
+        let corruptFile = fixture.directory.appendingPathComponent("config.json")
+        try Data("bad".utf8).write(to: corruptFile)
+        let downloader = InProcessModelDownloader(
+            manifest: fixture.manifest,
+            cacheRoot: fixture.root,
+            transport: fixture.transport
+        )
+
+        _ = try await downloader.downloadDefaultModel()
+
+        XCTAssertEqual(try Data(contentsOf: corruptFile), fixture.files["config.json"])
+        _ = try await downloader.verifyDefaultModel()
+    }
+
+    func testDownloadResumesPartialFile() async throws {
+        let fixture = try makeFixture(files: ["model.safetensors": Data("abcdef".utf8)])
+        try FileManager.default.createDirectory(at: fixture.directory, withIntermediateDirectories: true)
+        let partial = fixture.directory.appendingPathComponent(".model.safetensors.part")
+        try Data("abc".utf8).write(to: partial)
+        let downloader = InProcessModelDownloader(
+            manifest: fixture.manifest,
+            cacheRoot: fixture.root,
+            transport: fixture.transport
+        )
+
+        _ = try await downloader.downloadDefaultModel()
+
+        let requests = await fixture.transport.requests()
+        XCTAssertEqual(requests.first?.resumeOffset, 3)
+        XCTAssertEqual(
+            try Data(contentsOf: fixture.directory.appendingPathComponent("model.safetensors")),
+            Data("abcdef".utf8)
+        )
+    }
+
+    func testDeleteRemovesModelDirectory() async throws {
+        let fixture = try makeFixture()
+        try writeFixtureFiles(fixture)
+        let downloader = InProcessModelDownloader(
+            manifest: fixture.manifest,
+            cacheRoot: fixture.root,
+            transport: fixture.transport
+        )
+
+        try await downloader.deleteDefaultModel()
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fixture.directory.path))
+    }
+
+    private func makeFixture(
+        files: [String: Data] = [
+            "config.json": Data("{\"model\":\"test\"}".utf8),
+            "model.safetensors": Data("weights".utf8),
+        ]
+    ) throws -> DownloaderFixture {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("InProcessModelDownloaderTests-\(UUID().uuidString)", isDirectory: true)
+        let manifest = InProcessLocalModelManifest(
+            modelID: "example/test-model",
+            displayName: "Test Model",
+            repositoryID: "example/test-model",
+            revision: "main",
+            files: files.keys.sorted().map { path in
+                InProcessLocalModelFile(
+                    path: path,
+                    sizeBytes: UInt64(files[path]!.count),
+                    sha256: sha256Hex(files[path]!)
+                )
+            }
+        )
+        let directory = InProcessLocalModelCatalog.modelDirectory(for: manifest.modelID, cacheRoot: root)
+        let urlFiles = Dictionary(uniqueKeysWithValues: files.map { path, data in
+            (
+                URL(string: "https://huggingface.co/\(manifest.repositoryID)/resolve/\(manifest.revision)/\(path)")!,
+                data
+            )
+        })
+        return DownloaderFixture(
+            root: root,
+            directory: directory,
+            manifest: manifest,
+            files: files,
+            transport: MockInProcessModelDownloadTransport(files: urlFiles)
+        )
+    }
+
+    private func writeFixtureFiles(_ fixture: DownloaderFixture) throws {
+        try FileManager.default.createDirectory(at: fixture.directory, withIntermediateDirectories: true)
+        for (path, data) in fixture.files {
+            try data.write(to: fixture.directory.appendingPathComponent(path))
+        }
+    }
+
+    private func sha256Hex(_ data: Data) -> String {
+        SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+}
+
+private struct DownloaderFixture {
+    let root: URL
+    let directory: URL
+    let manifest: InProcessLocalModelManifest
+    let files: [String: Data]
+    let transport: MockInProcessModelDownloadTransport
+}
+
+private actor MockInProcessModelDownloadTransport: InProcessModelDownloadTransport {
+    private let files: [URL: Data]
+    private var capturedRequests: [InProcessModelDownloadRequest] = []
+
+    init(files: [URL: Data]) {
+        self.files = files
+    }
+
+    func download(
+        _ request: InProcessModelDownloadRequest,
+        to destination: URL,
+        onBytesReceived: @escaping @Sendable (UInt64) -> Void
+    ) async throws {
+        capturedRequests.append(request)
+        guard let data = files[request.url] else {
+            throw URLError(.badURL)
+        }
+        if !FileManager.default.fileExists(atPath: destination.path) || request.resumeOffset == 0 {
+            FileManager.default.createFile(atPath: destination.path, contents: nil)
+        }
+        let handle = try FileHandle(forWritingTo: destination)
+        defer { try? handle.close() }
+        if request.resumeOffset > 0 {
+            try handle.seekToEnd()
+        } else {
+            try handle.truncate(atOffset: 0)
+        }
+        let remaining = data.dropFirst(Int(request.resumeOffset))
+        handle.write(Data(remaining))
+        onBytesReceived(UInt64(remaining.count))
+    }
+
+    func requests() -> [InProcessModelDownloadRequest] {
+        capturedRequests
+    }
+}

--- a/Tests/MacParakeetTests/Services/LLM/InProcessModelDownloaderTests.swift
+++ b/Tests/MacParakeetTests/Services/LLM/InProcessModelDownloaderTests.swift
@@ -286,12 +286,14 @@ final class InProcessModelDownloaderTests: XCTestCase {
             }
         )
         let directory = InProcessLocalModelCatalog.modelDirectory(for: manifest.modelID, cacheRoot: root)
-        let urlFiles = Dictionary(uniqueKeysWithValues: files.map { path, data in
-            (
-                URL(string: "https://huggingface.co/\(manifest.repositoryID)/resolve/\(manifest.revision)/\(path)")!,
-                data
-            )
-        })
+        let urlFiles = Dictionary(
+            uniqueKeysWithValues: files.map { path, data in
+                (
+                    URL(
+                        string: "https://huggingface.co/\(manifest.repositoryID)/resolve/\(manifest.revision)/\(path)")!,
+                    data
+                )
+            })
         return DownloaderFixture(
             root: root,
             directory: directory,

--- a/Tests/MacParakeetTests/ViewModels/InProcessModelManagerViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/InProcessModelManagerViewModelTests.swift
@@ -1,0 +1,164 @@
+import XCTest
+@testable import MacParakeetCore
+@testable import MacParakeetViewModels
+
+@MainActor
+final class InProcessModelManagerViewModelTests: XCTestCase {
+    func testEnableLocalAIGatedBelowMinimumMemory() async {
+        let downloader = FakeInProcessModelDownloader()
+        let configStore = MockLLMConfigStore()
+        let client = MockLLMClient()
+        let viewModel = InProcessModelManagerViewModel(physicalMemoryBytes: 8 * 1024 * 1024 * 1024)
+        viewModel.configure(
+            downloader: downloader,
+            configStore: configStore,
+            llmClient: client,
+            physicalMemoryBytes: 8 * 1024 * 1024 * 1024
+        )
+
+        await viewModel.enableLocalAI()
+
+        XCTAssertEqual(
+            viewModel.state,
+            .failed(
+                reason: "Local AI needs 16 GB RAM. Use a cloud provider or bring your own local server instead.",
+                recoverable: false
+            )
+        )
+        let downloadCallCount = await downloader.downloadCallCount()
+        XCTAssertEqual(downloadCallCount, 0)
+        XCTAssertNil(configStore.config)
+    }
+
+    func testEnableLocalAIDownloadsVerifiesTestsAndSavesProvider() async {
+        let downloader = FakeInProcessModelDownloader()
+        let configStore = MockLLMConfigStore()
+        let client = MockLLMClient()
+        var configurationChangedCount = 0
+        let viewModel = InProcessModelManagerViewModel()
+        viewModel.configure(
+            downloader: downloader,
+            configStore: configStore,
+            llmClient: client,
+            physicalMemoryBytes: 32 * 1024 * 1024 * 1024,
+            onConfigurationChanged: { configurationChangedCount += 1 }
+        )
+
+        await viewModel.enableLocalAI()
+
+        XCTAssertEqual(viewModel.state, .ready)
+        XCTAssertTrue(viewModel.isModelDownloaded)
+        let downloadCallCount = await downloader.downloadCallCount()
+        let verifyCallCount = await downloader.verifyCallCount()
+        XCTAssertEqual(downloadCallCount, 1)
+        XCTAssertEqual(verifyCallCount, 1)
+        XCTAssertEqual(configStore.config?.id, .inProcessLocal)
+        XCTAssertEqual(configStore.config?.modelName, InProcessLocalModelCatalog.defaultManifest.modelID)
+        XCTAssertEqual(client.capturedContext?.providerConfig.id, .inProcessLocal)
+        XCTAssertEqual(configurationChangedCount, 1)
+    }
+
+    func testEnableLocalAIDoesNotSaveWhenRuntimeTestFails() async {
+        let downloader = FakeInProcessModelDownloader()
+        let configStore = MockLLMConfigStore()
+        let client = MockLLMClient()
+        client.testConnectionError = LLMError.connectionFailed("runtime unavailable")
+        let viewModel = InProcessModelManagerViewModel()
+        viewModel.configure(
+            downloader: downloader,
+            configStore: configStore,
+            llmClient: client,
+            physicalMemoryBytes: 32 * 1024 * 1024 * 1024
+        )
+
+        await viewModel.enableLocalAI()
+
+        XCTAssertNil(configStore.config)
+        guard case .failed(let reason, let recoverable) = viewModel.state else {
+            return XCTFail("Expected failed state")
+        }
+        XCTAssertTrue(reason.contains("runtime unavailable"))
+        XCTAssertTrue(recoverable)
+    }
+
+    func testDeleteModelClearsSavedLocalProvider() async {
+        let downloader = FakeInProcessModelDownloader(isDownloaded: true)
+        let configStore = MockLLMConfigStore()
+        configStore.config = .inProcessLocal()
+        let client = MockLLMClient()
+        let viewModel = InProcessModelManagerViewModel()
+        viewModel.configure(
+            downloader: downloader,
+            configStore: configStore,
+            llmClient: client,
+            physicalMemoryBytes: 32 * 1024 * 1024 * 1024
+        )
+        await viewModel.refresh()
+
+        await viewModel.deleteModel()
+
+        XCTAssertEqual(viewModel.state, .setUpNeeded)
+        XCTAssertFalse(viewModel.isModelDownloaded)
+        XCTAssertNil(configStore.config)
+        let deleteCallCount = await downloader.deleteCallCount()
+        XCTAssertEqual(deleteCallCount, 1)
+    }
+}
+
+private actor FakeInProcessModelDownloader: InProcessModelDownloading {
+    private var isDownloaded: Bool
+    private var downloadCalls = 0
+    private var verifyCalls = 0
+    private var deleteCalls = 0
+
+    init(isDownloaded: Bool = false) {
+        self.isDownloaded = isDownloaded
+    }
+
+    nonisolated func defaultModelDirectory() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("FakeInProcessModelDownloader", isDirectory: true)
+    }
+
+    func isDefaultModelDownloaded() async -> Bool {
+        isDownloaded
+    }
+
+    func verifyDefaultModel() async throws -> URL {
+        verifyCalls += 1
+        isDownloaded = true
+        return defaultModelDirectory()
+    }
+
+    func downloadDefaultModel(
+        progress: @escaping InProcessModelDownloadProgressHandler
+    ) async throws -> URL {
+        downloadCalls += 1
+        isDownloaded = true
+        await progress(InProcessModelDownloadProgress(
+            completedBytes: 1,
+            totalBytes: 1,
+            completedFiles: 1,
+            totalFiles: 1,
+            currentFile: "model.safetensors"
+        ))
+        return defaultModelDirectory()
+    }
+
+    func deleteDefaultModel() async throws {
+        deleteCalls += 1
+        isDownloaded = false
+    }
+
+    func downloadCallCount() -> Int {
+        downloadCalls
+    }
+
+    func verifyCallCount() -> Int {
+        verifyCalls
+    }
+
+    func deleteCallCount() -> Int {
+        deleteCalls
+    }
+}

--- a/Tests/MacParakeetTests/ViewModels/InProcessModelManagerViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/InProcessModelManagerViewModelTests.swift
@@ -126,6 +126,34 @@ final class InProcessModelManagerViewModelTests: XCTestCase {
         XCTAssertNil(configStore.config)
     }
 
+    func testRefreshDuringActiveSetupKeepsDownloadingState() async throws {
+        let downloader = BlockingInProcessModelDownloader()
+        let viewModel = InProcessModelManagerViewModel()
+        viewModel.configure(
+            downloader: downloader,
+            configStore: MockLLMConfigStore(),
+            llmClient: MockLLMClient(),
+            physicalMemoryBytes: 32 * 1024 * 1024 * 1024
+        )
+
+        viewModel.startEnableLocalAI()
+        while !(await downloader.hasStartedDownload()) {
+            try await Task.sleep(nanoseconds: 1_000_000)
+        }
+
+        await viewModel.refresh()
+
+        guard case .downloading = viewModel.state else {
+            return XCTFail("Expected downloading state, got \(viewModel.state)")
+        }
+
+        viewModel.cancelSetup()
+        let deadline = Date().addingTimeInterval(10)
+        while viewModel.isWorking, Date() < deadline {
+            try await Task.sleep(nanoseconds: 1_000_000)
+        }
+    }
+
     func testRefreshSurfacesPartialArtifactsAndDeleteClearsThem() async {
         let downloader = FakeInProcessModelDownloader(isDownloaded: false, hasArtifacts: true)
         let viewModel = InProcessModelManagerViewModel()

--- a/Tests/MacParakeetTests/ViewModels/InProcessModelManagerViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/InProcessModelManagerViewModelTests.swift
@@ -51,7 +51,7 @@ final class InProcessModelManagerViewModelTests: XCTestCase {
         let downloadCallCount = await downloader.downloadCallCount()
         let verifyCallCount = await downloader.verifyCallCount()
         XCTAssertEqual(downloadCallCount, 1)
-        XCTAssertEqual(verifyCallCount, 1)
+        XCTAssertEqual(verifyCallCount, 0)
         XCTAssertEqual(configStore.config?.id, .inProcessLocal)
         XCTAssertEqual(configStore.config?.modelName, InProcessLocalModelCatalog.defaultManifest.modelID)
         XCTAssertEqual(client.capturedContext?.providerConfig.id, .inProcessLocal)
@@ -81,6 +81,51 @@ final class InProcessModelManagerViewModelTests: XCTestCase {
         XCTAssertTrue(recoverable)
     }
 
+    func testRefreshBelowMinimumMemoryStillReportsDownloadedModel() async {
+        let downloader = FakeInProcessModelDownloader(isDownloaded: true)
+        let viewModel = InProcessModelManagerViewModel()
+        viewModel.configure(
+            downloader: downloader,
+            configStore: MockLLMConfigStore(),
+            llmClient: MockLLMClient(),
+            physicalMemoryBytes: 8 * 1024 * 1024 * 1024
+        )
+
+        await viewModel.refresh()
+
+        XCTAssertTrue(viewModel.isModelDownloaded)
+        XCTAssertFalse(viewModel.meetsMemoryRequirement)
+    }
+
+    func testCancelSetupDuringDownloadReportsCanceledStateAndSavesNothing() async throws {
+        let downloader = BlockingInProcessModelDownloader()
+        let configStore = MockLLMConfigStore()
+        let viewModel = InProcessModelManagerViewModel()
+        viewModel.configure(
+            downloader: downloader,
+            configStore: configStore,
+            llmClient: MockLLMClient(),
+            physicalMemoryBytes: 32 * 1024 * 1024 * 1024
+        )
+
+        viewModel.startEnableLocalAI()
+        while !(await downloader.hasStartedDownload()) {
+            try await Task.sleep(nanoseconds: 1_000_000)
+        }
+        viewModel.cancelSetup()
+
+        let deadline = Date().addingTimeInterval(10)
+        while viewModel.isWorking, Date() < deadline {
+            try await Task.sleep(nanoseconds: 1_000_000)
+        }
+
+        XCTAssertEqual(
+            viewModel.state,
+            .failed(reason: "Local AI setup was canceled.", recoverable: true)
+        )
+        XCTAssertNil(configStore.config)
+    }
+
     func testDeleteModelClearsSavedLocalProvider() async {
         let downloader = FakeInProcessModelDownloader(isDownloaded: true)
         let configStore = MockLLMConfigStore()
@@ -102,6 +147,39 @@ final class InProcessModelManagerViewModelTests: XCTestCase {
         XCTAssertNil(configStore.config)
         let deleteCallCount = await downloader.deleteCallCount()
         XCTAssertEqual(deleteCallCount, 1)
+    }
+}
+
+private actor BlockingInProcessModelDownloader: InProcessModelDownloading {
+    private var downloadStarted = false
+
+    nonisolated func defaultModelDirectory() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("BlockingInProcessModelDownloader", isDirectory: true)
+    }
+
+    func isDefaultModelDownloaded() async -> Bool {
+        false
+    }
+
+    func verifyDefaultModel() async throws -> URL {
+        defaultModelDirectory()
+    }
+
+    func downloadDefaultModel(
+        progress: @escaping InProcessModelDownloadProgressHandler
+    ) async throws -> URL {
+        downloadStarted = true
+        while true {
+            try Task.checkCancellation()
+            try? await Task.sleep(nanoseconds: 1_000_000)
+        }
+    }
+
+    func deleteDefaultModel() async throws {}
+
+    func hasStartedDownload() -> Bool {
+        downloadStarted
     }
 }
 

--- a/Tests/MacParakeetTests/ViewModels/InProcessModelManagerViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/InProcessModelManagerViewModelTests.swift
@@ -126,6 +126,27 @@ final class InProcessModelManagerViewModelTests: XCTestCase {
         XCTAssertNil(configStore.config)
     }
 
+    func testRefreshSurfacesPartialArtifactsAndDeleteClearsThem() async {
+        let downloader = FakeInProcessModelDownloader(isDownloaded: false, hasArtifacts: true)
+        let viewModel = InProcessModelManagerViewModel()
+        viewModel.configure(
+            downloader: downloader,
+            configStore: MockLLMConfigStore(),
+            llmClient: MockLLMClient(),
+            physicalMemoryBytes: 32 * 1024 * 1024 * 1024
+        )
+
+        await viewModel.refresh()
+
+        XCTAssertFalse(viewModel.isModelDownloaded)
+        XCTAssertTrue(viewModel.hasModelArtifacts)
+
+        await viewModel.deleteModel()
+
+        XCTAssertFalse(viewModel.hasModelArtifacts)
+        XCTAssertEqual(viewModel.state, .setUpNeeded)
+    }
+
     func testDeleteModelClearsSavedLocalProvider() async {
         let downloader = FakeInProcessModelDownloader(isDownloaded: true)
         let configStore = MockLLMConfigStore()
@@ -162,6 +183,10 @@ private actor BlockingInProcessModelDownloader: InProcessModelDownloading {
         false
     }
 
+    func hasDefaultModelArtifacts() async -> Bool {
+        downloadStarted
+    }
+
     func verifyDefaultModel() async throws -> URL {
         defaultModelDirectory()
     }
@@ -185,12 +210,14 @@ private actor BlockingInProcessModelDownloader: InProcessModelDownloading {
 
 private actor FakeInProcessModelDownloader: InProcessModelDownloading {
     private var isDownloaded: Bool
+    private var hasArtifacts: Bool
     private var downloadCalls = 0
     private var verifyCalls = 0
     private var deleteCalls = 0
 
-    init(isDownloaded: Bool = false) {
+    init(isDownloaded: Bool = false, hasArtifacts: Bool? = nil) {
         self.isDownloaded = isDownloaded
+        self.hasArtifacts = hasArtifacts ?? isDownloaded
     }
 
     nonisolated func defaultModelDirectory() -> URL {
@@ -200,6 +227,10 @@ private actor FakeInProcessModelDownloader: InProcessModelDownloading {
 
     func isDefaultModelDownloaded() async -> Bool {
         isDownloaded
+    }
+
+    func hasDefaultModelArtifacts() async -> Bool {
+        hasArtifacts
     }
 
     func verifyDefaultModel() async throws -> URL {
@@ -213,6 +244,7 @@ private actor FakeInProcessModelDownloader: InProcessModelDownloading {
     ) async throws -> URL {
         downloadCalls += 1
         isDownloaded = true
+        hasArtifacts = true
         await progress(InProcessModelDownloadProgress(
             completedBytes: 1,
             totalBytes: 1,
@@ -226,6 +258,7 @@ private actor FakeInProcessModelDownloader: InProcessModelDownloading {
     func deleteDefaultModel() async throws {
         deleteCalls += 1
         isDownloaded = false
+        hasArtifacts = false
     }
 
     func downloadCallCount() -> Int {

--- a/Tests/MacParakeetTests/ViewModels/InProcessModelManagerViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/InProcessModelManagerViewModelTests.swift
@@ -273,13 +273,14 @@ private actor FakeInProcessModelDownloader: InProcessModelDownloading {
         downloadCalls += 1
         isDownloaded = true
         hasArtifacts = true
-        await progress(InProcessModelDownloadProgress(
-            completedBytes: 1,
-            totalBytes: 1,
-            completedFiles: 1,
-            totalFiles: 1,
-            currentFile: "model.safetensors"
-        ))
+        await progress(
+            InProcessModelDownloadProgress(
+                completedBytes: 1,
+                totalBytes: 1,
+                completedFiles: 1,
+                totalFiles: 1,
+                currentFile: "model.safetensors"
+            ))
         return defaultModelDirectory()
     }
 

--- a/plans/active/2026-06-27-on-device-local-llm.md
+++ b/plans/active/2026-06-27-on-device-local-llm.md
@@ -115,6 +115,8 @@ Our LLM stack is already cleanly abstracted; the change is additive.
 
 **Build gating (decided 2026-07-04, from live verification):** MLX **cannot** land as a plain dependency — command-line SwiftPM can't build the Metal shaders (xcodebuild required; Jan's app ships this way, copying `default.metallib`), and mlx-swift-lm needs Swift tools 6.1 vs our tools 5.9 and CI's Xcode 16.1. Therefore: `LocalLLMRuntime` protocol + `InProcessLLMClient` live in `MacParakeetCore` with **no MLX import**; the MLX implementation lives in a separate opt-in target/module wired only into app builds, gated the same way as the existing no-Whisper gate, so `swift build` / `swift test` / CI never resolve or compile MLX. App release builds (xcodebuild, Daniel's machine) turn the gate on.
 
+**PR2 implementation note (2026-07-05):** the verified downloader, `InProcessModelManagerViewModel`, and one-click Settings card are allowed to exist behind the developer enable path while `AppFeatures.inProcessLocalLLMEnabled` remains `false`. This does not flip the public product surface: downloads are opt-in, RAM-gated at 16 GB, verified by size + SHA-256 manifest, and tested before `.inProcessLocal` is saved.
+
 Build the **chunking / map-reduce / retrieval layer** for long transcripts regardless (summary/QA need it; mitigates MLX long-prefill).
 
 ---

--- a/spec/03-architecture.md
+++ b/spec/03-architecture.md
@@ -1045,6 +1045,7 @@ deleted.
 | Parakeet STT models | FluidAudio-managed CoreML cache (~465 MB per build) |
 | Cohere STT model | `~/Library/Application Support/FluidAudio/Models/cohere-transcribe/q8` |
 | Whisper STT models | `~/Library/Application Support/MacParakeet/models/stt/whisper/` |
+| Local LLM models (developer-gated, opt-in download) | `~/Library/Application Support/MacParakeet/LLMModels/` |
 | yt-dlp binary | `~/Library/Application Support/MacParakeet/bin/yt-dlp` |
 | FFmpeg binary | `~/Library/Application Support/MacParakeet/bin/ffmpeg` |
 | Logs | `~/Library/Logs/MacParakeet/` |
@@ -1062,6 +1063,7 @@ deleted.
     ├── models/                     # MacParakeet-owned downloaded ML models
     │   └── stt/
     │       └── whisper/            # WhisperKit models
+    ├── LLMModels/                  # Verified opt-in local LLM model cache (developer-gated)
     └── bin/                        # Standalone binaries
         ├── yt-dlp                  # YouTube downloader (~35 MB, self-updating)
         └── ffmpeg                  # Video demuxing (~80 MB)

--- a/spec/11-llm-integration.md
+++ b/spec/11-llm-integration.md
@@ -5,7 +5,9 @@
 > ADR: ADR-011 (Cloud API keys + optional local providers)
 > Note: §1 (Transcript Summary) is superseded by [spec/12-processing-layer.md](12-processing-layer.md) — Prompt Library + multi-summary architecture. §3's old UserDefaults custom-transform design is superseded by ADR-022's productized `Prompt.Category.transform` Transforms. Provider protocol, formatter, chat, and CLI sections remain current.
 
-This spec defines how MacParakeet integrates LLM-powered features via external providers.
+This spec defines how MacParakeet integrates LLM-powered features via user-selected providers,
+including external providers, local servers/CLI tools, and a developer-gated in-process local
+model option.
 
 ---
 
@@ -18,12 +20,12 @@ This spec defines how MacParakeet integrates LLM-powered features via external p
 
 ## Non-Goals
 
-1. Bundling any LLM runtime or model today (no mlx-swift-lm, no llama.cpp, no model downloads in the current accepted architecture).
+1. Bundling any LLM runtime/model or making local LLMs the public default. The in-process MLX runtime remains a gated app-build target, and the verified model downloader/setup UI stays hidden behind a developer enable path while `AppFeatures.inProcessLocalLLMEnabled == false`.
 2. Bundled/default LLM processing in the dictation hot path. The AI formatter is opt-in, runs after deterministic cleanup, and falls back to the deterministic result if the provider fails.
 3. Building a hosted backend or proxy service.
 4. Automatic fallback between providers.
 
-**Future direction (updated 2026-07-04):** A first-party local model (Qwen/Gemma-class via MLX) will be offered as a dead-simple, one-click *option* once Phase 0 evidence shows it is trust-safe and clearly better than the deterministic pipeline for at least one surface (cleanup is the likely first). Cloud/frontier providers remain the recommended quality path per surface until the local model reaches parity there; cross-library / cross-meeting analysis, durable tool calling, and agent workflows stay cloud-first until local capability is proven. See `plans/active/2026-06-27-on-device-local-llm.md`.
+**Local MLX status (updated 2026-07-05):** The in-process provider, MLX runtime seam, verified model downloader, and one-click Settings card now exist as a developer-gated path. The public feature flag remains off, downloads are never automatic, and cloud/frontier providers remain the recommended quality path per surface until local capability reaches parity there. See `plans/active/2026-06-27-on-device-local-llm.md`.
 
 ---
 
@@ -34,6 +36,7 @@ User triggers LLM action (Summary / Chat / Formatter / Transform)
     → LLMService (builds prompt with transcript context)
     → LLMExecutionContextResolver (resolves provider config + CLI config)
     → RoutingLLMClient
+        → .inProcessLocal: InProcessLLMClient → LocalLLMRuntime (MLX only in gated app builds)
         → .localCLI: LocalCLILLMClient → LocalCLIExecutor (posix_spawn)
         → .other:    LLMClient (URLSession)
             → .anthropic: POST /v1/messages
@@ -50,6 +53,7 @@ The current branch does not flatten every provider into one wire protocol. `Rout
 - **Ollama** uses the native chat API (`POST /api/chat`) so thinking can be disabled.
 - **OpenAI, Gemini, OpenRouter, and LM Studio** use the OpenAI-compatible chat completions API (`POST /chat/completions` off each provider's configured base URL).
 - **Local CLI** is not HTTP at all; prompts are passed to a subprocess via stdin/environment.
+- **Local MLX** is in-process through `InProcessLLMClient` and `LocalLLMRuntime`; the concrete MLX target is compiled only for gated app builds.
 
 Streaming is provider-specific under the hood:
 
@@ -72,6 +76,7 @@ The service boundary stays stable even though the transport is mixed.
 | LM Studio | Local | `http://localhost:1234/v1` | Optional API token (`Authorization: Bearer`) |
 | OpenRouter | Cloud | `https://openrouter.ai/api/v1` | `Authorization: Bearer` |
 | Local CLI | CLI | N/A (subprocess) | N/A (tool manages its own auth) |
+| Local MLX | In-process local, developer-gated | `inprocess://local` | N/A |
 
 **Local CLI:** Users with Claude Code or Codex subscriptions can use their CLI tools directly. The app runs the configured command as a subprocess via `posix_spawn`, delivering prompts via stdin and `MACPARAKEET_*` environment variables. No API key needed — the CLI tool manages its own authentication. Built-in presets for Claude Code (`claude -p --model haiku`) and Codex (`codex exec --model gpt-5.4-mini`), or any custom command. See PR #47.
 
@@ -99,6 +104,7 @@ public enum LLMProviderID: String, Codable, Sendable, CaseIterable {
     case ollama
     case lmstudio
     case localCLI    // CLI tools (claude -p, codex exec) — no HTTP, no API key
+    case inProcessLocal // Developer-gated Local MLX option; no HTTP, no API key
 }
 ```
 
@@ -339,6 +345,14 @@ Respond with only the transformed text. Do not add explanations or preamble.
 ## UI
 
 ### Settings > AI
+
+The public Settings flow defaults to no AI provider and recommends cloud/frontier
+providers for best answer quality. The Local MLX one-click card is visible only
+when the developer override is active (`MacParakeetEnableInProcessLocalLLM` or
+`--enable-local-ai`); the public feature flag remains off. That card RAM-gates
+machines below 16 GB, downloads the verified Qwen3 model to
+`Application Support/MacParakeet/LLMModels/`, verifies size + SHA-256 hashes,
+tests the in-process runtime, and only then saves `.inProcessLocal`.
 
 ```
 ┌─────────────────────────────────────────────┐

--- a/spec/README.md
+++ b/spec/README.md
@@ -80,7 +80,7 @@ Current `main` feature gates in `Sources/MacParakeetCore/AppFeatures.swift`:
 | `meetingVadLiveChunkingEnabled` | `true` | VAD-guided meeting live-preview chunking; final post-stop transcript path unchanged |
 | `liveDictationStreamingEnabled` | `true` | Display-only live dictation preview enabled on `main`; final paste remains stop-time transcription |
 | `aiFormatterProfilesEnabled` | `false` | App-aware AI Formatter profiles are code-complete but held out of the current tagged release train |
-| `inProcessLocalLLMEnabled` | `false` | In-process local LLM (MLX) foundation seam is compiled and tested, but provider lists hide the option; the real MLX runtime links only in opt-in `MACPARAKEET_ENABLE_MLX_LOCAL_LLM=1` app builds |
+| `inProcessLocalLLMEnabled` | `false` | In-process local LLM (MLX) foundation seam, verified model downloader, and one-click Settings card are compiled and tested, but provider lists hide the option unless the developer override (`MacParakeetEnableInProcessLocalLLM` default or `--enable-local-ai`) is active; the real MLX runtime links only in opt-in `MACPARAKEET_ENABLE_MLX_LOCAL_LLM=1` app builds |
 
 ## Architecture Decision Records (ADRs)
 

--- a/spec/adr/002-local-only.md
+++ b/spec/adr/002-local-only.md
@@ -84,7 +84,7 @@ Cloud LLM costs are paid directly by the user to their provider (Anthropic, Open
 - Transcription works fully offline — no degradation
 - LLM features use best-available models (Claude, GPT-4) without bundling a runtime
 - Local-only users can use Ollama
-- Zero resource impact from LLM (no GPU memory, no model downloads)
+- Zero resource impact from LLM in the default configuration (no GPU memory, no automatic model downloads; the developer-gated Local MLX path in ADR-011 is explicit opt-in)
 - Business model remains flexible: current public builds are free/GPL, while official paid distribution/support can be added without changing the local-first architecture
 - App Store compatible
 

--- a/spec/adr/011-llm-cloud-and-local-providers.md
+++ b/spec/adr/011-llm-cloud-and-local-providers.md
@@ -54,13 +54,15 @@ The current branch supports these provider/runtime types through one shared serv
 
 ### Locked Decisions
 
-1. **No bundled LLM runtime.** No mlx-swift-lm, no llama.cpp, no Cactus, no model downloads. Zero GPU/memory impact from LLM.
+1. **No bundled/default LLM runtime.** No LLM model is bundled, no local model downloads automatically, and no local LLM is public-default. The in-process MLX implementation is isolated behind a gated app-build target, and the verified first-party model downloader/setup UI is developer-gated while the public feature flag remains off.
 2. **Provider-aware transport behind one shared service boundary.** Runtime choices are external providers, OpenAI-compatible endpoints, local servers, or Local CLI tools. Transport details may vary per provider.
 3. **LLM features are optional.** The app is fully functional without any provider configured. Transcription, dictation, export — all work without LLM.
 4. **No default provider.** User must explicitly choose and configure. No "sign up for our cloud" upsell.
 5. **Transcription stays local.** Audio never leaves the device. The app can remain fully local when users choose only local providers/features. Only transcript text is sent to providers/CLI tools when the user explicitly triggers an LLM feature. This distinction must be clear in the UI.
 
 **Amendment (2026-07-04): direction confirmed, positioning fixed.** Product decision: MacParakeet will offer a first-party local model (Qwen/Gemma-class via MLX) as a dead-simple, one-click *option* aimed at non-technical and privacy-first users, while cloud/frontier providers remain the recommended quality path per surface until the local model demonstrably reaches parity there. The accepted architecture is unchanged for now — the Phase 0 eval in `plans/active/2026-06-27-on-device-local-llm.md` still gates adding any runtime or model download. Shipping bar per surface: fidelity-safe and clearly above the deterministic pipeline to *offer*; cloud parity to *recommend*. Agentic/tool-calling and whole-library analysis stay cloud-first until proven.
+
+**Amendment (2026-07-05): developer-gated Local MLX foundation.** The provider seam, gated MLX runtime wiring, verified model downloader, and one-click Settings card may exist in `main` as non-public infrastructure. `AppFeatures.inProcessLocalLLMEnabled` stays `false`; developers expose the option with `MacParakeetEnableInProcessLocalLLM` or `--enable-local-ai`. The app still never bundles a model, never downloads one automatically, and never recommends Local MLX over cloud/frontier quality until surface-specific evidence justifies that change.
 
 ### Features Enabled
 
@@ -82,7 +84,7 @@ Local 8B models produce mediocre summaries. Cloud models (Claude Sonnet, GPT-4o)
 
 ### Zero resource impact
 
-No GPU memory, no model downloads, no ANE contention. The app's resource profile stays focused on STT. LLM inference happens entirely outside the app's process — either on a remote server, in Ollama's separate process, or inside an external CLI tool.
+No GPU memory, model downloads, or ANE contention in the public/default product path. The app's resource profile stays focused on STT unless a developer explicitly enables and tests the gated Local MLX path. Public LLM inference still happens outside the app's process — either on a remote server, in Ollama's separate process, or inside an external CLI tool.
 
 ### Privacy spectrum, user's choice
 
@@ -97,7 +99,7 @@ Users choose their privacy/quality tradeoff. The app makes the tradeoff explicit
 
 ### Implementation simplicity
 
-One Swift service boundary with provider-aware routing. The current implementation keeps UI/domain code simple while allowing provider-specific transport where needed. No model management, no GPU scheduling, no memory pressure handling, no idle unload timers. Compare this to the mlx-swift-lm integration which touched 15+ files.
+One Swift service boundary with provider-aware routing. The current implementation keeps UI/domain code simple while allowing provider-specific transport where needed. The developer-gated Local MLX path owns its model management, runtime lifetime, and idle unload behavior behind `InProcessLLMClient`; normal provider call sites do not change.
 
 ### Bring-your-own-model via local providers
 


### PR DESCRIPTION
## Summary
- Adds the developer-gated one-click Local AI setup path while keeping `AppFeatures.inProcessLocalLLMEnabled == false`.
- Adds a verified downloader for `mlx-community/Qwen3-4B-Instruct-2507-DDWQ` (size + SHA-256 manifest, resume, corrupt-cache repair, progress, delete) under `Application Support/MacParakeet/LLMModels/`.
- Adds `InProcessModelManagerViewModel` and a Settings > AI card with the 16 GB RAM gate, optional/cloud-recommended positioning, and download -> verify -> runtime test -> save behavior.
- Updates `InProcessLLMClient` to resolve the verified cache by default and improves local map/reduce chunking to prefer paragraph/sentence boundaries.
- Updates the LLM spec, ADR-011, and active plan to reflect the developer-gated local model path without making it public/default.

## Developer Enable Path
Local AI remains hidden by default. To expose the Settings card/provider picker locally, use either:

```bash
defaults write com.macparakeet.MacParakeet MacParakeetEnableInProcessLocalLLM -bool true
```

or launch with:

```bash
--enable-local-ai
```

The actual MLX runtime is still only linked in gated app builds (`MACPARAKEET_ENABLE_MLX_LOCAL_LLM=1`). Plain `swift build`, `swift test`, and CI do not resolve or compile MLX packages.

## Verification
- `swift test --filter InProcessModelDownloaderTests`
- `swift test --filter InProcessModelManagerViewModelTests`
- `swift test --filter InProcessLLMClientTests`
- `swift test --filter LLMProviderDescriptorTests`
- `swift test --filter LLM` (422 tests, 1 expected MLX integration skip)
- `swift build`
- `swift package describe --type json | jq -r '.dependencies[]?.url' | rg -i 'mlx' || true` (no default MLX dependencies)
- `MACPARAKEET_SKIP_WHISPERKIT=1 swift build --build-path .build-swift6-no-whisper -Xswiftc -swift-version -Xswiftc 6`
- `git diff --check`

## UI / Manual QA
No screenshot/recording captured yet: the card is intentionally developer-gated, and end-to-end ready state requires a gated MLX app build plus the 2.53 GB verified model. This PR has compile coverage for the SwiftUI surface and focused unit coverage for the ViewModel state machine.

## Source Notes
- Default model manifest was verified against Hugging Face metadata/content for `mlx-community/Qwen3-4B-Instruct-2507-DDWQ`: https://huggingface.co/mlx-community/Qwen3-4B-Instruct-2507-DDWQ

## Review Follow-up
- `eaafc7c58be4ecdccd9aa6b36ac85d843bc1c2e6` handles URLSession model-download write failures with throwing `FileHandle.write(contentsOf:)` and cancels the data task on write errors.
- The same commit removes the view-model progress sink helper and uses a direct weak-self main-actor progress update.

## Post-Deploy Monitoring & Validation
No public production monitoring required in this draft PR: the public feature flag remains off, the Settings card is hidden without the developer override, and no model downloads start automatically. Dogfood validation should watch local setup state transitions, recoverable downloader failures, and `Application Support/MacParakeet/LLMModels/` cache contents while running a gated MLX app build.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a developer-gated one‑click Local AI setup that downloads, verifies (SHA‑256), and tests a `Qwen3 4B` model, with readiness gated by a verified marker and a safer default cache. Polishes the Settings flow and keeps the in‑process client on the verified cache with smarter paragraph/sentence chunking.

- **New Features**
  - Dev-gated Settings > AI “Local AI” card with a 16 GB RAM gate and a download → verify → runtime test → save flow; includes cancel/delete and partial-artifact cleanup.
  - Verified downloader for `mlx-community/Qwen3-4B-Instruct-2507-DDWQ` to `Application Support/MacParakeet/LLMModels/` with resume and corrupt‑cache repair; `InProcessLLMClient` defaults to this verified cache (env override still supported).

- **Bug Fixes**
  - Readiness now requires a SHA‑verified manifest marker; validates manifest paths, rejects symlinks, uses atomic file promotion, restricts redirects to HTTPS `hf.co`, and fixes resume progress when Range is ignored.
  - Downloader surfaces disk write failures via throwing writes and cancels on error; hashing is cancellable; progress forwarding simplified.
  - Settings polish: preserves in‑flight setup state, softens the ready copy, caches Local AI selection, and avoids per‑render Keychain reads.

<sup>Written for commit 5be8f5266a19d34a6be5978cee364037acb1c156. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/738?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional **Local AI** setup section in Settings with model download, progress, verification, readiness, and removal actions.
  * Introduced a **developer-gated** Local AI option that only appears when enabled, including memory/RAM gating before setup.
  * Improved in-process LLM **text chunking** to preserve paragraph/sentence boundaries when possible.
* **Bug Fixes**
  * Enhanced local model downloads with **resume support**, integrity verification, and safe retries.
  * Improved **provider selection** so the Local AI option only appears/updates when it’s actually available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->