### PR TITLE
Disable vocabulary recognition boosting by default

### DIFF
--- a/Sources/CLI/Commands/VocabWordsCommand.swift
+++ b/Sources/CLI/Commands/VocabWordsCommand.swift
@@ -24,7 +24,11 @@ struct VocabWordsCommand: AsyncParsableCommand {
             nemotronModelVariant: SpeechEnginePreference.nemotronModelVariant(defaults: defaults),
             whisperModelVariant: SpeechEnginePreference.whisperModelVariant(defaults: defaults)
         )
-        let status = CustomVocabularyBoostingPresentation.status(for: capabilities)
+        let runtimePreferences = UserDefaultsAppRuntimePreferences(defaults: defaults)
+        let status = CustomVocabularyBoostingPresentation.status(
+            for: capabilities,
+            recognitionBoostingEnabled: runtimePreferences.customVocabularyRecognitionBoostingEnabled
+        )
         return "Custom vocabulary: \(status.title) - \(status.detail)"
     }
 

--- a/Sources/MacParakeet/App/AppEnvironment.swift
+++ b/Sources/MacParakeet/App/AppEnvironment.swift
@@ -90,7 +90,10 @@ final class AppEnvironment {
             speechEngine: SpeechEnginePreference.current(),
             nemotronModelVariant: SpeechEnginePreference.nemotronModelVariant(),
             whisperModelVariant: SpeechEnginePreference.whisperModelVariant(),
-            customVocabularyProvider: RepositoryCustomVocabularyBoostingTermProvider(repository: customWordRepo)
+            customVocabularyProvider: RepositoryCustomVocabularyBoostingTermProvider(repository: customWordRepo),
+            customVocabularyRecognitionBoostingEnabled: { [runtimePreferences] in
+                runtimePreferences.customVocabularyRecognitionBoostingEnabled
+            }
         )
         sttScheduler = STTScheduler(runtime: sttRuntime)
         // Ship raw meeting mic capture by default. VPIO remains available for

