### PR TITLE
Add independent meeting speaker detection setting

### DIFF
--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -91,6 +91,9 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
 
 ### Added
 
+- `config get|set|list` now includes `meeting-speaker-detection`, the saved
+  app-default speaker-detection setting used for meeting recording and meeting
+  retranscription.
 - `meetings artifact <meeting> --json|--envelope` now materializes a
   deterministic top-level `meeting.md` alongside the existing
   `manifest.json`, `transcript.json`, notes, and prompt-result files. The
@@ -125,6 +128,11 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
 
 ### Changed
 
+- `retranscribe --kind meeting --speaker-detection app-default` now follows
+  the saved meeting speaker-detection preference. `transcribe` and
+  transcription retranscription continue to follow the saved file/URL
+  `speaker-detection` preference; explicit `--speaker-detection on|off`
+  remains a per-run override.
 - `transcribe` / `retranscribe` now apply local recognition-time custom
   vocabulary boosting when the selected engine is Parakeet TDT (`v3` or `v2`)
   and enabled `vocab words` entries have no replacement text. Unsupported
@@ -137,10 +145,12 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
   prompt-result index, artifact paths, and `speakerLabelsIncluded` metadata.
 - `spec --json` now documents `meetings export` JSON stdout mode as
   `--stdout --format json`, matching the command's file-output default.
-- `transcribe` / `retranscribe` app-default speaker detection now resolves to
-  `on` for a fresh preference store. `config get speaker-detection` reports
-  `on` when unset; an explicit saved `off`, `--speaker-detection off`, or
-  `--no-diarize` still disables diarization.
+- `transcribe` and transcription `retranscribe` app-default speaker detection
+  now resolve to `on` for a fresh file/URL preference store. `config get
+  speaker-detection` reports `on` when unset; meeting retranscription uses the
+  new `meeting-speaker-detection` app-default value. An explicit saved `off`,
+  `--speaker-detection off`, or `--no-diarize` still disables diarization for
+  the relevant workflow.
 - Plain-text `retranscribe` validation/misuse failures now use exit code `2`,
   matching the JSON envelope path and the public exit-code contract.
 

