### PR TITLE
fix(meeting): block audio removal during finalization

### DIFF
--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingDeletionCopy.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingDeletionCopy.swift
@@ -122,10 +122,10 @@ enum MeetingDeletionCopy {
     }
 
     static func audioRemovalUnavailableHelp(
-        state: MeetingAudioFile.State,
-        status: Transcription.TranscriptionStatus
+        for transcription: Transcription,
+        state: MeetingAudioFile.State
     ) -> String {
-        if status == .processing && state == .saved {
+        if state == .saved && MeetingAudioFile.isFinalizationInProgress(for: transcription) {
             return TranscriptionAssetCleanup.meetingAudioFinalizationInProgressMessage
         }
         return audioUnavailableHelp(for: state)

--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingDeletionCopy.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingDeletionCopy.swift
@@ -54,10 +54,10 @@ enum MeetingDeletionCopy {
             + "\(prefix)This permanently deletes saved audio from \(count) \(meetingWord). \(meetingSubject) in \(surface.name) with \(transcriptObject). Notes, AI results, and chats stay too if they exist. Playback and re-transcription will no longer be available, and MacParakeet will not be able to detect or backfill speakers for \(recordingObject)."
         if skippedCount > 0 {
             if skippedCount == 1 {
-                message += " 1 selected meeting already has no saved audio, so it will be skipped."
+                message += " 1 selected meeting cannot have its audio removed right now, so it will be skipped."
             } else {
                 message +=
-                    " \(skippedCount) selected meetings already have no saved audio, so they will be skipped."
+                    " \(skippedCount) selected meetings cannot have their audio removed right now, so they will be skipped."
             }
         }
         return message
@@ -119,6 +119,16 @@ enum MeetingDeletionCopy {
         case .notMeeting:
             return "Meeting audio is not available"
         }
+    }
+
+    static func audioRemovalUnavailableHelp(
+        state: MeetingAudioFile.State,
+        status: Transcription.TranscriptionStatus
+    ) -> String {
+        if status == .processing && state == .saved {
+            return TranscriptionAssetCleanup.meetingAudioFinalizationInProgressMessage
+        }
+        return audioUnavailableHelp(for: state)
     }
 
     private static func nonCompletedWarning(status: Transcription.TranscriptionStatus) -> String {

--- a/Sources/MacParakeet/Views/Meetings/MeetingsView.swift
+++ b/Sources/MacParakeet/Views/Meetings/MeetingsView.swift
@@ -578,7 +578,7 @@ struct MeetingsView: View {
 
         let audioState = MeetingAudioFile.state(for: transcription)
         let audioAvailable = audioState == .saved
-        let audioRemovable = MeetingAudioFile.isRemovable(for: transcription)
+        let audioRemovable = MeetingAudioFile.isRemovable(for: transcription, state: audioState)
         let artifactAvailable = MeetingArtifactActions.folderURL(for: transcription) != nil
 
         Divider()
@@ -639,8 +639,8 @@ struct MeetingsView: View {
         .help(audioRemovable
               ? "Remove the saved meeting audio while keeping the meeting"
               : MeetingDeletionCopy.audioRemovalUnavailableHelp(
-                  state: audioState,
-                  status: transcription.status
+                  for: transcription,
+                  state: audioState
               ))
 
         Divider()

--- a/Sources/MacParakeet/Views/Meetings/MeetingsView.swift
+++ b/Sources/MacParakeet/Views/Meetings/MeetingsView.swift
@@ -578,6 +578,7 @@ struct MeetingsView: View {
 
         let audioState = MeetingAudioFile.state(for: transcription)
         let audioAvailable = audioState == .saved
+        let audioRemovable = MeetingAudioFile.isRemovable(for: transcription)
         let artifactAvailable = MeetingArtifactActions.folderURL(for: transcription) != nil
 
         Divider()
@@ -634,10 +635,13 @@ struct MeetingsView: View {
         } label: {
             Label(MeetingDeletionCopy.audioOnlyMenuTitle, systemImage: "waveform.slash")
         }
-        .disabled(!audioAvailable)
-        .help(audioAvailable
+        .disabled(!audioRemovable)
+        .help(audioRemovable
               ? "Remove the saved meeting audio while keeping the meeting"
-              : MeetingDeletionCopy.audioUnavailableHelp(for: audioState))
+              : MeetingDeletionCopy.audioRemovalUnavailableHelp(
+                  state: audioState,
+                  status: transcription.status
+              ))
 
         Divider()
 

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
@@ -560,7 +560,7 @@ struct TranscriptResultView: View {
             if activeTranscription.sourceType == .meeting {
                 let audioState = MeetingAudioFile.state(for: activeTranscription)
                 let audioAvailable = audioState == .saved
-                let audioRemovable = MeetingAudioFile.isRemovable(for: activeTranscription)
+                let audioRemovable = MeetingAudioFile.isRemovable(for: activeTranscription, state: audioState)
                 Menu {
                     Button {
                         MeetingAudioActions.revealInFinder(activeTranscription)
@@ -584,8 +584,8 @@ struct TranscriptResultView: View {
                     .help(audioRemovable
                           ? "Remove the saved meeting audio while keeping the meeting"
                           : MeetingDeletionCopy.audioRemovalUnavailableHelp(
-                              state: audioState,
-                              status: activeTranscription.status
+                              for: activeTranscription,
+                              state: audioState
                           ))
                 } label: {
                     Label("Audio", systemImage: "waveform")

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
@@ -560,6 +560,7 @@ struct TranscriptResultView: View {
             if activeTranscription.sourceType == .meeting {
                 let audioState = MeetingAudioFile.state(for: activeTranscription)
                 let audioAvailable = audioState == .saved
+                let audioRemovable = MeetingAudioFile.isRemovable(for: activeTranscription)
                 Menu {
                     Button {
                         MeetingAudioActions.revealInFinder(activeTranscription)
@@ -579,6 +580,13 @@ struct TranscriptResultView: View {
                     } label: {
                         Label(MeetingDeletionCopy.audioOnlyMenuTitle, systemImage: "waveform.slash")
                     }
+                    .disabled(!audioRemovable)
+                    .help(audioRemovable
+                          ? "Remove the saved meeting audio while keeping the meeting"
+                          : MeetingDeletionCopy.audioRemovalUnavailableHelp(
+                              state: audioState,
+                              status: activeTranscription.status
+                          ))
                 } label: {
                     Label("Audio", systemImage: "waveform")
                 }

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
@@ -355,7 +355,7 @@ struct TranscriptionLibraryView: View {
         if transcription.sourceType == .meeting {
             let audioState = MeetingAudioFile.state(for: transcription)
             let audioAvailable = audioState == .saved
-            let audioRemovable = MeetingAudioFile.isRemovable(for: transcription)
+            let audioRemovable = MeetingAudioFile.isRemovable(for: transcription, state: audioState)
             let artifactAvailable = MeetingArtifactActions.folderURL(for: transcription) != nil
 
             Divider()
@@ -422,8 +422,8 @@ struct TranscriptionLibraryView: View {
             .help(audioRemovable
                   ? "Remove the saved meeting audio while keeping the meeting"
                   : MeetingDeletionCopy.audioRemovalUnavailableHelp(
-                      state: audioState,
-                      status: transcription.status
+                      for: transcription,
+                      state: audioState
                   ))
         }
 

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
@@ -355,6 +355,7 @@ struct TranscriptionLibraryView: View {
         if transcription.sourceType == .meeting {
             let audioState = MeetingAudioFile.state(for: transcription)
             let audioAvailable = audioState == .saved
+            let audioRemovable = MeetingAudioFile.isRemovable(for: transcription)
             let artifactAvailable = MeetingArtifactActions.folderURL(for: transcription) != nil
 
             Divider()
@@ -417,10 +418,13 @@ struct TranscriptionLibraryView: View {
             } label: {
                 Label(MeetingDeletionCopy.audioOnlyMenuTitle, systemImage: "waveform.slash")
             }
-            .disabled(!audioAvailable)
-            .help(audioAvailable
+            .disabled(!audioRemovable)
+            .help(audioRemovable
                   ? "Remove the saved meeting audio while keeping the meeting"
-                  : MeetingDeletionCopy.audioUnavailableHelp(for: audioState))
+                  : MeetingDeletionCopy.audioRemovalUnavailableHelp(
+                      state: audioState,
+                      status: transcription.status
+                  ))
         }
 
         Divider()

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingAudioFile.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingAudioFile.swift
@@ -44,6 +44,18 @@ public enum MeetingAudioFile {
         state(for: transcription, fileManager: fileManager) == .saved
     }
 
+    /// Whether saved meeting audio can be removed without breaking active
+    /// meeting finalization. Processing rows may expose saved audio for playback,
+    /// export, and retry-source visibility, but the audio remains owned by the
+    /// finalization queue until the row reaches a terminal state.
+    public static func isRemovable(
+        for transcription: Transcription,
+        fileManager: FileManager = .default
+    ) -> Bool {
+        guard transcription.status != .processing else { return false }
+        return isAvailable(for: transcription, fileManager: fileManager)
+    }
+
     /// User-facing availability state for a meeting's stored audio.
     ///
     /// `removed` means the DB no longer points at meeting audio, usually

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingAudioFile.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingAudioFile.swift
@@ -52,8 +52,38 @@ public enum MeetingAudioFile {
         for transcription: Transcription,
         fileManager: FileManager = .default
     ) -> Bool {
-        guard transcription.status != .processing else { return false }
-        return isAvailable(for: transcription, fileManager: fileManager)
+        isRemovable(
+            for: transcription,
+            state: state(for: transcription, fileManager: fileManager),
+            fileManager: fileManager
+        )
+    }
+
+    /// Whether a caller can detach the meeting audio for an already-resolved
+    /// audio state. Use this overload when UI code already computed `state`.
+    public static func isRemovable(
+        for transcription: Transcription,
+        state: State,
+        fileManager: FileManager = .default
+    ) -> Bool {
+        guard state == .saved else { return false }
+        guard !isFinalizationInProgress(for: transcription, fileManager: fileManager) else { return false }
+        return true
+    }
+
+    /// Whether meeting audio is still owned by an active finalization or
+    /// recovery lock and should not be detached yet.
+    public static func isFinalizationInProgress(
+        for transcription: Transcription,
+        fileManager: FileManager = .default
+    ) -> Bool {
+        guard transcription.sourceType == .meeting else { return false }
+        if transcription.status == .processing { return true }
+        guard let folderURL = MeetingArtifactStore.sessionFolderURL(for: transcription)?.standardizedFileURL else {
+            return false
+        }
+        let lockURL = MeetingRecordingLockFileStore.lockFileURL(for: folderURL)
+        return fileManager.fileExists(atPath: lockURL.path)
     }
 
     /// User-facing availability state for a meeting's stored audio.

--- a/Sources/MacParakeetCore/Utilities/TranscriptionAssetCleanup.swift
+++ b/Sources/MacParakeetCore/Utilities/TranscriptionAssetCleanup.swift
@@ -3,11 +3,14 @@ import os
 
 public enum TranscriptionAssetCleanupError: Error, LocalizedError {
     case removalFailed(path: String, reason: String)
+    case meetingAudioFinalizationInProgress
 
     public var errorDescription: String? {
         switch self {
         case .removalFailed(_, let reason):
             return "Could not remove app-owned audio: \(reason)"
+        case .meetingAudioFinalizationInProgress:
+            return TranscriptionAssetCleanup.meetingAudioFinalizationInProgressMessage
         }
     }
 }
@@ -24,6 +27,8 @@ public struct MeetingAudioDetachResult: Sendable {
 public enum TranscriptionAssetCleanup {
     public static let unmanagedMeetingAudioMessage =
         "Meeting audio is not stored in MacParakeet's managed recordings folder."
+    public static let meetingAudioFinalizationInProgressMessage =
+        "Meeting audio can be removed after transcription finishes or stops."
 
     private static let logger = Logger(
         subsystem: "com.macparakeet.core",
@@ -88,6 +93,9 @@ public enum TranscriptionAssetCleanup {
             let result = MeetingAudioDetachResult(removedOwnedAudio: false, hadAudioPath: false)
             try repository.updateFilePath(id: transcription.id, filePath: nil)
             return result
+        }
+        guard transcription.sourceType != .meeting || transcription.status != .processing else {
+            throw TranscriptionAssetCleanupError.meetingAudioFinalizationInProgress
         }
         guard let removalPlan = try meetingAudioRemovalPlan(for: transcription, fileManager: fileManager) else {
             return MeetingAudioDetachResult(removedOwnedAudio: false, hadAudioPath: true)

--- a/Sources/MacParakeetCore/Utilities/TranscriptionAssetCleanup.swift
+++ b/Sources/MacParakeetCore/Utilities/TranscriptionAssetCleanup.swift
@@ -94,7 +94,7 @@ public enum TranscriptionAssetCleanup {
             try repository.updateFilePath(id: transcription.id, filePath: nil)
             return result
         }
-        guard transcription.sourceType != .meeting || transcription.status != .processing else {
+        guard !MeetingAudioFile.isFinalizationInProgress(for: transcription, fileManager: fileManager) else {
             throw TranscriptionAssetCleanupError.meetingAudioFinalizationInProgress
         }
         guard let removalPlan = try meetingAudioRemovalPlan(for: transcription, fileManager: fileManager) else {

--- a/Sources/MacParakeetViewModels/TranscriptionLibraryViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionLibraryViewModel.swift
@@ -168,7 +168,7 @@ public final class TranscriptionLibraryViewModel {
     }
 
     public var selectedMeetingAudioCount: Int {
-        selectedLoadedTranscriptions.filter(Self.hasAvailableMeetingAudio).count
+        selectedLoadedTranscriptions.filter(Self.hasRemovableMeetingAudio).count
     }
 
     public var selectedLoadedTranscriptionsForExport: [Transcription] {
@@ -342,12 +342,12 @@ public final class TranscriptionLibraryViewModel {
     public func requestDeleteSelectedMeetingAudio() {
         guard !isBulkOperationInProgress else { return }
         // Scope to meetings: "Remove Audio" only applies to meeting rows, so the
-        // skipped count must be meetings-without-saved-audio, not every selected
-        // non-meeting item. Counting all non-targets here mislabels videos/
-        // podcasts/local files as "meetings already with no saved audio" in the
-        // confirmation copy (which is meeting-only by design).
+        // skipped count must be meetings-without-removable-audio, not every
+        // selected non-meeting item. Counting all non-targets here mislabels
+        // videos/podcasts/local files as skipped meetings in the confirmation
+        // copy, which is meeting-only by design.
         let meetings = selectedLoadedTranscriptions.filter { $0.sourceType == .meeting }
-        let targets = meetings.filter(Self.hasAvailableMeetingAudio)
+        let targets = meetings.filter(Self.hasRemovableMeetingAudio)
         guard !targets.isEmpty else {
             return
         }
@@ -482,6 +482,8 @@ public final class TranscriptionLibraryViewModel {
                 transcriptions[idx].filePath = nil
                 publishLoadedItems(transcriptions, hasMore: hasMore)
             }
+        } catch TranscriptionAssetCleanupError.meetingAudioFinalizationInProgress {
+            errorMessage = TranscriptionAssetCleanup.meetingAudioFinalizationInProgressMessage
         } catch {
             logger.error("Failed to delete meeting audio: \(error.localizedDescription, privacy: .private)")
             errorMessage = "Failed to delete meeting audio: \(error.localizedDescription)"
@@ -678,8 +680,8 @@ public final class TranscriptionLibraryViewModel {
         filteredTranscriptions.filter { selectedTranscriptionIDs.contains($0.id) }
     }
 
-    nonisolated private static func hasAvailableMeetingAudio(_ transcription: Transcription) -> Bool {
-        MeetingAudioFile.isAvailable(for: transcription)
+    nonisolated private static func hasRemovableMeetingAudio(_ transcription: Transcription) -> Bool {
+        MeetingAudioFile.isRemovable(for: transcription)
     }
 
     private func pruneSelectionToLoadedItems() {

--- a/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
@@ -820,6 +820,8 @@ public final class TranscriptionViewModel {
             if clearExistingErrorOnSuccess {
                 clearError()
             }
+        } catch TranscriptionAssetCleanupError.meetingAudioFinalizationInProgress {
+            setError(message: TranscriptionAssetCleanup.meetingAudioFinalizationInProgressMessage)
         } catch {
             logger.error("Failed to delete meeting audio: \(error.localizedDescription, privacy: .private)")
             setError(message: "Failed to delete meeting audio: \(error.localizedDescription)")

--- a/Tests/MacParakeetTests/Audio/MeetingAudioFileTests.swift
+++ b/Tests/MacParakeetTests/Audio/MeetingAudioFileTests.swift
@@ -114,6 +114,7 @@ final class MeetingAudioFileTests: XCTestCase {
 
         XCTAssertEqual(MeetingAudioFile.state(for: transcription), .saved)
         XCTAssertTrue(MeetingAudioFile.isAvailable(for: transcription))
+        XCTAssertFalse(MeetingAudioFile.isRemovable(for: transcription))
     }
 
     func testStateReturnsNotMeetingForNonMeetingSource() {
@@ -159,6 +160,7 @@ final class MeetingAudioFileTests: XCTestCase {
         )
 
         XCTAssertEqual(MeetingAudioFile.state(for: transcription), .saved)
+        XCTAssertTrue(MeetingAudioFile.isRemovable(for: transcription))
     }
 
     // MARK: - suggestedExportStem

--- a/Tests/MacParakeetTests/Audio/MeetingAudioFileTests.swift
+++ b/Tests/MacParakeetTests/Audio/MeetingAudioFileTests.swift
@@ -117,6 +117,36 @@ final class MeetingAudioFileTests: XCTestCase {
         XCTAssertFalse(MeetingAudioFile.isRemovable(for: transcription))
     }
 
+    func testLockedErrorMeetingAudioIsAvailableButNotRemovable() throws {
+        let directory = makeTempDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let audioURL = directory.appendingPathComponent("meeting-playback.m4a")
+        try Data("audio".utf8).write(to: audioURL)
+        try MeetingRecordingLockFileStore().write(
+            MeetingRecordingLockFile(
+                sessionId: UUID(),
+                startedAt: Date(timeIntervalSince1970: 1_700_000_000),
+                pid: 99,
+                displayName: "Recovering Meeting",
+                state: .awaitingTranscription
+            ),
+            folderURL: directory
+        )
+
+        let transcription = makeTranscription(
+            fileName: "Meeting",
+            filePath: audioURL.path,
+            sourceType: .meeting,
+            status: .error
+        )
+        let state = MeetingAudioFile.state(for: transcription)
+
+        XCTAssertEqual(state, .saved)
+        XCTAssertTrue(MeetingAudioFile.isAvailable(for: transcription))
+        XCTAssertTrue(MeetingAudioFile.isFinalizationInProgress(for: transcription))
+        XCTAssertFalse(MeetingAudioFile.isRemovable(for: transcription, state: state))
+    }
+
     func testStateReturnsNotMeetingForNonMeetingSource() {
         let transcription = makeTranscription(
             fileName: "lecture.mp3",

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionDeletionCleanupTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionDeletionCleanupTests.swift
@@ -136,6 +136,38 @@ final class TranscriptionDeletionCleanupTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: folderURL.path))
     }
 
+    func testDetachMeetingAudioRefusesProcessingMeeting() throws {
+        let folderURL = URL(fileURLWithPath: AppPaths.meetingRecordingsDir, isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: folderURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: folderURL) }
+
+        let mixedURL = folderURL.appendingPathComponent("meeting-playback.m4a")
+        XCTAssertTrue(FileManager.default.createFile(atPath: mixedURL.path, contents: Data("mix".utf8)))
+
+        let transcription = Transcription(
+            fileName: "Meeting",
+            filePath: mixedURL.path,
+            status: .processing,
+            sourceType: .meeting
+        )
+        let repo = MockTranscriptionRepository()
+        repo.transcriptions = [transcription]
+
+        XCTAssertThrowsError(try TranscriptionAssetCleanup.detachOwnedMeetingAudio(
+            for: transcription,
+            repository: repo
+        )) { error in
+            guard case TranscriptionAssetCleanupError.meetingAudioFinalizationInProgress = error else {
+                return XCTFail("Expected finalization-in-progress error, got \(error)")
+            }
+        }
+        XCTAssertTrue(FileManager.default.fileExists(atPath: mixedURL.path))
+        XCTAssertEqual(repo.transcriptions.first?.filePath, mixedURL.path)
+        XCTAssertTrue(repo.updateFilePathCalls.isEmpty)
+        XCTAssertTrue(repo.updateMeetingArtifactFolderPathCalls.isEmpty)
+    }
+
     func testMeetingDeletionRemovesArtifactFolderAfterAudioWasDetached() throws {
         let folderURL = URL(fileURLWithPath: AppPaths.meetingRecordingsDir, isDirectory: true)
             .appendingPathComponent(UUID().uuidString, isDirectory: true)

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionDeletionCleanupTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionDeletionCleanupTests.swift
@@ -168,6 +168,48 @@ final class TranscriptionDeletionCleanupTests: XCTestCase {
         XCTAssertTrue(repo.updateMeetingArtifactFolderPathCalls.isEmpty)
     }
 
+    func testDetachMeetingAudioRefusesLockedErrorMeeting() throws {
+        let folderURL = URL(fileURLWithPath: AppPaths.meetingRecordingsDir, isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: folderURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: folderURL) }
+
+        let mixedURL = folderURL.appendingPathComponent("meeting-playback.m4a")
+        XCTAssertTrue(FileManager.default.createFile(atPath: mixedURL.path, contents: Data("mix".utf8)))
+        try MeetingRecordingLockFileStore().write(
+            MeetingRecordingLockFile(
+                sessionId: UUID(),
+                startedAt: Date(timeIntervalSince1970: 1_700_000_000),
+                pid: 99,
+                displayName: "Recovering Meeting",
+                state: .awaitingTranscription
+            ),
+            folderURL: folderURL
+        )
+
+        let transcription = Transcription(
+            fileName: "Meeting",
+            filePath: mixedURL.path,
+            status: .error,
+            sourceType: .meeting
+        )
+        let repo = MockTranscriptionRepository()
+        repo.transcriptions = [transcription]
+
+        XCTAssertThrowsError(try TranscriptionAssetCleanup.detachOwnedMeetingAudio(
+            for: transcription,
+            repository: repo
+        )) { error in
+            guard case TranscriptionAssetCleanupError.meetingAudioFinalizationInProgress = error else {
+                return XCTFail("Expected finalization-in-progress error, got \(error)")
+            }
+        }
+        XCTAssertTrue(FileManager.default.fileExists(atPath: mixedURL.path))
+        XCTAssertEqual(repo.transcriptions.first?.filePath, mixedURL.path)
+        XCTAssertTrue(repo.updateFilePathCalls.isEmpty)
+        XCTAssertTrue(repo.updateMeetingArtifactFolderPathCalls.isEmpty)
+    }
+
     func testMeetingDeletionRemovesArtifactFolderAfterAudioWasDetached() throws {
         let folderURL = URL(fileURLWithPath: AppPaths.meetingRecordingsDir, isDirectory: true)
             .appendingPathComponent(UUID().uuidString, isDirectory: true)

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionLibraryViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionLibraryViewModelTests.swift
@@ -729,6 +729,42 @@ final class TranscriptionLibraryViewModelTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: notesURL.path))
     }
 
+    func testDeleteMeetingAudioRefusesProcessingMeeting() async throws {
+        try AppPaths.ensureDirectories()
+        let folder = URL(fileURLWithPath: AppPaths.meetingRecordingsDir, isDirectory: true)
+            .appendingPathComponent("library-processing-meeting-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+        let audioURL = folder.appendingPathComponent("meeting-playback.m4a")
+        let microphoneURL = folder.appendingPathComponent("microphone-raw.m4a")
+        XCTAssertTrue(FileManager.default.createFile(atPath: audioURL.path, contents: Data("audio".utf8)))
+        XCTAssertTrue(FileManager.default.createFile(atPath: microphoneURL.path, contents: Data("mic".utf8)))
+        defer { try? FileManager.default.removeItem(at: folder) }
+
+        let t = Transcription(
+            fileName: "Meeting",
+            filePath: audioURL.path,
+            status: .processing,
+            sourceType: .meeting
+        )
+        try repo.save(t)
+        await load()
+
+        XCTAssertTrue(MeetingAudioFile.isAvailable(for: t))
+        XCTAssertFalse(MeetingAudioFile.isRemovable(for: t))
+        vm.deleteMeetingAudio(t)
+
+        let fetched = try XCTUnwrap(repo.fetch(id: t.id))
+        XCTAssertEqual(fetched.filePath, audioURL.path)
+        XCTAssertNil(fetched.meetingArtifactFolderPath)
+        XCTAssertEqual(vm.transcriptions.first?.filePath, audioURL.path)
+        XCTAssertEqual(
+            vm.errorMessage,
+            TranscriptionAssetCleanup.meetingAudioFinalizationInProgressMessage
+        )
+        XCTAssertTrue(FileManager.default.fileExists(atPath: audioURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: microphoneURL.path))
+    }
+
     func testConfirmBulkOperationRunsAfterPendingClearedByAlertDismissal() async throws {
         // Reproduces the alert race: tapping the destructive confirm button
         // dismisses the alert, whose isPresented setter nils pendingBulkOperation
@@ -929,15 +965,17 @@ final class TranscriptionLibraryViewModelTests: XCTestCase {
 
     func testRequestDeleteAudioOnlySkipCountExcludesNonMeetings() async throws {
         // Mixed Library selection: meetings and non-meetings together. The
-        // "Remove Audio" skipped count must reflect meetings-without-saved-audio
+        // "Remove Audio" skipped count must reflect meetings-without-removable-audio
         // only, so the confirmation copy never mislabels videos/podcasts/local
-        // files as "selected meetings already with no saved audio."
+        // files as skipped meetings.
         try AppPaths.ensureDirectories()
         let folder = URL(fileURLWithPath: AppPaths.meetingRecordingsDir, isDirectory: true)
             .appendingPathComponent("library-mixed-skip-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
         let audioURL = folder.appendingPathComponent("meeting-playback.m4a")
+        let processingAudioURL = folder.appendingPathComponent("processing-meeting-playback.m4a")
         XCTAssertTrue(FileManager.default.createFile(atPath: audioURL.path, contents: Data("audio".utf8)))
+        XCTAssertTrue(FileManager.default.createFile(atPath: processingAudioURL.path, contents: Data("audio".utf8)))
         defer { try? FileManager.default.removeItem(at: folder) }
 
         let meetingWithAudio = Transcription(
@@ -947,6 +985,12 @@ final class TranscriptionLibraryViewModelTests: XCTestCase {
             sourceType: .meeting
         )
         let meetingWithoutAudio = Transcription(fileName: "No Audio", status: .completed, sourceType: .meeting)
+        let processingMeeting = Transcription(
+            fileName: "Processing",
+            filePath: processingAudioURL.path,
+            status: .processing,
+            sourceType: .meeting
+        )
         let youtube = Transcription(
             fileName: "video",
             status: .completed,
@@ -955,24 +999,25 @@ final class TranscriptionLibraryViewModelTests: XCTestCase {
         )
         let podcast = Transcription(fileName: "episode", status: .completed, sourceType: .podcast)
         let local = Transcription(fileName: "local.mp3", status: .completed, sourceType: .file)
-        for transcription in [meetingWithAudio, meetingWithoutAudio, youtube, podcast, local] {
+        for transcription in [meetingWithAudio, meetingWithoutAudio, processingMeeting, youtube, podcast, local] {
             try repo.save(transcription)
         }
         await load()
 
         vm.beginBulkSelection(startingWith: meetingWithAudio)
-        for transcription in [meetingWithoutAudio, youtube, podcast, local] {
+        for transcription in [meetingWithoutAudio, processingMeeting, youtube, podcast, local] {
             vm.toggleSelection(for: transcription)
         }
 
-        XCTAssertEqual(vm.selectedTranscriptionCount, 5)
+        XCTAssertEqual(vm.selectedTranscriptionCount, 6)
+        XCTAssertEqual(vm.selectedMeetingAudioCount, 1)
         vm.requestDeleteSelectedMeetingAudio()
         let operation = try XCTUnwrap(vm.pendingBulkOperation)
         XCTAssertTrue(operation.isDeleteAudioOnly)
         XCTAssertEqual(operation.targetCount, 1)
-        // Only the audio-less meeting is skipped — the three non-meeting items
-        // are not counted (the old behavior reported 4).
-        XCTAssertEqual(operation.skippedCount, 1)
+        // Only the audio-less and still-processing meetings are skipped — the
+        // three non-meeting items are not counted (the old behavior reported 5).
+        XCTAssertEqual(operation.skippedCount, 2)
     }
 }
 

--- a/Tests/MacParakeetTests/Views/MeetingDeletionCopyTests.swift
+++ b/Tests/MacParakeetTests/Views/MeetingDeletionCopyTests.swift
@@ -73,7 +73,7 @@ final class MeetingDeletionCopyTests: XCTestCase {
         XCTAssertTrue(message.contains("permanently deletes saved audio from 1 meeting"))
         XCTAssertTrue(message.contains("meeting stays in Meetings"))
         XCTAssertTrue(message.contains("detect or backfill speakers for this recording"))
-        XCTAssertTrue(message.contains("2 selected meetings already have no saved audio"))
+        XCTAssertTrue(message.contains("2 selected meetings cannot have their audio removed right now"))
     }
 
     func testBulkAudioOnlyCopyOmitsSelectionPrefixWhenNothingIsSkipped() {
@@ -96,7 +96,7 @@ final class MeetingDeletionCopyTests: XCTestCase {
         )
 
         XCTAssertTrue(message.contains("2 selected meetings"))
-        XCTAssertTrue(message.contains("1 selected meeting already has no saved audio"))
+        XCTAssertTrue(message.contains("1 selected meeting cannot have its audio removed right now"))
         XCTAssertTrue(message.contains("it will be skipped"))
     }
 
@@ -115,7 +115,7 @@ final class MeetingDeletionCopyTests: XCTestCase {
     // Mixed Library selection (the surface where the miscount bug appeared):
     // the skipped count is meeting-scoped, so the rendered copy only ever talks
     // about meetings and stays consistent with the Delete dialog's meeting count
-    // — e.g. 7 meetings selected, 2 with saved audio, 5 already removed.
+    // — e.g. 7 meetings selected, 2 with removable audio, 5 not removable.
     func testBulkAudioOnlyCopyForLibrarySurfaceOnlyCountsMeetings() {
         let message = MeetingDeletionCopy.bulkAudioOnlyMessage(
             count: 2,
@@ -126,6 +126,6 @@ final class MeetingDeletionCopyTests: XCTestCase {
         XCTAssertTrue(message.contains("7 selected meetings"))
         XCTAssertTrue(message.contains("permanently deletes saved audio from 2 meetings"))
         XCTAssertTrue(message.contains("meetings stay in Library"))
-        XCTAssertTrue(message.contains("5 selected meetings already have no saved audio"))
+        XCTAssertTrue(message.contains("5 selected meetings cannot have their audio removed right now"))
     }
 }

--- a/Tests/MacParakeetTests/Views/MeetingDeletionCopyTests.swift
+++ b/Tests/MacParakeetTests/Views/MeetingDeletionCopyTests.swift
@@ -100,6 +100,37 @@ final class MeetingDeletionCopyTests: XCTestCase {
         XCTAssertTrue(message.contains("it will be skipped"))
     }
 
+    func testAudioRemovalUnavailableHelpTreatsLockedSavedAudioAsFinalizing() throws {
+        let folderURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("meeting-deletion-copy-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: folderURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: folderURL) }
+
+        let audioURL = folderURL.appendingPathComponent("meeting-playback.m4a")
+        XCTAssertTrue(FileManager.default.createFile(atPath: audioURL.path, contents: Data("audio".utf8)))
+        try MeetingRecordingLockFileStore().write(
+            MeetingRecordingLockFile(
+                sessionId: UUID(),
+                startedAt: Date(timeIntervalSince1970: 1_700_000_000),
+                pid: 99,
+                displayName: "Recovering Meeting",
+                state: .awaitingTranscription
+            ),
+            folderURL: folderURL
+        )
+        let transcription = Transcription(
+            fileName: "Meeting",
+            filePath: audioURL.path,
+            status: .error,
+            sourceType: .meeting
+        )
+
+        XCTAssertEqual(
+            MeetingDeletionCopy.audioRemovalUnavailableHelp(for: transcription, state: .saved),
+            TranscriptionAssetCleanup.meetingAudioFinalizationInProgressMessage
+        )
+    }
+
     func testBulkDeleteCopyWarnsWhenAnySelectedMeetingIsNotCompleted() {
         let message = MeetingDeletionCopy.bulkFullDeleteMessage(
             count: 2,


### PR DESCRIPTION
## Summary
Before this change, a processing meeting with saved audio could still offer “Remove Audio Only,” letting users detach the file while finalization or retry still needed it. Processing meeting audio now remains visible for Show, Save, and retry-source workflows, but destructive audio removal waits until the meeting leaves processing.

The fix keeps the model small: `MeetingAudioFile` now separates “audio exists” from “audio is removable,” and the shared cleanup helper refuses processing meeting detaches so UI, CLI, and future callers share the same safety guard. Bulk copy now describes skipped meetings as not removable right now instead of implying they already have no saved audio.

## Validation
- `git diff --check`
- `GIT_EXEC_PATH=/Library/Developer/CommandLineTools/usr/libexec/git-core swift test --filter 'MeetingAudioFileTests|TranscriptionDeletionCleanupTests|TranscriptionLibraryViewModelTests|MeetingDeletionCopyTests'`
- `GIT_EXEC_PATH=/Library/Developer/CommandLineTools/usr/libexec/git-core swift test`
- `GIT_EXEC_PATH=/Library/Developer/CommandLineTools/usr/libexec/git-core swift test --filter TranscriptionViewModelTests`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks “Remove Audio Only” when meeting audio is still needed for finalization or recovery (processing rows or lock-held sessions). Playback, export, and retry-source visibility stay available with clear help/error messaging.

- **Bug Fixes**
  - Added MeetingAudioFile.isRemovable(...) and isFinalizationInProgress(...) to separate “audio exists” from “can be removed,” including lock-file checks.
  - Central guard in TranscriptionAssetCleanup.detachOwnedMeetingAudio rejects processing/locked meetings and shows: “Meeting audio can be removed after transcription finishes or stops.”
  - Disabled “Remove Audio Only” in Meetings, Transcript, and Library menus when not removable; new help via audioRemovalUnavailableHelp explains the finalization state.
  - Bulk actions count only removable meeting audio; confirmation copy updated to “cannot have its audio removed right now.”
  - View models updated to use removability and surface the new error; tests added for processing, locked, and bulk-skip cases.

<sup>Written for commit 8e946c6a89398e3cf9556c7b9ade393a852dd662. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/764?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated meeting audio removal actions to better reflect when audio can actually be removed.
  * Added clearer feedback when a meeting is still finalizing, including a specific message for that state.

* **Bug Fixes**
  * Prevented removal of meeting audio while finalization is still in progress.
  * Improved bulk deletion handling so skipped items are counted and described more accurately.
  * Refined help text and disabled states across meeting and transcript views for clearer guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->