--- a/Sources/MacParakeetCore/AppRuntimePreferences.swift
+++ b/Sources/MacParakeetCore/AppRuntimePreferences.swift
@@ -25,6 +25,7 @@ public protocol AppRuntimePreferencesProtocol: Sendable {
     var pauseMediaDuringDictation: Bool { get }
     var instantDictationEnabled: Bool { get }
     var preferBuiltInMicWhenBluetoothOutput: Bool { get }
+    var customVocabularyRecognitionBoostingEnabled: Bool { get }
     var showLiveDictationPreview: Bool { get }
     var dictationPreviewTextSize: DictationPreviewTextSize { get }
     var dictationUndoCountdown: DictationUndoCountdown { get }
@@ -530,6 +531,7 @@ public final class UserDefaultsAppRuntimePreferences: AppRuntimePreferencesProto
     /// first; this only changes the system-default path or the fallback behind
     /// a failed explicit attempt.
     public static let preferBuiltInMicWhenBluetoothOutputKey = "preferBuiltInMicWhenBluetoothOutput"
+    public static let customVocabularyRecognitionBoostingEnabledKey = "customVocabularyRecognitionBoostingEnabled"
     public static let showLiveDictationPreviewKey = "showLiveDictationPreview"
     public static let dictationPreviewTextSizeKey = "dictationPreviewTextSize"
     public static let dictationUndoCountdownKey = "dictationUndoCountdown"
@@ -687,6 +689,10 @@ public final class UserDefaultsAppRuntimePreferences: AppRuntimePreferencesProto
 
     public var preferBuiltInMicWhenBluetoothOutput: Bool {
         defaults.object(forKey: Self.preferBuiltInMicWhenBluetoothOutputKey) as? Bool ?? true
+    }
+
+    public var customVocabularyRecognitionBoostingEnabled: Bool {
+        defaults.object(forKey: Self.customVocabularyRecognitionBoostingEnabledKey) as? Bool ?? false
     }
 
     public var showLiveDictationPreview: Bool {

--- a/Sources/MacParakeetCore/STT/CustomVocabularyBoosting.swift
+++ b/Sources/MacParakeetCore/STT/CustomVocabularyBoosting.swift
@@ -31,9 +31,10 @@ public struct CustomVocabularyBoostingSupportPresentation: Equatable, Sendable {
 }
 
 public enum CustomVocabularyBoostingPresentation {
-    public static func status(for capabilities: SpeechEngineCapabilities?)
-        -> CustomVocabularyBoostingSupportPresentation
-    {
+    public static func status(
+        for capabilities: SpeechEngineCapabilities?,
+        recognitionBoostingEnabled: Bool = true
+    ) -> CustomVocabularyBoostingSupportPresentation {
         guard let capabilities else {
             return CustomVocabularyBoostingSupportPresentation(
                 title: "Clean corrections only",
@@ -41,12 +42,21 @@ public enum CustomVocabularyBoostingPresentation {
                     "This engine does not support recognition-time vocabulary boosting; enabled rules still run after transcription."
             )
         }
-        return status(for: capabilities)
+        return status(for: capabilities, recognitionBoostingEnabled: recognitionBoostingEnabled)
     }
 
-    public static func status(for capabilities: SpeechEngineCapabilities) -> CustomVocabularyBoostingSupportPresentation
-    {
+    public static func status(
+        for capabilities: SpeechEngineCapabilities,
+        recognitionBoostingEnabled: Bool = true
+    ) -> CustomVocabularyBoostingSupportPresentation {
         if capabilities.supportsCustomVocabulary {
+            guard recognitionBoostingEnabled else {
+                return CustomVocabularyBoostingSupportPresentation(
+                    title: "Clean corrections only",
+                    detail:
+                        "Recognition boosting is paused; enabled rules still run after transcription."
+                )
+            }
             return CustomVocabularyBoostingSupportPresentation(
                 title: "Recognition boosting on",
                 detail:

--- a/Sources/MacParakeetCore/STT/STTClient.swift
+++ b/Sources/MacParakeetCore/STT/STTClient.swift
@@ -17,10 +17,15 @@ public actor STTClient: STTManaging, STTDictationPreviewTranscribing, SpeechEngi
         whisperModelVariant: String = SpeechEnginePreference.defaultWhisperModelVariant,
         defaults: UserDefaults = .standard,
         customWordRepository: (any CustomWordRepositoryProtocol)? = nil,
-        customVocabularyRescorer: (any CustomVocabularyRescoring)? = nil
+        customVocabularyRescorer: (any CustomVocabularyRescoring)? = nil,
+        customVocabularyRecognitionBoostingEnabled: (@Sendable () -> Bool)? = nil
     ) {
         let customVocabularyProvider = customWordRepository.map {
             RepositoryCustomVocabularyBoostingTermProvider(repository: $0)
+        }
+        let runtimePreferences = UserDefaultsAppRuntimePreferences(defaults: defaults)
+        let recognitionBoostingEnabled = customVocabularyRecognitionBoostingEnabled ?? {
+            runtimePreferences.customVocabularyRecognitionBoostingEnabled
         }
         let runtime = STTRuntime(
             parakeetModelVariant: parakeetModelVariant,
@@ -29,7 +34,8 @@ public actor STTClient: STTManaging, STTDictationPreviewTranscribing, SpeechEngi
             whisperModelVariant: whisperModelVariant,
             defaults: defaults,
             customVocabularyProvider: customVocabularyProvider,
-            customVocabularyRescorer: customVocabularyRescorer
+            customVocabularyRescorer: customVocabularyRescorer,
+            customVocabularyRecognitionBoostingEnabled: recognitionBoostingEnabled
         )
         self.scheduler = STTScheduler(runtime: runtime)
     }

--- a/Sources/MacParakeetCore/STT/STTRuntime.swift
+++ b/Sources/MacParakeetCore/STT/STTRuntime.swift
@@ -168,6 +168,7 @@ public actor STTRuntime: STTRuntimeProtocol {
     private let inferenceGate: ANEInferenceGate
     private let customVocabularyProvider: (any CustomVocabularyBoostingTermProviding)?
     private let customVocabularyRescorer: any CustomVocabularyRescoring
+    private let customVocabularyRecognitionBoostingEnabled: @Sendable () -> Bool
 
     private var interactiveManager: AsrManager?
     private var backgroundManager: AsrManager?
@@ -242,7 +243,8 @@ public actor STTRuntime: STTRuntimeProtocol {
         inferenceGate: ANEInferenceGate = .shared,
         physicalMemoryBytes: @escaping @Sendable () -> UInt64 = { ProcessInfo.processInfo.physicalMemory },
         customVocabularyProvider: (any CustomVocabularyBoostingTermProviding)? = nil,
-        customVocabularyRescorer: (any CustomVocabularyRescoring)? = nil
+        customVocabularyRescorer: (any CustomVocabularyRescoring)? = nil,
+        customVocabularyRecognitionBoostingEnabled: @escaping @Sendable () -> Bool = { false }
     ) {
         self.currentParakeetVariant = parakeetModelVariant
         // `.unified` has no TDT version; the TDT path is never taken for it, so a
@@ -257,6 +259,7 @@ public actor STTRuntime: STTRuntimeProtocol {
         self.physicalMemoryBytes = physicalMemoryBytes
         self.customVocabularyProvider = customVocabularyProvider
         self.customVocabularyRescorer = customVocabularyRescorer ?? FluidAudioCustomVocabularyRescorer()
+        self.customVocabularyRecognitionBoostingEnabled = customVocabularyRecognitionBoostingEnabled
     }
 
     #if DEBUG
@@ -807,6 +810,7 @@ public actor STTRuntime: STTRuntimeProtocol {
         preparationMode: CustomVocabularyBoostingPreparationMode,
         loadAudioSamples: () throws -> [Float]
     ) async throws -> ASRResult {
+        guard customVocabularyRecognitionBoostingEnabled() else { return result }
         guard let customVocabularyProvider else { return result }
         try Task.checkCancellation()
         let capabilities = SpeechEngineCapabilityRegistry.capabilities(for: .parakeet(currentParakeetVariant))
@@ -838,9 +842,11 @@ public actor STTRuntime: STTRuntimeProtocol {
         inferenceGate: ANEInferenceGate,
         preparationMode: CustomVocabularyBoostingPreparationMode = .awaitPreparation,
         logger: Logger? = nil,
-        backgroundPreparationTaskRegistered: (@Sendable () async -> Void)? = nil
+        backgroundPreparationTaskRegistered: (@Sendable () async -> Void)? = nil,
+        recognitionBoostingEnabled: Bool = true
     ) async throws -> ASRResult {
         try Task.checkCancellation()
+        guard recognitionBoostingEnabled else { return result }
         guard capabilities.supportsCustomVocabulary,
               !vocabulary.isEmpty,
               !audioSamples.isEmpty,
@@ -1128,7 +1134,8 @@ public actor STTRuntime: STTRuntimeProtocol {
         rescorer: any CustomVocabularyRescoring,
         inferenceGate: ANEInferenceGate = ANEInferenceGate(serializationRequired: false),
         preparationMode: CustomVocabularyBoostingPreparationMode = .awaitPreparation,
-        backgroundPreparationTaskRegistered: (@Sendable () async -> Void)? = nil
+        backgroundPreparationTaskRegistered: (@Sendable () async -> Void)? = nil,
+        recognitionBoostingEnabled: Bool = true
     ) async throws -> ASRResult {
         let result = ASRResult(
             text: transcript,
@@ -1145,7 +1152,8 @@ public actor STTRuntime: STTRuntimeProtocol {
             rescorer: rescorer,
             inferenceGate: inferenceGate,
             preparationMode: preparationMode,
-            backgroundPreparationTaskRegistered: backgroundPreparationTaskRegistered
+            backgroundPreparationTaskRegistered: backgroundPreparationTaskRegistered,
+            recognitionBoostingEnabled: recognitionBoostingEnabled
         )
     }
     #endif

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -400,12 +400,19 @@ public final class SettingsViewModel {
     public var customWordCount: Int = 0
     public var snippetCount: Int = 0
     public var customVocabularyRecognitionStatus: CustomVocabularyBoostingSupportPresentation {
-        CustomVocabularyBoostingPresentation.status(for: SpeechEngineCapabilityRegistry.capabilities(
+        guard let capabilities = SpeechEngineCapabilityRegistry.capabilities(
             for: engine.speechEnginePreference,
             parakeetModelVariant: engine.parakeetModelVariant,
             nemotronModelVariant: engine.nemotronModelVariant,
             whisperModelVariant: engine.whisperModelVariant.rawValue
-        ))
+        ) else {
+            return CustomVocabularyBoostingPresentation.status(for: Optional<SpeechEngineCapabilities>.none)
+        }
+        let runtimePreferences = UserDefaultsAppRuntimePreferences(defaults: defaults)
+        return CustomVocabularyBoostingPresentation.status(
+            for: capabilities,
+            recognitionBoostingEnabled: runtimePreferences.customVocabularyRecognitionBoostingEnabled
+        )
     }
 
     // Storage

--- a/Tests/CLITests/VocabCommandTests.swift
+++ b/Tests/CLITests/VocabCommandTests.swift
@@ -108,9 +108,21 @@ final class VocabCommandTests: XCTestCase {
         SpeechEnginePreference.saveParakeetModelVariant(.v3, defaults: defaults)
         XCTAssertTrue(
             VocabWordsCommand.recognitionBoostingStatusLine(defaults: defaults)
+                .contains("Recognition boosting is paused")
+        )
+
+        defaults.set(
+            true,
+            forKey: UserDefaultsAppRuntimePreferences.customVocabularyRecognitionBoostingEnabledKey
+        )
+        XCTAssertTrue(
+            VocabWordsCommand.recognitionBoostingStatusLine(defaults: defaults)
                 .contains("Recognition boosting on")
         )
 
+        defaults.removeObject(
+            forKey: UserDefaultsAppRuntimePreferences.customVocabularyRecognitionBoostingEnabledKey
+        )
         SpeechEnginePreference.saveParakeetModelVariant(.unified, defaults: defaults)
         let unifiedLine = VocabWordsCommand.recognitionBoostingStatusLine(defaults: defaults)
         XCTAssertTrue(unifiedLine.contains("Clean corrections only"))

--- a/Tests/MacParakeetTests/AppRuntimePreferencesTests.swift
+++ b/Tests/MacParakeetTests/AppRuntimePreferencesTests.swift
@@ -39,6 +39,19 @@ final class AppRuntimePreferencesTests: XCTestCase {
         XCTAssertTrue(preferences.shouldKeepDictationOnClipboard)
     }
 
+    func testCustomVocabularyRecognitionBoostingDefaultsOffAndReadsStoredValue() {
+        let suite = "app-runtime-prefs-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let preferences = UserDefaultsAppRuntimePreferences(defaults: defaults)
+
+        XCTAssertFalse(preferences.customVocabularyRecognitionBoostingEnabled)
+
+        defaults.set(true, forKey: UserDefaultsAppRuntimePreferences.customVocabularyRecognitionBoostingEnabledKey)
+
+        XCTAssertTrue(preferences.customVocabularyRecognitionBoostingEnabled)
+    }
+
     func testShowMeetingRecordingPillDefaultsToTrueAndReadsStoredValue() {
         let suite = "app-runtime-prefs-\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suite)!

--- a/Tests/MacParakeetTests/STT/CustomVocabularyBoostingTests.swift
+++ b/Tests/MacParakeetTests/STT/CustomVocabularyBoostingTests.swift
@@ -81,6 +81,23 @@ final class CustomVocabularyBoostingTests: XCTestCase {
         XCTAssertEqual(requestCount, 0)
     }
 
+    func testDisabledRecognitionBoostingSkipsSidecarInvocation() async throws {
+        let rescorer = FakeCustomVocabularyRescorer()
+        let result = try await STTRuntime.applyCustomVocabularyBoostingForTesting(
+            transcript: "MAC Parakeet",
+            tokenTimings: Self.tokenTimings,
+            audioSamples: [0.1, 0.2, 0.3],
+            capabilities: SpeechEngineCapabilityRegistry.capabilities(for: .parakeet(.v3)),
+            vocabulary: CustomVocabularyBoostingVocabulary(terms: ["MacParakeet"]),
+            rescorer: rescorer,
+            recognitionBoostingEnabled: false
+        )
+
+        XCTAssertEqual(result.text, "MAC Parakeet")
+        let requestCount = await rescorer.requestCount()
+        XCTAssertEqual(requestCount, 0)
+    }
+
     func testDictationUnpreparedVocabularyReturnsUnboostedAndStartsBackgroundPreparation() async throws {
         let rescorer = FakeCustomVocabularyRescorer(text: "MacParakeet", isPrepared: false)
         let result = try await STTRuntime.applyCustomVocabularyBoostingForTesting(

--- a/Tests/MacParakeetTests/STT/SpeechEngineCapabilitiesTests.swift
+++ b/Tests/MacParakeetTests/STT/SpeechEngineCapabilitiesTests.swift
@@ -43,10 +43,18 @@ final class SpeechEngineCapabilitiesTests: XCTestCase {
 
     func testCustomVocabularyPresentationReadsCapabilitySupport() {
         let tdtStatus = CustomVocabularyBoostingPresentation.status(
-            for: SpeechEngineCapabilityRegistry.capabilities(for: .parakeet(.v3))
+            for: SpeechEngineCapabilityRegistry.capabilities(for: .parakeet(.v3)),
+            recognitionBoostingEnabled: true
         )
         XCTAssertEqual(tdtStatus.title, "Recognition boosting on")
         XCTAssertTrue(tdtStatus.detail.contains("Parakeet TDT"))
+
+        let pausedTDTStatus = CustomVocabularyBoostingPresentation.status(
+            for: SpeechEngineCapabilityRegistry.capabilities(for: .parakeet(.v3)),
+            recognitionBoostingEnabled: false
+        )
+        XCTAssertEqual(pausedTDTStatus.title, "Clean corrections only")
+        XCTAssertTrue(pausedTDTStatus.detail.contains("paused"))
 
         let unifiedStatus = CustomVocabularyBoostingPresentation.status(
             for: SpeechEngineCapabilityRegistry.capabilities(for: .parakeet(.unified))


### PR DESCRIPTION
## Summary
- Disable recognition-time custom vocabulary boosting by default behind a runtime preference flag.
- Keep post-transcription clean corrections and vocabulary replacement rules active.
- Update app/CLI status copy so Parakeet TDT reports recognition boosting as paused unless explicitly enabled.

## Root cause
v0.7 enabled FluidAudio recognition-time vocabulary rescoring for Parakeet TDT final transcripts. Preview transcripts bypass that path, which matches issue #776: preview is fine, final output is over-replaced. The shipped boosting path can treat custom vocabulary anchors as preferred recognition candidates too aggressively, so short vocab lists can dominate the final transcript.

## Validation
- `git diff --check`
- `swift test --filter CustomVocabularyBoostingTests --filter SpeechEngineCapabilitiesTests --filter AppRuntimePreferencesTests --filter VocabCommandTests --filter TextProcessingPipelineTests`
- `swift test` (4,722 XCTest tests + 17 Swift Testing tests, 16 expected skips, 0 failures)

Fixes #776


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable recognition-time custom vocabulary boosting by default to stop over-replacements in final Parakeet TDT transcripts while keeping post-transcription clean corrections active. App and CLI now show boosting as paused unless explicitly enabled. Addresses #776.

- **Bug Fixes**
  - Gate TDT rescoring behind a new runtime preference `customVocabularyRecognitionBoostingEnabled` (default: false).
  - Thread preference through `STTRuntime`, `STTClient`, app environment, settings view model, and CLI status output.
  - Update status presentation to show "Clean corrections only" when boosting is paused, even if the engine supports it.
  - Add tests for default-off behavior, preference toggle, and capability-driven status.

<sup>Written for commit 8bbb7606530b1eeeb515cff8012e4843f4dc28ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/777?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

