### PR TITLE
Harden LocalVQE release asset prep

### DIFF
--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -52,6 +52,21 @@ It is roughly 2.9 MB before compression. The source-built runtime is copied to
 exactly one GGUF model so asset verification and runtime model resolution cannot
 drift.
 
+The native CMake build uses host parallelism by default; if that build fails,
+the script cleans the build directory and retries once with `-j1`. If an
+interrupted prior build leaves a Git index lock in the default generated
+LocalVQE source checkout under `.build/`, the prep script discards that generated
+checkout and clones it again. Custom `LOCALVQE_SOURCE_DIR` checkouts are left in
+place and require manual cleanup on lock errors.
+
+For a deliberately serialized release build, set:
+
+```bash
+export LOCALVQE_CMAKE_BUILD_JOBS=1
+export REQUIRE_MEETING_ECHO_ASSETS=1
+VERSION=X.Y.Z scripts/dist/build_app_bundle.sh
+```
+
 To use prebuilt assets instead of the pinned auto-prep path, set both source
 paths explicitly:
 

--- a/scripts/dist/build_app_bundle.sh
+++ b/scripts/dist/build_app_bundle.sh
@@ -35,6 +35,7 @@ set -euo pipefail
 #   REQUIRE_MEETING_ECHO_ASSETS (default: 0) fail if echo assets are not bundled
 #   MACPARAKEET_MEETING_ECHO_AUTO_PREPARE (default: 1) build/download pinned default echo assets when paths are unset
 #   MACPARAKEET_MEETING_ECHO_ASSETS_DIR (default: .build/meeting-echo-assets) prepared asset output/cache
+#   LOCALVQE_CMAKE_BUILD_JOBS optional CMake parallelism for auto-prepared echo runtime; failed parallel builds retry once with -j1
 #   MACPARAKEET_MEETING_ECHO_LIBRARY source dylib for meeting echo suppression
 #   MACPARAKEET_MEETING_ECHO_DYLIB_DIR optional directory of dependent dylibs to copy into Frameworks
 #   MACPARAKEET_MEETING_ECHO_MODEL source GGUF model for meeting echo suppression

--- a/scripts/dist/prepare_meeting_echo_assets.sh
+++ b/scripts/dist/prepare_meeting_echo_assets.sh
@@ -15,7 +15,8 @@ DEFAULT_LOCALVQE_FETCH_REF="refs/heads/main"
 DEFAULT_MODEL_URL="https://huggingface.co/LocalAI-io/LocalVQE/resolve/main/${DEFAULT_MEETING_ECHO_MODEL_NAME}"
 
 ASSETS_DIR="${MACPARAKEET_MEETING_ECHO_ASSETS_DIR:-$ROOT_DIR/.build/meeting-echo-assets}"
-SOURCE_DIR="${LOCALVQE_SOURCE_DIR:-$ROOT_DIR/.build/localvqe-src}"
+DEFAULT_SOURCE_DIR="$ROOT_DIR/.build/localvqe-src"
+SOURCE_DIR="${LOCALVQE_SOURCE_DIR:-$DEFAULT_SOURCE_DIR}"
 BUILD_DIR="${LOCALVQE_BUILD_DIR:-$ASSETS_DIR/build}"
 LIB_DIR="$ASSETS_DIR/lib"
 MODEL_DIR="$ASSETS_DIR/model"
@@ -44,6 +45,10 @@ require_tool cmake
 require_tool curl
 require_tool shasum
 
