### PR TITLE
Align README benchmarks and CLI positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The [notarized DMG](https://downloads.macparakeet.com/MacParakeet.dmg) is the st
 
 | Channel | Status | Includes |
 |---------|--------|----------|
-| Stable DMG `0.6.24` | Recommended for normal use | Dictation, file/video/media URL and podcast transcription, meeting recording with selectable mic/system capture and audio-retention controls, meeting calendar reminders and opt-in auto-start, Transforms, VAD-guided meeting live-preview chunking, Parakeet v3/v2/Unified model selection, optional Nemotron Beta and WhisperKit, exports, vocabulary, AI features |
+| Stable DMG | Recommended for normal use | Dictation, file/video/media URL and podcast transcription, meeting recording with selectable mic/system capture and audio-retention controls, meeting calendar reminders and opt-in auto-start, Transforms, VAD-guided meeting live-preview chunking, Parakeet v3/v2/Unified model selection, optional Nemotron Beta and WhisperKit, exports, vocabulary, AI features |
 | `main` branch | Development | Latest stable release plus Cohere Transcribe, meeting echo-cancellation/cleaned-mic artifact work for the next release train, recognition-time custom vocabulary boosting, and developer-gated in-process MLX local LLM groundwork that is compiled/tested but hidden from normal users |
 
 Meeting calendar support is live in the stable DMG. MacParakeet reads upcoming meetings from the local macOS Calendar store through EventKit, can show reminders, and can optionally start a recording after a countdown. Auto-start defaults to `.off` and must be opted into; recordings still stop manually.
@@ -85,7 +85,7 @@ Meeting calendar support is live in the stable DMG. MacParakeet reads upcoming m
 ### Limitations
 
 - Apple Silicon only (M1/M2/M3/M4)
-- Parakeet is best for English and supported European languages; the v3 default is not a CJK/Korean engine
+- Parakeet is best for English and its 25 supported European languages (v3 auto-detects among them); the v3 default is not a CJK/Korean engine
 - Nemotron is Beta while real-world quality is benchmarked
 - Nemotron, WhisperKit, and Cohere Transcribe require separate local model downloads before first use
 - Cohere is batch-only: it can be used for dictation after recording stops, file transcription, and meeting finalization, but it does not show live dictation preview or meeting live-preview chunks and does not provide word timestamps/speaker labels

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@
 
 ---
 
-MacParakeet runs NVIDIA's Parakeet TDT on Apple's Neural Engine via [FluidAudio](https://github.com/FluidInference/FluidAudio) CoreML. The current stable release includes system-wide dictation, file/URL transcription, meeting recording with selectable microphone/system capture, meeting calendar support, Parakeet v3/v2/Unified model selection, optional local Nemotron Beta and WhisperKit recognition, and Transforms for selected-text rewrites. All speech recognition happens on your Mac.
+MacParakeet runs NVIDIA's Parakeet TDT on Apple's Neural Engine via [FluidAudio](https://github.com/FluidInference/FluidAudio) CoreML. The current stable release includes system-wide dictation, file/URL transcription, meeting recording with selectable microphone/system capture, meeting calendar support, Parakeet v3/v2/Unified model selection, optional local Nemotron Beta and WhisperKit recognition, and Transforms for selected-text rewrites. Current `main` adds opt-in Cohere Transcribe and other unreleased development work. All speech recognition happens on your Mac.
 
 ## Release status
 
@@ -63,8 +63,8 @@ The [notarized DMG](https://downloads.macparakeet.com/MacParakeet.dmg) is the st
 
 | Channel | Status | Includes |
 |---------|--------|----------|
-| Stable DMG | Recommended for normal use | Dictation, file/video/media URL and podcast transcription, meeting recording with selectable mic/system capture and audio-retention controls, meeting calendar reminders and opt-in auto-start, Transforms, VAD-guided meeting live-preview chunking, Parakeet v3/v2/Unified model selection, optional Nemotron Beta and WhisperKit, exports, vocabulary, AI features |
-| `main` branch | Development | Latest stable release plus untagged in-progress fixes, Cohere Transcribe, and development changes |
+| Stable DMG `0.6.24` | Recommended for normal use | Dictation, file/video/media URL and podcast transcription, meeting recording with selectable mic/system capture and audio-retention controls, meeting calendar reminders and opt-in auto-start, Transforms, VAD-guided meeting live-preview chunking, Parakeet v3/v2/Unified model selection, optional Nemotron Beta and WhisperKit, exports, vocabulary, AI features |
+| `main` branch | Development | Latest stable release plus Cohere Transcribe, meeting echo-cancellation/cleaned-mic artifact work for the next release train, recognition-time custom vocabulary boosting, and developer-gated in-process MLX local LLM groundwork that is compiled/tested but hidden from normal users |
 
 Meeting calendar support is live in the stable DMG. MacParakeet reads upcoming meetings from the local macOS Calendar store through EventKit, can show reminders, and can optionally start a recording after a countdown. Auto-start defaults to `.off` and must be opted into; recordings still stop manually.
 
@@ -82,23 +82,49 @@ Meeting calendar support is live in the stable DMG. MacParakeet reads upcoming m
 
 **AI features** — Optional summaries, chat, AI formatter, and Transforms for rewriting selected text through your configured provider. Connect any cloud provider (OpenAI, Anthropic, Gemini, OpenRouter), local runtime (Ollama, LM Studio), OpenAI-compatible endpoint, or CLI tool (Claude Code, Codex). Entirely opt-in.
 
-### Performance
-
-- ~155x realtime — 60 min of audio in ~23 seconds
-- ~2.5% word error rate with the default Parakeet TDT 0.6B-v3 model
-- Optional English-only Parakeet v2 model (~2.1% WER) for users who do not want v3 language auto-detect
-- Optional English-only Parakeet Unified model with punctuation/capitalization and word timestamps
-- ~66 MB working memory per active Parakeet inference slot
-- 25 European languages with Parakeet auto-detection
-- Optional local Nemotron Beta engine for fast multilingual ASR (a smaller English-only build is also available), WhisperKit for broad language coverage, and Cohere Transcribe for opt-in batch accuracy work
-
 ### Limitations
 
 - Apple Silicon only (M1/M2/M3/M4)
-- Parakeet is best for English and supported European languages
+- Parakeet is best for English and supported European languages; the v3 default is not a CJK/Korean engine
 - Nemotron is Beta while real-world quality is benchmarked
 - Nemotron, WhisperKit, and Cohere Transcribe require separate local model downloads before first use
 - Cohere is batch-only: it can be used for dictation after recording stops, file transcription, and meeting finalization, but it does not show live dictation preview or meeting live-preview chunks and does not provide word timestamps/speaker labels
+
+## ASR benchmarks
+
+The current ASR benchmark lives in [`benchmarks/asr/`](benchmarks/asr/). It scores every engine through the same normalizer, uses full LibriSpeech `test-clean` + `test-other` for English, uses capped FLEURS slices for multilingual coverage, and reports hardware-specific speed/memory on an Apple M4 Pro with 48 GB RAM on macOS 15. Run `benchmarks/asr/run_all.sh verify` to re-score the committed hypotheses and validate the benchmark contract.
+
+English accuracy, full LibriSpeech sets:
+
+| Engine | Runtime | Macro WER | `test-clean` WER | `test-other` WER |
+|--------|---------|----------:|-----------------:|-----------------:|
+| Cohere Transcribe q8 | FluidAudio CoreML | **2.07%** | 1.49% | **2.65%** |
+| Parakeet Unified | FluidAudio CoreML | 2.38% | 1.64% | 3.13% |
+| Parakeet v2 | FluidAudio CoreML | 2.57% | 1.86% | 3.27% |
+| Whisper large-v3 turbo | WhisperKit | 3.00% | 1.96% | 4.04% |
+| Parakeet v3 default | FluidAudio CoreML | 3.22% | 2.31% | 4.14% |
+| Nemotron English Beta | FluidAudio CoreML | 3.70% | 2.40% | 5.01% |
+| Nemotron Multilingual Beta | FluidAudio CoreML | 5.17% | 3.17% | 7.16% |
+
+Multilingual coverage, FLEURS first 150 utterances per language. English is WER; Korean, Japanese, and Chinese are CER:
+
+| Engine | en | ko | ja | zh | Notes |
+|--------|---:|---:|---:|---:|-------|
+| Cohere Transcribe q8 | 4.69 | 7.15 | **5.56** | 12.49 | Best Japanese; clean English/Korean/Chinese are statistical ties with the best alternative |
+| Whisper large-v3 turbo | 5.71 | **6.37** | 13.42 | **11.56** | Light broad-language fallback |
+| Nemotron Multilingual Beta | 7.08 | 9.32 | 15.29 | 19.47 | Still Beta by quality evidence |
+| Parakeet v3 default | **4.40** | 171.2 | 159.2 | 124.1 | Works for supported European languages; fails CJK/Korean here by romanizing output |
+
+Speed and memory, same Apple M4 Pro micro-benchmark:
+
+| Engine family | Cold start | Steady throughput | Peak RSS |
+|---------------|-----------:|------------------:|---------:|
+| Parakeet v2/v3/Unified | 0.38-0.93 s | ~81-93x realtime | 115-131 MB |
+| Nemotron EN/Multilingual Beta | 0.70-0.87 s | ~57-61x realtime | 141-142 MB |
+| Whisper large-v3 turbo | 2.29 s | ~14x realtime | 274 MB |
+| Cohere Transcribe q8 | ~73 s | ~11x realtime | ~11.6 GB |
+
+Cohere is the most accurate on-device engine in this benchmark, but its statistically clear wins are noisy English and Japanese. Clean English, Korean, and Chinese are ties with the best alternative under the paired-bootstrap test. Parakeet remains the default because it is fast, low-memory, timestamped, and strong on supported languages. Cohere is opt-in for accuracy-critical batch work on 16 GB+ Macs. The committed Cohere speed/memory row is still the older FluidAudio reference measurement; rerun the MacParakeet CLI Cohere path before making release or Settings claims from those numbers.
 
 ## Get it
 
@@ -141,35 +167,53 @@ scripts/dev/run_app.sh    # build, sign, launch
 
 The dev script creates a signed `.app` bundle so macOS grants mic and accessibility permissions. It disables target-level Xcode signing, then signs the finished bundle with the best available local identity. Override with `MACPARAKEET_CODESIGN_IDENTITY="Your Identity"` if needed.
 
-**CLI:**
+## Command line and agent automation
+
+`macparakeet-cli` is the public automation surface for MacParakeet: the canonical Swift-native interface to Parakeet TDT on Apple Silicon, plus the scriptable entry point for MacParakeet's local library, model cache, prompts, meetings, and JSON contracts. Use [`integrations/README.md`](integrations/README.md) for the agent-facing automation guide and [`Sources/CLI/CHANGELOG.md`](Sources/CLI/CHANGELOG.md) for compatibility notes.
+
+Discover the current machine-readable command catalog:
+
+```bash
+macparakeet-cli spec --json
+macparakeet-cli health --json
+```
+
+Transcribe files, folders, media URLs, or podcasts:
 
 ```bash
 macparakeet-cli transcribe /path/to/audio.mp3
 macparakeet-cli transcribe /path/to/audio.mp3 --format transcript --no-history
 macparakeet-cli transcribe lecture1.m4a lecture2.m4a --output-dir Transcripts --format transcript
+macparakeet-cli transcribe --podcast "Lex Fridman episode 400" --format json
+macparakeet-cli transcribe /path/to/meeting.m4a --engine nemotron --language auto --format json
+macparakeet-cli transcribe /path/to/japanese.m4a --engine cohere --language ja --format json
+macparakeet-cli transcribe /path/to/korean.mp3 --engine whisper --language ko --format json
+```
+
+Manage local models and shared app/CLI defaults:
+
+```bash
 macparakeet-cli models download nemotron-multilingual-1120ms
 macparakeet-cli models download cohere-transcribe
 macparakeet-cli models download whisper-large-v3-v20240930-turbo-632MB
 macparakeet-cli models list
 macparakeet-cli models select parakeet-v3
 macparakeet-cli config set parakeet-model v2
-macparakeet-cli transcribe /path/to/meeting.m4a --engine nemotron --language auto --format json
-macparakeet-cli transcribe /path/to/japanese.m4a --engine cohere --language ja --format json
-macparakeet-cli transcribe /path/to/korean.mp3 --engine whisper --language ko --format json
 macparakeet-cli models status
-macparakeet-cli history
 ```
 
-Use `--format transcript` for transcript-only stdout in shell pipelines. Add
-`--no-history` when you want a one-off transcription without saving a completed
-row to MacParakeet history. Multiple inputs or `--output-dir` write one transcript
-file per input. `models list` and `models select` inspect or update the shared
-speech default used by the app and `--engine app-default`; Parakeet rows are
-`parakeet-v3` and `parakeet-v2`, Nemotron rows are `nemotron-multilingual-1120ms`
-and `nemotron-english-1120ms`, Cohere is `cohere-transcribe`, and Whisper rows
-use the configured `whisper-*` model id. The Nemotron, Cohere, and Whisper CLI
-commands above require their local models to be downloaded first. When
-developing from source, prefix the same commands with `swift run`.
+Inspect and update local history, saved meetings, and agent-readable artifacts:
+
+```bash
+macparakeet-cli history transcriptions --json
+macparakeet-cli retranscribe <id-or-prefix-or-title> --update --json
+macparakeet-cli meetings list --json
+macparakeet-cli meetings show <meeting-id> --json
+macparakeet-cli meetings artifact <meeting-id> --json
+macparakeet-cli meetings export <meeting-id> --stdout --format json
+```
+
+Use `--format transcript` for transcript-only stdout in shell pipelines. Add `--no-history` when you want a one-off transcription without saving a completed row to MacParakeet history. Multiple inputs or `--output-dir` write one transcript file per input. `models list` and `models select` inspect or update the shared speech default used by the app and `--engine app-default`; Parakeet rows are `parakeet-v3`, `parakeet-v2`, and `parakeet-unified`, Nemotron rows are `nemotron-multilingual-1120ms` and `nemotron-english-1120ms`, Cohere is `cohere-transcribe`, and Whisper rows use the configured `whisper-*` model id. The Nemotron, Cohere, and Whisper CLI commands above require their local models to be downloaded first. When developing from source, prefix the same commands with `swift run`.
 
 ## Tech stack
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Speed and memory, same Apple M4 Pro micro-benchmark:
 | Whisper large-v3 turbo | 2.29 s | ~14x realtime | 274 MB |
 | Cohere Transcribe q8 | ~73 s | ~11x realtime | ~11.6 GB |
 
-Cohere is the most accurate on-device engine in this benchmark, but its statistically clear wins are noisy English and Japanese. Clean English, Korean, and Chinese are ties with the best alternative under the paired-bootstrap test. Parakeet remains the default because it is fast, low-memory, timestamped, and strong on supported languages. Cohere is opt-in for accuracy-critical batch work on 16 GB+ Macs. The committed Cohere speed/memory row is still the older FluidAudio reference measurement; rerun the MacParakeet CLI Cohere path before making release or Settings claims from those numbers.
+Cohere is the most accurate on-device engine in this benchmark, but its statistically clear wins are noisy English and Japanese. Clean English, Korean, and Chinese are ties with the best alternative under the paired-bootstrap test. Parakeet remains the default because it is fast, low-memory, timestamped, and strong on supported languages. Cohere is opt-in for accuracy-critical batch work on 16 GB+ Macs. The Cohere speed/memory row is a reference measurement; see [`benchmarks/asr/`](benchmarks/asr/) for method notes.
 
 ## Get it
 

--- a/spec/06-stt-engine.md
+++ b/spec/06-stt-engine.md
@@ -14,9 +14,9 @@ MacParakeet's default speech engine family is Parakeet TDT 0.6B via FluidAudio C
 |----------|-------|
 | Model | Parakeet TDT 0.6B (`v3` default, `v2` opt-in) |
 | Runtime | FluidAudio SDK (CoreML on ANE) |
-| Word Error Rate | ~2.5% (v3 multilingual) / ~2.1% (v2 English-only) |
-| Speed | ~155x realtime on Apple Silicon |
-| Peak working RAM | ~66 MB per active Parakeet inference slot (~130 MB with custom vocabulary boosting) |
+| Benchmark accuracy | Full-LibriSpeech macro WER: 3.22% (v3 multilingual), 2.57% (v2 English-only), 2.38% (Unified). FLEURS directional pass: v3 is strong on English but fails CJK/Korean by romanizing output. |
+| Speed | Apple M4 Pro speed/memory micro-bench: ~81x realtime (v3), ~90x (v2), ~93x (Unified) steady RTFx |
+| Peak working RAM | Apple M4 Pro speed/memory micro-bench: 131 MB (v3), 123 MB (v2), 115 MB (Unified) peak RSS, before recognition-time custom vocabulary boosting |
 | Model download | ~465 MB CoreML bundle per build (one-time; v2 and v3 cache independently) |
 | Output | Word-level timestamps with per-word confidence scores |
 | Input format | 16kHz mono Float32 samples (FluidAudio's AudioConverter handles resampling) |
@@ -192,9 +192,11 @@ Runtime behavior:
 - Vocabulary contents are user data. MacParakeet does not log or emit telemetry
   with the term strings.
 
-When active, peak working RAM is approximately the Parakeet TDT slot plus the
-CTC sidecar (~130 MB total). The intended term count remains small user
-vocabularies rather than full dictionaries.
+When active, peak working RAM is the Parakeet TDT slot plus the CTC sidecar. The
+published speed/memory benchmark currently measures the non-boosted Parakeet
+paths at 115-131 MB peak RSS on an M4 Pro; rerun a representative boosted-vocab
+case before publishing a boosted-memory number. The intended term count remains
+small user vocabularies rather than full dictionaries.
 
 ### Additional Capabilities (via FluidAudio)
 
@@ -494,7 +496,7 @@ This replaces the previous Python venv bootstrap (~500 MB deps + ~2.5 GB model).
 - CoreML runs in-process (not a separate daemon) — no subprocess crash isolation
 - Wrap transcription calls in error handling
 - On CoreML failure, log the error, report to user, allow retry
-- Memory pressure: CoreML uses ~66 MB working RAM per active Parakeet inference slot, far less likely to trigger OOM than the previous ~2 GB MLX path
+- Memory pressure: the current M4 Pro benchmark measures Parakeet builds at 115-131 MB peak RSS in the isolated CLI speed/memory harness, far less likely to trigger OOM than the previous ~2 GB MLX path. Cohere is the exceptional opt-in batch engine and is budgeted separately.
 
 ### Engine Switching Errors
 
@@ -506,37 +508,39 @@ This replaces the previous Python venv bootstrap (~500 MB deps + ~2.5 GB model).
 
 - Transcription requests have a timeout proportional to audio duration
 - Short dictations: 30-second timeout
-- Long files: generous timeout (model runs at ~155x realtime)
+- Long files: generous timeout (Parakeet builds measured ~81-93x steady RTFx on the current M4 Pro benchmark; other engines vary by model)
 - Warm-up/model download allows a longer timeout (first-run downloads can take minutes)
 
 ---
 
 ## Performance
 
-| Scenario | Latency |
-|----------|---------|
-| CoreML compilation (first load) | ~3.4 seconds |
-| Model warm load (cached) | ~162 ms |
-| Short dictation (5-10 seconds audio) | <100ms transcription |
-| Long file transcription | ~23 seconds per hour of audio |
+| Scenario | Current benchmark evidence |
+|----------|----------------------------|
+| Parakeet cold start | 0.38 s (v3), 0.55 s (v2), 0.93 s (Unified) in the Apple M4 Pro speed/memory micro-bench |
+| Short dictation (5-10 seconds audio) | Usually sub-100ms STT work once the selected Parakeet build is ready |
+| Long file transcription | Parakeet v3/v2/Unified measured ~81-93x steady RTFx, roughly 39-44 seconds per hour of audio before I/O and post-processing overhead |
+| Optional engines | Nemotron measured ~57-61x, Whisper ~14x, and Cohere ~11x with a ~73 s cold start and ~11.6 GB peak RSS in the committed reference row |
 
-These figures are Parakeet/FluidAudio targets. WhisperKit exists for language coverage and should not be described as matching Parakeet latency.
+These figures are Apple M4 Pro benchmark evidence from `benchmarks/asr/`, not universal latency promises. WhisperKit exists for language coverage and should not be described as matching Parakeet latency. Cohere exists for accuracy-critical batch work and should not be described as matching Parakeet memory or cold-start behavior.
 
 ### Speed Comparison
 
-| Audio length | CoreML/ANE | Perceptible? |
-|-------------|-----------|-------------|
-| 5 seconds | 0.03s | No |
-| 30 seconds | 0.2s | No |
-| 1 minute | 0.4s | No |
-| 5 minutes | 1.9s | Barely |
-| 1 hour | 23s | Yes, but very fast |
+| Audio length | Parakeet v3 at ~81x steady RTFx | Perceptible? |
+|-------------|------------------------------|-------------|
+| 5 seconds | ~0.06 s | No |
+| 30 seconds | ~0.37 s | No |
+| 1 minute | ~0.74 s | Barely |
+| 5 minutes | ~3.7 s | Yes |
+| 1 hour | ~44 s | Yes, but still fast |
 
 For dictation (the primary use case), transcription time is imperceptible. For long file transcription, the ANE path is still remarkably fast.
 
 ### Memory Budget
 
-- Parakeet STT: ~66 MB working RAM per active slot (~130 MB with vocab boosting)
+- Parakeet STT: 115-131 MB peak RSS in the non-boosted M4 Pro speed/memory benchmark, depending on build
+- Recognition-time custom vocabulary boosting: adds the CTC sidecar; benchmark a representative boosted-vocab case before publishing a boosted memory number
+- Cohere Transcribe: ~11.6 GB peak RSS in the committed speed/memory reference row; treat it as a 16 GB+ opt-in batch engine
 - App process (UI + services): ~100 MB
 - Audio buffers: ~50 MB
 - Illustrative warm single-slot budget: ~200-250 MB before diarization

--- a/spec/README.md
+++ b/spec/README.md
@@ -50,7 +50,7 @@ These decisions are final. Do not second-guess them.
 
 | Decision | Choice | Rationale |
 |----------|--------|-----------|
-| Local STT | Parakeet TDT 0.6B via FluidAudio CoreML/ANE (`v3` multilingual default, `v2` English-only opt-in); Nemotron 3.5 Beta, WhisperKit, and Cohere Transcribe optional | Parakeet gives 155x realtime and low RAM for supported languages; v2 avoids language auto-detect for English-only use; Nemotron is a fast opt-in Beta path with multilingual (default) and English-only builds; Whisper adds mature broad multilingual coverage locally; Cohere is a larger batch-only accuracy path |
+| Local STT | Parakeet TDT 0.6B via FluidAudio CoreML/ANE (`v3` multilingual default, `v2` English-only opt-in, `unified` English-only opt-in); Nemotron 3.5 Beta, WhisperKit, and Cohere Transcribe optional | Parakeet gives the best speed/memory profile for supported languages in the current M4 Pro harness (~81-93x steady RTFx, 115-131 MB peak RSS by build); v2 avoids language auto-detect for English-only use; Unified adds punctuation/capitalization and token-derived timestamps; Nemotron is a fast opt-in Beta path with multilingual and English-only builds; Whisper adds mature broad multilingual coverage locally; Cohere is a larger batch-only accuracy path |
 | Database | SQLite via GRDB | Single file, embedded, zero config |
 | Platform | macOS 14.2+ (Apple Silicon only) | FluidAudio requires Apple Silicon; Swift 6 language mode (tools-version 5.9) |
 | Business model | Current public build free/GPL/unlocked; official paid distribution/support remains possible | Originally $49 one-time (ADR-003), went free with open-source release in v0.5; retained purchase activation plumbing is future-option code |
@@ -62,8 +62,8 @@ These decisions are final. Do not second-guess them.
 
 | Channel | Status | Notes |
 |---------|--------|-------|
-| Stable DMG | User-facing release, recommended for normal use | Dictation, file/media URL transcription, meeting recording, calendar auto-start (opt-in, default off), Transforms, VAD-guided meeting live-preview chunking, optional Nemotron Beta and WhisperKit, exports, vocabulary, AI features |
-| `main` | Development | Latest stable release plus untagged fixes, Cohere Transcribe, and the flag delta below |
+| Stable DMG `0.6.24` | User-facing release, recommended for normal use | Dictation, file/media URL transcription, meeting recording, calendar auto-start (opt-in, default off), Transforms, VAD-guided meeting live-preview chunking, optional Nemotron Beta and WhisperKit, exports, vocabulary, AI features |
+| `main` | Development | Latest stable release plus untagged fixes, Cohere Transcribe, recognition-time custom vocabulary boosting, meeting echo-cancellation/cleaned-mic artifact work for the next release train, developer-gated in-process MLX local LLM groundwork, and the flag delta below |
 
 Current `main` feature gates in `Sources/MacParakeetCore/AppFeatures.swift`:
 
@@ -127,7 +127,7 @@ All ADRs live in `spec/adr/`. These are locked -- they record decisions already 
 | v0.4 | Polish & Launch | Diarization, custom hotkey, non-blocking progress, direct distribution | **Implemented** |
 | v0.5 | Data, UI & Prompts | Private dictation, favorites, video player, split-pane detail, library grid, prompt library, multi-summary | **Implemented** |
 | v0.6 | Meeting Recording + Multilingual STT + Transforms | System audio + mic capture, concurrent with dictation, local transcription, VAD-guided live-preview chunking, library integration, optional Nemotron Beta and WhisperKit engines, system-wide selected-text rewrites, calendar auto-start | **Implemented** |
-| v0.7 | Post-v0.6 polish | Activity-based auto-stop (ADR-023 implemented behind default-off flag), meeting reliability (ADR-025 Phase A implemented behind default-on kill-switch), activity-based detection (ADR-024 Phases A+B implemented behind default-off flag), Cohere Transcribe on `main`, display-only live dictation transcript preview (`liveDictationStreamingEnabled`, enabled on `main`), meeting audio N-day retention, plus other follow-up polish | **In progress on `main`** |
+| v0.7 | Post-v0.6 polish | Activity-based auto-stop (ADR-023 implemented behind default-off flag), meeting reliability (ADR-025 Phase A implemented behind default-on kill-switch), activity-based detection (ADR-024 Phases A+B implemented behind default-off flag), Cohere Transcribe on `main`, display-only live dictation transcript preview (`liveDictationStreamingEnabled`, enabled on `main`), meeting echo-cancellation/cleaned-mic artifacts, recognition-time custom vocabulary boosting, meeting audio N-day retention, developer-gated local MLX groundwork, plus other follow-up polish | **In progress on `main`** |
 
 ## Version Progress
 


### PR DESCRIPTION
## Summary

Aligns the root README with current `main` by replacing stale ad hoc Parakeet performance bullets with the committed ASR benchmark evidence and by giving `macparakeet-cli` its own top-level automation section. The README now separates stable DMG `0.6.24` from development-only `main` work, including Cohere, meeting echo cancellation, recognition-time vocabulary boosting, and developer-gated local MLX groundwork.

## Design

The benchmark section is intentionally table-first: English full LibriSpeech WER, FLEURS multilingual coverage, and Apple M4 Pro speed/memory appear together with the caveats that make the numbers safe to publish. Cohere is framed as opt-in batch accuracy work, not a default replacement, and the speed/memory row keeps the benchmark doc's warning that the committed Cohere row is still the legacy FluidAudio reference measurement.

The CLI section keeps install commands in `Get it`, then moves usage into a separate automation section linked to `integrations/README.md` and `Sources/CLI/CHANGELOG.md`. It shows discovery (`spec --json`), health, transcription, model/default management, saved-record retranscription, and meeting artifact/export commands without trying to duplicate the full generated command catalog.

## Spec alignment

Touched governing docs only where verified drift was found:

| File | Alignment |
|---|---|
| `spec/README.md` | Updates the root STT decision row and release-channel row away from the old 155x / low-RAM shorthand; records stable `0.6.24`, current `main` Cohere/vocab/AEC/local-MLX posture, and v0.7 roadmap alignment. |
| `spec/06-stt-engine.md` | Replaces stale Parakeet WER/speed/RAM rows and deeper performance/memory budget text with benchmark-grounded M4 Pro values and explicit boosted-vocab/Cohere caveats. |

No ADR history was rewritten. ADR-001 already carries the Parakeet-default / Cohere-opt-in decision, and ADR-028 already records meeting echo cancellation as derived cleaned-mic artifact work.

## Risk surface

This is docs-only. The main risk is overclaiming benchmark or release status, so the diff keeps hardware/dataset context on the numbers, leaves Local MLX as developer-gated only, and keeps AEC in the `main`/next-release-train bucket rather than the stable DMG bucket.

Out of scope: product code, package files, website copy, appcast changes, release artifacts, and any change to `AGENTS.md`, `CLAUDE.md`, `.claude/`, or `journal/`.

## Test evidence

- `PY=/tmp/macparakeet-asr-readme-align-venv/bin/python benchmarks/asr/run_all.sh verify`
  - Manifest/scorer tests passed.
  - Re-scored committed multilingual and full English hypotheses, reproducing README headline numbers.
- `swift run macparakeet-cli spec --json`
  - Built successfully.
  - Generated `macparakeet.cli.spec` schema v1 with 83 commands and 23 config keys.
- `git diff --check`
- `scripts/dev/format.sh` inspected; it formats Swift only, so it was skipped for this Markdown-only diff.

## Author's Notes

The brief's Parakeet speed shorthand said roughly 70x realtime. The in-repo speed artifact is more precise for the micro-bench: Parakeet v3/v2/Unified are ~81x / ~90x / ~93x steady RTFx with 131 / 123 / 115 MB peak RSS. This PR uses those artifact numbers in README and the active STT spec, while the benchmark narrative/ADR can keep their rough decision-level framing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishes the in-repo ASR benchmark tables in the README and promotes `macparakeet-cli` to a top-level automation section. Aligns STT specs with benchmarked speed/memory and clarifies release-channel posture; moves the developer-only Cohere rerun note to the benchmark docs.

- **README**
  - Replaces performance bullets with ASR tables (English WER, FLEURS coverage, Apple M4 Pro speed/memory); frames Cohere as opt-in batch accuracy with a reference speed/memory row, and moves rerun instructions to `benchmarks/asr/README.md`.
  - Adds “Command line and agent automation” for `macparakeet-cli` with links to `integrations/README.md` and `Sources/CLI/CHANGELOG.md`; shows discovery, transcription, model/default management, and history/meetings export.
  - Splits release channels without pinning a version in README; notes Cohere, AEC, recognition-time vocab boosting, and dev‑gated local MLX on `main`; restores the 25‑European‑languages limitation.

- **Spec alignment**
  - `spec/06-stt-engine.md`: Replaces 155x/66 MB with M4 Pro numbers (~81–93x steady RTFx; 115–131 MB peak RSS by build) and adds boosted‑vocab/Cohere memory caveats.
  - `spec/README.md`: Adds `unified` to the STT decision row; updates speed/memory posture and release‑channel notes (Cohere, AEC, vocab boosting, dev‑gated MLX).

<sup>Written for commit 3caf031b2e1cbdf0e47682c7fa5b48ecedde70e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/756?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with clearer branch/channel details and expanded command-line examples for transcribing, model management, history review, and retracing work.
  * Reworked performance and limitations docs with refreshed benchmark methodology plus updated accuracy, speed, and memory tables.
  * Refined STT engine and spec documentation to reflect newer benchmark figures, memory guidance, and supported feature/channel notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->