### PR TITLE
Clarify dictation Bluetooth mic setting

### DIFF
--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -1151,7 +1151,7 @@ struct SettingsView: View {
 
                 settingsToggleRow(
                     title: "Use Mac mic with Bluetooth headphones",
-                    detail: "When the microphone is set to System Default and output is AirPods or other Bluetooth headphones, use the Mac's built-in mic first. This keeps headphone audio clear and helps avoid missed starts. Specific microphone choices above still take priority.",
+                    detail: "When the microphone is set to System Default and output is AirPods or other Bluetooth headphones, use the Mac's built-in mic first. This keeps headphone audio clear and helps avoid missed starts. Specific microphone choices above still take priority when available.",
                     isOn: $viewModel.preferBuiltInMicWhenBluetoothOutput
                 )
 

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -1055,32 +1055,6 @@ struct SettingsView: View {
                 Divider()
 
                 settingsToggleRow(
-                    title: "Pause media while dictating",
-                    detail: "Pauses playing media during dictation and resumes it when capture stops. On speakers, a moment of media sound can reach the mic before the pause lands — speak as you press, or use headphones.",
-                    isBeta: true,
-                    isOn: $viewModel.pauseMediaDuringDictation
-                )
-
-                Divider()
-
-                settingsToggleRow(
-                    title: "Instant dictation",
-                    detail: "Keeps the mic ready so dictation starts faster and catches your first words; macOS shows the mic indicator while it's on. Pauses for Bluetooth mics like AirPods to protect playback quality.",
-                    isBeta: true,
-                    isOn: $viewModel.instantDictationEnabled
-                )
-
-                Divider()
-
-                settingsToggleRow(
-                    title: "Use built-in mic with Bluetooth headphones",
-                    detail: "When sound is playing to AirPods or other Bluetooth headphones, dictation records from the built-in mic instead of the headset. Keeps playback in full quality and avoids the brief Bluetooth mode switch that can drop your first words or capture silence. Turn off to always record from your headset's mic. If you pick a specific microphone above, MacParakeet tries it first.",
-                    isOn: $viewModel.preferBuiltInMicWhenBluetoothOutput
-                )
-
-                Divider()
-
-                settingsToggleRow(
                     title: "Live transcript preview",
                     detail: liveDictationPreviewDetail,
                     isBeta: true,
@@ -1154,6 +1128,32 @@ struct SettingsView: View {
                         .frame(width: 140)
                     }
                 }
+
+                Divider()
+
+                settingsToggleRow(
+                    title: "Instant dictation",
+                    detail: "Keeps the mic ready so dictation starts faster and catches your first words; macOS shows the mic indicator while it's on. Pauses for Bluetooth mics like AirPods to protect playback quality.",
+                    isBeta: true,
+                    isOn: $viewModel.instantDictationEnabled
+                )
+
+                Divider()
+
+                settingsToggleRow(
+                    title: "Pause media while dictating",
+                    detail: "Pauses playing media during dictation and resumes it when capture stops. On speakers, a moment of media sound can reach the mic before the pause lands — speak as you press, or use headphones.",
+                    isBeta: true,
+                    isOn: $viewModel.pauseMediaDuringDictation
+                )
+
+                Divider()
+
+                settingsToggleRow(
+                    title: "Use Mac mic with Bluetooth headphones",
+                    detail: "When the microphone is set to System Default and output is AirPods or other Bluetooth headphones, use the Mac's built-in mic first. This keeps headphone audio clear and helps avoid missed starts. Specific microphone choices above still take priority.",
+                    isOn: $viewModel.preferBuiltInMicWhenBluetoothOutput
+                )
 
                 Divider()
 


### PR DESCRIPTION
## Summary
- move lower-priority dictation capture helpers below the everyday preview/undo/auto-stop controls
- rename the Bluetooth headset mic row to describe the Mac mic fallback more plainly
- clarify that the behavior applies to System Default and that explicit mic selections still take priority

## Verification
- git diff --check
- swift test --filter SettingsViewModelTests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reordered lower-priority dictation helpers below the live preview/undo/auto-stop controls to keep common actions up top. Renamed the Bluetooth mic setting to “Use Mac mic with Bluetooth headphones” and clarified the fallback: it only applies when the microphone is set to System Default and output is Bluetooth; specific mic selections still take priority when available.

<sup>Written for commit 31a8022376efa2f5f353fdda247cc2e55370979d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/741?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Reorganized the Dictation settings so beta options now appear later in the section, after the undo and silence controls.
  * Updated the Bluetooth mic option label and description for clearer wording when using headphones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->