+is_positive_integer() {
+  [[ "$1" =~ ^[1-9][0-9]*$ ]]
+}
+
 if [[ "$MODEL_NAME" == */* || "$(printf '%s' "$MODEL_NAME" | tr '[:upper:]' '[:lower:]')" != *.gguf ]]; then
   echo "Error: MACPARAKEET_MEETING_ECHO_MODEL_NAME must be a GGUF filename, not a path." >&2
   exit 1
@@ -63,6 +68,23 @@ else
 fi
 
 mkdir -p "$ASSETS_DIR" "$LIB_DIR" "$MODEL_DIR"
+
+reset_generated_source_dir_if_locked() {
+  local lock_path="$SOURCE_DIR/.git/index.lock"
+  [[ -e "$lock_path" ]] || return 0
+
+  case "$SOURCE_DIR" in
+    "$DEFAULT_SOURCE_DIR" | "$DEFAULT_SOURCE_DIR/")
+      echo "Removing generated LocalVQE source cache because a Git lock exists: $lock_path" >&2
+      rm -rf "$SOURCE_DIR"
+      ;;
+    *)
+      echo "Error: LocalVQE source checkout is locked: $lock_path" >&2
+      echo "Remove the lock manually after confirming no Git process is using LOCALVQE_SOURCE_DIR." >&2
+      exit 1
+      ;;
+  esac
+}
 
 ensure_localvqe_source() {
   if [[ -d "$SOURCE_DIR/.git" ]]; then
@@ -157,8 +179,19 @@ ensure_model() {
   echo "Meeting echo model SHA256 verified: $actual_sha"
 }
 
-build_localvqe_runtime() {
-  echo "Building LocalVQE runtime from ${LOCALVQE_REF}"
+localvqe_cmake_jobs() {
+  local jobs="${LOCALVQE_CMAKE_BUILD_JOBS:-}"
+  if [[ -z "$jobs" ]]; then
+    jobs="$(sysctl -n hw.ncpu 2>/dev/null || echo 4)"
+  fi
+  if ! is_positive_integer "$jobs"; then
+    echo "Error: LOCALVQE_CMAKE_BUILD_JOBS must be a positive integer." >&2
+    exit 1
+  fi
+  printf '%s\n' "$jobs"
+}
+
+configure_localvqe_runtime() {
   local cmake_build_type_upper
   cmake_build_type_upper="$(printf '%s' "$CMAKE_BUILD_TYPE" | tr '[:lower:]' '[:upper:]')"
   local cmake_args=(
@@ -179,10 +212,27 @@ build_localvqe_runtime() {
   fi
 
   cmake "${cmake_args[@]}"
+}
+
+build_localvqe_runtime() {
+  echo "Building LocalVQE runtime from ${LOCALVQE_REF}"
+  configure_localvqe_runtime
 
   local jobs
-  jobs="$(sysctl -n hw.ncpu 2>/dev/null || echo 4)"
-  cmake --build "$BUILD_DIR" --target localvqe_shared -j"$jobs"
+  jobs="$(localvqe_cmake_jobs)"
+  echo "Building LocalVQE runtime with ${jobs} CMake job(s)"
+  if cmake --build "$BUILD_DIR" --target localvqe_shared -j"$jobs"; then
+    return 0
+  fi
+
+  if [[ "$jobs" == "1" ]]; then
+    return 1
+  fi
+
+  echo "Warning: parallel LocalVQE build failed; retrying once with LOCALVQE_CMAKE_BUILD_JOBS=1." >&2
+  reset_build_dir
+  configure_localvqe_runtime
+  cmake --build "$BUILD_DIR" --target localvqe_shared -j1
 }
 
 runtime_stamp_value() {
@@ -218,6 +268,7 @@ ensure_localvqe_runtime() {
 
   rm -f "$RUNTIME_STAMP" "$RUNTIME_MANIFEST"
   reset_build_dir
+  reset_generated_source_dir_if_locked
   if localvqe_source_is_current; then
     echo "LocalVQE source already pinned: $SOURCE_DIR"
   else


### PR DESCRIPTION
## Summary
- make LocalVQE auto-prep tolerate an interrupted generated source cache by recloning only the default `.build/localvqe-src` checkout when it has a Git index lock
- add `LOCALVQE_CMAKE_BUILD_JOBS` and retry a failed parallel CMake build once with `-j1`
- document the serialized strict release command for meeting echo assets

## Design Notes
- No general lock manager or new release orchestration.
- Custom `LOCALVQE_SOURCE_DIR` is never deleted automatically, even when it lives under `.build`; a lock there fails with a manual cleanup message.
- The retry is limited to the native LocalVQE build path used by `REQUIRE_MEETING_ECHO_ASSETS=1`.

## Verification
- `git diff --check origin/main...HEAD`
- `bash -n scripts/dist/prepare_meeting_echo_assets.sh scripts/dist/build_app_bundle.sh scripts/dist/verify_meeting_echo_assets.sh scripts/dev/release_demo_smoke.sh`
- custom locked `.build/my-localvqe-worktree` repro: failed with the manual cleanup error and preserved the sentinel file
- default generated `.build/localvqe-src/.git/index.lock` repro: discarded the generated checkout, recloned LocalVQE, and rebuilt with `LOCALVQE_CMAKE_BUILD_JOBS=1`
- `GIT_EXEC_PATH=/Library/Developer/CommandLineTools/usr/libexec/git-core VERSION=0.7.0 BUILD_SYSTEM=swiftpm SKIP_BUILD=1 LOCALVQE_CMAKE_BUILD_JOBS=1 BUNDLE_YTDLP=0 BUNDLE_NODE=0 REQUIRE_MEETING_ECHO_ASSETS=1 scripts/dist/build_app_bundle.sh && rm -rf /tmp/macparakeet-release-asset-hardening-smoke-small && scripts/dev/release_demo_smoke.sh --cli dist/MacParakeet.app/Contents/MacOS/macparakeet-cli --output-dir /tmp/macparakeet-release-asset-hardening-smoke-small`
- GitHub PR checks on `6d84eb369804997f85a5e8c824ebabfd62494d6c`: CodeRabbit, Greptile Review, and both `swift-test` contexts passed

## Notes
- `no-mistakes` is not available in this local environment, so I used manual focused gates plus GitHub CI.
- This machine still needs the Command Line Tools `GIT_EXEC_PATH` workaround for `git submodule` until the selected Xcode Git is fixed.