### PR TITLE
chore(core): scope FluidAudio model caches under MACPARAKEET_DEBUG_APP_STATE_DIR

### DIFF
--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -130,6 +130,12 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
 
 ### Changed
 
+- In DEBUG builds with `MACPARAKEET_DEBUG_APP_STATE_DIR` set, FluidAudio
+  speech/speaker models now resolve under that throwaway state root, and
+  `models clear` removes only that root instead of FluidAudio's global cache.
+  Destructive model commands (`models delete`, `models clear`) therefore no
+  longer touch the real user cache during scoped test runs. Release builds and
+  runs without the override are unchanged.
 - Meeting artifact audio filenames are now role-explicit: `microphone.m4a` →
   `microphone-raw.m4a`, `system.m4a` → `system-raw.m4a`, and `meeting.m4a` →
   `meeting-playback.m4a`. Paths surfaced through `MeetingArtifactSnapshot` and

--- a/Sources/MacParakeetCore/STT/CohereTranscribeEngine.swift
+++ b/Sources/MacParakeetCore/STT/CohereTranscribeEngine.swift
@@ -755,18 +755,7 @@ public actor CohereTranscribeEngine: STTTranscribing {
     /// `<Application Support>/FluidAudio/Models` — the base FluidAudio's
     /// download/load resolves against, shared with the Parakeet/Nemotron engines.
     nonisolated static func modelsBaseDirectory() -> URL {
-        let appSupport =
-            FileManager.default.urls(
-                for: .applicationSupportDirectory,
-                in: .userDomainMask
-            ).first
-            ?? FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent("Library", isDirectory: true)
-            .appendingPathComponent("Application Support", isDirectory: true)
-        return
-            appSupport
-            .appendingPathComponent("FluidAudio", isDirectory: true)
-            .appendingPathComponent("Models", isDirectory: true)
+        AppPaths.fluidAudioModelsDirURL
     }
 
     /// `…/Models/cohere-transcribe/q8` — `DownloadUtils.downloadRepo` strips the

--- a/Sources/MacParakeetCore/STT/CustomVocabularyBoosting.swift
+++ b/Sources/MacParakeetCore/STT/CustomVocabularyBoosting.swift
@@ -417,9 +417,9 @@ public actor FluidAudioCustomVocabularyRescorer: CustomVocabularyRescoring {
 
     private static func loadCtcResources() async throws -> CtcResources {
         try Task.checkCancellation()
-        let models = try await CtcModels.downloadAndLoad(variant: .ctc110m)
+        let modelDirectory = AppPaths.fluidAudioModelDirectory(for: CtcModelVariant.ctc110m.repo)
+        let models = try await CtcModels.downloadAndLoad(to: modelDirectory, variant: .ctc110m)
         try Task.checkCancellation()
-        let modelDirectory = CtcModels.defaultCacheDirectory(for: models.variant)
         let tokenizer = try await CtcTokenizer.load(from: modelDirectory)
         try Task.checkCancellation()
         let resources = CtcResources(

--- a/Sources/MacParakeetCore/STT/NemotronEngine.swift
+++ b/Sources/MacParakeetCore/STT/NemotronEngine.swift
@@ -215,16 +215,7 @@ public actor NemotronEngine: STTTranscribing, NativeLiveDictating {
     }
 
     public nonisolated static func defaultCacheRoot() -> URL {
-        let appSupport = FileManager.default.urls(
-            for: .applicationSupportDirectory,
-            in: .userDomainMask
-        ).first ?? FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent("Library", isDirectory: true)
-            .appendingPathComponent("Application Support", isDirectory: true)
-        return appSupport
-            .appendingPathComponent("FluidAudio", isDirectory: true)
-            .appendingPathComponent("Models", isDirectory: true)
-            .appendingPathComponent(Repo.nemotronMultilingual.folderName, isDirectory: true)
+        AppPaths.fluidAudioModelDirectory(for: .nemotronMultilingual)
     }
 
     public nonisolated static func defaultVariantDirectory(
@@ -354,6 +345,7 @@ public actor NemotronEngine: STTTranscribing, NativeLiveDictating {
         return try await StreamingNemotronMultilingualAsrManager.downloadVariant(
             languageCode: SpeechEnginePreference.normalizeNemotronLanguage(language) ?? "auto",
             chunkMs: modelVariant.chunkMilliseconds,
+            to: AppPaths.fluidAudioModelsDirURL,
             progressHandler: progressHandler
         )
     }
@@ -369,6 +361,7 @@ public actor NemotronEngine: STTTranscribing, NativeLiveDictating {
         let shared = try await StreamingNemotronMultilingualAsrManager.downloadAndPreloadShared(
             languageCode: languageCode,
             chunkMs: modelVariant.chunkMilliseconds,
+            to: AppPaths.fluidAudioModelsDirURL,
             progressHandler: progressHandler
         )
 

--- a/Sources/MacParakeetCore/STT/NemotronEnglishEngine.swift
+++ b/Sources/MacParakeetCore/STT/NemotronEnglishEngine.swift
@@ -240,15 +240,7 @@ public actor NemotronEnglishEngine: STTTranscribing, NativeLiveDictating {
     /// `<Application Support>/FluidAudio/Models` — the base FluidAudio's
     /// `loadModels(to:)` resolves when no directory is passed.
     nonisolated static func modelsBaseDirectory() -> URL {
-        let appSupport = FileManager.default.urls(
-            for: .applicationSupportDirectory,
-            in: .userDomainMask
-        ).first ?? FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent("Library", isDirectory: true)
-            .appendingPathComponent("Application Support", isDirectory: true)
-        return appSupport
-            .appendingPathComponent("FluidAudio", isDirectory: true)
-            .appendingPathComponent("Models", isDirectory: true)
+        AppPaths.fluidAudioModelsDirURL
     }
 
     /// The 1120 ms tier directory (`…/Models/nemotron-streaming/1120ms`).
@@ -336,12 +328,12 @@ public actor NemotronEnglishEngine: STTTranscribing, NativeLiveDictating {
         let loadedInteractiveManager = StreamingNemotronAsrManager(requestedChunkSize: .ms1120)
         let loadedBackgroundManager = StreamingNemotronAsrManager(requestedChunkSize: .ms1120)
         try await loadedInteractiveManager.loadModels(
-            to: nil,
+            to: Self.modelsBaseDirectory(),
             configuration: nil,
             progressHandler: progressHandler
         )
         try await loadedBackgroundManager.loadModels(
-            to: nil,
+            to: Self.modelsBaseDirectory(),
             configuration: nil,
             progressHandler: progressHandler
         )

--- a/Sources/MacParakeetCore/STT/ParakeetUnifiedEngine.swift
+++ b/Sources/MacParakeetCore/STT/ParakeetUnifiedEngine.swift
@@ -229,15 +229,7 @@ public actor ParakeetUnifiedEngine: STTTranscribing, NativeLiveDictating {
     /// `<Application Support>/FluidAudio/Models` — the base FluidAudio's
     /// `loadModels(to:)` resolves when no directory is passed.
     nonisolated static func modelsBaseDirectory() -> URL {
-        let appSupport = FileManager.default.urls(
-            for: .applicationSupportDirectory,
-            in: .userDomainMask
-        ).first ?? FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent("Library", isDirectory: true)
-            .appendingPathComponent("Application Support", isDirectory: true)
-        return appSupport
-            .appendingPathComponent("FluidAudio", isDirectory: true)
-            .appendingPathComponent("Models", isDirectory: true)
+        AppPaths.fluidAudioModelsDirURL
     }
 
     /// `.../Models/parakeet-unified-en-0.6b` - keyed off FluidAudio's own
@@ -345,13 +337,13 @@ public actor ParakeetUnifiedEngine: STTTranscribing, NativeLiveDictating {
         let loadedBackgroundManager = StreamingUnifiedAsrManager(encoderPrecision: Self.encoderPrecision)
         do {
             try await loadedInteractiveManager.loadModels(
-                to: nil,
+                to: Self.modelsBaseDirectory(),
                 configuration: nil,
                 progressHandler: progressHandler
             )
             try Task.checkCancellation()
             try await loadedBackgroundManager.loadModels(
-                to: nil,
+                to: Self.modelsBaseDirectory(),
                 configuration: nil,
                 progressHandler: progressHandler
             )

--- a/Sources/MacParakeetCore/STT/STTRuntime.swift
+++ b/Sources/MacParakeetCore/STT/STTRuntime.swift
@@ -1396,7 +1396,7 @@ public actor STTRuntime: STTRuntimeProtocol {
         let activeSpeechEngine = speechEngine
         let engineVariant = telemetryEngineVariant(for: activeSpeechEngine)
         await shutdown()
-        DownloadUtils.clearAllModelCaches()
+        Self.clearFluidAudioModelCaches()
         try? FileManager.default.removeItem(atPath: AppPaths.whisperModelsDir)
         _ = Self.removeNemotronModelFiles(at: NemotronEngine.defaultCacheRoot())
         // The English build caches under its own family root
@@ -1423,6 +1423,16 @@ public actor STTRuntime: STTRuntimeProtocol {
             durationSeconds: Observability.durationSeconds(since: operationContext.startedAt),
             errorType: nil
         ))
+    }
+
+    nonisolated static func clearFluidAudioModelCaches(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) {
+        if AppPaths.hasDebugAppStateDirOverride(environment: environment) {
+            try? FileManager.default.removeItem(at: AppPaths.resolvedFluidAudioModelsDir(environment: environment))
+            return
+        }
+        DownloadUtils.clearAllModelCaches()
     }
 
     public func setSpeechEngine(_ preference: SpeechEnginePreference) async throws {
@@ -1747,7 +1757,11 @@ public actor STTRuntime: STTRuntimeProtocol {
         onProgress: (@Sendable (String) -> Void)? = nil
     ) async throws {
         let progressHandler = makeDownloadProgressHandler(onProgress)
-        _ = try await AsrModels.download(version: version, progressHandler: progressHandler)
+        _ = try await AsrModels.download(
+            to: AppPaths.fluidAudioModelDirectory(forASRVersion: version),
+            version: version,
+            progressHandler: progressHandler
+        )
     }
 
     public func currentSpeechEngineSelection() async -> SpeechEngineSelection {
@@ -1762,7 +1776,7 @@ public actor STTRuntime: STTRuntimeProtocol {
     }
 
     public nonisolated static func isModelCached(version: AsrModelVersion = .v3) -> Bool {
-        let cacheDir = AsrModels.defaultCacheDirectory(for: version)
+        let cacheDir = AppPaths.fluidAudioModelDirectory(forASRVersion: version)
         return AsrModels.modelsExist(at: cacheDir, version: version)
     }
 
@@ -1789,7 +1803,9 @@ public actor STTRuntime: STTRuntimeProtocol {
     @discardableResult
     public nonisolated static func deleteParakeetModel(version: AsrModelVersion) -> Bool {
         let operationContext = Observability.childOperationContext()
-        let removed = removeParakeetModelFiles(at: AsrModels.defaultCacheDirectory(for: version))
+        let removed = removeParakeetModelFiles(
+            at: AppPaths.fluidAudioModelDirectory(forASRVersion: version)
+        )
         Telemetry.send(.modelOperation(
             operationID: operationContext.operationID,
             operationContext: operationContext,
@@ -2159,6 +2175,7 @@ public actor STTRuntime: STTRuntimeProtocol {
             let progressHandler = Self.makeDownloadProgressHandler(warmUpProgressHandler)
 
             let downloadedModels = try await AsrModels.downloadAndLoad(
+                to: AppPaths.fluidAudioModelDirectory(forASRVersion: version),
                 version: version,
                 progressHandler: progressHandler
             )

--- a/Sources/MacParakeetCore/Services/AppPaths.swift
+++ b/Sources/MacParakeetCore/Services/AppPaths.swift
@@ -1,3 +1,4 @@
+import FluidAudio
 import Foundation
 
 /// Centralized path management for MacParakeet runtime files.
@@ -117,6 +118,83 @@ public enum AppPaths {
     /// Verified opt-in local LLM model cache.
     public static var llmModelsDir: String {
         "\(appSupportDir)/LLMModels"
+    }
+
+    /// FluidAudio model cache base.
+    ///
+    /// Production intentionally delegates to FluidAudio's own default resolver.
+    /// Debug/test runs with `MACPARAKEET_DEBUG_APP_STATE_DIR` keep FluidAudio
+    /// models inside the same throwaway state root as the rest of MacParakeet.
+    public static var fluidAudioModelsDir: String {
+        fluidAudioModelsDirURL.path
+    }
+
+    public static var fluidAudioModelsDirURL: URL {
+        resolvedFluidAudioModelsDir(environment: ProcessInfo.processInfo.environment)
+    }
+
+    static var hasDebugAppStateDirOverride: Bool {
+        hasDebugAppStateDirOverride(environment: ProcessInfo.processInfo.environment)
+    }
+
+    static func hasDebugAppStateDirOverride(environment: [String: String]) -> Bool {
+        #if DEBUG
+        debugAppStateDir(environment: environment) != nil
+        #else
+        false
+        #endif
+    }
+
+    static var fluidAudioBaseDirURL: URL {
+        fluidAudioModelsDirURL.deletingLastPathComponent()
+    }
+
+    static func fluidAudioModelDirectory(for repo: Repo) -> URL {
+        fluidAudioModelsDirURL.appendingPathComponent(repo.folderName, isDirectory: true)
+    }
+
+    static func fluidAudioModelDirectory(forASRVersion version: AsrModelVersion) -> URL {
+        fluidAudioModelDirectory(for: fluidAudioRepo(forASRVersion: version))
+    }
+
+    static func resolvedFluidAudioModelsDir(environment: [String: String]) -> URL {
+        #if DEBUG
+        if let override = debugAppStateDir(environment: environment) {
+            return URL(fileURLWithPath: override, isDirectory: true)
+                .appendingPathComponent("FluidAudio", isDirectory: true)
+                .appendingPathComponent("Models", isDirectory: true)
+                .standardizedFileURL
+        }
+        #endif
+        return MLModelConfigurationUtils.defaultModelsDirectory()
+    }
+
+    static func resolvedFluidAudioModelDirectory(for repo: Repo, environment: [String: String]) -> URL {
+        resolvedFluidAudioModelsDir(environment: environment)
+            .appendingPathComponent(repo.folderName, isDirectory: true)
+    }
+
+    static func resolvedFluidAudioModelDirectory(
+        forASRVersion version: AsrModelVersion,
+        environment: [String: String]
+    ) -> URL {
+        resolvedFluidAudioModelDirectory(
+            for: fluidAudioRepo(forASRVersion: version),
+            environment: environment
+        )
+    }
+
+    private static func fluidAudioRepo(forASRVersion version: AsrModelVersion) -> Repo {
+        switch version {
+        case .v2:
+            return .parakeetV2
+        case .v3:
+            return .parakeetV3
+        case .tdtCtc110m:
+            return .parakeetTdtCtc110m
+        case .tdtJa:
+            return .parakeetJa
+        }
     }
 
     /// WhisperKit CoreML model cache base.

--- a/Sources/MacParakeetCore/Services/Diarization/DiarizationService.swift
+++ b/Sources/MacParakeetCore/Services/Diarization/DiarizationService.swift
@@ -76,7 +76,7 @@ public actor DiarizationService: DiarizationServiceProtocol {
     ) {
         self.init(
             manager: OfflineDiarizerManager(config: config),
-            modelsDirectory: modelsDirectory ?? OfflineDiarizerModels.defaultModelsDirectory()
+            modelsDirectory: modelsDirectory ?? AppPaths.fluidAudioModelsDirURL
         )
     }
 
@@ -191,7 +191,7 @@ public actor DiarizationService: DiarizationServiceProtocol {
     }
 
     nonisolated static func modelCacheDirectory(directory: URL? = nil) -> URL {
-        let baseDirectory = (directory ?? OfflineDiarizerModels.defaultModelsDirectory()).standardizedFileURL
+        let baseDirectory = (directory ?? AppPaths.fluidAudioModelsDirURL).standardizedFileURL
         return baseDirectory.appendingPathComponent(Repo.diarizer.folderName, isDirectory: true)
     }
 

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingVADService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingVADService.swift
@@ -92,7 +92,10 @@ actor MeetingVADService: MeetingVoiceActivityDetecting {
             return nil
         }
         do {
-            let manager = try await VadManager(config: VadConfig(computeUnits: computeUnits))
+            let manager = try await VadManager(
+                config: VadConfig(computeUnits: computeUnits),
+                modelDirectory: AppPaths.fluidAudioBaseDirURL
+            )
             guard await manager.isAvailable else {
                 logger.error("meeting_vad_init_unavailable — model loaded but not available")
                 return nil
@@ -107,7 +110,7 @@ actor MeetingVADService: MeetingVoiceActivityDetecting {
     /// `true` when every required Silero VAD model file already exists in the
     /// shared FluidAudio model cache.
     static func isModelCached() -> Bool {
-        let directory = MLModelConfigurationUtils.defaultModelsDirectory(for: .vad)
+        let directory = AppPaths.fluidAudioModelDirectory(for: .vad)
         return ModelNames.VAD.requiredModels.allSatisfy { modelName in
             FileManager.default.fileExists(
                 atPath: directory.appendingPathComponent(modelName, isDirectory: false).path
@@ -122,7 +125,10 @@ actor MeetingVADService: MeetingVoiceActivityDetecting {
     /// on download/compile failure. FluidAudio's `VadManager` init handles the
     /// cached-or-download decision internally.
     static func downloadModel(computeUnits: MLComputeUnits = .cpuOnly) async throws {
-        _ = try await VadManager(config: VadConfig(computeUnits: computeUnits))
+        _ = try await VadManager(
+            config: VadConfig(computeUnits: computeUnits),
+            modelDirectory: AppPaths.fluidAudioBaseDirURL
+        )
     }
 
     func makeStreamState() async -> MeetingVADStreamState {

--- a/Tests/MacParakeetTests/STT/ModelDeletionTests.swift
+++ b/Tests/MacParakeetTests/STT/ModelDeletionTests.swift
@@ -18,6 +18,23 @@ final class ModelDeletionTests: XCTestCase {
         if let tempRoot { try? FileManager.default.removeItem(at: tempRoot) }
     }
 
+    #if DEBUG
+    func testClearFluidAudioModelCachesUsesDebugScopedModelsRoot() throws {
+        let environment = [AppPaths.debugAppStateDirEnvironmentKey: tempRoot.path]
+        let modelsRoot = AppPaths.resolvedFluidAudioModelsDir(environment: environment)
+        try FileManager.default.createDirectory(at: modelsRoot, withIntermediateDirectories: true)
+        try "model".write(
+            to: modelsRoot.appendingPathComponent("sentinel.mlmodelc", isDirectory: false),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        STTRuntime.clearFluidAudioModelCaches(environment: environment)
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: modelsRoot.path))
+    }
+    #endif
+
     // MARK: - Parakeet build file removal
 
     func testRemoveParakeetModelFilesDeletesPopulatedDirectory() throws {

--- a/Tests/MacParakeetTests/Services/AppPathsTests.swift
+++ b/Tests/MacParakeetTests/Services/AppPathsTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import FluidAudio
 @testable import MacParakeetCore
 
 final class AppPathsTests: XCTestCase {
@@ -37,6 +38,13 @@ final class AppPathsTests: XCTestCase {
         XCTAssertTrue(AppPaths.defaultMeetingRecordingsDir.hasSuffix("meeting-recordings"))
     }
 
+    func testFluidAudioModelsDirUsesFluidAudioDefaultWithoutDebugOverride() {
+        XCTAssertEqual(
+            AppPaths.resolvedFluidAudioModelsDir(environment: [:]),
+            MLModelConfigurationUtils.defaultModelsDirectory()
+        )
+    }
+
     func testMeetingRecordingsDirCanBeConfiguredFromDefaults() {
         let suiteName = "macparakeet.test.paths.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!
@@ -63,6 +71,26 @@ final class AppPathsTests: XCTestCase {
 
         XCTAssertEqual(AppPaths.resolvedAppSupportDir(environment: environment), root.path)
         XCTAssertEqual(AppPaths.defaultMeetingRecordingsDir(environment: environment), root.appendingPathComponent("meeting-recordings").path)
+    }
+
+    func testDebugAppStateDirScopesFluidAudioModelsInsideThrowawayRoot() {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("macparakeet-debug-state-\(UUID().uuidString)", isDirectory: true)
+            .standardizedFileURL
+        let environment = [AppPaths.debugAppStateDirEnvironmentKey: root.path]
+        let expectedModelsDir = root
+            .appendingPathComponent("FluidAudio", isDirectory: true)
+            .appendingPathComponent("Models", isDirectory: true)
+
+        XCTAssertEqual(AppPaths.resolvedFluidAudioModelsDir(environment: environment), expectedModelsDir)
+        XCTAssertEqual(
+            AppPaths.resolvedFluidAudioModelDirectory(forASRVersion: .v3, environment: environment),
+            expectedModelsDir.appendingPathComponent(Repo.parakeetV3.folderName, isDirectory: true)
+        )
+        XCTAssertEqual(
+            AppPaths.resolvedFluidAudioModelDirectory(for: .vad, environment: environment),
+            expectedModelsDir.appendingPathComponent(Repo.vad.folderName, isDirectory: true)
+        )
     }
 
     func testDebugAppStateDirKeepsMeetingRecordingsInsideThrowawayRoot() {

--- a/docs/cli-testing.md
+++ b/docs/cli-testing.md
@@ -549,6 +549,11 @@ Parakeet build, the Nemotron Beta model, Cohere Transcribe, or the Whisper
 variant - and protects the active model plus Parakeet's configured build unless `--force` is passed;
 `models clear` still wipes everything.
 
+When running DEBUG builds with `MACPARAKEET_DEBUG_APP_STATE_DIR` set, CLI state
+is scoped to that throwaway directory. This includes MacParakeet's app support
+files and FluidAudio's speech/speaker model cache, so destructive model commands
+such as `models delete` and `models clear` do not touch the real user cache.
+
 ## Text Pipeline
 
 ```bash

--- a/spec/09-testing.md
+++ b/spec/09-testing.md
@@ -142,7 +142,7 @@ timing instead of ignoring it.
 - `transforms` saved-prompt CRUD/run JSON envelopes and local history commands
 - `vocab` process/words/snippets command parsing and JSON output
 
-**Tip:** For runtime smoke runs, use a throwaway database path (e.g. `--database /tmp/macparakeet-cli-test.db`) to avoid polluting the real app database. For DEBUG app-level smoke runs, set `MACPARAKEET_DEBUG_APP_STATE_DIR` to an absolute throwaway directory before launching the app so the database, meeting artifacts, AppPaths-managed helper caches, and logs stay away from real user state.
+**Tip:** For runtime smoke runs, use a throwaway database path (e.g. `--database /tmp/macparakeet-cli-test.db`) to avoid polluting the real app database. For DEBUG app-level smoke runs, set `MACPARAKEET_DEBUG_APP_STATE_DIR` to an absolute throwaway directory before launching the app so the database, meeting artifacts, AppPaths-managed helper caches, the FluidAudio speech/speaker model cache, and logs stay away from real user state — including destructive `models delete`/`models clear` runs.
 
 ### LLM Metadata + Transforms Tests
 


### PR DESCRIPTION
## What Changed

- `AppPaths` now owns FluidAudio model cache resolution: in DEBUG builds with `MACPARAKEET_DEBUG_APP_STATE_DIR` set, FluidAudio speech/speaker/VAD models resolve under `<override>/FluidAudio/Models` instead of FluidAudio's global cache; release builds and runs without the override still delegate to FluidAudio's default resolver.
- STT engines (Parakeet, Nemotron, Cohere), diarization, meeting VAD, and vocabulary boosting were switched from hardcoded FluidAudio cache paths to the new `AppPaths` helpers, and `STTRuntime`'s destructive model operations (`models delete`, `models clear`) now remove only the scoped root when the override is active — protecting the real user cache during scoped test runs.
- Added focused tests (`AppPathsTests`, `ModelDeletionTests`) and synced docs: CLI changelog entry, `docs/cli-testing.md`, and a `spec/09-testing.md` refresh describing the debug-scoped cache behavior.

Review pipeline passed with three informational notes (minor dead-code surface in `AppPaths` and a duplicated FluidAudio repo mapping worth watching upstream); tests, lint, and docs checks all passed.

## Risk Assessment

✅ Low: Release-build behavior is provably unchanged (all new paths resolve to the exact same directories FluidAudio's defaults used), the debug-only override is compile-guarded behind #if DEBUG, and both the override and passthrough paths have focused test coverage; the only findings are minor dead code and informational notes.

## Testing

Completed 1 recorded test check.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 3 infos</summary>

- ℹ️ `Sources/MacParakeetCore/Services/AppPaths.swift:128` - AppPaths.fluidAudioModelsDir (the String variant) and the no-argument hasDebugAppStateDirOverride computed property are never referenced outside AppPaths itself; only the URL variant and the environment-parameterized function are used. Small dead-code surface that could be trimmed.
- ℹ️ `Sources/MacParakeetCore/Services/AppPaths.swift:186` - AppPaths.fluidAudioRepo(forASRVersion:) duplicates FluidAudio&#39;s internal AsrModelVersion.repo mapping (it is not public upstream). The exhaustive switch will catch new enum cases at compile time, but if FluidAudio ever changes an existing version&#39;s repo/folderName, this copy would silently point at a different directory than FluidAudio&#39;s own default resolvers. Worth a comment or an upstream PR to expose the mapping.
- ℹ️ `Sources/MacParakeetCore/STT/STTRuntime.swift:1428` - In debug-override mode, clearFluidAudioModelCaches removes only the scoped FluidAudio/Models directory, while production DownloadUtils.clearAllModelCaches() additionally clears FluidAudio TTS caches under the fluidaudio root. MacParakeet does not currently use FluidAudio TTS, so this asymmetry is harmless today, but if TTS is ever adopted the debug clear path will diverge from production.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `swift test`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
