### PR TITLE
fix: read legacy meeting artifact filenames

### DIFF
--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -135,9 +135,9 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
   `meeting-playback.m4a`. Paths surfaced through `MeetingArtifactSnapshot` and
   meeting JSON output (`rawMicrophoneAudioPath`, `cleanedMicrophoneAudioPath`,
   `rawSystemAudioPath`, `playbackAudioPath`, and `filePath` for playback) use
-  the new names. There is deliberately no backward compatibility with
-  old-name recordings: the meeting artifact contract is pre-hardening, so this
-  rename ships without a version bump.
+  the new names for newly captured recordings. Archive loading, retranscription,
+  recovery, and cleanup continue to read the old filenames for recordings
+  created by earlier releases.
 - `retranscribe --kind meeting --speaker-detection app-default` now follows
   the saved meeting speaker-detection preference. `transcribe` and
   transcription retranscription continue to follow the saved file/URL

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingArtifactAudioFileNames.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingArtifactAudioFileNames.swift
@@ -6,10 +6,89 @@ public enum MeetingArtifactAudioFileNames {
     public static let rawSystem = "system-raw.m4a"
     public static let playback = "meeting-playback.m4a"
 
+    static let legacyRawMicrophone = "microphone.m4a"
+    static let legacyRawSystem = "system.m4a"
+    static let legacyPlayback = "meeting.m4a"
+
     static let managedCurrent: Set<String> = [
         playback,
         rawMicrophone,
         rawSystem,
         cleanedMicrophone,
     ]
+
+    static let managedReadCompatible: Set<String> = managedCurrent.union([
+        legacyPlayback,
+        legacyRawMicrophone,
+        legacyRawSystem,
+    ])
+
+    static func resolveRawMicrophoneURL(
+        in folderURL: URL,
+        fileManager: FileManager = .default
+    ) -> (url: URL, exists: Bool) {
+        resolveCurrentOrLegacyURL(
+            in: folderURL,
+            currentFileName: rawMicrophone,
+            legacyFileName: legacyRawMicrophone,
+            fileManager: fileManager)
+    }
+
+    static func resolveRawSystemURL(
+        in folderURL: URL,
+        fileManager: FileManager = .default
+    ) -> (url: URL, exists: Bool) {
+        resolveCurrentOrLegacyURL(
+            in: folderURL,
+            currentFileName: rawSystem,
+            legacyFileName: legacyRawSystem,
+            fileManager: fileManager)
+    }
+
+    static func resolvePlaybackURL(
+        in folderURL: URL,
+        fileManager: FileManager = .default
+    ) -> (url: URL, exists: Bool) {
+        resolveCurrentOrLegacyURL(
+            in: folderURL,
+            currentFileName: playback,
+            legacyFileName: legacyPlayback,
+            fileManager: fileManager)
+    }
+
+    static func rawMicrophoneURL(in folderURL: URL, fileManager: FileManager = .default) -> URL {
+        resolveRawMicrophoneURL(in: folderURL, fileManager: fileManager).url
+    }
+
+    static func rawSystemURL(in folderURL: URL, fileManager: FileManager = .default) -> URL {
+        resolveRawSystemURL(in: folderURL, fileManager: fileManager).url
+    }
+
+    static func playbackURL(in folderURL: URL, fileManager: FileManager = .default) -> URL {
+        resolvePlaybackURL(in: folderURL, fileManager: fileManager).url
+    }
+
+    static func playbackCandidates(in folderURL: URL) -> [URL] {
+        [
+            folderURL.appendingPathComponent(playback),
+            folderURL.appendingPathComponent(legacyPlayback),
+        ]
+    }
+
+    private static func resolveCurrentOrLegacyURL(
+        in folderURL: URL,
+        currentFileName: String,
+        legacyFileName: String,
+        fileManager: FileManager
+    ) -> (url: URL, exists: Bool) {
+        let currentURL = folderURL.appendingPathComponent(currentFileName)
+        if fileManager.fileExists(atPath: currentURL.path) {
+            return (currentURL, true)
+        }
+        let legacyURL = folderURL.appendingPathComponent(legacyFileName)
+        if fileManager.fileExists(atPath: legacyURL.path) {
+            return (legacyURL, true)
+        }
+        return (currentURL, false)
+    }
 }

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingOutput.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingOutput.swift
@@ -142,8 +142,15 @@ public struct MeetingRecordingOutput: Sendable, Equatable {
         let metadata = try MeetingRecordingMetadataStore.load(
             from: folderURL,
             fileManager: fileManager)
-        let microphoneAudioURL = folderURL.appendingPathComponent(MeetingArtifactAudioFileNames.rawMicrophone)
-        let systemAudioURL = folderURL.appendingPathComponent(MeetingArtifactAudioFileNames.rawSystem)
+        let playbackAudio = MeetingArtifactAudioFileNames.resolvePlaybackURL(
+            in: folderURL,
+            fileManager: fileManager)
+        let microphoneAudio = MeetingArtifactAudioFileNames.resolveRawMicrophoneURL(
+            in: folderURL,
+            fileManager: fileManager)
+        let systemAudio = MeetingArtifactAudioFileNames.resolveRawSystemURL(
+            in: folderURL,
+            fileManager: fileManager)
         let cleanedURL = folderURL.appendingPathComponent(
             MeetingCleanedMicRenderer.cleanedMicrophoneFileName)
         // Keep archive loading cheap; this is called from UI list/reopen paths.
@@ -155,24 +162,26 @@ public struct MeetingRecordingOutput: Sendable, Equatable {
             : nil
 
         if metadata.sourceAlignment.microphone != nil,
-           !hasFile(at: microphoneAudioURL, fileManager: fileManager) {
+           !microphoneAudio.exists {
             throw MeetingAudioError.storageFailed(
-                "Missing archived meeting source file: \(MeetingArtifactAudioFileNames.rawMicrophone)")
+                "Missing archived meeting source file: \(MeetingArtifactAudioFileNames.rawMicrophone)"
+                    + " or \(MeetingArtifactAudioFileNames.legacyRawMicrophone)")
         }
 
         if metadata.sourceAlignment.system != nil,
-           !hasFile(at: systemAudioURL, fileManager: fileManager) {
+           !systemAudio.exists {
             throw MeetingAudioError.storageFailed(
-                "Missing archived meeting source file: \(MeetingArtifactAudioFileNames.rawSystem)")
+                "Missing archived meeting source file: \(MeetingArtifactAudioFileNames.rawSystem)"
+                    + " or \(MeetingArtifactAudioFileNames.legacyRawSystem)")
         }
 
         return MeetingRecordingOutput(
             sessionID: UUID(),
             displayName: displayName,
             folderURL: folderURL,
-            mixedAudioURL: mixedAudioURL,
-            microphoneAudioURL: microphoneAudioURL,
-            systemAudioURL: systemAudioURL,
+            mixedAudioURL: playbackAudio.url,
+            microphoneAudioURL: microphoneAudio.url,
+            systemAudioURL: systemAudio.url,
             cleanedMicrophoneAudioURL: cleanedMicrophoneAudioURL,
             durationSeconds: durationSeconds,
             sourceAlignment: metadata.sourceAlignment,

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingRecoveryService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingRecoveryService.swift
@@ -151,8 +151,7 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
 
     private func canOfferRecovery(for lock: MeetingRecordingLockFile) throws -> Bool {
         guard let folderURL = lock.folderURL else { return false }
-        let mixedURL = folderURL.appendingPathComponent(MeetingArtifactAudioFileNames.playback)
-        if try existingCompletedTranscription(for: mixedURL) != nil {
+        if try existingCompletedTranscription(in: folderURL) != nil {
             return true
         }
         return hasViableAudio(in: lock)
@@ -160,8 +159,14 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
 
     private func hasViableAudio(in lock: MeetingRecordingLockFile) -> Bool {
         guard let folderURL = lock.folderURL else { return false }
-        let micSize = fileSize(at: folderURL.appendingPathComponent(MeetingArtifactAudioFileNames.rawMicrophone))
-        let sysSize = fileSize(at: folderURL.appendingPathComponent(MeetingArtifactAudioFileNames.rawSystem))
+        let microphoneAudio = MeetingArtifactAudioFileNames.resolveRawMicrophoneURL(
+            in: folderURL,
+            fileManager: fileManager)
+        let systemAudio = MeetingArtifactAudioFileNames.resolveRawSystemURL(
+            in: folderURL,
+            fileManager: fileManager)
+        let micSize = microphoneAudio.exists ? fileSize(at: microphoneAudio.url) : 0
+        let sysSize = systemAudio.exists ? fileSize(at: systemAudio.url) : 0
         return max(micSize, sysSize) >= Self.minViableAudioBytes
     }
 
@@ -173,23 +178,27 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
             throw MeetingRecordingRecoveryError.missingSessionFolder
         }
 
-        let microphoneURL = folderURL.appendingPathComponent(MeetingArtifactAudioFileNames.rawMicrophone)
-        let systemURL = folderURL.appendingPathComponent(MeetingArtifactAudioFileNames.rawSystem)
+        let microphoneAudio = MeetingArtifactAudioFileNames.resolveRawMicrophoneURL(
+            in: folderURL,
+            fileManager: fileManager)
+        let systemAudio = MeetingArtifactAudioFileNames.resolveRawSystemURL(
+            in: folderURL,
+            fileManager: fileManager)
         let mixedURL = folderURL.appendingPathComponent(MeetingArtifactAudioFileNames.playback)
 
-        if let existing = try existingCompletedTranscription(for: mixedURL) {
+        if let existing = try existingCompletedTranscription(in: folderURL) {
             await writeNotesSidecar(for: lock, folderURL: folderURL)
             return try await completeExistingTranscription(existing, folderURL: folderURL, lock: lock)
         }
-        let incompleteRows = try existingIncompleteTranscriptions(for: mixedURL)
+        let incompleteRows = try existingIncompleteTranscriptions(in: folderURL)
         let rowToUpdate = selectedIncompleteTranscription(from: incompleteRows)
         try deleteDuplicateIncompleteTranscriptions(incompleteRows, keeping: rowToUpdate?.id)
 
         var recoveredSources: [RecoverableSource] = []
-        for (source, url) in [(AudioSource.microphone, microphoneURL), (.system, systemURL)] {
-            guard fileManager.fileExists(atPath: url.path), fileSize(at: url) > 0 else { continue }
+        for (source, audio) in [(AudioSource.microphone, microphoneAudio), (.system, systemAudio)] {
+            guard audio.exists, fileSize(at: audio.url) > 0 else { continue }
             do {
-                let repaired = try await repairIfNeeded(url)
+                let repaired = try await repairIfNeeded(audio.url)
                 recoveredSources.append(
                     RecoverableSource(
                         source: source,
@@ -250,8 +259,8 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
             displayName: lock.displayName,
             folderURL: folderURL,
             mixedAudioURL: mixedURL,
-            microphoneAudioURL: microphoneURL,
-            systemAudioURL: systemURL,
+            microphoneAudioURL: microphoneAudio.url,
+            systemAudioURL: systemAudio.url,
             cleanedMicrophoneAudioURL: cleanedMicrophoneReadiness.outputURL,
             cleanedMicrophoneReadiness: cleanedMicrophoneReadiness,
             durationSeconds: duration,
@@ -283,8 +292,7 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
     public func discard(_ lock: MeetingRecordingLockFile) async throws {
         guard let folderURL = lock.folderURL else { return }
         if fileManager.fileExists(atPath: folderURL.path) {
-            let mixedURL = folderURL.appendingPathComponent(MeetingArtifactAudioFileNames.playback)
-            if let completed = try existingCompletedTranscription(for: mixedURL) {
+            if let completed = try existingCompletedTranscription(in: folderURL) {
                 try await settlement.settleCompletedTranscription(
                     folderURL: folderURL,
                     transcriptionID: completed.id,
@@ -366,27 +374,32 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
         }
     }
 
-    private func existingCompletedTranscription(for mixedURL: URL) throws -> Transcription? {
-        try existingTranscriptions(for: mixedURL).first {
+    private func existingCompletedTranscription(in folderURL: URL) throws -> Transcription? {
+        try existingTranscriptions(in: folderURL).first {
             $0.sourceType == .meeting
                 && $0.status == .completed
         }
     }
 
-    private func existingTranscriptions(for mixedURL: URL) throws -> [Transcription] {
+    private func existingTranscriptions(in folderURL: URL) throws -> [Transcription] {
         var seenIDs = Set<UUID>()
         var transcriptions: [Transcription] = []
-        for path in MeetingArtifactPathAliases.aliases(for: mixedURL) {
-            for transcription in try transcriptionRepo.fetchByFilePath(path, sourceType: .meeting) {
-                guard seenIDs.insert(transcription.id).inserted else { continue }
-                transcriptions.append(transcription)
+        for url in MeetingArtifactAudioFileNames.playbackCandidates(in: folderURL) {
+            for path in MeetingArtifactPathAliases.aliases(for: url) {
+                let matches = try transcriptionRepo.fetchByFilePath(
+                    path,
+                    sourceType: .meeting)
+                for transcription in matches {
+                    guard seenIDs.insert(transcription.id).inserted else { continue }
+                    transcriptions.append(transcription)
+                }
             }
         }
         return transcriptions
     }
 
-    private func existingIncompleteTranscriptions(for mixedURL: URL) throws -> [Transcription] {
-        try existingTranscriptions(for: mixedURL)
+    private func existingIncompleteTranscriptions(in folderURL: URL) throws -> [Transcription] {
+        try existingTranscriptions(in: folderURL)
             .filter { $0.status != .completed }
     }
 

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingSettlement.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingSettlement.swift
@@ -79,10 +79,9 @@ public struct MeetingRecordingSettlement: Sendable {
         }
 
         guard let filePath = transcription.filePath else { return false }
-        return MeetingArtifactPathAliases.matches(
-            filePath,
-            for: folderURL.appendingPathComponent(MeetingArtifactAudioFileNames.playback)
-        )
+        return MeetingArtifactAudioFileNames.playbackCandidates(in: folderURL).contains { playbackURL in
+            MeetingArtifactPathAliases.matches(filePath, for: playbackURL)
+        }
     }
 }
 

--- a/Sources/MacParakeetCore/Utilities/TranscriptionAssetCleanup.swift
+++ b/Sources/MacParakeetCore/Utilities/TranscriptionAssetCleanup.swift
@@ -29,7 +29,7 @@ public enum TranscriptionAssetCleanup {
         subsystem: "com.macparakeet.core",
         category: "TranscriptionAssetCleanup"
     )
-    private static let standardMeetingAudioFileNames = MeetingArtifactAudioFileNames.managedCurrent
+    private static let standardMeetingAudioFileNames = MeetingArtifactAudioFileNames.managedReadCompatible
     private static let managedMeetingAudioExtensions: Set<String> = [
         "aac",
         "caf",

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingOutputTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingOutputTests.swift
@@ -374,6 +374,28 @@ final class MeetingRecordingOutputTests: XCTestCase {
         XCTAssertNil(output.cleanedMicrophoneAudioURL)
     }
 
+    func testLoadArchivedReadsLegacyMeetingAudioFileNames() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try MeetingRecordingMetadataStore.save(
+            MeetingRecordingMetadata(sourceAlignment: dualSourceAlignment()),
+            folderURL: dir
+        )
+        try writeM4A(to: dir.appendingPathComponent("microphone.m4a"))
+        try writeM4A(to: dir.appendingPathComponent("system.m4a"))
+        try writeM4A(to: dir.appendingPathComponent("meeting.m4a"))
+
+        let output = try MeetingRecordingOutput.loadArchived(
+            displayName: "Archived",
+            mixedAudioURL: dir.appendingPathComponent("meeting-playback.m4a"),
+            durationSeconds: 12
+        )
+
+        XCTAssertEqual(output.mixedAudioURL.lastPathComponent, "meeting.m4a")
+        XCTAssertEqual(output.microphoneAudioURL.lastPathComponent, "microphone.m4a")
+        XCTAssertEqual(output.systemAudioURL.lastPathComponent, "system.m4a")
+    }
+
     func testLoadArchivedPreservesCalendarSnapshotFromMetadata() throws {
         let dir = try makeTempDir()
         defer { try? FileManager.default.removeItem(at: dir) }

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingRecoveryServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingRecoveryServiceTests.swift
@@ -180,6 +180,28 @@ final class MeetingRecordingRecoveryServiceTests: XCTestCase {
         XCTAssertEqual(Double(microphone.writtenFrameCount), 44_100, accuracy: 2_000)
     }
 
+    func testRecoverReadsLegacySourceNamesAndWritesCurrentPlaybackName() async throws {
+        let fixture = try makeLegacyRecoverableSession()
+
+        let pending = try await recoveryService.discoverPendingRecoveries()
+        XCTAssertEqual(pending.map(\.sessionId), [fixture.lock.sessionId])
+
+        let recovered = try await recoveryService.recover(fixture.lock)
+
+        XCTAssertTrue(recovered.recoveredFromCrash)
+        let recording = try XCTUnwrap(transcriptionService.recordings.first)
+        XCTAssertEqual(recording.microphoneAudioURL.lastPathComponent, "microphone.m4a")
+        XCTAssertEqual(recording.systemAudioURL.lastPathComponent, "system.m4a")
+        XCTAssertEqual(recording.mixedAudioURL.lastPathComponent, "meeting-playback.m4a")
+        XCTAssertEqual(
+            audioConverter.mixes.first?.inputs.map(\.lastPathComponent),
+            ["microphone.m4a", "system.m4a"])
+        XCTAssertEqual(audioConverter.mixes.first?.output.lastPathComponent, "meeting-playback.m4a")
+        XCTAssertTrue(
+            FileManager.default.fileExists(
+                atPath: fixture.folderURL.appendingPathComponent("meeting-playback.m4a").path))
+    }
+
     func testRecoverCleansAwaitingTranscriptionLockWhenTranscriptAlreadyExists() async throws {
         let fixture = try makeRecoverableSession(
             lockState: .awaitingTranscription,
@@ -203,6 +225,41 @@ final class MeetingRecordingRecoveryServiceTests: XCTestCase {
         let notesURL = MeetingNotesFile.fileURL(for: fixture.folderURL)
         let notesContent = try String(contentsOf: notesURL, encoding: .utf8)
         XCTAssertEqual(notesContent, "# Recovered Team Sync\n\nexisting transcript note\n")
+    }
+
+    func testRecoverSettlesCompletedLegacyPlaybackRow() async throws {
+        let sessionID = UUID()
+        let folderURL = tempRoot.appendingPathComponent(sessionID.uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: folderURL, withIntermediateDirectories: true)
+        let legacyMixedURL = folderURL.appendingPathComponent("meeting.m4a")
+        FileManager.default.createFile(atPath: legacyMixedURL.path, contents: Data("mixed".utf8))
+        let existing = Transcription(
+            fileName: "Recovered Team Sync",
+            filePath: legacyMixedURL.path,
+            status: .completed,
+            sourceType: .meeting
+        )
+        try transcriptionRepo.save(existing)
+        let lock = MeetingRecordingLockFile(
+            sessionId: sessionID,
+            startedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            pid: 42,
+            displayName: "Recovered Team Sync",
+            state: .awaitingTranscription,
+            folderURL: folderURL
+        )
+        try lockStore.write(lock, folderURL: folderURL)
+
+        let pending = try await recoveryService.discoverPendingRecoveries()
+        XCTAssertEqual(pending.map(\.sessionId), [sessionID])
+
+        let recovered = try await recoveryService.recover(lock)
+
+        XCTAssertEqual(recovered.id, existing.id)
+        XCTAssertFalse(recovered.recoveredFromCrash)
+        XCTAssertNil(try lockStore.read(folderURL: folderURL))
+        XCTAssertTrue(audioConverter.mixes.isEmpty)
+        XCTAssertTrue(transcriptionService.recordings.isEmpty)
     }
 
     func testRecoverUpdatesExistingAwaitingTranscriptionStub() async throws {
@@ -708,6 +765,27 @@ final class MeetingRecordingRecoveryServiceTests: XCTestCase {
             displayName: "Recovered Team Sync",
             state: lockState,
             notes: notes,
+            folderURL: folderURL
+        )
+        try lockStore.write(lock, folderURL: folderURL)
+        return (folderURL, lock)
+    }
+
+    private func makeLegacyRecoverableSession() throws -> (
+        folderURL: URL,
+        lock: MeetingRecordingLockFile
+    ) {
+        let sessionID = UUID()
+        let folderURL = tempRoot.appendingPathComponent(sessionID.uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: folderURL, withIntermediateDirectories: true)
+        try writeM4A(to: folderURL.appendingPathComponent("microphone.m4a"))
+        try writeM4A(to: folderURL.appendingPathComponent("system.m4a"))
+
+        let lock = MeetingRecordingLockFile(
+            sessionId: sessionID,
+            startedAt: Date(timeIntervalSince1970: 1_700_000_000),
+            pid: 42,
+            displayName: "Recovered Team Sync",
             folderURL: folderURL
         )
         try lockStore.write(lock, folderURL: folderURL)

--- a/Tests/MacParakeetTests/Services/MeetingRecording/TranscriptionAssetCleanupCleanedMicTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/TranscriptionAssetCleanupCleanedMicTests.swift
@@ -13,6 +13,9 @@ final class TranscriptionAssetCleanupCleanedMicTests: XCTestCase {
         XCTAssertTrue(TranscriptionAssetCleanup.isStandardMeetingAudioFileName("microphone-raw.m4a"))
         XCTAssertTrue(TranscriptionAssetCleanup.isStandardMeetingAudioFileName("system-raw.m4a"))
         XCTAssertTrue(TranscriptionAssetCleanup.isStandardMeetingAudioFileName("meeting-playback.m4a"))
+        XCTAssertTrue(TranscriptionAssetCleanup.isStandardMeetingAudioFileName("microphone.m4a"))
+        XCTAssertTrue(TranscriptionAssetCleanup.isStandardMeetingAudioFileName("system.m4a"))
+        XCTAssertTrue(TranscriptionAssetCleanup.isStandardMeetingAudioFileName("meeting.m4a"))
         XCTAssertEqual(
             "microphone-cleaned.m4a",
             MeetingCleanedMicRenderer.cleanedMicrophoneFileName,
@@ -26,7 +29,15 @@ final class TranscriptionAssetCleanupCleanedMicTests: XCTestCase {
         try FileManager.default.createDirectory(at: session, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: root) }
 
-        let audioFiles = ["meeting-playback.m4a", "microphone-raw.m4a", "system-raw.m4a", "microphone-cleaned.m4a"]
+        let audioFiles = [
+            "meeting-playback.m4a",
+            "microphone-raw.m4a",
+            "system-raw.m4a",
+            "microphone-cleaned.m4a",
+            "meeting.m4a",
+            "microphone.m4a",
+            "system.m4a",
+        ]
         for name in audioFiles {
             try Data([0x00]).write(to: session.appendingPathComponent(name))
         }


### PR DESCRIPTION
## Summary

Users upgrading from 0.6.24 can keep opening, recovering, and retranscribing meeting recordings saved with the old artifact filenames. New recordings still write the role-explicit names, but archive loading, crash recovery/settlement, retranscription, and cleanup now read `microphone.m4a`, `system.m4a`, and `meeting.m4a` when the new names are absent.

This keeps the artifact rename while removing the release-blocking upgrade break for existing user data.

## Validation

- `swift test --parallel --filter 'MeetingRecordingOutputTests|MeetingRecordingRecoveryServiceTests|MeetingRecordingSettlementTests|TranscriptionAssetCleanupCleanedMicTests|TranscriptionDeletionCleanupTests|RetranscribeCommandTests|MeetingsCommandTests'` -> 114 selected tests, 0 failures
- `git diff --check`
- `swift run macparakeet-cli spec --json >/tmp/macparakeet-spec-legacy-names.json`
- `xcrun swift-format lint --configuration .swift-format ...` on touched Swift files; lint is informational in this repo and still reports pre-existing style warnings in touched files

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores compatibility with v0.6.24 meeting recordings by reading legacy artifact filenames. New recordings still write the role‑explicit names.

- **Bug Fixes**
  - Archive loading falls back to `microphone.m4a`, `system.m4a`, and `meeting.m4a` when current names are missing.
  - Recovery reads legacy source files, detects existing transcripts for both playback names, and writes mixed output as `meeting-playback.m4a`.
  - Settlement matches transcripts against both `meeting-playback.m4a` and `meeting.m4a`.
  - Cleanup treats legacy names as standard to avoid false deletes.
  - Added focused tests for archived legacy folders, crash recovery with legacy sources, settlement of legacy playback rows, and cleanup classification.

<sup>Written for commit ca6b7494e7e9f43e65e7804ecb39fd209108af9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/747?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Legacy meeting audio filenames are now supported across archive loading, recovery, settlement, and cleanup, with “current-or-legacy” resolution when files already exist.

* **Bug Fixes**
  * Improved recovery when transcription artifacts and audio use legacy names.
  * Enhanced completed-transcription settlement by validating against all playback candidates in the session folder.

* **Tests**
  * Added and expanded coverage for legacy filename behavior in archive loading, recovery, and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->