### PR TITLE
feat(llm): gate local AI setup on linked runtime + generation smoke test

### DIFF
--- a/Sources/MacParakeet/Views/Settings/LLMSettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/LLMSettingsView.swift
@@ -42,6 +42,10 @@ struct LLMSettingsView: View {
                 Divider()
 
                 localAISetupSection
+            } else if viewModel.shouldShowInProcessLocalUnavailableExplanation {
+                Divider()
+
+                localAIUnavailableSection
             }
 
             if viewModel.selectedProviderID != nil {
@@ -260,9 +264,31 @@ struct LLMSettingsView: View {
     }
 
     private var providerOrder: [LLMProviderID] {
-        LLMProviderID.userSelectableProviderIDs(
-            inProcessLocalLLMVisible: viewModel.shouldShowInProcessLocalSetup
-        )
+        viewModel.selectableProviderIDs
+    }
+
+    private var localAIUnavailableSection: some View {
+        HStack(alignment: .top, spacing: DesignSystem.Spacing.md) {
+            VStack(alignment: .leading, spacing: 3) {
+                HStack(spacing: 7) {
+                    Text("Local AI")
+                        .font(DesignSystem.Typography.body.weight(.semibold))
+                    Text("Unavailable in this build")
+                        .font(DesignSystem.Typography.micro.weight(.semibold))
+                        .foregroundStyle(DesignSystem.Colors.textSecondary)
+                        .padding(.horizontal, 7)
+                        .padding(.vertical, 3)
+                        .background(Capsule().fill(DesignSystem.Colors.surfaceElevated))
+                }
+                Text(viewModel.inProcessLocalUnavailableMessage ?? "")
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: DesignSystem.Spacing.md)
+        }
+        .id("ai.localAIUnavailable")
     }
 
     @ViewBuilder

--- a/Sources/MacParakeetCore/AppFeatures.swift
+++ b/Sources/MacParakeetCore/AppFeatures.swift
@@ -139,12 +139,36 @@ public enum AppFeatures {
             || arguments.contains(inProcessLocalLLMDeveloperLaunchArgument)
     }
 
-    public static func isInProcessLocalLLMVisible(
+    public static func isInProcessLocalLLMProductVisible(
         defaults: UserDefaults = .standard,
         arguments: [String] = ProcessInfo.processInfo.arguments
     ) -> Bool {
         inProcessLocalLLMEnabled
             || inProcessLocalLLMDeveloperOverrideEnabled(
+                defaults: defaults,
+                arguments: arguments
+            )
+    }
+
+    public static func isInProcessLocalLLMVisible(
+        defaults: UserDefaults = .standard,
+        arguments: [String] = ProcessInfo.processInfo.arguments,
+        runtimeAvailable: Bool = false
+    ) -> Bool {
+        runtimeAvailable
+            && isInProcessLocalLLMProductVisible(
+                defaults: defaults,
+                arguments: arguments
+            )
+    }
+
+    public static func shouldShowInProcessLocalLLMUnavailableExplanation(
+        defaults: UserDefaults = .standard,
+        arguments: [String] = ProcessInfo.processInfo.arguments,
+        runtimeAvailable: Bool
+    ) -> Bool {
+        !runtimeAvailable
+            && inProcessLocalLLMDeveloperOverrideEnabled(
                 defaults: defaults,
                 arguments: arguments
             )

--- a/Sources/MacParakeetCore/Services/LLM/InProcessLLMClient.swift
+++ b/Sources/MacParakeetCore/Services/LLM/InProcessLLMClient.swift
@@ -10,12 +10,14 @@ public final class InProcessLLMClient: LLMClientProtocol, Sendable {
     public static let defaultChunkCharacterThreshold = 24_000
     public static let defaultChunkCharacterLimit = 12_000
     public static let defaultIdleUnloadDelaySeconds: TimeInterval = 300
+    public static let defaultSmokeTestTimeoutSeconds: TimeInterval = 15
 
     private let runtime: any LocalLLMRuntime
     private let modelDirectoryResolver: LocalLLMModelDirectoryResolver
     private let chunkCharacterThreshold: Int
     private let chunkCharacterLimit: Int
     private let idleUnloadDelayNanoseconds: UInt64
+    private let smokeTestTimeoutNanoseconds: UInt64
     private let lifetimeCoordinator = LocalLLMLifetimeCoordinator()
     private let logger = Logger(subsystem: "com.macparakeet.core", category: "InProcessLLMClient")
 
@@ -26,7 +28,8 @@ public final class InProcessLLMClient: LLMClientProtocol, Sendable {
         },
         chunkCharacterThreshold: Int = InProcessLLMClient.defaultChunkCharacterThreshold,
         chunkCharacterLimit: Int = InProcessLLMClient.defaultChunkCharacterLimit,
-        idleUnloadDelaySeconds: TimeInterval = InProcessLLMClient.defaultIdleUnloadDelaySeconds
+        idleUnloadDelaySeconds: TimeInterval = InProcessLLMClient.defaultIdleUnloadDelaySeconds,
+        smokeTestTimeoutSeconds: TimeInterval = InProcessLLMClient.defaultSmokeTestTimeoutSeconds
     ) {
         self.runtime = runtime
         self.modelDirectoryResolver = modelDirectoryResolver
@@ -34,6 +37,12 @@ public final class InProcessLLMClient: LLMClientProtocol, Sendable {
         self.chunkCharacterLimit = max(1, chunkCharacterLimit)
         let boundedDelay = max(0, idleUnloadDelaySeconds)
         self.idleUnloadDelayNanoseconds = UInt64(boundedDelay * 1_000_000_000)
+        let boundedSmokeTestTimeout = max(0, smokeTestTimeoutSeconds)
+        self.smokeTestTimeoutNanoseconds = UInt64(boundedSmokeTestTimeout * 1_000_000_000)
+    }
+
+    public var supportsInProcessLocalLLM: Bool {
+        runtime.isAvailable
     }
 
     public func chatCompletion(
@@ -82,9 +91,14 @@ public final class InProcessLLMClient: LLMClientProtocol, Sendable {
     }
 
     public func testConnection(context: LLMExecutionContext) async throws {
+        guard context.providerConfig.id == .inProcessLocal else {
+            throw LLMError.providerError("InProcessLLMClient received \(context.providerConfig.id.rawValue).")
+        }
+
         try await withGenerationLease(delayNanoseconds: 0) {
             try Task.checkCancellation()
-            try await loadRuntime(for: context.providerConfig)
+            let model = try modelReference(for: context.providerConfig)
+            try await runtime.smokeTest(model: model, timeoutNanoseconds: smokeTestTimeoutNanoseconds)
         }
     }
 
@@ -194,12 +208,14 @@ public final class InProcessLLMClient: LLMClientProtocol, Sendable {
     }
 
     private func loadRuntime(for config: LLMProviderConfig) async throws {
+        try await runtime.load(model: try modelReference(for: config))
+    }
+
+    private func modelReference(for config: LLMProviderConfig) throws -> LocalLLMModelReference {
         let directory = try modelDirectoryResolver(config)
-        try await runtime.load(
-            model: LocalLLMModelReference(
-                modelName: config.modelName,
-                directory: directory
-            )
+        return LocalLLMModelReference(
+            modelName: config.modelName,
+            directory: directory
         )
     }
 

--- a/Sources/MacParakeetCore/Services/LLM/LLMClient.swift
+++ b/Sources/MacParakeetCore/Services/LLM/LLMClient.swift
@@ -3,6 +3,8 @@ import Foundation
 // MARK: - Protocol
 
 public protocol LLMClientProtocol: Sendable {
+    var supportsInProcessLocalLLM: Bool { get }
+
     func chatCompletion(
         messages: [ChatMessage],
         context: LLMExecutionContext,
@@ -22,6 +24,8 @@ public protocol LLMClientProtocol: Sendable {
 }
 
 public extension LLMClientProtocol {
+    var supportsInProcessLocalLLM: Bool { false }
+
     func chatCompletion(
         messages: [ChatMessage],
         config: LLMProviderConfig,

--- a/Sources/MacParakeetCore/Services/LLM/LocalLLMRuntime.swift
+++ b/Sources/MacParakeetCore/Services/LLM/LocalLLMRuntime.swift
@@ -16,17 +16,40 @@ public enum LocalLLMRuntimeEvent: Sendable, Equatable {
 }
 
 public protocol LocalLLMRuntime: Sendable {
+    var isAvailable: Bool { get }
+
     func load(model: LocalLLMModelReference) async throws
     func unload() async
     func generateStream(
         messages: [ChatMessage],
         options: ChatCompletionOptions
     ) async throws -> AsyncThrowingStream<LocalLLMRuntimeEvent, Error>
+    func smokeTest(
+        model: LocalLLMModelReference,
+        timeoutNanoseconds: UInt64
+    ) async throws
     func instrumentation() async -> LLMGenerationMetrics?
+}
+
+public extension LocalLLMRuntime {
+    var isAvailable: Bool { false }
+
+    func smokeTest(
+        model: LocalLLMModelReference,
+        timeoutNanoseconds: UInt64
+    ) async throws {
+        try await load(model: model)
+        try await LocalLLMRuntimeSmokeTest.run(
+            runtime: self,
+            timeoutNanoseconds: timeoutNanoseconds
+        )
+    }
 }
 
 public actor UnavailableLocalLLMRuntime: LocalLLMRuntime {
     public init() {}
+
+    public nonisolated var isAvailable: Bool { false }
 
     public func load(model: LocalLLMModelReference) async throws {
         throw LLMError.modelNotFound(
@@ -45,5 +68,68 @@ public actor UnavailableLocalLLMRuntime: LocalLLMRuntime {
 
     public func instrumentation() async -> LLMGenerationMetrics? {
         nil
+    }
+}
+
+private enum LocalLLMRuntimeSmokeTest {
+    static let messages: [ChatMessage] = [
+        ChatMessage(role: .system, content: "You are checking that local generation works."),
+        ChatMessage(role: .user, content: "Reply with OK."),
+    ]
+
+    static let options = ChatCompletionOptions(temperature: 0, maxTokens: 4)
+
+    static func run(
+        runtime: any LocalLLMRuntime,
+        timeoutNanoseconds: UInt64
+    ) async throws {
+        guard timeoutNanoseconds > 0 else {
+            try await consume(runtime: runtime)
+            return
+        }
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                try await consume(runtime: runtime)
+            }
+            group.addTask {
+                try await Task.sleep(nanoseconds: timeoutNanoseconds)
+                throw LLMError.providerError(
+                    "Local AI runtime loaded, but the generation smoke test timed out after \(timeoutDescription(timeoutNanoseconds))."
+                )
+            }
+
+            do {
+                _ = try await group.next()
+                group.cancelAll()
+            } catch {
+                group.cancelAll()
+                throw error
+            }
+        }
+    }
+
+    private static func consume(runtime: any LocalLLMRuntime) async throws {
+        let stream = try await runtime.generateStream(messages: messages, options: options)
+        for try await event in stream {
+            switch event {
+            case .text(let text):
+                if !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    return
+                }
+            case .metrics:
+                break
+            }
+        }
+
+        throw LLMError.providerError("Local AI runtime loaded, but the generation smoke test produced no text.")
+    }
+
+    private static func timeoutDescription(_ timeoutNanoseconds: UInt64) -> String {
+        let seconds = Double(timeoutNanoseconds) / 1_000_000_000
+        if seconds.rounded(.down) == seconds {
+            return "\(Int(seconds)) seconds"
+        }
+        return String(format: "%.1f seconds", seconds)
     }
 }

--- a/Sources/MacParakeetCore/Services/LLM/RoutingLLMClient.swift
+++ b/Sources/MacParakeetCore/Services/LLM/RoutingLLMClient.swift
@@ -18,6 +18,10 @@ public final class RoutingLLMClient: LLMClientProtocol, Sendable {
         self.inProcessClient = inProcessClient
     }
 
+    public var supportsInProcessLocalLLM: Bool {
+        inProcessClient.supportsInProcessLocalLLM
+    }
+
     public func chatCompletion(
         messages: [ChatMessage],
         context: LLMExecutionContext,

--- a/Sources/MacParakeetLocalLLM/MLXLocalLLMRuntime.swift
+++ b/Sources/MacParakeetLocalLLM/MLXLocalLLMRuntime.swift
@@ -19,6 +19,8 @@ public actor MLXLocalLLMRuntime: LocalLLMRuntime {
 
     public init() {}
 
+    public nonisolated var isAvailable: Bool { true }
+
     public func load(model: LocalLLMModelReference) async throws {
         try Task.checkCancellation()
         await drainGenerationIfNeeded()

--- a/Sources/MacParakeetViewModels/InProcessModelManagerViewModel.swift
+++ b/Sources/MacParakeetViewModels/InProcessModelManagerViewModel.swift
@@ -25,6 +25,7 @@ public final class InProcessModelManagerViewModel {
     private var llmClient: (any LLMClientProtocol)?
     private var onConfigurationChanged: (() -> Void)?
     private var physicalMemoryBytes: UInt64
+    private var isRuntimeAvailable = false
     private var setupTask: Task<Void, Never>?
 
     public init(physicalMemoryBytes: UInt64 = ProcessInfo.processInfo.physicalMemory) {
@@ -42,6 +43,7 @@ public final class InProcessModelManagerViewModel {
         self.configStore = configStore
         self.llmClient = llmClient
         self.physicalMemoryBytes = physicalMemoryBytes
+        self.isRuntimeAvailable = llmClient.supportsInProcessLocalLLM
         self.onConfigurationChanged = onConfigurationChanged
         refreshSelectionState()
     }
@@ -103,6 +105,14 @@ public final class InProcessModelManagerViewModel {
     }
 
     public func enableLocalAI() async {
+        guard isRuntimeAvailable else {
+            state = .failed(
+                reason:
+                    "Local AI is enabled by a developer override, but this app build does not include the MLX runtime. Use a gated MLX build to test it.",
+                recoverable: false
+            )
+            return
+        }
         guard meetsMemoryRequirement else {
             state = .failed(
                 reason:

--- a/Sources/MacParakeetViewModels/InProcessModelManagerViewModel.swift
+++ b/Sources/MacParakeetViewModels/InProcessModelManagerViewModel.swift
@@ -105,6 +105,10 @@ public final class InProcessModelManagerViewModel {
     }
 
     public func enableLocalAI() async {
+        guard let downloader, let configStore, let llmClient else {
+            state = .failed(reason: "Local AI setup is not configured yet.", recoverable: true)
+            return
+        }
         guard isRuntimeAvailable else {
             state = .failed(
                 reason:
@@ -119,10 +123,6 @@ public final class InProcessModelManagerViewModel {
                     "Local AI needs \(minimumMemoryDescription). Use a cloud provider or bring your own local server instead.",
                 recoverable: false
             )
-            return
-        }
-        guard let downloader, let configStore, let llmClient else {
-            state = .failed(reason: "Local AI setup is not configured yet.", recoverable: true)
             return
         }
 

--- a/Sources/MacParakeetViewModels/LLMSettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/LLMSettingsViewModel.swift
@@ -333,7 +333,33 @@ public final class LLMSettingsViewModel {
     }
 
     public var shouldShowInProcessLocalSetup: Bool {
-        AppFeatures.isInProcessLocalLLMVisible(defaults: defaults)
+        AppFeatures.isInProcessLocalLLMVisible(
+            defaults: defaults,
+            runtimeAvailable: isInProcessLocalLLMRuntimeAvailable
+        )
+    }
+
+    public var shouldShowInProcessLocalUnavailableExplanation: Bool {
+        AppFeatures.shouldShowInProcessLocalLLMUnavailableExplanation(
+            defaults: defaults,
+            runtimeAvailable: isInProcessLocalLLMRuntimeAvailable
+        )
+    }
+
+    public var inProcessLocalUnavailableMessage: String? {
+        guard shouldShowInProcessLocalUnavailableExplanation else { return nil }
+        return
+            "Local AI is enabled by a developer override, but this app build does not include the MLX runtime. Build with MACPARAKEET_ENABLE_MLX_LOCAL_LLM=1 to test it. The model download is disabled for this build."
+    }
+
+    public var selectableProviderIDs: [LLMProviderID] {
+        LLMProviderID.userSelectableProviderIDs(
+            inProcessLocalLLMVisible: shouldShowInProcessLocalSetup
+        )
+    }
+
+    private var isInProcessLocalLLMRuntimeAvailable: Bool {
+        llmClient?.supportsInProcessLocalLLM == true
     }
 
     public var validationMessage: String? {

--- a/Tests/MacParakeetTests/Models/LLMProviderDescriptorTests.swift
+++ b/Tests/MacParakeetTests/Models/LLMProviderDescriptorTests.swift
@@ -100,8 +100,37 @@ final class LLMProviderDescriptorTests: XCTestCase {
 
         XCTAssertFalse(AppFeatures.inProcessLocalLLMEnabled)
         XCTAssertTrue(AppFeatures.inProcessLocalLLMDeveloperOverrideEnabled(defaults: defaults, arguments: []))
-        XCTAssertTrue(AppFeatures.isInProcessLocalLLMVisible(defaults: defaults, arguments: []))
+        XCTAssertTrue(
+            AppFeatures.isInProcessLocalLLMProductVisible(defaults: defaults, arguments: [])
+        )
+        XCTAssertTrue(
+            AppFeatures.isInProcessLocalLLMVisible(defaults: defaults, arguments: [], runtimeAvailable: true)
+        )
         XCTAssertTrue(LLMProviderID.userSelectableProviderIDs(inProcessLocalLLMVisible: true).contains(.inProcessLocal))
+    }
+
+    func testDeveloperOverrideDoesNotExposeInProcessLocalProviderWhenRuntimeUnavailable() {
+        let suiteName = "LLMProviderDescriptorTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set(true, forKey: AppFeatures.inProcessLocalLLMDeveloperDefaultsKey)
+
+        XCTAssertTrue(
+            AppFeatures.isInProcessLocalLLMProductVisible(defaults: defaults, arguments: [])
+        )
+        XCTAssertFalse(
+            AppFeatures.isInProcessLocalLLMVisible(defaults: defaults, arguments: [], runtimeAvailable: false)
+        )
+        XCTAssertTrue(
+            AppFeatures.shouldShowInProcessLocalLLMUnavailableExplanation(
+                defaults: defaults,
+                arguments: [],
+                runtimeAvailable: false
+            )
+        )
+        XCTAssertFalse(
+            LLMProviderID.userSelectableProviderIDs(inProcessLocalLLMVisible: false).contains(.inProcessLocal))
     }
 
     func testDeveloperLaunchArgumentCanExposeInProcessLocalProviderWithoutFlippingPublicFlag() {
@@ -114,6 +143,23 @@ final class LLMProviderDescriptorTests: XCTestCase {
             AppFeatures.inProcessLocalLLMDeveloperOverrideEnabled(
                 defaults: defaults,
                 arguments: [AppFeatures.inProcessLocalLLMDeveloperLaunchArgument]
+            ))
+        XCTAssertTrue(
+            AppFeatures.isInProcessLocalLLMProductVisible(
+                defaults: defaults,
+                arguments: [AppFeatures.inProcessLocalLLMDeveloperLaunchArgument]
+            ))
+        XCTAssertFalse(
+            AppFeatures.isInProcessLocalLLMVisible(
+                defaults: defaults,
+                arguments: [AppFeatures.inProcessLocalLLMDeveloperLaunchArgument],
+                runtimeAvailable: false
+            ))
+        XCTAssertTrue(
+            AppFeatures.isInProcessLocalLLMVisible(
+                defaults: defaults,
+                arguments: [AppFeatures.inProcessLocalLLMDeveloperLaunchArgument],
+                runtimeAvailable: true
             ))
     }
 }

--- a/Tests/MacParakeetTests/Services/LLM/InProcessLLMClientTests.swift
+++ b/Tests/MacParakeetTests/Services/LLM/InProcessLLMClientTests.swift
@@ -495,7 +495,7 @@ final class InProcessLLMClientTests: XCTestCase {
 
     func testConnectionReleasesLeaseAndSchedulesImmediateUnload() async throws {
         let modelDirectory = temporaryModelDirectory()
-        let runtime = FakeLocalLLMRuntime(eventPlans: [])
+        let runtime = FakeLocalLLMRuntime(eventPlans: [[.text("ok")]])
         let client = InProcessLLMClient(
             runtime: runtime,
             modelDirectoryResolver: { _ in modelDirectory },
@@ -515,6 +515,51 @@ final class InProcessLLMClientTests: XCTestCase {
         XCTAssertEqual(unloadCount, 1)
     }
 
+    func testConnectionRunsBoundedGenerationSmoke() async throws {
+        let modelDirectory = temporaryModelDirectory()
+        let runtime = FakeLocalLLMRuntime(eventPlans: [[.text("OK")]])
+        let client = InProcessLLMClient(
+            runtime: runtime,
+            modelDirectoryResolver: { _ in modelDirectory },
+            idleUnloadDelaySeconds: 60
+        )
+
+        try await client.testConnection(
+            context: LLMExecutionContext(providerConfig: .inProcessLocal(model: "smoke-test"))
+        )
+
+        let requestContents = await runtime.requestContents()
+        let requestOptions = await runtime.requestOptions()
+        XCTAssertEqual(requestContents.count, 1)
+        XCTAssertTrue(requestContents[0].contains("Reply with OK."))
+        XCTAssertEqual(requestOptions.first?.temperature, 0)
+        XCTAssertEqual(requestOptions.first?.maxTokens, 4)
+    }
+
+    func testConnectionFailsWhenGenerationSmokeProducesNoText() async throws {
+        let modelDirectory = temporaryModelDirectory()
+        let runtime = FakeLocalLLMRuntime(eventPlans: [[.metrics(LLMGenerationMetrics())]])
+        let client = InProcessLLMClient(
+            runtime: runtime,
+            modelDirectoryResolver: { _ in modelDirectory },
+            idleUnloadDelaySeconds: 60
+        )
+
+        do {
+            try await client.testConnection(
+                context: LLMExecutionContext(providerConfig: .inProcessLocal(model: "smoke-failure"))
+            )
+            XCTFail("Expected smoke test to fail without generated text")
+        } catch let error as LLMError {
+            guard case .providerError(let message) = error else {
+                return XCTFail("Expected providerError, got \(error)")
+            }
+            XCTAssertTrue(message.contains("generation smoke test produced no text"))
+        } catch {
+            XCTFail("Expected LLMError.providerError, got \(error)")
+        }
+    }
+
     private func temporaryModelDirectory() -> URL {
         FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -528,6 +573,7 @@ private actor FakeLocalLLMRuntime: LocalLLMRuntime {
     private var loadCalls: [LocalLLMModelReference] = []
     private var unloadCalls = 0
     private var requests: [[ChatMessage]] = []
+    private var optionsRequests: [ChatCompletionOptions] = []
     private var latestMetricsValue: LLMGenerationMetrics?
     private var requestCountWaiters: [CountWaiter] = []
     private var unloadCountWaiters: [CountWaiter] = []
@@ -541,6 +587,8 @@ private actor FakeLocalLLMRuntime: LocalLLMRuntime {
         self.delayNanoseconds = delayNanoseconds
         self.unloadGate = unloadGate
     }
+
+    nonisolated var isAvailable: Bool { true }
 
     func load(model: LocalLLMModelReference) async throws {
         loadCalls.append(model)
@@ -559,6 +607,7 @@ private actor FakeLocalLLMRuntime: LocalLLMRuntime {
         options: ChatCompletionOptions
     ) async throws -> AsyncThrowingStream<LocalLLMRuntimeEvent, Error> {
         requests.append(messages)
+        optionsRequests.append(options)
         resumeSatisfiedWaiters(&requestCountWaiters, currentCount: requests.count)
         let events = eventPlans.isEmpty ? [.text("fallback")] : eventPlans.removeFirst()
         latestMetricsValue =
@@ -660,6 +709,10 @@ private actor FakeLocalLLMRuntime: LocalLLMRuntime {
         requests.map { request in
             request.map(\.content).joined(separator: "\n\n")
         }
+    }
+
+    func requestOptions() -> [ChatCompletionOptions] {
+        optionsRequests
     }
 
     private func resumeSatisfiedWaiters(

--- a/Tests/MacParakeetTests/Services/LLM/LLMServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/LLM/LLMServiceTests.swift
@@ -4,6 +4,7 @@ import XCTest
 // MARK: - Mocks
 
 final class MockLLMClient: LLMClientProtocol, @unchecked Sendable {
+    var supportsInProcessLocalLLM = true
     var capturedMessages: [ChatMessage] = []
     var capturedContext: LLMExecutionContext?
     var capturedOptions: ChatCompletionOptions?

--- a/Tests/MacParakeetTests/Services/LLM/MLXLocalLLMIntegrationTests.swift
+++ b/Tests/MacParakeetTests/Services/LLM/MLXLocalLLMIntegrationTests.swift
@@ -6,14 +6,15 @@ import XCTest
 #endif
 
 final class MLXLocalLLMIntegrationTests: XCTestCase {
-    func testRealMLXGenerationWhenGatedBuildAndLocalModelArePresent() async throws {
+    func testRealMLXConnectionSmokeWhenGatedBuildAndLocalModelArePresent() async throws {
         let environment = ProcessInfo.processInfo.environment
         try XCTSkipUnless(
             environment["MACPARAKEET_RUN_MLX_LOCAL_LLM_INTEGRATION"] == "1",
             "Set MACPARAKEET_RUN_MLX_LOCAL_LLM_INTEGRATION=1 to run the real MLX local LLM smoke."
         )
         guard let modelPath = environment[InProcessLLMClient.modelDirectoryEnvironmentVariable],
-              !modelPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            !modelPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else {
             throw XCTSkip("Set \(InProcessLLMClient.modelDirectoryEnvironmentVariable) to a local MLX model directory.")
         }
 
@@ -26,15 +27,8 @@ final class MLXLocalLLMIntegrationTests: XCTestCase {
             idleUnloadDelaySeconds: 0
         )
 
-        let response = try await client.chatCompletion(
-            messages: [ChatMessage(role: .user, content: "Reply with exactly: local mlx ok")],
-            context: LLMExecutionContext(providerConfig: .inProcessLocal()),
-            options: ChatCompletionOptions(temperature: 0, maxTokens: 16)
-        )
-
-        XCTAssertTrue(
-            response.content.localizedCaseInsensitiveContains("local mlx"),
-            "Expected the model to follow the zero-temperature instruction, got: \(response.content)"
+        try await client.testConnection(
+            context: LLMExecutionContext(providerConfig: .inProcessLocal())
         )
         #else
         throw XCTSkip("Run with MACPARAKEET_ENABLE_MLX_LOCAL_LLM=1 so the gated MLX target is linked.")

--- a/Tests/MacParakeetTests/ViewModels/InProcessModelManagerViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/InProcessModelManagerViewModelTests.swift
@@ -30,6 +30,31 @@ final class InProcessModelManagerViewModelTests: XCTestCase {
         XCTAssertNil(configStore.config)
     }
 
+    func testEnableLocalAIGatedWhenRuntimeUnavailable() async {
+        let downloader = FakeInProcessModelDownloader()
+        let configStore = MockLLMConfigStore()
+        let client = MockLLMClient()
+        client.supportsInProcessLocalLLM = false
+        let viewModel = InProcessModelManagerViewModel()
+        viewModel.configure(
+            downloader: downloader,
+            configStore: configStore,
+            llmClient: client,
+            physicalMemoryBytes: 32 * 1024 * 1024 * 1024
+        )
+
+        await viewModel.enableLocalAI()
+
+        guard case .failed(let reason, let recoverable) = viewModel.state else {
+            return XCTFail("Expected failed state")
+        }
+        XCTAssertTrue(reason.contains("does not include the MLX runtime"))
+        XCTAssertFalse(recoverable)
+        let downloadCallCount = await downloader.downloadCallCount()
+        XCTAssertEqual(downloadCallCount, 0)
+        XCTAssertNil(configStore.config)
+    }
+
     func testEnableLocalAIDownloadsVerifiesTestsAndSavesProvider() async {
         let downloader = FakeInProcessModelDownloader()
         let configStore = MockLLMConfigStore()

--- a/Tests/MacParakeetTests/ViewModels/LLMSettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/LLMSettingsViewModelTests.swift
@@ -45,6 +45,38 @@ final class LLMSettingsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.transcriptAIContextMode, .richTranscript)
     }
 
+    func testInProcessLocalSetupHiddenWithoutProductVisibility() {
+        mockClient.supportsInProcessLocalLLM = true
+        viewModel.configure(configStore: mockConfigStore, llmClient: mockClient)
+
+        XCTAssertFalse(viewModel.shouldShowInProcessLocalSetup)
+        XCTAssertFalse(viewModel.shouldShowInProcessLocalUnavailableExplanation)
+        XCTAssertNil(viewModel.inProcessLocalUnavailableMessage)
+        XCTAssertFalse(viewModel.selectableProviderIDs.contains(.inProcessLocal))
+    }
+
+    func testInProcessLocalSetupVisibleOnlyWhenProductGateAndRuntimeAreAvailable() {
+        defaults.set(true, forKey: AppFeatures.inProcessLocalLLMDeveloperDefaultsKey)
+        mockClient.supportsInProcessLocalLLM = true
+        viewModel.configure(configStore: mockConfigStore, llmClient: mockClient)
+
+        XCTAssertTrue(viewModel.shouldShowInProcessLocalSetup)
+        XCTAssertFalse(viewModel.shouldShowInProcessLocalUnavailableExplanation)
+        XCTAssertNil(viewModel.inProcessLocalUnavailableMessage)
+        XCTAssertTrue(viewModel.selectableProviderIDs.contains(.inProcessLocal))
+    }
+
+    func testDeveloperOverrideShowsUnavailableExplanationWhenRuntimeMissing() {
+        defaults.set(true, forKey: AppFeatures.inProcessLocalLLMDeveloperDefaultsKey)
+        mockClient.supportsInProcessLocalLLM = false
+        viewModel.configure(configStore: mockConfigStore, llmClient: mockClient)
+
+        XCTAssertFalse(viewModel.shouldShowInProcessLocalSetup)
+        XCTAssertTrue(viewModel.shouldShowInProcessLocalUnavailableExplanation)
+        XCTAssertTrue(viewModel.inProcessLocalUnavailableMessage?.contains("does not include the MLX runtime") == true)
+        XCTAssertFalse(viewModel.selectableProviderIDs.contains(.inProcessLocal))
+    }
+
     // MARK: - AI Formatter: dictation routing toggle (#408)
 
     func testAIFormatterEnabledForDictationDefaultsToFalse() {


### PR DESCRIPTION
## What

Implements findings 1 and 2 (both "blocks dogfood") of the MLX local LLM integration audit (2026-07-05): the two fixes required before any internal flag-flip of the dev-gated Local MLX path.

**1. Runtime capability gating.** Setup visibility previously checked only product flag / dev defaults / launch arg — in a non-MLX build with a dev override, a user could be invited into a ~2.5GB download that could never load. Now capability originates at the runtime and flows through the existing injection seam:

- `LocalLLMRuntime.isAvailable` (protocol default `false`; `MLXLocalLLMRuntime` returns `true`; `UnavailableLocalLLMRuntime` returns `false`)
- surfaced via `LLMClientProtocol.supportsInProcessLocalLLM` → `RoutingLLMClient` → view models
- `AppFeatures.isInProcessLocalLLMVisible(runtimeAvailable:)` requires product visibility AND runtime capability; `runtimeAvailable` defaults to `false` so callers fail closed
- dev override in a non-MLX build shows a dev-only "unavailable in this build" explanation; no download can start, and `.inProcessLocal` is absent from the provider picker

**2. Generation smoke test.** `InProcessLLMClient.testConnection` previously only loaded the model; load can succeed while tokenizer/chat-template/Metal generation fails. It now runs a bounded real generation (temperature 0, maxTokens 4, 15s timeout) via `LocalLLMRuntime.smokeTest(model:timeoutNanoseconds:)` before setup saves `.inProcessLocal`. Failures surface distinct errors for timeout vs. no-text. An opt-in integration test (env-gated on a local model dir) covers the real MLX smoke; normal CI downloads nothing.

Deliberately untouched: audit findings 3-9, including `LLMService` context/chunking policy (needs a design note + dogfood data first).

## Spec alignment

Governing docs: `docs/audits/2026-07-05-mlx-local-llm-integration-review.md` (findings 1-2, implemented exactly as recommended) and ADR-011's dev-gated foundation amendment. Companion doc-only PR #746 aligns spec/ADR status language.

## Verification

- `swift test --filter LLMProviderDescriptorTests` — 9 tests, 0 failures
- `swift test --filter InProcessModelManagerViewModelTests` — 9 tests, 0 failures
- `swift test --filter LLMSettingsViewModelTests` — 127 tests, 0 failures
- `swift test --filter InProcessLLMClientTests` — 17 tests, 0 failures
- `MACPARAKEET_ENABLE_MLX_LOCAL_LLM=1 MACPARAKEET_SKIP_WHISPERKIT=1 swift build --target MacParakeetLocalLLM` — builds (8.45s)
- `scripts/dev/format.sh` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate Local AI setup on the linked runtime and add a small generation smoke test so `.inProcessLocal` only appears and saves when MLX is linked and can generate text. Avoids big downloads on non-MLX builds and catches tokenizer/chat-template/Metal issues early.

- **New Features**
  - Runtime gating: `LocalLLMRuntime.isAvailable` → `LLMClientProtocol.supportsInProcessLocalLLM` → view models. `AppFeatures.isInProcessLocalLLMVisible(...)` now requires product/dev visibility AND a linked runtime; non-MLX builds with a dev override show “Unavailable in this build” and hide the picker/download.
  - Generation smoke test: `InProcessLLMClient.testConnection` calls `LocalLLMRuntime.smokeTest(model:timeoutNanoseconds:)` (temp 0, maxTokens 4, 15s). Fails on timeout or no text. `MLXLocalLLMRuntime.isAvailable` returns `true`; `UnavailableLocalLLMRuntime` blocks loading.
  - UI/view models: `LLMSettingsView` shows a small “Local AI • Unavailable in this build” section when gated. `LLMSettingsViewModel` exposes `selectableProviderIDs` and an explanation; enable flow in `InProcessModelManagerViewModel` refuses to proceed without a runtime.

- **Bug Fixes**
  - Corrected guard order in `InProcessModelManagerViewModel.enableLocalAI`: check setup is configured before runtime availability to avoid misreporting “MLX runtime missing” when not configured yet.

<sup>Written for commit dbd2fa4c143ba2e9ef656374f93a3d9703501799. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/749?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer local AI status in Settings, including an “Unavailable in this build” message when the feature is not supported.
  * Provider selection now adapts to whether local AI is actually available on the device/build.

* **Bug Fixes**
  * Improved local AI setup flow so unavailable runtimes are handled gracefully before users can proceed.
  * Connection checks for local AI now use a quicker smoke test, helping detect issues earlier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->