### PR TITLE
feat(llm): local AI setup lifecycle — disk preflight, remove-model, recovery copy

### DIFF
--- a/Sources/MacParakeet/Views/Settings/LLMSettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/LLMSettingsView.swift
@@ -25,10 +25,23 @@ struct LLMSettingsView: View {
     @State private var selectedSmartDefaultCategory: TelemetryAppCategory?
     @State private var aiFormatterAppIcons: [String: NSImage] = [:]
     @State private var aiFormatterAppIconLoadingIDs: Set<String> = []
+    @State private var pendingLocalAIModelRemoval: LocalAIModelRemoval?
 
     private static let smartDefaultGridColumns = [
         GridItem(.adaptive(minimum: 168), spacing: DesignSystem.Spacing.sm)
     ]
+
+    private enum LocalAIModelRemoval: Identifiable, Equatable {
+        case downloaded
+        case partial
+
+        var id: String {
+            switch self {
+            case .downloaded: "downloaded"
+            case .partial: "partial"
+            }
+        }
+    }
 
     var body: some View {
         VStack(spacing: DesignSystem.Spacing.md) {
@@ -189,6 +202,23 @@ struct LLMSettingsView: View {
                 await viewModel.inProcessModelManager.refresh()
             }
         }
+        .alert(
+            localAIModelRemovalAlertTitle,
+            isPresented: Binding(
+                get: { pendingLocalAIModelRemoval != nil },
+                set: { if !$0 { pendingLocalAIModelRemoval = nil } }
+            ),
+            presenting: pendingLocalAIModelRemoval
+        ) { _ in
+            Button("Cancel", role: .cancel) { pendingLocalAIModelRemoval = nil }
+            Button("Remove", role: .destructive) {
+                let manager = viewModel.inProcessModelManager
+                pendingLocalAIModelRemoval = nil
+                Task { await manager.deleteModel() }
+            }
+        } message: { removal in
+            Text(localAIModelRemovalMessage(for: removal))
+        }
     }
 
     @ViewBuilder
@@ -331,11 +361,22 @@ struct LLMSettingsView: View {
     private var localAIActionButtons: some View {
         let manager = viewModel.inProcessModelManager
         HStack(spacing: DesignSystem.Spacing.xs) {
-            if manager.isModelDownloaded || manager.hasModelArtifacts {
+            if manager.isModelDownloaded {
                 Button {
-                    Task { await manager.deleteModel() }
+                    pendingLocalAIModelRemoval = .downloaded
                 } label: {
-                    Label(manager.isModelDownloaded ? "Delete model" : "Delete partial download", systemImage: "trash")
+                    Label(
+                        "Remove downloaded model (\(manager.modelCacheSizeDescription))",
+                        systemImage: "trash"
+                    )
+                }
+                .parakeetAction(.secondary)
+                .disabled(manager.isWorking)
+            } else if manager.hasModelArtifacts {
+                Button {
+                    pendingLocalAIModelRemoval = .partial
+                } label: {
+                    Label("Delete partial download", systemImage: "trash")
                 }
                 .parakeetAction(.secondary)
                 .disabled(manager.isWorking)
@@ -355,7 +396,7 @@ struct LLMSettingsView: View {
             } label: {
                 Label(
                     localAIPrimaryButtonTitle,
-                    systemImage: manager.isModelDownloaded ? "checkmark.circle" : "arrow.down.circle")
+                    systemImage: localAIPrimaryButtonIcon)
             }
             .parakeetAction(.secondary)
             .disabled(!manager.meetsMemoryRequirement || manager.isWorking)
@@ -365,10 +406,21 @@ struct LLMSettingsView: View {
 
     private var localAIPrimaryButtonTitle: String {
         let manager = viewModel.inProcessModelManager
+        if case .failed(_, let recoverable) = manager.state, recoverable {
+            return "Retry setup"
+        }
         if manager.isModelDownloaded {
             return manager.isLocalAISelected ? "Test local AI" : "Use local AI"
         }
         return "Enable local AI"
+    }
+
+    private var localAIPrimaryButtonIcon: String {
+        let manager = viewModel.inProcessModelManager
+        if case .failed(_, let recoverable) = manager.state, recoverable {
+            return "arrow.clockwise"
+        }
+        return manager.isModelDownloaded ? "checkmark.circle" : "arrow.down.circle"
     }
 
     @ViewBuilder
@@ -455,6 +507,28 @@ struct LLMSettingsView: View {
             return "\(completed) of \(total) - \(currentFile)"
         }
         return "\(completed) of \(total)"
+    }
+
+    private var localAIModelRemovalAlertTitle: String {
+        switch pendingLocalAIModelRemoval {
+        case .downloaded:
+            return "Remove downloaded local AI model?"
+        case .partial:
+            return "Delete partial local AI download?"
+        case nil:
+            return "Remove local AI files?"
+        }
+    }
+
+    private func localAIModelRemovalMessage(for removal: LocalAIModelRemoval) -> String {
+        let manager = viewModel.inProcessModelManager
+        switch removal {
+        case .downloaded:
+            return
+                "This frees \(manager.modelCacheSizeDescription). You can download \(manager.modelDisplayName) again at any time."
+        case .partial:
+            return "This removes incomplete local AI model files from this Mac. You can restart setup at any time."
+        }
     }
 
     private var localNetworkHTTPSection: some View {

--- a/Sources/MacParakeetCore/Services/LLM/InProcessLLMClient.swift
+++ b/Sources/MacParakeetCore/Services/LLM/InProcessLLMClient.swift
@@ -112,11 +112,29 @@ public final class InProcessLLMClient: LLMClientProtocol, Sendable {
         do {
             await runtime.unload()
             try await operation()
-            await lifetimeCoordinator.endExclusiveOperation(lease)
+            await lifetimeCoordinator.endExclusiveOperation(
+                lease,
+                waitingGenerationError: Self.modelRemovedDuringRemovalError()
+            )
         } catch {
-            await lifetimeCoordinator.endExclusiveOperation(lease)
+            await lifetimeCoordinator.endExclusiveOperation(
+                lease,
+                waitingGenerationError: Self.modelRemovalFailedError(error)
+            )
             throw error
         }
+    }
+
+    private static func modelRemovedDuringRemovalError() -> LLMError {
+        .modelNotFound(
+            "The downloaded local AI model was removed. Download and verify it again before using local AI."
+        )
+    }
+
+    private static func modelRemovalFailedError(_ error: Error) -> LLMError {
+        .providerError(
+            "Local AI model removal did not complete before queued generation could start: \(error.localizedDescription)"
+        )
     }
 
     public static func environmentModelDirectory(for config: LLMProviderConfig) throws -> URL {
@@ -585,17 +603,14 @@ private actor LocalLLMLifetimeCoordinator {
         scheduleUnload(runtime: runtime, delayNanoseconds: delayNanoseconds)
     }
 
-    func endExclusiveOperation(_ lease: LocalLLMGenerationLease) {
+    func endExclusiveOperation(
+        _ lease: LocalLLMGenerationLease,
+        waitingGenerationError: any Error & Sendable
+    ) {
         guard activeGenerationID == lease.id else { return }
 
-        if !waitingGenerations.isEmpty {
-            let next = waitingGenerations.removeFirst()
-            activeGenerationID = next.lease.id
-            next.continuation.resume(returning: next.lease)
-            return
-        }
-
         activeGenerationID = nil
+        failWaitingGenerations(with: waitingGenerationError)
     }
 
     private func cancelWaitingGeneration(id: UUID) {
@@ -603,6 +618,12 @@ private actor LocalLLMLifetimeCoordinator {
 
         let waitingGeneration = waitingGenerations.remove(at: index)
         waitingGeneration.continuation.resume(throwing: CancellationError())
+    }
+
+    private func failWaitingGenerations(with error: any Error & Sendable) {
+        let waiting = waitingGenerations
+        waitingGenerations.removeAll()
+        waiting.forEach { $0.continuation.resume(throwing: error) }
     }
 
     private func cancelPendingUnload() {

--- a/Sources/MacParakeetCore/Services/LLM/InProcessLLMClient.swift
+++ b/Sources/MacParakeetCore/Services/LLM/InProcessLLMClient.swift
@@ -106,6 +106,19 @@ public final class InProcessLLMClient: LLMClientProtocol, Sendable {
         [context.providerConfig.modelName].filter { !$0.isEmpty }
     }
 
+    public func withInProcessLocalModelRemoval(_ operation: @Sendable () async throws -> Void) async throws {
+        try Task.checkCancellation()
+        let lease = try await lifetimeCoordinator.beginGeneration()
+        do {
+            await runtime.unload()
+            try await operation()
+            await lifetimeCoordinator.endExclusiveOperation(lease)
+        } catch {
+            await lifetimeCoordinator.endExclusiveOperation(lease)
+            throw error
+        }
+    }
+
     public static func environmentModelDirectory(for config: LLMProviderConfig) throws -> URL {
         guard let rawPath = ProcessInfo.processInfo.environment[modelDirectoryEnvironmentVariable],
             !rawPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -570,6 +583,19 @@ private actor LocalLLMLifetimeCoordinator {
 
         activeGenerationID = nil
         scheduleUnload(runtime: runtime, delayNanoseconds: delayNanoseconds)
+    }
+
+    func endExclusiveOperation(_ lease: LocalLLMGenerationLease) {
+        guard activeGenerationID == lease.id else { return }
+
+        if !waitingGenerations.isEmpty {
+            let next = waitingGenerations.removeFirst()
+            activeGenerationID = next.lease.id
+            next.continuation.resume(returning: next.lease)
+            return
+        }
+
+        activeGenerationID = nil
     }
 
     private func cancelWaitingGeneration(id: UUID) {

--- a/Sources/MacParakeetCore/Services/LLM/InProcessModelDownloader.swift
+++ b/Sources/MacParakeetCore/Services/LLM/InProcessModelDownloader.swift
@@ -64,9 +64,19 @@ public protocol InProcessModelDownloading: Sendable {
     func defaultModelDirectory() -> URL
     func isDefaultModelDownloaded() async -> Bool
     func hasDefaultModelArtifacts() async -> Bool
+    func defaultModelCacheSizeBytes() async -> UInt64
+    func remainingDefaultModelDownloadBytes() async throws -> UInt64
     func verifyDefaultModel() async throws -> URL
     func downloadDefaultModel(progress: @escaping InProcessModelDownloadProgressHandler) async throws -> URL
     func deleteDefaultModel() async throws
+}
+
+public extension InProcessModelDownloading {
+    func defaultModelCacheSizeBytes() async -> UInt64 { 0 }
+
+    func remainingDefaultModelDownloadBytes() async throws -> UInt64 {
+        InProcessLocalModelCatalog.defaultManifest.totalBytes
+    }
 }
 
 public enum InProcessModelDownloaderError: LocalizedError, Equatable {
@@ -474,6 +484,46 @@ public actor InProcessModelDownloader: InProcessModelDownloading {
         return !contents.isEmpty
     }
 
+    public func defaultModelCacheSizeBytes() async -> UInt64 {
+        directorySize(at: modelDirectory())
+    }
+
+    public func remainingDefaultModelDownloadBytes() async throws -> UInt64 {
+        try Task.checkCancellation()
+        let directory = modelDirectory()
+        if try InProcessLocalModelCatalog.hasValidVerificationMarker(
+            for: manifest,
+            in: directory,
+            fileManager: fileManager
+        ) {
+            return 0
+        }
+
+        var remaining: UInt64 = 0
+        for file in manifest.files {
+            try Task.checkCancellation()
+            if try isFileVerified(file, in: directory) {
+                continue
+            }
+
+            let destination = try InProcessLocalModelCatalog.fileURL(
+                for: file,
+                in: directory,
+                fileManager: fileManager
+            )
+            let partial = InProcessLocalModelCatalog.partialURL(for: destination)
+            let partialSize = try InProcessLocalModelCatalog.fileSize(at: partial, fileManager: fileManager) ?? 0
+            if partialSize == file.sizeBytes, try isVerified(file: file, at: partial) {
+                continue
+            } else if partialSize > 0, partialSize < file.sizeBytes {
+                remaining += file.sizeBytes - partialSize
+            } else {
+                remaining += file.sizeBytes
+            }
+        }
+        return remaining
+    }
+
     @discardableResult
     public func verifyDefaultModel() async throws -> URL {
         try Task.checkCancellation()
@@ -543,6 +593,7 @@ public actor InProcessModelDownloader: InProcessModelDownloading {
     public func deleteDefaultModel() async throws {
         try Task.checkCancellation()
         let directory = modelDirectory()
+        try assertManagedModelDirectory(directory)
         if fileManager.fileExists(atPath: directory.path) {
             try fileManager.removeItem(at: directory)
         }
@@ -550,6 +601,55 @@ public actor InProcessModelDownloader: InProcessModelDownloading {
 
     private nonisolated func modelDirectory() -> URL {
         InProcessLocalModelCatalog.modelDirectory(for: manifest.modelID, cacheRoot: cacheRoot)
+    }
+
+    private nonisolated func assertManagedModelDirectory(_ directory: URL) throws {
+        let expectedName = InProcessLocalModelCatalog.sanitizedDirectoryName(for: manifest.modelID)
+        guard directory.lastPathComponent == expectedName,
+            directory.deletingLastPathComponent().path == cacheRoot.path
+        else {
+            throw InProcessModelDownloaderError.manifestPathEscapesCache(directory.path)
+        }
+    }
+
+    private func directorySize(at url: URL) -> UInt64 {
+        guard fileManager.fileExists(atPath: url.path) else { return 0 }
+        var total: UInt64 = 0
+
+        if let rootValues = try? url.resourceValues(
+            forKeys: [.isRegularFileKey, .isSymbolicLinkKey, .fileSizeKey]
+        ) {
+            if rootValues.isSymbolicLink == true {
+                return 0
+            }
+            if rootValues.isRegularFile == true {
+                return UInt64(max(0, rootValues.fileSize ?? 0))
+            }
+        }
+
+        guard
+            let enumerator = fileManager.enumerator(
+                at: url,
+                includingPropertiesForKeys: [.isRegularFileKey, .isSymbolicLinkKey, .fileSizeKey]
+            )
+        else {
+            return 0
+        }
+
+        for case let childURL as URL in enumerator {
+            guard
+                let values = try? childURL.resourceValues(
+                    forKeys: [.isRegularFileKey, .isSymbolicLinkKey, .fileSizeKey]
+                ),
+                values.isSymbolicLink != true,
+                values.isRegularFile == true
+            else {
+                continue
+            }
+            total += UInt64(max(0, values.fileSize ?? 0))
+        }
+
+        return total
     }
 
     private func download(

--- a/Sources/MacParakeetCore/Services/LLM/LLMClient.swift
+++ b/Sources/MacParakeetCore/Services/LLM/LLMClient.swift
@@ -21,6 +21,11 @@ public protocol LLMClientProtocol: Sendable {
 
     /// Fetches available model IDs from the provider's /models endpoint.
     func listModels(context: LLMExecutionContext) async throws -> [String]
+
+    /// Runs `operation` after any active in-process local generation is finished
+    /// and before future in-process generations may start. Non in-process
+    /// clients execute the operation directly.
+    func withInProcessLocalModelRemoval(_ operation: @Sendable () async throws -> Void) async throws
 }
 
 public extension LLMClientProtocol {
@@ -56,6 +61,10 @@ public extension LLMClientProtocol {
 
     func listModels(config: LLMProviderConfig) async throws -> [String] {
         try await listModels(context: LLMExecutionContext(providerConfig: config))
+    }
+
+    func withInProcessLocalModelRemoval(_ operation: @Sendable () async throws -> Void) async throws {
+        try await operation()
     }
 }
 

--- a/Sources/MacParakeetCore/Services/LLM/RoutingLLMClient.swift
+++ b/Sources/MacParakeetCore/Services/LLM/RoutingLLMClient.swift
@@ -46,6 +46,10 @@ public final class RoutingLLMClient: LLMClientProtocol, Sendable {
         try await client(for: context).listModels(context: context)
     }
 
+    public func withInProcessLocalModelRemoval(_ operation: @Sendable () async throws -> Void) async throws {
+        try await inProcessClient.withInProcessLocalModelRemoval(operation)
+    }
+
     private func client(for context: LLMExecutionContext) -> any LLMClientProtocol {
         switch context.providerConfig.id {
         case .localCLI:

--- a/Sources/MacParakeetViewModels/InProcessModelManagerViewModel.swift
+++ b/Sources/MacParakeetViewModels/InProcessModelManagerViewModel.swift
@@ -1,6 +1,30 @@
 import Foundation
 import MacParakeetCore
 
+public typealias InProcessModelAvailableDiskSpaceProvider = @Sendable (URL) throws -> UInt64?
+
+public enum InProcessModelDiskSpace {
+    public static func availableCapacityForImportantUsage(at directory: URL) throws -> UInt64? {
+        let volumeURL = existingAncestor(for: directory)
+        let values = try volumeURL.resourceValues(forKeys: [.volumeAvailableCapacityForImportantUsageKey])
+        guard let capacity = values.volumeAvailableCapacityForImportantUsage, capacity >= 0 else {
+            return nil
+        }
+        return UInt64(capacity)
+    }
+
+    private static func existingAncestor(for url: URL, fileManager: FileManager = .default) -> URL {
+        var candidate = url.standardizedFileURL
+        var isDirectory = ObjCBool(false)
+        while !fileManager.fileExists(atPath: candidate.path, isDirectory: &isDirectory) {
+            let parent = candidate.deletingLastPathComponent()
+            guard parent.path != candidate.path else { return candidate }
+            candidate = parent
+        }
+        return isDirectory.boolValue ? candidate : candidate.deletingLastPathComponent()
+    }
+}
+
 @MainActor
 @Observable
 public final class InProcessModelManagerViewModel {
@@ -12,12 +36,14 @@ public final class InProcessModelManagerViewModel {
         case failed(reason: String, recoverable: Bool)
     }
 
-    public static let minimumPhysicalMemoryBytes: UInt64 = 16 * 1024 * 1024 * 1024
+    public nonisolated static let minimumPhysicalMemoryBytes: UInt64 = 16 * 1024 * 1024 * 1024
+    public nonisolated static let diskSafetyMarginBytes: UInt64 = 500 * 1000 * 1000
 
     public private(set) var state: State = .setUpNeeded
     public private(set) var progress: InProcessModelDownloadProgress?
     public private(set) var isModelDownloaded = false
     public private(set) var hasModelArtifacts = false
+    public private(set) var modelCacheSizeBytes: UInt64 = 0
     public private(set) var isWorking = false
 
     private var downloader: (any InProcessModelDownloading)?
@@ -25,6 +51,9 @@ public final class InProcessModelManagerViewModel {
     private var llmClient: (any LLMClientProtocol)?
     private var onConfigurationChanged: (() -> Void)?
     private var physicalMemoryBytes: UInt64
+    @ObservationIgnored
+    private var availableDiskSpaceBytes: InProcessModelAvailableDiskSpaceProvider =
+        { try InProcessModelDiskSpace.availableCapacityForImportantUsage(at: $0) }
     private var isRuntimeAvailable = false
     private var setupTask: Task<Void, Never>?
 
@@ -37,12 +66,15 @@ public final class InProcessModelManagerViewModel {
         configStore: any LLMConfigStoreProtocol,
         llmClient: any LLMClientProtocol,
         physicalMemoryBytes: UInt64 = ProcessInfo.processInfo.physicalMemory,
+        availableDiskSpaceBytes: @escaping InProcessModelAvailableDiskSpaceProvider =
+            { try InProcessModelDiskSpace.availableCapacityForImportantUsage(at: $0) },
         onConfigurationChanged: (() -> Void)? = nil
     ) {
         self.downloader = downloader
         self.configStore = configStore
         self.llmClient = llmClient
         self.physicalMemoryBytes = physicalMemoryBytes
+        self.availableDiskSpaceBytes = availableDiskSpaceBytes
         self.isRuntimeAvailable = llmClient.supportsInProcessLocalLLM
         self.onConfigurationChanged = onConfigurationChanged
         refreshSelectionState()
@@ -61,10 +93,11 @@ public final class InProcessModelManagerViewModel {
     }
 
     public var modelSizeDescription: String {
-        ByteCountFormatter.string(
-            fromByteCount: Int64(InProcessLocalModelCatalog.defaultManifest.totalBytes),
-            countStyle: .file
-        )
+        Self.formatBytes(InProcessLocalModelCatalog.defaultManifest.totalBytes)
+    }
+
+    public var modelCacheSizeDescription: String {
+        Self.formatBytes(modelCacheSizeBytes)
     }
 
     public private(set) var isLocalAISelected = false
@@ -79,10 +112,12 @@ public final class InProcessModelManagerViewModel {
         refreshSelectionState()
         guard let downloader else {
             state = .setUpNeeded
+            modelCacheSizeBytes = 0
             return
         }
         isModelDownloaded = await downloader.isDefaultModelDownloaded()
         hasModelArtifacts = await downloader.hasDefaultModelArtifacts()
+        modelCacheSizeBytes = await downloader.defaultModelCacheSizeBytes()
         guard setupTask == nil else { return }
         state = isModelDownloaded ? .ready : .setUpNeeded
     }
@@ -130,6 +165,8 @@ public final class InProcessModelManagerViewModel {
         defer { isWorking = false }
 
         do {
+            try await runDiskSpacePreflight(downloader: downloader)
+
             state = .downloading(progress: 0)
             progress = nil
             _ = try await downloader.downloadDefaultModel { [weak self] progress in
@@ -137,6 +174,7 @@ public final class InProcessModelManagerViewModel {
             }
             isModelDownloaded = true
             hasModelArtifacts = true
+            modelCacheSizeBytes = await downloader.defaultModelCacheSizeBytes()
 
             state = .verifying
 
@@ -152,9 +190,11 @@ public final class InProcessModelManagerViewModel {
         } catch is CancellationError {
             state = .failed(reason: "Local AI setup was canceled.", recoverable: true)
             hasModelArtifacts = await downloader.hasDefaultModelArtifacts()
+            modelCacheSizeBytes = await downloader.defaultModelCacheSizeBytes()
         } catch {
-            state = .failed(reason: error.localizedDescription, recoverable: true)
+            state = .failed(reason: Self.recoveryMessage(for: error, state: state), recoverable: true)
             hasModelArtifacts = await downloader.hasDefaultModelArtifacts()
+            modelCacheSizeBytes = await downloader.defaultModelCacheSizeBytes()
         }
     }
 
@@ -164,9 +204,16 @@ public final class InProcessModelManagerViewModel {
         defer { isWorking = false }
 
         do {
-            try await downloader.deleteDefaultModel()
+            if let llmClient {
+                try await llmClient.withInProcessLocalModelRemoval {
+                    try await downloader.deleteDefaultModel()
+                }
+            } else {
+                try await downloader.deleteDefaultModel()
+            }
             isModelDownloaded = false
             hasModelArtifacts = false
+            modelCacheSizeBytes = 0
             progress = nil
             refreshSelectionState()
             if isLocalAISelected {
@@ -180,9 +227,71 @@ public final class InProcessModelManagerViewModel {
         }
     }
 
+    private func runDiskSpacePreflight(downloader: any InProcessModelDownloading) async throws {
+        let remainingBytes = try await downloader.remainingDefaultModelDownloadBytes()
+        guard remainingBytes > 0 else { return }
+
+        let requiredBytes = remainingBytes.addingReportingOverflow(Self.diskSafetyMarginBytes)
+        let required = requiredBytes.overflow ? UInt64.max : requiredBytes.partialValue
+        let cacheDirectory = downloader.defaultModelDirectory()
+        guard let availableBytes = try availableDiskSpaceBytes(cacheDirectory) else {
+            throw InProcessModelSetupError.diskSpaceUnavailable(requiredBytes: required)
+        }
+        guard availableBytes >= required else {
+            throw InProcessModelSetupError.insufficientDiskSpace(
+                requiredBytes: required,
+                availableBytes: availableBytes
+            )
+        }
+    }
+
+    public nonisolated static func formatBytes(_ bytes: UInt64) -> String {
+        ByteCountFormatter.string(
+            fromByteCount: Int64(min(bytes, UInt64(Int64.max))),
+            countStyle: .file
+        )
+    }
+
+    private nonisolated static func recoveryMessage(for error: Error, state: State) -> String {
+        if let setupError = error as? InProcessModelSetupError {
+            return setupError.localizedDescription
+        }
+
+        let detail = error.localizedDescription
+        switch state {
+        case .downloading:
+            return "Local AI download failed: \(detail) Check your network connection, then retry."
+        case .verifying:
+            return
+                "Local AI downloaded, but the generation test failed: \(detail) Retry setup. If it keeps failing, choose another AI provider."
+        case .setUpNeeded:
+            return "Local AI setup failed before download: \(detail) Fix the issue, then retry."
+        case .ready:
+            return "Local AI setup failed while saving configuration: \(detail) Retry setup."
+        case .failed:
+            return detail
+        }
+    }
+
     fileprivate func updateDownloadProgress(_ progress: InProcessModelDownloadProgress) {
         guard case .downloading = state else { return }
         self.progress = progress
         state = .downloading(progress: progress.fractionCompleted)
+    }
+}
+
+private enum InProcessModelSetupError: LocalizedError {
+    case diskSpaceUnavailable(requiredBytes: UInt64)
+    case insufficientDiskSpace(requiredBytes: UInt64, availableBytes: UInt64)
+
+    var errorDescription: String? {
+        switch self {
+        case .diskSpaceUnavailable(let requiredBytes):
+            return
+                "Unable to check free disk space for Local AI setup. Verify at least \(InProcessModelManagerViewModel.formatBytes(requiredBytes)) is available, then retry."
+        case .insufficientDiskSpace(let requiredBytes, let availableBytes):
+            return
+                "Not enough free disk space for Local AI setup. Need \(InProcessModelManagerViewModel.formatBytes(requiredBytes)); available: \(InProcessModelManagerViewModel.formatBytes(availableBytes)). Free up space, then retry."
+        }
     }
 }

--- a/Tests/MacParakeetTests/Services/LLM/InProcessLLMClientTests.swift
+++ b/Tests/MacParakeetTests/Services/LLM/InProcessLLMClientTests.swift
@@ -374,6 +374,83 @@ final class InProcessLLMClientTests: XCTestCase {
         XCTAssertEqual(requestContents, ["First"])
     }
 
+    func testQueuedGenerationFailsWhenModelRemovalCompletes() async throws {
+        let modelDirectory = temporaryModelDirectory()
+        let firstGenerationGate = AsyncGate()
+        let removalStartedGate = AsyncGate()
+        let deleteGate = AsyncGate()
+        let queuedStartedGate = AsyncGate()
+        let runtime = FakeLocalLLMRuntime(
+            eventPlans: [
+                [.wait(firstGenerationGate), .text("first")],
+                [.text("second")],
+            ]
+        )
+        let client = InProcessLLMClient(
+            runtime: runtime,
+            modelDirectoryResolver: { _ in modelDirectory },
+            idleUnloadDelaySeconds: 60
+        )
+
+        let firstTask = Task {
+            try await client.chatCompletion(
+                messages: [ChatMessage(role: .user, content: "First")],
+                context: LLMExecutionContext(providerConfig: .inProcessLocal(model: "removal-queue-test")),
+                options: .default
+            )
+        }
+
+        try await withTimeout {
+            await runtime.waitForRequestCount(1)
+        }
+
+        let removalTask = Task {
+            try await client.withInProcessLocalModelRemoval {
+                await removalStartedGate.open()
+                await deleteGate.wait()
+            }
+        }
+
+        await firstGenerationGate.open()
+        _ = try await firstTask.value
+
+        try await withTimeout {
+            await removalStartedGate.wait()
+        }
+
+        let queuedTask = Task {
+            await queuedStartedGate.open()
+            return try await client.chatCompletion(
+                messages: [ChatMessage(role: .user, content: "Second")],
+                context: LLMExecutionContext(providerConfig: .inProcessLocal(model: "removal-queue-test")),
+                options: .default
+            )
+        }
+
+        try await withTimeout {
+            await queuedStartedGate.wait()
+        }
+        try await Task.sleep(nanoseconds: 10_000_000)
+        let requestCountBeforeDelete = await runtime.requestCallCount()
+        XCTAssertEqual(requestCountBeforeDelete, 1)
+
+        await deleteGate.open()
+        try await removalTask.value
+
+        do {
+            _ = try await queuedTask.value
+            XCTFail("Expected queued generation to fail after local model removal")
+        } catch {
+            XCTAssertTrue(
+                error.localizedDescription.contains("removed"),
+                "Expected removed-model error, got \(error.localizedDescription)"
+            )
+        }
+
+        let requestCountAfterDelete = await runtime.requestCallCount()
+        XCTAssertEqual(requestCountAfterDelete, 1)
+    }
+
     func testStreamingYieldsRuntimeChunks() async throws {
         let modelDirectory = temporaryModelDirectory()
         let runtime = FakeLocalLLMRuntime(eventPlans: [

--- a/Tests/MacParakeetTests/Services/LLM/InProcessModelDownloaderTests.swift
+++ b/Tests/MacParakeetTests/Services/LLM/InProcessModelDownloaderTests.swift
@@ -227,6 +227,27 @@ final class InProcessModelDownloaderTests: XCTestCase {
         XCTAssertEqual(size, 0)
     }
 
+    func testDefaultModelCacheSizeSkipsSymlinkedSubdirectoryContents() async throws {
+        let fixture = try makeFixture(files: ["config.json": Data(repeating: 0x01, count: 4)])
+        try writeFixtureFiles(fixture)
+        let external = fixture.root.appendingPathComponent("external-target", isDirectory: true)
+        try FileManager.default.createDirectory(at: external, withIntermediateDirectories: true)
+        try Data(repeating: 0x03, count: 9).write(to: external.appendingPathComponent("outside.bin"))
+        try FileManager.default.createSymbolicLink(
+            at: fixture.directory.appendingPathComponent("external-link", isDirectory: true),
+            withDestinationURL: external
+        )
+        let downloader = InProcessModelDownloader(
+            manifest: fixture.manifest,
+            cacheRoot: fixture.root,
+            transport: fixture.transport
+        )
+
+        let size = await downloader.defaultModelCacheSizeBytes()
+
+        XCTAssertEqual(size, 4)
+    }
+
     func testCanceledDownloadThrowsCancellationAndPreservesCompletePartial() async throws {
         let fixture = try makeFixture(files: ["model.safetensors": Data("abcdef".utf8)])
         try FileManager.default.createDirectory(at: fixture.directory, withIntermediateDirectories: true)

--- a/Tests/MacParakeetTests/Services/LLM/InProcessModelDownloaderTests.swift
+++ b/Tests/MacParakeetTests/Services/LLM/InProcessModelDownloaderTests.swift
@@ -138,6 +138,95 @@ final class InProcessModelDownloaderTests: XCTestCase {
         XCTAssertFalse(afterDelete)
     }
 
+    func testRemainingDownloadBytesAccountsForPartialFiles() async throws {
+        let fixture = try makeFixture(files: ["model.safetensors": Data("abcdef".utf8)])
+        try FileManager.default.createDirectory(at: fixture.directory, withIntermediateDirectories: true)
+        let partial = fixture.directory.appendingPathComponent(".model.safetensors.part")
+        try Data("abc".utf8).write(to: partial)
+        let downloader = InProcessModelDownloader(
+            manifest: fixture.manifest,
+            cacheRoot: fixture.root,
+            transport: fixture.transport
+        )
+
+        let remaining = try await downloader.remainingDefaultModelDownloadBytes()
+
+        XCTAssertEqual(remaining, 3)
+        let requests = await fixture.transport.requests()
+        XCTAssertTrue(requests.isEmpty)
+    }
+
+    func testRemainingDownloadBytesSkipsVerifiedCompletePartialFile() async throws {
+        let fixture = try makeFixture(files: ["model.safetensors": Data("abcdef".utf8)])
+        try FileManager.default.createDirectory(at: fixture.directory, withIntermediateDirectories: true)
+        let partial = fixture.directory.appendingPathComponent(".model.safetensors.part")
+        try Data("abcdef".utf8).write(to: partial)
+        let downloader = InProcessModelDownloader(
+            manifest: fixture.manifest,
+            cacheRoot: fixture.root,
+            transport: fixture.transport
+        )
+
+        let remaining = try await downloader.remainingDefaultModelDownloadBytes()
+
+        XCTAssertEqual(remaining, 0)
+        let requests = await fixture.transport.requests()
+        XCTAssertTrue(requests.isEmpty)
+    }
+
+    func testRemainingDownloadBytesIsZeroForVerifiedManagedCache() async throws {
+        let fixture = try makeFixture()
+        try writeFixtureFiles(fixture)
+        let downloader = InProcessModelDownloader(
+            manifest: fixture.manifest,
+            cacheRoot: fixture.root,
+            transport: fixture.transport
+        )
+
+        _ = try await downloader.verifyDefaultModel()
+
+        let remaining = try await downloader.remainingDefaultModelDownloadBytes()
+        XCTAssertEqual(remaining, 0)
+    }
+
+    func testDefaultModelCacheSizeCountsManagedFiles() async throws {
+        let fixture = try makeFixture(files: [
+            "config.json": Data(repeating: 0x01, count: 4),
+            "model.safetensors": Data(repeating: 0x02, count: 6),
+        ])
+        try writeFixtureFiles(fixture)
+        let downloader = InProcessModelDownloader(
+            manifest: fixture.manifest,
+            cacheRoot: fixture.root,
+            transport: fixture.transport
+        )
+
+        let size = await downloader.defaultModelCacheSizeBytes()
+
+        XCTAssertEqual(size, 10)
+    }
+
+    func testDefaultModelCacheSizeSkipsManagedDirectorySymlink() async throws {
+        let fixture = try makeFixture()
+        let external = fixture.root.appendingPathComponent("external-target", isDirectory: true)
+        try FileManager.default.createDirectory(at: external, withIntermediateDirectories: true)
+        try Data(repeating: 0x03, count: 9).write(to: external.appendingPathComponent("outside.bin"))
+        try FileManager.default.createDirectory(at: fixture.root, withIntermediateDirectories: true)
+        try FileManager.default.createSymbolicLink(
+            at: fixture.directory,
+            withDestinationURL: external
+        )
+        let downloader = InProcessModelDownloader(
+            manifest: fixture.manifest,
+            cacheRoot: fixture.root,
+            transport: fixture.transport
+        )
+
+        let size = await downloader.defaultModelCacheSizeBytes()
+
+        XCTAssertEqual(size, 0)
+    }
+
     func testCanceledDownloadThrowsCancellationAndPreservesCompletePartial() async throws {
         let fixture = try makeFixture(files: ["model.safetensors": Data("abcdef".utf8)])
         try FileManager.default.createDirectory(at: fixture.directory, withIntermediateDirectories: true)
@@ -260,6 +349,8 @@ final class InProcessModelDownloaderTests: XCTestCase {
     func testDeleteRemovesModelDirectory() async throws {
         let fixture = try makeFixture()
         try writeFixtureFiles(fixture)
+        let sibling = fixture.root.appendingPathComponent("sibling.txt")
+        try Data("keep".utf8).write(to: sibling)
         let downloader = InProcessModelDownloader(
             manifest: fixture.manifest,
             cacheRoot: fixture.root,
@@ -269,6 +360,30 @@ final class InProcessModelDownloaderTests: XCTestCase {
         try await downloader.deleteDefaultModel()
 
         XCTAssertFalse(FileManager.default.fileExists(atPath: fixture.directory.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: sibling.path))
+    }
+
+    func testDeleteRemovesManagedDirectorySymlinkWithoutFollowingIt() async throws {
+        let fixture = try makeFixture()
+        let external = fixture.root.appendingPathComponent("external-target", isDirectory: true)
+        try FileManager.default.createDirectory(at: external, withIntermediateDirectories: true)
+        let externalFile = external.appendingPathComponent("keep.txt")
+        try Data("keep".utf8).write(to: externalFile)
+        try FileManager.default.createDirectory(at: fixture.root, withIntermediateDirectories: true)
+        try FileManager.default.createSymbolicLink(
+            at: fixture.directory,
+            withDestinationURL: external
+        )
+        let downloader = InProcessModelDownloader(
+            manifest: fixture.manifest,
+            cacheRoot: fixture.root,
+            transport: fixture.transport
+        )
+
+        try await downloader.deleteDefaultModel()
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fixture.directory.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: externalFile.path))
     }
 
     private func makeFixture(

--- a/Tests/MacParakeetTests/Services/LLM/LLMServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/LLM/LLMServiceTests.swift
@@ -17,6 +17,9 @@ final class MockLLMClient: LLMClientProtocol, @unchecked Sendable {
     var testConnectionError: Error?
     var testConnectionDelayNs: UInt64 = 0
     var chatCompletionError: Error?
+    var holdInProcessModelRemoval = false
+    var inProcessModelRemovalCallCount = 0
+    private var inProcessModelRemovalContinuation: CheckedContinuation<Void, Never>?
 
     func chatCompletion(
         messages: [ChatMessage],
@@ -73,6 +76,22 @@ final class MockLLMClient: LLMClientProtocol, @unchecked Sendable {
         capturedContext = context
         if let error = listModelsError { throw error }
         return modelsList
+    }
+
+    func withInProcessLocalModelRemoval(_ operation: @Sendable () async throws -> Void) async throws {
+        inProcessModelRemovalCallCount += 1
+        if holdInProcessModelRemoval {
+            await withCheckedContinuation { continuation in
+                inProcessModelRemovalContinuation = continuation
+            }
+        }
+        try await operation()
+    }
+
+    func releaseInProcessModelRemoval() {
+        holdInProcessModelRemoval = false
+        inProcessModelRemovalContinuation?.resume()
+        inProcessModelRemovalContinuation = nil
     }
 }
 

--- a/Tests/MacParakeetTests/ViewModels/InProcessModelManagerViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/InProcessModelManagerViewModelTests.swift
@@ -83,6 +83,91 @@ final class InProcessModelManagerViewModelTests: XCTestCase {
         XCTAssertEqual(configurationChangedCount, 1)
     }
 
+    func testEnableLocalAIPassesDiskPreflightBeforeDownload() async {
+        let remainingBytes: UInt64 = 1_000
+        let downloader = FakeInProcessModelDownloader(remainingDownloadBytes: remainingBytes)
+        let configStore = MockLLMConfigStore()
+        let client = MockLLMClient()
+        let diskSpaceProbe = DiskSpaceProbe(
+            availableBytes: remainingBytes + InProcessModelManagerViewModel.diskSafetyMarginBytes
+        )
+        let viewModel = InProcessModelManagerViewModel()
+        viewModel.configure(
+            downloader: downloader,
+            configStore: configStore,
+            llmClient: client,
+            physicalMemoryBytes: 32 * 1024 * 1024 * 1024,
+            availableDiskSpaceBytes: { [diskSpaceProbe] url in diskSpaceProbe.capacity(for: url) }
+        )
+
+        await viewModel.enableLocalAI()
+
+        XCTAssertEqual(viewModel.state, .ready)
+        XCTAssertEqual(diskSpaceProbe.queriedURL(), downloader.defaultModelDirectory())
+        let downloadCallCount = await downloader.downloadCallCount()
+        XCTAssertEqual(downloadCallCount, 1)
+    }
+
+    func testEnableLocalAIFailsDiskPreflightBeforeDownload() async {
+        let remainingBytes: UInt64 = 2_000_000_000
+        let availableBytes: UInt64 = 1_000_000_000
+        let downloader = FakeInProcessModelDownloader(remainingDownloadBytes: remainingBytes)
+        let configStore = MockLLMConfigStore()
+        let client = MockLLMClient()
+        let viewModel = InProcessModelManagerViewModel()
+        viewModel.configure(
+            downloader: downloader,
+            configStore: configStore,
+            llmClient: client,
+            physicalMemoryBytes: 32 * 1024 * 1024 * 1024,
+            availableDiskSpaceBytes: { _ in availableBytes }
+        )
+
+        await viewModel.enableLocalAI()
+
+        guard case .failed(let reason, let recoverable) = viewModel.state else {
+            return XCTFail("Expected failed state")
+        }
+        XCTAssertTrue(reason.contains("Not enough free disk space"))
+        XCTAssertTrue(
+            reason.contains(
+                InProcessModelManagerViewModel.formatBytes(
+                    remainingBytes + InProcessModelManagerViewModel.diskSafetyMarginBytes
+                )
+            )
+        )
+        XCTAssertTrue(reason.contains(InProcessModelManagerViewModel.formatBytes(availableBytes)))
+        XCTAssertTrue(recoverable)
+        let downloadCallCount = await downloader.downloadCallCount()
+        XCTAssertEqual(downloadCallCount, 0)
+        XCTAssertNil(configStore.config)
+    }
+
+    func testEnableLocalAIFailsWhenDiskPreflightCannotReadCapacity() async {
+        let downloader = FakeInProcessModelDownloader(remainingDownloadBytes: 1_000)
+        let configStore = MockLLMConfigStore()
+        let client = MockLLMClient()
+        let viewModel = InProcessModelManagerViewModel()
+        viewModel.configure(
+            downloader: downloader,
+            configStore: configStore,
+            llmClient: client,
+            physicalMemoryBytes: 32 * 1024 * 1024 * 1024,
+            availableDiskSpaceBytes: { _ in nil }
+        )
+
+        await viewModel.enableLocalAI()
+
+        guard case .failed(let reason, let recoverable) = viewModel.state else {
+            return XCTFail("Expected failed state")
+        }
+        XCTAssertTrue(reason.contains("Unable to check free disk space"))
+        XCTAssertTrue(reason.contains("retry"))
+        XCTAssertTrue(recoverable)
+        let downloadCallCount = await downloader.downloadCallCount()
+        XCTAssertEqual(downloadCallCount, 0)
+    }
+
     func testEnableLocalAIDoesNotSaveWhenRuntimeTestFails() async {
         let downloader = FakeInProcessModelDownloader()
         let configStore = MockLLMConfigStore()
@@ -103,6 +188,31 @@ final class InProcessModelManagerViewModelTests: XCTestCase {
             return XCTFail("Expected failed state")
         }
         XCTAssertTrue(reason.contains("runtime unavailable"))
+        XCTAssertTrue(reason.contains("generation test failed"))
+        XCTAssertTrue(reason.contains("Retry setup"))
+        XCTAssertTrue(recoverable)
+    }
+
+    func testDownloadFailureShowsRetryRecoveryCopy() async {
+        let downloader = FakeInProcessModelDownloader(downloadError: URLError(.notConnectedToInternet))
+        let configStore = MockLLMConfigStore()
+        let client = MockLLMClient()
+        let viewModel = InProcessModelManagerViewModel()
+        viewModel.configure(
+            downloader: downloader,
+            configStore: configStore,
+            llmClient: client,
+            physicalMemoryBytes: 32 * 1024 * 1024 * 1024
+        )
+
+        await viewModel.enableLocalAI()
+
+        guard case .failed(let reason, let recoverable) = viewModel.state else {
+            return XCTFail("Expected failed state")
+        }
+        XCTAssertTrue(reason.contains("Local AI download failed"))
+        XCTAssertTrue(reason.contains("Check your network connection"))
+        XCTAssertTrue(reason.contains("retry"))
         XCTAssertTrue(recoverable)
     }
 
@@ -222,6 +332,83 @@ final class InProcessModelManagerViewModelTests: XCTestCase {
         let deleteCallCount = await downloader.deleteCallCount()
         XCTAssertEqual(deleteCallCount, 1)
     }
+
+    func testDeleteModelRunsDeletionInsideClientRemovalGate() async throws {
+        let downloader = FakeInProcessModelDownloader(isDownloaded: true, cacheSizeBytes: 123)
+        let configStore = MockLLMConfigStore()
+        configStore.config = .inProcessLocal()
+        let client = MockLLMClient()
+        client.holdInProcessModelRemoval = true
+        let viewModel = InProcessModelManagerViewModel()
+        viewModel.configure(
+            downloader: downloader,
+            configStore: configStore,
+            llmClient: client,
+            physicalMemoryBytes: 32 * 1024 * 1024 * 1024
+        )
+        await viewModel.refresh()
+
+        let deleteTask = Task { await viewModel.deleteModel() }
+        let deadline = Date().addingTimeInterval(5)
+        while client.inProcessModelRemovalCallCount == 0, Date() < deadline {
+            try await Task.sleep(nanoseconds: 1_000_000)
+        }
+
+        XCTAssertEqual(client.inProcessModelRemovalCallCount, 1)
+        let deleteCallCountBeforeRelease = await downloader.deleteCallCount()
+        XCTAssertEqual(deleteCallCountBeforeRelease, 0)
+
+        client.releaseInProcessModelRemoval()
+        await deleteTask.value
+
+        let deleteCallCountAfterRelease = await downloader.deleteCallCount()
+        XCTAssertEqual(deleteCallCountAfterRelease, 1)
+        XCTAssertNil(configStore.config)
+        XCTAssertEqual(viewModel.modelCacheSizeBytes, 0)
+    }
+
+    func testRefreshFormatsDownloadedModelCacheSize() async {
+        let cacheSizeBytes: UInt64 = 2_513_288_145
+        let downloader = FakeInProcessModelDownloader(isDownloaded: true, cacheSizeBytes: cacheSizeBytes)
+        let viewModel = InProcessModelManagerViewModel()
+        viewModel.configure(
+            downloader: downloader,
+            configStore: MockLLMConfigStore(),
+            llmClient: MockLLMClient(),
+            physicalMemoryBytes: 32 * 1024 * 1024 * 1024
+        )
+
+        await viewModel.refresh()
+
+        XCTAssertEqual(viewModel.modelCacheSizeBytes, cacheSizeBytes)
+        XCTAssertEqual(
+            viewModel.modelCacheSizeDescription,
+            InProcessModelManagerViewModel.formatBytes(cacheSizeBytes)
+        )
+    }
+}
+
+private final class DiskSpaceProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private let availableBytes: UInt64?
+    private var capturedURL: URL?
+
+    init(availableBytes: UInt64?) {
+        self.availableBytes = availableBytes
+    }
+
+    func capacity(for url: URL) -> UInt64? {
+        lock.lock()
+        capturedURL = url
+        lock.unlock()
+        return availableBytes
+    }
+
+    func queriedURL() -> URL? {
+        lock.lock()
+        defer { lock.unlock() }
+        return capturedURL
+    }
 }
 
 private actor BlockingInProcessModelDownloader: InProcessModelDownloading {
@@ -238,6 +425,14 @@ private actor BlockingInProcessModelDownloader: InProcessModelDownloading {
 
     func hasDefaultModelArtifacts() async -> Bool {
         downloadStarted
+    }
+
+    func defaultModelCacheSizeBytes() async -> UInt64 {
+        downloadStarted ? 1 : 0
+    }
+
+    func remainingDefaultModelDownloadBytes() async throws -> UInt64 {
+        0
     }
 
     func verifyDefaultModel() async throws -> URL {
@@ -267,10 +462,22 @@ private actor FakeInProcessModelDownloader: InProcessModelDownloading {
     private var downloadCalls = 0
     private var verifyCalls = 0
     private var deleteCalls = 0
+    private var remainingDownloadBytes: UInt64
+    private var cacheSizeBytes: UInt64
+    private var downloadError: Error?
 
-    init(isDownloaded: Bool = false, hasArtifacts: Bool? = nil) {
+    init(
+        isDownloaded: Bool = false,
+        hasArtifacts: Bool? = nil,
+        remainingDownloadBytes: UInt64 = 0,
+        cacheSizeBytes: UInt64 = 0,
+        downloadError: Error? = nil
+    ) {
         self.isDownloaded = isDownloaded
         self.hasArtifacts = hasArtifacts ?? isDownloaded
+        self.remainingDownloadBytes = remainingDownloadBytes
+        self.cacheSizeBytes = cacheSizeBytes
+        self.downloadError = downloadError
     }
 
     nonisolated func defaultModelDirectory() -> URL {
@@ -286,6 +493,14 @@ private actor FakeInProcessModelDownloader: InProcessModelDownloading {
         hasArtifacts
     }
 
+    func defaultModelCacheSizeBytes() async -> UInt64 {
+        cacheSizeBytes
+    }
+
+    func remainingDefaultModelDownloadBytes() async throws -> UInt64 {
+        remainingDownloadBytes
+    }
+
     func verifyDefaultModel() async throws -> URL {
         verifyCalls += 1
         isDownloaded = true
@@ -296,8 +511,13 @@ private actor FakeInProcessModelDownloader: InProcessModelDownloading {
         progress: @escaping InProcessModelDownloadProgressHandler
     ) async throws -> URL {
         downloadCalls += 1
+        if let downloadError {
+            throw downloadError
+        }
         isDownloaded = true
         hasArtifacts = true
+        remainingDownloadBytes = 0
+        cacheSizeBytes = max(cacheSizeBytes, 1)
         await progress(
             InProcessModelDownloadProgress(
                 completedBytes: 1,
@@ -313,6 +533,7 @@ private actor FakeInProcessModelDownloader: InProcessModelDownloading {
         deleteCalls += 1
         isDownloaded = false
         hasArtifacts = false
+        cacheSizeBytes = 0
     }
 
     func downloadCallCount() -> Int {

--- a/Tests/MacParakeetTests/ViewModels/LLMSettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/LLMSettingsViewModelTests.swift
@@ -66,6 +66,30 @@ final class LLMSettingsViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.selectableProviderIDs.contains(.inProcessLocal))
     }
 
+    func testRemovingDownloadedInProcessModelClearsSelectedProviderDraft() async {
+        defaults.set(true, forKey: AppFeatures.inProcessLocalLLMDeveloperDefaultsKey)
+        mockClient.supportsInProcessLocalLLM = true
+        mockConfigStore.config = .inProcessLocal()
+        let downloader = SettingsFakeInProcessModelDownloader(isDownloaded: true, cacheSizeBytes: 123)
+        viewModel.configure(
+            configStore: mockConfigStore,
+            llmClient: mockClient,
+            inProcessModelDownloader: downloader,
+            physicalMemoryBytes: 32 * 1024 * 1024 * 1024
+        )
+        await viewModel.inProcessModelManager.refresh()
+
+        XCTAssertEqual(viewModel.selectedProviderID, .inProcessLocal)
+        XCTAssertTrue(viewModel.inProcessModelManager.isModelDownloaded)
+
+        await viewModel.inProcessModelManager.deleteModel()
+
+        XCTAssertNil(mockConfigStore.config)
+        XCTAssertNil(viewModel.selectedProviderID)
+        XCTAssertFalse(viewModel.inProcessModelManager.isModelDownloaded)
+        XCTAssertEqual(viewModel.inProcessModelManager.modelCacheSizeBytes, 0)
+    }
+
     func testDeveloperOverrideShowsUnavailableExplanationWhenRuntimeMissing() {
         defaults.set(true, forKey: AppFeatures.inProcessLocalLLMDeveloperDefaultsKey)
         mockClient.supportsInProcessLocalLLM = false
@@ -1782,5 +1806,53 @@ final class LLMSettingsViewModelTests: XCTestCase {
         let saved = mockConfigStore.config
         XCTAssertEqual(saved?.id, .openaiCompatible)
         XCTAssertEqual(saved?.isLocal, true)
+    }
+}
+
+private actor SettingsFakeInProcessModelDownloader: InProcessModelDownloading {
+    private var isDownloaded: Bool
+    private var cacheSizeBytes: UInt64
+
+    init(isDownloaded: Bool, cacheSizeBytes: UInt64) {
+        self.isDownloaded = isDownloaded
+        self.cacheSizeBytes = cacheSizeBytes
+    }
+
+    nonisolated func defaultModelDirectory() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("SettingsFakeInProcessModelDownloader", isDirectory: true)
+    }
+
+    func isDefaultModelDownloaded() async -> Bool {
+        isDownloaded
+    }
+
+    func hasDefaultModelArtifacts() async -> Bool {
+        isDownloaded
+    }
+
+    func defaultModelCacheSizeBytes() async -> UInt64 {
+        cacheSizeBytes
+    }
+
+    func remainingDefaultModelDownloadBytes() async throws -> UInt64 {
+        isDownloaded ? 0 : InProcessLocalModelCatalog.defaultManifest.totalBytes
+    }
+
+    func verifyDefaultModel() async throws -> URL {
+        defaultModelDirectory()
+    }
+
+    func downloadDefaultModel(
+        progress: @escaping InProcessModelDownloadProgressHandler
+    ) async throws -> URL {
+        isDownloaded = true
+        cacheSizeBytes = InProcessLocalModelCatalog.defaultManifest.totalBytes
+        return defaultModelDirectory()
+    }
+
+    func deleteDefaultModel() async throws {
+        isDownloaded = false
+        cacheSizeBytes = 0
     }
 }


### PR DESCRIPTION
## What

Implements findings 5 and 8 of the MLX local LLM integration audit (2026-07-05), stacked on #749. Completes the setup lifecycle for the dev-gated Local MLX path.

- **Disk-space preflight (finding 5):** before any network I/O, setup checks available capacity (via `volumeAvailableCapacityForImportantUsage`, injectable for tests) against remaining download bytes — accounting for resumable partials — plus a 500MB margin. Insufficient space fails immediately with required-vs-available in human-readable units.
- **Remove downloaded model (finding 8):** first-class "Remove downloaded model" action in the Settings card, shown with the on-disk size of the managed cache. Confirm-before-delete; unloads the runtime under the generation lease so removal cannot race an in-flight generation; clears `.inProcessLocal` provider selection safely.
  - Path safety: deletion targets exactly `cacheRoot/<sanitized-model-id>` — `assertManagedModelDirectory` requires the final component to equal the sanitized manifest model ID and the parent to equal the cache root; the only filesystem delete is a single `removeItem` on that directory. Tests cover sibling preservation and symlink non-traversal.
- **Recovery copy:** download/preflight/smoke failures now state what happened and what to do, with a plain retry path. No card redesign; broader UX polish stays gated per the audit (finding 4).

Untouched by design: chunking/context policy, `LLMService.swift`, public UX language.

## Spec alignment

Governing doc: `docs/audits/2026-07-05-mlx-local-llm-integration-review.md`, findings 5 and 8, implemented as recommended. Companion PRs: #749 (dogfood gate, base of this stack), #746 (docs/licensing).

## Verification

- `swift test --filter InProcessModelDownloaderTests` — 17 passed
- `swift test --filter InProcessModelManagerViewModelTests` — 15 passed
- `swift test --filter LLMSettingsViewModelTests` — 128 passed
- `scripts/dev/format.sh` + `git diff --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Complete the local LLM setup lifecycle with a space-aware preflight, safe model removal, and clear recovery with a retry path. This prevents wasted downloads, avoids runtime/delete races (including queued generations), and lets users reclaim disk space.

- **New Features**
  - Disk-space preflight before any download: checks remaining bytes (accounts for partials) plus a 500 MB margin against the cache volume; fails early with required vs available in readable units.
  - Settings: confirmed “Remove downloaded model (size)” with copy showing freed space and model name; separate “Delete partial download”; clears `.inProcessLocal` selection after removal.
  - Safe removal: runs deletion inside a new `withInProcessLocalModelRemoval` client gate that waits for generations, unloads the runtime, then deletes; queued generations now fail with a clear removed-model error.
  - Path safety and size: delete only the sanitized managed directory under the cache root; compute cache size without following symlinks; preserve siblings.
  - Recovery copy: clearer, phase-aware failure reasons (download/verify/save) and a “Retry setup” primary action when recoverable.

- **Bug Fixes**
  - Fixed a race where requests queued during model removal could resume after deletion; they now complete immediately with a deterministic “model removed” error.

<sup>Written for commit 7fe0650675556ddac371d825b7f1019bd3b797e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/750?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safer in-app removal flow for local AI models, including confirmation prompts and clearer removal details.
  * Added disk-space checks before enabling local AI, with human-readable cache size and download size info.
  * Improved status handling so recovery actions are shown when the local model hits a recoverable failure.

* **Bug Fixes**
  * Prevented model removal from interrupting active or queued AI generation.
  * Improved download size tracking and cleanup behavior for partially downloaded or cached models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->