### PR TITLE
ci: surface slow type-check expressions locally before CI fails on them

### DIFF
--- a/scripts/dev/ci_local.sh
+++ b/scripts/dev/ci_local.sh
@@ -2,6 +2,18 @@
 set -euo pipefail
 
 # Local CI parity check: clean release build + full parallel test run.
+#
+# The type-check budget flags surface expressions that compile slowly. CI
+# runners are much slower than local Apple Silicon, so an expression that
+# type-checks locally can fail CI outright with "unable to type-check this
+# expression in reasonable time" (seen on PR #781). Treat any warning these
+# flags emit as a must-fix: break the expression into typed sub-expressions.
+TYPE_CHECK_BUDGET_MS=400
+BUDGET_FLAGS=(
+  -Xswiftc -warn-long-expression-type-checking="${TYPE_CHECK_BUDGET_MS}"
+  -Xswiftc -warn-long-function-bodies="${TYPE_CHECK_BUDGET_MS}"
+)
+
 swift package clean
-swift build -c release
-swift test --parallel
+swift build -c release "${BUDGET_FLAGS[@]}"
+swift test --parallel "${BUDGET_FLAGS[@]}"


### PR DESCRIPTION
Adds a type-check time budget (400ms warn threshold) to `scripts/dev/ci_local.sh` via `-warn-long-expression-type-checking` / `-warn-long-function-bodies`.

**Why:** CI failed on #781 with "the compiler is unable to type-check this expression in reasonable time" for a large test-fixture literal that compiled fine on local Apple Silicon — the compiler's time budget only bites on slower CI runners, so local verification can't see this failure class at all. With these flags, the slow expression shows up as a warning locally; the fix (break into typed sub-expressions) happens before CI ever runs.

Syntax-checked with `bash -n`. No behavior change to the build or tests themselves — warnings only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a 400ms type-check time budget to the local CI parity script to surface slow Swift type-check expressions as warnings before CI fails on them. This lets devs break up problematic code locally instead of discovering it on slower CI runners.

- **New Features**
  - Update `scripts/dev/ci_local.sh` to pass `-warn-long-expression-type-checking=400` and `-warn-long-function-bodies=400` to `swift build` and `swift test`.
  - No behavior change to builds or tests; warnings only.

<sup>Written for commit 39cd7297553846fbe9432a0d7374d4450a233a68. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/782?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Swift type-check performance warnings to local release builds and parallel test runs.
  * Established a 400 ms type-checking budget to help identify slow expressions and function bodies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->