### PR TITLE
fix: restore dictation success checkmark

### DIFF
--- a/Sources/MacParakeet/App/DictationFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/DictationFlowCoordinator.swift
@@ -495,7 +495,7 @@ final class DictationFlowCoordinator {
             overlayViewModel?.state = .cancelled(timeRemaining: seconds)
 
         case .showSuccess:
-            dismissCaption(outcome: .success)
+            clearCaptionVisualWhileAwaitingPasteOutcome()
             overlayViewModel?.state = .success
 
         case .showNoSpeech:
@@ -593,11 +593,8 @@ final class DictationFlowCoordinator {
             }
             let transcript = dictation.cleanTranscript ?? dictation.rawTranscript
             let insertionStyle = currentDictationInsertionStyle
-            actionTask = Task { @MainActor in
-                // Paste immediately — there's no success checkmark to wait for;
-                // the pasted text is the confirmation.
-                guard !Task.isCancelled else { return }
-
+            Task { @MainActor in
+                var completedDictation = dictation
                 let action = self.pendingPostPasteAction
                 self.pendingPostPasteAction = nil
                 let pastedToAppAtDispatch = NSWorkspace.shared.frontmostApplication?.bundleIdentifier
@@ -612,6 +609,7 @@ final class DictationFlowCoordinator {
                 do {
                     if action == nil && !transcriptHasText {
                         self.dictationLog.notice("dictation_paste_skipped gen=\(gen) reason=empty_transcript")
+                        guard self.stateMachine.generation == gen else { return }
                         self.dismissCaption(outcome: .success)
                         self.sendEvent(.pasteSucceeded(generation: gen))
                         return
@@ -634,32 +632,33 @@ final class DictationFlowCoordinator {
                             restoresClipboard: !keepDictationOnClipboard
                         )
                     }
-                    guard !Task.isCancelled else { return }
 
                     // Save pastedToApp metadata
                     if let pastedToApp = pastedToAppAtDispatch {
-                        self.currentDictation?.pastedToApp = pastedToApp
-                        self.currentDictation?.updatedAt = Date()
-                        if let d = self.currentDictation {
-                            do {
-                                try self.dictationRepo.save(d)
-                            } catch {
-                                self.dictationLog.error("Failed to save pastedToApp metadata error=\(error.localizedDescription, privacy: .public)")
+                        completedDictation.pastedToApp = pastedToApp
+                        completedDictation.updatedAt = Date()
+                        do {
+                            try self.dictationRepo.save(completedDictation)
+                            if self.currentDictation?.id == completedDictation.id {
+                                self.currentDictation = completedDictation
                             }
+                        } catch {
+                            self.dictationLog.error("Failed to save pastedToApp metadata error=\(error.localizedDescription, privacy: .public)")
                         }
                     }
 
                     let rawChars = dictation.rawTranscript.count
                     let cleanChars = dictation.cleanTranscript?.count ?? 0
-                    let app = self.currentDictation?.pastedToApp ?? "none"
+                    let app = completedDictation.pastedToApp ?? "none"
                     self.dictationLog.notice("dictation_completed gen=\(gen) outcome=success rawChars=\(rawChars) cleanChars=\(cleanChars) autoPasted=true pastedToApp=\(app, privacy: .public)")
 
+                    guard self.stateMachine.generation == gen else { return }
                     self.dismissCaption(outcome: .success)
                     self.sendEvent(.pasteSucceeded(generation: gen))
                 } catch {
-                    guard !Task.isCancelled else { return }
                     let bucket = Self.commandFailureBucket(for: error)
                     self.dictationLog.error("dictation_paste_failed gen=\(gen) bucket=\(bucket, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
+                    guard self.stateMachine.generation == gen else { return }
                     self.dismissCaption(outcome: .failure)
                     if !transcriptHasText {
                         // Pure action-only dictation (e.g., "press return") — nothing to paste
@@ -865,13 +864,7 @@ final class DictationFlowCoordinator {
     }
 
     private func dismissCaption(outcome: ProcessingLoadCaptionOutcome) {
-        captionGeneration += 1
-        captionGraceTimer?.cancel()
-        captionEscalationTimer?.cancel()
-        captionFailureDismissTask?.cancel()
-        captionGraceTimer = nil
-        captionEscalationTimer = nil
-        captionFailureDismissTask = nil
+        resetCaptionTimers()
 
         if let shownAt = captionShownAt {
             let durationMs = max(0, Int(Date().timeIntervalSince(shownAt) * 1000))
@@ -882,6 +875,21 @@ final class DictationFlowCoordinator {
             captionShownAt = nil
         }
         setProcessingLoadCaption(nil)
+    }
+
+    private func clearCaptionVisualWhileAwaitingPasteOutcome() {
+        resetCaptionTimers()
+        setProcessingLoadCaption(nil)
+    }
+
+    private func resetCaptionTimers() {
+        captionGeneration += 1
+        captionGraceTimer?.cancel()
+        captionEscalationTimer?.cancel()
+        captionFailureDismissTask?.cancel()
+        captionGraceTimer = nil
+        captionEscalationTimer = nil
+        captionFailureDismissTask = nil
     }
 
     private func showErrorAfterCaptionFailureIfNeeded(message: String) {

--- a/Sources/MacParakeetCore/DictationFlow/DictationFlowStateMachine.swift
+++ b/Sources/MacParakeetCore/DictationFlow/DictationFlowStateMachine.swift
@@ -383,12 +383,8 @@ public struct DictationFlowStateMachine: Sendable, Equatable {
 
         case (.processing, .transcriptionCompleted(let gen)):
             guard gen == generation else { return [] }
-            // No success checkmark — the pasted text is the confirmation. Keep
-            // the processing pill up through the paste, then drop straight to
-            // idle on pasteSucceeded (below) so the next dictation can start the
-            // instant the text lands.
             state = .finishing(outcome: .success)
-            return [.updateMenuBar(.idle), .resignKeyWindow, .pasteTranscript]
+            return [.showSuccess, .updateMenuBar(.idle), .resignKeyWindow, .resetHotkeyStateMachine, .pasteTranscript]
 
         case (.processing, .transcriptionFailedNoSpeech(let gen)):
             guard gen == generation else { return [] }
@@ -465,11 +461,10 @@ public struct DictationFlowStateMachine: Sendable, Equatable {
 
         case (.finishing(.success), .pasteSucceeded(let gen)):
             guard gen == generation else { return [] }
-            // Text is in — no checkmark dwell. Return to idle and re-arm the
-            // hotkey immediately so a press right after drop-in starts a new
-            // dictation instead of waiting out a success animation.
-            state = .idle
-            return [.hideOverlay, .reloadHistory, .resetHotkeyStateMachine, .updateMenuBar(.idle), .showIdlePill]
+            // Text is in; keep the success checkmark visible briefly so the
+            // dictation has a clear completion affordance. A fresh hotkey press
+            // while this dwells is still handled by the finishing restart path.
+            return [.startDisplayDismissTimer(seconds: 0.8)]
 
         case (.finishing(.success), .pasteFailed(let gen, let message)):
             guard gen == generation else { return [] }
@@ -490,7 +485,7 @@ public struct DictationFlowStateMachine: Sendable, Equatable {
             return [
                 .cancelAllTimers, .cancelActionTask,
                 .hideOverlay, .reloadHistory,
-                .hideIdlePill, .showReadyPill, .startReadyDismissTimer,
+                .hideIdlePill, .showReadyPill, .startReadyDismissTimer, .resetHotkeyStateMachine,
             ]
 
         case (.finishing, .startRequested(let mode)):
@@ -499,7 +494,7 @@ public struct DictationFlowStateMachine: Sendable, Equatable {
             return [
                 .cancelAllTimers, .cancelActionTask,
                 .hideOverlay, .reloadHistory,
-                .hideIdlePill, .checkEntitlements,
+                .hideIdlePill, .checkEntitlements, .resetHotkeyStateMachine,
             ]
 
         case (.finishing, .cancelRequested), (.finishing, .dismissRequested):

--- a/Tests/MacParakeetTests/DictationFlow/DictationFlowCoordinatorLoadCaptionTests.swift
+++ b/Tests/MacParakeetTests/DictationFlow/DictationFlowCoordinatorLoadCaptionTests.swift
@@ -80,6 +80,10 @@ final class DictationFlowCoordinatorLoadCaptionTests: XCTestCase {
         let cleared = await waitUntil { harness.coordinator.processingLoadCaptionForTesting == nil }
         XCTAssertTrue(cleared)
 
+        let recordedSuccess = await waitUntil {
+            harness.telemetry.snapshot().containsCaptionDuration(outcome: "success")
+        }
+        XCTAssertTrue(recordedSuccess)
         let events = harness.telemetry.snapshot()
         XCTAssertTrue(events.containsCaptionShown(firstInstall: true))
         XCTAssertTrue(events.containsCaptionDuration(outcome: "success"))
@@ -225,6 +229,34 @@ final class DictationFlowCoordinatorLoadCaptionTests: XCTestCase {
         XCTAssertNil(harness.coordinator.processingLoadCaptionForTesting)
     }
 
+    func testStalePasteCompletionDoesNotClearNextProcessingCaption() async throws {
+        let harness = try makeHarness(isReady: true, transcribeDelayMs: 5)
+        await harness.clipboard.setPasteDelayMs(150)
+
+        try await harness.startAndStop()
+        let successVisible = await waitUntil {
+            harness.coordinator.overlayStateForTesting?.isSuccessForTest == true
+        }
+        XCTAssertTrue(successVisible)
+
+        await harness.stt.setReady(false)
+        await harness.stt.setTranscribeDelay(milliseconds: 300)
+        harness.coordinator.startDictation(mode: .persistent, trigger: .hotkey)
+        let secondStarted = await waitUntil {
+            harness.coordinator.overlayStateForTesting?.isRecordingForTest == true
+        }
+        XCTAssertTrue(secondStarted)
+        harness.coordinator.stopDictation()
+
+        let secondCaptionShown = await harness.captionSignal.wait(for: .preparing)
+        XCTAssertTrue(secondCaptionShown)
+        let firstPasteCompleted = await waitUntilAsync {
+            await harness.clipboard.snapshot().pastedTexts.count == 1
+        }
+        XCTAssertTrue(firstPasteCompleted)
+        XCTAssertEqual(harness.coordinator.processingLoadCaptionForTesting, .preparing)
+    }
+
     func testKeepDictationOnClipboardPastesNormalPayloadWithoutRestore() async throws {
         let harness = try makeHarness(
             isReady: true,
@@ -277,15 +309,20 @@ final class DictationFlowCoordinatorLoadCaptionTests: XCTestCase {
         )
 
         // The paste uses the insertion style captured when the transcript was
-        // produced. With the success checkmark removed, paste is immediate, so a
-        // later preference change can no longer race ahead of it — the captured
-        // (inline) style is applied. (When the finalize queue lands, the deferred
-        // paste will snapshot the style into the job, re-establishing this
-        // guarantee against a mid-flight preference change.)
+        // produced. Even while the success checkmark is visible, a later
+        // preference change cannot race ahead of it — the captured (inline)
+        // style is applied.
         harness.coordinator.startDictation(mode: .persistent, trigger: .hotkey)
         let started = await waitUntil { harness.coordinator.overlayStateForTesting?.isRecordingForTest == true }
         XCTAssertTrue(started)
         harness.coordinator.stopDictation()
+        let completed = await waitUntil { harness.coordinator.overlayStateForTesting?.isSuccessForTest == true }
+        XCTAssertTrue(completed)
+
+        harness.preferencesDefaults.set(
+            DictationInsertionStyle.sentence.rawValue,
+            forKey: UserDefaultsAppRuntimePreferences.dictationInsertionStyleKey
+        )
 
         let pasted = await waitUntilAsync {
             await harness.clipboard.snapshot().lastPastedText != nil

--- a/Tests/MacParakeetTests/DictationFlow/DictationFlowCoordinatorTests.swift
+++ b/Tests/MacParakeetTests/DictationFlow/DictationFlowCoordinatorTests.swift
@@ -68,6 +68,43 @@ final class DictationFlowCoordinatorTests: XCTestCase {
         XCTAssertTrue(savedTranscripts.contains("second dictated message"))
     }
 
+    func testSuccessDwellRestartDoesNotCancelCompletedPaste() async throws {
+        let harness = try await makeRecordingHarness()
+        await harness.stt.configureSequence(results: [
+            STTResult(text: "first delayed paste"),
+            STTResult(text: "second dictation"),
+        ])
+        await harness.clipboard.setPasteDelayMs(100)
+
+        harness.coordinator.startDictation(mode: .persistent, trigger: .hotkey)
+        let firstStarted = await waitUntil { self.isFlowRecording(harness.coordinator.flowStateForTesting) }
+        XCTAssertTrue(firstStarted)
+
+        harness.coordinator.stopDictation()
+        let firstSuccessVisible = await waitUntil {
+            if case .success = harness.coordinator.overlayStateForTesting { return true }
+            return false
+        }
+        XCTAssertTrue(firstSuccessVisible)
+
+        harness.coordinator.startDictation(mode: .persistent, trigger: .hotkey)
+        let secondStarted = await waitUntil { self.isFlowRecording(harness.coordinator.flowStateForTesting) }
+        XCTAssertTrue(secondStarted)
+
+        harness.coordinator.stopDictation()
+        let bothPasted = await waitUntilAsync {
+            let snapshot = await harness.clipboard.snapshot()
+            return snapshot.pastedTexts.count == 2
+        }
+        XCTAssertTrue(bothPasted)
+
+        let clipboardSnapshot = await harness.clipboard.snapshot()
+        XCTAssertEqual(
+            clipboardSnapshot.pastedTexts,
+            ["first delayed paste ", "second dictation "]
+        )
+    }
+
     func testSuccessfulMicPermissionRequestDismissesStaleStartFailure() async throws {
         let harness = try await makeMicPermissionHarness(
             microphonePermission: .notDetermined,

--- a/Tests/MacParakeetTests/DictationFlow/DictationFlowStateMachineTests.swift
+++ b/Tests/MacParakeetTests/DictationFlow/DictationFlowStateMachineTests.swift
@@ -566,10 +566,10 @@ final class DictationFlowStateMachineTests: XCTestCase {
 
         let effects = m.handle(.transcriptionCompleted(generation: gen))
         XCTAssertEqual(m.state, .finishing(outcome: .success))
-        // No success checkmark — the pasted text is the confirmation.
-        XCTAssertFalse(effects.contains(.showSuccess))
+        XCTAssertTrue(effects.contains(.showSuccess))
         XCTAssertTrue(effects.contains(.updateMenuBar(.idle)))
         XCTAssertTrue(effects.contains(.resignKeyWindow))
+        XCTAssertTrue(effects.contains(.resetHotkeyStateMachine))
         XCTAssertTrue(effects.contains(.pasteTranscript))
     }
 
@@ -708,17 +708,12 @@ final class DictationFlowStateMachineTests: XCTestCase {
         _ = m.handle(.transcriptionCompleted(generation: gen))
 
         let effects = m.handle(.pasteSucceeded(generation: gen))
-        // No checkmark dwell — paste lands and we return to idle + re-arm the
-        // hotkey immediately so the next dictation can start right after.
-        XCTAssertEqual(m.state, .idle)
-        XCTAssertTrue(effects.contains(.hideOverlay))
-        XCTAssertTrue(effects.contains(.reloadHistory))
-        XCTAssertTrue(effects.contains(.resetHotkeyStateMachine))
-        XCTAssertTrue(effects.contains(.showIdlePill))
-        XCTAssertFalse(effects.contains(.startDisplayDismissTimer(seconds: 0.8)))
+        XCTAssertEqual(m.state, .finishing(outcome: .success))
+        XCTAssertTrue(effects.contains(.startDisplayDismissTimer(seconds: 0.8)))
+        XCTAssertFalse(effects.contains(.hideOverlay))
     }
 
-    func testPasteSuccessAcceptsImmediatePersistentRestart() {
+    func testSuccessDwellAcceptsImmediatePersistentRestart() {
         var m = machineInProcessing()
         let gen = m.generation
         _ = m.handle(.transcriptionCompleted(generation: gen))
@@ -730,6 +725,7 @@ final class DictationFlowStateMachineTests: XCTestCase {
         XCTAssertEqual(m.generation, gen + 1)
         XCTAssertTrue(effects.contains(.checkEntitlements))
         XCTAssertTrue(effects.contains(.hideIdlePill))
+        XCTAssertTrue(effects.contains(.resetHotkeyStateMachine))
     }
 
     func testFinishingPasteFailed() {
@@ -744,12 +740,10 @@ final class DictationFlowStateMachineTests: XCTestCase {
     }
 
     func testFinishingDisplayDismissExpired() {
-        // Success no longer uses a dismiss timer (it returns to idle on paste),
-        // so the dismiss-timer path is exercised via the no-speech leaf, which
-        // still dwells before clearing.
         var m = machineInProcessing()
         let gen = m.generation
-        _ = m.handle(.transcriptionFailedNoSpeech(generation: gen))
+        _ = m.handle(.transcriptionCompleted(generation: gen))
+        _ = m.handle(.pasteSucceeded(generation: gen))
 
         let effects = m.handle(.displayDismissExpired(generation: gen))
         XCTAssertEqual(m.state, .idle)
@@ -811,11 +805,12 @@ final class DictationFlowStateMachineTests: XCTestCase {
     func testFinishingStaleDisplayDismiss() {
         var m = machineInProcessing()
         let gen = m.generation
-        _ = m.handle(.transcriptionFailedNoSpeech(generation: gen))
+        _ = m.handle(.transcriptionCompleted(generation: gen))
+        _ = m.handle(.pasteSucceeded(generation: gen))
 
         let effects = m.handle(.displayDismissExpired(generation: gen - 1))
         XCTAssertTrue(effects.isEmpty)
-        XCTAssertEqual(m.state, .finishing(outcome: .noSpeech))
+        XCTAssertEqual(m.state, .finishing(outcome: .success))
     }
 
     func testFinishingReadyPillRequested() {
@@ -884,6 +879,7 @@ final class DictationFlowStateMachineTests: XCTestCase {
         XCTAssertEqual(m.state, .ready)
         XCTAssertTrue(effects.contains(.showReadyPill))
         XCTAssertTrue(effects.contains(.cancelActionTask))
+        XCTAssertTrue(effects.contains(.resetHotkeyStateMachine))
     }
 
     func testFinishingErrorStartRequested() {
@@ -942,8 +938,13 @@ final class DictationFlowStateMachineTests: XCTestCase {
         _ = m.handle(.transcriptionCompleted(generation: gen))
         XCTAssertEqual(m.state, .finishing(outcome: .success))
 
-        // → paste succeeded returns straight to idle (no checkmark dwell)
-        let effects = m.handle(.pasteSucceeded(generation: gen))
+        // → paste succeeded starts the success-checkmark dwell
+        let pasteEffects = m.handle(.pasteSucceeded(generation: gen))
+        XCTAssertEqual(m.state, .finishing(outcome: .success))
+        XCTAssertTrue(pasteEffects.contains(.startDisplayDismissTimer(seconds: 0.8)))
+
+        // → idle
+        let effects = m.handle(.displayDismissExpired(generation: gen))
         XCTAssertEqual(m.state, .idle)
         XCTAssertTrue(effects.contains(.reloadHistory))
         XCTAssertTrue(effects.contains(.resetHotkeyStateMachine))

--- a/Tests/MacParakeetTests/Services/System/MockClipboardService.swift
+++ b/Tests/MacParakeetTests/Services/System/MockClipboardService.swift
@@ -18,6 +18,7 @@ public actor MockClipboardService: ClipboardServiceProtocol {
     public var lastRestoresClipboard: Bool?
     public var pasteCallCount = 0
     private var pasteError: Error?
+    private var pasteDelayMs: UInt64 = 0
 
     public init() {}
 
@@ -38,6 +39,9 @@ public actor MockClipboardService: ClipboardServiceProtocol {
 
     public func pasteText(_ text: String, restoresClipboard: Bool) async throws {
         pasteCallCount += 1
+        if pasteDelayMs > 0 {
+            try await Task.sleep(for: .milliseconds(pasteDelayMs))
+        }
         if let pasteError {
             throw pasteError
         }
@@ -63,5 +67,9 @@ public actor MockClipboardService: ClipboardServiceProtocol {
 
     public func setPasteError(_ error: Error?) {
         pasteError = error
+    }
+
+    public func setPasteDelayMs(_ delayMs: UInt64) {
+        pasteDelayMs = delayMs
     }
 }


### PR DESCRIPTION
## Summary
Dictation now shows the green success checkmark again instead of jumping from spinner to disappearance after transcription. The flow restores the visible success affordance and keeps it visible briefly after paste succeeds, while preserving immediate next-dictation affordances during that dwell.

Paste still runs without an artificial pre-paste delay, and the completed transcript paste no longer lives in the generic cancellable `actionTask` slot. That means restart, ready, cancel, or dismiss transitions during the success dwell cannot silently cancel a paste that already belongs to a completed dictation. Stale paste completions are also generation-gated before touching caption UI or sending flow events, so a delayed first paste cannot clear the next dictation's processing caption.

The caption-loading path now clears its visual caption when success appears without recording success telemetry until the paste outcome is known. That keeps the visible UI clean while preserving success/failure/cancel duration accuracy.

## Risk + Scope
This is intentionally scoped to the dictation completion visual state and the tests that prove its timing. It does not change speech engine selection, transcription content, release metadata, signing/notarization, or appcast state.

## Validation
- `swift test --filter DictationFlowStateMachineTests` -> 85 tests, 0 failures
- `swift test --filter DictationFlowCoordinatorLoadCaptionTests` -> 17 tests, 0 failures
- `swift test --filter DictationFlowCoordinatorTests` -> 16 tests, 0 failures
- `git diff --check` -> clean

Review fixes included in the current head:
- Removed the pre-paste delay flagged by Greptile so restart cannot drop a completed transcript before paste.
- Moved completed transcript paste out of the cancellable action-task slot and added a delayed-paste restart regression test.
- Added generation guards so stale delayed paste completions cannot clear a newer processing caption.
- Reset the hotkey state when success is first shown, and on both success-dwell restart paths: direct start and ready pill.
- Extracted caption timer cleanup into a shared private helper.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5](https://img.shields.io/badge/GPT--5-000000)
