### PR TITLE
Polish undo window option order

### DIFF
--- a/Sources/MacParakeetCore/AppRuntimePreferences.swift
+++ b/Sources/MacParakeetCore/AppRuntimePreferences.swift
@@ -251,9 +251,9 @@ public enum DictationPreviewTextSize: String, CaseIterable, Hashable, Sendable, 
 }
 
 public enum DictationUndoCountdown: String, CaseIterable, Hashable, Sendable, Equatable {
-    case fiveSeconds = "fiveSeconds"
-    case oneSecond = "oneSecond"
     case off = "off"
+    case oneSecond = "oneSecond"
+    case fiveSeconds = "fiveSeconds"
 
     public var seconds: Double? {
         switch self {

--- a/Tests/MacParakeetTests/AppRuntimePreferencesTests.swift
+++ b/Tests/MacParakeetTests/AppRuntimePreferencesTests.swift
@@ -167,6 +167,11 @@ final class AppRuntimePreferencesTests: XCTestCase {
         XCTAssertEqual(preferences.dictationUndoCountdown.seconds, 5)
     }
 
+    func testDictationUndoCountdownCasesAreOrderedForSettingsPicker() {
+        XCTAssertEqual(DictationUndoCountdown.allCases, [.off, .oneSecond, .fiveSeconds])
+        XCTAssertEqual(DictationUndoCountdown.allCases.map(\.displayTitle), ["Off", "1 second", "5 seconds"])
+    }
+
     func testDictationUndoCountdownRoundTripsStoredValue() {
         for countdown in DictationUndoCountdown.allCases {
             let defaults = UserDefaults(suiteName: "app-runtime-prefs-\(UUID().uuidString)")!


### PR DESCRIPTION
## Summary
- Reorder the dictation undo-window segmented options to read `Off | 1 second | 5 seconds`
- Keep raw values and the default `fiveSeconds` behavior unchanged
- Add a focused regression test for the picker-facing order

## Verification
- `swift test --filter AppRuntimePreferencesTests/testDictationUndoCountdown`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reordered dictation undo window options so the settings picker shows Off | 1 second | 5 seconds. Raw values and the default fiveSeconds behavior are unchanged; added a regression test to lock the order and labels.

<sup>Written for commit 921bfbee833d63254b7c339fa9c6e4b71d57097a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/745?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to ensure dictation undo countdown options appear in the expected order in settings.
  * Verified the displayed labels match the user-facing values: “Off”, “1 second”, and “5 seconds”.
* **Style**
  * Updated the ordering of countdown options so they appear more naturally in the app’s settings list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->