### PR TITLE
Unify spinner motion language

### DIFF
--- a/Sources/MacParakeet/Views/Components/ParakeetSpinner.swift
+++ b/Sources/MacParakeet/Views/Components/ParakeetSpinner.swift
@@ -1,0 +1,71 @@
+import SwiftUI
+
+/// App-wide indeterminate loading spinner.
+///
+/// Wraps the existing compact Merkaba loader so new waiting states inherit the
+/// same sacred-geometry motion language as the dictation overlay, meeting pill,
+/// and Transform progress surfaces.
+struct ParakeetSpinner: View {
+    enum SizePreset {
+        case inline
+        case card
+        case hero
+
+        var points: CGFloat {
+            switch self {
+            case .inline: return 14
+            case .card: return 40
+            case .hero: return 72
+            }
+        }
+
+        var revolutionDuration: Double {
+            switch self {
+            case .inline: return 2.0
+            case .card: return 2.5
+            case .hero: return 3.0
+            }
+        }
+    }
+
+    private let size: SizePreset
+    private let tint: Color?
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    init(_ size: SizePreset = .inline, tint: Color? = nil) {
+        self.size = size
+        self.tint = tint
+    }
+
+    init(size: SizePreset, tint: Color? = nil) {
+        self.init(size, tint: tint)
+    }
+
+    private var resolvedTint: Color {
+        if let tint {
+            return tint
+        }
+
+        switch size {
+        case .inline:
+            return DesignSystem.Colors.textSecondary
+        case .card, .hero:
+            return DesignSystem.Colors.accent
+        }
+    }
+
+    var body: some View {
+        SpinnerRingView(
+            size: size.points,
+            revolutionDuration: size.revolutionDuration,
+            tintColor: resolvedTint,
+            animate: !reduceMotion
+        )
+        .frame(width: size.points, height: size.points)
+        .accessibilityElement()
+        .accessibilityLabel("Loading")
+        .accessibilityValue("In progress")
+        .accessibilityAddTraits(.updatesFrequently)
+    }
+}

--- a/Sources/MacParakeet/Views/Components/SacredGeometry.swift
+++ b/Sources/MacParakeet/Views/Components/SacredGeometry.swift
@@ -120,10 +120,15 @@ struct SpinnerRingView: View {
     }
 
     private func resetAnimationState() {
-        rotationCW = 0
-        rotationCCW = 0
-        centerPulse = 0.3
-        vertexPulse = 0.6
+        // A plain state write does not cancel an attached `.repeatForever`
+        // animation; the zero-duration override does, so the spinner stops
+        // costing CPU once `animate` flips off (e.g. Reduce Motion enabled).
+        withAnimation(.linear(duration: 0)) {
+            rotationCW = 0
+            rotationCCW = 0
+            centerPulse = 0.3
+            vertexPulse = 0.6
+        }
     }
 }
 