--- a/Sources/CLI/Commands/ConfigCommand.swift
+++ b/Sources/CLI/Commands/ConfigCommand.swift
@@ -41,6 +41,7 @@ struct ConfigCommand: ParsableCommand {
           whisper-language          auto|<Whisper language code>    default: auto
           cohere-language           <Cohere language code>          default: en (no auto)
           speaker-detection         on|off                          default: on
+          meeting-speaker-detection on|off                          default: on
           auto-meeting-titles       on|off                          default: on
           voice-return-enabled      on|off                          default: off
           voice-return-triggers     phrase[|phrase...]              default: press return
@@ -126,7 +127,13 @@ struct ConfigCommand: ParsableCommand {
             key: "speaker-detection",
             valueSyntax: "on|off",
             allowedValues: ["on", "off"],
-            summary: "Default file/meeting speaker diarization setting."
+            summary: "Default file and URL transcription speaker detection."
+        ),
+        CLIConfigKeySpec(
+            key: "meeting-speaker-detection",
+            valueSyntax: "on|off",
+            allowedValues: ["on", "off"],
+            summary: "Default meeting recording speaker detection."
         ),
         CLIConfigKeySpec(
             key: "auto-meeting-titles",
@@ -328,6 +335,9 @@ struct ConfigCommand: ParsableCommand {
         case "speaker-detection":
             let on = UserDefaultsAppRuntimePreferences.speakerDiarizationEnabled(defaults: store)
             return on ? "on" : "off"
+        case "meeting-speaker-detection":
+            let on = UserDefaultsAppRuntimePreferences.meetingSpeakerDiarizationEnabled(defaults: store)
+            return on ? "on" : "off"
         case "auto-meeting-titles":
             let on = store.object(forKey: UserDefaultsAppRuntimePreferences.autoGenerateMeetingTitlesKey) as? Bool ?? true
             return on ? "on" : "off"
@@ -420,6 +430,10 @@ struct ConfigCommand: ParsableCommand {
         case "speaker-detection":
             let parsed = try parseBool(value, key: key)
             store.set(parsed, forKey: UserDefaultsAppRuntimePreferences.speakerDiarizationKey)
+            return parsed ? "on" : "off"
+        case "meeting-speaker-detection":
+            let parsed = try parseBool(value, key: key)
+            store.set(parsed, forKey: UserDefaultsAppRuntimePreferences.meetingSpeakerDiarizationKey)
             return parsed ? "on" : "off"
         case "auto-meeting-titles":
             let parsed = try parseBool(value, key: key)

--- a/Sources/CLI/Commands/RetranscribeCommand.swift
+++ b/Sources/CLI/Commands/RetranscribeCommand.swift
@@ -404,7 +404,10 @@ struct RetranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding 
             promptResultRepo: promptResultRepo,
             customWordRepo: customWordRepo,
             snippetRepo: snippetRepo,
-            defaults: defaults
+            defaults: defaults,
+            storedSpeakerDetection: defaults.object(
+                forKey: UserDefaultsAppRuntimePreferences.speakerDiarizationKey
+            ) as? Bool
         )
         printErr("Retranscribing \(original.fileName) with \(speechEngine.engine.rawValue)...")
         let updated = try await service.retranscribe(
@@ -436,7 +439,10 @@ struct RetranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding 
             promptResultRepo: promptResultRepo,
             customWordRepo: customWordRepo,
             snippetRepo: snippetRepo,
-            defaults: defaults
+            defaults: defaults,
+            storedSpeakerDetection: defaults.object(
+                forKey: UserDefaultsAppRuntimePreferences.meetingSpeakerDiarizationKey
+            ) as? Bool
         )
         printErr("Retranscribing meeting \(original.fileName) with \(speechEngine.engine.rawValue)...")
         let progress = Self.progressHandler(prefix: "Retranscribing meeting")
@@ -468,11 +474,12 @@ struct RetranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding 
         promptResultRepo: PromptResultRepository,
         customWordRepo: CustomWordRepository,
         snippetRepo: TextSnippetRepository,
-        defaults: UserDefaults
+        defaults: UserDefaults,
+        storedSpeakerDetection: Bool?
     ) -> TranscriptionService {
         let resolvedSpeakerDetection = TranscribeCommand.resolveSpeakerDetection(
             speakerDetection,
-            storedEnabled: defaults.object(forKey: UserDefaultsAppRuntimePreferences.speakerDiarizationKey) as? Bool,
+            storedEnabled: storedSpeakerDetection,
             noDiarize: noDiarize,
             speakerCount: speakerCount,
             speakerMin: speakerMin,
@@ -491,6 +498,7 @@ struct RetranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding 
             snippetRepo: snippetRepo,
             processingMode: { processingMode },
             shouldDiarize: { resolvedSpeakerDetection.enabled },
+            shouldDiarizeMeetings: { resolvedSpeakerDetection.enabled },
             diarizationService: TranscribeCommand.makeDiarizationService(for: resolvedSpeakerDetection)
         )
     }

--- a/Sources/CLI/Commands/SpecCommand.swift
+++ b/Sources/CLI/Commands/SpecCommand.swift
@@ -227,7 +227,7 @@ private extension CLISpecCommand {
                 CLISpecParameter.option("--language", valueName: "CODE", summary: "Language hint for Nemotron, Whisper, or Cohere; Cohere has no auto-detect."),
                 CLISpecParameter.option("--parakeet-model", valueName: "app-default|v3|v2|unified", summary: "Parakeet build: v3 supported languages, v2 English timestamps, or Unified readable English without timestamps."),
                 CLISpecParameter.option("--nemotron-model", valueName: "app-default|multilingual-1120ms|english-1120ms", summary: "Nemotron Beta build for this rerun; ignored for Parakeet, Cohere, and Whisper."),
-                CLISpecParameter.option("--speaker-detection", valueName: "app-default|on|off", summary: "Speaker detection for saved transcriptions and meetings."),
+                CLISpecParameter.option("--speaker-detection", valueName: "app-default|on|off", summary: "Speaker detection for saved transcriptions and meetings; app-default follows the record type's saved preference."),
                 CLISpecParameter.option("--speaker-count", valueName: "N", summary: "Exact known speaker count for saved transcriptions and meetings."),
                 CLISpecParameter.option("--speaker-min", valueName: "N", summary: "Minimum speaker count bound for saved transcriptions and meetings."),
                 CLISpecParameter.option("--speaker-max", valueName: "N", summary: "Maximum speaker count bound for saved transcriptions and meetings."),

--- a/Sources/CLI/Commands/TranscribeCommand.swift
+++ b/Sources/CLI/Commands/TranscribeCommand.swift
@@ -571,6 +571,7 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
                     shouldKeepDownloadedAudio
                 },
                 shouldDiarize: { resolvedSpeakerDetection.enabled },
+                shouldDiarizeMeetings: { resolvedSpeakerDetection.enabled },
                 youtubeDownloader: youtubeDownloader,
                 podcastResolver: PodcastEpisodeResolver(),
                 podcastSearchResolver: PodcastQueryResolver(),

--- a/Sources/MacParakeet/App/AppEnvironment.swift
+++ b/Sources/MacParakeet/App/AppEnvironment.swift
@@ -358,6 +358,7 @@ final class AppEnvironment {
             shouldAutoGenerateMeetingTitles: meetingTitleGenerationEnabledClosure,
             shouldKeepDownloadedAudio: { [runtimePreferences] in runtimePreferences.shouldSaveTranscriptionAudio },
             shouldDiarize: { [runtimePreferences] in runtimePreferences.shouldDiarize },
+            shouldDiarizeMeetings: { [runtimePreferences] in runtimePreferences.shouldDiarizeMeetings },
             youtubeDownloader: youtubeDownloader,
             podcastResolver: PodcastEpisodeResolver(),
             podcastSearchResolver: PodcastQueryResolver(),

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -1227,6 +1227,14 @@ struct SettingsView: View {
                 Divider()
 
                 settingsToggleRow(
+                    title: "Speaker detection",
+                    detail: "Split captured system audio into other speakers after recording when audio is clear.",
+                    isOn: $viewModel.meetingSpeakerDiarization
+                )
+
+                Divider()
+
+                settingsToggleRow(
                     title: "Auto-save meetings to disk",
                     detail: "Automatically write a file to the chosen folder after every meeting recording completes.",
                     isOn: $viewModel.meetingAutoSave
@@ -1372,7 +1380,7 @@ struct SettingsView: View {
 
                 settingsToggleRow(
                     title: "Speaker detection",
-                    detail: "Optional. Adds speaker labels when audio is clear; leave off if labels are unreliable.",
+                    detail: "Add speaker labels to file and URL transcriptions when audio is clear.",
                     isOn: $viewModel.speakerDiarization
                 )
 

--- a/Sources/MacParakeetCore/AppRuntimePreferences.swift
+++ b/Sources/MacParakeetCore/AppRuntimePreferences.swift
@@ -13,6 +13,7 @@ public protocol AppRuntimePreferencesProtocol: Sendable {
     var shouldAutoGenerateMeetingTitles: Bool { get }
     var youtubeAudioQuality: YouTubeAudioQuality { get }
     var shouldDiarize: Bool { get }
+    var shouldDiarizeMeetings: Bool { get }
     var aiFormatterEnabled: Bool { get }
     var aiFormatterEnabledForDictation: Bool { get }
     var aiFormatterEnabledForTranscriptions: Bool { get }
@@ -502,6 +503,8 @@ public final class UserDefaultsAppRuntimePreferences: AppRuntimePreferencesProto
     public static let youtubeAudioQualityKey = "youtubeAudioQuality"
     public static let speakerDiarizationKey = "speakerDiarization"
     public static let defaultSpeakerDiarizationEnabled = true
+    public static let meetingSpeakerDiarizationKey = "meetingSpeakerDiarization"
+    public static let defaultMeetingSpeakerDiarizationEnabled = true
     public static let aiFormatterEnabledKey = "aiFormatterEnabled"
     public static let aiFormatterEnabledForDictationKey = "aiFormatterEnabledForDictation"
     public static let aiFormatterEnabledForTranscriptionsKey = "aiFormatterEnabledForTranscriptions"
@@ -570,6 +573,10 @@ public final class UserDefaultsAppRuntimePreferences: AppRuntimePreferencesProto
         defaults.object(forKey: speakerDiarizationKey) as? Bool ?? defaultSpeakerDiarizationEnabled
     }
 
+    public static func meetingSpeakerDiarizationEnabled(defaults: UserDefaults = .standard) -> Bool {
+        defaults.object(forKey: meetingSpeakerDiarizationKey) as? Bool ?? defaultMeetingSpeakerDiarizationEnabled
+    }
+
     public static func showMeetingRecordingPill(defaults: UserDefaults = .standard) -> Bool {
         defaults.object(forKey: showMeetingRecordingPillKey) as? Bool ?? true
     }
@@ -622,6 +629,10 @@ public final class UserDefaultsAppRuntimePreferences: AppRuntimePreferencesProto
 
     public var shouldDiarize: Bool {
         Self.speakerDiarizationEnabled(defaults: defaults)
+    }
+
+    public var shouldDiarizeMeetings: Bool {
+        Self.meetingSpeakerDiarizationEnabled(defaults: defaults)
     }
 
     public var aiFormatterEnabled: Bool {

--- a/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
+++ b/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
@@ -502,6 +502,7 @@ public enum TelemetrySettingName: String, Sendable, Equatable {
     case meetingAudioRetention = "meeting_audio_retention"
     case youtubeAudioQuality = "youtube_audio_quality"
     case speakerDiarization = "speaker_diarization"
+    case meetingSpeakerDiarization = "meeting_speaker_diarization"
     case parakeetModelVariant = "parakeet_model_variant"
     case nemotronModelVariant = "nemotron_model_variant"
     case whisperDefaultLanguage = "whisper_default_language"

--- a/Sources/MacParakeetCore/Services/TranscriptionService.swift
+++ b/Sources/MacParakeetCore/Services/TranscriptionService.swift
@@ -229,6 +229,7 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
     private let shouldAutoGenerateMeetingTitles: @Sendable () -> Bool
     private let shouldKeepDownloadedAudio: @Sendable () -> Bool
     private let shouldDiarize: @Sendable () -> Bool
+    private let shouldDiarizeMeetings: @Sendable () -> Bool
     private let youtubeDownloader: YouTubeDownloading?
     private let podcastResolver: PodcastResolving?
     private let podcastSearchResolver: PodcastSearchResolving?
@@ -259,6 +260,7 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
         shouldAutoGenerateMeetingTitles: (@Sendable () -> Bool)? = nil,
         shouldKeepDownloadedAudio: (@Sendable () -> Bool)? = nil,
         shouldDiarize: (@Sendable () -> Bool)? = nil,
+        shouldDiarizeMeetings: (@Sendable () -> Bool)? = nil,
         youtubeDownloader: YouTubeDownloading? = nil,
         podcastResolver: PodcastResolving? = nil,
         podcastSearchResolver: PodcastSearchResolving? = nil,
@@ -287,6 +289,7 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
             shouldAutoGenerateMeetingTitles: shouldAutoGenerateMeetingTitles,
             shouldKeepDownloadedAudio: shouldKeepDownloadedAudio,
             shouldDiarize: shouldDiarize,
+            shouldDiarizeMeetings: shouldDiarizeMeetings,
             youtubeDownloader: youtubeDownloader,
             podcastResolver: podcastResolver,
             podcastSearchResolver: podcastSearchResolver,
@@ -318,6 +321,7 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
         shouldAutoGenerateMeetingTitles: (@Sendable () -> Bool)? = nil,
         shouldKeepDownloadedAudio: (@Sendable () -> Bool)? = nil,
         shouldDiarize: (@Sendable () -> Bool)? = nil,
+        shouldDiarizeMeetings: (@Sendable () -> Bool)? = nil,
         youtubeDownloader: YouTubeDownloading? = nil,
         podcastResolver: PodcastResolving? = nil,
         podcastSearchResolver: PodcastSearchResolving? = nil,
@@ -345,7 +349,9 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
         self.aiFormatterPromptTemplate = aiFormatterPromptTemplate ?? { AIFormatter.defaultPromptTemplate }
         self.shouldAutoGenerateMeetingTitles = shouldAutoGenerateMeetingTitles ?? { false }
         self.shouldKeepDownloadedAudio = shouldKeepDownloadedAudio ?? { true }
-        self.shouldDiarize = shouldDiarize ?? { true }
+        let resolvedShouldDiarize = shouldDiarize ?? { true }
+        self.shouldDiarize = resolvedShouldDiarize
+        self.shouldDiarizeMeetings = shouldDiarizeMeetings ?? resolvedShouldDiarize
         self.youtubeDownloader = youtubeDownloader
         self.podcastResolver = podcastResolver
         self.podcastSearchResolver = podcastSearchResolver
@@ -1147,7 +1153,7 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
     ) async throws -> Transcription {
         let processingStartedAt = Date()
         var lifecycleStage: TelemetryTranscriptionStage = .audioConversion
-        let diarizationRequested = diarizationService != nil && shouldDiarize() && recording.sourceAlignment.system != nil
+        let diarizationRequested = diarizationService != nil && shouldDiarizeMeetings() && recording.sourceAlignment.system != nil
         var temporaryWavURLs: [URL] = []
         var sourceWavURLs: [AudioSource: URL] = [:]
         defer {

--- a/Sources/MacParakeetViewModels/SettingsSearchIndex.swift
+++ b/Sources/MacParakeetViewModels/SettingsSearchIndex.swift
@@ -84,6 +84,7 @@ public enum SettingsSearchIndex {
     private static let meetingGatedIds: Set<String> = [
         "meeting",
         "meeting.floatingControls",
+        "meeting.speakerDetection",
         "meeting.autoStop",
         "meeting.calendar",
         "system.permissions.screen"
@@ -250,6 +251,14 @@ public enum SettingsSearchIndex {
                 "floating controls", "meeting pill", "recording pill", "hide meeting",
                 "hide recording", "recording ui", "menu bar", "overlay"
             ],
+            cardAnchor: "meeting"
+        ),
+        SettingsSearchEntry(
+            id: "meeting.speakerDetection",
+            tab: .capture,
+            title: "Speaker detection",
+            subtitle: "in Meeting Recording",
+            keywords: ["speaker", "speaker labels", "diarization", "participants", "others", "system audio"],
             cardAnchor: "meeting"
         ),
         SettingsSearchEntry(

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -443,6 +443,12 @@ public final class SettingsViewModel {
             Telemetry.send(.settingChanged(setting: .speakerDiarization))
         }
     }
+    public var meetingSpeakerDiarization: Bool {
+        didSet {
+            defaults.set(meetingSpeakerDiarization, forKey: UserDefaultsAppRuntimePreferences.meetingSpeakerDiarizationKey)
+            Telemetry.send(.settingChanged(setting: .meetingSpeakerDiarization))
+        }
+    }
     public private(set) var pendingMeetingRecoveryCount = 0
     public var onRecoverPendingMeetingRecordings: (() -> Void)?
 
@@ -740,6 +746,7 @@ public final class SettingsViewModel {
         meetingAudioRetention = UserDefaultsAppRuntimePreferences.meetingAudioRetention(defaults: defaults)
         youtubeAudioQuality = YouTubeAudioQuality.current(defaults: defaults)
         speakerDiarization = UserDefaultsAppRuntimePreferences.speakerDiarizationEnabled(defaults: defaults)
+        meetingSpeakerDiarization = UserDefaultsAppRuntimePreferences.meetingSpeakerDiarizationEnabled(defaults: defaults)
         // Ensure auto-save folders are configured before reading paths.
         // Idempotent: existing user-chosen folders are preserved; only
         // unset bookmarks get the default. This guarantees the read

--- a/Tests/CLITests/ConfigCommandTests.swift
+++ b/Tests/CLITests/ConfigCommandTests.swift
@@ -36,6 +36,7 @@ final class ConfigCommandTests: XCTestCase {
             "whisper-language",
             "cohere-language",
             "speaker-detection",
+            "meeting-speaker-detection",
             "auto-meeting-titles",
             "voice-return-enabled",
             "voice-return-triggers",
@@ -73,6 +74,11 @@ final class ConfigCommandTests: XCTestCase {
         XCTAssertEqual(try ConfigCommand.read(key: "speaker-detection", defaults: defaults), "off")
     }
 
+    func testReadMeetingSpeakerDetectionReflectsExplicitFalse() throws {
+        defaults.set(false, forKey: UserDefaultsAppRuntimePreferences.meetingSpeakerDiarizationKey)
+        XCTAssertEqual(try ConfigCommand.read(key: "meeting-speaker-detection", defaults: defaults), "off")
+    }
+
     func testReadAgentDefaultsReflectGUIFallbacks() throws {
         XCTAssertEqual(try ConfigCommand.read(key: "processing-mode", defaults: defaults), "raw")
         XCTAssertEqual(try ConfigCommand.read(key: "speech-engine", defaults: defaults), "parakeet")
@@ -82,6 +88,7 @@ final class ConfigCommandTests: XCTestCase {
         XCTAssertEqual(try ConfigCommand.read(key: "whisper-language", defaults: defaults), "auto")
         XCTAssertEqual(try ConfigCommand.read(key: "cohere-language", defaults: defaults), "en")
         XCTAssertEqual(try ConfigCommand.read(key: "speaker-detection", defaults: defaults), "on")
+        XCTAssertEqual(try ConfigCommand.read(key: "meeting-speaker-detection", defaults: defaults), "on")
         XCTAssertEqual(try ConfigCommand.read(key: "auto-meeting-titles", defaults: defaults), "on")
         XCTAssertEqual(try ConfigCommand.read(key: "voice-return-enabled", defaults: defaults), "off")
         XCTAssertEqual(try ConfigCommand.read(key: "voice-return-triggers", defaults: defaults), "press return")
@@ -110,6 +117,7 @@ final class ConfigCommandTests: XCTestCase {
     func testCanonicalKeyNormalizesUnderscoreAliases() throws {
         XCTAssertEqual(try ConfigCommand.canonicalKey(" youtube_audio_quality "), "youtube-audio-quality")
         XCTAssertEqual(try ConfigCommand.canonicalKey("SPEAKER_DETECTION"), "speaker-detection")
+        XCTAssertEqual(try ConfigCommand.canonicalKey("MEETING_SPEAKER_DETECTION"), "meeting-speaker-detection")
     }
 
     func testReadUnknownKeyThrowsValidationError() {
@@ -162,6 +170,12 @@ final class ConfigCommandTests: XCTestCase {
 
         XCTAssertEqual(try ConfigCommand.write(key: "speaker-detection", value: "on", defaults: defaults), "on")
         XCTAssertEqual(defaults.object(forKey: UserDefaultsAppRuntimePreferences.speakerDiarizationKey) as? Bool, true)
+
+        XCTAssertEqual(try ConfigCommand.write(key: "meeting-speaker-detection", value: "off", defaults: defaults), "off")
+        XCTAssertEqual(
+            defaults.object(forKey: UserDefaultsAppRuntimePreferences.meetingSpeakerDiarizationKey) as? Bool,
+            false
+        )
 
         XCTAssertEqual(try ConfigCommand.write(key: "auto-meeting-titles", value: "off", defaults: defaults), "off")
         XCTAssertEqual(defaults.object(forKey: UserDefaultsAppRuntimePreferences.autoGenerateMeetingTitlesKey) as? Bool, false)
@@ -233,6 +247,11 @@ final class ConfigCommandTests: XCTestCase {
     func testWriteCanonicalizesUnderscoreKeys() throws {
         XCTAssertEqual(try ConfigCommand.write(key: "speaker_detection", value: "on", defaults: defaults), "on")
         XCTAssertEqual(defaults.object(forKey: UserDefaultsAppRuntimePreferences.speakerDiarizationKey) as? Bool, true)
+        XCTAssertEqual(try ConfigCommand.write(key: "meeting_speaker_detection", value: "off", defaults: defaults), "off")
+        XCTAssertEqual(
+            defaults.object(forKey: UserDefaultsAppRuntimePreferences.meetingSpeakerDiarizationKey) as? Bool,
+            false
+        )
         XCTAssertEqual(
             try ConfigCommand.write(key: "meeting_audio_retention", value: "30d", defaults: defaults),
             "delete-after-30-days"

--- a/Tests/CLITests/SpecCommandTests.swift
+++ b/Tests/CLITests/SpecCommandTests.swift
@@ -258,6 +258,9 @@ final class SpecCommandTests: XCTestCase {
         let bluetoothMicPreference = try XCTUnwrap(configKeys.first { ($0["key"] as? String) == "prefer-built-in-mic-bluetooth-output" })
         XCTAssertEqual(bluetoothMicPreference["allowedValues"] as? [String], ["on", "off"])
 
+        let meetingSpeakerDetection = try XCTUnwrap(configKeys.first { ($0["key"] as? String) == "meeting-speaker-detection" })
+        XCTAssertEqual(meetingSpeakerDetection["allowedValues"] as? [String], ["on", "off"])
+
         let timeout = try XCTUnwrap(configKeys.first { ($0["key"] as? String) == "meeting-hook-timeout" })
         XCTAssertEqual(timeout["valueSyntax"] as? String, "seconds 1-300")
     }

--- a/Tests/MacParakeetTests/AppRuntimePreferencesTests.swift
+++ b/Tests/MacParakeetTests/AppRuntimePreferencesTests.swift
@@ -68,6 +68,33 @@ final class AppRuntimePreferencesTests: XCTestCase {
         XCTAssertFalse(preferences.shouldDiarize)
     }
 
+    func testMeetingSpeakerDiarizationDefaultsToTrueWhenUnset() {
+        let preferences = makePreferences()
+        XCTAssertTrue(preferences.shouldDiarizeMeetings)
+    }
+
+    func testMeetingSpeakerDiarizationRespectsExplicitFalse() {
+        let suite = "app-runtime-prefs-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+        defaults.set(false, forKey: UserDefaultsAppRuntimePreferences.meetingSpeakerDiarizationKey)
+
+        let preferences = UserDefaultsAppRuntimePreferences(defaults: defaults)
+        XCTAssertFalse(preferences.shouldDiarizeMeetings)
+    }
+
+    func testSpeakerDiarizationPreferencesAreIndependent() {
+        let suite = "app-runtime-prefs-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+        defaults.set(false, forKey: UserDefaultsAppRuntimePreferences.speakerDiarizationKey)
+        defaults.set(true, forKey: UserDefaultsAppRuntimePreferences.meetingSpeakerDiarizationKey)
+
+        let preferences = UserDefaultsAppRuntimePreferences(defaults: defaults)
+        XCTAssertFalse(preferences.shouldDiarize)
+        XCTAssertTrue(preferences.shouldDiarizeMeetings)
+    }
+
     func testVoiceReturnTriggersAreDisabledWhenToggleIsOff() {
         let suite = "app-runtime-prefs-\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suite)!

--- a/Tests/MacParakeetTests/Services/TranscriptionServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/TranscriptionServiceTests.swift
@@ -2207,6 +2207,44 @@ final class TranscriptionServiceTests: XCTestCase {
         ])
     }
 
+    func testTranscribeMeetingUsesMeetingDiarizationPreference() async throws {
+        let recording = try makeDualSourceMeetingRecording(displayName: "Meeting Diarization Off")
+        defer { try? FileManager.default.removeItem(at: recording.folderURL) }
+
+        await mockSTT.configureSequence(results: meetingSourceSTTResults())
+
+        let diarization = MockDiarizationService()
+        await diarization.configure(result: MacParakeetDiarizationResult(
+            segments: [
+                SpeakerSegment(speakerId: "S1", startMs: 0, endMs: 200),
+            ],
+            speakerCount: 1,
+            speakers: [
+                SpeakerInfo(id: "S1", label: "Speaker 1"),
+            ]
+        ))
+
+        let service = TranscriptionService(
+            audioProcessor: mockAudio,
+            sttTranscriber: mockSTT,
+            transcriptionRepo: transcriptionRepo,
+            shouldDiarize: { true },
+            shouldDiarizeMeetings: { false },
+            diarizationService: diarization
+        )
+
+        let result = try await service.transcribeMeeting(recording: recording)
+        let diarizeCalled = await diarization.diarizeCalled
+
+        XCTAssertFalse(diarizeCalled)
+        XCTAssertEqual(result.speakerCount, 2)
+        XCTAssertEqual(result.speakers, [
+            SpeakerInfo(id: "microphone", label: "Me"),
+            SpeakerInfo(id: "system", label: "Others"),
+        ])
+        XCTAssertEqual(result.wordTimestamps?.map(\.speakerId), ["microphone", "system"])
+    }
+
     func testTranscribeMeetingPreservesOverlappingMicrophoneAndSystemSpeech() async throws {
         let recordingFolder = URL(fileURLWithPath: AppPaths.tempDir)
             .appendingPathComponent(UUID().uuidString, isDirectory: true)

--- a/Tests/MacParakeetTests/ViewModels/SettingsSearchIndexTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/SettingsSearchIndexTests.swift
@@ -110,6 +110,19 @@ final class SettingsSearchIndexTests: XCTestCase {
         }
     }
 
+    func testMeetingSpeakerDetectionQueriesFindMeetingSetting() {
+        let queries = ["system audio", "participants", "others", "speaker labels"]
+
+        for query in queries {
+            let ids = Set(SettingsSearchIndex.matches(query).map(\.id))
+            if AppFeatures.meetingRecordingEnabled {
+                XCTAssertTrue(ids.contains("meeting.speakerDetection"), "Query \(query) should find meeting speaker detection")
+            } else {
+                XCTAssertFalse(ids.contains("meeting.speakerDetection"), "Query \(query) should not reveal hidden meeting settings")
+            }
+        }
+    }
+
     func testRowEntryHasBreadcrumbSubtitle() {
         let results = SettingsSearchIndex.matches("screen recording")
         let rowEntry = results.first { $0.id == "system.permissions.screen" }
@@ -215,6 +228,7 @@ final class SettingsSearchIndexTests: XCTestCase {
         let meetingGatedIds: Set<String> = [
             "meeting",
             "meeting.floatingControls",
+            "meeting.speakerDetection",
             "meeting.autoStop",
             "meeting.calendar",
             "system.permissions.screen"

--- a/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
@@ -229,6 +229,7 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.saveMeetingAudio, "saveMeetingAudio should default to true")
         XCTAssertEqual(viewModel.youtubeAudioQuality, .m4a, "youtubeAudioQuality should default to Apple-friendly saved audio")
         XCTAssertTrue(viewModel.speakerDiarization, "speakerDiarization should default to true")
+        XCTAssertTrue(viewModel.meetingSpeakerDiarization, "meetingSpeakerDiarization should default to true")
         XCTAssertEqual(viewModel.meetingHotkeyTrigger, .chord(modifiers: ["command", "shift"], keyCode: 46))
         XCTAssertEqual(viewModel.meetingAudioSourceMode, .microphoneAndSystem)
         XCTAssertTrue(viewModel.showMeetingRecordingPill, "showMeetingRecordingPill should default to true")
@@ -265,6 +266,7 @@ final class SettingsViewModelTests: XCTestCase {
             forKey: UserDefaultsAppRuntimePreferences.youtubeAudioQualityKey
         )
         testDefaults.set(true, forKey: UserDefaultsAppRuntimePreferences.speakerDiarizationKey)
+        testDefaults.set(false, forKey: UserDefaultsAppRuntimePreferences.meetingSpeakerDiarizationKey)
         testDefaults.set("usb-mic-uid", forKey: UserDefaultsAppRuntimePreferences.selectedMicrophoneDeviceUIDKey)
         testDefaults.set(
             MeetingAudioSourceMode.systemOnly.rawValue,
@@ -295,6 +297,7 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertFalse(vm.saveMeetingAudio)
         XCTAssertEqual(vm.youtubeAudioQuality, .bestAvailable)
         XCTAssertTrue(vm.speakerDiarization)
+        XCTAssertFalse(vm.meetingSpeakerDiarization)
         XCTAssertEqual(vm.selectedMicrophoneDeviceUID, "usb-mic-uid")
         XCTAssertEqual(vm.meetingAudioSourceMode, .systemOnly)
         XCTAssertFalse(vm.showMeetingRecordingPill)
@@ -963,6 +966,31 @@ final class SettingsViewModelTests: XCTestCase {
             testDefaults.object(forKey: UserDefaultsAppRuntimePreferences.speakerDiarizationKey) as? Bool,
             false
         )
+        XCTAssertNil(testDefaults.object(forKey: UserDefaultsAppRuntimePreferences.meetingSpeakerDiarizationKey))
+    }
+
+    func testSettingMeetingSpeakerDiarizationPersistsExplicitFalse() {
+        viewModel.meetingSpeakerDiarization = false
+
+        XCTAssertEqual(
+            testDefaults.object(forKey: UserDefaultsAppRuntimePreferences.meetingSpeakerDiarizationKey) as? Bool,
+            false
+        )
+        XCTAssertNil(testDefaults.object(forKey: UserDefaultsAppRuntimePreferences.speakerDiarizationKey))
+    }
+
+    func testMeetingSpeakerDiarizationEmitsDistinctTelemetry() {
+        let telemetry = SettingsTelemetrySpy()
+        Telemetry.configure(telemetry)
+
+        viewModel.meetingSpeakerDiarization = false
+        viewModel.speakerDiarization = false
+
+        let settings = telemetry.snapshot().compactMap { event -> TelemetrySettingName? in
+            guard case .settingChanged(let setting) = event else { return nil }
+            return setting
+        }
+        XCTAssertEqual(settings, [.meetingSpeakerDiarization, .speakerDiarization])
     }
 
     func testMeetingHotkeyPersistsToDedicatedDefaultsKey() {
@@ -2594,6 +2622,7 @@ final class SettingsViewModelTests: XCTestCase {
         viewModel.saveTranscriptionAudio = false
         viewModel.saveMeetingAudio = false
         viewModel.speakerDiarization = true
+        viewModel.meetingSpeakerDiarization = false
 
         // Create a new ViewModel reading from the same defaults
         let vm2 = SettingsViewModel(defaults: testDefaults)
@@ -2609,6 +2638,7 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertEqual(vm2.meetingAudioRetention, .deleteImmediately)
         XCTAssertFalse(vm2.saveMeetingAudio)
         XCTAssertTrue(vm2.speakerDiarization)
+        XCTAssertFalse(vm2.meetingSpeakerDiarization)
     }
 
     // MARK: - Model deletion

--- a/docs/cli-testing.md
+++ b/docs/cli-testing.md
@@ -274,9 +274,10 @@ transcriptions and meetings; dictations reject those flags.
 
 ### Speaker Diarization
 
-Speaker detection follows the saved app/CLI preference by default. A fresh
-preference store resolves to `on`, matching the GUI default where supported.
-Pin a run with the explicit option, or use the legacy alias to force it off:
+Speaker detection follows the workflow-specific saved app/CLI preference by
+default. A fresh preference store resolves to `on`, matching the GUI default
+where supported. Pin a run with the explicit option, or use the legacy alias to
+force it off:
 
 ```bash
 swift run macparakeet-cli transcribe "<FILE>" --speaker-detection on
@@ -293,8 +294,10 @@ constraints. They imply speaker detection when `--speaker-detection` is left at
 and/or `--speaker-max` for bounds; values must be positive, and
 `--speaker-min` cannot exceed `--speaker-max`.
 
-`config get speaker-detection` reports the saved app-default value used by
-bare `transcribe` and by `--speaker-detection app-default`.
+`config get speaker-detection` reports the saved file/URL app-default value
+used by bare `transcribe` and transcription retranscription. `config get
+meeting-speaker-detection` reports the saved meeting app-default value used by
+meeting retranscription when `--speaker-detection` is left at `app-default`.
 
 ### Shared Config
 
@@ -312,6 +315,7 @@ swift run macparakeet-cli config set nemotron-model english-1120ms
 swift run macparakeet-cli config set nemotron-language auto
 swift run macparakeet-cli config set whisper-language ko
 swift run macparakeet-cli config set speaker-detection off
+swift run macparakeet-cli config set meeting-speaker-detection off
 swift run macparakeet-cli config set auto-meeting-titles on
 swift run macparakeet-cli config set save-transcription-audio off
 swift run macparakeet-cli config set meeting-audio-retention keep-forever
@@ -326,11 +330,11 @@ swift run macparakeet-cli config set prefer-built-in-mic-bluetooth-output on
 
 Supported keys: `telemetry`, `processing-mode`, `speech-engine`,
 `parakeet-model`, `nemotron-model`, `nemotron-language`, `whisper-language`,
-`cohere-language`, `speaker-detection`, `auto-meeting-titles`,
-`save-transcription-audio`, `meeting-audio-retention`, `meeting-audio-source`,
-`save-meeting-audio`, `youtube-audio-quality`, `meeting-artifacts-folder`,
-`meeting-hook-enabled`, `meeting-hook-path`, `meeting-hook-timeout`,
-`voice-return-enabled`, `voice-return-triggers`,
+`cohere-language`, `speaker-detection`, `meeting-speaker-detection`,
+`auto-meeting-titles`, `save-transcription-audio`, `meeting-audio-retention`,
+`meeting-audio-source`, `save-meeting-audio`, `youtube-audio-quality`,
+`meeting-artifacts-folder`, `meeting-hook-enabled`, `meeting-hook-path`,
+`meeting-hook-timeout`, `voice-return-enabled`, `voice-return-triggers`,
 `prefer-built-in-mic-bluetooth-output`.
 Underscore aliases such as `youtube_audio_quality` are accepted on input; JSON
 output uses canonical hyphenated keys.

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -234,10 +234,12 @@ macparakeet-cli transcribe /path/to/korean.mp3 --engine whisper --language ko --
 ```
 
 To test the same defaults a user selected in the GUI, make every app-default
-read explicit. Bare `transcribe` already follows the saved speaker-detection
-preference, but the full flag group below also opts into saved speech-engine,
-processing, audio-retention, and YouTube-quality defaults. This does not
-exercise GUI-only UI, playback, hotkey, export, or optional AI formatter output.
+read explicit. Bare `transcribe` already follows the saved file/URL
+speaker-detection preference, while `retranscribe --kind meeting` follows the
+saved meeting speaker-detection preference when left at app-default. The full
+flag group below also opts into saved speech-engine, processing,
+audio-retention, and YouTube-quality defaults. This does not exercise GUI-only
+UI, playback, hotkey, export, or optional AI formatter output.
 
 ```bash
 macparakeet-cli transcribe /path/to/audio.mp3 \
@@ -275,6 +277,7 @@ macparakeet-cli config set whisper-language ko
 macparakeet-cli config set cohere-language ja
 macparakeet-cli config set processing-mode raw
 macparakeet-cli config set speaker-detection off
+macparakeet-cli config set meeting-speaker-detection off
 macparakeet-cli config set save-transcription-audio off
 macparakeet-cli config set youtube-audio-quality m4a
 ```
@@ -524,6 +527,7 @@ macparakeet-cli transcribe "<path-or-media-url>" \
 macparakeet-cli config list --json
 macparakeet-cli config set speech-engine parakeet --json
 macparakeet-cli config set speaker-detection off --json
+macparakeet-cli config set meeting-speaker-detection off --json
 macparakeet-cli history transcriptions --json
 macparakeet-cli history search-transcriptions "<query>" --json
 macparakeet-cli history search "<query>" --json
@@ -567,12 +571,14 @@ macparakeet-cli prompts run "<prompt-name>" \
   `--mode app-default`, `--downloaded-audio app-default`, and
   `--media-audio-quality app-default`) when you are intentionally checking
   GUI-default behavior. Pin explicit flags for reproducible agent tests.
-- `config get speaker-detection` reports the saved app-default value, which is
-  `on` for a fresh preference store. Bare `transcribe` and
-  `--speaker-detection app-default` use that value; pass
-  `--speaker-detection on` or `off` to override it for one run. For known
-  speaker counts, use per-run `--speaker-count`, `--speaker-min`, or
-  `--speaker-max` instead of mutating the saved default.
+- `config get speaker-detection` reports the saved file/URL app-default value,
+  which is `on` for a fresh preference store. `config get
+  meeting-speaker-detection` reports the saved meeting app-default value, also
+  defaulting to `on`. Bare `transcribe` uses the file/URL value; meeting
+  retranscription uses the meeting value when `--speaker-detection` is left at
+  `app-default`. Pass `--speaker-detection on` or `off` to override it for one
+  run. For known speaker counts, use per-run `--speaker-count`,
+  `--speaker-min`, or `--speaker-max` instead of mutating the saved default.
 ````
 
 ## Conventions

--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -54,7 +54,7 @@ If MacParakeet.app is already installed, the bundled CLI is also available at
 | Use GUI/default preferences | `macparakeet-cli transcribe <path> --engine app-default --parakeet-model app-default --speaker-detection app-default --mode app-default --downloaded-audio app-default --media-audio-quality app-default --format json` |
 | Inspect/select speech models | `macparakeet-cli models list --json` / `macparakeet-cli models select parakeet-v3 --json` / `macparakeet-cli models select parakeet-v2 --json` / `macparakeet-cli models select nemotron-multilingual-1120ms --json` / `macparakeet-cli models select cohere-transcribe --json` |
 | Download optional speech models | `macparakeet-cli models download nemotron-multilingual-1120ms` / `macparakeet-cli models download cohere-transcribe` / `macparakeet-cli models download whisper-large-v3-v20240930-turbo-632MB` |
-| Configure shared defaults | `macparakeet-cli config set speaker-detection off --json`; `macparakeet-cli config set parakeet-model v3 --json`; `macparakeet-cli config set speech-engine nemotron --json`; `macparakeet-cli config set cohere-language ja --json` |
+| Configure shared defaults | `macparakeet-cli config set speaker-detection off --json`; `macparakeet-cli config set meeting-speaker-detection off --json`; `macparakeet-cli config set parakeet-model v3 --json`; `macparakeet-cli config set speech-engine nemotron --json`; `macparakeet-cli config set cohere-language ja --json` |
 | List recent transcriptions | `macparakeet-cli history transcriptions --json` |
 | Search transcriptions | `macparakeet-cli history search-transcriptions "<query>" --json` |
 | Search dictations | `macparakeet-cli history search "<query>" --json` |

--- a/spec/02-features.md
+++ b/spec/02-features.md
@@ -1393,8 +1393,8 @@ new scheduling architecture.
 - [x] Single-speaker files handled gracefully (one speaker label)
 - [x] Diarization failure is non-fatal (ASR result preserved)
 - [x] Progress shows "Identifying speakers..." headline
-- [x] Settings toggle for speaker detection (on by default where supported; explicit off is preserved)
-- [x] CLI: `macparakeet-cli transcribe` follows the saved speaker-detection preference (on by default when unset); `--speaker-detection off` / `--no-diarize` to force off, speaker-count constraints to force on
+- [x] Settings toggles for file/URL and meeting speaker detection (on by default where supported; explicit off is preserved)
+- [x] CLI: `macparakeet-cli transcribe` follows the saved file/URL speaker-detection preference; meeting retranscription follows the saved meeting speaker-detection preference when app-default; `--speaker-detection off` / `--no-diarize` force off per run, and speaker-count constraints force on
 
 ---
 

--- a/spec/adr/010-speaker-diarization.md
+++ b/spec/adr/010-speaker-diarization.md
@@ -125,11 +125,11 @@ If diarization fails (e.g. `noSpeechDetected`, model error, timeout), the ASR re
 
 **Progress UX:** When enabled, show "Transcribing..." during ASR, then "Identifying speakers..." during diarization. When disabled, the diarization step is skipped entirely (no progress indicator for it).
 
-~~**No global toggle.**~~ **Global toggle added.** A "Speaker detection" toggle in Settings → Transcription controls whether diarization runs. The original concern about "why don't I see speakers?" confusion is addressed by the toggle being clearly labeled and discoverable.
+~~**No global toggle.**~~ **Settings toggles added.** Separate "Speaker detection" toggles in Settings → Transcription and Settings → Meeting Recording control whether diarization runs for file/URL transcription and meeting recordings. The original concern about "why don't I see speakers?" confusion is addressed by the toggles being clearly labeled and discoverable in the relevant capture workflow.
 
-Skip diarization for: dictation (single speaker by design), or when the Settings toggle is off.
+Skip diarization for: dictation (single speaker by design), or when the corresponding Settings toggle is off.
 
-**CLI:** `macparakeet-cli transcribe` follows the saved speaker-detection preference; when unset, the preference defaults to on where supported. Use `--no-diarize` / `--speaker-detection off` to skip, or a speaker-count constraint to force it on. Text output shows speaker labels at turn changes; JSON output includes all speaker data via Codable.
+**CLI:** `macparakeet-cli transcribe` follows the saved file/URL speaker-detection preference; `macparakeet-cli retranscribe --kind meeting` follows the saved meeting speaker-detection preference when `--speaker-detection app-default` is used. When unset, both preferences default to on where supported. Use `--no-diarize` / `--speaker-detection off` to skip for one run, or a speaker-count constraint to force it on. Text output shows speaker labels at turn changes; JSON output includes all speaker data via Codable.
 
 **Readiness contract:** Diarization remains a separate service from the STT scheduler, but when speaker detection is enabled (on by default where supported — see the 2026-07-03 amendment) the onboarding/ready-state path must account for diarization-model readiness before claiming file transcription is fully ready.
 
@@ -160,6 +160,13 @@ Skip diarization for: dictation (single speaker by design), or when the Settings
 > with ADR-027's private speech-memory direction: speaker structure is only
 > recoverable while raw meeting audio exists, so capture-time diarization is the
 > last chance to preserve speaker labels in the corpus.
+>
+> **Amendment (2026-07-05):** The single saved value was split by workflow.
+> File and URL transcription continue to use the `speakerDiarization`
+> preference. Meeting recording now uses the independent
+> `meetingSpeakerDiarization` preference, also UserDefaults-backed and default
+> on where supported. Meetings still diarize only the isolated system-audio
+> track after capture; microphone words remain source-labeled as `Me`.
 >
 > **2. The FluidAudio dependency surface has grown.** The core decision above
 > still stands — MacParakeet ships only the offline batch pipeline and uses


### PR DESCRIPTION
## Summary
- Split speaker detection into independent file/URL transcription and meeting recording preferences.
- Add the Meetings settings toggle, settings search entry, telemetry name, and runtime wiring so meeting finalization uses the meeting-specific value.
- Add `meeting-speaker-detection` to CLI config/spec docs and make meeting retranscription app-defaults follow the meeting preference.

## Verification
- `git diff --check`
- `swift test --filter 'AppRuntimePreferencesTests|SettingsViewModelTests|SettingsSearchIndexTests|ConfigCommandTests|SpecCommandTests|TranscriptionServiceTests'`\n- `swift test`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an independent meeting speaker detection preference, separate from file/URL transcription, so meetings can use their own setting by default. Updates the Settings UI, CLI config keys, runtime behavior, telemetry, and docs to honor the split.

- New Features
  - Split preferences: file/URL `speaker-detection` and meeting `meeting-speaker-detection` (both default to on when unset).
  - Settings: Added a Meeting Recording “Speaker detection” toggle and search entry; meeting finalization reads this value.
  - CLI: `config get|set|list` supports `meeting-speaker-detection`; `retranscribe --kind meeting --speaker-detection app-default` now uses the meeting preference; `--speaker-detection on|off` still overrides per run.
  - Runtime: `TranscriptionService` gains `shouldDiarizeMeetings`; meeting diarization now respects the meeting-specific toggle; app environment and commands wired accordingly.
  - Telemetry: Added `meeting_speaker_diarization` setting name.
  - Docs/Specs/Tests: Updated CLI docs, integrations, feature spec, ADR, and added coverage across config, preferences, view model, search index, service behavior, and spec output.

<sup>Written for commit 7eaa6684ac5d65fa0fffdc2eed7c6d9df49c6500. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/740?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added separate speaker-detection controls for meeting recordings and standard transcription.
  * `app-default` now respects the saved preference for each workflow, with meeting retranscription using its own saved setting.
  * Search in Settings now includes the new meeting speaker-detection option.

* **Bug Fixes**
  * Improved diarization behavior so meeting and transcription preferences are handled independently.
  * Kept per-run overrides working as expected for disabling speaker detection.

* **Documentation**
  * Updated CLI help, testing guides, and integration docs to reflect the new meeting speaker-detection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->