### PR TITLE
fix(meeting): resolve legacy raw-audio filenames in regenerated markdown/manifest

### DIFF
--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -89,6 +89,13 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
 
 ## [Unreleased]
 
+### Fixed
+
+- Regenerated meeting artifact manifests and Markdown now populate
+  `rawMicrophoneAudioPath` and `rawSystemAudioPath` for retained meeting folders
+  that still use the legacy `microphone.m4a` and `system.m4a` raw-audio
+  filenames.
+
 ## [2.12.0] -- 2026-07-06
 
 ### Added

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingMarkdownRenderer.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingMarkdownRenderer.swift
@@ -84,8 +84,14 @@ public struct MeetingMarkdownArtifactPaths: Sendable, Equatable {
             MeetingArtifactStore.promptResultsDirectoryName,
             isDirectory: true
         )
-        let microphoneURL = folderURL.appendingPathComponent(MeetingArtifactAudioFileNames.rawMicrophone)
-        let systemURL = folderURL.appendingPathComponent(MeetingArtifactAudioFileNames.rawSystem)
+        let microphoneAudio = MeetingArtifactAudioFileNames.resolveRawMicrophoneURL(
+            in: folderURL,
+            fileManager: fileManager
+        )
+        let systemAudio = MeetingArtifactAudioFileNames.resolveRawSystemURL(
+            in: folderURL,
+            fileManager: fileManager
+        )
         let cleanedMicrophoneURL = folderURL.appendingPathComponent(
             MeetingCleanedMicRenderer.cleanedMicrophoneFileName
         )
