### PR TITLE
Add interruption-phase attribution to meeting recovery telemetry

### DIFF
--- a/Sources/MacParakeet/App/MeetingRecoveryCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingRecoveryCoordinator.swift
@@ -59,7 +59,11 @@ final class MeetingRecoveryCoordinator {
             let recoveries = try await recoveryService.discoverPendingRecoveries()
             settingsViewModel.refreshPendingMeetingRecoveries()
             guard !recoveries.isEmpty else { return }
-            Telemetry.send(.meetingRecoveryDiscovered(count: recoveries.count, source: source))
+            Telemetry.send(.meetingRecoveryDiscovered(
+                count: recoveries.count,
+                source: source,
+                phases: Self.telemetryPhases(for: recoveries)
+            ))
             await presentMeetingRecoveryDialog(recoveries, recoveryService: recoveryService, source: source)
         } catch {
             await presentMeetingRecoveryError(error)
@@ -131,7 +135,11 @@ final class MeetingRecoveryCoordinator {
         source: TelemetryMeetingRecoverySource
     ) async {
         let startedAt = Date()
-        Telemetry.send(.meetingRecoveryStarted(count: recoveries.count, source: source))
+        Telemetry.send(.meetingRecoveryStarted(
+            count: recoveries.count,
+            source: source,
+            phases: Self.telemetryPhases(for: recoveries)
+        ))
         var lastRecoveredIndex = -1
         do {
             var recovered: [Transcription] = []
@@ -142,7 +150,8 @@ final class MeetingRecoveryCoordinator {
             Telemetry.send(.meetingRecoveryCompleted(
                 count: recovered.count,
                 durationSeconds: Date().timeIntervalSince(startedAt),
-                source: source
+                source: source,
+                phases: Self.telemetryPhases(for: recoveries)
             ))
             libraryViewModel.loadTranscriptions()
             onRecoveredTranscriptionsChanged()
@@ -155,6 +164,7 @@ final class MeetingRecoveryCoordinator {
             Telemetry.send(.meetingRecoveryFailed(
                 count: pendingRecoveries.count,
                 source: source,
+                phases: Self.telemetryPhases(for: pendingRecoveries),
                 errorType: TelemetryErrorClassifier.classify(error),
                 errorDetail: TelemetryErrorClassifier.errorDetail(error)
             ))
@@ -177,12 +187,17 @@ final class MeetingRecoveryCoordinator {
             for recovery in recoveries {
                 try await recoveryService.discard(recovery)
             }
-            Telemetry.send(.meetingRecoveryDiscarded(count: recoveries.count, source: source))
+            Telemetry.send(.meetingRecoveryDiscarded(
+                count: recoveries.count,
+                source: source,
+                phases: Self.telemetryPhases(for: recoveries)
+            ))
             settingsViewModel.refreshPendingMeetingRecoveries()
         } catch {
             Telemetry.send(.meetingRecoveryFailed(
                 count: recoveries.count,
                 source: source,
+                phases: Self.telemetryPhases(for: recoveries),
                 errorType: TelemetryErrorClassifier.classify(error),
                 errorDetail: TelemetryErrorClassifier.errorDetail(error)
             ))
@@ -223,5 +238,9 @@ final class MeetingRecoveryCoordinator {
 
         // Launch recovery can happen before there is a window to host a sheet.
         return alert.runModal()
+    }
+
+    nonisolated static func telemetryPhases(for recoveries: [MeetingRecordingLockFile]) -> String {
+        TelemetryMeetingRecoveryPhases.aggregate(lockStates: recoveries.map(\.state))
     }
 }

--- a/Sources/MacParakeet/App/MeetingRecoveryCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingRecoveryCoordinator.swift
@@ -183,9 +183,11 @@ final class MeetingRecoveryCoordinator {
         recoveryService: MeetingRecordingRecoveryServicing,
         source: TelemetryMeetingRecoverySource
     ) async {
+        var lastDiscardedIndex = -1
         do {
-            for recovery in recoveries {
+            for (index, recovery) in recoveries.enumerated() {
                 try await recoveryService.discard(recovery)
+                lastDiscardedIndex = index
             }
             Telemetry.send(.meetingRecoveryDiscarded(
                 count: recoveries.count,
@@ -194,10 +196,11 @@ final class MeetingRecoveryCoordinator {
             ))
             settingsViewModel.refreshPendingMeetingRecoveries()
         } catch {
+            let pending = Array(recoveries.dropFirst(lastDiscardedIndex + 1))
             Telemetry.send(.meetingRecoveryFailed(
-                count: recoveries.count,
+                count: pending.count,
                 source: source,
-                phases: Self.telemetryPhases(for: recoveries),
+                phases: Self.telemetryPhases(for: pending),
                 errorType: TelemetryErrorClassifier.classify(error),
                 errorDetail: TelemetryErrorClassifier.errorDetail(error)
             ))
@@ -240,7 +243,7 @@ final class MeetingRecoveryCoordinator {
         return alert.runModal()
     }
 
-    nonisolated static func telemetryPhases(for recoveries: [MeetingRecordingLockFile]) -> String {
-        TelemetryMeetingRecoveryPhases.aggregate(lockStates: recoveries.map(\.state))
+    nonisolated static func telemetryPhases(for recoveries: [MeetingRecordingLockFile]) -> [MeetingRecordingLockState] {
+        recoveries.map(\.state)
     }
 }

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingLockFileStore.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingLockFileStore.swift
@@ -1,7 +1,7 @@
 import Darwin
 import Foundation
 
-public enum MeetingRecordingLockState: String, Codable, Sendable, Equatable {
+public enum MeetingRecordingLockState: String, Codable, Sendable, Equatable, CaseIterable {
     case recording
     case awaitingTranscription
 }

--- a/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
+++ b/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
@@ -882,19 +882,19 @@ public enum TelemetryEventSpec: Sendable {
         notesLengthBucket: String?,
         errorType: String?
     )
-    case meetingRecoveryDiscovered(count: Int, source: TelemetryMeetingRecoverySource, phases: String)
-    case meetingRecoveryStarted(count: Int, source: TelemetryMeetingRecoverySource, phases: String)
+    case meetingRecoveryDiscovered(count: Int, source: TelemetryMeetingRecoverySource, phases: [MeetingRecordingLockState])
+    case meetingRecoveryStarted(count: Int, source: TelemetryMeetingRecoverySource, phases: [MeetingRecordingLockState])
     case meetingRecoveryCompleted(
         count: Int,
         durationSeconds: Double,
         source: TelemetryMeetingRecoverySource,
-        phases: String
+        phases: [MeetingRecordingLockState]
     )
-    case meetingRecoveryDiscarded(count: Int, source: TelemetryMeetingRecoverySource, phases: String)
+    case meetingRecoveryDiscarded(count: Int, source: TelemetryMeetingRecoverySource, phases: [MeetingRecordingLockState])
     case meetingRecoveryFailed(
         count: Int,
         source: TelemetryMeetingRecoverySource,
-        phases: String,
+        phases: [MeetingRecordingLockState],
         errorType: String,
         errorDetail: String? = nil
     )
@@ -1613,32 +1613,32 @@ extension TelemetryEventSpec {
             return [
                 "count": "\(count)",
                 "source": source.rawValue,
-                "phases": Self.safeMeetingRecoveryPhases(phases),
+                "phases": TelemetryMeetingRecoveryPhases.aggregate(lockStates: phases),
             ]
         case .meetingRecoveryStarted(let count, let source, let phases):
             return [
                 "count": "\(count)",
                 "source": source.rawValue,
-                "phases": Self.safeMeetingRecoveryPhases(phases),
+                "phases": TelemetryMeetingRecoveryPhases.aggregate(lockStates: phases),
             ]
         case .meetingRecoveryCompleted(let count, let durationSeconds, let source, let phases):
             return [
                 "count": "\(count)",
                 "duration_seconds": Self.format(durationSeconds),
                 "source": source.rawValue,
-                "phases": Self.safeMeetingRecoveryPhases(phases),
+                "phases": TelemetryMeetingRecoveryPhases.aggregate(lockStates: phases),
             ]
         case .meetingRecoveryDiscarded(let count, let source, let phases):
             return [
                 "count": "\(count)",
                 "source": source.rawValue,
-                "phases": Self.safeMeetingRecoveryPhases(phases),
+                "phases": TelemetryMeetingRecoveryPhases.aggregate(lockStates: phases),
             ]
         case .meetingRecoveryFailed(let count, let source, let phases, let errorType, let errorDetail):
             var props = [
                 "count": "\(count)",
                 "source": source.rawValue,
-                "phases": Self.safeMeetingRecoveryPhases(phases),
+                "phases": TelemetryMeetingRecoveryPhases.aggregate(lockStates: phases),
                 "error_type": errorType,
             ]
             if let errorDetail = Self.sanitizedErrorDetail(errorDetail) { props["error_detail"] = errorDetail }
@@ -1760,10 +1760,6 @@ extension TelemetryEventSpec {
         return String(TelemetryErrorClassifier.sanitize(detail).prefix(512))
     }
 
-    private static func safeMeetingRecoveryPhases(_ phases: String) -> String {
-        let trimmed = phases.trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed.isEmpty ? TelemetryMeetingRecoveryPhases.unknown : trimmed
-    }
 
     private static func safeEngineVariant(_ variant: String?) -> String? {
         guard let variant,

--- a/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
+++ b/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
@@ -432,6 +432,49 @@ public enum TelemetryMeetingRecoverySource: String, Sendable, Equatable {
     case settings
 }
 
+public enum TelemetryMeetingRecoveryPhases {
+    public static let unknown = "unknown"
+
+    public static func aggregate(lockStates: [MeetingRecordingLockState]) -> String {
+        aggregate(rawPhases: lockStates.map(\.rawValue))
+    }
+
+    public static func aggregate(rawPhases: [String]) -> String {
+        var counts: [String: Int] = [:]
+        for phase in rawPhases {
+            counts[normalizedPhase(phase), default: 0] += 1
+        }
+
+        guard !counts.isEmpty else { return unknown }
+
+        return counts.keys.sorted(by: sortPhases).map { phase in
+            "\(phase):\(counts[phase] ?? 0)"
+        }.joined(separator: ",")
+    }
+
+    private static let phaseSortOrder: [String: Int] = Dictionary(
+        uniqueKeysWithValues: MeetingRecordingLockState.allCases.enumerated().map { pair in
+            (pair.element.rawValue, pair.offset)
+        }
+    )
+
+    private static func normalizedPhase(_ phase: String) -> String {
+        let trimmed = phase.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return unknown }
+        guard trimmed == unknown || phaseSortOrder[trimmed] != nil else { return unknown }
+        return trimmed
+    }
+
+    private static func sortPhases(_ lhs: String, _ rhs: String) -> Bool {
+        if let lhsIndex = phaseSortOrder[lhs], let rhsIndex = phaseSortOrder[rhs] {
+            return lhsIndex < rhsIndex
+        }
+        if phaseSortOrder[lhs] != nil { return true }
+        if phaseSortOrder[rhs] != nil { return false }
+        return lhs < rhs
+    }
+}
+
 /// Outcome of a launch-time Silero VAD model prep attempt (Phase 4.5,
 /// `plans/completed/2026-05-meeting-vad-guided-live-chunking.md` §6). The full
 /// vocabulary is modeled here, but the launch hook only transmits the
@@ -839,13 +882,19 @@ public enum TelemetryEventSpec: Sendable {
         notesLengthBucket: String?,
         errorType: String?
     )
-    case meetingRecoveryDiscovered(count: Int, source: TelemetryMeetingRecoverySource)
-    case meetingRecoveryStarted(count: Int, source: TelemetryMeetingRecoverySource)
-    case meetingRecoveryCompleted(count: Int, durationSeconds: Double, source: TelemetryMeetingRecoverySource)
-    case meetingRecoveryDiscarded(count: Int, source: TelemetryMeetingRecoverySource)
+    case meetingRecoveryDiscovered(count: Int, source: TelemetryMeetingRecoverySource, phases: String)
+    case meetingRecoveryStarted(count: Int, source: TelemetryMeetingRecoverySource, phases: String)
+    case meetingRecoveryCompleted(
+        count: Int,
+        durationSeconds: Double,
+        source: TelemetryMeetingRecoverySource,
+        phases: String
+    )
+    case meetingRecoveryDiscarded(count: Int, source: TelemetryMeetingRecoverySource, phases: String)
     case meetingRecoveryFailed(
         count: Int,
         source: TelemetryMeetingRecoverySource,
+        phases: String,
         errorType: String,
         errorDetail: String? = nil
     )
@@ -1560,31 +1609,36 @@ extension TelemetryEventSpec {
                 ("notes_length_bucket", notesLengthBucket),
                 ("error_type", errorType)
             )
-        case .meetingRecoveryDiscovered(let count, let source):
+        case .meetingRecoveryDiscovered(let count, let source, let phases):
             return [
                 "count": "\(count)",
                 "source": source.rawValue,
+                "phases": Self.safeMeetingRecoveryPhases(phases),
             ]
-        case .meetingRecoveryStarted(let count, let source):
+        case .meetingRecoveryStarted(let count, let source, let phases):
             return [
                 "count": "\(count)",
                 "source": source.rawValue,
+                "phases": Self.safeMeetingRecoveryPhases(phases),
             ]
-        case .meetingRecoveryCompleted(let count, let durationSeconds, let source):
+        case .meetingRecoveryCompleted(let count, let durationSeconds, let source, let phases):
             return [
                 "count": "\(count)",
                 "duration_seconds": Self.format(durationSeconds),
                 "source": source.rawValue,
+                "phases": Self.safeMeetingRecoveryPhases(phases),
             ]
-        case .meetingRecoveryDiscarded(let count, let source):
+        case .meetingRecoveryDiscarded(let count, let source, let phases):
             return [
                 "count": "\(count)",
                 "source": source.rawValue,
+                "phases": Self.safeMeetingRecoveryPhases(phases),
             ]
-        case .meetingRecoveryFailed(let count, let source, let errorType, let errorDetail):
+        case .meetingRecoveryFailed(let count, let source, let phases, let errorType, let errorDetail):
             var props = [
                 "count": "\(count)",
                 "source": source.rawValue,
+                "phases": Self.safeMeetingRecoveryPhases(phases),
                 "error_type": errorType,
             ]
             if let errorDetail = Self.sanitizedErrorDetail(errorDetail) { props["error_detail"] = errorDetail }
@@ -1704,6 +1758,11 @@ extension TelemetryEventSpec {
     private static func sanitizedErrorDetail(_ detail: String?) -> String? {
         guard let detail, !detail.isEmpty else { return nil }
         return String(TelemetryErrorClassifier.sanitize(detail).prefix(512))
+    }
+
+    private static func safeMeetingRecoveryPhases(_ phases: String) -> String {
+        let trimmed = phases.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? TelemetryMeetingRecoveryPhases.unknown : trimmed
     }
 
     private static func safeEngineVariant(_ variant: String?) -> String? {
@@ -1833,11 +1892,11 @@ public enum TelemetryImplementedContract {
         .meetingRecordingCancelled: ["duration_seconds"],
         .meetingRecordingFailed: ["error_type"],
         .meetingOperation: ["operation_id", "outcome"],
-        .meetingRecoveryDiscovered: ["count", "source"],
-        .meetingRecoveryStarted: ["count", "source"],
-        .meetingRecoveryCompleted: ["count", "duration_seconds", "source"],
-        .meetingRecoveryDiscarded: ["count", "source"],
-        .meetingRecoveryFailed: ["count", "source", "error_type"],
+        .meetingRecoveryDiscovered: ["count", "source", "phases"],
+        .meetingRecoveryStarted: ["count", "source", "phases"],
+        .meetingRecoveryCompleted: ["count", "duration_seconds", "source", "phases"],
+        .meetingRecoveryDiscarded: ["count", "source", "phases"],
+        .meetingRecoveryFailed: ["count", "source", "phases", "error_type"],
         .meetingAutoStopProposed: ["reason"],
         .meetingAutoStopConfirmed: ["reason"],
         .meetingAutoStopVetoed: ["reason"],

--- a/Tests/MacParakeetTests/App/MeetingRecoveryCoordinatorTests.swift
+++ b/Tests/MacParakeetTests/App/MeetingRecoveryCoordinatorTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+
+import MacParakeetCore
+@testable import MacParakeet
+
+@MainActor
+final class MeetingRecoveryCoordinatorTests: XCTestCase {
+    func testTelemetryPhasesAggregateByLockStateOrder() {
+        let recoveries = [
+            makeLock(state: .awaitingTranscription),
+            makeLock(state: .recording),
+            makeLock(state: .recording),
+        ]
+
+        XCTAssertEqual(
+            MeetingRecoveryCoordinator.telemetryPhases(for: recoveries),
+            "recording:2,awaitingTranscription:1"
+        )
+    }
+
+    private func makeLock(state: MeetingRecordingLockState) -> MeetingRecordingLockFile {
+        MeetingRecordingLockFile(
+            sessionId: UUID(),
+            startedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            pid: 0,
+            displayName: "Meeting",
+            state: state
+        )
+    }
+}

--- a/Tests/MacParakeetTests/App/MeetingRecoveryCoordinatorTests.swift
+++ b/Tests/MacParakeetTests/App/MeetingRecoveryCoordinatorTests.swift
@@ -13,7 +13,9 @@ final class MeetingRecoveryCoordinatorTests: XCTestCase {
         ]
 
         XCTAssertEqual(
-            MeetingRecoveryCoordinator.telemetryPhases(for: recoveries),
+            TelemetryMeetingRecoveryPhases.aggregate(
+                lockStates: MeetingRecoveryCoordinator.telemetryPhases(for: recoveries)
+            ),
             "recording:2,awaitingTranscription:1"
         )
     }

--- a/Tests/MacParakeetTests/TelemetryServiceTests.swift
+++ b/Tests/MacParakeetTests/TelemetryServiceTests.swift
@@ -397,7 +397,13 @@ final class TelemetryServiceTests: XCTestCase {
             .restoreFailed(errorType: "network", errorDetail: rawDetail),
             .modelDownloadFailed(errorType: "network", errorDetail: rawDetail),
             .meetingRecordingFailed(errorType: "runtime", errorDetail: rawDetail),
-            .meetingRecoveryFailed(count: 1, source: .settings, errorType: "runtime", errorDetail: rawDetail),
+            .meetingRecoveryFailed(
+                count: 1,
+                source: .settings,
+                phases: "recording:1",
+                errorType: "runtime",
+                errorDetail: rawDetail
+            ),
         ]
 
         let encoder = JSONEncoder()
@@ -493,7 +499,12 @@ final class TelemetryServiceTests: XCTestCase {
 
     func testMeetingRecoveryCompletedSerializesSafeProps() throws {
         let event = TelemetryEvent(
-            spec: .meetingRecoveryCompleted(count: 2, durationSeconds: 4.25, source: .settings),
+            spec: .meetingRecoveryCompleted(
+                count: 2,
+                durationSeconds: 4.25,
+                source: .settings,
+                phases: "recording:1,awaitingTranscription:1"
+            ),
             appVer: "0.4.2",
             osVer: "15.3",
             locale: "en-US",
@@ -511,8 +522,55 @@ final class TelemetryServiceTests: XCTestCase {
         XCTAssertEqual(props["count"], "2")
         XCTAssertEqual(props["duration_seconds"], "4.2")
         XCTAssertEqual(props["source"], "settings")
+        XCTAssertEqual(props["phases"], "recording:1,awaitingTranscription:1")
         XCTAssertNil(props["session_id"])
         XCTAssertNil(props["file_path"])
+    }
+
+    func testMeetingRecoveryEventsSerializePhases() throws {
+        let phases = "recording:2,awaitingTranscription:1"
+        let specs: [TelemetryEventSpec] = [
+            .meetingRecoveryDiscovered(count: 3, source: .launch, phases: phases),
+            .meetingRecoveryStarted(count: 3, source: .launch, phases: phases),
+            .meetingRecoveryCompleted(count: 3, durationSeconds: 4.25, source: .launch, phases: phases),
+            .meetingRecoveryDiscarded(count: 3, source: .settings, phases: phases),
+            .meetingRecoveryFailed(count: 3, source: .settings, phases: phases, errorType: "no_audio"),
+        ]
+
+        for spec in specs {
+            let event = TelemetryEvent(
+                spec: spec,
+                appVer: "0.4.2",
+                osVer: "15.3",
+                locale: "en-US",
+                chip: "Apple M1",
+                session: "test-session"
+            )
+
+            XCTAssertEqual(event.props?["phases"], phases, spec.name.rawValue)
+        }
+    }
+
+    func testMeetingRecoveryPhaseSummaryUsesLockStateOrderAndUnknownFallback() {
+        XCTAssertEqual(
+            TelemetryMeetingRecoveryPhases.aggregate(lockStates: [
+                .awaitingTranscription,
+                .recording,
+                .recording,
+            ]),
+            "recording:2,awaitingTranscription:1"
+        )
+
+        XCTAssertEqual(
+            TelemetryMeetingRecoveryPhases.aggregate(rawPhases: [
+                "awaitingTranscription",
+                "recording",
+                "",
+                "future_state",
+                "recording",
+            ]),
+            "recording:2,awaitingTranscription:1,unknown:2"
+        )
     }
 
     func testCanonicalOperationSerializesSafeDimensionsOnly() throws {
@@ -1599,11 +1657,11 @@ final class TelemetryServiceTests: XCTestCase {
                 notesLengthBucket: "1_200",
                 errorType: nil
             ),
-            .meetingRecoveryDiscovered(count: 1, source: .launch),
-            .meetingRecoveryStarted(count: 1, source: .launch),
-            .meetingRecoveryCompleted(count: 1, durationSeconds: 4.2, source: .launch),
-            .meetingRecoveryDiscarded(count: 1, source: .settings),
-            .meetingRecoveryFailed(count: 1, source: .settings, errorType: "no_audio"),
+            .meetingRecoveryDiscovered(count: 1, source: .launch, phases: "recording:1"),
+            .meetingRecoveryStarted(count: 1, source: .launch, phases: "recording:1"),
+            .meetingRecoveryCompleted(count: 1, durationSeconds: 4.2, source: .launch, phases: "recording:1"),
+            .meetingRecoveryDiscarded(count: 1, source: .settings, phases: "recording:1"),
+            .meetingRecoveryFailed(count: 1, source: .settings, phases: "recording:1", errorType: "no_audio"),
             .meetingAutoStopProposed(reason: .meetingAppClosed),
             .meetingAutoStopConfirmed(reason: .meetingAppClosed),
             .meetingAutoStopVetoed(reason: .prolongedSilence),

--- a/Tests/MacParakeetTests/TelemetryServiceTests.swift
+++ b/Tests/MacParakeetTests/TelemetryServiceTests.swift
@@ -400,7 +400,7 @@ final class TelemetryServiceTests: XCTestCase {
             .meetingRecoveryFailed(
                 count: 1,
                 source: .settings,
-                phases: "recording:1",
+                phases: [.recording],
                 errorType: "runtime",
                 errorDetail: rawDetail
             ),
@@ -503,7 +503,7 @@ final class TelemetryServiceTests: XCTestCase {
                 count: 2,
                 durationSeconds: 4.25,
                 source: .settings,
-                phases: "recording:1,awaitingTranscription:1"
+                phases: [.recording, .awaitingTranscription]
             ),
             appVer: "0.4.2",
             osVer: "15.3",
@@ -528,7 +528,7 @@ final class TelemetryServiceTests: XCTestCase {
     }
 
     func testMeetingRecoveryEventsSerializePhases() throws {
-        let phases = "recording:2,awaitingTranscription:1"
+        let phases: [MeetingRecordingLockState] = [.recording, .recording, .awaitingTranscription]
         let specs: [TelemetryEventSpec] = [
             .meetingRecoveryDiscovered(count: 3, source: .launch, phases: phases),
             .meetingRecoveryStarted(count: 3, source: .launch, phases: phases),
@@ -547,7 +547,7 @@ final class TelemetryServiceTests: XCTestCase {
                 session: "test-session"
             )
 
-            XCTAssertEqual(event.props?["phases"], phases, spec.name.rawValue)
+            XCTAssertEqual(event.props?["phases"], "recording:2,awaitingTranscription:1", spec.name.rawValue)
         }
     }
 
@@ -1657,11 +1657,11 @@ final class TelemetryServiceTests: XCTestCase {
                 notesLengthBucket: "1_200",
                 errorType: nil
             ),
-            .meetingRecoveryDiscovered(count: 1, source: .launch, phases: "recording:1"),
-            .meetingRecoveryStarted(count: 1, source: .launch, phases: "recording:1"),
-            .meetingRecoveryCompleted(count: 1, durationSeconds: 4.2, source: .launch, phases: "recording:1"),
-            .meetingRecoveryDiscarded(count: 1, source: .settings, phases: "recording:1"),
-            .meetingRecoveryFailed(count: 1, source: .settings, phases: "recording:1", errorType: "no_audio"),
+            .meetingRecoveryDiscovered(count: 1, source: .launch, phases: [.recording]),
+            .meetingRecoveryStarted(count: 1, source: .launch, phases: [.recording]),
+            .meetingRecoveryCompleted(count: 1, durationSeconds: 4.2, source: .launch, phases: [.recording]),
+            .meetingRecoveryDiscarded(count: 1, source: .settings, phases: [.recording]),
+            .meetingRecoveryFailed(count: 1, source: .settings, phases: [.recording], errorType: "no_audio"),
             .meetingAutoStopProposed(reason: .meetingAppClosed),
             .meetingAutoStopConfirmed(reason: .meetingAppClosed),
             .meetingAutoStopVetoed(reason: .prolongedSilence),

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -349,11 +349,11 @@ prompt-customization trend.
 
 | Event | Props | Question It Answers |
 |---|---|---|
-| `meeting_recovery_discovered` | `count`, `source` (launch, settings) | How often interrupted recordings are found, and where users encounter them |
-| `meeting_recovery_started` | `count`, `source` | How often users choose to recover |
-| `meeting_recovery_completed` | `count`, `duration_seconds`, `source` | Recovery success rate and latency |
-| `meeting_recovery_discarded` | `count`, `source` | How often users intentionally discard interrupted recordings |
-| `meeting_recovery_failed` | `count`, `source`, `error_type`, `error_detail` | What blocks recovery in the field |
+| `meeting_recovery_discovered` | `count`, `source` (launch, settings), `phases` | How often interrupted recordings are found, what lock phase they were interrupted in, and where users encounter them |
+| `meeting_recovery_started` | `count`, `source`, `phases` | How often users choose to recover, by interrupted lock phase |
+| `meeting_recovery_completed` | `count`, `duration_seconds`, `source`, `phases` | Recovery success rate and latency by interrupted lock phase |
+| `meeting_recovery_discarded` | `count`, `source`, `phases` | How often users intentionally discard interrupted recordings, by interrupted lock phase |
+| `meeting_recovery_failed` | `count`, `source`, `phases`, `error_type`, `error_detail` | What blocks recovery in the field, by interrupted lock phase |
 
 ### 4c. Meeting Recording — "Is meeting capture healthy?"
 


### PR DESCRIPTION
## Why

D1 baseline (last 8 weeks, 0.6.x): `meeting_recovery_discovered` fired 113 times across 107 sessions (~2/day fleet-wide), and of 49 recovery attempts, 15 failed (~30%). We know recovery outcomes but not causes: no event records **which phase the session died in** (mid-recording vs awaiting transcription), so we can't weight recovery-hardening or fault-injection work by the real crash distribution.

## What

All five `meeting_recovery_*` events now carry a `phases` prop — a deterministic aggregated string derived from each pending session's `recording.lock` state, e.g. `recording:2,awaitingTranscription:1`, with `unknown` fallback for unreadable/blank states.

| Event | Props (new in bold) |
|---|---|
| `meeting_recovery_discovered` | count, source, **phases** |
| `meeting_recovery_started` | count, source, **phases** |
| `meeting_recovery_completed` | count, duration_seconds, source, **phases** |
| `meeting_recovery_discarded` | count, source, **phases** |
| `meeting_recovery_failed` | count, source, **phases**, error_type, error_detail |

- `TelemetryMeetingRecoveryPhases` (TelemetryEvent.swift) owns the aggregation: declaration-order sort keyed off `MeetingRecordingLockState.allCases` (now `CaseIterable`), unknown normalization.
- `MeetingRecoveryCoordinator` threads lock states into all five emissions.
- `TelemetryImplementedContract` and `docs/telemetry.md` updated.
- **No website change needed**: event names are unchanged; `ALLOWED_EVENTS` mirroring applies to new `TelemetryEventName` cases only (verified against `functions/api/telemetry.ts`).

## Spec alignment

Follow-up from `docs/audits/2026-07-05-meeting-stop-back-to-back-readiness.md` (observability-before-contract). Scope deliberately minimal: no new event names, no stop-stage timing (separate concern), no recovery behavior changes. Matches the agreed brief with no deviations.

## Evidence

`swift test --filter 'MeetingRecoveryCoordinatorTests|TelemetryServiceTests'` → 62 tests, 0 failures. New coverage: phase aggregation determinism, unknown fallback, per-event prop contract.

Implemented by Codex (GPT-5.5) under brief; diff-reviewed and independently test-verified by orchestrator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add interruption-phase attribution to meeting recovery telemetry so we can see which lock phase sessions were in when recovery ran. Phases are passed as typed lock states and aggregated deterministically (e.g., "recording:2,awaitingTranscription:1"); discard-failure telemetry now reports only the remaining pending recoveries.

- **New Features**
  - Added `phases` to: `meeting_recovery_discovered`, `meeting_recovery_started`, `meeting_recovery_completed`, `meeting_recovery_discarded`, `meeting_recovery_failed`.
  - Aggregated at serialization from typed `[MeetingRecordingLockState]` in stable order with `unknown` fallback; prevents unnormalized strings.
  - Coordinator threads states through; discard-failure events send remaining pending count + phases. Contract and docs updated; event names unchanged.

<sup>Written for commit ffbe6adf86bbfdae6dd7761ca9c99d7b51f8785d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/743?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Meeting recovery telemetry now includes a `phases` field, giving a clearer breakdown of recovery states across discovered, started, completed, discarded, and failed events.

* **Bug Fixes**
  * Telemetry now falls back to `unknown` when phase data is missing or unrecognized, helping keep event reporting consistent.

* **Documentation**
  * Updated telemetry docs to reflect the new meeting recovery fields, including `phases` and failure details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->