--- a/Sources/MacParakeet/Views/Components/SacredGeometry.swift
+++ b/Sources/MacParakeet/Views/Components/SacredGeometry.swift
@@ -32,6 +32,7 @@ struct SpinnerRingView: View {
     var size: CGFloat = 26
     var revolutionDuration: Double = 3.0
     var tintColor: Color = .white
+    var animate: Bool = true
 
     @State private var rotationCW: Double = 0
     @State private var rotationCCW: Double = 0
@@ -39,6 +40,10 @@ struct SpinnerRingView: View {
     @State private var vertexPulse: Double = 0.6
 
     private var radius: CGFloat { size * 0.423 }
+    private var displayedRotationCW: Double { animate ? rotationCW : 0 }
+    private var displayedRotationCCW: Double { animate ? rotationCCW : 60 }
+    private var displayedCenterPulse: Double { animate ? centerPulse : 0.7 }
+    private var displayedVertexPulse: Double { animate ? vertexPulse : 0.85 }
 
     var body: some View {
         ZStack {
@@ -46,29 +51,29 @@ struct SpinnerRingView: View {
                 .stroke(tintColor.opacity(0.05), lineWidth: 0.5)
                 .frame(width: size, height: size)
 
-            triangleLayer(rotation: rotationCW, opacity: 0.7, vertexOpacity: vertexPulse)
-            triangleLayer(rotation: rotationCCW, opacity: 0.4, vertexOpacity: vertexPulse * 0.7)
+            triangleLayer(rotation: displayedRotationCW, opacity: 0.7, vertexOpacity: displayedVertexPulse)
+            triangleLayer(rotation: displayedRotationCCW, opacity: 0.4, vertexOpacity: displayedVertexPulse * 0.7)
 
             // Center nexus — shadow for glow instead of blur
             Circle()
-                .fill(tintColor.opacity(centerPulse))
+                .fill(tintColor.opacity(displayedCenterPulse))
                 .frame(width: size * 0.115, height: size * 0.115)
-                .shadow(color: tintColor.opacity(centerPulse * 0.5), radius: size * 0.154)
+                .shadow(color: tintColor.opacity(displayedCenterPulse * 0.5), radius: size * 0.154)
         }
         .frame(width: size, height: size)
         .drawingGroup()
         .onAppear {
-            withAnimation(.linear(duration: revolutionDuration).repeatForever(autoreverses: false)) {
-                rotationCW = 360
+            if animate {
+                startAnimation()
+            } else {
+                resetAnimationState()
             }
-            withAnimation(.linear(duration: revolutionDuration).repeatForever(autoreverses: false)) {
-                rotationCCW = -360
-            }
-            withAnimation(.easeInOut(duration: 1.4).repeatForever(autoreverses: true)) {
-                centerPulse = 0.9
-            }
-            withAnimation(.easeInOut(duration: 1.0).repeatForever(autoreverses: true)) {
-                vertexPulse = 1.0
+        }
+        .onChange(of: animate) { _, shouldAnimate in
+            if shouldAnimate {
+                startAnimation()
+            } else {
+                resetAnimationState()
             }
         }
     }
@@ -96,6 +101,29 @@ struct SpinnerRingView: View {
             .frame(width: size * 0.096, height: size * 0.096)
             .shadow(color: tintColor.opacity(vertexOpacity * 0.4), radius: size * 0.115)
             .offset(x: x, y: y)
+    }
+
+    private func startAnimation() {
+        resetAnimationState()
+        withAnimation(.linear(duration: revolutionDuration).repeatForever(autoreverses: false)) {
+            rotationCW = 360
+        }
+        withAnimation(.linear(duration: revolutionDuration).repeatForever(autoreverses: false)) {
+            rotationCCW = -360
+        }
+        withAnimation(.easeInOut(duration: 1.4).repeatForever(autoreverses: true)) {
+            centerPulse = 0.9
+        }
+        withAnimation(.easeInOut(duration: 1.0).repeatForever(autoreverses: true)) {
+            vertexPulse = 1.0
+        }
+    }
+
+    private func resetAnimationState() {
+        rotationCW = 0
+        rotationCCW = 0
+        centerPulse = 0.3
+        vertexPulse = 0.6
     }
 }
 

--- a/Sources/MacParakeet/Views/History/DictationSubTabPicker.swift
+++ b/Sources/MacParakeet/Views/History/DictationSubTabPicker.swift
@@ -34,7 +34,7 @@ struct DictationSubTabPicker: View {
         let isSelected = selection == tab
         let isHovered = hoveredTab == tab
         Button {
-            withAnimation(.spring(response: 0.36, dampingFraction: 0.82)) {
+            withAnimation(DesignSystem.Animation.contentSwap) {
                 selection = tab
             }
         } label: {

--- a/Sources/MacParakeet/Views/MeetingRecording/LiveAskPaneView.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/LiveAskPaneView.swift
@@ -343,11 +343,11 @@ struct LiveAskPaneView: View {
                 .disabled(!viewModel.canSendMessage)
                 .onSubmit { send() }
                 .background(
-                    RoundedRectangle(cornerRadius: 14)
+                    RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius)
                         .fill(DesignSystem.Colors.surfaceElevated)
                 )
                 .overlay(
-                    RoundedRectangle(cornerRadius: 14)
+                    RoundedRectangle(cornerRadius: DesignSystem.Layout.cardCornerRadius)
                         .strokeBorder(DesignSystem.Colors.border.opacity(0.3), lineWidth: 1)
                 )
 

--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingRecordingPanelView.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingRecordingPanelView.swift
@@ -375,8 +375,7 @@ struct MeetingRecordingPanelView: View {
                 .frame(width: 8, height: 8)
                 .animation(.easeInOut(duration: 0.2), value: viewModel.isPaused)
         case .transcribing:
-            ProgressView()
-                .controlSize(.small)
+            ParakeetSpinner(.inline, tint: DesignSystem.Colors.accent)
         case .error:
             Image(systemName: "exclamationmark.triangle.fill")
                 .foregroundStyle(DesignSystem.Colors.warningAmber)

--- a/Sources/MacParakeet/Views/Meetings/MeetingsView.swift
+++ b/Sources/MacParakeet/Views/Meetings/MeetingsView.swift
@@ -918,8 +918,7 @@ private struct CalendarInlineControlsRow: View {
         case .notDetermined:
             Button(action: connectCalendar) {
                 if isRequestingPermission {
-                    ProgressView()
-                        .controlSize(.small)
+                    ParakeetSpinner(.inline)
                         .frame(maxWidth: .infinity)
                 } else {
                     Label("Connect Calendar", systemImage: "calendar.badge.plus")
@@ -1230,8 +1229,7 @@ private struct MeetingsLoadingRow: View {
 
     var body: some View {
         HStack(spacing: DesignSystem.Spacing.sm) {
-            ProgressView()
-                .controlSize(.small)
+            ParakeetSpinner(.inline)
             Text(title)
                 .font(DesignSystem.Typography.bodySmall)
                 .foregroundStyle(DesignSystem.Colors.textSecondary)

--- a/Sources/MacParakeet/Views/Settings/CalendarSettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/CalendarSettingsView.swift
@@ -133,7 +133,7 @@ struct CalendarSettingsView: View {
                 requestPermission()
             } label: {
                 if isRequestingPermission {
-                    ProgressView().controlSize(.small)
+                    ParakeetSpinner(.inline)
                 } else {
                     Text("Turn On…")
                 }

--- a/Sources/MacParakeet/Views/Settings/Components/EngineOptionTile.swift
+++ b/Sources/MacParakeet/Views/Settings/Components/EngineOptionTile.swift
@@ -303,8 +303,7 @@ struct EngineDownloadBanner: View {
                 .accessibilityLabel("Download \(title)")
         case .downloading:
             HStack(spacing: DesignSystem.Spacing.xs) {
-                ProgressView()
-                    .controlSize(.small)
+                ParakeetSpinner(.inline)
                 Text("Downloading…")
                     .font(DesignSystem.Typography.caption)
                     .foregroundStyle(.secondary)

--- a/Sources/MacParakeet/Views/Settings/LLMSettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/LLMSettingsView.swift
@@ -459,8 +459,7 @@ struct LLMSettingsView: View {
                 }
             case .verifying:
                 HStack(spacing: 8) {
-                    ProgressView()
-                        .controlSize(.small)
+                    ParakeetSpinner(.inline)
                     Text("Verifying files and testing the local runtime.")
                         .font(DesignSystem.Typography.caption)
                         .foregroundStyle(.secondary)
@@ -1412,8 +1411,7 @@ struct LLMSettingsView: View {
                 LazyVStack(alignment: .leading, spacing: 2) {
                     if isLoadingAIFormatterInstalledApps, aiFormatterInstalledApps.isEmpty {
                         HStack(spacing: DesignSystem.Spacing.sm) {
-                            ProgressView()
-                                .controlSize(.small)
+                            ParakeetSpinner(.inline)
                             Text("Loading apps...")
                                 .font(DesignSystem.Typography.caption)
                                 .foregroundStyle(.secondary)
@@ -1970,8 +1968,7 @@ struct LLMSettingsView: View {
             EmptyView()
         case .testing:
             HStack(spacing: 4) {
-                ProgressView()
-                    .controlSize(.small)
+                ParakeetSpinner(.inline)
                 Text("Testing...")
                     .font(DesignSystem.Typography.caption)
                     .foregroundStyle(.secondary)

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -2648,8 +2648,7 @@ struct SettingsView: View {
 
     private func speechEngineSwitchBanner(title: String, detail: String) -> some View {
         HStack(alignment: .center, spacing: DesignSystem.Spacing.md) {
-            ProgressView()
-                .controlSize(.small)
+            ParakeetSpinner(.inline)
                 .frame(width: 18, height: 18)
 
             VStack(alignment: .leading, spacing: 2) {
@@ -3413,8 +3412,7 @@ struct SettingsView: View {
                         .help(overflowActions.count == 1 ? (overflowActions[0].help ?? "More actions") : "More actions")
                         .accessibilityLabel("More actions")
                     } else if isWorking || status == .checking || status == .repairing || status == .preparing {
-                        ProgressView()
-                            .controlSize(.small)
+                        ParakeetSpinner(.inline)
                             .frame(width: 22, height: 22)
                     } else {
                         Color.clear.frame(width: 22, height: 22)

--- a/Sources/MacParakeet/Views/Transcription/BulkTranscriptionSelectionBar.swift
+++ b/Sources/MacParakeet/Views/Transcription/BulkTranscriptionSelectionBar.swift
@@ -79,8 +79,7 @@ struct BulkTranscriptionSelectionBar: View {
     private var selectionSummary: some View {
         HStack(spacing: 8) {
             if isPerformingOperation {
-                ProgressView()
-                    .controlSize(.small)
+                ParakeetSpinner(.inline)
             } else {
                 Image(systemName: "checkmark.circle.fill")
                     .font(.system(size: 14, weight: .semibold))

--- a/Sources/MacParakeet/Views/Transcription/MeetingRecordingTile.swift
+++ b/Sources/MacParakeet/Views/Transcription/MeetingRecordingTile.swift
@@ -232,8 +232,7 @@ struct MeetingRecordingTile: View {
     private var backgroundTranscriptionBadge: some View {
         if viewModel.backgroundTranscriptionCount > 0 {
             HStack(spacing: 5) {
-                ProgressView()
-                    .controlSize(.small)
+                ParakeetSpinner(.inline)
                     .scaleEffect(0.55)
                     .frame(width: 12, height: 12)
                 Text(backgroundTranscriptionText)

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
@@ -2622,10 +2622,10 @@ struct TranscriptResultView: View {
                     ChatLoadingSweep()
                 } else {
                     let bubbleShape = UnevenRoundedRectangle(
-                        topLeadingRadius: 16,
-                        bottomLeadingRadius: isUser ? 16 : 4,
-                        bottomTrailingRadius: isUser ? 4 : 16,
-                        topTrailingRadius: 16
+                        topLeadingRadius: DesignSystem.Layout.cornerRadius,
+                        bottomLeadingRadius: isUser ? DesignSystem.Layout.cornerRadius : 4,
+                        bottomTrailingRadius: isUser ? 4 : DesignSystem.Layout.cornerRadius,
+                        topTrailingRadius: DesignSystem.Layout.cornerRadius
                     )
 
                     VStack(alignment: .leading, spacing: 0) {

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
@@ -832,8 +832,7 @@ struct TranscriptionLibraryView: View {
     private var loadingState: some View {
         VStack {
             Spacer()
-            ProgressView()
-                .controlSize(.small)
+            ParakeetSpinner(.inline)
             Spacer()
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -854,8 +853,7 @@ struct TranscriptionLibraryView: View {
                 Spacer()
             }
         } else if viewModel.isLoading {
-            ProgressView()
-                .controlSize(.small)
+            ParakeetSpinner(.inline)
                 .frame(maxWidth: .infinity)
         }
     }


### PR DESCRIPTION
## Summary
MacParakeet has a signature waiting-state language: sacred-geometry loaders (`RhodoneaScribeLoader`, `SpinnerRingView` in `Sources/MacParakeet/Views/Components/`) used by the dictation overlay, meeting pill, and Transform progress panel. But 20+ other user-visible surfaces still showed the stock SwiftUI `ProgressView()` spinner, including two surfaces that can show the same state of the same meeting with different spinners: the pill uses `SpinnerRingView`, while the panel status dot used generic `ProgressView`.

This PR adds `ParakeetSpinner` as the shared app-wide indeterminate spinner, backed by the existing `SpinnerRingView` geometry primitive, then replaces the current circular spinner-style call sites with it. It also aligns the dictation sub-tab picker to the shared `DesignSystem.Animation.contentSwap` motion token and replaces the named radius literals with existing `DesignSystem.Layout` tokens.

## Design
`ParakeetSpinner` lives next to `DesignSystem` and exposes `.inline`, `.card`, and `.hero` presets. Inline defaults to secondary text tint; card/hero default to the app accent. It preserves the existing layout footprint by keeping preset dimensions fixed and letting call sites retain their current frame/scale modifiers.

Reduce Motion is handled by adding an `animate` switch to `SpinnerRingView`. `ParakeetSpinner` passes `animate: false` when `accessibilityReduceMotion` is enabled, rendering the same Merkaba motif as a static frame with no continuous animation.

Spec alignment: this implements `spec/04-ui-patterns.md`'s design philosophy: shared motifs, simple native surfaces, and consistent app chrome. No spec changes are needed because this is component-level polish that brings existing views into alignment with the stated UI language.

The radius tokens in this branch live under `DesignSystem.Layout` at the referenced `DesignSystem.swift` lines, so the PR uses `DesignSystem.Layout.cardCornerRadius` and `DesignSystem.Layout.cornerRadius`. The 4pt transcript bubble tail corners stay literal because they are intentionally outside the token scale and encode the chat-bubble tail shape.

## Before / After
| Surface | Before | After |
|---|---|---|
| Shared component layer | No app-wide spinner wrapper; call sites used `ProgressView()` directly | `ParakeetSpinner` with inline/card/hero presets, contextual tint, Reduce Motion support, and loading accessibility label/value |
| `SpinnerRingView` primitive | Always started repeat-forever animation on appear | Supports `animate: false` for static Reduce Motion frames while preserving default behavior for existing users |
| Meetings calendar connect button | Stock small `ProgressView` while requesting permission | Inline geometry spinner, same full-width button label frame |
| Meetings loading row | Stock small `ProgressView` | Inline geometry spinner |
| Meeting recording panel status dot | Stock small `ProgressView` during transcribing | Inline accent geometry spinner matching the meeting pill ring family |
| Meeting recording tile background badge | Stock small scaled `ProgressView` | Inline geometry spinner with the existing `scaleEffect(0.55)` and 12pt frame preserved |
| LLM local AI verifying state | Stock small `ProgressView` | Inline geometry spinner |
| LLM AI Formatter app picker loading | Stock small `ProgressView` | Inline geometry spinner |
| LLM connection test status | Stock small `ProgressView` | Inline geometry spinner |
| Calendar settings permission button | Stock small `ProgressView` | Inline geometry spinner |
| Engine option download banner | Stock small `ProgressView` | Inline geometry spinner |
| Bulk transcription selection bar operation | Stock small `ProgressView` | Inline geometry spinner |
| Transcription library loading state | Stock small `ProgressView` | Inline geometry spinner |
| Transcription library load-more footer | Stock small `ProgressView` | Inline geometry spinner, full-width footer frame preserved |
| Settings speech-engine switch banner | Stock small `ProgressView` | Inline geometry spinner with existing 18pt frame preserved |
| Settings model row working/checking/repairing/preparing indicator | Stock small `ProgressView` | Inline geometry spinner with existing 22pt frame preserved |
| Dictation sub-tab picker | Hard-coded spring animation | Shared `DesignSystem.Animation.contentSwap` token with existing matched-geometry pill |
| Live Ask input | Hard-coded 14pt rounded rectangle | `DesignSystem.Layout.cardCornerRadius` |
| Transcript chat bubbles | Hard-coded 16pt large bubble corners | `DesignSystem.Layout.cornerRadius`; 4pt tail corners intentionally remain literal |

## Excluded Call Sites
- `Sources/MacParakeet/Views/Onboarding/OnboardingFlowView.swift:691`: intentionally left as `ProgressView().progressViewStyle(.linear)` because it is an indeterminate linear setup bar, not a circular spinner surface.
- `Sources/MacParakeet/Views/Transcription/TranscribeView.swift:446`: intentionally left as `ProgressView().progressViewStyle(.linear)` because it is an indeterminate linear transcription progress bar, not a circular spinner surface.
- `ProgressView(value:)` determinate bars were left unchanged by scope.

## Risk Surface
This is view-layer only: no persistence, audio, STT, meeting-flow, or CLI behavior changes. Main review points are layout stability around small button/menu labels, Reduce Motion behavior, and accessibility semantics for the replacement spinner.

## Test Evidence
Commands run from `/Users/dmoon/code/macparakeet-motion-language`:

```bash
scripts/dev/format.sh
```
Result:
```text
Formatting Sources/ and Tests/ with swift-format…
Done. Review with: git diff --stat
```
Note: the script rewrote hundreds of unrelated files in this checkout, so that formatting-only churn was reverted and the scoped diff was reapplied.

```bash
GIT_EXEC_PATH=/Library/Developer/CommandLineTools/usr/libexec/git-core swift build
```
Result:
```text
Build complete! (33.11s)
```
Plain `swift build` initially failed before compilation because this machine's `/usr/bin/git` resolves helpers through Xcode's git-core, which is missing `git-submodule`; the CommandLineTools `GIT_EXEC_PATH` provides the helper and let SwiftPM complete.

```bash
GIT_EXEC_PATH=/Library/Developer/CommandLineTools/usr/libexec/git-core swift test --filter DesignSystem
```
Result:
```text
Executed 1 test, with 0 failures (0 unexpected) in 0.054 (0.054) seconds
```

```bash
GIT_EXEC_PATH=/Library/Developer/CommandLineTools/usr/libexec/git-core swift test --filter Dictation
```
Result:
```text
Executed 528 tests, with 1 test skipped and 0 failures (0 unexpected) in 35.817 (35.864) seconds
```

```bash
git diff --check
git diff --cached --check
```
Result: no output.

```bash
rg -n "ProgressView\(\)" Sources/MacParakeet --glob '!*Tests*'
```
Result:
```text
Sources/MacParakeet/Views/Onboarding/OnboardingFlowView.swift:691:                            ProgressView()
Sources/MacParakeet/Views/Transcription/TranscribeView.swift:446:                        ProgressView()
```
Both remaining hits are the excluded linear bars listed above.

## Manual QA
- [ ] Meetings -> connect Calendar from the inline calendar prompt -> button spinner is the geometry loader while permission is requested.
- [ ] Meetings -> open the workspace while meeting/calendar rows are loading -> loading row uses the geometry loader.
- [ ] Start a meeting -> open the floating meeting panel -> finish/transition to transcribing -> panel status dot uses the accent geometry loader.
- [ ] Transcribe -> Record Meeting -> finish one meeting while another background transcription remains -> tile badge spinner is the tiny geometry loader and text stays aligned.
- [ ] Settings -> AI -> Local AI -> trigger verifying files/runtime -> verifying row uses the geometry loader.
- [ ] Settings -> AI -> AI Formatter app picker -> open while installed apps load -> loading row uses the geometry loader.
- [ ] Settings -> AI -> provider connection test -> click Test Connection -> testing indicator uses the geometry loader.
- [ ] Settings -> Calendar -> click Turn On -> permission button uses the geometry loader.
- [ ] Settings -> Engine -> download an engine/model option -> download banner uses the geometry loader.
- [ ] Library -> Select Many -> start a bulk delete/remove operation -> selection bar operation indicator uses the geometry loader.
- [ ] Library -> open while transcriptions are loading -> central loading indicator uses the geometry loader.
- [ ] Library -> scroll/load more while more rows load -> footer loading indicator uses the geometry loader and remains centered.
- [ ] Settings -> Engine -> switch speech engine -> switch banner uses the geometry loader in the existing 18pt slot.
- [ ] Settings -> Engine -> model row checking/repairing/preparing/downloading state -> trailing row indicator uses the geometry loader in the existing 22pt slot.
- [ ] Dictations -> switch History/Stats sub-tabs -> selected pill motion feels identical to Settings tab transitions.
- [ ] Start a meeting -> open panel -> Ask tab -> input field corner shape is unchanged visually and uses the tokenized radius.
- [ ] Library -> open a transcript with chat -> send an Ask message -> chat bubble large corners look unchanged and tail corners remain tighter.
- [ ] Reduce Motion ON renders static frames on every changed spinner surface.
- [ ] Light AND dark appearance render the spinner tint and geometry clearly.
- [ ] Layout is unshifted at each changed site, especially button labels and 12/18/22pt framed indicators.
- [ ] VoiceOver announces the replacement spinner as a loading/in-progress state.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies the app’s loading motion by introducing a shared `ParakeetSpinner` and replacing circular `ProgressView` spinners across the UI. Honors Reduce Motion (including cancelling animations when turned off), preserves layout, and aligns animation/radius tokens with `DesignSystem`.

- **New Features**
  - Added `ParakeetSpinner` with `.inline`, `.card`, `.hero` presets and contextual tinting.
  - Extended `SpinnerRingView` with `animate` to render a static frame when Reduce Motion is on.
  - Replaced circular `ProgressView()` on calendar, meetings, settings, LLM, transcription, and library surfaces while preserving existing frames/scale; determinate and linear bars left as-is.
  - Accessibility: added loading label/value and frequent-updates trait.

- **Bug Fixes**
  - Cancelled repeat-forever spinner animations when motion stops, so toggling Reduce Motion no longer leaves invisible animations running.

<sup>Written for commit af457ee018fe4628f3f49da5004c97c5caebd6bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/760?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new in-app loading spinner with multiple sizes, customizable color, and reduced-motion support.
  * Improved accessibility for loading states with clearer spoken feedback.

* **UI Improvements**
  * Replaced several generic loading indicators with the new spinner across settings, meetings, transcription, and recording screens.
  * Updated a few spacing and corner-radius styles to align more closely with the app’s design system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->