@@ -98,8 +104,8 @@ public struct MeetingMarkdownArtifactPaths: Sendable, Equatable {
             transcriptPath: transcriptURL.path,
             notesPath: normalizedNonEmptyText(transcription.userNotes) == nil ? nil : notesURL.path,
             playbackAudioPath: transcription.filePath,
-            rawMicrophoneAudioPath: fileManager.fileExists(atPath: microphoneURL.path) ? microphoneURL.path : nil,
-            rawSystemAudioPath: fileManager.fileExists(atPath: systemURL.path) ? systemURL.path : nil,
+            rawMicrophoneAudioPath: microphoneAudio.exists ? microphoneAudio.url.path : nil,
+            rawSystemAudioPath: systemAudio.exists ? systemAudio.url.path : nil,
             cleanedMicrophoneAudioPath: MeetingRecordingOutput.isViableCleanedMicrophoneFile(
                 at: cleanedMicrophoneURL,
                 fileManager: fileManager

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingArtifactStoreTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingArtifactStoreTests.swift
@@ -223,6 +223,27 @@ final class MeetingArtifactStoreTests: XCTestCase {
         XCTAssertTrue(markdown.contains("cleanedMicrophoneAudioPath: \"\(cleanedURL.path)\""))
     }
 
+    func testMaterializeKeepsCurrentRawAudioPathsForRegeneratedMarkdownAndManifest() async throws {
+        try await assertMaterializedRawAudioPaths(
+            microphoneURL: folderURL.appendingPathComponent("microphone-raw.m4a"),
+            systemURL: folderURL.appendingPathComponent("system-raw.m4a")
+        )
+    }
+
+    func testMaterializeResolvesLegacyRawAudioPathsForRegeneratedMarkdownAndManifest() async throws {
+        try FileManager.default.removeItem(at: folderURL.appendingPathComponent("microphone-raw.m4a"))
+        try FileManager.default.removeItem(at: folderURL.appendingPathComponent("system-raw.m4a"))
+        let legacyMicrophoneURL = folderURL.appendingPathComponent("microphone.m4a")
+        let legacySystemURL = folderURL.appendingPathComponent("system.m4a")
+        try Data("legacy mic".utf8).write(to: legacyMicrophoneURL)
+        try Data("legacy system".utf8).write(to: legacySystemURL)
+
+        try await assertMaterializedRawAudioPaths(
+            microphoneURL: legacyMicrophoneURL,
+            systemURL: legacySystemURL
+        )
+    }
+
     func testMaterializeWritesCalendarSnapshotIntoArtifactMetadata() async throws {
         let calendarSnapshot = makeCalendarSnapshot(confidence: .confirmed)
         let transcription = makeMeeting(
@@ -394,6 +415,41 @@ final class MeetingArtifactStoreTests: XCTestCase {
             engine: "parakeet",
             engineVariant: "v3",
             calendarEventSnapshot: calendarEventSnapshot
+        )
+    }
+
+    private func assertMaterializedRawAudioPaths(
+        microphoneURL: URL,
+        systemURL: URL,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws {
+        let transcription = makeMeeting(notes: nil)
+
+        let snapshot = try await MeetingArtifactStore().materialize(
+            transcription: transcription,
+            promptResults: []
+        )
+
+        XCTAssertEqual(snapshot.rawMicrophoneAudioPath, microphoneURL.path, file: file, line: line)
+        XCTAssertEqual(snapshot.rawSystemAudioPath, systemURL.path, file: file, line: line)
+
+        let manifest = try jsonObject(at: URL(fileURLWithPath: snapshot.manifestPath))
+        let files = try XCTUnwrap(manifest["files"] as? [String: Any], file: file, line: line)
+        XCTAssertEqual(files["rawMicrophoneAudioPath"] as? String, microphoneURL.path, file: file, line: line)
+        XCTAssertEqual(files["rawSystemAudioPath"] as? String, systemURL.path, file: file, line: line)
+
+        let markdownPath = try XCTUnwrap(snapshot.markdownPath, file: file, line: line)
+        let markdown = try String(contentsOfFile: markdownPath, encoding: .utf8)
+        XCTAssertTrue(
+            markdown.contains("rawMicrophoneAudioPath: \"\(microphoneURL.path)\""),
+            file: file,
+            line: line
+        )
+        XCTAssertTrue(
+            markdown.contains("rawSystemAudioPath: \"\(systemURL.path)\""),
+            file: file,
+            line: line
         )
     }
 

--- a/spec/contracts/meeting-artifacts-v1.md
+++ b/spec/contracts/meeting-artifacts-v1.md
@@ -76,6 +76,14 @@ The v1 folder can contain these stable filenames:
 - `prompt-results/*.md`: filenames use a stable two-digit 1-based index prefix
   plus sanitized prompt-result name.
 
+New recordings write the role-explicit audio filenames above. For read
+compatibility with folders created before the in-place v1 audio filename
+rename, readers and artifact materializers must also resolve legacy
+`microphone.m4a` and `system.m4a` when the current raw-audio filename is absent.
+Regenerated `manifest.json` and `meeting.md` path fields point to the actual
+existing current or legacy raw-audio file. New captures must not create legacy
+raw-audio filenames.
+
 ## Stable JSON Fields
 
 `MeetingArtifactSnapshot` and CLI artifact output keep these fields stable:


### PR DESCRIPTION
## Problem

PR #744 renamed meeting raw-audio artifacts from `microphone.m4a` / `system.m4a` to `microphone-raw.m4a` / `system-raw.m4a`, and PR #747 added shared current-or-legacy resolvers. Regenerated `meeting.md` and `manifest.json` still probed only the new raw filenames, so older retained meeting folders could regenerate with missing raw-audio paths even though playback/recovery could resolve the files.

## Before / After

For a legacy retained folder containing only:

```text
microphone.m4a
system.m4a
```

Before regenerated manifest fields:

```json
{
  "rawMicrophoneAudioPath": null,
  "rawSystemAudioPath": null
}
```

After regenerated manifest fields:

```json
{
  "rawMicrophoneAudioPath": "/path/to/meeting/microphone.m4a",
  "rawSystemAudioPath": "/path/to/meeting/system.m4a"
}
```

Folders using the current `microphone-raw.m4a` / `system-raw.m4a` names still surface those current paths.

## Verification

- `scripts/dev/format.sh`
- `git diff --check`
- `GIT_EXEC_PATH=/Library/Developer/CommandLineTools/usr/libexec/git-core swift test --filter MeetingArtifactStoreTests`
  - Executed 10 tests, 0 failures

## Notes

- No file rename or migration is added; this is read-compatibility only.
- Cleaned-mic path logic is unchanged.
- Other source call sites audited: `MeetingAudioStorageWriter` appends `rawMicrophone` / `rawSystem` only to create new recordings, so it should continue writing the role-explicit current filenames.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes regenerated `meeting.md` and `manifest.json` to correctly populate raw-audio paths by resolving both current `*-raw.m4a` and legacy `.m4a` filenames. Restores read-compatibility for older meeting folders without changing how new recordings are written.

- **Bug Fixes**
  - Use `MeetingArtifactAudioFileNames.resolveRawMicrophoneURL` and `resolveRawSystemURL` to find current or legacy files.
  - New captures still write `microphone-raw.m4a` and `system-raw.m4a`; no migration or renames.
  - Added tests for current and legacy paths; updated spec and changelog.

<sup>Written for commit 9cd3ceb55329b840871e48acbe75f2ac3fc85eea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/770?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

