### PR TITLE
fix(meeting): retry follow-ups from Greptile review of #761

### DIFF
--- a/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
+++ b/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
@@ -384,8 +384,10 @@ final class AppEnvironmentConfigurer {
 
         Task { [weak self] in
             do {
+                let protectedIDs = meetingCoordinator.queuedMeetingTranscriptionIDs
                 let reconciled = try await MeetingFinalizationReconciler.reconcileStaleProcessingRows(
-                    repository: env.transcriptionRepo
+                    repository: env.transcriptionRepo,
+                    excludingTranscriptionIDs: protectedIDs
                 )
                 guard !reconciled.isEmpty, let self else { return }
                 self.libraryViewModel.loadTranscriptions()

--- a/Sources/MacParakeet/App/MeetingFinalizationReconciler.swift
+++ b/Sources/MacParakeet/App/MeetingFinalizationReconciler.swift
@@ -7,10 +7,12 @@ enum MeetingFinalizationReconciler {
 
     @discardableResult
     static func reconcileStaleProcessingRows(
-        repository: TranscriptionRepositoryProtocol
+        repository: TranscriptionRepositoryProtocol,
+        excludingTranscriptionIDs protectedIDs: Set<UUID> = []
     ) async throws -> [UUID] {
         try await Task.detached(priority: .utility) {
             let staleRows = try repository.fetchMeetings(withStatus: .processing)
+                .filter { !protectedIDs.contains($0.id) }
             for row in staleRows {
                 try repository.updateStatus(
                     id: row.id,

--- a/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
@@ -25,7 +25,7 @@ private enum MeetingFinalizationRetryError: LocalizedError, Sendable {
         case .alreadyCompleted:
             return "This meeting has already been transcribed."
         case .notRetryable:
-            return "Only failed meeting transcriptions can be retried."
+            return "Only failed or stopped meeting transcriptions can be retried."
         case .missingArtifactFolder:
             return "The saved meeting folder is no longer available."
         }
@@ -1396,6 +1396,10 @@ final class MeetingRecordingFlowCoordinator {
         meetingTranscriptionQueue.enqueue(item)
     }
 
+    var queuedMeetingTranscriptionIDs: Set<UUID> {
+        meetingTranscriptionQueue.queuedTranscriptionIDs
+    }
+
     private func hideMeetingPanel() {
         panelController?.hide()
     }
@@ -1441,7 +1445,7 @@ final class MeetingRecordingFlowCoordinator {
             guard latest.sourceType == .meeting else {
                 throw MeetingFinalizationRetryError.notMeeting
             }
-            guard latest.status == .error else {
+            guard latest.status == .error || latest.status == .cancelled else {
                 if latest.status == .processing {
                     throw MeetingFinalizationRetryError.alreadyProcessing
                 }

--- a/Sources/MacParakeet/App/MeetingTranscriptionQueue.swift
+++ b/Sources/MacParakeet/App/MeetingTranscriptionQueue.swift
@@ -70,6 +70,14 @@ final class MeetingTranscriptionQueue {
         Snapshot(activeItem: activeItem, pendingCount: pendingItems.count)
     }
 
+    var queuedTranscriptionIDs: Set<UUID> {
+        var ids = Set(pendingItems.map(\.transcriptionID))
+        if let activeID = activeItem?.transcriptionID {
+            ids.insert(activeID)
+        }
+        return ids
+    }
+
     func enqueue(_ item: Item) {
         guard !containsQueuedTranscription(id: item.transcriptionID) else {
             logger.info(

--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingRowCard.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingRowCard.swift
@@ -340,7 +340,8 @@ struct MeetingRowCard<MenuContent: View>: View {
     }
 
     private var showsRetryButton: Bool {
-        transcription.sourceType == .meeting && transcription.status == .error
+        transcription.sourceType == .meeting
+            && (transcription.status == .error || transcription.status == .cancelled)
     }
 
     private var retryButtonForeground: Color {

--- a/Sources/MacParakeet/Views/Meetings/MeetingsView.swift
+++ b/Sources/MacParakeet/Views/Meetings/MeetingsView.swift
@@ -582,7 +582,7 @@ struct MeetingsView: View {
 
         Divider()
 
-        if transcription.status == .error {
+        if transcription.status == .error || transcription.status == .cancelled {
             Button {
                 viewModel.recentMeetingsViewModel.retryMeetingTranscription(transcription)
             } label: {

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
@@ -359,7 +359,7 @@ struct TranscriptionLibraryView: View {
 
             Divider()
 
-            if transcription.status == .error {
+            if transcription.status == .error || transcription.status == .cancelled {
                 Button {
                     viewModel.retryMeetingTranscription(transcription)
                 } label: {

--- a/Sources/MacParakeetViewModels/TranscriptionLibraryViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionLibraryViewModel.swift
@@ -540,6 +540,12 @@ public final class TranscriptionLibraryViewModel {
     private func refreshLoadedTranscription(id: UUID) throws {
         guard let repo = transcriptionRepo else { return }
         guard let index = transcriptions.firstIndex(where: { $0.id == id }) else { return }
+        // An in-flight load would later publish a snapshot fetched before this
+        // refresh, resurrecting the row's pre-retry status. Invalidate it; the
+        // generation bump makes any late publish a no-op.
+        if loadTask != nil {
+            cancelActiveLoad()
+        }
         guard let refreshed = try repo.fetch(id: id) else {
             removeLoadedTranscriptions(withIDs: [id])
             return

--- a/Sources/MacParakeetViewModels/TranscriptionLibraryViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionLibraryViewModel.swift
@@ -241,7 +241,7 @@ public final class TranscriptionLibraryViewModel {
     @discardableResult
     public func retryMeetingTranscription(_ transcription: Transcription) -> Task<Void, Never> {
         guard transcription.sourceType == .meeting,
-            transcription.status == .error,
+            Self.isRetryableMeetingTranscription(transcription),
             !retryingMeetingTranscriptionIDs.contains(transcription.id)
         else {
             return Task {}
@@ -252,11 +252,6 @@ public final class TranscriptionLibraryViewModel {
         }
 
         retryingMeetingTranscriptionIDs.insert(transcription.id)
-        setLoadedStatus(
-            id: transcription.id,
-            status: .processing,
-            errorMessage: nil
-        )
 
         return Task { @MainActor [weak self] in
             guard let self else { return }
@@ -265,9 +260,8 @@ public final class TranscriptionLibraryViewModel {
             }
             do {
                 try await retry(transcription)
-                self.cancelActiveLoad()
                 do {
-                    try self.reloadLoadedWindow()
+                    try self.refreshLoadedTranscription(id: transcription.id)
                 } catch {
                     self.logger.error(
                         "Retried meeting transcription but failed to refresh Library: \(error.localizedDescription, privacy: .private)"
@@ -278,11 +272,7 @@ public final class TranscriptionLibraryViewModel {
                 self.logger.error(
                     "Failed to retry meeting transcription: \(error.localizedDescription, privacy: .private)")
                 self.errorMessage = "Failed to retry meeting transcription: \(error.localizedDescription)"
-                self.setLoadedStatus(
-                    id: transcription.id,
-                    status: .error,
-                    errorMessage: error.localizedDescription
-                )
+                try? self.refreshLoadedTranscription(id: transcription.id)
             }
         }
     }
@@ -547,6 +537,17 @@ public final class TranscriptionLibraryViewModel {
         publishLoadedItems(page.items, hasMore: page.hasMore)
     }
 
+    private func refreshLoadedTranscription(id: UUID) throws {
+        guard let repo = transcriptionRepo else { return }
+        guard let index = transcriptions.firstIndex(where: { $0.id == id }) else { return }
+        guard let refreshed = try repo.fetch(id: id) else {
+            removeLoadedTranscriptions(withIDs: [id])
+            return
+        }
+        transcriptions[index] = refreshed
+        publishLoadedItems(transcriptions, hasMore: hasMore)
+    }
+
     private func cancelActiveLoad() {
         loadTask?.cancel()
         loadTask = nil
@@ -705,6 +706,10 @@ public final class TranscriptionLibraryViewModel {
         transcriptions[index].errorMessage = errorMessage
         transcriptions[index].updatedAt = Date()
         publishLoadedItems(transcriptions, hasMore: hasMore)
+    }
+
+    nonisolated private static func isRetryableMeetingTranscription(_ transcription: Transcription) -> Bool {
+        transcription.status == .error || transcription.status == .cancelled
     }
 
     private func restoreFailedSelectionIfCurrent(_ failedIDs: [UUID], operationGeneration: Int) {

--- a/Tests/MacParakeetTests/App/MeetingFinalizationReconcilerTests.swift
+++ b/Tests/MacParakeetTests/App/MeetingFinalizationReconcilerTests.swift
@@ -40,4 +40,103 @@ final class MeetingFinalizationReconcilerTests: XCTestCase {
         XCTAssertEqual(try repo.fetch(id: completedMeeting.id)?.status, .completed)
         XCTAssertEqual(try repo.fetch(id: processingFile.id)?.status, .processing)
     }
+
+    @MainActor
+    func testReconcileSkipsProcessingRowsOwnedByQueue() async throws {
+        let repo = MockTranscriptionRepository()
+        let transcriptionService = MockTranscriptionService()
+        await transcriptionService.holdMeetingFinalization()
+        await transcriptionService.persistFinalizedMeetings(to: repo)
+        let lockStore = ReconcilerRecordingLockFileStore()
+        let queue = MeetingTranscriptionQueue(
+            transcriptionService: transcriptionService,
+            transcriptionRepo: repo,
+            meetingRecordingSettlement: MeetingRecordingSettlement(
+                lockFileStore: lockStore,
+                transcriptionRepo: repo
+            )
+        )
+        let recording = makeRecordingOutput(displayName: "Live meeting")
+        let transcriptionID = UUID()
+        try repo.save(
+            Transcription(
+                id: transcriptionID,
+                fileName: recording.displayName,
+                filePath: recording.mixedAudioURL.path,
+                meetingArtifactFolderPath: recording.folderURL.path,
+                status: .processing,
+                sourceType: .meeting
+            ))
+        let item = MeetingTranscriptionQueue.Item(
+            recording: recording,
+            transcriptionID: transcriptionID,
+            operationContext: ObservabilityOperationContext(),
+            trigger: .manual,
+            liveWordCount: 0,
+            liveTranscriptLagged: false
+        )
+
+        queue.enqueue(item)
+        try await waitUntil {
+            queue.queuedTranscriptionIDs == [transcriptionID]
+        }
+
+        let reconciledIDs = try await MeetingFinalizationReconciler.reconcileStaleProcessingRows(
+            repository: repo,
+            excludingTranscriptionIDs: queue.queuedTranscriptionIDs
+        )
+
+        XCTAssertTrue(reconciledIDs.isEmpty)
+        XCTAssertEqual(try repo.fetch(id: transcriptionID)?.status, .processing)
+
+        await transcriptionService.releaseMeetingFinalization()
+        await queue.waitUntilIdle()
+    }
+
+    private func makeRecordingOutput(displayName: String) -> MeetingRecordingOutput {
+        let folder = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let track = MeetingSourceAlignment.Track(
+            firstHostTime: 1,
+            lastHostTime: 2,
+            startOffsetMs: 0,
+            writtenFrameCount: 48_000,
+            sampleRate: 48_000
+        )
+        return MeetingRecordingOutput(
+            sessionID: UUID(),
+            displayName: displayName,
+            folderURL: folder,
+            mixedAudioURL: folder.appendingPathComponent(MeetingArtifactAudioFileNames.playback),
+            microphoneAudioURL: folder.appendingPathComponent(MeetingArtifactAudioFileNames.rawMicrophone),
+            systemAudioURL: folder.appendingPathComponent(MeetingArtifactAudioFileNames.rawSystem),
+            durationSeconds: 42,
+            sourceAlignment: MeetingSourceAlignment(
+                meetingOriginHostTime: 1,
+                microphone: track,
+                system: track
+            )
+        )
+    }
+
+    private func waitUntil(
+        timeout: Duration = .seconds(1),
+        predicate: @escaping @MainActor () -> Bool
+    ) async throws {
+        let startedAt = ContinuousClock.now
+        while await !predicate() {
+            if startedAt.duration(to: .now) > timeout {
+                XCTFail("Timed out waiting for condition")
+                return
+            }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+    }
+}
+
+private final class ReconcilerRecordingLockFileStore: MeetingRecordingLockFileStoring, @unchecked Sendable {
+    func write(_ file: MeetingRecordingLockFile, folderURL: URL) throws {}
+    func read(folderURL: URL) throws -> MeetingRecordingLockFile? { nil }
+    func delete(folderURL: URL) throws {}
+    func discoverOrphans(meetingsRoot: URL) throws -> [MeetingRecordingLockFile] { [] }
 }

--- a/Tests/MacParakeetTests/MeetingRecordingFlow/MeetingTranscriptionQueueTests.swift
+++ b/Tests/MacParakeetTests/MeetingRecordingFlow/MeetingTranscriptionQueueTests.swift
@@ -211,6 +211,43 @@ final class MeetingTranscriptionQueueTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: item.recording.mixedAudioURL.path))
     }
 
+    func testCancelledFinalizationCanBeRetriedFromSameRow() async throws {
+        let transcriptionRepo = MockTranscriptionRepository()
+        let lockStore = QueueRecordingLockFileStore()
+        let transcriptionService = QueueTranscriptionServiceSpy(transcriptionRepo: transcriptionRepo)
+        let queue = MeetingTranscriptionQueue(
+            transcriptionService: transcriptionService,
+            transcriptionRepo: transcriptionRepo,
+            meetingRecordingSettlement: MeetingRecordingSettlement(
+                lockFileStore: lockStore,
+                transcriptionRepo: transcriptionRepo
+            )
+        )
+        let item = makeItem(name: "Cancelled Retry")
+        try persistProcessingRows([item], in: transcriptionRepo)
+        try createAudioFile(for: item)
+        await transcriptionService.cancel(transcriptionID: item.transcriptionID)
+
+        queue.enqueue(item)
+        await queue.waitUntilIdle()
+
+        let cancelled = try XCTUnwrap(transcriptionRepo.fetch(id: item.transcriptionID))
+        XCTAssertEqual(cancelled.status, .cancelled)
+        XCTAssertNil(cancelled.errorMessage)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: item.recording.mixedAudioURL.path))
+
+        await transcriptionService.clearFailures(transcriptionID: item.transcriptionID)
+        queue.enqueue(item)
+        await queue.waitUntilIdle()
+
+        let retried = try XCTUnwrap(transcriptionRepo.fetch(id: item.transcriptionID))
+        XCTAssertEqual(retried.status, .completed)
+        XCTAssertNil(retried.errorMessage)
+        XCTAssertEqual(transcriptionRepo.transcriptions.map(\.id), [item.transcriptionID])
+        let finalizedIDs = await transcriptionService.snapshot()
+        XCTAssertEqual(finalizedIDs, [item.transcriptionID, item.transcriptionID])
+    }
+
     func testQueueDropsDuplicateRetryWhileItemIsActive() async throws {
         let transcriptionRepo = MockTranscriptionRepository()
         let lockStore = QueueRecordingLockFileStore()
@@ -370,6 +407,7 @@ private actor QueueTranscriptionServiceSpy: TranscriptionServiceProtocol {
     private let transcriptionRepo: MockTranscriptionRepository
     private(set) var finalizedIDs: [UUID] = []
     private var failingIDs: Set<UUID> = []
+    private var cancellationIDs: Set<UUID> = []
     private var settlementMismatchIDs: Set<UUID> = []
     var holdFinalization = false
     private var finalizationWaiters: [CheckedContinuation<Void, Never>] = []
@@ -388,6 +426,15 @@ private actor QueueTranscriptionServiceSpy: TranscriptionServiceProtocol {
 
     func fail(transcriptionID: UUID) {
         failingIDs.insert(transcriptionID)
+    }
+
+    func cancel(transcriptionID: UUID) {
+        cancellationIDs.insert(transcriptionID)
+    }
+
+    func clearFailures(transcriptionID: UUID) {
+        failingIDs.remove(transcriptionID)
+        cancellationIDs.remove(transcriptionID)
     }
 
     func mismatchSettlementPaths(transcriptionID: UUID) {
@@ -453,6 +500,9 @@ private actor QueueTranscriptionServiceSpy: TranscriptionServiceProtocol {
             await withCheckedContinuation { continuation in
                 finalizationWaiters.append(continuation)
             }
+        }
+        if cancellationIDs.contains(transcriptionID) {
+            throw CancellationError()
         }
         if failingIDs.contains(transcriptionID) {
             throw QueueTestError.failed

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionLibraryViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionLibraryViewModelTests.swift
@@ -433,7 +433,7 @@ final class TranscriptionLibraryViewModelTests: XCTestCase {
         let retryTask = vm.retryMeetingTranscription(failed)
 
         XCTAssertTrue(vm.isRetryingMeetingTranscription(failed))
-        XCTAssertEqual(vm.transcriptions.first?.status, .processing)
+        XCTAssertEqual(vm.transcriptions.first?.status, .error)
 
         await retryTask.value
 
@@ -443,6 +443,115 @@ final class TranscriptionLibraryViewModelTests: XCTestCase {
         XCTAssertEqual(vm.transcriptions.first?.status, .completed)
         XCTAssertNil(vm.transcriptions.first?.errorMessage)
         XCTAssertEqual(try repo.count(), 1)
+    }
+
+    func testRetryMeetingTranscriptionAcceptsCancelledMeetingRows() async throws {
+        let cancelled = Transcription(
+            fileName: "Interrupted Design Review",
+            status: .cancelled,
+            sourceType: .meeting
+        )
+        try repo.save(cancelled)
+        await load()
+
+        var retriedIDs: [UUID] = []
+        vm.onRetryMeetingTranscription = { transcription in
+            retriedIDs.append(transcription.id)
+            try self.repo.updateStatus(
+                id: transcription.id,
+                status: .completed,
+                errorMessage: nil
+            )
+        }
+
+        let retryTask = vm.retryMeetingTranscription(cancelled)
+        await retryTask.value
+
+        XCTAssertEqual(retriedIDs, [cancelled.id])
+        XCTAssertFalse(vm.isRetryingMeetingTranscription(cancelled))
+        XCTAssertEqual(vm.transcriptions.map(\.id), [cancelled.id])
+        XCTAssertEqual(vm.transcriptions.first?.status, .completed)
+    }
+
+    func testRetryMeetingTranscriptionRefreshesRowWhenLoadedWindowReloadWouldFail() async throws {
+        let mockRepo = MockTranscriptionRepository()
+        let viewModel = TranscriptionLibraryViewModel()
+        let failed = Transcription(
+            fileName: "Refresh Failure Meeting",
+            status: .error,
+            errorMessage: "Previous failure",
+            sourceType: .meeting
+        )
+        mockRepo.transcriptions = [failed]
+        viewModel.configure(transcriptionRepo: mockRepo)
+        await load(viewModel)
+
+        mockRepo.fetchAllError = LibraryRenameTestError.reloadFailed
+        viewModel.onRetryMeetingTranscription = { transcription in
+            try mockRepo.updateStatus(
+                id: transcription.id,
+                status: .completed,
+                errorMessage: nil
+            )
+        }
+
+        let retryTask = viewModel.retryMeetingTranscription(failed)
+        await retryTask.value
+
+        XCTAssertEqual(viewModel.transcriptions.map(\.id), [failed.id])
+        XCTAssertEqual(viewModel.transcriptions.first?.status, .completed)
+        XCTAssertNil(viewModel.transcriptions.first?.errorMessage)
+    }
+
+    func testRetryMeetingTranscriptionRefreshesOnlyAffectedRowAndPreservesLoadedWindow() async throws {
+        let mockRepo = MockTranscriptionRepository()
+        let viewModel = TranscriptionLibraryViewModel()
+        viewModel.pageSize = 2
+        let first = Transcription(
+            createdAt: Date(timeIntervalSinceReferenceDate: 300),
+            fileName: "First",
+            status: .completed,
+            sourceType: .meeting
+        )
+        let second = Transcription(
+            createdAt: Date(timeIntervalSinceReferenceDate: 200),
+            fileName: "Second",
+            status: .completed,
+            sourceType: .meeting
+        )
+        let failed = Transcription(
+            createdAt: Date(timeIntervalSinceReferenceDate: 100),
+            fileName: "Third",
+            status: .error,
+            errorMessage: "Previous failure",
+            sourceType: .meeting
+        )
+        mockRepo.transcriptions = [first, second, failed]
+        viewModel.configure(transcriptionRepo: mockRepo)
+
+        await load(viewModel)
+        XCTAssertEqual(viewModel.transcriptions.map(\.id), [first.id, second.id])
+        XCTAssertTrue(viewModel.hasMore)
+        await viewModel.loadMoreTranscriptions()?.value
+        let loadedIDs = viewModel.transcriptions.map(\.id)
+        let fetchAllCallCount = mockRepo.fetchAllCalls.count
+
+        viewModel.onRetryMeetingTranscription = { transcription in
+            try mockRepo.updateStatus(
+                id: transcription.id,
+                status: .completed,
+                errorMessage: nil
+            )
+        }
+
+        let retryTask = viewModel.retryMeetingTranscription(failed)
+        await retryTask.value
+
+        XCTAssertEqual(mockRepo.fetchAllCalls.count, fetchAllCallCount)
+        XCTAssertEqual(viewModel.transcriptions.map(\.id), loadedIDs)
+        XCTAssertFalse(viewModel.hasMore)
+        XCTAssertEqual(viewModel.transcriptions.last?.status, .completed)
+        XCTAssertNil(viewModel.transcriptions.last?.errorMessage)
     }
 
     // MARK: - Bulk Selection

--- a/Tests/MacParakeetTests/ViewModels/ViewModelMocks.swift
+++ b/Tests/MacParakeetTests/ViewModels/ViewModelMocks.swift
@@ -139,6 +139,7 @@ final class MockTranscriptionRepository: TranscriptionRepositoryProtocol, @unche
     var updateFilePathCalls: [(id: UUID, filePath: String?)] = []
     var updateMeetingArtifactFolderPathCalls: [(id: UUID, folderPath: String?)] = []
     var fetchMeetingsWithStatusCalls: [Transcription.TranscriptionStatus] = []
+    var fetchAllCalls: [Int?] = []
     var fetchAllError: Error?
     var fetchAllHandler: (@Sendable (Int?) throws -> [Transcription])?
     var fetchMeetingsWithStatusHandler: (@Sendable (Transcription.TranscriptionStatus) throws -> [Transcription])?
@@ -164,6 +165,7 @@ final class MockTranscriptionRepository: TranscriptionRepositoryProtocol, @unche
     }
 
     func fetchAll(limit: Int?) throws -> [Transcription] {
+        fetchAllCalls.append(limit)
         if let fetchAllError {
             throw fetchAllError
         }


### PR DESCRIPTION
## Summary
Follow-up to the Greptile review on #761. This keeps cancelled queued meeting finalizations retryable, protects active queue work from startup reconciliation, and makes retry refresh update only the affected Library row.

## Design
- Cancellation keeps its existing meaning: the queue still persists `.cancelled` for `CancellationError`, and cancelled meeting rows are now retryable in the VM, coordinator, row button, and menus.
- Startup reconciliation now receives the meeting queue pending+active transcription IDs and skips those rows, avoiding timestamp heuristics and preserving the queue as the single `.processing` writer.
- Library retry no longer writes an optimistic `.processing` row or reloads from offset 0. It refreshes the touched row by `fetch(id:)`, preserving the loaded pagination window and preventing stale Transcribing UI after reload failures.

## Greptile Follow-ups
| Finding | Fix | Test |
|---|---|---|
| [P1: Cancellation Becomes Unretryable](https://github.com/moona3k/macparakeet/pull/761#discussion_r3538632394) | Keep `.cancelled` semantics and allow cancelled meeting rows through retry admission and row/menu UI. | `testCancelledFinalizationCanBeRetriedFromSameRow`, `testRetryMeetingTranscriptionAcceptsCancelledMeetingRows` |
| [P2: Current Rows Look Stale](https://github.com/moona3k/macparakeet/pull/761#discussion_r3538632482) | Pass queue-owned pending+active transcription IDs into `MeetingFinalizationReconciler` and skip them. | `testReconcileSkipsProcessingRowsOwnedByQueue` |
| [P2: Successful Retry Can Stay Processing](https://github.com/moona3k/macparakeet/pull/761#discussion_r3538636944) | Remove VM optimistic `.processing` write and refresh the affected row from repo truth after retry. | `testRetryMeetingTranscriptionRefreshesRowWhenLoadedWindowReloadWouldFail` |
| [P2: Retry Reload Resets Window](https://github.com/moona3k/macparakeet/pull/761#discussion_r3538637079) | Replace `reloadLoadedWindow()` with single-row `fetch(id:)` replacement. | `testRetryMeetingTranscriptionRefreshesOnlyAffectedRowAndPreservesLoadedWindow` |

## Risk Surface
The main risk is retry admission around `.cancelled` rows, because cancellation has user-visible meaning outside meeting retry. This PR scopes that admission to meeting rows only and keeps file/URL cancellation behavior unchanged. The reconciler change is startup hygiene only; it does not alter queue processing or completion paths.

## Test Evidence
- `GIT_EXEC_PATH=/Library/Developer/CommandLineTools/usr/libexec/git-core swift build`
- `GIT_EXEC_PATH=/Library/Developer/CommandLineTools/usr/libexec/git-core swift test --filter MeetingTranscriptionQueue`
- `GIT_EXEC_PATH=/Library/Developer/CommandLineTools/usr/libexec/git-core swift test --filter MeetingFinalizationReconciler`
- `GIT_EXEC_PATH=/Library/Developer/CommandLineTools/usr/libexec/git-core swift test --filter TranscriptionLibraryViewModel`
- `git diff --check`

## Manual QA Checklist
- Cancelled finalization is retryable from the meeting row and completes from saved audio.
- Retry from a later loaded page keeps scroll position and load-more state stable.
- A row never remains stuck in Transcribing after a retry succeeds but Library refresh fails.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make cancelled meeting transcriptions retryable and protect live queue work during startup reconciliation. Library retry now refreshes only the changed row and cancels any in-flight loads to prevent stale pre-retry “Transcribing” state while keeping pagination intact.

- **Bug Fixes**
  - Allow retry for `.cancelled` meeting rows across the coordinator, `TranscriptionLibraryViewModel`, and row/menu buttons.
  - Skip queue-owned IDs during startup reconciliation to avoid clobbering active/pending work (passes `queuedTranscriptionIDs` via `AppEnvironmentConfigurer` to `MeetingFinalizationReconciler`).
  - Remove optimistic `.processing` write on retry and refresh only the affected row via `fetch(id:)`, cancelling any active load to avoid resurrecting stale state and preserving pagination after reload failures.

<sup>Written for commit 61fb34a877dc83d23aa3a60495463a1697a2d91c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/762?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * You can now retry cancelled meeting transcriptions, not just failed ones.
  * Retry options are now available in more places across the app for cancelled items.

* **Bug Fixes**
  * Startup cleanup now avoids marking actively queued transcriptions as stale.
  * Retrying a transcription now refreshes the affected item more precisely, improving reliability and reducing unnecessary reloads.
  * Cancelled transcriptions can be retried from the same row without losing progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->