### PR TITLE
fix(app): add command line tool installer

### DIFF
--- a/Sources/MacParakeet/App/AppEnvironment.swift
+++ b/Sources/MacParakeet/App/AppEnvironment.swift
@@ -46,6 +46,7 @@ final class AppEnvironment {
     let focusedAppContextService: FocusedAppContextService
     let entitlementsService: EntitlementsService
     let launchAtLoginService: LaunchAtLoginService
+    let commandLineToolInstallService: CommandLineToolInstallService
     let checkoutURL: URL?
     let telemetryService: TelemetryService
     let llmClient: RoutingLLMClient
@@ -173,6 +174,7 @@ final class AppEnvironment {
         accessibilityService = AccessibilityService()
         focusedAppContextService = FocusedAppContextService()
         launchAtLoginService = LaunchAtLoginService()
+        commandLineToolInstallService = CommandLineToolInstallService()
 
         // Retained purchase activation / entitlements. Current free/GPL builds
         // always report unlocked, but the old activation plumbing is preserved

--- a/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
+++ b/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
@@ -129,6 +129,7 @@ final class AppEnvironmentConfigurer {
             transformHistoryRepo: env.transformHistoryRepo,
             entitlementsService: env.entitlementsService,
             launchAtLoginService: env.launchAtLoginService,
+            commandLineToolInstallService: env.commandLineToolInstallService,
             checkoutURL: env.checkoutURL,
             customWordRepo: env.customWordRepo,
             snippetRepo: env.snippetRepo,

--- a/Sources/MacParakeet/App/AppWindowCoordinator.swift
+++ b/Sources/MacParakeet/App/AppWindowCoordinator.swift
@@ -97,8 +97,8 @@ final class AppWindowCoordinator: NSObject, NSWindowDelegate {
         NSApp.activate(ignoringOtherApps: true)
     }
 
-    func openMainWindowToSettings(tab: SettingsTab? = nil) {
-        mainWindowState.navigateToSettings(tab: tab)
+    func openMainWindowToSettings(tab: SettingsTab? = nil, anchor: String? = nil) {
+        mainWindowState.navigateToSettings(tab: tab, anchor: anchor)
         openMainWindow()
     }
 

--- a/Sources/MacParakeet/App/MenuBarCoordinator.swift
+++ b/Sources/MacParakeet/App/MenuBarCoordinator.swift
@@ -19,6 +19,7 @@ final class MenuBarCoordinator: NSObject, NSMenuDelegate {
     private let dictationCaptureActiveProvider: () -> Bool
     private let onOpenMainWindow: () -> Void
     private let onOpenSettings: () -> Void
+    private let onOpenCommandLineToolSettings: () -> Void
     private let onNavigate: (SidebarItem) -> Void
     private let onNewTranscription: () -> Void
     private let onStartDictation: () -> Void
@@ -66,6 +67,7 @@ final class MenuBarCoordinator: NSObject, NSMenuDelegate {
         dictationCaptureActiveProvider: @escaping () -> Bool,
         onOpenMainWindow: @escaping () -> Void,
         onOpenSettings: @escaping () -> Void,
+        onOpenCommandLineToolSettings: @escaping () -> Void,
         onNavigate: @escaping (SidebarItem) -> Void,
         onNewTranscription: @escaping () -> Void,
         onStartDictation: @escaping () -> Void,
@@ -88,6 +90,7 @@ final class MenuBarCoordinator: NSObject, NSMenuDelegate {
         self.dictationCaptureActiveProvider = dictationCaptureActiveProvider
         self.onOpenMainWindow = onOpenMainWindow
         self.onOpenSettings = onOpenSettings
+        self.onOpenCommandLineToolSettings = onOpenCommandLineToolSettings
         self.onNavigate = onNavigate
         self.onNewTranscription = onNewTranscription
         self.onStartDictation = onStartDictation
@@ -146,6 +149,14 @@ final class MenuBarCoordinator: NSObject, NSMenuDelegate {
         )
         settingsItem.target = self
         appMenu.addItem(settingsItem)
+
+        let installCLIItem = NSMenuItem(
+            title: "Install Command Line Tool...",
+            action: #selector(showCommandLineToolSettings),
+            keyEquivalent: ""
+        )
+        installCLIItem.target = self
+        appMenu.addItem(installCLIItem)
 
         let checkForUpdatesItem = NSMenuItem(
             title: "Check for Updates...",
@@ -574,6 +585,10 @@ final class MenuBarCoordinator: NSObject, NSMenuDelegate {
     // which would trigger automatic gear SF Symbol decoration on the menu item.
     @objc private func showSettingsWindow() {
         onOpenSettings()
+    }
+
+    @objc private func showCommandLineToolSettings() {
+        onOpenCommandLineToolSettings()
     }
 
     @objc private func showTranscribe() {

--- a/Sources/MacParakeet/AppDelegate.swift
+++ b/Sources/MacParakeet/AppDelegate.swift
@@ -270,6 +270,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         onOpenSettings: { [weak self] in
             self?.windowCoordinator.openMainWindowToSettings()
         },
+        onOpenCommandLineToolSettings: { [weak self] in
+            self?.windowCoordinator.openMainWindowToSettings(tab: .system, anchor: "system.startup")
+        },
         onNavigate: { [weak self] item in
             self?.mainWindowState.navigate(to: item)
         },

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -178,6 +178,7 @@ struct SettingsView: View {
         .background(focusSearchHotkey)
         .onAppear {
             viewModel.refreshLaunchAtLoginStatus()
+            viewModel.refreshCommandLineToolStatus()
             viewModel.startPermissionPolling()
             viewModel.refreshStats()
             viewModel.refreshEntitlements()
@@ -189,6 +190,7 @@ struct SettingsView: View {
         }
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
             viewModel.refreshPermissions()
+            viewModel.refreshCommandLineToolStatus()
             viewModel.engine.refreshSpeechEngineSwitchAvailability()
             Task { await viewModel.refreshCalendarNotificationAuthorization() }
         }
@@ -637,6 +639,23 @@ struct SettingsView: View {
         } message: { pending in
             Text(meetingAudioRetentionConfirmationMessage(for: pending.retention))
         }
+        .alert(
+            "Replace command line tool link?",
+            isPresented: Binding(
+                get: { viewModel.pendingCommandLineToolOverwriteTarget != nil },
+                set: { if !$0 { viewModel.cancelCommandLineToolOverwrite() } }
+            ),
+            presenting: viewModel.pendingCommandLineToolOverwriteTarget
+        ) { _ in
+            Button("Cancel", role: .cancel) {
+                viewModel.cancelCommandLineToolOverwrite()
+            }
+            Button("Replace Link") {
+                viewModel.confirmCommandLineToolOverwrite()
+            }
+        } message: { target in
+            Text("/usr/local/bin/macparakeet-cli currently points to \(target). Replace it with this copy of MacParakeet?")
+        }
     }
 
     /// Common scaffold for all four tab bodies: ScrollView wrapped in a
@@ -930,7 +949,7 @@ struct SettingsView: View {
     private var startupCard: some View {
         settingsCard(
             title: "Startup",
-            subtitle: "How MacParakeet shows up on your Mac at sign-in.",
+            subtitle: "How MacParakeet integrates with macOS and Terminal.",
             icon: "power"
         ) {
             VStack(spacing: DesignSystem.Spacing.md) {
@@ -964,6 +983,39 @@ struct SettingsView: View {
                     detail: "Hide the Dock icon and run from the menu bar only.",
                     isOn: $viewModel.menuBarOnlyMode
                 )
+
+                Divider()
+
+                HStack(alignment: .center, spacing: DesignSystem.Spacing.md) {
+                    rowText(
+                        title: "Command line tool",
+                        detail: viewModel.commandLineToolDetail
+                    )
+
+                    Spacer()
+
+                    if viewModel.commandLineToolStatusChecking || viewModel.commandLineToolInstallInProgress {
+                        ProgressView()
+                            .controlSize(.small)
+                    }
+
+                    Text(viewModel.commandLineToolStatusLabel)
+                        .font(DesignSystem.Typography.caption)
+                        .foregroundStyle(.secondary)
+
+                    Button(viewModel.commandLineToolActionTitle) {
+                        viewModel.installCommandLineTool()
+                    }
+                    .parakeetAction(.secondary)
+                    .disabled(!viewModel.canInstallCommandLineTool)
+                }
+
+                if let error = viewModel.commandLineToolError {
+                    Text(error)
+                        .font(DesignSystem.Typography.caption)
+                        .foregroundStyle(DesignSystem.Colors.errorRed)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
             }
         }
     }

--- a/Sources/MacParakeetCore/Services/System/CommandLineToolInstallService.swift
+++ b/Sources/MacParakeetCore/Services/System/CommandLineToolInstallService.swift
@@ -37,7 +37,7 @@ public protocol CommandLineToolInstalling {
     func install(overwriteExisting: Bool) async throws -> CommandLineToolInstallStatus
 }
 
-public final class CommandLineToolInstallService: CommandLineToolInstalling {
+public actor CommandLineToolInstallService: CommandLineToolInstalling {
     public static let defaultLinkName = "macparakeet-cli"
 
     private let fileManager: FileManager

--- a/Sources/MacParakeetCore/Services/System/CommandLineToolInstallService.swift
+++ b/Sources/MacParakeetCore/Services/System/CommandLineToolInstallService.swift
@@ -1,0 +1,176 @@
+import Foundation
+
+public enum CommandLineToolInstallStatus: Equatable, Sendable {
+    case installed
+    case notInstalled
+    case staleSymlink(currentTarget: String)
+    case pathConflict(path: String)
+    case unsupportedTranslocated
+    case unsupportedEnvironment(String)
+}
+
+public enum CommandLineToolInstallError: Error, LocalizedError, Equatable, Sendable {
+    case staleSymlink(currentTarget: String)
+    case pathConflict(path: String)
+    case unsupportedTranslocated
+    case unsupportedEnvironment(String)
+    case operationFailed(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .staleSymlink(let currentTarget):
+            return "macparakeet-cli already points to \(currentTarget). Review before replacing it."
+        case .pathConflict(let path):
+            return "\(path) already exists and is not a symbolic link."
+        case .unsupportedTranslocated:
+            return "Move MacParakeet to /Applications, relaunch it, then try again."
+        case .unsupportedEnvironment(let message):
+            return message
+        case .operationFailed(let message):
+            return message
+        }
+    }
+}
+
+public protocol CommandLineToolInstalling {
+    func currentStatus() async -> CommandLineToolInstallStatus
+    func install(overwriteExisting: Bool) async throws -> CommandLineToolInstallStatus
+}
+
+public final class CommandLineToolInstallService: CommandLineToolInstalling {
+    public static let defaultLinkName = "macparakeet-cli"
+
+    private let fileManager: FileManager
+    private let bundledToolURL: URL
+    private let installDirectory: URL
+    private let linkName: String
+
+    public init(
+        fileManager: FileManager = .default,
+        bundledToolURL: URL = CommandLineToolInstallService.defaultBundledToolURL(),
+        installDirectory: URL = URL(fileURLWithPath: "/usr/local/bin", isDirectory: true),
+        linkName: String = CommandLineToolInstallService.defaultLinkName
+    ) {
+        self.fileManager = fileManager
+        self.bundledToolURL = bundledToolURL
+        self.installDirectory = installDirectory
+        self.linkName = linkName
+    }
+
+    public static func defaultBundledToolURL(bundle: Bundle = .main) -> URL {
+        if bundle.bundleURL.pathExtension == "app" {
+            return bundle.bundleURL
+                .appendingPathComponent("Contents", isDirectory: true)
+                .appendingPathComponent("MacOS", isDirectory: true)
+                .appendingPathComponent(defaultLinkName)
+        }
+
+        if let executableURL = bundle.executableURL {
+            return executableURL
+                .deletingLastPathComponent()
+                .appendingPathComponent(defaultLinkName)
+        }
+
+        return URL(fileURLWithPath: defaultLinkName)
+    }
+
+    public func currentStatus() async -> CommandLineToolInstallStatus {
+        if let unavailable = unavailableStatusForBundledTool() {
+            return unavailable
+        }
+
+        if let currentTarget = symbolicLinkDestination(at: linkURL) {
+            return pointsAtBundledTool(currentTarget)
+                ? .installed
+                : .staleSymlink(currentTarget: currentTarget.path)
+        }
+
+        if fileManager.fileExists(atPath: linkURL.path) {
+            return .pathConflict(path: linkURL.path)
+        }
+
+        return .notInstalled
+    }
+
+    public func install(overwriteExisting: Bool) async throws -> CommandLineToolInstallStatus {
+        if let unavailable = unavailableStatusForBundledTool() {
+            throw error(for: unavailable)
+        }
+
+        do {
+            try fileManager.createDirectory(at: installDirectory, withIntermediateDirectories: true)
+
+            if let currentTarget = symbolicLinkDestination(at: linkURL) {
+                if pointsAtBundledTool(currentTarget) {
+                    return .installed
+                }
+
+                guard overwriteExisting else {
+                    throw CommandLineToolInstallError.staleSymlink(currentTarget: currentTarget.path)
+                }
+                try fileManager.removeItem(at: linkURL)
+            } else if fileManager.fileExists(atPath: linkURL.path) {
+                throw CommandLineToolInstallError.pathConflict(path: linkURL.path)
+            }
+
+            try fileManager.createSymbolicLink(atPath: linkURL.path, withDestinationPath: bundledToolURL.path)
+            return .installed
+        } catch let error as CommandLineToolInstallError {
+            throw error
+        } catch {
+            throw CommandLineToolInstallError.operationFailed(error.localizedDescription)
+        }
+    }
+
+    private var linkURL: URL {
+        installDirectory.appendingPathComponent(linkName)
+    }
+
+    private func unavailableStatusForBundledTool() -> CommandLineToolInstallStatus? {
+        if bundledToolURL.path.contains("/AppTranslocation/") {
+            return .unsupportedTranslocated
+        }
+
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: bundledToolURL.path, isDirectory: &isDirectory), !isDirectory.boolValue else {
+            return .unsupportedEnvironment("Bundled macparakeet-cli was not found.")
+        }
+
+        return nil
+    }
+
+    private func symbolicLinkDestination(at url: URL) -> URL? {
+        guard let destinationPath = try? fileManager.destinationOfSymbolicLink(atPath: url.path) else {
+            return nil
+        }
+
+        if destinationPath.hasPrefix("/") {
+            return URL(fileURLWithPath: destinationPath).standardizedFileURL
+        }
+
+        return url
+            .deletingLastPathComponent()
+            .appendingPathComponent(destinationPath)
+            .standardizedFileURL
+    }
+
+    private func pointsAtBundledTool(_ target: URL) -> Bool {
+        target.standardizedFileURL.resolvingSymlinksInPath().path
+            == bundledToolURL.standardizedFileURL.resolvingSymlinksInPath().path
+    }
+
+    private func error(for status: CommandLineToolInstallStatus) -> CommandLineToolInstallError {
+        switch status {
+        case .installed, .notInstalled:
+            return .operationFailed("Command line tool installation could not determine the current state.")
+        case .staleSymlink(let currentTarget):
+            return .staleSymlink(currentTarget: currentTarget)
+        case .pathConflict(let path):
+            return .pathConflict(path: path)
+        case .unsupportedTranslocated:
+            return .unsupportedTranslocated
+        case .unsupportedEnvironment(let message):
+            return .unsupportedEnvironment(message)
+        }
+    }
+}

--- a/Sources/MacParakeetCore/Services/System/README.md
+++ b/Sources/MacParakeetCore/Services/System/README.md
@@ -23,6 +23,8 @@ replace them with mocks.
 - `SystemMediaController.swift` -- media pause/resume bridge used before
   dictation capture.
 - `LaunchAtLoginService.swift` -- launch-at-login integration.
+- `CommandLineToolInstallService.swift` -- `/usr/local/bin/macparakeet-cli`
+  symlink status and install/replace flow for the bundled CLI.
 
 ## What To Know Before Editing
 

--- a/Sources/MacParakeetViewModels/SettingsSearchIndex.swift
+++ b/Sources/MacParakeetViewModels/SettingsSearchIndex.swift
@@ -429,6 +429,17 @@ public enum SettingsSearchIndex {
             cardAnchor: "system.startup"
         ),
         SettingsSearchEntry(
+            id: "system.commandLineTool",
+            tab: .system,
+            title: "Command Line Tool",
+            subtitle: "Install macparakeet-cli into Terminal's PATH.",
+            keywords: [
+                "cli", "command line", "terminal", "shell", "path",
+                "symlink", "alias", "install cli", "macparakeet-cli"
+            ],
+            cardAnchor: "system.startup"
+        ),
+        SettingsSearchEntry(
             id: "system.permissions",
             tab: .system,
             title: "Permissions",

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -46,6 +46,69 @@ public final class SettingsViewModel {
     }
     public var launchAtLoginDetail: String = ""
     public var launchAtLoginError: String?
+    public var commandLineToolStatus: CommandLineToolInstallStatus = .notInstalled
+    public var commandLineToolStatusChecking = false
+    public var commandLineToolInstallInProgress = false
+    public var commandLineToolError: String?
+    public var pendingCommandLineToolOverwriteTarget: String?
+    public var commandLineToolStatusLabel: String {
+        if commandLineToolStatusChecking {
+            return "Checking..."
+        }
+
+        switch commandLineToolStatus {
+        case .installed:
+            return "Installed"
+        case .notInstalled:
+            return "Not installed"
+        case .staleSymlink:
+            return "Needs review"
+        case .pathConflict:
+            return "Blocked"
+        case .unsupportedTranslocated, .unsupportedEnvironment:
+            return "Unavailable"
+        }
+    }
+    public var commandLineToolDetail: String {
+        if commandLineToolStatusChecking {
+            return "Checking /usr/local/bin/macparakeet-cli."
+        }
+
+        switch commandLineToolStatus {
+        case .installed:
+            return "macparakeet-cli is linked into /usr/local/bin and ready in Terminal."
+        case .notInstalled:
+            return "Install a symlink into /usr/local/bin so Terminal can run macparakeet-cli."
+        case .staleSymlink(let currentTarget):
+            return "macparakeet-cli already points to \(currentTarget). Review before replacing it."
+        case .pathConflict(let path):
+            return "\(path) already exists and is not a symlink."
+        case .unsupportedTranslocated:
+            return "Move MacParakeet to /Applications, relaunch it, then try again."
+        case .unsupportedEnvironment(let message):
+            return message
+        }
+    }
+    public var commandLineToolActionTitle: String {
+        switch commandLineToolStatus {
+        case .installed:
+            return "Installed"
+        case .staleSymlink:
+            return "Replace Link..."
+        default:
+            return "Install"
+        }
+    }
+    public var canInstallCommandLineTool: Bool {
+        guard !commandLineToolStatusChecking, !commandLineToolInstallInProgress else { return false }
+
+        switch commandLineToolStatus {
+        case .notInstalled, .staleSymlink:
+            return true
+        case .installed, .pathConflict, .unsupportedTranslocated, .unsupportedEnvironment:
+            return false
+        }
+    }
     public var menuBarOnlyMode: Bool {
         didSet {
             defaults.set(menuBarOnlyMode, forKey: AppPreferences.menuBarOnlyModeKey)
@@ -636,6 +699,7 @@ public final class SettingsViewModel {
     private var snippetRepo: TextSnippetRepositoryProtocol?
     private var entitlementsService: EntitlementsService?
     private var launchAtLoginService: LaunchAtLoginControlling?
+    private var commandLineToolInstallService: CommandLineToolInstalling?
     private var meetingRecoveryService: MeetingRecordingRecoveryServicing?
     private var sharedMicStream: SharedMicrophoneStream?
     private let defaults: UserDefaults
@@ -1053,6 +1117,7 @@ public final class SettingsViewModel {
         transformHistoryRepo: TransformHistoryRepositoryProtocol? = nil,
         entitlementsService: EntitlementsService,
         launchAtLoginService: LaunchAtLoginControlling? = nil,
+        commandLineToolInstallService: CommandLineToolInstalling? = nil,
         checkoutURL: URL?,
         customWordRepo: CustomWordRepositoryProtocol? = nil,
         snippetRepo: TextSnippetRepositoryProtocol? = nil,
@@ -1068,6 +1133,7 @@ public final class SettingsViewModel {
         self.transformHistoryRepo = transformHistoryRepo
         self.entitlementsService = entitlementsService
         self.launchAtLoginService = launchAtLoginService
+        self.commandLineToolInstallService = commandLineToolInstallService
         self.checkoutURL = checkoutURL
         self.customWordRepo = customWordRepo
         self.snippetRepo = snippetRepo
@@ -1079,6 +1145,7 @@ public final class SettingsViewModel {
         self.meetingRecoveryService = meetingRecoveryService
         self.sharedMicStream = sharedMicStream
         refreshLaunchAtLoginStatus()
+        refreshCommandLineToolStatus()
         refreshPermissions()
         refreshStats()
         refreshEntitlements()
@@ -1117,6 +1184,70 @@ public final class SettingsViewModel {
 
         applyLaunchAtLoginStatus(service.currentStatus())
         launchAtLoginError = nil
+    }
+
+    public func refreshCommandLineToolStatus() {
+        guard let service = commandLineToolInstallService else {
+            commandLineToolStatusChecking = false
+            commandLineToolStatus = .unsupportedEnvironment("Command line tool installation is unavailable in this build.")
+            commandLineToolError = nil
+            pendingCommandLineToolOverwriteTarget = nil
+            return
+        }
+
+        commandLineToolStatusChecking = true
+        Task {
+            let status = await service.currentStatus()
+            commandLineToolStatus = status
+            commandLineToolStatusChecking = false
+            commandLineToolError = nil
+            pendingCommandLineToolOverwriteTarget = nil
+        }
+    }
+
+    public func installCommandLineTool(overwriteExisting: Bool = false) {
+        guard let service = commandLineToolInstallService else {
+            commandLineToolStatusChecking = false
+            commandLineToolStatus = .unsupportedEnvironment("Command line tool installation is unavailable in this build.")
+            commandLineToolError = "Command line tool installation is unavailable in this build."
+            return
+        }
+
+        if case .staleSymlink(let currentTarget) = commandLineToolStatus, !overwriteExisting {
+            pendingCommandLineToolOverwriteTarget = currentTarget
+            commandLineToolError = nil
+            return
+        }
+
+        commandLineToolInstallInProgress = true
+        commandLineToolStatusChecking = false
+        commandLineToolError = nil
+        pendingCommandLineToolOverwriteTarget = nil
+
+        Task {
+            defer { commandLineToolInstallInProgress = false }
+
+            do {
+                commandLineToolStatus = try await service.install(overwriteExisting: overwriteExisting)
+                commandLineToolStatusChecking = false
+            } catch CommandLineToolInstallError.staleSymlink(let currentTarget) {
+                commandLineToolStatus = .staleSymlink(currentTarget: currentTarget)
+                commandLineToolStatusChecking = false
+                pendingCommandLineToolOverwriteTarget = currentTarget
+            } catch {
+                commandLineToolStatus = await service.currentStatus()
+                commandLineToolStatusChecking = false
+                commandLineToolError = error.localizedDescription
+            }
+        }
+    }
+
+    public func confirmCommandLineToolOverwrite() {
+        installCommandLineTool(overwriteExisting: true)
+    }
+
+    public func cancelCommandLineToolOverwrite() {
+        pendingCommandLineToolOverwriteTarget = nil
     }
 
     public func refreshPermissions() {

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -715,6 +715,7 @@ public final class SettingsViewModel {
     // model lifetime; unsafe access lets deinit cancel/unregister.
     @ObservationIgnored nonisolated(unsafe) private var permissionPollingTask: Task<Void, Never>?
     @ObservationIgnored nonisolated(unsafe) private var microphoneTestTask: Task<Void, Never>?
+    @ObservationIgnored nonisolated(unsafe) private var commandLineToolStatusTask: Task<Void, Never>?
     @ObservationIgnored nonisolated(unsafe) private var storageStatsTask: Task<Void, Never>?
     @ObservationIgnored nonisolated(unsafe) private var calendarSettingsObserver: NSObjectProtocol?
     /// Re-entrancy guard so `observeCalendarSettings()` doesn't fire `didSet`
@@ -881,6 +882,7 @@ public final class SettingsViewModel {
     deinit {
         permissionPollingTask?.cancel()
         microphoneTestTask?.cancel()
+        commandLineToolStatusTask?.cancel()
         storageStatsTask?.cancel()
         if let calendarSettingsObserver {
             NotificationCenter.default.removeObserver(calendarSettingsObserver)
@@ -1188,20 +1190,26 @@ public final class SettingsViewModel {
 
     public func refreshCommandLineToolStatus() {
         guard let service = commandLineToolInstallService else {
+            commandLineToolStatusTask?.cancel()
+            commandLineToolStatusTask = nil
             commandLineToolStatusChecking = false
             commandLineToolStatus = .unsupportedEnvironment("Command line tool installation is unavailable in this build.")
             commandLineToolError = nil
             pendingCommandLineToolOverwriteTarget = nil
             return
         }
+        guard !commandLineToolInstallInProgress else { return }
 
+        commandLineToolStatusTask?.cancel()
         commandLineToolStatusChecking = true
-        Task {
+        commandLineToolStatusTask = Task { @MainActor [weak self] in
             let status = await service.currentStatus()
-            commandLineToolStatus = status
-            commandLineToolStatusChecking = false
-            commandLineToolError = nil
-            pendingCommandLineToolOverwriteTarget = nil
+            guard !Task.isCancelled, let self else { return }
+            self.commandLineToolStatus = status
+            self.commandLineToolStatusChecking = false
+            self.commandLineToolError = nil
+            self.pendingCommandLineToolOverwriteTarget = nil
+            self.commandLineToolStatusTask = nil
         }
     }
 
@@ -1212,6 +1220,7 @@ public final class SettingsViewModel {
             commandLineToolError = "Command line tool installation is unavailable in this build."
             return
         }
+        guard !commandLineToolInstallInProgress else { return }
 
         if case .staleSymlink(let currentTarget) = commandLineToolStatus, !overwriteExisting {
             pendingCommandLineToolOverwriteTarget = currentTarget
@@ -1219,25 +1228,28 @@ public final class SettingsViewModel {
             return
         }
 
+        commandLineToolStatusTask?.cancel()
+        commandLineToolStatusTask = nil
         commandLineToolInstallInProgress = true
         commandLineToolStatusChecking = false
         commandLineToolError = nil
         pendingCommandLineToolOverwriteTarget = nil
 
-        Task {
-            defer { commandLineToolInstallInProgress = false }
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            defer { self.commandLineToolInstallInProgress = false }
 
             do {
-                commandLineToolStatus = try await service.install(overwriteExisting: overwriteExisting)
-                commandLineToolStatusChecking = false
+                self.commandLineToolStatus = try await service.install(overwriteExisting: overwriteExisting)
+                self.commandLineToolStatusChecking = false
             } catch CommandLineToolInstallError.staleSymlink(let currentTarget) {
-                commandLineToolStatus = .staleSymlink(currentTarget: currentTarget)
-                commandLineToolStatusChecking = false
-                pendingCommandLineToolOverwriteTarget = currentTarget
+                self.commandLineToolStatus = .staleSymlink(currentTarget: currentTarget)
+                self.commandLineToolStatusChecking = false
+                self.pendingCommandLineToolOverwriteTarget = currentTarget
             } catch {
-                commandLineToolStatus = await service.currentStatus()
-                commandLineToolStatusChecking = false
-                commandLineToolError = error.localizedDescription
+                self.commandLineToolStatus = await service.currentStatus()
+                self.commandLineToolStatusChecking = false
+                self.commandLineToolError = error.localizedDescription
             }
         }
     }

--- a/Tests/MacParakeetTests/Services/System/CommandLineToolInstallServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/System/CommandLineToolInstallServiceTests.swift
@@ -1,0 +1,158 @@
+import XCTest
+@testable import MacParakeetCore
+
+final class CommandLineToolInstallServiceTests: XCTestCase {
+    private var sandbox: URL!
+    private var bundledToolURL: URL!
+    private var installDirectory: URL!
+
+    override func setUpWithError() throws {
+        sandbox = FileManager.default.temporaryDirectory
+            .appendingPathComponent("macparakeet-cli-install-\(UUID().uuidString)", isDirectory: true)
+        bundledToolURL = sandbox.appendingPathComponent("MacParakeet.app/Contents/MacOS/macparakeet-cli")
+        installDirectory = sandbox.appendingPathComponent("usr/local/bin", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: bundledToolURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try "#!/bin/sh\nexit 0\n".write(to: bundledToolURL, atomically: true, encoding: .utf8)
+    }
+
+    override func tearDownWithError() throws {
+        if let sandbox {
+            try? FileManager.default.removeItem(at: sandbox)
+        }
+    }
+
+    func testCurrentStatusReportsNotInstalledWhenLinkIsMissing() async throws {
+        let service = makeService()
+
+        let status = await service.currentStatus()
+
+        XCTAssertEqual(status, .notInstalled)
+    }
+
+    func testInstallCreatesSymlinkToBundledTool() async throws {
+        let service = makeService()
+
+        let status = try await service.install(overwriteExisting: false)
+        let linkURL = installDirectory.appendingPathComponent("macparakeet-cli")
+        let destination = try FileManager.default.destinationOfSymbolicLink(atPath: linkURL.path)
+
+        XCTAssertEqual(status, .installed)
+        XCTAssertEqual(destination, bundledToolURL.path)
+    }
+
+    func testCurrentStatusReportsInstalledForMatchingSymlink() async throws {
+        try FileManager.default.createDirectory(at: installDirectory, withIntermediateDirectories: true)
+        let linkURL = installDirectory.appendingPathComponent("macparakeet-cli")
+        try FileManager.default.createSymbolicLink(atPath: linkURL.path, withDestinationPath: bundledToolURL.path)
+        let service = makeService()
+
+        let status = await service.currentStatus()
+
+        XCTAssertEqual(status, .installed)
+    }
+
+    func testCurrentStatusReportsStaleSymlinkForDifferentTarget() async throws {
+        try FileManager.default.createDirectory(at: installDirectory, withIntermediateDirectories: true)
+        let otherTarget = sandbox.appendingPathComponent("Other.app/Contents/MacOS/macparakeet-cli")
+        try FileManager.default.createDirectory(at: otherTarget.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try "old".write(to: otherTarget, atomically: true, encoding: .utf8)
+        let linkURL = installDirectory.appendingPathComponent("macparakeet-cli")
+        try FileManager.default.createSymbolicLink(atPath: linkURL.path, withDestinationPath: otherTarget.path)
+        let service = makeService()
+
+        let status = await service.currentStatus()
+
+        XCTAssertEqual(status, .staleSymlink(currentTarget: otherTarget.path))
+    }
+
+    func testInstallRequiresOverwriteForStaleSymlink() async throws {
+        try FileManager.default.createDirectory(at: installDirectory, withIntermediateDirectories: true)
+        let otherTarget = sandbox.appendingPathComponent("Other.app/Contents/MacOS/macparakeet-cli")
+        let linkURL = installDirectory.appendingPathComponent("macparakeet-cli")
+        try FileManager.default.createSymbolicLink(atPath: linkURL.path, withDestinationPath: otherTarget.path)
+        let service = makeService()
+
+        do {
+            _ = try await service.install(overwriteExisting: false)
+            XCTFail("Expected stale symlink error")
+        } catch let error as CommandLineToolInstallError {
+            XCTAssertEqual(error, .staleSymlink(currentTarget: otherTarget.path))
+        }
+    }
+
+    func testInstallCanOverwriteStaleSymlink() async throws {
+        try FileManager.default.createDirectory(at: installDirectory, withIntermediateDirectories: true)
+        let otherTarget = sandbox.appendingPathComponent("Other.app/Contents/MacOS/macparakeet-cli")
+        let linkURL = installDirectory.appendingPathComponent("macparakeet-cli")
+        try FileManager.default.createSymbolicLink(atPath: linkURL.path, withDestinationPath: otherTarget.path)
+        let service = makeService()
+
+        let status = try await service.install(overwriteExisting: true)
+        let destination = try FileManager.default.destinationOfSymbolicLink(atPath: linkURL.path)
+
+        XCTAssertEqual(status, .installed)
+        XCTAssertEqual(destination, bundledToolURL.path)
+    }
+
+    func testCurrentStatusReportsPathConflictForNonSymlink() async throws {
+        try FileManager.default.createDirectory(at: installDirectory, withIntermediateDirectories: true)
+        let linkURL = installDirectory.appendingPathComponent("macparakeet-cli")
+        try "not a link".write(to: linkURL, atomically: true, encoding: .utf8)
+        let service = makeService()
+
+        let status = await service.currentStatus()
+
+        XCTAssertEqual(status, .pathConflict(path: linkURL.path))
+    }
+
+    func testInstallThrowsPathConflictForNonSymlink() async throws {
+        try FileManager.default.createDirectory(at: installDirectory, withIntermediateDirectories: true)
+        let linkURL = installDirectory.appendingPathComponent("macparakeet-cli")
+        try "not a link".write(to: linkURL, atomically: true, encoding: .utf8)
+        let service = makeService()
+
+        do {
+            _ = try await service.install(overwriteExisting: true)
+            XCTFail("Expected path conflict")
+        } catch let error as CommandLineToolInstallError {
+            XCTAssertEqual(error, .pathConflict(path: linkURL.path))
+        }
+    }
+
+    func testMissingBundledToolIsUnavailable() async throws {
+        try FileManager.default.removeItem(at: bundledToolURL)
+        let service = makeService()
+
+        let status = await service.currentStatus()
+
+        XCTAssertEqual(status, .unsupportedEnvironment("Bundled macparakeet-cli was not found."))
+    }
+
+    func testTranslocatedBundleIsUnavailable() async throws {
+        let translocatedTool = sandbox
+            .appendingPathComponent("AppTranslocation/123/d/MacParakeet.app/Contents/MacOS/macparakeet-cli")
+        try FileManager.default.createDirectory(
+            at: translocatedTool.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try "tool".write(to: translocatedTool, atomically: true, encoding: .utf8)
+        let service = CommandLineToolInstallService(
+            bundledToolURL: translocatedTool,
+            installDirectory: installDirectory
+        )
+
+        let status = await service.currentStatus()
+
+        XCTAssertEqual(status, .unsupportedTranslocated)
+    }
+
+    private func makeService() -> CommandLineToolInstallService {
+        CommandLineToolInstallService(
+            bundledToolURL: bundledToolURL,
+            installDirectory: installDirectory
+        )
+    }
+}

--- a/Tests/MacParakeetTests/ViewModels/SettingsSearchIndexTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/SettingsSearchIndexTests.swift
@@ -63,6 +63,17 @@ final class SettingsSearchIndexTests: XCTestCase {
         )
     }
 
+    func testCommandLineToolQueriesFindInstallerSetting() {
+        for query in ["cli", "command line", "terminal", "macparakeet-cli"] {
+            let results = SettingsSearchIndex.matches(query)
+
+            XCTAssertTrue(
+                results.contains(where: { $0.id == "system.commandLineTool" }),
+                "Query \(query) should land on the command line tool installer"
+            )
+        }
+    }
+
     func testTitleMatches() {
         let results = SettingsSearchIndex.matches("Speech Recognition")
         XCTAssertTrue(results.contains(where: { $0.id == "engine.selector" }))

--- a/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
@@ -842,6 +842,92 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.launchAtLoginError, LaunchAtLoginError.invalidSignature.localizedDescription)
     }
 
+    func testConfigureRefreshesCommandLineToolStatus() async throws {
+        let installer = MockCommandLineToolInstallService(status: .installed)
+
+        viewModel.configure(
+            permissionService: mockPermissions,
+            dictationRepo: mockRepo,
+            entitlementsService: entitlements,
+            commandLineToolInstallService: installer,
+            checkoutURL: nil
+        )
+
+        try await waitUntil { !viewModel.commandLineToolStatusChecking }
+        XCTAssertEqual(viewModel.commandLineToolStatus, .installed)
+        XCTAssertEqual(viewModel.commandLineToolStatusLabel, "Installed")
+        XCTAssertFalse(viewModel.canInstallCommandLineTool)
+    }
+
+    func testInstallCommandLineToolUpdatesStatus() async throws {
+        let installer = MockCommandLineToolInstallService(status: .notInstalled, installResult: .installed)
+
+        viewModel.configure(
+            permissionService: mockPermissions,
+            dictationRepo: mockRepo,
+            entitlementsService: entitlements,
+            commandLineToolInstallService: installer,
+            checkoutURL: nil
+        )
+
+        try await waitUntil { !viewModel.commandLineToolStatusChecking }
+        XCTAssertTrue(viewModel.canInstallCommandLineTool)
+
+        viewModel.installCommandLineTool()
+
+        try await waitUntil { !viewModel.commandLineToolInstallInProgress }
+        XCTAssertEqual(installer.installOverwriteCalls, [false])
+        XCTAssertEqual(viewModel.commandLineToolStatus, .installed)
+        XCTAssertNil(viewModel.commandLineToolError)
+    }
+
+    func testInstallCommandLineToolRequiresConfirmForStaleSymlink() async throws {
+        let installer = MockCommandLineToolInstallService(
+            status: .staleSymlink(currentTarget: "/Applications/Old.app/Contents/MacOS/macparakeet-cli")
+        )
+
+        viewModel.configure(
+            permissionService: mockPermissions,
+            dictationRepo: mockRepo,
+            entitlementsService: entitlements,
+            commandLineToolInstallService: installer,
+            checkoutURL: nil
+        )
+
+        try await waitUntil { !viewModel.commandLineToolStatusChecking }
+        viewModel.installCommandLineTool()
+
+        XCTAssertEqual(
+            viewModel.pendingCommandLineToolOverwriteTarget,
+            "/Applications/Old.app/Contents/MacOS/macparakeet-cli"
+        )
+        XCTAssertTrue(installer.installOverwriteCalls.isEmpty)
+    }
+
+    func testConfirmCommandLineToolOverwriteInstallsOverStaleSymlink() async throws {
+        let installer = MockCommandLineToolInstallService(
+            status: .staleSymlink(currentTarget: "/Applications/Old.app/Contents/MacOS/macparakeet-cli"),
+            installResult: .installed
+        )
+
+        viewModel.configure(
+            permissionService: mockPermissions,
+            dictationRepo: mockRepo,
+            entitlementsService: entitlements,
+            commandLineToolInstallService: installer,
+            checkoutURL: nil
+        )
+
+        try await waitUntil { !viewModel.commandLineToolStatusChecking }
+        viewModel.installCommandLineTool()
+        viewModel.confirmCommandLineToolOverwrite()
+
+        try await waitUntil { !viewModel.commandLineToolInstallInProgress }
+        XCTAssertEqual(installer.installOverwriteCalls, [true])
+        XCTAssertNil(viewModel.pendingCommandLineToolOverwriteTarget)
+        XCTAssertEqual(viewModel.commandLineToolStatus, .installed)
+    }
+
     func testSettingMenuBarOnlyModePersists() {
         viewModel.menuBarOnlyMode = true
 

--- a/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
@@ -881,6 +881,35 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertNil(viewModel.commandLineToolError)
     }
 
+    func testInstallCommandLineToolCancelsStaleStatusRefresh() async throws {
+        let installer = MockCommandLineToolInstallService(status: .notInstalled, installResult: .installed)
+        installer.currentStatusResults = [.notInstalled]
+        installer.currentStatusDelayNanoseconds = 100_000_000
+
+        viewModel.configure(
+            permissionService: mockPermissions,
+            dictationRepo: mockRepo,
+            entitlementsService: entitlements,
+            commandLineToolInstallService: installer,
+            checkoutURL: nil
+        )
+
+        XCTAssertTrue(viewModel.commandLineToolStatusChecking)
+
+        viewModel.installCommandLineTool()
+
+        try await waitUntil { !viewModel.commandLineToolInstallInProgress }
+        XCTAssertEqual(viewModel.commandLineToolStatus, .installed)
+
+        try await Task.sleep(nanoseconds: 150_000_000)
+        XCTAssertEqual(
+            viewModel.commandLineToolStatus,
+            .installed,
+            "A cancelled pre-install status refresh must not overwrite the install result."
+        )
+        XCTAssertFalse(viewModel.commandLineToolStatusChecking)
+    }
+
     func testInstallCommandLineToolRequiresConfirmForStaleSymlink() async throws {
         let installer = MockCommandLineToolInstallService(
             status: .staleSymlink(currentTarget: "/Applications/Old.app/Contents/MacOS/macparakeet-cli")

--- a/Tests/MacParakeetTests/ViewModels/ViewModelMocks.swift
+++ b/Tests/MacParakeetTests/ViewModels/ViewModelMocks.swift
@@ -410,6 +410,38 @@ final class MockLaunchAtLoginService: LaunchAtLoginControlling {
     }
 }
 
+// MARK: - MockCommandLineToolInstallService
+
+final class MockCommandLineToolInstallService: CommandLineToolInstalling {
+    var status: CommandLineToolInstallStatus
+    var installResult: CommandLineToolInstallStatus
+    var installError: Error?
+    var installOverwriteCalls: [Bool] = []
+
+    init(
+        status: CommandLineToolInstallStatus = .notInstalled,
+        installResult: CommandLineToolInstallStatus = .installed,
+        installError: Error? = nil
+    ) {
+        self.status = status
+        self.installResult = installResult
+        self.installError = installError
+    }
+
+    func currentStatus() async -> CommandLineToolInstallStatus {
+        status
+    }
+
+    func install(overwriteExisting: Bool) async throws -> CommandLineToolInstallStatus {
+        installOverwriteCalls.append(overwriteExisting)
+        if let installError {
+            throw installError
+        }
+        status = installResult
+        return installResult
+    }
+}
+
 // MARK: - MockTranscriptionService
 
 actor MockTranscriptionService: SpeechEngineOverrideTranscriptionService {

--- a/Tests/MacParakeetTests/ViewModels/ViewModelMocks.swift
+++ b/Tests/MacParakeetTests/ViewModels/ViewModelMocks.swift
@@ -414,6 +414,9 @@ final class MockLaunchAtLoginService: LaunchAtLoginControlling {
 
 final class MockCommandLineToolInstallService: CommandLineToolInstalling {
     var status: CommandLineToolInstallStatus
+    var currentStatusResults: [CommandLineToolInstallStatus] = []
+    var currentStatusDelayNanoseconds: UInt64 = 0
+    var currentStatusCallCount = 0
     var installResult: CommandLineToolInstallStatus
     var installError: Error?
     var installOverwriteCalls: [Bool] = []
@@ -429,7 +432,14 @@ final class MockCommandLineToolInstallService: CommandLineToolInstalling {
     }
 
     func currentStatus() async -> CommandLineToolInstallStatus {
-        status
+        currentStatusCallCount += 1
+        if currentStatusDelayNanoseconds > 0 {
+            try? await Task.sleep(nanoseconds: currentStatusDelayNanoseconds)
+        }
+        if !currentStatusResults.isEmpty {
+            return currentStatusResults.removeFirst()
+        }
+        return status
     }
 
     func install(overwriteExisting: Bool) async throws -> CommandLineToolInstallStatus {

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -105,6 +105,10 @@ WhisperKit model downloads live under
 
 For convenience, symlink it onto your `$PATH`:
 
+- From the app: choose **MacParakeet > Install Command Line Tool...** or open
+  **Settings > System > Startup > Command line tool**.
+- Manually:
+
 ```bash
 ln -s /Applications/MacParakeet.app/Contents/MacOS/macparakeet-cli \
       /usr/local/bin/macparakeet-cli


### PR DESCRIPTION
## Summary
Users can now install the bundled `macparakeet-cli` from MacParakeet instead of discovering the app-bundle path and writing their own symlink. The app menu exposes **Install Command Line Tool...**, and Settings > System > Startup shows the `/usr/local/bin/macparakeet-cli` status, installs the link, and asks before replacing a stale symlink.

The installer keeps the behavior narrow: it only creates/replaces a symlink, refuses non-symlink conflicts, reports a missing bundled CLI, and blocks App Translocation so the generated link does not point at a temporary app path.

Fixes #595.

## Validation
- `swift test --scratch-path /private/tmp/macparakeet-issue-562-20260709/.build --filter CommandLineTool`
- `swift test --scratch-path /private/tmp/macparakeet-issue-562-20260709/.build --filter SettingsViewModelTests`
- `swift test --scratch-path /private/tmp/macparakeet-issue-562-20260709/.build --filter SettingsSearchIndexTests`
- `swift test --scratch-path /private/tmp/macparakeet-issue-562-20260709/.build --filter MenuBarCoordinatorTests`
- `git diff --check`

Manual signed-app QA is still needed to click the installer from an app running in `/Applications` and verify real `/usr/local/bin` permissions on macOS.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an in-app installer for the bundled `macparakeet-cli`. Users can install or replace the `/usr/local/bin/macparakeet-cli` symlink from the app menu or Settings; fixes #595.

- **New Features**
  - App menu adds “Install Command Line Tool…” and opens Settings > System > Startup.
  - Settings shows CLI status, progress, actions, and errors; supports Installed, Not installed, Stale symlink, Path conflict, and Unavailable states.
  - Prompts before replacing a stale symlink and refuses non-symlink conflicts.
  - Blocks installs when the app is translocated; requires running from /Applications.
  - Adds `CommandLineToolInstallService`, a search entry for “Command Line Tool,” and unit tests.

- **Bug Fixes**
  - Stabilized installer tasks: refresh status on open and app focus, cancel stale refresh during install, and disable actions while checking or installing.

<sup>Written for commit 60f22c5eda6dd881e234619802fac27f30492bcb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/775?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Command Line Tool” section in Settings with live install status, progress, and install/replace actions.
  * Added an app menu item to jump directly to the command line tool setup in Settings.
  * Added a searchable Settings destination for quick access to the installer section.
* **Bug Fixes**
  * Automatically refreshes command-line tool status when Settings opens and when the app becomes active.
  * Adds a confirmation flow when replacing a stale existing link is required.
* **Documentation**
  * Updated install instructions to include the in-app setup flow.
* **Tests**
  * Added coverage for install/status handling and stale/conflict/unsupported scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->