### PR TITLE
fix(ui): remove floating-controls toggle from menu bar menu

### DIFF
--- a/Sources/MacParakeet/App/MenuBarCoordinator.swift
+++ b/Sources/MacParakeet/App/MenuBarCoordinator.swift
@@ -16,7 +16,6 @@ final class MenuBarCoordinator: NSObject, NSMenuDelegate {
     private let youtubeTranscriptionHotkeyTriggerProvider: () -> HotkeyTrigger
     private let meetingRecordingActiveProvider: () -> Bool
     private let liveMeetingPanelAvailableProvider: () -> Bool
-    private let showFloatingMeetingControlsProvider: () -> Bool
     private let dictationCaptureActiveProvider: () -> Bool
     private let onOpenMainWindow: () -> Void
     private let onOpenSettings: () -> Void
@@ -25,7 +24,6 @@ final class MenuBarCoordinator: NSObject, NSMenuDelegate {
     private let onStartDictation: () -> Void
     private let onToggleMeetingRecording: () -> Void
     private let onOpenLiveMeetingPanel: () -> Void
-    private let onToggleFloatingMeetingControls: () -> Void
     private let onCreateTransform: () -> Void
     private let onQuit: () -> Void
     private let onShowAboutPanel: () -> Void
@@ -40,7 +38,6 @@ final class MenuBarCoordinator: NSObject, NSMenuDelegate {
     private var recentTransformsMenuItem: NSMenuItem?
     private var recordMeetingMenuItems: [NSMenuItem] = []
     private var openLiveMeetingPanelMenuItem: NSMenuItem?
-    private var showFloatingMeetingControlsMenuItem: NSMenuItem?
     private var transcribeFileMenuItems: [NSMenuItem] = []
     private var transcribeYouTubeMenuItems: [NSMenuItem] = []
     private var hotkeyMenuItem: NSMenuItem?
@@ -53,8 +50,6 @@ final class MenuBarCoordinator: NSObject, NSMenuDelegate {
         let recordingEnabled: Bool
         let openLiveMeetingPanelHidden: Bool
         let openLiveMeetingPanelEnabled: Bool
-        let showFloatingMeetingControlsEnabled: Bool
-        let showFloatingMeetingControlsState: NSControl.StateValue
     }
 
     init(
@@ -68,7 +63,6 @@ final class MenuBarCoordinator: NSObject, NSMenuDelegate {
         youtubeTranscriptionHotkeyTriggerProvider: @escaping () -> HotkeyTrigger,
         meetingRecordingActiveProvider: @escaping () -> Bool,
         liveMeetingPanelAvailableProvider: @escaping () -> Bool,
-        showFloatingMeetingControlsProvider: @escaping () -> Bool,
         dictationCaptureActiveProvider: @escaping () -> Bool,
         onOpenMainWindow: @escaping () -> Void,
         onOpenSettings: @escaping () -> Void,
@@ -77,7 +71,6 @@ final class MenuBarCoordinator: NSObject, NSMenuDelegate {
         onStartDictation: @escaping () -> Void,
         onToggleMeetingRecording: @escaping () -> Void,
         onOpenLiveMeetingPanel: @escaping () -> Void,
-        onToggleFloatingMeetingControls: @escaping () -> Void,
         onCreateTransform: @escaping () -> Void,
         onQuit: @escaping () -> Void,
         onShowAboutPanel: @escaping () -> Void
@@ -92,7 +85,6 @@ final class MenuBarCoordinator: NSObject, NSMenuDelegate {
         self.youtubeTranscriptionHotkeyTriggerProvider = youtubeTranscriptionHotkeyTriggerProvider
         self.meetingRecordingActiveProvider = meetingRecordingActiveProvider
         self.liveMeetingPanelAvailableProvider = liveMeetingPanelAvailableProvider
-        self.showFloatingMeetingControlsProvider = showFloatingMeetingControlsProvider
         self.dictationCaptureActiveProvider = dictationCaptureActiveProvider
         self.onOpenMainWindow = onOpenMainWindow
         self.onOpenSettings = onOpenSettings
@@ -101,7 +93,6 @@ final class MenuBarCoordinator: NSObject, NSMenuDelegate {
         self.onStartDictation = onStartDictation
         self.onToggleMeetingRecording = onToggleMeetingRecording
         self.onOpenLiveMeetingPanel = onOpenLiveMeetingPanel
-        self.onToggleFloatingMeetingControls = onToggleFloatingMeetingControls
         self.onCreateTransform = onCreateTransform
         self.onQuit = onQuit
         self.onShowAboutPanel = onShowAboutPanel
@@ -122,16 +113,13 @@ final class MenuBarCoordinator: NSObject, NSMenuDelegate {
     static func meetingRecordingMenuPresentation(
         environmentReady: Bool,
         isMeetingRecordingActive: Bool,
-        canOpenLiveMeetingPanel: Bool,
-        showFloatingMeetingControls: Bool
+        canOpenLiveMeetingPanel: Bool
     ) -> MeetingRecordingMenuPresentation {
         MeetingRecordingMenuPresentation(
             recordingTitle: isMeetingRecordingActive ? "Stop Recording" : "Start Recording",
             recordingEnabled: environmentReady,
             openLiveMeetingPanelHidden: !isMeetingRecordingActive,
-            openLiveMeetingPanelEnabled: environmentReady && canOpenLiveMeetingPanel,
-            showFloatingMeetingControlsEnabled: environmentReady,
-            showFloatingMeetingControlsState: showFloatingMeetingControls ? .on : .off
+            openLiveMeetingPanelEnabled: environmentReady && canOpenLiveMeetingPanel
         )
     }
 
@@ -460,15 +448,6 @@ final class MenuBarCoordinator: NSObject, NSMenuDelegate {
             openLiveMeetingPanelItem.target = self
             menu.addItem(openLiveMeetingPanelItem)
             openLiveMeetingPanelMenuItem = openLiveMeetingPanelItem
-
-            let showFloatingMeetingControlsItem = NSMenuItem(
-                title: "Show Floating Meeting Controls",
-                action: #selector(toggleFloatingMeetingControlsFromMenu),
-                keyEquivalent: ""
-            )
-            showFloatingMeetingControlsItem.target = self
-            menu.addItem(showFloatingMeetingControlsItem)
-            showFloatingMeetingControlsMenuItem = showFloatingMeetingControlsItem
         }
 
         menu.addItem(NSMenuItem.separator())
@@ -733,17 +712,12 @@ final class MenuBarCoordinator: NSObject, NSMenuDelegate {
         onOpenLiveMeetingPanel()
     }
 
-    @objc private func toggleFloatingMeetingControlsFromMenu() {
-        onToggleFloatingMeetingControls()
-    }
-
     func menuNeedsUpdate(_ menu: NSMenu) {
         let environmentReady = environmentProvider() != nil
         let meetingPresentation = Self.meetingRecordingMenuPresentation(
             environmentReady: environmentReady,
             isMeetingRecordingActive: meetingRecordingActiveProvider(),
-            canOpenLiveMeetingPanel: liveMeetingPanelAvailableProvider(),
-            showFloatingMeetingControls: showFloatingMeetingControlsProvider()
+            canOpenLiveMeetingPanel: liveMeetingPanelAvailableProvider()
         )
         newTranscriptionMenuItem?.isEnabled = environmentReady
         startDictationMenuItem?.isEnabled = environmentReady && !dictationCaptureActiveProvider()
@@ -756,8 +730,6 @@ final class MenuBarCoordinator: NSObject, NSMenuDelegate {
         }
         openLiveMeetingPanelMenuItem?.isHidden = meetingPresentation.openLiveMeetingPanelHidden
         openLiveMeetingPanelMenuItem?.isEnabled = meetingPresentation.openLiveMeetingPanelEnabled
-        showFloatingMeetingControlsMenuItem?.isEnabled = meetingPresentation.showFloatingMeetingControlsEnabled
-        showFloatingMeetingControlsMenuItem?.state = meetingPresentation.showFloatingMeetingControlsState
 
         updateCohereLanguageMenu()
 

--- a/Sources/MacParakeet/AppDelegate.swift
+++ b/Sources/MacParakeet/AppDelegate.swift
@@ -261,9 +261,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         liveMeetingPanelAvailableProvider: { [weak self] in
             self?.meetingRecordingFlowCoordinator?.canPresentLiveMeetingPanel == true
         },
-        showFloatingMeetingControlsProvider: { [weak self] in
-            self?.settingsViewModel.showMeetingRecordingPill ?? true
-        },
         dictationCaptureActiveProvider: { [weak self] in
             self?.dictationFlowCoordinator?.isCapturingAudio == true
         },
@@ -288,9 +285,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         },
         onOpenLiveMeetingPanel: { [weak self] in
             self?.meetingRecordingFlowCoordinator?.presentLiveMeetingPanel()
-        },
-        onToggleFloatingMeetingControls: { [weak self] in
-            self?.settingsViewModel.showMeetingRecordingPill.toggle()
         },
         onCreateTransform: { [weak self] in
             self?.mainWindowState.beginCreatingTransform()

--- a/Sources/MacParakeetViewModels/SettingsSearchIndex.swift
+++ b/Sources/MacParakeetViewModels/SettingsSearchIndex.swift
@@ -248,9 +248,9 @@ public enum SettingsSearchIndex {
             title: "Show floating meeting controls",
             subtitle: "in Meeting Recording",
             keywords: [
-                "floating", "pill", "meeting controls", "floating controls",
-                "meeting pill", "recording pill", "hide meeting", "hide recording",
-                "recording ui", "menu bar", "overlay"
+                "floating controls", "meeting pill", "recording pill",
+                "hide meeting", "hide recording", "recording ui", "menu bar",
+                "overlay"
             ],
             cardAnchor: "meeting"
         ),

--- a/Sources/MacParakeetViewModels/SettingsSearchIndex.swift
+++ b/Sources/MacParakeetViewModels/SettingsSearchIndex.swift
@@ -248,8 +248,9 @@ public enum SettingsSearchIndex {
             title: "Show floating meeting controls",
             subtitle: "in Meeting Recording",
             keywords: [
-                "floating controls", "meeting pill", "recording pill", "hide meeting",
-                "hide recording", "recording ui", "menu bar", "overlay"
+                "floating", "pill", "meeting controls", "floating controls",
+                "meeting pill", "recording pill", "hide meeting", "hide recording",
+                "recording ui", "menu bar", "overlay"
             ],
             cardAnchor: "meeting"
         ),

--- a/Tests/MacParakeetTests/App/MenuBarCoordinatorTests.swift
+++ b/Tests/MacParakeetTests/App/MenuBarCoordinatorTests.swift
@@ -8,53 +8,44 @@ final class MenuBarCoordinatorTests: XCTestCase {
         let presentation = MenuBarCoordinator.meetingRecordingMenuPresentation(
             environmentReady: true,
             isMeetingRecordingActive: false,
-            canOpenLiveMeetingPanel: false,
-            showFloatingMeetingControls: true
+            canOpenLiveMeetingPanel: false
         )
 
         XCTAssertEqual(presentation.recordingTitle, "Start Recording")
         XCTAssertTrue(presentation.recordingEnabled)
         XCTAssertTrue(presentation.openLiveMeetingPanelHidden)
         XCTAssertFalse(presentation.openLiveMeetingPanelEnabled)
-        XCTAssertTrue(presentation.showFloatingMeetingControlsEnabled)
-        XCTAssertEqual(presentation.showFloatingMeetingControlsState, .on)
     }
 
-    func testMeetingRecordingMenuPresentationWhileRecordingWithPillHidden() {
+    func testMeetingRecordingMenuPresentationWhileRecording() {
         let presentation = MenuBarCoordinator.meetingRecordingMenuPresentation(
             environmentReady: true,
             isMeetingRecordingActive: true,
-            canOpenLiveMeetingPanel: true,
-            showFloatingMeetingControls: false
+            canOpenLiveMeetingPanel: true
         )
 
         XCTAssertEqual(presentation.recordingTitle, "Stop Recording")
         XCTAssertTrue(presentation.recordingEnabled)
         XCTAssertFalse(presentation.openLiveMeetingPanelHidden)
         XCTAssertTrue(presentation.openLiveMeetingPanelEnabled)
-        XCTAssertTrue(presentation.showFloatingMeetingControlsEnabled)
-        XCTAssertEqual(presentation.showFloatingMeetingControlsState, .off)
     }
 
     func testMeetingRecordingMenuPresentationDisablesActionsBeforeEnvironmentIsReady() {
         let presentation = MenuBarCoordinator.meetingRecordingMenuPresentation(
             environmentReady: false,
             isMeetingRecordingActive: true,
-            canOpenLiveMeetingPanel: true,
-            showFloatingMeetingControls: false
+            canOpenLiveMeetingPanel: true
         )
 
         XCTAssertFalse(presentation.recordingEnabled)
         XCTAssertFalse(presentation.openLiveMeetingPanelEnabled)
-        XCTAssertFalse(presentation.showFloatingMeetingControlsEnabled)
     }
 
     func testMeetingRecordingMenuPresentationKeepsPanelActionDisabledUntilPanelExists() {
         let presentation = MenuBarCoordinator.meetingRecordingMenuPresentation(
             environmentReady: true,
             isMeetingRecordingActive: true,
-            canOpenLiveMeetingPanel: false,
-            showFloatingMeetingControls: false
+            canOpenLiveMeetingPanel: false
         )
 
         XCTAssertFalse(presentation.openLiveMeetingPanelHidden)

--- a/Tests/MacParakeetTests/ViewModels/SettingsSearchIndexTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/SettingsSearchIndexTests.swift
@@ -98,7 +98,10 @@ final class SettingsSearchIndexTests: XCTestCase {
     }
 
     func testMeetingPillQueriesFindFloatingControlsSetting() {
-        let queries = ["floating controls", "meeting pill", "hide meeting", "recording ui"]
+        let queries = [
+            "floating", "pill", "meeting controls", "floating controls",
+            "meeting pill", "hide meeting", "recording ui"
+        ]
 
         for query in queries {
             let ids = Set(SettingsSearchIndex.matches(query).map(\.id))

--- a/spec/04-ui-patterns.md
+++ b/spec/04-ui-patterns.md
@@ -514,7 +514,7 @@ Default-on floating pill that appears during meeting recording unless the user d
 - **Stays visible** during concurrent dictation — dictation overlay appears separately
 - **Hides** idle pill while visible (meeting pill replaces it)
 - **Disappears** when recording stops (transitions to transcription in library)
-- **Status menu fallback** exposes Stop Recording, Open Live Meeting Panel, and the Show Floating Meeting Controls toggle so hidden-pill recordings remain controllable
+- **Status menu fallback** exposes Stop Recording and Open Live Meeting Panel so hidden-pill recordings remain controllable
 
 ### Panel: `NSPanel` (non-activating)
 


### PR DESCRIPTION
## Summary

The status-item meeting menu no longer exposes a persistent preference as an action. Before, the meeting block mixed recording actions with a `Show Floating Meeting Controls` checkbox; after, pill visibility stays in Settings and the status menu only offers meeting actions.

## Before / After

| Before | After |
| --- | --- |
| Start/Stop Recording | Start/Stop Recording |
| Open Live Meeting Panel | Open Live Meeting Panel |
| Show Floating Meeting Controls | Removed |

## Settings Search

The Settings search index now explicitly covers `floating`, `pill`, and `meeting controls` for the existing floating meeting controls toggle, with focused test coverage.

## Verification

- `git diff --check`
- `GIT_EXEC_PATH=/Library/Developer/CommandLineTools/usr/libexec/git-core swift test --filter MenuBarCoordinatorTests` — 4 tests, 0 failures
- `GIT_EXEC_PATH=/Library/Developer/CommandLineTools/usr/libexec/git-core swift test --filter SettingsSearchIndexTests` — 28 tests, 0 failures

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5_Codex](https://img.shields.io/badge/GPT--5_Codex-000000)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the “Show Floating Meeting Controls” toggle from the menu bar status menu. The status menu now only shows meeting actions; floating pill visibility stays in Settings.

- **Bug Fixes**
  - Removed related menu wiring in `MenuBarCoordinator` and `AppDelegate`; updated tests and UI patterns doc.
  - Dropped redundant Settings search keywords and added tests to cover “floating”, “pill”, and “meeting controls”.

<sup>Written for commit aaa3678fa977168a94dbc6916d6dec3305f942df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/773?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified the meeting recording status menu so it now shows only the recording and live panel actions.
  * Removed the floating meeting controls option from menu behavior and related settings search handling.
  * Updated tests to match the revised menu and search experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->