### PR TITLE
Persist meeting finalization status

### DIFF
--- a/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
+++ b/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
@@ -2,6 +2,14 @@ import Foundation
 import MacParakeetCore
 import MacParakeetViewModels
 
+private enum MeetingFinalizationRetryBridgeError: LocalizedError {
+    case coordinatorUnavailable
+
+    var errorDescription: String? {
+        "Meeting retry is not available right now."
+    }
+}
+
 @MainActor
 final class AppEnvironmentConfigurer {
     private final class CoordinatorRefs {
@@ -238,7 +246,8 @@ final class AppEnvironmentConfigurer {
         promptResultsViewModel.shouldMarkPromptResultUnread = { [weak self] promptResultID in
             guard let self else { return true }
             if case .result(let id) = self.transcriptionViewModel.selectedTab,
-               id == promptResultID {
+                id == promptResultID
+            {
                 return false
             }
             return true
@@ -340,6 +349,12 @@ final class AppEnvironmentConfigurer {
                     callbacks.onOpenMainWindow()
                 }
             },
+            onQueuedTranscriptionFailed: { [weak self] content in
+                guard let self else { return }
+                self.libraryViewModel.loadTranscriptions()
+                self.meetingsWorkspaceViewModel.refreshRecentMeetings()
+                TranscriptionCompletionPresenter.presentNotification(content)
+            },
             onRecordingBegan: {
                 coordinatorRefs.dictation?.hideIdlePill()
                 isMeetingAutoStopObservingRecording = true
@@ -357,6 +372,29 @@ final class AppEnvironmentConfigurer {
         )
         coordinatorRefs.meeting = meetingCoordinator
         liveMeetingCoordinator = meetingCoordinator
+        let retryMeetingFinalization: (Transcription) async throws -> Void = {
+            [weak meetingCoordinator] transcription in
+            guard let meetingCoordinator else {
+                throw MeetingFinalizationRetryBridgeError.coordinatorUnavailable
+            }
+            try await meetingCoordinator.retryMeetingFinalization(transcription)
+        }
+        libraryViewModel.onRetryMeetingTranscription = retryMeetingFinalization
+        meetingsWorkspaceViewModel.recentMeetingsViewModel.onRetryMeetingTranscription = retryMeetingFinalization
+
+        Task { [weak self] in
+            do {
+                let reconciled = try await MeetingFinalizationReconciler.reconcileStaleProcessingRows(
+                    repository: env.transcriptionRepo
+                )
+                guard !reconciled.isEmpty, let self else { return }
+                self.libraryViewModel.loadTranscriptions()
+                self.meetingsWorkspaceViewModel.refreshRecentMeetings()
+            } catch {
+                // Best-effort startup hygiene. The row remains visible on the
+                // next successful Library refresh if reconciliation fails.
+            }
+        }
 
         let hotkeyCoordinator = AppHotkeyCoordinator(
             settingsViewModel: settingsViewModel,

--- a/Sources/MacParakeet/App/MeetingFinalizationReconciler.swift
+++ b/Sources/MacParakeet/App/MeetingFinalizationReconciler.swift
@@ -1,0 +1,26 @@
+import Foundation
+import MacParakeetCore
+
+enum MeetingFinalizationReconciler {
+    static let staleProcessingErrorMessage =
+        "MacParakeet quit before meeting transcription finished. Your audio is saved."
+
+    @discardableResult
+    static func reconcileStaleProcessingRows(
+        repository: TranscriptionRepositoryProtocol
+    ) async throws -> [UUID] {
+        try await Task.detached(priority: .utility) {
+            let staleRows = try repository.fetchAll(limit: nil).filter {
+                $0.sourceType == .meeting && $0.status == .processing
+            }
+            for row in staleRows {
+                try repository.updateStatus(
+                    id: row.id,
+                    status: .error,
+                    errorMessage: staleProcessingErrorMessage
+                )
+            }
+            return staleRows.map(\.id)
+        }.value
+    }
+}

--- a/Sources/MacParakeet/App/MeetingFinalizationReconciler.swift
+++ b/Sources/MacParakeet/App/MeetingFinalizationReconciler.swift
@@ -10,9 +10,7 @@ enum MeetingFinalizationReconciler {
         repository: TranscriptionRepositoryProtocol
     ) async throws -> [UUID] {
         try await Task.detached(priority: .utility) {
-            let staleRows = try repository.fetchAll(limit: nil).filter {
-                $0.sourceType == .meeting && $0.status == .processing
-            }
+            let staleRows = try repository.fetchMeetings(withStatus: .processing)
             for row in staleRows {
                 try repository.updateStatus(
                     id: row.id,

--- a/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
@@ -12,6 +12,8 @@ enum MeetingRecordingQuitState {
 private enum MeetingFinalizationRetryError: LocalizedError, Sendable {
     case notMeeting
     case alreadyProcessing
+    case alreadyCompleted
+    case notRetryable
     case missingArtifactFolder
 
     var errorDescription: String? {
@@ -20,6 +22,10 @@ private enum MeetingFinalizationRetryError: LocalizedError, Sendable {
             return "Only meeting transcriptions can be retried from saved meeting audio."
         case .alreadyProcessing:
             return "This meeting is already being transcribed."
+        case .alreadyCompleted:
+            return "This meeting has already been transcribed."
+        case .notRetryable:
+            return "Only failed meeting transcriptions can be retried."
         case .missingArtifactFolder:
             return "The saved meeting folder is no longer available."
         }
@@ -1435,8 +1441,14 @@ final class MeetingRecordingFlowCoordinator {
             guard latest.sourceType == .meeting else {
                 throw MeetingFinalizationRetryError.notMeeting
             }
-            guard latest.status != .processing else {
-                throw MeetingFinalizationRetryError.alreadyProcessing
+            guard latest.status == .error else {
+                if latest.status == .processing {
+                    throw MeetingFinalizationRetryError.alreadyProcessing
+                }
+                if latest.status == .completed {
+                    throw MeetingFinalizationRetryError.alreadyCompleted
+                }
+                throw MeetingFinalizationRetryError.notRetryable
             }
             guard let folderURL = MeetingArtifactStore.sessionFolderURL(for: latest)?.standardizedFileURL else {
                 throw MeetingFinalizationRetryError.missingArtifactFolder
@@ -1449,11 +1461,6 @@ final class MeetingRecordingFlowCoordinator {
                 displayName: latest.effectiveDisplayTitle,
                 mixedAudioURL: mixedAudioURL,
                 durationSeconds: durationSeconds
-            )
-            try repo.updateStatus(
-                id: latest.id,
-                status: .processing,
-                errorMessage: nil
             )
             return MeetingTranscriptionQueue.Item(
                 recording: recording,

--- a/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
@@ -9,6 +9,23 @@ enum MeetingRecordingQuitState {
     case finishing
 }
 
+private enum MeetingFinalizationRetryError: LocalizedError, Sendable {
+    case notMeeting
+    case alreadyProcessing
+    case missingArtifactFolder
+
+    var errorDescription: String? {
+        switch self {
+        case .notMeeting:
+            return "Only meeting transcriptions can be retried from saved meeting audio."
+        case .alreadyProcessing:
+            return "This meeting is already being transcribed."
+        case .missingArtifactFolder:
+            return "The saved meeting folder is no longer available."
+        }
+    }
+}
+
 @MainActor
 final class MeetingRecordingFlowCoordinator {
     private let logger = Logger(subsystem: "com.macparakeet", category: "MeetingRecordingFlow")
@@ -67,6 +84,7 @@ final class MeetingRecordingFlowCoordinator {
     private let onMenuBarIconUpdate: (BreathWaveIcon.MenuBarState) -> Void
     private let onTranscriptionReady: (Transcription) -> Void
     private let onQueuedTranscriptionReady: (Transcription, Bool) -> Void
+    private let onQueuedTranscriptionFailed: (TranscriptionCompletionNotifier.Content) -> Void
     private let onRecordingBegan: () -> Void
     private let onRecordingStopping: () -> Void
     private let onFlowReturnedToIdle: () -> Void
@@ -134,6 +152,7 @@ final class MeetingRecordingFlowCoordinator {
         onMenuBarIconUpdate: @escaping (BreathWaveIcon.MenuBarState) -> Void,
         onTranscriptionReady: @escaping (Transcription) -> Void,
         onQueuedTranscriptionReady: ((Transcription, Bool) -> Void)? = nil,
+        onQueuedTranscriptionFailed: ((TranscriptionCompletionNotifier.Content) -> Void)? = nil,
         onRecordingBegan: @escaping () -> Void = {},
         onRecordingStopping: @escaping () -> Void = {},
         onFlowReturnedToIdle: @escaping () -> Void = {}
@@ -158,6 +177,7 @@ final class MeetingRecordingFlowCoordinator {
             meetingTranscriptionQueue
             ?? MeetingTranscriptionQueue(
                 transcriptionService: transcriptionService,
+                transcriptionRepo: transcriptionRepo,
                 meetingRecordingSettlement: meetingRecordingSettlement
             )
         self.onMenuBarIconUpdate = onMenuBarIconUpdate
@@ -165,6 +185,10 @@ final class MeetingRecordingFlowCoordinator {
         self.onQueuedTranscriptionReady =
             onQueuedTranscriptionReady ?? { transcription, _ in
                 onTranscriptionReady(transcription)
+            }
+        self.onQueuedTranscriptionFailed =
+            onQueuedTranscriptionFailed ?? { content in
+                TranscriptionCompletionPresenter.presentNotification(content)
             }
         self.onRecordingBegan = onRecordingBegan
         self.onRecordingStopping = onRecordingStopping
@@ -255,7 +279,8 @@ final class MeetingRecordingFlowCoordinator {
         pendingTitle = title
         pendingAudioSourceMode = sourceMode
         pendingStartContext = makeStartContext(trigger: resolvedTrigger, sourceMode: sourceMode)
-        pendingCalendarEventSnapshot = (resolvedTrigger != .calendarAutoStart && title == nil)
+        pendingCalendarEventSnapshot =
+            (resolvedTrigger != .calendarAutoStart && title == nil)
             ? probableCalendarSnapshotProvider()
             : nil
         currentMeetingOperationContext = ObservabilityOperationContext()
@@ -612,7 +637,8 @@ final class MeetingRecordingFlowCoordinator {
             let title = pendingTitle
             let calendarEventSnapshot = pendingCalendarEventSnapshot
             let sourceMode = pendingAudioSourceMode ?? meetingAudioSourceModeProvider()
-            let startContext = pendingStartContext
+            let startContext =
+                pendingStartContext
                 ?? makeStartContext(trigger: trigger ?? .manual, sourceMode: sourceMode)
             pendingTrigger = nil
             pendingTitle = nil
@@ -910,6 +936,7 @@ final class MeetingRecordingFlowCoordinator {
             // its live-Ask chat persisted (in .stopRecordingAndTranscribe), so
             // tear it down now; the floating pill alone carries the celebration.
             meetingDurablySaved = true
+            pillViewModel.showAudioSavedConfirmation()
             teardownMeetingPanel()
             // The Metatron resolves to the checkmark once its minimum bloom has
             // also elapsed, then the pill self-dismisses. Interruptible: a
@@ -1000,6 +1027,7 @@ final class MeetingRecordingFlowCoordinator {
         savedCompletionDismissTask = nil
         meetingDurablySaved = false
         metatronBloomSettled = false
+        pillViewModel.clearAudioSavedConfirmation()
     }
 
     /// Tear down the floating pill + panel and return the pill view model to
@@ -1301,9 +1329,9 @@ final class MeetingRecordingFlowCoordinator {
         guard let speechEngineSelectionProvider else { return }
         Task { @MainActor [weak self, weak panelViewModel] in
             guard let self,
-                  let panelViewModel,
-                  self.panelViewModel === panelViewModel,
-                  let selection = await speechEngineSelectionProvider()
+                let panelViewModel,
+                self.panelViewModel === panelViewModel,
+                let selection = await speechEngineSelectionProvider()
             else { return }
             guard selection.engine == .cohere else { return }
             panelViewModel.updateLiveTranscriptStatus(.previewUnsupported(engine: selection.engine))
@@ -1357,6 +1385,11 @@ final class MeetingRecordingFlowCoordinator {
         showMeetingPanel()
     }
 
+    func retryMeetingFinalization(_ transcription: Transcription) async throws {
+        let item = try await makeRetryQueueItem(from: transcription)
+        meetingTranscriptionQueue.enqueue(item)
+    }
+
     private func hideMeetingPanel() {
         panelController?.hide()
     }
@@ -1391,7 +1424,46 @@ final class MeetingRecordingFlowCoordinator {
                 liveTranscriptLagged: item.liveTranscriptLagged,
                 errorType: TelemetryErrorClassifier.classify(error)
             )
+            onQueuedTranscriptionFailed(TranscriptionCompletionNotifier.meetingNeedsRetryContent())
         }
+    }
+
+    private func makeRetryQueueItem(from transcription: Transcription) async throws -> MeetingTranscriptionQueue.Item {
+        let repo = transcriptionRepo
+        return try await Task.detached(priority: .userInitiated) {
+            let latest = try repo.fetch(id: transcription.id) ?? transcription
+            guard latest.sourceType == .meeting else {
+                throw MeetingFinalizationRetryError.notMeeting
+            }
+            guard latest.status != .processing else {
+                throw MeetingFinalizationRetryError.alreadyProcessing
+            }
+            guard let folderURL = MeetingArtifactStore.sessionFolderURL(for: latest)?.standardizedFileURL else {
+                throw MeetingFinalizationRetryError.missingArtifactFolder
+            }
+            let mixedAudioURL =
+                MeetingAudioFile.mixedAudioURL(for: latest)
+                ?? folderURL.appendingPathComponent(MeetingArtifactAudioFileNames.playback)
+            let durationSeconds = latest.durationMs.map { max(0, Double($0) / 1000.0) } ?? 0
+            let recording = try MeetingRecordingOutput.loadArchived(
+                displayName: latest.effectiveDisplayTitle,
+                mixedAudioURL: mixedAudioURL,
+                durationSeconds: durationSeconds
+            )
+            try repo.updateStatus(
+                id: latest.id,
+                status: .processing,
+                errorMessage: nil
+            )
+            return MeetingTranscriptionQueue.Item(
+                recording: recording,
+                transcriptionID: latest.id,
+                operationContext: ObservabilityOperationContext(),
+                trigger: nil,
+                liveWordCount: 0,
+                liveTranscriptLagged: false
+            )
+        }.value
     }
 
     private func persistLiveAskConversationIfNeeded(transcriptionID: UUID) {

--- a/Sources/MacParakeet/App/MeetingTranscriptionQueue.swift
+++ b/Sources/MacParakeet/App/MeetingTranscriptionQueue.swift
@@ -38,6 +38,11 @@ final class MeetingTranscriptionQueue {
         case failure(item: Item, error: Error)
     }
 
+    private enum ProcessingAdmission {
+        case admitted(Item)
+        case alreadyCompleted(Transcription)
+    }
+
     private let logger = Logger(subsystem: "com.macparakeet", category: "MeetingTranscriptionQueue")
     private let transcriptionService: TranscriptionServiceProtocol
     private let transcriptionRepo: TranscriptionRepositoryProtocol
@@ -66,6 +71,12 @@ final class MeetingTranscriptionQueue {
     }
 
     func enqueue(_ item: Item) {
+        guard !containsQueuedTranscription(id: item.transcriptionID) else {
+            logger.info(
+                "queued_meeting_transcription_duplicate_dropped id=\(item.transcriptionID.uuidString, privacy: .public)"
+            )
+            return
+        }
         pendingItems.append(item)
         notifyStateChanged()
         startNextIfNeeded()
@@ -93,7 +104,16 @@ final class MeetingTranscriptionQueue {
     private func process(_ originalItem: Item) async {
         let item: Item
         do {
-            item = try await ensureProcessingRow(for: originalItem)
+            switch try await ensureProcessingRow(for: originalItem) {
+            case .admitted(let admittedItem):
+                item = admittedItem
+            case .alreadyCompleted(let transcription):
+                logger.info(
+                    "queued_meeting_transcription_already_completed id=\(transcription.id.uuidString, privacy: .public)"
+                )
+                finishActiveItem(nil)
+                return
+            }
             if activeItem?.transcriptionID != item.transcriptionID {
                 activeItem = item
                 notifyStateChanged()
@@ -138,19 +158,27 @@ final class MeetingTranscriptionQueue {
         finishActiveItem(.success(item: item, transcription: transcription))
     }
 
-    private func ensureProcessingRow(for item: Item) async throws -> Item {
-        if try await fetchTranscription(id: item.transcriptionID) != nil {
-            try await updateStatus(
-                id: item.transcriptionID,
-                status: .processing,
-                errorMessage: nil
-            )
-            return item
+    private func ensureProcessingRow(for item: Item) async throws -> ProcessingAdmission {
+        if let existing = try await fetchTranscription(id: item.transcriptionID) {
+            guard existing.status != .completed else {
+                return .alreadyCompleted(existing)
+            }
+            if existing.status != .processing || existing.errorMessage != nil {
+                try await updateStatus(
+                    id: item.transcriptionID,
+                    status: .processing,
+                    errorMessage: nil
+                )
+            }
+            return .admitted(item)
         }
 
         let prepared = try await transcriptionService.prepareMeetingTranscription(
             recording: item.recording
         )
+        guard prepared.status != .completed else {
+            return .alreadyCompleted(prepared)
+        }
         if prepared.status != .processing {
             try await updateStatus(
                 id: prepared.id,
@@ -158,7 +186,7 @@ final class MeetingTranscriptionQueue {
                 errorMessage: nil
             )
         }
-        return item.withTranscriptionID(prepared.id)
+        return .admitted(item.withTranscriptionID(prepared.id))
     }
 
     private func markFailed(_ item: Item, error: Error) async {
@@ -193,10 +221,16 @@ final class MeetingTranscriptionQueue {
         }.value
     }
 
-    private func finishActiveItem(_ completion: Completion) {
+    private func containsQueuedTranscription(id: UUID) -> Bool {
+        activeItem?.transcriptionID == id || pendingItems.contains { $0.transcriptionID == id }
+    }
+
+    private func finishActiveItem(_ completion: Completion?) {
         activeTask = nil
         activeItem = nil
-        onCompletion?(completion)
+        if let completion {
+            onCompletion?(completion)
+        }
         notifyStateChanged()
         resumeIdleWaitersIfNeeded()
         startNextIfNeeded()

--- a/Sources/MacParakeet/App/MeetingTranscriptionQueue.swift
+++ b/Sources/MacParakeet/App/MeetingTranscriptionQueue.swift
@@ -11,6 +11,17 @@ final class MeetingTranscriptionQueue {
         let trigger: TelemetryMeetingOperationTrigger?
         let liveWordCount: Int
         let liveTranscriptLagged: Bool
+
+        func withTranscriptionID(_ transcriptionID: UUID) -> Item {
+            Item(
+                recording: recording,
+                transcriptionID: transcriptionID,
+                operationContext: operationContext,
+                trigger: trigger,
+                liveWordCount: liveWordCount,
+                liveTranscriptLagged: liveTranscriptLagged
+            )
+        }
     }
 
     struct Snapshot: Equatable {
@@ -29,6 +40,7 @@ final class MeetingTranscriptionQueue {
 
     private let logger = Logger(subsystem: "com.macparakeet", category: "MeetingTranscriptionQueue")
     private let transcriptionService: TranscriptionServiceProtocol
+    private let transcriptionRepo: TranscriptionRepositoryProtocol
     private let meetingRecordingSettlement: MeetingRecordingSettlement
 
     private var pendingItems: [Item] = []
@@ -41,9 +53,11 @@ final class MeetingTranscriptionQueue {
 
     init(
         transcriptionService: TranscriptionServiceProtocol,
+        transcriptionRepo: TranscriptionRepositoryProtocol,
         meetingRecordingSettlement: MeetingRecordingSettlement
     ) {
         self.transcriptionService = transcriptionService
+        self.transcriptionRepo = transcriptionRepo
         self.meetingRecordingSettlement = meetingRecordingSettlement
     }
 
@@ -76,7 +90,22 @@ final class MeetingTranscriptionQueue {
         }
     }
 
-    private func process(_ item: Item) async {
+    private func process(_ originalItem: Item) async {
+        let item: Item
+        do {
+            item = try await ensureProcessingRow(for: originalItem)
+            if activeItem?.transcriptionID != item.transcriptionID {
+                activeItem = item
+                notifyStateChanged()
+            }
+        } catch {
+            logger.error(
+                "queued_meeting_transcription_prepare_failed session=\(originalItem.recording.sessionID.uuidString, privacy: .public) error_type=\(TelemetryErrorClassifier.classify(error), privacy: .public) error_detail=\(error.localizedDescription, privacy: .private)"
+            )
+            finishActiveItem(.failure(item: originalItem, error: error))
+            return
+        }
+
         let transcription: Transcription
         do {
             transcription = try await Observability.withOperationContext(item.operationContext) {
@@ -90,6 +119,7 @@ final class MeetingTranscriptionQueue {
             logger.error(
                 "queued_meeting_transcription_failed session=\(item.recording.sessionID.uuidString, privacy: .public) error_type=\(TelemetryErrorClassifier.classify(error), privacy: .public) error_detail=\(error.localizedDescription, privacy: .private)"
             )
+            await markFailed(item, error: error)
             finishActiveItem(.failure(item: item, error: error))
             return
         }
@@ -106,6 +136,61 @@ final class MeetingTranscriptionQueue {
             )
         }
         finishActiveItem(.success(item: item, transcription: transcription))
+    }
+
+    private func ensureProcessingRow(for item: Item) async throws -> Item {
+        if try await fetchTranscription(id: item.transcriptionID) != nil {
+            try await updateStatus(
+                id: item.transcriptionID,
+                status: .processing,
+                errorMessage: nil
+            )
+            return item
+        }
+
+        let prepared = try await transcriptionService.prepareMeetingTranscription(
+            recording: item.recording
+        )
+        if prepared.status != .processing {
+            try await updateStatus(
+                id: prepared.id,
+                status: .processing,
+                errorMessage: nil
+            )
+        }
+        return item.withTranscriptionID(prepared.id)
+    }
+
+    private func markFailed(_ item: Item, error: Error) async {
+        do {
+            try await updateStatus(
+                id: item.transcriptionID,
+                status: error is CancellationError ? .cancelled : .error,
+                errorMessage: error is CancellationError ? nil : error.localizedDescription
+            )
+        } catch {
+            logger.error(
+                "queued_meeting_status_update_failed id=\(item.transcriptionID.uuidString, privacy: .public) error=\(error.localizedDescription, privacy: .private)"
+            )
+        }
+    }
+
+    private func fetchTranscription(id: UUID) async throws -> Transcription? {
+        let repo = transcriptionRepo
+        return try await Task.detached(priority: .userInitiated) {
+            try repo.fetch(id: id)
+        }.value
+    }
+
+    private func updateStatus(
+        id: UUID,
+        status: Transcription.TranscriptionStatus,
+        errorMessage: String?
+    ) async throws {
+        let repo = transcriptionRepo
+        try await Task.detached(priority: .userInitiated) {
+            try repo.updateStatus(id: id, status: status, errorMessage: errorMessage)
+        }.value
     }
 
     private func finishActiveItem(_ completion: Completion) {

--- a/Sources/MacParakeet/App/TranscriptionCompletionPresenter.swift
+++ b/Sources/MacParakeet/App/TranscriptionCompletionPresenter.swift
@@ -25,6 +25,10 @@ enum TranscriptionCompletionPresenter {
         postBanner(content)
     }
 
+    static func presentNotification(_ content: TranscriptionCompletionNotifier.Content) {
+        postBanner(content)
+    }
+
     private static func postBanner(_ content: TranscriptionCompletionNotifier.Content) {
         Task {
             guard await CalendarNotificationAuthorization.requestIfNeeded() else {

--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingDeletionCopy.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingDeletionCopy.swift
@@ -25,13 +25,22 @@ enum MeetingDeletionCopy {
     static let fullDeleteMenuTitle = "Delete Meeting"
 
     static func singleAudioOnlyMessage(surface: Surface) -> String {
-        "This permanently deletes the saved audio for this meeting. The meeting stays in \(surface.name) with its transcript. Notes, AI results, and chats stay too if they exist. Playback and re-transcription will no longer be available, and MacParakeet will not be able to detect or backfill speakers for this recording."
+        singleAudioOnlyMessage(surface: surface, status: .completed)
+    }
+
+    static func singleAudioOnlyMessage(
+        surface: Surface,
+        status: Transcription.TranscriptionStatus
+    ) -> String {
+        nonCompletedWarning(status: status)
+            + "This permanently deletes the saved audio for this meeting. The meeting stays in \(surface.name) with its transcript. Notes, AI results, and chats stay too if they exist. Playback and re-transcription will no longer be available, and MacParakeet will not be able to detect or backfill speakers for this recording."
     }
 
     static func bulkAudioOnlyMessage(
         count: Int,
         skippedCount: Int,
-        surface: Surface
+        surface: Surface,
+        hasNonCompletedMeeting: Bool = false
     ) -> String {
         let selectedCount = count + skippedCount
         let selectedWord = selectedCount == 1 ? "meeting" : "meetings"
@@ -41,7 +50,8 @@ enum MeetingDeletionCopy {
         let recordingObject = count == 1 ? "this recording" : "these recordings"
         let prefix = skippedCount > 0 ? "\(selectedCount) selected \(selectedWord). " : ""
         var message =
-            "\(prefix)This permanently deletes saved audio from \(count) \(meetingWord). \(meetingSubject) in \(surface.name) with \(transcriptObject). Notes, AI results, and chats stay too if they exist. Playback and re-transcription will no longer be available, and MacParakeet will not be able to detect or backfill speakers for \(recordingObject)."
+            bulkNonCompletedWarning(hasNonCompletedMeeting: hasNonCompletedMeeting)
+            + "\(prefix)This permanently deletes saved audio from \(count) \(meetingWord). \(meetingSubject) in \(surface.name) with \(transcriptObject). Notes, AI results, and chats stay too if they exist. Playback and re-transcription will no longer be available, and MacParakeet will not be able to detect or backfill speakers for \(recordingObject)."
         if skippedCount > 0 {
             if skippedCount == 1 {
                 message += " 1 selected meeting already has no saved audio, so it will be skipped."
@@ -54,31 +64,53 @@ enum MeetingDeletionCopy {
     }
 
     static func singleFullDeleteMessage(title: String) -> String {
-        "This permanently deletes \"\(title)\", including its transcript and saved audio. Notes, AI results, and chats for this meeting are also deleted if they exist."
+        singleFullDeleteMessage(title: title, status: .completed)
     }
 
-    static func bulkFullDeleteMessage(count: Int) -> String {
+    static func singleFullDeleteMessage(
+        title: String,
+        status: Transcription.TranscriptionStatus
+    ) -> String {
+        nonCompletedWarning(status: status)
+            + "This permanently deletes \"\(title)\", including its transcript and saved audio. Notes, AI results, and chats for this meeting are also deleted if they exist."
+    }
+
+    static func singleFullDeleteMessage(for transcription: Transcription) -> String {
+        singleFullDeleteMessage(
+            title: transcription.fileName,
+            status: transcription.status
+        )
+    }
+
+    static func bulkFullDeleteMessage(
+        count: Int,
+        hasNonCompletedMeeting: Bool = false
+    ) -> String {
         let meetingWord = count == 1 ? "meeting" : "meetings"
         let transcriptObject = count == 1 ? "its transcript and saved audio" : "transcripts and saved audio"
         let artifactSubject = count == 1 ? "this meeting" : "those meetings"
         return
-            "This permanently deletes \(count) \(meetingWord), including \(transcriptObject). Notes, AI results, and chats for \(artifactSubject) are also deleted if they exist."
+            bulkNonCompletedWarning(hasNonCompletedMeeting: hasNonCompletedMeeting)
+            + "This permanently deletes \(count) \(meetingWord), including \(transcriptObject). Notes, AI results, and chats for \(artifactSubject) are also deleted if they exist."
     }
 
     static func mixedBulkFullDeleteMessage(
         totalCount: Int,
-        meetingCount: Int
+        meetingCount: Int,
+        hasNonCompletedMeeting: Bool = false
     ) -> String {
         let itemWord = totalCount == 1 ? "item" : "items"
         let meetingWord = meetingCount == 1 ? "meeting" : "meetings"
         return
-            "This permanently deletes \(totalCount) \(itemWord), including \(meetingCount) \(meetingWord). Meeting transcripts, saved audio, notes, AI results, and chats are removed if they exist. Original local source files are not removed."
+            bulkNonCompletedWarning(hasNonCompletedMeeting: hasNonCompletedMeeting)
+            + "This permanently deletes \(totalCount) \(itemWord), including \(meetingCount) \(meetingWord). Meeting transcripts, saved audio, notes, AI results, and chats are removed if they exist. Original local source files are not removed."
     }
 
     static func audioUnavailableHelp(for state: MeetingAudioFile.State) -> String {
         switch state {
         case .saved:
-            assertionFailure("audioUnavailableHelp called for .saved state; callers should show positive help text instead.")
+            assertionFailure(
+                "audioUnavailableHelp called for .saved state; callers should show positive help text instead.")
             return "Meeting audio is available"
         case .removed:
             return "Saved meeting audio has been removed"
@@ -87,5 +119,15 @@ enum MeetingDeletionCopy {
         case .notMeeting:
             return "Meeting audio is not available"
         }
+    }
+
+    private static func nonCompletedWarning(status: Transcription.TranscriptionStatus) -> String {
+        guard status != .completed else { return "" }
+        return "This meeting hasn't been transcribed yet — deleting the audio makes that permanent. "
+    }
+
+    private static func bulkNonCompletedWarning(hasNonCompletedMeeting: Bool) -> String {
+        guard hasNonCompletedMeeting else { return "" }
+        return "At least one selected meeting hasn't been transcribed yet — deleting the audio makes that permanent. "
     }
 }

--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingRowCard.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingRowCard.swift
@@ -18,28 +18,26 @@ struct MeetingRowCard<MenuContent: View>: View {
     @State private var showsErrorDetail = false
 
     var body: some View {
-        HStack(alignment: .top, spacing: DesignSystem.Spacing.md) {
-            if showsSelectionControls {
-                selectionBadge
-                    .padding(.top, 1)
+        VStack(alignment: .leading, spacing: 3) {
+            HStack(alignment: .top, spacing: DesignSystem.Spacing.md) {
+                rowActivationButton
+
+                if showsRetryButton {
+                    retryButton
+                        .padding(.top, 4)
+                }
             }
-            contentColumn
-            trailingColumn
+
+            errorDetailDisclosure
         }
         .padding(.horizontal, DesignSystem.Spacing.lg)
         .padding(.vertical, 12)
         .frame(minHeight: 64, alignment: .top)
-        .contentShape(Rectangle())
         .background(rowBackground)
-        .onTapGesture(perform: onTap)
         .help(hoverTooltip)
         .onHover { hovered = $0 }
         .animation(DesignSystem.Animation.hoverTransition, value: hovered)
         .contextMenu { menuContent() }
-        .accessibilityElement(children: .combine)
-        .accessibilityValue(showsSelectionControls ? (isSelected ? "Selected" : "Not selected") : "")
-        .accessibilityHint(showsSelectionControls ? "Toggles selection" : hoverTooltip)
-        .accessibilityAddTraits(.isButton)
     }
 
     // MARK: - Backgrounds
@@ -84,6 +82,25 @@ struct MeetingRowCard<MenuContent: View>: View {
     }
 
     // MARK: - Content
+
+    private var rowActivationButton: some View {
+        Button(action: onTap) {
+            HStack(alignment: .top, spacing: DesignSystem.Spacing.md) {
+                if showsSelectionControls {
+                    selectionBadge
+                        .padding(.top, 1)
+                }
+                contentColumn
+                metadataColumn
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityElement(children: .combine)
+        .accessibilityValue(showsSelectionControls ? (isSelected ? "Selected" : "Not selected") : "")
+        .accessibilityHint(showsSelectionControls ? "Toggles selection" : hoverTooltip)
+    }
 
     private var contentColumn: some View {
         VStack(alignment: .leading, spacing: 3) {
@@ -158,7 +175,7 @@ struct MeetingRowCard<MenuContent: View>: View {
                     .lineLimit(1)
             }
         } else if transcription.status == .error {
-            failedStatusContent
+            failedHeadlineRow
         } else if transcription.status == .cancelled {
             // Keep-Audio outcome of the stop-transcription flow (issue #487):
             // the audio is intact and retranscribable from the detail view.
@@ -169,19 +186,26 @@ struct MeetingRowCard<MenuContent: View>: View {
         }
     }
 
-    private var failedStatusContent: some View {
-        VStack(alignment: .leading, spacing: 3) {
-            HStack(spacing: 5) {
-                Image(systemName: "exclamationmark.triangle.fill")
-                    .font(.system(size: 10, weight: .semibold))
-                    .foregroundStyle(DesignSystem.Colors.warningAmber)
-                Text(failedHeadline)
-                    .font(DesignSystem.Typography.bodySmall)
-                    .foregroundStyle(DesignSystem.Colors.textSecondary)
-                    .lineLimit(1)
-            }
+    private var failedHeadlineRow: some View {
+        HStack(spacing: 5) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(DesignSystem.Colors.warningAmber)
+            Text(failedHeadline)
+                .font(DesignSystem.Typography.bodySmall)
+                .foregroundStyle(DesignSystem.Colors.textSecondary)
+                .lineLimit(1)
+        }
+    }
 
-            if let detail = errorDetail {
+    @ViewBuilder
+    private var errorDetailDisclosure: some View {
+        if transcription.status == .error, let detail = errorDetail {
+            HStack(alignment: .top, spacing: DesignSystem.Spacing.md) {
+                if showsSelectionControls {
+                    Color.clear
+                        .frame(width: 18, height: 1)
+                }
                 DisclosureGroup(isExpanded: $showsErrorDetail) {
                     Text(detail)
                         .font(DesignSystem.Typography.micro)
@@ -202,7 +226,7 @@ struct MeetingRowCard<MenuContent: View>: View {
 
     // MARK: - Trailing
 
-    private var trailingColumn: some View {
+    private var metadataColumn: some View {
         VStack(alignment: .trailing, spacing: 3) {
             if let durationMs = transcription.durationMs {
                 Text(durationMs.formattedDurationCompact)
@@ -217,11 +241,6 @@ struct MeetingRowCard<MenuContent: View>: View {
                 .foregroundStyle(DesignSystem.Colors.textTertiary)
                 .monospacedDigit()
                 .lineLimit(1)
-
-            if showsRetryButton {
-                retryButton
-                    .padding(.top, 4)
-            }
         }
         .fixedSize()
     }

--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingRowCard.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingRowCard.swift
@@ -149,9 +149,8 @@ struct MeetingRowCard<MenuContent: View>: View {
                 .truncationMode(.tail)
         } else if transcription.status == .processing {
             HStack(spacing: 5) {
-                ProgressView()
-                    .controlSize(.small)
-                    .scaleEffect(0.55)
+                ParakeetSpinner(.inline)
+                    .scaleEffect(0.85)
                     .frame(width: 12, height: 12)
                 Text(statusLine("Transcribing"))
                     .font(DesignSystem.Typography.bodySmall)
@@ -233,9 +232,8 @@ struct MeetingRowCard<MenuContent: View>: View {
         } label: {
             HStack(spacing: 5) {
                 if isRetrying {
-                    ProgressView()
-                        .controlSize(.small)
-                        .scaleEffect(0.55)
+                    ParakeetSpinner(.inline)
+                        .scaleEffect(0.85)
                         .frame(width: 12, height: 12)
                 } else {
                     Image(systemName: "arrow.clockwise")

--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingRowCard.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingRowCard.swift
@@ -9,28 +9,29 @@ struct MeetingRowCard<MenuContent: View>: View {
     var searchText: String = ""
     var isSelected: Bool = false
     var showsSelectionControls: Bool = false
+    var isRetrying: Bool = false
     var onTap: () -> Void
+    var onRetry: (() -> Void)? = nil
     @ViewBuilder var menuContent: () -> MenuContent
 
     @State private var hovered = false
+    @State private var showsErrorDetail = false
 
     var body: some View {
-        Button(action: onTap) {
-            HStack(alignment: .top, spacing: DesignSystem.Spacing.md) {
-                if showsSelectionControls {
-                    selectionBadge
-                        .padding(.top, 1)
-                }
-                contentColumn
-                trailingColumn
+        HStack(alignment: .top, spacing: DesignSystem.Spacing.md) {
+            if showsSelectionControls {
+                selectionBadge
+                    .padding(.top, 1)
             }
-            .padding(.horizontal, DesignSystem.Spacing.lg)
-            .padding(.vertical, 12)
-            .frame(minHeight: 64, alignment: .top)
-            .contentShape(Rectangle())
-            .background(rowBackground)
+            contentColumn
+            trailingColumn
         }
-        .buttonStyle(.plain)
+        .padding(.horizontal, DesignSystem.Spacing.lg)
+        .padding(.vertical, 12)
+        .frame(minHeight: 64, alignment: .top)
+        .contentShape(Rectangle())
+        .background(rowBackground)
+        .onTapGesture(perform: onTap)
         .help(hoverTooltip)
         .onHover { hovered = $0 }
         .animation(DesignSystem.Animation.hoverTransition, value: hovered)
@@ -38,6 +39,7 @@ struct MeetingRowCard<MenuContent: View>: View {
         .accessibilityElement(children: .combine)
         .accessibilityValue(showsSelectionControls ? (isSelected ? "Selected" : "Not selected") : "")
         .accessibilityHint(showsSelectionControls ? "Toggles selection" : hoverTooltip)
+        .accessibilityAddTraits(.isButton)
     }
 
     // MARK: - Backgrounds
@@ -146,15 +148,18 @@ struct MeetingRowCard<MenuContent: View>: View {
                 .lineLimit(1)
                 .truncationMode(.tail)
         } else if transcription.status == .processing {
-            Text("Transcribing…")
-                .font(DesignSystem.Typography.bodySmall)
-                .foregroundStyle(DesignSystem.Colors.textTertiary)
-                .lineLimit(1)
+            HStack(spacing: 5) {
+                ProgressView()
+                    .controlSize(.small)
+                    .scaleEffect(0.55)
+                    .frame(width: 12, height: 12)
+                Text(statusLine("Transcribing"))
+                    .font(DesignSystem.Typography.bodySmall)
+                    .foregroundStyle(DesignSystem.Colors.textTertiary)
+                    .lineLimit(1)
+            }
         } else if transcription.status == .error {
-            Text(statusLine("Transcription failed"))
-                .font(DesignSystem.Typography.bodySmall)
-                .foregroundStyle(DesignSystem.Colors.errorRed.opacity(0.85))
-                .lineLimit(1)
+            failedStatusContent
         } else if transcription.status == .cancelled {
             // Keep-Audio outcome of the stop-transcription flow (issue #487):
             // the audio is intact and retranscribable from the detail view.
@@ -162,6 +167,37 @@ struct MeetingRowCard<MenuContent: View>: View {
                 .font(DesignSystem.Typography.bodySmall)
                 .foregroundStyle(DesignSystem.Colors.textTertiary)
                 .lineLimit(1)
+        }
+    }
+
+    private var failedStatusContent: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            HStack(spacing: 5) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(DesignSystem.Colors.warningAmber)
+                Text(failedHeadline)
+                    .font(DesignSystem.Typography.bodySmall)
+                    .foregroundStyle(DesignSystem.Colors.textSecondary)
+                    .lineLimit(1)
+            }
+
+            if let detail = errorDetail {
+                DisclosureGroup(isExpanded: $showsErrorDetail) {
+                    Text(detail)
+                        .font(DesignSystem.Typography.micro)
+                        .foregroundStyle(DesignSystem.Colors.textTertiary)
+                        .lineLimit(3)
+                        .textSelection(.enabled)
+                        .padding(.top, 1)
+                } label: {
+                    Text("Details")
+                        .font(DesignSystem.Typography.micro.weight(.medium))
+                        .foregroundStyle(DesignSystem.Colors.textTertiary)
+                }
+                .disclosureGroupStyle(.automatic)
+                .fixedSize(horizontal: false, vertical: true)
+            }
         }
     }
 
@@ -182,8 +218,48 @@ struct MeetingRowCard<MenuContent: View>: View {
                 .foregroundStyle(DesignSystem.Colors.textTertiary)
                 .monospacedDigit()
                 .lineLimit(1)
+
+            if showsRetryButton {
+                retryButton
+                    .padding(.top, 4)
+            }
         }
         .fixedSize()
+    }
+
+    private var retryButton: some View {
+        Button {
+            onRetry?()
+        } label: {
+            HStack(spacing: 5) {
+                if isRetrying {
+                    ProgressView()
+                        .controlSize(.small)
+                        .scaleEffect(0.55)
+                        .frame(width: 12, height: 12)
+                } else {
+                    Image(systemName: "arrow.clockwise")
+                        .font(.system(size: 10, weight: .semibold))
+                }
+                Text(isRetrying ? "Retrying" : "Retry")
+                    .font(DesignSystem.Typography.micro.weight(.semibold))
+            }
+            .foregroundStyle(retryButtonForeground)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 5)
+            .background(
+                Capsule()
+                    .fill(DesignSystem.Colors.surfaceElevated.opacity(0.72))
+                    .overlay(
+                        Capsule()
+                            .strokeBorder(DesignSystem.Colors.border.opacity(0.8), lineWidth: 0.6)
+                    )
+            )
+        }
+        .buttonStyle(.plain)
+        .disabled(isRetrying || onRetry == nil || audioState != .saved)
+        .help(retryHelp)
+        .accessibilityLabel(isRetrying ? "Retrying transcription" : "Retry transcription")
     }
 
     // MARK: - Derived display values
@@ -196,7 +272,8 @@ struct MeetingRowCard<MenuContent: View>: View {
     }
 
     private var displayedSnippet: String? {
-        if let derived = transcription.derivedSnippet?.trimmingCharacters(in: .whitespacesAndNewlines), !derived.isEmpty {
+        if let derived = transcription.derivedSnippet?.trimmingCharacters(in: .whitespacesAndNewlines), !derived.isEmpty
+        {
             return derived
         }
         return legacySnippet
@@ -206,7 +283,8 @@ struct MeetingRowCard<MenuContent: View>: View {
         guard let text = transcription.cleanTranscript ?? transcription.rawTranscript, !text.isEmpty else {
             return nil
         }
-        let cleaned = text
+        let cleaned =
+            text
             .replacingOccurrences(of: "\n", with: " ")
             .trimmingCharacters(in: .whitespacesAndNewlines)
         guard !cleaned.isEmpty else { return nil }
@@ -220,6 +298,51 @@ struct MeetingRowCard<MenuContent: View>: View {
 
     private var audioState: MeetingAudioFile.State {
         MeetingAudioFile.state(for: transcription)
+    }
+
+    private var errorDetail: String? {
+        guard let detail = transcription.errorMessage?.trimmingCharacters(in: .whitespacesAndNewlines),
+            !detail.isEmpty
+        else {
+            return nil
+        }
+        return detail
+    }
+
+    private var failedHeadline: String {
+        switch audioState {
+        case .saved:
+            return "Transcription failed — audio is saved"
+        case .removed:
+            return "Transcription failed — audio removed"
+        case .missing:
+            return "Transcription failed — audio missing"
+        case .notMeeting:
+            return "Transcription failed"
+        }
+    }
+
+    private var showsRetryButton: Bool {
+        transcription.sourceType == .meeting && transcription.status == .error
+    }
+
+    private var retryButtonForeground: Color {
+        if isRetrying || onRetry == nil || audioState != .saved {
+            return DesignSystem.Colors.textTertiary
+        }
+        return DesignSystem.Colors.accent
+    }
+
+    private var retryHelp: String {
+        if isRetrying {
+            return "Retry is already in progress"
+        }
+        guard onRetry != nil else {
+            return "Retry is not available"
+        }
+        return audioState == .saved
+            ? "Retry transcription from saved meeting audio"
+            : "Saved meeting audio is required before retrying transcription"
     }
 
     private var showsAudioInline: Bool {

--- a/Sources/MacParakeet/Views/Meetings/MeetingsView.swift
+++ b/Sources/MacParakeet/Views/Meetings/MeetingsView.swift
@@ -103,7 +103,12 @@ struct MeetingsView: View {
                 }
             }
         } message: {
-            Text(MeetingDeletionCopy.singleAudioOnlyMessage(surface: .meetings))
+            Text(
+                MeetingDeletionCopy.singleAudioOnlyMessage(
+                    surface: .meetings,
+                    status: pendingDeleteAudio?.status ?? .completed
+                )
+            )
         }
         .alert(
             MeetingDeletionCopy.fullDeleteAlertTitle,
@@ -123,7 +128,7 @@ struct MeetingsView: View {
             }
         } message: {
             if let pendingDeleteMeeting {
-                Text(MeetingDeletionCopy.singleFullDeleteMessage(title: pendingDeleteMeeting.fileName))
+                Text(MeetingDeletionCopy.singleFullDeleteMessage(for: pendingDeleteMeeting))
             }
         }
         .alert(
@@ -531,6 +536,7 @@ struct MeetingsView: View {
                         searchText: viewModel.recentMeetingsViewModel.searchText,
                         isSelected: viewModel.recentMeetingsViewModel.isTranscriptionSelected(transcription),
                         showsSelectionControls: viewModel.recentMeetingsViewModel.isBulkSelectionModeEnabled,
+                        isRetrying: viewModel.recentMeetingsViewModel.isRetryingMeetingTranscription(transcription),
                         onTap: {
                             if viewModel.recentMeetingsViewModel.isBulkOperationInProgress {
                                 return
@@ -540,6 +546,9 @@ struct MeetingsView: View {
                             } else {
                                 onSelectMeeting(transcription)
                             }
+                        },
+                        onRetry: {
+                            viewModel.recentMeetingsViewModel.retryMeetingTranscription(transcription)
                         },
                         menuContent: { recentMeetingMenu(for: transcription) }
                     )
@@ -572,6 +581,17 @@ struct MeetingsView: View {
         let artifactAvailable = MeetingArtifactActions.folderURL(for: transcription) != nil
 
         Divider()
+
+        if transcription.status == .error {
+            Button {
+                viewModel.recentMeetingsViewModel.retryMeetingTranscription(transcription)
+            } label: {
+                Label("Retry Transcription", systemImage: "arrow.clockwise")
+            }
+            .disabled(viewModel.recentMeetingsViewModel.isRetryingMeetingTranscription(transcription) || audioState != .saved)
+
+            Divider()
+        }
 
         Button {
             MeetingArtifactActions.openFolder(for: transcription)
@@ -772,11 +792,15 @@ struct MeetingsView: View {
             return MeetingDeletionCopy.bulkAudioOnlyMessage(
                 count: operation.targetCount,
                 skippedCount: operation.skippedCount,
-                surface: .meetings
+                surface: .meetings,
+                hasNonCompletedMeeting: operation.hasNonCompletedMeeting
             )
         }
 
-        return MeetingDeletionCopy.bulkFullDeleteMessage(count: operation.targetCount)
+        return MeetingDeletionCopy.bulkFullDeleteMessage(
+            count: operation.targetCount,
+            hasNonCompletedMeeting: operation.hasNonCompletedMeeting
+        )
     }
 
     private func handleRecentMeetingsSelectionKeyPress(_ press: KeyPress) -> KeyPress.Result {

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -1890,7 +1890,7 @@ struct SettingsView: View {
                             buttonTitle: "Clear…",
                             accessibilityLabel: "Clear meeting audio",
                             confirmationTitle: "Clear Meeting Audio?",
-                            confirmationMessage: "This will delete all saved meeting audio, including interrupted recovery recordings, and detach audio from existing meeting transcripts. Meeting transcripts stay. This cannot be undone.",
+                            confirmationMessage: "This will delete all saved meeting audio, including interrupted recovery recordings, and detach audio from existing meeting transcripts. Meeting transcripts stay. Any meeting that hasn't been transcribed yet will lose its retry source permanently. This cannot be undone.",
                             confirmButtonLabel: "Clear Audio",
                             perform: viewModel.clearMeetingAudio
                         )

--- a/Sources/MacParakeet/Views/Transcription/MeetingRecordingTile.swift
+++ b/Sources/MacParakeet/Views/Transcription/MeetingRecordingTile.swift
@@ -155,6 +155,7 @@ struct MeetingRecordingTile: View {
                     .font(DesignSystem.Typography.caption)
                     .foregroundStyle(DesignSystem.Colors.textSecondary)
                     .lineLimit(2)
+                audioSavedConfirmationBadge
                 backgroundTranscriptionBadge
             }
 
@@ -214,6 +215,7 @@ struct MeetingRecordingTile: View {
                         MeetingSourceHealthInlineBadge(chip: warning)
                     }
                 }
+                audioSavedConfirmationBadge
                 backgroundTranscriptionBadge
             }
 
@@ -225,6 +227,18 @@ struct MeetingRecordingTile: View {
                 }
                 stopButton
             }
+        }
+    }
+
+    @ViewBuilder
+    private var audioSavedConfirmationBadge: some View {
+        if viewModel.showsAudioSavedConfirmation {
+            Label("Audio saved", systemImage: "checkmark.circle.fill")
+                .font(DesignSystem.Typography.micro.weight(.medium))
+                .foregroundStyle(DesignSystem.Colors.successGreen)
+                .lineLimit(1)
+                .transition(.opacity)
+                .accessibilityLabel("Audio saved")
         }
     }
 
@@ -290,7 +304,7 @@ struct MeetingRecordingTile: View {
                 Text("Saved to Library")
                     .font(DesignSystem.Typography.sectionTitle)
                     .foregroundStyle(DesignSystem.Colors.textPrimary)
-                Text("Your meeting is ready.")
+                Text("Audio saved")
                     .font(DesignSystem.Typography.caption)
                     .foregroundStyle(DesignSystem.Colors.textSecondary)
                     .lineLimit(1)
@@ -433,9 +447,10 @@ private struct StartRecordingButton: View {
             if hovering { NSCursor.pointingHand.push() } else { NSCursor.pop() }
         }
         .accessibilityLabel(permissionState.isReady ? "Start recording" : "Enable meeting recording")
-        .accessibilityHint(permissionState.isReady
-            ? "Captures system audio and microphone, then transcribes locally."
-            : "Opens the required macOS permission flow before recording.")
+        .accessibilityHint(
+            permissionState.isReady
+                ? "Captures system audio and microphone, then transcribes locally."
+                : "Opens the required macOS permission flow before recording.")
     }
 }
 
@@ -482,9 +497,11 @@ private struct TilePauseResumeButton: View {
             .padding(.vertical, 7)
             .background(
                 Capsule()
-                    .fill(isHovered
-                        ? DesignSystem.Colors.warningAmber.opacity(0.12)
-                        : DesignSystem.Colors.surfaceElevated.opacity(0.7))
+                    .fill(
+                        isHovered
+                            ? DesignSystem.Colors.warningAmber.opacity(0.12)
+                            : DesignSystem.Colors.surfaceElevated.opacity(0.7)
+                    )
                     .overlay(
                         Capsule()
                             .stroke(

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
@@ -695,7 +695,12 @@ struct TranscriptResultView: View {
                 deleteMeetingAudioFromActionBar()
             }
         } message: {
-            Text(MeetingDeletionCopy.singleAudioOnlyMessage(surface: .library))
+            Text(
+                MeetingDeletionCopy.singleAudioOnlyMessage(
+                    surface: .library,
+                    status: activeTranscription.status
+                )
+            )
         }
         .popover(item: $exportConfirmation, arrowEdge: .top) { confirmation in
             exportConfirmationPopover(confirmation)

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
@@ -182,7 +182,12 @@ struct TranscriptionLibraryView: View {
                 }
             }
         } message: {
-            Text(MeetingDeletionCopy.singleAudioOnlyMessage(surface: .library))
+            Text(
+                MeetingDeletionCopy.singleAudioOnlyMessage(
+                    surface: .library,
+                    status: pendingDeleteAudio?.status ?? .completed
+                )
+            )
         }
         .alert(
             bulkOperationTitle,
@@ -294,6 +299,7 @@ struct TranscriptionLibraryView: View {
                             searchText: viewModel.searchText,
                             isSelected: viewModel.isTranscriptionSelected(transcription),
                             showsSelectionControls: viewModel.isBulkSelectionModeEnabled,
+                            isRetrying: viewModel.isRetryingMeetingTranscription(transcription),
                             onTap: {
                                 if viewModel.isBulkOperationInProgress || bulkExportInProgress {
                                     return
@@ -303,6 +309,9 @@ struct TranscriptionLibraryView: View {
                                 } else {
                                     onSelect(transcription)
                                 }
+                            },
+                            onRetry: {
+                                viewModel.retryMeetingTranscription(transcription)
                             },
                             menuContent: { libraryMenuItems(for: transcription) }
                         )
@@ -349,6 +358,17 @@ struct TranscriptionLibraryView: View {
             let artifactAvailable = MeetingArtifactActions.folderURL(for: transcription) != nil
 
             Divider()
+
+            if transcription.status == .error {
+                Button {
+                    viewModel.retryMeetingTranscription(transcription)
+                } label: {
+                    Label("Retry Transcription", systemImage: "arrow.clockwise")
+                }
+                .disabled(viewModel.isRetryingMeetingTranscription(transcription) || audioState != .saved)
+
+                Divider()
+            }
 
             Button {
                 MeetingArtifactActions.openFolder(for: transcription)
@@ -892,17 +912,22 @@ struct TranscriptionLibraryView: View {
             return MeetingDeletionCopy.bulkAudioOnlyMessage(
                 count: operation.targetCount,
                 skippedCount: operation.skippedCount,
-                surface: .library
+                surface: .library,
+                hasNonCompletedMeeting: operation.hasNonCompletedMeeting
             )
         }
 
         if operation.meetingCount > 0 {
             if operation.meetingCount == operation.targetCount {
-                return MeetingDeletionCopy.bulkFullDeleteMessage(count: operation.targetCount)
+                return MeetingDeletionCopy.bulkFullDeleteMessage(
+                    count: operation.targetCount,
+                    hasNonCompletedMeeting: operation.hasNonCompletedMeeting
+                )
             }
             return MeetingDeletionCopy.mixedBulkFullDeleteMessage(
                 totalCount: operation.targetCount,
-                meetingCount: operation.meetingCount
+                meetingCount: operation.meetingCount,
+                hasNonCompletedMeeting: operation.hasNonCompletedMeeting
             )
         }
 
@@ -919,7 +944,7 @@ struct TranscriptionLibraryView: View {
 
     private func singleDeleteMessage(for transcription: Transcription) -> String {
         if transcription.sourceType == .meeting {
-            return MeetingDeletionCopy.singleFullDeleteMessage(title: transcription.fileName)
+            return MeetingDeletionCopy.singleFullDeleteMessage(for: transcription)
         }
         return "\"\(transcription.fileName)\" will be permanently deleted. Original local source files are not removed."
     }

--- a/Sources/MacParakeetCore/Database/TranscriptionLibraryQuery.swift
+++ b/Sources/MacParakeetCore/Database/TranscriptionLibraryQuery.swift
@@ -14,6 +14,7 @@ public struct TranscriptionLibraryQuery: Sendable, Equatable {
     public var limit: Int
     public var offset: Int
     public var includeProcessing: Bool
+    public var includeProcessingMeetings: Bool
 
     public init(
         sourceType: Transcription.SourceType? = nil,
@@ -22,7 +23,8 @@ public struct TranscriptionLibraryQuery: Sendable, Equatable {
         sortOrder: TranscriptionLibrarySortOrder = .dateDescending,
         limit: Int = 100,
         offset: Int = 0,
-        includeProcessing: Bool = false
+        includeProcessing: Bool = false,
+        includeProcessingMeetings: Bool = false
     ) {
         self.sourceType = sourceType
         self.favoritesOnly = favoritesOnly
@@ -31,6 +33,7 @@ public struct TranscriptionLibraryQuery: Sendable, Equatable {
         self.limit = limit
         self.offset = offset
         self.includeProcessing = includeProcessing
+        self.includeProcessingMeetings = includeProcessingMeetings
     }
 }
 

--- a/Sources/MacParakeetCore/Database/TranscriptionRepository.swift
+++ b/Sources/MacParakeetCore/Database/TranscriptionRepository.swift
@@ -7,6 +7,7 @@ public protocol TranscriptionRepositoryProtocol: Sendable {
     func fetchAll(limit: Int?) throws -> [Transcription]
     func fetchLibraryPage(query: TranscriptionLibraryQuery) throws -> TranscriptionLibraryPage
     func fetchByFilePath(_ filePath: String, sourceType: Transcription.SourceType?) throws -> [Transcription]
+    func fetchMeetings(withStatus status: Transcription.TranscriptionStatus) throws -> [Transcription]
     func fetchMeetingAudioRetentionCandidates(createdAtOrBefore cutoff: Date) throws -> [Transcription]
     func fetchCompletedByVideoID(_ videoID: String) throws -> Transcription?
     func count() throws -> Int
@@ -44,6 +45,12 @@ extension TranscriptionRepositoryProtocol {
                 && !($0.filePath?.isEmpty ?? true)
                 && $0.status == .completed
                 && $0.createdAt <= cutoff
+        }
+    }
+
+    public func fetchMeetings(withStatus status: Transcription.TranscriptionStatus) throws -> [Transcription] {
+        try fetchAll(limit: nil).filter {
+            $0.sourceType == .meeting && $0.status == status
         }
     }
 
@@ -350,6 +357,16 @@ public final class TranscriptionRepository: TranscriptionRepositoryProtocol, @un
                 request = request.filter(Transcription.Columns.sourceType == sourceType.rawValue)
             }
             return try request.fetchAll(db)
+        }
+    }
+
+    public func fetchMeetings(withStatus status: Transcription.TranscriptionStatus) throws -> [Transcription] {
+        try dbQueue.read { db in
+            try Transcription
+                .filter(Transcription.Columns.sourceType == Transcription.SourceType.meeting.rawValue)
+                .filter(Transcription.Columns.status == status.rawValue)
+                .order(Transcription.Columns.createdAt.desc)
+                .fetchAll(db)
         }
     }
 

--- a/Sources/MacParakeetCore/Database/TranscriptionRepository.swift
+++ b/Sources/MacParakeetCore/Database/TranscriptionRepository.swift
@@ -54,7 +54,10 @@ extension TranscriptionRepositoryProtocol {
         var results = try fetchAll(limit: nil)
 
         if !query.includeProcessing {
-            results = results.filter { $0.status != .processing }
+            results = results.filter {
+                $0.status != .processing
+                    || (query.includeProcessingMeetings && $0.sourceType == .meeting)
+            }
         }
         if let sourceType = query.sourceType {
             results = results.filter { $0.sourceType == sourceType }
@@ -166,8 +169,14 @@ public final class TranscriptionRepository: TranscriptionRepositoryProtocol, @un
             var arguments: [any DatabaseValueConvertible] = []
 
             if !query.includeProcessing {
-                whereClauses.append("status != ?")
-                arguments.append(Transcription.TranscriptionStatus.processing.rawValue)
+                if query.includeProcessingMeetings {
+                    whereClauses.append("(status != ? OR sourceType = ?)")
+                    arguments.append(Transcription.TranscriptionStatus.processing.rawValue)
+                    arguments.append(Transcription.SourceType.meeting.rawValue)
+                } else {
+                    whereClauses.append("status != ?")
+                    arguments.append(Transcription.TranscriptionStatus.processing.rawValue)
+                }
             }
             if let sourceType = query.sourceType {
                 whereClauses.append("sourceType = ?")

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingAudioFile.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingAudioFile.swift
@@ -28,14 +28,15 @@ public enum MeetingAudioFile {
     public static func mixedAudioURL(for transcription: Transcription) -> URL? {
         guard transcription.sourceType == .meeting else { return nil }
         guard let path = transcription.filePath,
-              !path.trimmingCharacters(in: .whitespaces).isEmpty else {
+            !path.trimmingCharacters(in: .whitespaces).isEmpty
+        else {
             return nil
         }
         return URL(fileURLWithPath: path)
     }
 
-    /// Whether finalized meeting audio is reachable on disk. Returns false for
-    /// non-meeting rows, actively processing rows, and missing audio files.
+    /// Whether meeting audio is reachable on disk. Returns false for
+    /// non-meeting rows and missing audio files.
     public static func isAvailable(
         for transcription: Transcription,
         fileManager: FileManager = .default
@@ -53,8 +54,7 @@ public enum MeetingAudioFile {
         for transcription: Transcription,
         fileManager: FileManager = .default
     ) -> State {
-        guard transcription.sourceType == .meeting,
-              transcription.status != .processing else {
+        guard transcription.sourceType == .meeting else {
             return .notMeeting
         }
         guard let url = mixedAudioURL(for: transcription) else { return .removed }
@@ -125,7 +125,8 @@ public enum MeetingAudioFile {
     ///   name (`"Meeting May 11, 2026 at 1:32 PM"`); appending another
     ///   date would just create noise.
     public static func suggestedExportStem(for transcription: Transcription) -> String {
-        let derived = transcription.derivedTitle?
+        let derived =
+            transcription.derivedTitle?
             .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         if !derived.isEmpty {
             let datePart = isoDateFormatter.string(from: transcription.createdAt)
@@ -164,14 +165,16 @@ public enum MeetingAudioFile {
         var disallowed = CharacterSet(charactersIn: "/:\\\"")
         disallowed.formUnion(.controlCharacters)
 
-        let cleaned = input
+        let cleaned =
+            input
             .components(separatedBy: disallowed)
             .joined(separator: " ")
             .components(separatedBy: .whitespacesAndNewlines)
             .filter { !$0.isEmpty }
             .joined(separator: " ")
 
-        let capped = cleaned.count <= maxStemLength
+        let capped =
+            cleaned.count <= maxStemLength
             ? cleaned
             : String(cleaned.prefix(maxStemLength))
                 .trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/MacParakeetViewModels/MeetingRecordingPillViewModel.swift
+++ b/Sources/MacParakeetViewModels/MeetingRecordingPillViewModel.swift
@@ -21,11 +21,34 @@ public final class MeetingRecordingPillViewModel {
     public var systemLevel: Float = 0
     public var captureHealth: MeetingCaptureHealthSummary = .notRecording
     public var backgroundTranscriptionCount: Int = 0
+    public private(set) var showsAudioSavedConfirmation = false
     public var onStop: (() -> Void)?
     public var onPauseToggle: (() -> Void)?
     public var onCompletionAnimationFinished: (() -> Void)?
 
+    @ObservationIgnored private var audioSavedConfirmationTask: Task<Void, Never>?
+
     public init() {}
+
+    deinit {
+        audioSavedConfirmationTask?.cancel()
+    }
+
+    public func showAudioSavedConfirmation(duration: Duration = .seconds(4)) {
+        showsAudioSavedConfirmation = true
+        audioSavedConfirmationTask?.cancel()
+        audioSavedConfirmationTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: duration)
+            guard !Task.isCancelled else { return }
+            self?.showsAudioSavedConfirmation = false
+        }
+    }
+
+    public func clearAudioSavedConfirmation() {
+        audioSavedConfirmationTask?.cancel()
+        audioSavedConfirmationTask = nil
+        showsAudioSavedConfirmation = false
+    }
 
     public var formattedElapsed: String {
         let minutes = elapsedSeconds / 60

--- a/Sources/MacParakeetViewModels/TranscriptionCompletionNotifier.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionCompletionNotifier.swift
@@ -53,6 +53,16 @@ public enum TranscriptionCompletionNotifier {
         )
     }
 
+    /// Critical meeting finalization failure content. This is independent of
+    /// the completion-notification preference because it tells the user saved
+    /// audio needs action, not that background work succeeded.
+    public static func meetingNeedsRetryContent() -> Content {
+        Content(
+            title: "Meeting needs a retry",
+            body: "Your audio is saved."
+        )
+    }
+
     static func wordsLabel(_ count: Int) -> String {
         "\(count) \(count == 1 ? "word" : "words")"
     }

--- a/Sources/MacParakeetViewModels/TranscriptionLibraryViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionLibraryViewModel.swift
@@ -87,6 +87,15 @@ public enum BulkTranscriptionOperation: Sendable {
         }
     }
 
+    public var hasNonCompletedMeeting: Bool {
+        switch self {
+        case .deleteItems(let targets), .deleteAudioOnly(let targets, _):
+            return targets.contains { transcription in
+                transcription.sourceType == .meeting && transcription.status != .completed
+            }
+        }
+    }
+
     public var isDeleteAudioOnly: Bool {
         if case .deleteAudioOnly = self { return true }
         return false
@@ -123,6 +132,8 @@ public final class TranscriptionLibraryViewModel {
     public private(set) var isBulkSelectionModeEnabled = false
     public private(set) var isBulkOperationInProgress = false
     public private(set) var pendingBulkOperation: BulkTranscriptionOperation?
+    public private(set) var retryingMeetingTranscriptionIDs: Set<UUID> = []
+    public var onRetryMeetingTranscription: ((Transcription) async throws -> Void)?
 
     /// Override for tests; production code uses `Date()`.
     public var nowProvider: @Sendable () -> Date = { Date() }
@@ -184,7 +195,8 @@ public final class TranscriptionLibraryViewModel {
             bucketed[group, default: []].append(item)
         }
 
-        return encounterOrder
+        return
+            encounterOrder
             .sorted { $0.sortKey < $1.sortKey }
             .map { group in (group: group, items: bucketed[group] ?? []) }
     }
@@ -219,6 +231,59 @@ public final class TranscriptionLibraryViewModel {
         } catch {
             logger.error("Failed to update transcription favorite: \(error.localizedDescription, privacy: .private)")
             errorMessage = "Failed to update favorite: \(error.localizedDescription)"
+        }
+    }
+
+    public func isRetryingMeetingTranscription(_ transcription: Transcription) -> Bool {
+        retryingMeetingTranscriptionIDs.contains(transcription.id)
+    }
+
+    @discardableResult
+    public func retryMeetingTranscription(_ transcription: Transcription) -> Task<Void, Never> {
+        guard transcription.sourceType == .meeting,
+            transcription.status == .error,
+            !retryingMeetingTranscriptionIDs.contains(transcription.id)
+        else {
+            return Task {}
+        }
+        guard let retry = onRetryMeetingTranscription else {
+            errorMessage = "Meeting retry is not available."
+            return Task {}
+        }
+
+        retryingMeetingTranscriptionIDs.insert(transcription.id)
+        setLoadedStatus(
+            id: transcription.id,
+            status: .processing,
+            errorMessage: nil
+        )
+
+        return Task { @MainActor [weak self] in
+            guard let self else { return }
+            defer {
+                self.retryingMeetingTranscriptionIDs.remove(transcription.id)
+            }
+            do {
+                try await retry(transcription)
+                self.cancelActiveLoad()
+                do {
+                    try self.reloadLoadedWindow()
+                } catch {
+                    self.logger.error(
+                        "Retried meeting transcription but failed to refresh Library: \(error.localizedDescription, privacy: .private)"
+                    )
+                    self.errorMessage = "Retried meeting, but failed to refresh Library: \(error.localizedDescription)"
+                }
+            } catch {
+                self.logger.error(
+                    "Failed to retry meeting transcription: \(error.localizedDescription, privacy: .private)")
+                self.errorMessage = "Failed to retry meeting transcription: \(error.localizedDescription)"
+                self.setLoadedStatus(
+                    id: transcription.id,
+                    status: .error,
+                    errorMessage: error.localizedDescription
+                )
+            }
         }
     }
 
@@ -353,7 +418,8 @@ public final class TranscriptionLibraryViewModel {
             if !result.failedIDs.isEmpty {
                 isBulkOperationInProgress = false
                 restoreFailedSelectionIfCurrent(result.failedIDs, operationGeneration: operationGeneration)
-                errorMessage = Self.bulkDeleteFailureMessage(succeeded: result.succeededIDs.count, failed: result.failedIDs.count)
+                errorMessage = Self.bulkDeleteFailureMessage(
+                    succeeded: result.succeededIDs.count, failed: result.failedIDs.count)
             } else {
                 isBulkOperationInProgress = false
                 finishBulkSelection()
@@ -420,7 +486,8 @@ public final class TranscriptionLibraryViewModel {
                 return
             }
             if let idx = transcriptions.firstIndex(where: { $0.id == transcription.id }) {
-                transcriptions[idx].meetingArtifactFolderPath = transcriptions[idx].meetingArtifactFolderPath
+                transcriptions[idx].meetingArtifactFolderPath =
+                    transcriptions[idx].meetingArtifactFolderPath
                     ?? MeetingArtifactStore.sessionFolderURL(for: transcription)?.standardizedFileURL.path
                 transcriptions[idx].filePath = nil
                 publishLoadedItems(transcriptions, hasMore: hasMore)
@@ -436,7 +503,8 @@ public final class TranscriptionLibraryViewModel {
         guard transcription.sourceType == .file else { return false }
         guard let repo = transcriptionRepo else { return false }
         guard let normalizedTitle = Transcription.normalizedTitleOverride(from: title),
-              normalizedTitle != transcription.effectiveDisplayTitle else {
+            normalizedTitle != transcription.effectiveDisplayTitle
+        else {
             return false
         }
 
@@ -453,7 +521,9 @@ public final class TranscriptionLibraryViewModel {
         do {
             try reloadLoadedWindow()
         } catch {
-            logger.error("Renamed transcription title but failed to refresh Library: \(error.localizedDescription, privacy: .private)")
+            logger.error(
+                "Renamed transcription title but failed to refresh Library: \(error.localizedDescription, privacy: .private)"
+            )
             errorMessage = "Renamed transcription, but failed to refresh Library: \(error.localizedDescription)"
         }
         return true
@@ -580,7 +650,8 @@ public final class TranscriptionLibraryViewModel {
             sortOrder: sortOrder,
             limit: pageSize,
             offset: offset,
-            includeProcessing: false
+            includeProcessing: false,
+            includeProcessingMeetings: true
         )
     }
 
@@ -616,10 +687,23 @@ public final class TranscriptionLibraryViewModel {
 
     private func clearLoadedMeetingAudio(forIDs ids: Set<UUID>) {
         for index in transcriptions.indices where ids.contains(transcriptions[index].id) {
-            transcriptions[index].meetingArtifactFolderPath = transcriptions[index].meetingArtifactFolderPath
+            transcriptions[index].meetingArtifactFolderPath =
+                transcriptions[index].meetingArtifactFolderPath
                 ?? MeetingArtifactStore.sessionFolderURL(for: transcriptions[index])?.standardizedFileURL.path
             transcriptions[index].filePath = nil
         }
+        publishLoadedItems(transcriptions, hasMore: hasMore)
+    }
+
+    private func setLoadedStatus(
+        id: UUID,
+        status: Transcription.TranscriptionStatus,
+        errorMessage: String?
+    ) {
+        guard let index = transcriptions.firstIndex(where: { $0.id == id }) else { return }
+        transcriptions[index].status = status
+        transcriptions[index].errorMessage = errorMessage
+        transcriptions[index].updatedAt = Date()
         publishLoadedItems(transcriptions, hasMore: hasMore)
     }
 
@@ -693,7 +777,10 @@ public final class TranscriptionLibraryViewModel {
             parts.append("Deleted audio for \(succeeded) \(succeeded == 1 ? "meeting" : "meetings").")
         }
         if failed > 0 {
-            parts.append(failed == 1 ? "1 meeting audio file could not be deleted." : "\(failed) meeting audio files could not be deleted.")
+            parts.append(
+                failed == 1
+                    ? "1 meeting audio file could not be deleted."
+                    : "\(failed) meeting audio files could not be deleted.")
         }
         if skipped > 0 {
             parts.append(skipped == 1 ? "1 selected item was skipped." : "\(skipped) selected items were skipped.")

--- a/Tests/MacParakeetTests/App/MeetingFinalizationReconcilerTests.swift
+++ b/Tests/MacParakeetTests/App/MeetingFinalizationReconcilerTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+
+@testable import MacParakeet
+@testable import MacParakeetCore
+
+final class MeetingFinalizationReconcilerTests: XCTestCase {
+    func testReconcileStaleProcessingRowsMarksOnlyProcessingMeetingsFailed() async throws {
+        let repo = MockTranscriptionRepository()
+        let staleMeeting = Transcription(
+            fileName: "Stale meeting",
+            status: .processing,
+            sourceType: .meeting
+        )
+        let completedMeeting = Transcription(
+            fileName: "Completed meeting",
+            status: .completed,
+            sourceType: .meeting
+        )
+        let processingFile = Transcription(
+            fileName: "Processing file",
+            status: .processing,
+            sourceType: .file
+        )
+        try repo.save(staleMeeting)
+        try repo.save(completedMeeting)
+        try repo.save(processingFile)
+
+        let reconciledIDs = try await MeetingFinalizationReconciler.reconcileStaleProcessingRows(
+            repository: repo
+        )
+
+        XCTAssertEqual(reconciledIDs, [staleMeeting.id])
+        let reconciled = try XCTUnwrap(repo.fetch(id: staleMeeting.id))
+        XCTAssertEqual(reconciled.status, .error)
+        XCTAssertEqual(
+            reconciled.errorMessage,
+            MeetingFinalizationReconciler.staleProcessingErrorMessage
+        )
+        XCTAssertEqual(try repo.fetch(id: completedMeeting.id)?.status, .completed)
+        XCTAssertEqual(try repo.fetch(id: processingFile.id)?.status, .processing)
+    }
+}

--- a/Tests/MacParakeetTests/App/MeetingFinalizationReconcilerTests.swift
+++ b/Tests/MacParakeetTests/App/MeetingFinalizationReconcilerTests.swift
@@ -29,6 +29,7 @@ final class MeetingFinalizationReconcilerTests: XCTestCase {
             repository: repo
         )
 
+        XCTAssertEqual(repo.fetchMeetingsWithStatusCalls, [.processing])
         XCTAssertEqual(reconciledIDs, [staleMeeting.id])
         let reconciled = try XCTUnwrap(repo.fetch(id: staleMeeting.id))
         XCTAssertEqual(reconciled.status, .error)

--- a/Tests/MacParakeetTests/Audio/MeetingAudioFileTests.swift
+++ b/Tests/MacParakeetTests/Audio/MeetingAudioFileTests.swift
@@ -96,7 +96,10 @@ final class MeetingAudioFileTests: XCTestCase {
 
     // MARK: - state
 
-    func testStateReturnsNotMeetingWhenStatusIsProcessing() throws {
+    func testStateReturnsSavedWhenStatusIsProcessing() throws {
+        // Processing meetings are visible rows with durably saved audio; the
+        // capture contract ("audio is saved") must hold before transcription
+        // completes, so their audio state is .saved, not hidden.
         let directory = makeTempDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }
         let audioURL = directory.appendingPathComponent("meeting-playback.m4a")
@@ -109,8 +112,8 @@ final class MeetingAudioFileTests: XCTestCase {
             status: .processing
         )
 
-        XCTAssertEqual(MeetingAudioFile.state(for: transcription), .notMeeting)
-        XCTAssertFalse(MeetingAudioFile.isAvailable(for: transcription))
+        XCTAssertEqual(MeetingAudioFile.state(for: transcription), .saved)
+        XCTAssertTrue(MeetingAudioFile.isAvailable(for: transcription))
     }
 
     func testStateReturnsNotMeetingForNonMeetingSource() {

--- a/Tests/MacParakeetTests/Database/TranscriptionRepositoryTests.swift
+++ b/Tests/MacParakeetTests/Database/TranscriptionRepositoryTests.swift
@@ -469,6 +469,20 @@ final class TranscriptionRepositoryTests: XCTestCase {
         XCTAssertEqual(Set(page.items.map(\.fileName)), ["done.mp3", "working.mp3"])
     }
 
+    func testFetchLibraryPageCanIncludeProcessingMeetingsOnly() throws {
+        try repo.save(Transcription(fileName: "done.mp3", status: .completed, sourceType: .file))
+        try repo.save(Transcription(fileName: "working-file.mp3", status: .processing, sourceType: .file))
+        try repo.save(Transcription(fileName: "working-video.mp3", status: .processing, sourceType: .youtube))
+        try repo.save(Transcription(fileName: "working-meeting.m4a", status: .processing, sourceType: .meeting))
+
+        let page = try repo.fetchLibraryPage(query: TranscriptionLibraryQuery(
+            limit: 10,
+            includeProcessingMeetings: true
+        ))
+
+        XCTAssertEqual(Set(page.items.map(\.fileName)), ["done.mp3", "working-meeting.m4a"])
+    }
+
     func testFetchLibraryPageFiltersBySourceType() throws {
         let local = Transcription(fileName: "local.mp3", status: .completed, sourceType: .file)
         let youtube = Transcription(fileName: "video.mp3", status: .completed, sourceType: .youtube)

--- a/Tests/MacParakeetTests/MeetingRecordingFlow/MeetingRecordingFlowCoordinatorTests.swift
+++ b/Tests/MacParakeetTests/MeetingRecordingFlow/MeetingRecordingFlowCoordinatorTests.swift
@@ -166,10 +166,11 @@ final class MeetingRecordingFlowCoordinatorTests: XCTestCase {
         )
 
         try await coordinator.retryMeetingFinalization(failed)
-
-        let processing = try XCTUnwrap(settlementHarness.transcriptionRepo.fetch(id: failed.id))
-        XCTAssertEqual(processing.status, .processing)
-        XCTAssertNil(processing.errorMessage)
+        try await waitForTranscriptionStatus(
+            id: failed.id,
+            in: settlementHarness.transcriptionRepo,
+            status: .processing
+        )
 
         await transcriptionService.releaseMeetingFinalization()
         await coordinator.testHook_waitForMeetingTranscriptionQueue()
@@ -832,6 +833,28 @@ final class MeetingRecordingFlowCoordinatorTests: XCTestCase {
             }
             if startedAt.duration(to: .now) > .seconds(1) {
                 XCTFail("Expected queued meeting finalization to start.")
+                return
+            }
+            try await Task.sleep(for: .milliseconds(20))
+        }
+    }
+
+    private func waitForTranscriptionStatus(
+        id: UUID,
+        in repo: MockTranscriptionRepository,
+        status: Transcription.TranscriptionStatus
+    ) async throws {
+        let startedAt = ContinuousClock.now
+        while true {
+            let transcription = try XCTUnwrap(repo.fetch(id: id))
+            if transcription.status == status {
+                XCTAssertNil(transcription.errorMessage)
+                return
+            }
+            if startedAt.duration(to: .now) > .seconds(1) {
+                XCTFail(
+                    "Timed out waiting for transcription \(id) status \(status); latest status: \(transcription.status)"
+                )
                 return
             }
             try await Task.sleep(for: .milliseconds(20))

--- a/Tests/MacParakeetTests/MeetingRecordingFlow/MeetingRecordingFlowCoordinatorTests.swift
+++ b/Tests/MacParakeetTests/MeetingRecordingFlow/MeetingRecordingFlowCoordinatorTests.swift
@@ -60,6 +60,7 @@ final class MeetingRecordingFlowCoordinatorTests: XCTestCase {
 
         XCTAssertTrue(coordinator.stopRecording(operationTrigger: .autoStop))
         await coordinator.testHook_waitForActionTask()
+        try await waitForMeetingFinalizeCall(on: transcriptionService)
 
         let recordingSnapshot = await recordingService.snapshot()
         let transcriptionSnapshot = await transcriptionService.meetingFlowSnapshot()
@@ -88,6 +89,104 @@ final class MeetingRecordingFlowCoordinatorTests: XCTestCase {
         XCTAssertEqual(operation.durationSeconds, output.durationSeconds)
         XCTAssertEqual(operation.microphoneTrackPresent, true)
         XCTAssertEqual(operation.systemTrackPresent, true)
+    }
+
+    func testQueuedFinalizationFailurePersistsRetryableRowAndPostsOneNotification() async throws {
+        let output = makeRecordingOutput()
+        let recordingService = MeetingRecordingServiceSpy(output: output)
+        let transcriptionService = MockTranscriptionService()
+        await transcriptionService.configureMeetingFinalization(error: FlowTestError.finalizationFailed)
+        let settlementHarness = await makeSettlementHarness(transcriptionService: transcriptionService)
+
+        var retryNotifications: [TranscriptionCompletionNotifier.Content] = []
+        let coordinator = MeetingRecordingFlowCoordinator(
+            meetingRecordingService: recordingService,
+            transcriptionService: transcriptionService,
+            permissionService: MockPermissionService(),
+            transcriptionRepo: settlementHarness.transcriptionRepo,
+            conversationRepo: MockChatConversationRepository(),
+            quickPromptRepo: NoOpQuickPromptRepository(),
+            configStore: NoOpLLMConfigStore(),
+            llmService: nil,
+            pillViewModel: MeetingRecordingPillViewModel(),
+            meetingRecordingSettlement: settlementHarness.settlement,
+            onMenuBarIconUpdate: { _ in },
+            onTranscriptionReady: { _ in },
+            onQueuedTranscriptionFailed: { content in
+                retryNotifications.append(content)
+            }
+        )
+        coordinator.testHook_enterRecording()
+
+        XCTAssertTrue(coordinator.stopRecording(operationTrigger: .manual))
+        await coordinator.testHook_waitForActionTask()
+        await coordinator.testHook_waitForMeetingTranscriptionQueue()
+
+        let rows = try settlementHarness.transcriptionRepo.fetchAll(limit: nil)
+        let row = try XCTUnwrap(rows.first)
+        XCTAssertEqual(rows.count, 1)
+        XCTAssertEqual(row.status, .error)
+        XCTAssertEqual(row.sourceType, .meeting)
+        XCTAssertEqual(row.errorMessage, FlowTestError.finalizationFailed.localizedDescription)
+        XCTAssertEqual(retryNotifications, [TranscriptionCompletionNotifier.meetingNeedsRetryContent()])
+        XCTAssertTrue(settlementHarness.lockStore.deletes.isEmpty)
+    }
+
+    func testRetryMeetingFinalizationReusesPersistedRowAndAudioFolder() async throws {
+        let transcriptionService = MockTranscriptionService()
+        await transcriptionService.holdMeetingFinalization()
+        let settlementHarness = await makeSettlementHarness(transcriptionService: transcriptionService)
+        let folderURL = try makeArchivedRetryFolder()
+        defer { try? FileManager.default.removeItem(at: folderURL) }
+        let playbackURL = folderURL.appendingPathComponent(MeetingArtifactAudioFileNames.playback)
+        let failed = Transcription(
+            id: UUID(),
+            fileName: "Retry meeting",
+            filePath: playbackURL.path,
+            meetingArtifactFolderPath: folderURL.path,
+            durationMs: 12_000,
+            status: .error,
+            errorMessage: "Previous failure",
+            sourceType: .meeting
+        )
+        try settlementHarness.transcriptionRepo.save(failed)
+        let coordinator = MeetingRecordingFlowCoordinator(
+            meetingRecordingService: MeetingRecordingServiceSpy(output: makeRecordingOutput()),
+            transcriptionService: transcriptionService,
+            permissionService: MockPermissionService(),
+            transcriptionRepo: settlementHarness.transcriptionRepo,
+            conversationRepo: MockChatConversationRepository(),
+            quickPromptRepo: NoOpQuickPromptRepository(),
+            configStore: NoOpLLMConfigStore(),
+            llmService: nil,
+            pillViewModel: MeetingRecordingPillViewModel(),
+            meetingRecordingSettlement: settlementHarness.settlement,
+            onMenuBarIconUpdate: { _ in },
+            onTranscriptionReady: { _ in }
+        )
+
+        try await coordinator.retryMeetingFinalization(failed)
+
+        let processing = try XCTUnwrap(settlementHarness.transcriptionRepo.fetch(id: failed.id))
+        XCTAssertEqual(processing.status, .processing)
+        XCTAssertNil(processing.errorMessage)
+
+        await transcriptionService.releaseMeetingFinalization()
+        await coordinator.testHook_waitForMeetingTranscriptionQueue()
+
+        let completed = try XCTUnwrap(settlementHarness.transcriptionRepo.fetch(id: failed.id))
+        XCTAssertEqual(completed.status, .completed)
+        XCTAssertNil(completed.errorMessage)
+        XCTAssertEqual(settlementHarness.transcriptionRepo.transcriptions.map(\.id), [failed.id])
+        XCTAssertTrue(FileManager.default.fileExists(atPath: playbackURL.path))
+        XCTAssertEqual(settlementHarness.lockStore.deletes, [folderURL.standardizedFileURL])
+
+        let snapshot = await transcriptionService.meetingFlowSnapshot()
+        XCTAssertEqual(snapshot.prepareMeetingCallCount, 0)
+        XCTAssertEqual(snapshot.finalizeMeetingCallCount, 1)
+        XCTAssertEqual(snapshot.finalizedMeetingTranscriptionIDs, [failed.id])
+        XCTAssertEqual(snapshot.finalizedMeetingRecordings.first?.displayName, failed.fileName)
+        XCTAssertEqual(snapshot.finalizedMeetingRecordings.first?.durationSeconds, 12)
     }
 
     func testCaptureFailureSignalUsesStopTranscribeFlowExactlyOnce() async throws {
@@ -398,10 +497,12 @@ final class MeetingRecordingFlowCoordinatorTests: XCTestCase {
         XCTAssertEqual(conversationRepo.conversations.count, 1)
         let savedConversation = try XCTUnwrap(conversationRepo.conversations.first)
         XCTAssertEqual(savedConversation.title, "What did I miss?")
-        XCTAssertEqual(savedConversation.messages, [
-            ChatMessage(role: .user, content: "What did I miss?"),
-            ChatMessage(role: .assistant, content: "Answer saved"),
-        ])
+        XCTAssertEqual(
+            savedConversation.messages,
+            [
+                ChatMessage(role: .user, content: "What did I miss?"),
+                ChatMessage(role: .assistant, content: "Answer saved"),
+            ])
 
         await transcriptionService.releaseMeetingFinalization()
         await coordinator.testHook_waitForMeetingTranscriptionQueue()
@@ -495,11 +596,12 @@ final class MeetingRecordingFlowCoordinatorTests: XCTestCase {
 
         XCTAssertNotNil(coordinator.startRecording(trigger: .manual))
         await coordinator.testHook_waitForActionTask()
-        for _ in 0..<20 {
+        let startedAt = ContinuousClock.now
+        while startedAt.duration(to: .now) <= .seconds(1) {
             if coordinator.testHook_panelViewModel?.liveTranscriptStatus == .previewUnsupported(engine: .cohere) {
                 break
             }
-            await Task.yield()
+            try await Task.sleep(for: .milliseconds(20))
         }
 
         let panelViewModel = try XCTUnwrap(coordinator.testHook_panelViewModel)
@@ -718,6 +820,24 @@ final class MeetingRecordingFlowCoordinatorTests: XCTestCase {
         }
     }
 
+    private func waitForMeetingFinalizeCall(
+        on service: MockTranscriptionService,
+        expectedCount: Int = 1
+    ) async throws {
+        let startedAt = ContinuousClock.now
+        while true {
+            let snapshot = await service.meetingFlowSnapshot()
+            if snapshot.finalizeMeetingCallCount >= expectedCount {
+                return
+            }
+            if startedAt.duration(to: .now) > .seconds(1) {
+                XCTFail("Expected queued meeting finalization to start.")
+                return
+            }
+            try await Task.sleep(for: .milliseconds(20))
+        }
+    }
+
     private func makeRecordingOutput() -> MeetingRecordingOutput {
         let folder = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -742,6 +862,37 @@ final class MeetingRecordingFlowCoordinatorTests: XCTestCase {
                 system: track
             )
         )
+    }
+
+    private func makeArchivedRetryFolder() throws -> URL {
+        let folder = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("meeting-retry-\(UUID().uuidString)", isDirectory: true)
+            .standardizedFileURL
+        try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+        let playbackURL = folder.appendingPathComponent(MeetingArtifactAudioFileNames.playback)
+        try Data("audio".utf8).write(to: playbackURL)
+        try MeetingRecordingMetadataStore.save(
+            MeetingRecordingMetadata(
+                sourceAlignment: MeetingSourceAlignment(
+                    meetingOriginHostTime: nil,
+                    microphone: nil,
+                    system: nil
+                )
+            ),
+            folderURL: folder
+        )
+        return folder
+    }
+}
+
+private enum FlowTestError: LocalizedError {
+    case finalizationFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .finalizationFailed:
+            return "Finalization failed"
+        }
     }
 }
 
@@ -797,12 +948,13 @@ private actor MeetingRecordingServiceSpy: MeetingRecordingServiceProtocol {
         calendarEventSnapshot: MeetingCalendarSnapshot?
     ) async throws {
         startCallCount += 1
-        startCalls.append(StartCall(
-            title: title,
-            sourceMode: sourceMode,
-            startContext: startContext,
-            calendarEventSnapshot: calendarEventSnapshot
-        ))
+        startCalls.append(
+            StartCall(
+                title: title,
+                sourceMode: sourceMode,
+                startContext: startContext,
+                calendarEventSnapshot: calendarEventSnapshot
+            ))
         startTitles.append(title)
         calendarEventSnapshots.append(calendarEventSnapshot)
         paused = false
@@ -1016,21 +1168,23 @@ private struct MeetingOperationPayload: Equatable {
 
 private extension TelemetryEventSpec {
     var meetingOperationPayload: MeetingOperationPayload? {
-        guard case .meetingOperation(
-            _,
-            _,
-            let outcome,
-            let trigger,
-            _,
-            let durationSeconds,
-            _,
-            _,
-            let microphoneTrackPresent,
-            let systemTrackPresent,
-            _,
-            _,
-            _
-        ) = self else {
+        guard
+            case .meetingOperation(
+                _,
+                _,
+                let outcome,
+                let trigger,
+                _,
+                let durationSeconds,
+                _,
+                _,
+                let microphoneTrackPresent,
+                let systemTrackPresent,
+                _,
+                _,
+                _
+            ) = self
+        else {
             return nil
         }
 

--- a/Tests/MacParakeetTests/MeetingRecordingFlow/MeetingTranscriptionQueueTests.swift
+++ b/Tests/MacParakeetTests/MeetingRecordingFlow/MeetingTranscriptionQueueTests.swift
@@ -10,6 +10,7 @@ final class MeetingTranscriptionQueueTests: XCTestCase {
         let transcriptionService = QueueTranscriptionServiceSpy(transcriptionRepo: transcriptionRepo)
         let queue = MeetingTranscriptionQueue(
             transcriptionService: transcriptionService,
+            transcriptionRepo: transcriptionRepo,
             meetingRecordingSettlement: MeetingRecordingSettlement(
                 lockFileStore: lockStore,
                 transcriptionRepo: transcriptionRepo
@@ -17,6 +18,7 @@ final class MeetingTranscriptionQueueTests: XCTestCase {
         )
         let first = makeItem(name: "A")
         let second = makeItem(name: "B")
+        try persistProcessingRows([first, second], in: transcriptionRepo)
 
         queue.enqueue(first)
         queue.enqueue(second)
@@ -38,6 +40,7 @@ final class MeetingTranscriptionQueueTests: XCTestCase {
         let transcriptionService = QueueTranscriptionServiceSpy(transcriptionRepo: transcriptionRepo)
         let queue = MeetingTranscriptionQueue(
             transcriptionService: transcriptionService,
+            transcriptionRepo: transcriptionRepo,
             meetingRecordingSettlement: MeetingRecordingSettlement(
                 lockFileStore: lockStore,
                 transcriptionRepo: transcriptionRepo
@@ -45,6 +48,8 @@ final class MeetingTranscriptionQueueTests: XCTestCase {
         )
         let first = makeItem(name: "A")
         let second = makeItem(name: "B")
+        try persistProcessingRows([first, second], in: transcriptionRepo)
+        try createAudioFile(for: first)
         await transcriptionService.fail(transcriptionID: first.transcriptionID)
 
         var completions: [String] = []
@@ -65,6 +70,10 @@ final class MeetingTranscriptionQueueTests: XCTestCase {
         XCTAssertEqual(completions, ["failure:A", "success:B"])
         XCTAssertEqual(transcriptionSnapshot, [first.transcriptionID, second.transcriptionID])
         XCTAssertEqual(lockStore.deletes, [second.recording.folderURL])
+        let failed = try XCTUnwrap(transcriptionRepo.fetch(id: first.transcriptionID))
+        XCTAssertEqual(failed.status, .error)
+        XCTAssertNotNil(failed.errorMessage)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: first.recording.mixedAudioURL.path))
     }
 
     func testSettlementRefusalAfterFinalizeStillReportsSuccessAndRetainsLock() async throws {
@@ -73,12 +82,14 @@ final class MeetingTranscriptionQueueTests: XCTestCase {
         let transcriptionService = QueueTranscriptionServiceSpy(transcriptionRepo: transcriptionRepo)
         let queue = MeetingTranscriptionQueue(
             transcriptionService: transcriptionService,
+            transcriptionRepo: transcriptionRepo,
             meetingRecordingSettlement: MeetingRecordingSettlement(
                 lockFileStore: lockStore,
                 transcriptionRepo: transcriptionRepo
             )
         )
         let item = makeItem(name: "A")
+        try persistProcessingRows([item], in: transcriptionRepo)
         await transcriptionService.mismatchSettlementPaths(transcriptionID: item.transcriptionID)
 
         var completions: [String] = []
@@ -105,6 +116,7 @@ final class MeetingTranscriptionQueueTests: XCTestCase {
         await transcriptionService.setHoldFinalization(true)
         let queue = MeetingTranscriptionQueue(
             transcriptionService: transcriptionService,
+            transcriptionRepo: transcriptionRepo,
             meetingRecordingSettlement: MeetingRecordingSettlement(
                 lockFileStore: lockStore,
                 transcriptionRepo: transcriptionRepo
@@ -112,6 +124,7 @@ final class MeetingTranscriptionQueueTests: XCTestCase {
         )
         let first = makeItem(name: "A")
         let second = makeItem(name: "B")
+        try persistProcessingRows([first, second], in: transcriptionRepo)
 
         queue.enqueue(first)
         queue.enqueue(second)
@@ -127,6 +140,77 @@ final class MeetingTranscriptionQueueTests: XCTestCase {
         XCTAssertEqual(queue.snapshot.totalCount, 0)
     }
 
+    func testQueueCreatesProcessingRowWhenEnqueuedItemHasNoRow() async throws {
+        let transcriptionRepo = MockTranscriptionRepository()
+        let lockStore = QueueRecordingLockFileStore()
+        let transcriptionService = QueueTranscriptionServiceSpy(transcriptionRepo: transcriptionRepo)
+        await transcriptionService.setHoldFinalization(true)
+        let queue = MeetingTranscriptionQueue(
+            transcriptionService: transcriptionService,
+            transcriptionRepo: transcriptionRepo,
+            meetingRecordingSettlement: MeetingRecordingSettlement(
+                lockFileStore: lockStore,
+                transcriptionRepo: transcriptionRepo
+            )
+        )
+        let item = makeItem(name: "Missing Row")
+
+        queue.enqueue(item)
+        try await waitUntil {
+            queue.snapshot.activeItem?.transcriptionID != nil
+                && queue.snapshot.activeItem?.transcriptionID != item.transcriptionID
+        }
+
+        let preparedID = try XCTUnwrap(queue.snapshot.activeItem?.transcriptionID)
+        let prepared = try XCTUnwrap(transcriptionRepo.fetch(id: preparedID))
+        XCTAssertEqual(prepared.status, .processing)
+        XCTAssertEqual(prepared.sourceType, .meeting)
+        XCTAssertEqual(transcriptionRepo.transcriptions.count, 1)
+
+        await transcriptionService.releaseFinalization()
+        await queue.waitUntilIdle()
+
+        let finalizedIDs = await transcriptionService.snapshot()
+        XCTAssertEqual(finalizedIDs, [preparedID])
+        XCTAssertEqual(transcriptionRepo.transcriptions.map(\.id), [preparedID])
+        XCTAssertEqual(transcriptionRepo.transcriptions.first?.status, .completed)
+    }
+
+    func testQueueRetryReusesFailedRowAndDoesNotDuplicate() async throws {
+        let transcriptionRepo = MockTranscriptionRepository()
+        let lockStore = QueueRecordingLockFileStore()
+        let transcriptionService = QueueTranscriptionServiceSpy(transcriptionRepo: transcriptionRepo)
+        let queue = MeetingTranscriptionQueue(
+            transcriptionService: transcriptionService,
+            transcriptionRepo: transcriptionRepo,
+            meetingRecordingSettlement: MeetingRecordingSettlement(
+                lockFileStore: lockStore,
+                transcriptionRepo: transcriptionRepo
+            )
+        )
+        let item = makeItem(name: "Retry")
+        let failed = Transcription(
+            id: item.transcriptionID,
+            fileName: item.recording.displayName,
+            filePath: item.recording.mixedAudioURL.path,
+            meetingArtifactFolderPath: item.recording.folderURL.path,
+            status: .error,
+            errorMessage: "Previous failure",
+            sourceType: .meeting
+        )
+        try transcriptionRepo.save(failed)
+        try createAudioFile(for: item)
+
+        queue.enqueue(item)
+        await queue.waitUntilIdle()
+
+        let fetched = try XCTUnwrap(transcriptionRepo.fetch(id: item.transcriptionID))
+        XCTAssertEqual(fetched.status, .completed)
+        XCTAssertNil(fetched.errorMessage)
+        XCTAssertEqual(transcriptionRepo.transcriptions.map(\.id), [item.transcriptionID])
+        XCTAssertTrue(FileManager.default.fileExists(atPath: item.recording.mixedAudioURL.path))
+    }
+
     private func makeItem(name: String) -> MeetingTranscriptionQueue.Item {
         let output = makeRecordingOutput(displayName: name)
         return MeetingTranscriptionQueue.Item(
@@ -137,6 +221,35 @@ final class MeetingTranscriptionQueueTests: XCTestCase {
             liveWordCount: 0,
             liveTranscriptLagged: false
         )
+    }
+
+    private func persistProcessingRows(
+        _ items: [MeetingTranscriptionQueue.Item],
+        in repo: MockTranscriptionRepository
+    ) throws {
+        for item in items {
+            try repo.save(
+                Transcription(
+                    id: item.transcriptionID,
+                    fileName: item.recording.displayName,
+                    filePath: item.recording.mixedAudioURL.path,
+                    meetingArtifactFolderPath: item.recording.folderURL.path,
+                    status: .processing,
+                    sourceType: .meeting
+                ))
+        }
+    }
+
+    private func createAudioFile(for item: MeetingTranscriptionQueue.Item) throws {
+        try FileManager.default.createDirectory(
+            at: item.recording.folderURL,
+            withIntermediateDirectories: true
+        )
+        XCTAssertTrue(
+            FileManager.default.createFile(
+                atPath: item.recording.mixedAudioURL.path,
+                contents: Data("audio".utf8)
+            ))
     }
 
     private func makeRecordingOutput(displayName: String) -> MeetingRecordingOutput {
@@ -246,12 +359,15 @@ private actor QueueTranscriptionServiceSpy: TranscriptionServiceProtocol {
     }
 
     func prepareMeetingTranscription(recording: MeetingRecordingOutput) async throws -> Transcription {
-        Transcription(
+        let transcription = Transcription(
             fileName: recording.displayName,
             filePath: recording.mixedAudioURL.path,
+            meetingArtifactFolderPath: recording.folderURL.path,
             status: .processing,
             sourceType: .meeting
         )
+        try transcriptionRepo.save(transcription)
+        return transcription
     }
 
     func finalizeMeetingTranscription(

--- a/Tests/MacParakeetTests/MeetingRecordingFlow/MeetingTranscriptionQueueTests.swift
+++ b/Tests/MacParakeetTests/MeetingRecordingFlow/MeetingTranscriptionQueueTests.swift
@@ -211,6 +211,71 @@ final class MeetingTranscriptionQueueTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: item.recording.mixedAudioURL.path))
     }
 
+    func testQueueDropsDuplicateRetryWhileItemIsActive() async throws {
+        let transcriptionRepo = MockTranscriptionRepository()
+        let lockStore = QueueRecordingLockFileStore()
+        let transcriptionService = QueueTranscriptionServiceSpy(transcriptionRepo: transcriptionRepo)
+        await transcriptionService.setHoldFinalization(true)
+        let queue = MeetingTranscriptionQueue(
+            transcriptionService: transcriptionService,
+            transcriptionRepo: transcriptionRepo,
+            meetingRecordingSettlement: MeetingRecordingSettlement(
+                lockFileStore: lockStore,
+                transcriptionRepo: transcriptionRepo
+            )
+        )
+        let item = makeItem(name: "Duplicate Retry")
+        try persistRow(status: .error, item: item, in: transcriptionRepo)
+        try createAudioFile(for: item)
+
+        queue.enqueue(item)
+        queue.enqueue(item)
+        try await waitUntil {
+            queue.snapshot.activeItem?.transcriptionID == item.transcriptionID
+        }
+        XCTAssertEqual(queue.snapshot.pendingCount, 0)
+
+        await transcriptionService.releaseFinalization()
+        await queue.waitUntilIdle()
+
+        let transcriptionSnapshot = await transcriptionService.snapshot()
+        XCTAssertEqual(transcriptionSnapshot, [item.transcriptionID])
+        let fetched = try XCTUnwrap(transcriptionRepo.fetch(id: item.transcriptionID))
+        XCTAssertEqual(fetched.status, .completed)
+        XCTAssertEqual(transcriptionRepo.transcriptions.map(\.id), [item.transcriptionID])
+    }
+
+    func testQueueDoesNotRegressCompletedRowBackToProcessing() async throws {
+        let transcriptionRepo = MockTranscriptionRepository()
+        let lockStore = QueueRecordingLockFileStore()
+        let transcriptionService = QueueTranscriptionServiceSpy(transcriptionRepo: transcriptionRepo)
+        let queue = MeetingTranscriptionQueue(
+            transcriptionService: transcriptionService,
+            transcriptionRepo: transcriptionRepo,
+            meetingRecordingSettlement: MeetingRecordingSettlement(
+                lockFileStore: lockStore,
+                transcriptionRepo: transcriptionRepo
+            )
+        )
+        let item = makeItem(name: "Already Done")
+        try persistRow(status: .completed, item: item, in: transcriptionRepo)
+
+        var completions: [MeetingTranscriptionQueue.Completion] = []
+        queue.onCompletion = { completion in
+            completions.append(completion)
+        }
+
+        queue.enqueue(item)
+        await queue.waitUntilIdle()
+
+        XCTAssertTrue(completions.isEmpty)
+        let transcriptionSnapshot = await transcriptionService.snapshot()
+        XCTAssertEqual(transcriptionSnapshot, [])
+        let fetched = try XCTUnwrap(transcriptionRepo.fetch(id: item.transcriptionID))
+        XCTAssertEqual(fetched.status, .completed)
+        XCTAssertNil(fetched.errorMessage)
+    }
+
     private func makeItem(name: String) -> MeetingTranscriptionQueue.Item {
         let output = makeRecordingOutput(displayName: name)
         return MeetingTranscriptionQueue.Item(
@@ -228,16 +293,24 @@ final class MeetingTranscriptionQueueTests: XCTestCase {
         in repo: MockTranscriptionRepository
     ) throws {
         for item in items {
-            try repo.save(
-                Transcription(
-                    id: item.transcriptionID,
-                    fileName: item.recording.displayName,
-                    filePath: item.recording.mixedAudioURL.path,
-                    meetingArtifactFolderPath: item.recording.folderURL.path,
-                    status: .processing,
-                    sourceType: .meeting
-                ))
+            try persistRow(status: .processing, item: item, in: repo)
         }
+    }
+
+    private func persistRow(
+        status: Transcription.TranscriptionStatus,
+        item: MeetingTranscriptionQueue.Item,
+        in repo: MockTranscriptionRepository
+    ) throws {
+        try repo.save(
+            Transcription(
+                id: item.transcriptionID,
+                fileName: item.recording.displayName,
+                filePath: item.recording.mixedAudioURL.path,
+                meetingArtifactFolderPath: item.recording.folderURL.path,
+                status: status,
+                sourceType: .meeting
+            ))
     }
 
     private func createAudioFile(for item: MeetingTranscriptionQueue.Item) throws {

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionCompletionNotifierTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionCompletionNotifierTests.swift
@@ -69,4 +69,13 @@ final class TranscriptionCompletionNotifierTests: XCTestCase {
         XCTAssertEqual(content?.title, "Transcriptions finished with errors")
         XCTAssertEqual(content?.body, "38 transcribed \u{00B7} 2 failed")
     }
+
+    // MARK: - Meeting retry
+
+    func testMeetingNeedsRetryContentIsIndependentFailureCopy() {
+        let content = TranscriptionCompletionNotifier.meetingNeedsRetryContent()
+
+        XCTAssertEqual(content.title, "Meeting needs a retry")
+        XCTAssertEqual(content.body, "Your audio is saved.")
+    }
 }

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionLibraryViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionLibraryViewModelTests.swift
@@ -28,14 +28,16 @@ final class TranscriptionLibraryViewModelTests: XCTestCase {
         XCTAssertEqual(vm.transcriptions.count, 2)
     }
 
-    func testLoadTranscriptionsExcludesProcessingRows() async throws {
-        try repo.save(Transcription(fileName: "done.mp3", status: .completed))
-        try repo.save(Transcription(fileName: "working.mp3", status: .processing))
+    func testLoadTranscriptionsIncludesProcessingMeetingRowsOnly() async throws {
+        try repo.save(Transcription(fileName: "done.mp3", status: .completed, sourceType: .file))
+        try repo.save(Transcription(fileName: "working-file.mp3", status: .processing, sourceType: .file))
+        try repo.save(Transcription(fileName: "working-video.mp3", status: .processing, sourceType: .youtube))
+        try repo.save(Transcription(fileName: "working-meeting.m4a", status: .processing, sourceType: .meeting))
 
         await load()
 
-        XCTAssertEqual(vm.transcriptions.map(\.fileName), ["done.mp3"])
-        XCTAssertEqual(vm.filteredTranscriptions.map(\.fileName), ["done.mp3"])
+        XCTAssertEqual(Set(vm.transcriptions.map(\.fileName)), ["done.mp3", "working-meeting.m4a"])
+        XCTAssertEqual(Set(vm.filteredTranscriptions.map(\.fileName)), ["done.mp3", "working-meeting.m4a"])
     }
 
     func testLoadTranscriptionsIncludesCancelledAndErrorRows() async throws {
@@ -134,11 +136,16 @@ final class TranscriptionLibraryViewModelTests: XCTestCase {
         meetingVM.configure(transcriptionRepo: repo)
 
         try repo.save(Transcription(fileName: "meeting.mp3", status: .completed, sourceType: .meeting))
+        try repo.save(Transcription(fileName: "processing meeting.mp3", status: .processing, sourceType: .meeting))
+        try repo.save(Transcription(fileName: "failed meeting.mp3", status: .error, sourceType: .meeting))
         try repo.save(Transcription(fileName: "local.mp3", status: .completed, sourceType: .file))
 
         await load(meetingVM)
 
-        XCTAssertEqual(meetingVM.filteredTranscriptions.map(\.fileName), ["meeting.mp3"])
+        XCTAssertEqual(
+            Set(meetingVM.filteredTranscriptions.map(\.fileName)),
+            ["meeting.mp3", "processing meeting.mp3", "failed meeting.mp3"]
+        )
     }
 
     func testMeetingsScopeComposesWithFavoritesAndConflictingFilters() async throws {
@@ -399,6 +406,43 @@ final class TranscriptionLibraryViewModelTests: XCTestCase {
 
         XCTAssertTrue(vm.filteredTranscriptions.isEmpty)
         XCTAssertFalse(try repo.fetch(id: favorite.id)?.isFavorite ?? true)
+    }
+
+    // MARK: - Retry
+
+    func testRetryMeetingTranscriptionReloadsSameRowAfterCallback() async throws {
+        let failed = Transcription(
+            fileName: "Design Review",
+            status: .error,
+            errorMessage: "decoder failed",
+            sourceType: .meeting
+        )
+        try repo.save(failed)
+        await load()
+
+        var retriedIDs: [UUID] = []
+        vm.onRetryMeetingTranscription = { transcription in
+            retriedIDs.append(transcription.id)
+            try self.repo.updateStatus(
+                id: transcription.id,
+                status: .completed,
+                errorMessage: nil
+            )
+        }
+
+        let retryTask = vm.retryMeetingTranscription(failed)
+
+        XCTAssertTrue(vm.isRetryingMeetingTranscription(failed))
+        XCTAssertEqual(vm.transcriptions.first?.status, .processing)
+
+        await retryTask.value
+
+        XCTAssertEqual(retriedIDs, [failed.id])
+        XCTAssertFalse(vm.isRetryingMeetingTranscription(failed))
+        XCTAssertEqual(vm.transcriptions.map(\.id), [failed.id])
+        XCTAssertEqual(vm.transcriptions.first?.status, .completed)
+        XCTAssertNil(vm.transcriptions.first?.errorMessage)
+        XCTAssertEqual(try repo.count(), 1)
     }
 
     // MARK: - Bulk Selection

--- a/Tests/MacParakeetTests/ViewModels/ViewModelMocks.swift
+++ b/Tests/MacParakeetTests/ViewModels/ViewModelMocks.swift
@@ -400,6 +400,7 @@ final class MockLaunchAtLoginService: LaunchAtLoginControlling {
 actor MockTranscriptionService: SpeechEngineOverrideTranscriptionService {
     var transcribeResult: Transcription?
     var transcribeError: Error?
+    var meetingFinalizationError: Error?
     var transcribeCallCount = 0
     var lastFileURL: URL?
     var lastSource: TelemetryTranscriptionSource?
@@ -416,6 +417,7 @@ actor MockTranscriptionService: SpeechEngineOverrideTranscriptionService {
     var preparedMeetingRecordings: [MeetingRecordingOutput] = []
     var finalizedMeetingRecordings: [MeetingRecordingOutput] = []
     var finalizedMeetingTranscriptionIDs: [UUID] = []
+    private var preparedMeetingSaveHook: (@Sendable (Transcription) -> Void)?
     private var finalizedMeetingSaveHook: (@Sendable (Transcription) -> Void)?
     private var meetingFinalizationHeld = false
     private var meetingFinalizationContinuations: [CheckedContinuation<Void, Never>] = []
@@ -441,6 +443,10 @@ actor MockTranscriptionService: SpeechEngineOverrideTranscriptionService {
         self.transcribeResult = nil
     }
 
+    func configureMeetingFinalization(error: Error?) {
+        meetingFinalizationError = error
+    }
+
     func configureURLProgress(phases: [TranscriptionProgress]) {
         self.transcribeURLProgressPhases = phases
     }
@@ -462,6 +468,9 @@ actor MockTranscriptionService: SpeechEngineOverrideTranscriptionService {
     }
 
     func persistFinalizedMeetings(to repository: MockTranscriptionRepository) {
+        preparedMeetingSaveHook = { transcription in
+            try? repository.save(transcription)
+        }
         finalizedMeetingSaveHook = { transcription in
             try? repository.save(transcription)
         }
@@ -563,14 +572,17 @@ actor MockTranscriptionService: SpeechEngineOverrideTranscriptionService {
             throw error
         }
 
-        return Transcription(
+        let transcription = Transcription(
             fileName: recording.displayName,
             filePath: recording.mixedAudioURL.path,
+            meetingArtifactFolderPath: recording.folderURL.path,
             durationMs: Int((recording.durationSeconds * 1000).rounded()),
             rawTranscript: nil,
             status: .processing,
             sourceType: .meeting
         )
+        preparedMeetingSaveHook?(transcription)
+        return transcription
     }
 
     func finalizeMeetingTranscription(
@@ -598,7 +610,7 @@ actor MockTranscriptionService: SpeechEngineOverrideTranscriptionService {
             try await Task.sleep(nanoseconds: transcribeDelayMs * 1_000_000)
         }
 
-        if let error = transcribeError {
+        if let error = meetingFinalizationError ?? transcribeError {
             throw error
         }
 

--- a/Tests/MacParakeetTests/ViewModels/ViewModelMocks.swift
+++ b/Tests/MacParakeetTests/ViewModels/ViewModelMocks.swift
@@ -138,8 +138,10 @@ final class MockTranscriptionRepository: TranscriptionRepositoryProtocol, @unche
     var updateSpeakersCalls: [(id: UUID, speakers: [SpeakerInfo]?)] = []
     var updateFilePathCalls: [(id: UUID, filePath: String?)] = []
     var updateMeetingArtifactFolderPathCalls: [(id: UUID, folderPath: String?)] = []
+    var fetchMeetingsWithStatusCalls: [Transcription.TranscriptionStatus] = []
     var fetchAllError: Error?
     var fetchAllHandler: (@Sendable (Int?) throws -> [Transcription])?
+    var fetchMeetingsWithStatusHandler: (@Sendable (Transcription.TranscriptionStatus) throws -> [Transcription])?
     var updateTitleOverrideError: Error?
     var updateFilePathError: Error?
     var updateSpeakersError: Error?
@@ -171,6 +173,17 @@ final class MockTranscriptionRepository: TranscriptionRepositoryProtocol, @unche
         let sorted = transcriptions.sorted { $0.createdAt > $1.createdAt }
         if let limit { return Array(sorted.prefix(limit)) }
         return sorted
+    }
+
+    func fetchMeetings(withStatus status: Transcription.TranscriptionStatus) throws -> [Transcription] {
+        fetchMeetingsWithStatusCalls.append(status)
+        if let fetchMeetingsWithStatusHandler {
+            return try fetchMeetingsWithStatusHandler(status)
+        }
+        return
+            transcriptions
+            .filter { $0.sourceType == .meeting && $0.status == status }
+            .sorted { $0.createdAt > $1.createdAt }
     }
 
     func fetchCompletedByVideoID(_ videoID: String) throws -> Transcription? {

--- a/Tests/MacParakeetTests/Views/MeetingDeletionCopyTests.swift
+++ b/Tests/MacParakeetTests/Views/MeetingDeletionCopyTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 
 @testable import MacParakeet
+@testable import MacParakeetCore
 
 final class MeetingDeletionCopyTests: XCTestCase {
     func testAudioOnlyCopyKeepsMeetingAndNamesOptionalArtifacts() {
@@ -20,6 +21,37 @@ final class MeetingDeletionCopyTests: XCTestCase {
         XCTAssertTrue(message.contains("permanently deletes \"Roadmap sync\""))
         XCTAssertTrue(message.contains("including its transcript and saved audio"))
         XCTAssertTrue(message.contains("Notes, AI results, and chats for this meeting are also deleted if they exist"))
+    }
+
+    func testAudioOnlyCopyWarnsWhenMeetingIsNotCompleted() {
+        let message = MeetingDeletionCopy.singleAudioOnlyMessage(
+            surface: .library,
+            status: .processing
+        )
+
+        XCTAssertTrue(
+            message.hasPrefix("This meeting hasn't been transcribed yet — deleting the audio makes that permanent."))
+        XCTAssertTrue(message.contains("permanently deletes the saved audio"))
+    }
+
+    func testCompletedAudioOnlyCopyDoesNotShowRetentionWarning() {
+        let message = MeetingDeletionCopy.singleAudioOnlyMessage(
+            surface: .library,
+            status: .completed
+        )
+
+        XCTAssertFalse(message.contains("hasn't been transcribed yet"))
+    }
+
+    func testFullDeleteCopyWarnsWhenMeetingIsNotCompleted() {
+        let message = MeetingDeletionCopy.singleFullDeleteMessage(
+            title: "Roadmap sync",
+            status: .error
+        )
+
+        XCTAssertTrue(
+            message.hasPrefix("This meeting hasn't been transcribed yet — deleting the audio makes that permanent."))
+        XCTAssertTrue(message.contains("permanently deletes \"Roadmap sync\""))
     }
 
     func testBulkFullDeleteCopyUsesSingularMeetingCopy() {
@@ -66,6 +98,18 @@ final class MeetingDeletionCopyTests: XCTestCase {
         XCTAssertTrue(message.contains("2 selected meetings"))
         XCTAssertTrue(message.contains("1 selected meeting already has no saved audio"))
         XCTAssertTrue(message.contains("it will be skipped"))
+    }
+
+    func testBulkDeleteCopyWarnsWhenAnySelectedMeetingIsNotCompleted() {
+        let message = MeetingDeletionCopy.bulkFullDeleteMessage(
+            count: 2,
+            hasNonCompletedMeeting: true
+        )
+
+        XCTAssertTrue(
+            message.hasPrefix(
+                "At least one selected meeting hasn't been transcribed yet — deleting the audio makes that permanent."))
+        XCTAssertTrue(message.contains("permanently deletes 2 meetings"))
     }
 
     // Mixed Library selection (the surface where the miscount bug appeared):

--- a/Tests/MacParakeetTests/Views/MeetingRecordingTileTests.swift
+++ b/Tests/MacParakeetTests/Views/MeetingRecordingTileTests.swift
@@ -92,4 +92,14 @@ final class MeetingRecordingTileTests: XCTestCase {
             "Unmute microphone"
         )
     }
+
+    func testAudioSavedConfirmationAutoClears() async throws {
+        let viewModel = MeetingRecordingPillViewModel()
+
+        viewModel.showAudioSavedConfirmation(duration: .milliseconds(10))
+
+        XCTAssertTrue(viewModel.showsAudioSavedConfirmation)
+        try await Task.sleep(for: .milliseconds(40))
+        XCTAssertFalse(viewModel.showsAudioSavedConfirmation)
+    }
 }


### PR DESCRIPTION
## Why

MacParakeet's product contract is "capture is sacred; post-processing is background and recoverable." The meeting finalization pipeline violated that contract: when queued final transcription failed, the failure went to telemetry only, and the Library query filtered out processing rows, so a finalizing meeting could have no visible row anywhere. If final transcription failed, an hour of unrepeatable audio could silently produce nothing.

This PR makes the meeting's own row the finishing surface. No new floating chrome: Library and Meetings show the row as processing, failed, retrying, or completed, while the recording pill's post-stop lifecycle remains unchanged.

## What Changed

- Persist meeting finalization truth through the existing `Transcription` row:
  - queued/pending finalization rows stay `.processing`
  - success remains `.completed` through the existing finalization path
  - finalization failure becomes `.error` with an error message and saved audio left untouched
- Show processing meeting rows in Library and Meetings without exposing processing file/URL rows.
- Add quiet row-level processing and failed states, including Retry from saved meeting audio.
- Re-enqueue retries through the same meeting transcription queue using the archived meeting folder.
- Reconcile stale processing meeting rows on startup into retryable failed rows.
- Post one local notification on queued meeting finalization failure: "Meeting needs a retry" / "Your audio is saved."
- Add retention warnings before deleting meeting audio for non-completed rows.
- Show a subtle "Audio saved" confirmation on the Transcribe meeting tile after durable queueing.

## Before / After

| State | Old behavior | New behavior |
| --- | --- | --- |
| Meeting stopped and durably queued | Recording pill showed saved/completing, but Library could hide the processing row | Library and Meetings show a processing meeting row with "Transcribing" |
| Final transcription succeeds | Completed row appears | Completed row appears, same row/id |
| Final transcription fails | Telemetry only; no durable user-visible failure | Row becomes failed with "Transcription failed — audio is saved", details disclosure, and Retry |
| App quits while row is processing | Row could remain processing indefinitely | Startup reconciliation marks stale processing meeting rows failed and retryable |
| User retries | No row-level retry from saved artifacts | Retry sets same row back to processing and reuses the same queue path |
| User deletes non-completed meeting audio | Existing delete warnings did not call out the permanent loss of retry source | Warning says deleting audio makes the missing transcription permanent |

## State Diagram

```mermaid
stateDiagram-v2
    [*] --> processing: stop saves audio + prepares row
    processing --> completed: final transcription succeeds
    processing --> error: final transcription fails
    processing --> error: app relaunch reconciliation
    error --> processing: Retry from archived folder
    completed --> [*]
```

## Retry Notes

Retry reconstructs the queue item from durable state: the persisted `Transcription` row plus the saved meeting artifact folder and playback audio. Fields that were only live-session context are intentionally neutral on retry: telemetry trigger is nil, operation context is fresh, live word count is 0, live transcript lag is false, and the archived recording loader supplies the session identity from disk metadata where available.

The persisted failed state uses the existing `Transcription.TranscriptionStatus.error` case; the brief used `.failed`, but this codebase's current status enum names that terminal failure state `.error`.

## Spec Alignment

This implements the capture-layer contract in ADR-027's north star: durable local artifacts remain the source of truth, and post-processing is recoverable. No spec/contract doc update is needed because this uses the existing database status model, repository API, meeting artifacts, and app UI surfaces; it does not change the public CLI contract or add a schema/telemetry contract. No new telemetry event names were introduced.

## Verification

- `scripts/dev/format.sh`
- `GIT_EXEC_PATH=/Library/Developer/CommandLineTools/usr/libexec/git-core swift test --filter 'TranscriptionRepositoryTests|TranscriptionLibraryViewModelTests|MeetingRecordingFlowCoordinatorTests|MeetingTranscriptionQueueTests|MeetingFinalizationReconcilerTests|TranscriptionCompletionNotifierTests|MeetingDeletionCopyTests|MeetingRecordingTileTests'`
- `GIT_EXEC_PATH=/Library/Developer/CommandLineTools/usr/libexec/git-core swift build`
- `git diff --check`

## Manual QA

- [ ] Record a short meeting -> row shows processing -> completes.
- [ ] Simulate transcription failure by forcing `finalizeMeetingTranscription` to throw after `prepareMeetingTranscription` succeeds (same failure point covered by the test hook) -> failed row + Retry + notification.
- [ ] Retry succeeds and updates the same row.
- [ ] Quit during processing -> relaunch -> row is failed and retryable.
- [ ] Two back-to-back meetings finalize with two visible rows.
- [ ] Remove-audio warning appears on a non-completed meeting row.
- [ ] Hide-UI user path, with floating pill hidden, still gets the failure notification.
- [ ] Light and dark appearances.

### Review fixes

- [ ] Retry from a failed meeting row does not open the row or toggle the error details disclosure.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes meeting finalization durable and visible across the app. Processing, failed, and completed states now live on the meeting row, with guarded retries owned by the queue to avoid duplicate work or status regressions.

- **New Features**
  - Persist finalization on the `Transcription` row: keep `.processing`; set `.error` with a message on failure; success unchanged.
  - Show processing meeting rows in Library and Meetings (processing files/URLs stay hidden). Quiet UI with spinner; failed rows show details and a Retry button.
  - Retry from Library/Meetings reuses the same row and archived folder. The queue is the status gate: rejects duplicates, treats already-completed rows as a no-op, and writes `.processing` only on admission.
  - Queue ensures a processing row exists; marks failures retryable; refreshes lists and posts one failure notification (“Meeting needs a retry” · “Your audio is saved.”).
  - On startup, reconcile stale processing meetings into failed, retryable rows.
  - Deletion copy warns when a meeting isn’t completed yet (single/bulk); Settings “Clear meeting audio” warns that unfinished meetings lose their retry source.
  - Recording tile shows a brief “Audio saved” confirmation after durable queueing.
  - Processing meetings now expose saved audio (.saved) so playback and retry are available before transcription completes.

- **Bug Fixes**
  - Meeting rows restore keyboard and VoiceOver activation with a standard row Button; Retry and error details remain separate controls.
  - Startup reconciliation filters by meeting status at the repository level for accuracy and performance.

<sup>Written for commit 46c7c792a08b8a96b0f412f04e12d8243787894f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/761?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added retry actions for failed meeting transcriptions.
  * Shows clearer “Audio saved” and retry-related status indicators in meeting views.
  * Recent meetings can now display and manage transcription retry state.

* **Bug Fixes**
  * Improves recovery from interrupted or stale meeting finalization.
  * Prevents duplicate transcription processing and better handles already-finished items.
  * Updates deletion warnings to reflect when audio may not be fully completed yet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->