### PR TITLE
Fix Meetings list render-path jank

### DIFF
--- a/Sources/MacParakeet/Views/Components/ParakeetSpinner.swift
+++ b/Sources/MacParakeet/Views/Components/ParakeetSpinner.swift
@@ -55,17 +55,28 @@ struct ParakeetSpinner: View {
         }
     }
 
+    private var shouldAnimate: Bool {
+        guard !reduceMotion else { return false }
+        switch size {
+        case .inline:
+            // Inline spinners sit inside list rows and other deep view trees.
+            // Keep the Merkaba identity but avoid repeat-forever invalidation
+            // driving whole-window layout and accessibility updates.
+            return false
+        case .card, .hero:
+            return true
+        }
+    }
+
     var body: some View {
         SpinnerRingView(
             size: size.points,
             revolutionDuration: size.revolutionDuration,
             tintColor: resolvedTint,
-            animate: !reduceMotion
+            animate: shouldAnimate
         )
         .frame(width: size.points, height: size.points)
         .accessibilityElement()
         .accessibilityLabel("Loading")
-        .accessibilityValue("In progress")
-        .accessibilityAddTraits(.updatesFrequently)
     }
 }

--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingDeletionCopy.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingDeletionCopy.swift
@@ -131,6 +131,17 @@ enum MeetingDeletionCopy {
         return audioUnavailableHelp(for: state)
     }
 
+    /// Filesystem-free variant for eagerly evaluated row menus.
+    static func audioRemovalUnavailableHelp(
+        state: MeetingAudioFile.State,
+        isRemovable: Bool
+    ) -> String {
+        if state == .saved && !isRemovable {
+            return TranscriptionAssetCleanup.meetingAudioFinalizationInProgressMessage
+        }
+        return audioUnavailableHelp(for: state)
+    }
+
     private static func nonCompletedWarning(status: Transcription.TranscriptionStatus) -> String {
         guard status != .completed else { return "" }
         return "This meeting hasn't been transcribed yet — deleting the audio makes that permanent. "

--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingRowCard.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingRowCard.swift
@@ -6,6 +6,7 @@ import SwiftUI
 /// (recovered dot, speaker count) appear only when they carry signal.
 struct MeetingRowCard<MenuContent: View>: View {
     let transcription: Transcription
+    let audioState: MeetingAudioFile.State
     var searchText: String = ""
     var isSelected: Bool = false
     var showsSelectionControls: Bool = false
@@ -311,10 +312,6 @@ struct MeetingRowCard<MenuContent: View>: View {
     private var displayedSpeakerCount: Int? {
         let count = transcription.speakerCount ?? transcription.speakers?.count ?? 0
         return count >= 2 ? count : nil
-    }
-
-    private var audioState: MeetingAudioFile.State {
-        MeetingAudioFile.state(for: transcription)
     }
 
     private var errorDetail: String? {

--- a/Sources/MacParakeet/Views/Meetings/MeetingsView.swift
+++ b/Sources/MacParakeet/Views/Meetings/MeetingsView.swift
@@ -160,23 +160,17 @@ struct MeetingsView: View {
                 Text(recentMeetingsBulkOperationMessage(for: operation))
             }
         }
-        .sheet(
-            isPresented: $showingAskPromptsSheet,
-            onDismiss: {
-                viewModel.quickPromptsViewModel.cancelCreating()
-                viewModel.quickPromptsViewModel.editingPrompt = nil
-                viewModel.refreshQuickPrompts()
-            }
-        ) {
+        .sheet(isPresented: $showingAskPromptsSheet, onDismiss: {
+            viewModel.quickPromptsViewModel.cancelCreating()
+            viewModel.quickPromptsViewModel.editingPrompt = nil
+            viewModel.refreshQuickPrompts()
+        }) {
             AskPromptsSheet(viewModel: viewModel.quickPromptsViewModel)
         }
-        .sheet(
-            isPresented: $showingPromptLibrary,
-            onDismiss: {
-                viewModel.promptsViewModel.editingPrompt = nil
-                viewModel.refreshAutoNotes()
-            }
-        ) {
+        .sheet(isPresented: $showingPromptLibrary, onDismiss: {
+            viewModel.promptsViewModel.editingPrompt = nil
+            viewModel.refreshAutoNotes()
+        }) {
             PromptLibraryView(viewModel: viewModel.promptsViewModel)
         }
     }
@@ -404,8 +398,7 @@ struct MeetingsView: View {
                 MeetingsInlineState(
                     icon: "sparkles",
                     title: "Set up AI for auto-notes",
-                    detail:
-                        "Choose an AI provider and MacParakeet will write notes for you automatically when a meeting ends.",
+                    detail: "Choose an AI provider and MacParakeet will write notes for you automatically when a meeting ends.",
                     actionTitle: "Set Up AI",
                     actionIcon: "gearshape",
                     action: onOpenAISettings
@@ -498,8 +491,7 @@ struct MeetingsView: View {
                 }
 
                 if viewModel.recentMeetingsViewModel.isLoading
-                    && viewModel.recentMeetingsViewModel.filteredTranscriptions.isEmpty
-                {
+                    && viewModel.recentMeetingsViewModel.filteredTranscriptions.isEmpty {
                     MeetingsLoadingRow(title: "Loading meetings")
                 } else if viewModel.recentMeetingsViewModel.filteredTranscriptions.isEmpty {
                     MeetingsInlineState(
@@ -604,8 +596,7 @@ struct MeetingsView: View {
             } label: {
                 Label("Retry Transcription", systemImage: "arrow.clockwise")
             }
-            .disabled(
-                viewModel.recentMeetingsViewModel.isRetryingMeetingTranscription(transcription) || audioState != .saved)
+            .disabled(viewModel.recentMeetingsViewModel.isRetryingMeetingTranscription(transcription) || audioState != .saved)
 
             Divider()
         }
@@ -632,10 +623,9 @@ struct MeetingsView: View {
             Label("Show Audio in Finder", systemImage: "waveform")
         }
         .disabled(!audioAvailable)
-        .help(
-            audioAvailable
-                ? "Reveal the meeting audio file in Finder"
-                : MeetingDeletionCopy.audioUnavailableHelp(for: audioState))
+        .help(audioAvailable
+              ? "Reveal the meeting audio file in Finder"
+              : MeetingDeletionCopy.audioUnavailableHelp(for: audioState))
 
         Button {
             saveMeetingAudio(transcription)
@@ -643,10 +633,9 @@ struct MeetingsView: View {
             Label("Save Audio As…", systemImage: "square.and.arrow.down")
         }
         .disabled(!audioAvailable)
-        .help(
-            audioAvailable
-                ? "Save a copy of the meeting audio to a chosen location"
-                : MeetingDeletionCopy.audioUnavailableHelp(for: audioState))
+        .help(audioAvailable
+              ? "Save a copy of the meeting audio to a chosen location"
+              : MeetingDeletionCopy.audioUnavailableHelp(for: audioState))
 
         Button(role: .destructive) {
             pendingDeleteAudio = transcription
@@ -654,13 +643,12 @@ struct MeetingsView: View {
             Label(MeetingDeletionCopy.audioOnlyMenuTitle, systemImage: "waveform.slash")
         }
         .disabled(!audioRemovable)
-        .help(
-            audioRemovable
-                ? "Remove the saved meeting audio while keeping the meeting"
-                : MeetingDeletionCopy.audioRemovalUnavailableHelp(
-                    state: audioState,
-                    isRemovable: audioRemovable
-                ))
+        .help(audioRemovable
+              ? "Remove the saved meeting audio while keeping the meeting"
+              : MeetingDeletionCopy.audioRemovalUnavailableHelp(
+                  state: audioState,
+                  isRemovable: audioRemovable
+              ))
 
         Divider()
 
@@ -753,6 +741,7 @@ struct MeetingsView: View {
             sourceMode: viewModel.settingsViewModel.meetingAudioSourceMode
         )
     }
+
 
     private var recentMeetingsSearchText: String {
         viewModel.recentMeetingsViewModel.searchText.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -1594,10 +1583,9 @@ private struct AutoNoteChip: View {
             .padding(.vertical, 5)
             .background(
                 Capsule()
-                    .fill(
-                        isOn
-                            ? DesignSystem.Colors.accent.opacity(0.12)
-                            : DesignSystem.Colors.surfaceElevated.opacity(0.72))
+                    .fill(isOn
+                          ? DesignSystem.Colors.accent.opacity(0.12)
+                          : DesignSystem.Colors.surfaceElevated.opacity(0.72))
             )
             .overlay(
                 Capsule()
@@ -1613,9 +1601,6 @@ private struct AutoNoteChip: View {
         .accessibilityLabel("\(title) auto-note")
         .accessibilityValue(isOn ? "On" : "Off")
         .accessibilityAddTraits(isOn ? [.isButton, .isSelected] : .isButton)
-        .help(
-            isOn
-                ? "Generated automatically after meetings — click to turn off"
-                : "Click to generate this automatically after meetings")
+        .help(isOn ? "Generated automatically after meetings — click to turn off" : "Click to generate this automatically after meetings")
     }
 }

--- a/Sources/MacParakeet/Views/Meetings/MeetingsView.swift
+++ b/Sources/MacParakeet/Views/Meetings/MeetingsView.swift
@@ -160,17 +160,23 @@ struct MeetingsView: View {
                 Text(recentMeetingsBulkOperationMessage(for: operation))
             }
         }
-        .sheet(isPresented: $showingAskPromptsSheet, onDismiss: {
-            viewModel.quickPromptsViewModel.cancelCreating()
-            viewModel.quickPromptsViewModel.editingPrompt = nil
-            viewModel.refreshQuickPrompts()
-        }) {
+        .sheet(
+            isPresented: $showingAskPromptsSheet,
+            onDismiss: {
+                viewModel.quickPromptsViewModel.cancelCreating()
+                viewModel.quickPromptsViewModel.editingPrompt = nil
+                viewModel.refreshQuickPrompts()
+            }
+        ) {
             AskPromptsSheet(viewModel: viewModel.quickPromptsViewModel)
         }
-        .sheet(isPresented: $showingPromptLibrary, onDismiss: {
-            viewModel.promptsViewModel.editingPrompt = nil
-            viewModel.refreshAutoNotes()
-        }) {
+        .sheet(
+            isPresented: $showingPromptLibrary,
+            onDismiss: {
+                viewModel.promptsViewModel.editingPrompt = nil
+                viewModel.refreshAutoNotes()
+            }
+        ) {
             PromptLibraryView(viewModel: viewModel.promptsViewModel)
         }
     }
@@ -398,7 +404,8 @@ struct MeetingsView: View {
                 MeetingsInlineState(
                     icon: "sparkles",
                     title: "Set up AI for auto-notes",
-                    detail: "Choose an AI provider and MacParakeet will write notes for you automatically when a meeting ends.",
+                    detail:
+                        "Choose an AI provider and MacParakeet will write notes for you automatically when a meeting ends.",
                     actionTitle: "Set Up AI",
                     actionIcon: "gearshape",
                     action: onOpenAISettings
@@ -491,7 +498,8 @@ struct MeetingsView: View {
                 }
 
                 if viewModel.recentMeetingsViewModel.isLoading
-                    && viewModel.recentMeetingsViewModel.filteredTranscriptions.isEmpty {
+                    && viewModel.recentMeetingsViewModel.filteredTranscriptions.isEmpty
+                {
                     MeetingsLoadingRow(title: "Loading meetings")
                 } else if viewModel.recentMeetingsViewModel.filteredTranscriptions.isEmpty {
                     MeetingsInlineState(
@@ -533,8 +541,10 @@ struct MeetingsView: View {
             ForEach(viewModel.recentMeetingsViewModel.groupedTranscriptions, id: \.group) { section in
                 MeetingDateGroupHeader(group: section.group)
                 ForEach(Array(section.items.enumerated()), id: \.element.id) { idx, transcription in
+                    let fileState = viewModel.recentMeetingsViewModel.meetingRowFileState(for: transcription)
                     MeetingRowCard(
                         transcription: transcription,
+                        audioState: fileState.audioState,
                         searchText: viewModel.recentMeetingsViewModel.searchText,
                         isSelected: viewModel.recentMeetingsViewModel.isTranscriptionSelected(transcription),
                         showsSelectionControls: viewModel.recentMeetingsViewModel.isBulkSelectionModeEnabled,
@@ -552,7 +562,7 @@ struct MeetingsView: View {
                         onRetry: {
                             viewModel.recentMeetingsViewModel.retryMeetingTranscription(transcription)
                         },
-                        menuContent: { recentMeetingMenu(for: transcription) }
+                        menuContent: { recentMeetingMenu(for: transcription, fileState: fileState) }
                     )
                     if idx < section.items.count - 1 {
                         MeetingRowHairline()
@@ -563,7 +573,10 @@ struct MeetingsView: View {
     }
 
     @ViewBuilder
-    private func recentMeetingMenu(for transcription: Transcription) -> some View {
+    private func recentMeetingMenu(
+        for transcription: Transcription,
+        fileState: MeetingRowFileState
+    ) -> some View {
         Button {
             onSelectMeeting(transcription)
         } label: {
@@ -578,10 +591,10 @@ struct MeetingsView: View {
             }
         }
 
-        let audioState = MeetingAudioFile.state(for: transcription)
+        let audioState = fileState.audioState
         let audioAvailable = audioState == .saved
-        let audioRemovable = MeetingAudioFile.isRemovable(for: transcription, state: audioState)
-        let artifactAvailable = MeetingArtifactActions.folderURL(for: transcription) != nil
+        let audioRemovable = fileState.isAudioRemovable
+        let artifactAvailable = fileState.isArtifactFolderAvailable
 
         Divider()
 
@@ -591,7 +604,8 @@ struct MeetingsView: View {
             } label: {
                 Label("Retry Transcription", systemImage: "arrow.clockwise")
             }
-            .disabled(viewModel.recentMeetingsViewModel.isRetryingMeetingTranscription(transcription) || audioState != .saved)
+            .disabled(
+                viewModel.recentMeetingsViewModel.isRetryingMeetingTranscription(transcription) || audioState != .saved)
 
             Divider()
         }
@@ -618,9 +632,10 @@ struct MeetingsView: View {
             Label("Show Audio in Finder", systemImage: "waveform")
         }
         .disabled(!audioAvailable)
-        .help(audioAvailable
-              ? "Reveal the meeting audio file in Finder"
-              : MeetingDeletionCopy.audioUnavailableHelp(for: audioState))
+        .help(
+            audioAvailable
+                ? "Reveal the meeting audio file in Finder"
+                : MeetingDeletionCopy.audioUnavailableHelp(for: audioState))
 
         Button {
             saveMeetingAudio(transcription)
@@ -628,9 +643,10 @@ struct MeetingsView: View {
             Label("Save Audio As…", systemImage: "square.and.arrow.down")
         }
         .disabled(!audioAvailable)
-        .help(audioAvailable
-              ? "Save a copy of the meeting audio to a chosen location"
-              : MeetingDeletionCopy.audioUnavailableHelp(for: audioState))
+        .help(
+            audioAvailable
+                ? "Save a copy of the meeting audio to a chosen location"
+                : MeetingDeletionCopy.audioUnavailableHelp(for: audioState))
 
         Button(role: .destructive) {
             pendingDeleteAudio = transcription
@@ -638,12 +654,13 @@ struct MeetingsView: View {
             Label(MeetingDeletionCopy.audioOnlyMenuTitle, systemImage: "waveform.slash")
         }
         .disabled(!audioRemovable)
-        .help(audioRemovable
-              ? "Remove the saved meeting audio while keeping the meeting"
-              : MeetingDeletionCopy.audioRemovalUnavailableHelp(
-                  for: transcription,
-                  state: audioState
-              ))
+        .help(
+            audioRemovable
+                ? "Remove the saved meeting audio while keeping the meeting"
+                : MeetingDeletionCopy.audioRemovalUnavailableHelp(
+                    state: audioState,
+                    isRemovable: audioRemovable
+                ))
 
         Divider()
 
@@ -736,7 +753,6 @@ struct MeetingsView: View {
             sourceMode: viewModel.settingsViewModel.meetingAudioSourceMode
         )
     }
-
 
     private var recentMeetingsSearchText: String {
         viewModel.recentMeetingsViewModel.searchText.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -1578,9 +1594,10 @@ private struct AutoNoteChip: View {
             .padding(.vertical, 5)
             .background(
                 Capsule()
-                    .fill(isOn
-                          ? DesignSystem.Colors.accent.opacity(0.12)
-                          : DesignSystem.Colors.surfaceElevated.opacity(0.72))
+                    .fill(
+                        isOn
+                            ? DesignSystem.Colors.accent.opacity(0.12)
+                            : DesignSystem.Colors.surfaceElevated.opacity(0.72))
             )
             .overlay(
                 Capsule()
@@ -1596,6 +1613,9 @@ private struct AutoNoteChip: View {
         .accessibilityLabel("\(title) auto-note")
         .accessibilityValue(isOn ? "On" : "Off")
         .accessibilityAddTraits(isOn ? [.isButton, .isSelected] : .isButton)
-        .help(isOn ? "Generated automatically after meetings — click to turn off" : "Click to generate this automatically after meetings")
+        .help(
+            isOn
+                ? "Generated automatically after meetings — click to turn off"
+                : "Click to generate this automatically after meetings")
     }
 }

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
@@ -254,10 +254,15 @@ struct TranscriptionLibraryView: View {
         ScrollView {
             VStack(spacing: DesignSystem.Spacing.md) {
                 LazyVGrid(
-                    columns: [GridItem(.adaptive(minimum: DesignSystem.Layout.thumbnailCardMinWidth), spacing: DesignSystem.Spacing.md)],
+                    columns: [
+                        GridItem(
+                            .adaptive(minimum: DesignSystem.Layout.thumbnailCardMinWidth),
+                            spacing: DesignSystem.Spacing.md)
+                    ],
                     spacing: DesignSystem.Spacing.md
                 ) {
                     ForEach(viewModel.filteredTranscriptions) { transcription in
+                        let fileState = viewModel.meetingRowFileState(for: transcription)
                         TranscriptionThumbnailCard(
                             transcription: transcription,
                             searchText: viewModel.searchText,
@@ -273,10 +278,10 @@ struct TranscriptionLibraryView: View {
                                 onSelect(transcription)
                             }
                         } menuContent: {
-                            libraryMenuItems(for: transcription)
+                            libraryMenuItems(for: transcription, fileState: fileState)
                         }
                         .contextMenu {
-                            libraryMenuItems(for: transcription)
+                            libraryMenuItems(for: transcription, fileState: fileState)
                         }
                     }
                 }
@@ -294,8 +299,10 @@ struct TranscriptionLibraryView: View {
                 ForEach(viewModel.groupedTranscriptions, id: \.group) { section in
                     MeetingDateGroupHeader(group: section.group)
                     ForEach(Array(section.items.enumerated()), id: \.element.id) { idx, transcription in
+                        let fileState = viewModel.meetingRowFileState(for: transcription)
                         MeetingRowCard(
                             transcription: transcription,
+                            audioState: fileState.audioState,
                             searchText: viewModel.searchText,
                             isSelected: viewModel.isTranscriptionSelected(transcription),
                             showsSelectionControls: viewModel.isBulkSelectionModeEnabled,
@@ -313,7 +320,7 @@ struct TranscriptionLibraryView: View {
                             onRetry: {
                                 viewModel.retryMeetingTranscription(transcription)
                             },
-                            menuContent: { libraryMenuItems(for: transcription) }
+                            menuContent: { libraryMenuItems(for: transcription, fileState: fileState) }
                         )
                         if idx < section.items.count - 1 {
                             MeetingRowHairline()
@@ -329,7 +336,10 @@ struct TranscriptionLibraryView: View {
     }
 
     @ViewBuilder
-    private func libraryMenuItems(for transcription: Transcription) -> some View {
+    private func libraryMenuItems(
+        for transcription: Transcription,
+        fileState: MeetingRowFileState
+    ) -> some View {
         Button {
             onSelect(transcription)
         } label: {
@@ -353,10 +363,10 @@ struct TranscriptionLibraryView: View {
         }
 
         if transcription.sourceType == .meeting {
-            let audioState = MeetingAudioFile.state(for: transcription)
+            let audioState = fileState.audioState
             let audioAvailable = audioState == .saved
-            let audioRemovable = MeetingAudioFile.isRemovable(for: transcription, state: audioState)
-            let artifactAvailable = MeetingArtifactActions.folderURL(for: transcription) != nil
+            let audioRemovable = fileState.isAudioRemovable
+            let artifactAvailable = fileState.isArtifactFolderAvailable
 
             Divider()
 
@@ -377,9 +387,10 @@ struct TranscriptionLibraryView: View {
                 Label("Open Meeting Folder", systemImage: "folder")
             }
             .disabled(!artifactAvailable)
-            .help(artifactAvailable
-                  ? "Open the meeting artifact folder in Finder"
-                  : "Meeting artifact folder is not available")
+            .help(
+                artifactAvailable
+                    ? "Open the meeting artifact folder in Finder"
+                    : "Meeting artifact folder is not available")
 
             Button {
                 MeetingArtifactActions.copyFolderPath(for: transcription)
@@ -387,9 +398,10 @@ struct TranscriptionLibraryView: View {
                 Label("Copy Artifact Folder Path", systemImage: "doc.on.doc")
             }
             .disabled(!artifactAvailable)
-            .help(artifactAvailable
-                  ? "Copy the meeting artifact folder path"
-                  : "Meeting artifact folder is not available")
+            .help(
+                artifactAvailable
+                    ? "Copy the meeting artifact folder path"
+                    : "Meeting artifact folder is not available")
 
             Divider()
 
@@ -399,9 +411,10 @@ struct TranscriptionLibraryView: View {
                 Label("Show Audio in Finder", systemImage: "waveform")
             }
             .disabled(!audioAvailable)
-            .help(audioAvailable
-                  ? "Reveal the meeting audio file in Finder"
-                  : MeetingDeletionCopy.audioUnavailableHelp(for: audioState))
+            .help(
+                audioAvailable
+                    ? "Reveal the meeting audio file in Finder"
+                    : MeetingDeletionCopy.audioUnavailableHelp(for: audioState))
 
             Button {
                 saveMeetingAudio(transcription)
@@ -409,9 +422,10 @@ struct TranscriptionLibraryView: View {
                 Label("Save Audio As…", systemImage: "square.and.arrow.down")
             }
             .disabled(!audioAvailable)
-            .help(audioAvailable
-                  ? "Save a copy of the meeting audio to a chosen location"
-                  : MeetingDeletionCopy.audioUnavailableHelp(for: audioState))
+            .help(
+                audioAvailable
+                    ? "Save a copy of the meeting audio to a chosen location"
+                    : MeetingDeletionCopy.audioUnavailableHelp(for: audioState))
 
             Button(role: .destructive) {
                 pendingDeleteAudio = transcription
@@ -419,12 +433,13 @@ struct TranscriptionLibraryView: View {
                 Label(MeetingDeletionCopy.audioOnlyMenuTitle, systemImage: "waveform.slash")
             }
             .disabled(!audioRemovable)
-            .help(audioRemovable
-                  ? "Remove the saved meeting audio while keeping the meeting"
-                  : MeetingDeletionCopy.audioRemovalUnavailableHelp(
-                      for: transcription,
-                      state: audioState
-                  ))
+            .help(
+                audioRemovable
+                    ? "Remove the saved meeting audio while keeping the meeting"
+                    : MeetingDeletionCopy.audioRemovalUnavailableHelp(
+                        state: audioState,
+                        isRemovable: audioRemovable
+                    ))
         }
 
         Divider()
@@ -443,7 +458,9 @@ struct TranscriptionLibraryView: View {
         Button(role: .destructive) {
             pendingDelete = transcription
         } label: {
-            Label(transcription.sourceType == .meeting ? MeetingDeletionCopy.fullDeleteMenuTitle : "Delete", systemImage: "trash")
+            Label(
+                transcription.sourceType == .meeting ? MeetingDeletionCopy.fullDeleteMenuTitle : "Delete",
+                systemImage: "trash")
         }
     }
 
@@ -524,8 +541,8 @@ struct TranscriptionLibraryView: View {
     private static let bulkExportFormatOrder: [TranscriptExportFormat] = {
         let preferredOrder: [TranscriptExportFormat] = [.txt, .md, .srt, .vtt, .json, .pdf, .docx]
         precondition(
-            preferredOrder.count == TranscriptExportFormat.allCases.count &&
-                Set(preferredOrder) == Set(TranscriptExportFormat.allCases),
+            preferredOrder.count == TranscriptExportFormat.allCases.count
+                && Set(preferredOrder) == Set(TranscriptExportFormat.allCases),
             "Bulk export format order must include every TranscriptExportFormat case"
         )
         return preferredOrder
@@ -553,9 +570,7 @@ struct TranscriptionLibraryView: View {
     }
 
     private var isBulkExportActionDisabled: Bool {
-        selectedBulkExportTargets.isEmpty ||
-            bulkExportInProgress ||
-            viewModel.isBulkOperationInProgress
+        selectedBulkExportTargets.isEmpty || bulkExportInProgress || viewModel.isBulkOperationInProgress
     }
 
     private var bulkExportOptionsPopover: some View {
@@ -837,17 +852,21 @@ struct TranscriptionLibraryView: View {
             Image(systemName: emptyStateIcon)
                 .font(.system(size: 40, weight: .light))
                 .foregroundStyle(DesignSystem.Colors.textTertiary)
-            Text(viewModel.searchText.isEmpty
-                 ? emptyStateTitle
-                 : "No matching transcriptions")
-                .font(DesignSystem.Typography.body)
-                .foregroundStyle(DesignSystem.Colors.textSecondary)
-            Text(viewModel.searchText.isEmpty
-                 ? emptyStateMessage
-                 : "Try different words or clear your search.")
-                .font(DesignSystem.Typography.bodySmall)
-                .foregroundStyle(DesignSystem.Colors.textTertiary)
-                .multilineTextAlignment(.center)
+            Text(
+                viewModel.searchText.isEmpty
+                    ? emptyStateTitle
+                    : "No matching transcriptions"
+            )
+            .font(DesignSystem.Typography.body)
+            .foregroundStyle(DesignSystem.Colors.textSecondary)
+            Text(
+                viewModel.searchText.isEmpty
+                    ? emptyStateMessage
+                    : "Try different words or clear your search."
+            )
+            .font(DesignSystem.Typography.bodySmall)
+            .foregroundStyle(DesignSystem.Colors.textTertiary)
+            .multilineTextAlignment(.center)
             Spacer()
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -935,7 +954,8 @@ struct TranscriptionLibraryView: View {
             )
         }
 
-        return "Delete \(operation.targetCount) \(operation.targetCount == 1 ? "item" : "items")? This permanently deletes the Library rows and app-owned files. Original local source files are not removed."
+        return
+            "Delete \(operation.targetCount) \(operation.targetCount == 1 ? "item" : "items")? This permanently deletes the Library rows and app-owned files. Original local source files are not removed."
     }
 
     private func singleDeleteTitle(for transcription: Transcription) -> String {

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
@@ -254,11 +254,7 @@ struct TranscriptionLibraryView: View {
         ScrollView {
             VStack(spacing: DesignSystem.Spacing.md) {
                 LazyVGrid(
-                    columns: [
-                        GridItem(
-                            .adaptive(minimum: DesignSystem.Layout.thumbnailCardMinWidth),
-                            spacing: DesignSystem.Spacing.md)
-                    ],
+                    columns: [GridItem(.adaptive(minimum: DesignSystem.Layout.thumbnailCardMinWidth), spacing: DesignSystem.Spacing.md)],
                     spacing: DesignSystem.Spacing.md
                 ) {
                     ForEach(viewModel.filteredTranscriptions) { transcription in
@@ -387,10 +383,9 @@ struct TranscriptionLibraryView: View {
                 Label("Open Meeting Folder", systemImage: "folder")
             }
             .disabled(!artifactAvailable)
-            .help(
-                artifactAvailable
-                    ? "Open the meeting artifact folder in Finder"
-                    : "Meeting artifact folder is not available")
+            .help(artifactAvailable
+                  ? "Open the meeting artifact folder in Finder"
+                  : "Meeting artifact folder is not available")
 
             Button {
                 MeetingArtifactActions.copyFolderPath(for: transcription)
@@ -398,10 +393,9 @@ struct TranscriptionLibraryView: View {
                 Label("Copy Artifact Folder Path", systemImage: "doc.on.doc")
             }
             .disabled(!artifactAvailable)
-            .help(
-                artifactAvailable
-                    ? "Copy the meeting artifact folder path"
-                    : "Meeting artifact folder is not available")
+            .help(artifactAvailable
+                  ? "Copy the meeting artifact folder path"
+                  : "Meeting artifact folder is not available")
 
             Divider()
 
@@ -411,10 +405,9 @@ struct TranscriptionLibraryView: View {
                 Label("Show Audio in Finder", systemImage: "waveform")
             }
             .disabled(!audioAvailable)
-            .help(
-                audioAvailable
-                    ? "Reveal the meeting audio file in Finder"
-                    : MeetingDeletionCopy.audioUnavailableHelp(for: audioState))
+            .help(audioAvailable
+                  ? "Reveal the meeting audio file in Finder"
+                  : MeetingDeletionCopy.audioUnavailableHelp(for: audioState))
 
             Button {
                 saveMeetingAudio(transcription)
@@ -422,10 +415,9 @@ struct TranscriptionLibraryView: View {
                 Label("Save Audio As…", systemImage: "square.and.arrow.down")
             }
             .disabled(!audioAvailable)
-            .help(
-                audioAvailable
-                    ? "Save a copy of the meeting audio to a chosen location"
-                    : MeetingDeletionCopy.audioUnavailableHelp(for: audioState))
+            .help(audioAvailable
+                  ? "Save a copy of the meeting audio to a chosen location"
+                  : MeetingDeletionCopy.audioUnavailableHelp(for: audioState))
 
             Button(role: .destructive) {
                 pendingDeleteAudio = transcription
@@ -433,13 +425,12 @@ struct TranscriptionLibraryView: View {
                 Label(MeetingDeletionCopy.audioOnlyMenuTitle, systemImage: "waveform.slash")
             }
             .disabled(!audioRemovable)
-            .help(
-                audioRemovable
-                    ? "Remove the saved meeting audio while keeping the meeting"
-                    : MeetingDeletionCopy.audioRemovalUnavailableHelp(
-                        state: audioState,
-                        isRemovable: audioRemovable
-                    ))
+            .help(audioRemovable
+                  ? "Remove the saved meeting audio while keeping the meeting"
+                  : MeetingDeletionCopy.audioRemovalUnavailableHelp(
+                      state: audioState,
+                      isRemovable: audioRemovable
+                  ))
         }
 
         Divider()
@@ -458,9 +449,7 @@ struct TranscriptionLibraryView: View {
         Button(role: .destructive) {
             pendingDelete = transcription
         } label: {
-            Label(
-                transcription.sourceType == .meeting ? MeetingDeletionCopy.fullDeleteMenuTitle : "Delete",
-                systemImage: "trash")
+            Label(transcription.sourceType == .meeting ? MeetingDeletionCopy.fullDeleteMenuTitle : "Delete", systemImage: "trash")
         }
     }
 
@@ -541,8 +530,8 @@ struct TranscriptionLibraryView: View {
     private static let bulkExportFormatOrder: [TranscriptExportFormat] = {
         let preferredOrder: [TranscriptExportFormat] = [.txt, .md, .srt, .vtt, .json, .pdf, .docx]
         precondition(
-            preferredOrder.count == TranscriptExportFormat.allCases.count
-                && Set(preferredOrder) == Set(TranscriptExportFormat.allCases),
+            preferredOrder.count == TranscriptExportFormat.allCases.count &&
+                Set(preferredOrder) == Set(TranscriptExportFormat.allCases),
             "Bulk export format order must include every TranscriptExportFormat case"
         )
         return preferredOrder
@@ -570,7 +559,9 @@ struct TranscriptionLibraryView: View {
     }
 
     private var isBulkExportActionDisabled: Bool {
-        selectedBulkExportTargets.isEmpty || bulkExportInProgress || viewModel.isBulkOperationInProgress
+        selectedBulkExportTargets.isEmpty ||
+            bulkExportInProgress ||
+            viewModel.isBulkOperationInProgress
     }
 
     private var bulkExportOptionsPopover: some View {
@@ -852,21 +843,17 @@ struct TranscriptionLibraryView: View {
             Image(systemName: emptyStateIcon)
                 .font(.system(size: 40, weight: .light))
                 .foregroundStyle(DesignSystem.Colors.textTertiary)
-            Text(
-                viewModel.searchText.isEmpty
-                    ? emptyStateTitle
-                    : "No matching transcriptions"
-            )
-            .font(DesignSystem.Typography.body)
-            .foregroundStyle(DesignSystem.Colors.textSecondary)
-            Text(
-                viewModel.searchText.isEmpty
-                    ? emptyStateMessage
-                    : "Try different words or clear your search."
-            )
-            .font(DesignSystem.Typography.bodySmall)
-            .foregroundStyle(DesignSystem.Colors.textTertiary)
-            .multilineTextAlignment(.center)
+            Text(viewModel.searchText.isEmpty
+                 ? emptyStateTitle
+                 : "No matching transcriptions")
+                .font(DesignSystem.Typography.body)
+                .foregroundStyle(DesignSystem.Colors.textSecondary)
+            Text(viewModel.searchText.isEmpty
+                 ? emptyStateMessage
+                 : "Try different words or clear your search.")
+                .font(DesignSystem.Typography.bodySmall)
+                .foregroundStyle(DesignSystem.Colors.textTertiary)
+                .multilineTextAlignment(.center)
             Spacer()
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -954,8 +941,7 @@ struct TranscriptionLibraryView: View {
             )
         }
 
-        return
-            "Delete \(operation.targetCount) \(operation.targetCount == 1 ? "item" : "items")? This permanently deletes the Library rows and app-owned files. Original local source files are not removed."
+        return "Delete \(operation.targetCount) \(operation.targetCount == 1 ? "item" : "items")? This permanently deletes the Library rows and app-owned files. Original local source files are not removed."
     }
 
     private func singleDeleteTitle(for transcription: Transcription) -> String {

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
@@ -261,6 +261,7 @@ struct TranscriptionLibraryView: View {
                         let fileState = viewModel.meetingRowFileState(for: transcription)
                         TranscriptionThumbnailCard(
                             transcription: transcription,
+                            meetingAudioState: fileState.audioState,
                             searchText: viewModel.searchText,
                             isSelected: viewModel.isTranscriptionSelected(transcription),
                             showsSelectionControls: viewModel.isBulkSelectionModeEnabled

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionThumbnailCard.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionThumbnailCard.swift
@@ -6,6 +6,7 @@ private let sharedThumbnailCache = ThumbnailCacheService.shared
 /// Thumbnail card for displaying a transcription in a grid layout.
 struct TranscriptionThumbnailCard<MenuContent: View>: View {
     let transcription: Transcription
+    let meetingAudioState: MeetingAudioFile.State
     var searchText: String = ""
     var isSelected: Bool = false
     var showsSelectionControls: Bool = false
@@ -149,9 +150,8 @@ struct TranscriptionThumbnailCard<MenuContent: View>: View {
             }
             .overlay(alignment: .bottomLeading) {
                 if transcription.sourceType == .meeting {
-                    let state = MeetingAudioFile.state(for: transcription)
-                    if state != .notMeeting {
-                        MeetingAudioStateChip(state: state)
+                    if meetingAudioState != .notMeeting {
+                        MeetingAudioStateChip(state: meetingAudioState)
                             .padding(8)
                     }
                 }

--- a/Sources/MacParakeetViewModels/TranscriptionLibraryViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionLibraryViewModel.swift
@@ -123,16 +123,6 @@ public struct MeetingRowFileState: Equatable, Sendable {
     public let audioState: MeetingAudioFile.State
     public let isAudioRemovable: Bool
     public let isArtifactFolderAvailable: Bool
-
-    public init(
-        audioState: MeetingAudioFile.State,
-        isAudioRemovable: Bool,
-        isArtifactFolderAvailable: Bool
-    ) {
-        self.audioState = audioState
-        self.isAudioRemovable = isAudioRemovable
-        self.isArtifactFolderAvailable = isArtifactFolderAvailable
-    }
 }
 
 @MainActor @Observable
@@ -508,11 +498,7 @@ public final class TranscriptionLibraryViewModel {
                     transcriptions[idx].meetingArtifactFolderPath
                     ?? MeetingArtifactStore.sessionFolderURL(for: transcription)?.standardizedFileURL.path
                 transcriptions[idx].filePath = nil
-                meetingRowFileStates[transcription.id] = MeetingRowFileState(
-                    audioState: .removed,
-                    isAudioRemovable: false,
-                    isArtifactFolderAvailable: true
-                )
+                markMeetingAudioRemoved(for: transcription.id)
                 publishLoadedItems(transcriptions, hasMore: hasMore)
             }
         } catch TranscriptionAssetCleanupError.meetingAudioFinalizationInProgress {
@@ -749,13 +735,17 @@ public final class TranscriptionLibraryViewModel {
                 transcriptions[index].meetingArtifactFolderPath
                 ?? MeetingArtifactStore.sessionFolderURL(for: transcriptions[index])?.standardizedFileURL.path
             transcriptions[index].filePath = nil
-            meetingRowFileStates[transcriptions[index].id] = MeetingRowFileState(
-                audioState: .removed,
-                isAudioRemovable: false,
-                isArtifactFolderAvailable: true
-            )
+            markMeetingAudioRemoved(for: transcriptions[index].id)
         }
         publishLoadedItems(transcriptions, hasMore: hasMore)
+    }
+
+    private func markMeetingAudioRemoved(for id: UUID) {
+        meetingRowFileStates[id] = MeetingRowFileState(
+            audioState: .removed,
+            isAudioRemovable: false,
+            isArtifactFolderAvailable: true
+        )
     }
 
     nonisolated private static func resolveMeetingRowFileStates(
@@ -808,8 +798,10 @@ public final class TranscriptionLibraryViewModel {
                 isArtifactFolderAvailable: false
             )
         }
+        let hasStoredAudioPath =
+            transcription.filePath?.trimmingCharacters(in: .whitespaces).isEmpty == false
         return MeetingRowFileState(
-            audioState: transcription.filePath == nil ? .removed : .missing,
+            audioState: hasStoredAudioPath ? .missing : .removed,
             isAudioRemovable: false,
             isArtifactFolderAvailable: false
         )

--- a/Sources/MacParakeetViewModels/TranscriptionLibraryViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionLibraryViewModel.swift
@@ -114,6 +114,27 @@ public struct BulkOperationResult: Sendable, Equatable {
     }
 }
 
+/// Filesystem-backed values needed to render one meeting row and its menus.
+///
+/// The library resolves this snapshot off the main actor when rows load. Views
+/// must read this value instead of consulting `FileManager` during `body` or
+/// eager menu evaluation.
+public struct MeetingRowFileState: Equatable, Sendable {
+    public let audioState: MeetingAudioFile.State
+    public let isAudioRemovable: Bool
+    public let isArtifactFolderAvailable: Bool
+
+    public init(
+        audioState: MeetingAudioFile.State,
+        isAudioRemovable: Bool,
+        isArtifactFolderAvailable: Bool
+    ) {
+        self.audioState = audioState
+        self.isAudioRemovable = isAudioRemovable
+        self.isArtifactFolderAvailable = isArtifactFolderAvailable
+    }
+}
+
 @MainActor @Observable
 public final class TranscriptionLibraryViewModel {
     private let logger = Logger(subsystem: "com.macparakeet.viewmodels", category: "TranscriptionLibrary")
@@ -144,6 +165,7 @@ public final class TranscriptionLibraryViewModel {
     private var searchDebounceTask: Task<Void, Never>?
     private var loadGeneration = 0
     private var bulkSelectionGeneration = 0
+    private var meetingRowFileStates: [UUID: MeetingRowFileState] = [:]
     public let scope: TranscriptionLibraryScope
 
     public init(scope: TranscriptionLibraryScope = .all) {
@@ -168,11 +190,17 @@ public final class TranscriptionLibraryViewModel {
     }
 
     public var selectedMeetingAudioCount: Int {
-        selectedLoadedTranscriptions.filter(Self.hasRemovableMeetingAudio).count
+        selectedLoadedTranscriptions.filter { meetingRowFileState(for: $0).isAudioRemovable }.count
     }
 
     public var selectedLoadedTranscriptionsForExport: [Transcription] {
         selectedLoadedTranscriptions
+    }
+
+    /// Cached row state. This accessor is intentionally filesystem-free because
+    /// SwiftUI may evaluate it many times while rendering rows and menus.
+    public func meetingRowFileState(for transcription: Transcription) -> MeetingRowFileState {
+        meetingRowFileStates[transcription.id] ?? Self.conservativeMeetingRowFileState(for: transcription)
     }
 
     private func groupByDate(_ items: [Transcription]) -> [(group: TranscriptionDateGroup, items: [Transcription])] {
@@ -261,7 +289,7 @@ public final class TranscriptionLibraryViewModel {
             do {
                 try await retry(transcription)
                 do {
-                    try self.refreshLoadedTranscription(id: transcription.id)
+                    try await self.refreshLoadedTranscription(id: transcription.id)
                 } catch {
                     self.logger.error(
                         "Retried meeting transcription but failed to refresh Library: \(error.localizedDescription, privacy: .private)"
@@ -272,7 +300,7 @@ public final class TranscriptionLibraryViewModel {
                 self.logger.error(
                     "Failed to retry meeting transcription: \(error.localizedDescription, privacy: .private)")
                 self.errorMessage = "Failed to retry meeting transcription: \(error.localizedDescription)"
-                try? self.refreshLoadedTranscription(id: transcription.id)
+                try? await self.refreshLoadedTranscription(id: transcription.id)
             }
         }
     }
@@ -347,7 +375,7 @@ public final class TranscriptionLibraryViewModel {
         // videos/podcasts/local files as skipped meetings in the confirmation
         // copy, which is meeting-only by design.
         let meetings = selectedLoadedTranscriptions.filter { $0.sourceType == .meeting }
-        let targets = meetings.filter(Self.hasRemovableMeetingAudio)
+        let targets = meetings.filter { meetingRowFileState(for: $0).isAudioRemovable }
         guard !targets.isEmpty else {
             return
         }
@@ -480,6 +508,11 @@ public final class TranscriptionLibraryViewModel {
                     transcriptions[idx].meetingArtifactFolderPath
                     ?? MeetingArtifactStore.sessionFolderURL(for: transcription)?.standardizedFileURL.path
                 transcriptions[idx].filePath = nil
+                meetingRowFileStates[transcription.id] = MeetingRowFileState(
+                    audioState: .removed,
+                    isAudioRemovable: false,
+                    isArtifactFolderAvailable: true
+                )
                 publishLoadedItems(transcriptions, hasMore: hasMore)
             }
         } catch TranscriptionAssetCleanupError.meetingAudioFinalizationInProgress {
@@ -539,20 +572,28 @@ public final class TranscriptionLibraryViewModel {
         publishLoadedItems(page.items, hasMore: page.hasMore)
     }
 
-    private func refreshLoadedTranscription(id: UUID) throws {
+    private func refreshLoadedTranscription(id: UUID) async throws {
         guard let repo = transcriptionRepo else { return }
-        guard let index = transcriptions.firstIndex(where: { $0.id == id }) else { return }
+        guard transcriptions.contains(where: { $0.id == id }) else { return }
         // An in-flight load would later publish a snapshot fetched before this
         // refresh, resurrecting the row's pre-retry status. Invalidate it; the
         // generation bump makes any late publish a no-op.
         if loadTask != nil {
             cancelActiveLoad()
         }
-        guard let refreshed = try repo.fetch(id: id) else {
+        let refreshedResult: (Transcription, MeetingRowFileState)? = try await Task.detached(
+            priority: .userInitiated
+        ) {
+            guard let refreshed = try repo.fetch(id: id) else { return nil }
+            return (refreshed, Self.resolveMeetingRowFileState(for: refreshed))
+        }.value
+        guard let (refreshed, fileState) = refreshedResult else {
             removeLoadedTranscriptions(withIDs: [id])
             return
         }
+        guard let index = transcriptions.firstIndex(where: { $0.id == id }) else { return }
         transcriptions[index] = refreshed
+        meetingRowFileStates[id] = fileState
         publishLoadedItems(transcriptions, hasMore: hasMore)
     }
 
@@ -599,12 +640,15 @@ public final class TranscriptionLibraryViewModel {
 
         let task = Task { @MainActor [weak self, repo, query] in
             do {
-                let page = try await Task.detached(priority: .userInitiated) {
-                    try repo.fetchLibraryPage(query: query)
+                let (page, loadedFileStates) = try await Task.detached(priority: .userInitiated) {
+                    let page = try repo.fetchLibraryPage(query: query)
+                    return (page, Self.resolveMeetingRowFileStates(for: page.items))
                 }.value
                 guard let self, !Task.isCancelled, self.loadGeneration == generation else { return }
                 let items = append ? self.transcriptions + page.items : page.items
-                self.publishLoadedItems(items, hasMore: page.hasMore)
+                var fileStates = append ? self.meetingRowFileStates : [:]
+                fileStates.merge(loadedFileStates) { _, refreshed in refreshed }
+                self.publishLoadedItems(items, hasMore: page.hasMore, meetingRowFileStates: fileStates)
                 self.isLoading = false
             } catch {
                 guard let self, !Task.isCancelled, self.loadGeneration == generation else { return }
@@ -664,11 +708,20 @@ public final class TranscriptionLibraryViewModel {
         )
     }
 
-    private func publishLoadedItems(_ items: [Transcription], hasMore: Bool) {
+    private func publishLoadedItems(
+        _ items: [Transcription],
+        hasMore: Bool,
+        meetingRowFileStates refreshedFileStates: [UUID: MeetingRowFileState]? = nil
+    ) {
         transcriptions = items
         filteredTranscriptions = items
         groupedTranscriptions = groupByDate(items)
         self.hasMore = hasMore
+        if let refreshedFileStates {
+            meetingRowFileStates = refreshedFileStates
+        }
+        let loadedIDs = Set(items.map(\.id))
+        meetingRowFileStates = meetingRowFileStates.filter { loadedIDs.contains($0.key) }
         pruneSelectionToLoadedItems()
     }
 
@@ -678,10 +731,6 @@ public final class TranscriptionLibraryViewModel {
 
     private var selectedLoadedTranscriptions: [Transcription] {
         filteredTranscriptions.filter { selectedTranscriptionIDs.contains($0.id) }
-    }
-
-    nonisolated private static func hasRemovableMeetingAudio(_ transcription: Transcription) -> Bool {
-        MeetingAudioFile.isRemovable(for: transcription)
     }
 
     private func pruneSelectionToLoadedItems() {
@@ -700,8 +749,70 @@ public final class TranscriptionLibraryViewModel {
                 transcriptions[index].meetingArtifactFolderPath
                 ?? MeetingArtifactStore.sessionFolderURL(for: transcriptions[index])?.standardizedFileURL.path
             transcriptions[index].filePath = nil
+            meetingRowFileStates[transcriptions[index].id] = MeetingRowFileState(
+                audioState: .removed,
+                isAudioRemovable: false,
+                isArtifactFolderAvailable: true
+            )
         }
         publishLoadedItems(transcriptions, hasMore: hasMore)
+    }
+
+    nonisolated private static func resolveMeetingRowFileStates(
+        for transcriptions: [Transcription]
+    ) -> [UUID: MeetingRowFileState] {
+        var states: [UUID: MeetingRowFileState] = [:]
+        for transcription in transcriptions where transcription.sourceType == .meeting {
+            states[transcription.id] = resolveMeetingRowFileState(for: transcription)
+        }
+        return states
+    }
+
+    nonisolated private static func resolveMeetingRowFileState(
+        for transcription: Transcription,
+        fileManager: FileManager = .default
+    ) -> MeetingRowFileState {
+        let audioState = MeetingAudioFile.state(for: transcription, fileManager: fileManager)
+        let isAudioRemovable = MeetingAudioFile.isRemovable(
+            for: transcription,
+            state: audioState,
+            fileManager: fileManager
+        )
+
+        let isArtifactFolderAvailable: Bool
+        if let folderURL = MeetingArtifactStore.sessionFolderURL(for: transcription) {
+            var isDirectory: ObjCBool = false
+            isArtifactFolderAvailable =
+                fileManager.fileExists(
+                    atPath: folderURL.path,
+                    isDirectory: &isDirectory
+                ) && isDirectory.boolValue
+        } else {
+            isArtifactFolderAvailable = false
+        }
+
+        return MeetingRowFileState(
+            audioState: audioState,
+            isAudioRemovable: isAudioRemovable,
+            isArtifactFolderAvailable: isArtifactFolderAvailable
+        )
+    }
+
+    nonisolated private static func conservativeMeetingRowFileState(
+        for transcription: Transcription
+    ) -> MeetingRowFileState {
+        guard transcription.sourceType == .meeting else {
+            return MeetingRowFileState(
+                audioState: .notMeeting,
+                isAudioRemovable: false,
+                isArtifactFolderAvailable: false
+            )
+        }
+        return MeetingRowFileState(
+            audioState: transcription.filePath == nil ? .removed : .missing,
+            isAudioRemovable: false,
+            isArtifactFolderAvailable: false
+        )
     }
 
     private func setLoadedStatus(

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionLibraryViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionLibraryViewModelTests.swift
@@ -93,13 +93,12 @@ final class TranscriptionLibraryViewModelTests: XCTestCase {
 
     func testFilterAll() async throws {
         try repo.save(Transcription(fileName: "local.mp3", status: .completed))
-        try repo.save(
-            Transcription(
-                fileName: "youtube.mp3",
-                status: .completed,
-                sourceURL: "https://youtube.com/watch?v=abc",
-                sourceType: .youtube
-            ))
+        try repo.save(Transcription(
+            fileName: "youtube.mp3",
+            status: .completed,
+            sourceURL: "https://youtube.com/watch?v=abc",
+            sourceType: .youtube
+        ))
 
         vm.filter = .all
         await load()
@@ -108,13 +107,12 @@ final class TranscriptionLibraryViewModelTests: XCTestCase {
 
     func testFilterYouTube() async throws {
         try repo.save(Transcription(fileName: "local.mp3", status: .completed))
-        try repo.save(
-            Transcription(
-                fileName: "youtube.mp3",
-                status: .completed,
-                sourceURL: "https://youtube.com/watch?v=abc",
-                sourceType: .youtube
-            ))
+        try repo.save(Transcription(
+            fileName: "youtube.mp3",
+            status: .completed,
+            sourceURL: "https://youtube.com/watch?v=abc",
+            sourceType: .youtube
+        ))
 
         vm.filter = .youtube
         await load()
@@ -124,17 +122,13 @@ final class TranscriptionLibraryViewModelTests: XCTestCase {
 
     func testFilterPodcast() async throws {
         try repo.save(Transcription(fileName: "local.mp3", status: .completed, sourceType: .file))
-        try repo.save(
-            Transcription(
-                fileName: "youtube.mp3", status: .completed, sourceURL: "https://youtube.com/watch?v=abc",
-                sourceType: .youtube))
-        try repo.save(
-            Transcription(
-                fileName: "episode.mp3",
-                status: .completed,
-                sourceURL: "https://podcasts.apple.com/us/podcast/x/id1?i=2",
-                sourceType: .podcast
-            ))
+        try repo.save(Transcription(fileName: "youtube.mp3", status: .completed, sourceURL: "https://youtube.com/watch?v=abc", sourceType: .youtube))
+        try repo.save(Transcription(
+            fileName: "episode.mp3",
+            status: .completed,
+            sourceURL: "https://podcasts.apple.com/us/podcast/x/id1?i=2",
+            sourceType: .podcast
+        ))
 
         vm.filter = .podcast
         await load()
@@ -145,10 +139,7 @@ final class TranscriptionLibraryViewModelTests: XCTestCase {
     func testFilterLocal() async throws {
         try repo.save(Transcription(fileName: "local.mp3", status: .completed, sourceType: .file))
         try repo.save(Transcription(fileName: "meeting.mp3", status: .completed, sourceType: .meeting))
-        try repo.save(
-            Transcription(
-                fileName: "youtube.mp3", status: .completed, sourceURL: "https://youtube.com/watch?v=abc",
-                sourceType: .youtube))
+        try repo.save(Transcription(fileName: "youtube.mp3", status: .completed, sourceURL: "https://youtube.com/watch?v=abc", sourceType: .youtube))
 
         vm.filter = .local
         await load()
@@ -197,8 +188,7 @@ final class TranscriptionLibraryViewModelTests: XCTestCase {
         let meetingVM = TranscriptionLibraryViewModel(scope: .meetings)
         meetingVM.configure(transcriptionRepo: repo)
 
-        try repo.save(
-            Transcription(fileName: "fav meeting.mp3", status: .completed, isFavorite: true, sourceType: .meeting))
+        try repo.save(Transcription(fileName: "fav meeting.mp3", status: .completed, isFavorite: true, sourceType: .meeting))
         try repo.save(Transcription(fileName: "normal meeting.mp3", status: .completed, sourceType: .meeting))
         try repo.save(Transcription(fileName: "fav local.mp3", status: .completed, isFavorite: true, sourceType: .file))
 
@@ -237,13 +227,12 @@ final class TranscriptionLibraryViewModelTests: XCTestCase {
     }
 
     func testSearchByChannel() async throws {
-        try repo.save(
-            Transcription(
-                fileName: "Video",
-                status: .completed,
-                sourceURL: "https://youtube.com/watch?v=abc",
-                channelName: "TechChannel"
-            ))
+        try repo.save(Transcription(
+            fileName: "Video",
+            status: .completed,
+            sourceURL: "https://youtube.com/watch?v=abc",
+            channelName: "TechChannel"
+        ))
         try repo.save(Transcription(fileName: "Other", status: .completed))
 
         vm.searchText = "techchannel"
@@ -633,12 +622,9 @@ final class TranscriptionLibraryViewModelTests: XCTestCase {
 
     func testSelectLoadedVisibleTranscriptionsExcludesUnloadedRows() async throws {
         vm.pageSize = 2
-        try repo.save(
-            Transcription(createdAt: Date(timeIntervalSince1970: 3), fileName: "third.mp3", status: .completed))
-        try repo.save(
-            Transcription(createdAt: Date(timeIntervalSince1970: 2), fileName: "second.mp3", status: .completed))
-        try repo.save(
-            Transcription(createdAt: Date(timeIntervalSince1970: 1), fileName: "first.mp3", status: .completed))
+        try repo.save(Transcription(createdAt: Date(timeIntervalSince1970: 3), fileName: "third.mp3", status: .completed))
+        try repo.save(Transcription(createdAt: Date(timeIntervalSince1970: 2), fileName: "second.mp3", status: .completed))
+        try repo.save(Transcription(createdAt: Date(timeIntervalSince1970: 1), fileName: "first.mp3", status: .completed))
 
         await load()
 
@@ -670,8 +656,7 @@ final class TranscriptionLibraryViewModelTests: XCTestCase {
 
     func testSelectedLoadedTranscriptionsForExportFollowsVisibleOrder() async throws {
         let first = Transcription(createdAt: Date(timeIntervalSince1970: 2), fileName: "first.mp3", status: .completed)
-        let second = Transcription(
-            createdAt: Date(timeIntervalSince1970: 1), fileName: "second.mp3", status: .completed)
+        let second = Transcription(createdAt: Date(timeIntervalSince1970: 1), fileName: "second.mp3", status: .completed)
         try repo.save(second)
         try repo.save(first)
 

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionLibraryViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionLibraryViewModelTests.swift
@@ -53,16 +53,53 @@ final class TranscriptionLibraryViewModelTests: XCTestCase {
         XCTAssertEqual(Set(vm.filteredTranscriptions.map(\.fileName)), ["done.mp3", "cancelled.mp3", "failed.mp3"])
     }
 
+    func testMeetingRowFileStateIsCachedUntilLoadedStatusRefresh() async throws {
+        let folder = FileManager.default.temporaryDirectory
+            .appendingPathComponent("meeting-row-state-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+        let audioURL = folder.appendingPathComponent("meeting-playback.m4a")
+        XCTAssertTrue(FileManager.default.createFile(atPath: audioURL.path, contents: Data("audio".utf8)))
+        defer { try? FileManager.default.removeItem(at: folder) }
+
+        let meeting = Transcription(
+            fileName: "Meeting",
+            filePath: audioURL.path,
+            status: .processing,
+            sourceType: .meeting
+        )
+        try repo.save(meeting)
+        await load()
+
+        let loaded = try XCTUnwrap(vm.transcriptions.first)
+        let cached = vm.meetingRowFileState(for: loaded)
+        XCTAssertEqual(cached.audioState, .saved)
+        XCTAssertFalse(cached.isAudioRemovable)
+        XCTAssertTrue(cached.isArtifactFolderAvailable)
+
+        try FileManager.default.removeItem(at: audioURL)
+
+        // Rendering reads the snapshot rather than re-statting the filesystem.
+        XCTAssertEqual(vm.meetingRowFileState(for: loaded), cached)
+
+        try repo.updateStatus(id: meeting.id, status: .completed, errorMessage: nil)
+        await load()
+
+        let refreshed = try XCTUnwrap(vm.transcriptions.first)
+        XCTAssertEqual(vm.meetingRowFileState(for: refreshed).audioState, .missing)
+        XCTAssertFalse(vm.meetingRowFileState(for: refreshed).isAudioRemovable)
+    }
+
     // MARK: - Filter
 
     func testFilterAll() async throws {
         try repo.save(Transcription(fileName: "local.mp3", status: .completed))
-        try repo.save(Transcription(
-            fileName: "youtube.mp3",
-            status: .completed,
-            sourceURL: "https://youtube.com/watch?v=abc",
-            sourceType: .youtube
-        ))
+        try repo.save(
+            Transcription(
+                fileName: "youtube.mp3",
+                status: .completed,
+                sourceURL: "https://youtube.com/watch?v=abc",
+                sourceType: .youtube
+            ))
 
         vm.filter = .all
         await load()
@@ -71,12 +108,13 @@ final class TranscriptionLibraryViewModelTests: XCTestCase {
 
     func testFilterYouTube() async throws {
         try repo.save(Transcription(fileName: "local.mp3", status: .completed))
-        try repo.save(Transcription(
-            fileName: "youtube.mp3",
-            status: .completed,
-            sourceURL: "https://youtube.com/watch?v=abc",
-            sourceType: .youtube
-        ))
+        try repo.save(
+            Transcription(
+                fileName: "youtube.mp3",
+                status: .completed,
+                sourceURL: "https://youtube.com/watch?v=abc",
+                sourceType: .youtube
+            ))
 
         vm.filter = .youtube
         await load()
@@ -86,13 +124,17 @@ final class TranscriptionLibraryViewModelTests: XCTestCase {
 
     func testFilterPodcast() async throws {
         try repo.save(Transcription(fileName: "local.mp3", status: .completed, sourceType: .file))
-        try repo.save(Transcription(fileName: "youtube.mp3", status: .completed, sourceURL: "https://youtube.com/watch?v=abc", sourceType: .youtube))
-        try repo.save(Transcription(
-            fileName: "episode.mp3",
-            status: .completed,
-            sourceURL: "https://podcasts.apple.com/us/podcast/x/id1?i=2",
-            sourceType: .podcast
-        ))
+        try repo.save(
+            Transcription(
+                fileName: "youtube.mp3", status: .completed, sourceURL: "https://youtube.com/watch?v=abc",
+                sourceType: .youtube))
+        try repo.save(
+            Transcription(
+                fileName: "episode.mp3",
+                status: .completed,
+                sourceURL: "https://podcasts.apple.com/us/podcast/x/id1?i=2",
+                sourceType: .podcast
+            ))
 
         vm.filter = .podcast
         await load()
@@ -103,7 +145,10 @@ final class TranscriptionLibraryViewModelTests: XCTestCase {
     func testFilterLocal() async throws {
         try repo.save(Transcription(fileName: "local.mp3", status: .completed, sourceType: .file))
         try repo.save(Transcription(fileName: "meeting.mp3", status: .completed, sourceType: .meeting))
-        try repo.save(Transcription(fileName: "youtube.mp3", status: .completed, sourceURL: "https://youtube.com/watch?v=abc", sourceType: .youtube))
+        try repo.save(
+            Transcription(
+                fileName: "youtube.mp3", status: .completed, sourceURL: "https://youtube.com/watch?v=abc",
+                sourceType: .youtube))
 
         vm.filter = .local
         await load()
@@ -152,7 +197,8 @@ final class TranscriptionLibraryViewModelTests: XCTestCase {
         let meetingVM = TranscriptionLibraryViewModel(scope: .meetings)
         meetingVM.configure(transcriptionRepo: repo)
 
-        try repo.save(Transcription(fileName: "fav meeting.mp3", status: .completed, isFavorite: true, sourceType: .meeting))
+        try repo.save(
+            Transcription(fileName: "fav meeting.mp3", status: .completed, isFavorite: true, sourceType: .meeting))
         try repo.save(Transcription(fileName: "normal meeting.mp3", status: .completed, sourceType: .meeting))
         try repo.save(Transcription(fileName: "fav local.mp3", status: .completed, isFavorite: true, sourceType: .file))
 
@@ -191,12 +237,13 @@ final class TranscriptionLibraryViewModelTests: XCTestCase {
     }
 
     func testSearchByChannel() async throws {
-        try repo.save(Transcription(
-            fileName: "Video",
-            status: .completed,
-            sourceURL: "https://youtube.com/watch?v=abc",
-            channelName: "TechChannel"
-        ))
+        try repo.save(
+            Transcription(
+                fileName: "Video",
+                status: .completed,
+                sourceURL: "https://youtube.com/watch?v=abc",
+                channelName: "TechChannel"
+            ))
         try repo.save(Transcription(fileName: "Other", status: .completed))
 
         vm.searchText = "techchannel"
@@ -586,9 +633,12 @@ final class TranscriptionLibraryViewModelTests: XCTestCase {
 
     func testSelectLoadedVisibleTranscriptionsExcludesUnloadedRows() async throws {
         vm.pageSize = 2
-        try repo.save(Transcription(createdAt: Date(timeIntervalSince1970: 3), fileName: "third.mp3", status: .completed))
-        try repo.save(Transcription(createdAt: Date(timeIntervalSince1970: 2), fileName: "second.mp3", status: .completed))
-        try repo.save(Transcription(createdAt: Date(timeIntervalSince1970: 1), fileName: "first.mp3", status: .completed))
+        try repo.save(
+            Transcription(createdAt: Date(timeIntervalSince1970: 3), fileName: "third.mp3", status: .completed))
+        try repo.save(
+            Transcription(createdAt: Date(timeIntervalSince1970: 2), fileName: "second.mp3", status: .completed))
+        try repo.save(
+            Transcription(createdAt: Date(timeIntervalSince1970: 1), fileName: "first.mp3", status: .completed))
 
         await load()
 
@@ -620,7 +670,8 @@ final class TranscriptionLibraryViewModelTests: XCTestCase {
 
     func testSelectedLoadedTranscriptionsForExportFollowsVisibleOrder() async throws {
         let first = Transcription(createdAt: Date(timeIntervalSince1970: 2), fileName: "first.mp3", status: .completed)
-        let second = Transcription(createdAt: Date(timeIntervalSince1970: 1), fileName: "second.mp3", status: .completed)
+        let second = Transcription(
+            createdAt: Date(timeIntervalSince1970: 1), fileName: "second.mp3", status: .completed)
         try repo.save(second)
         try repo.save(first)
 
@@ -723,6 +774,10 @@ final class TranscriptionLibraryViewModelTests: XCTestCase {
         XCTAssertEqual(vm.transcriptions.first?.id, t.id)
         XCTAssertNil(vm.transcriptions.first?.filePath)
         XCTAssertEqual(vm.transcriptions.first?.meetingArtifactFolderPath, folder.standardizedFileURL.path)
+        let rowState = vm.meetingRowFileState(for: try XCTUnwrap(vm.transcriptions.first))
+        XCTAssertEqual(rowState.audioState, .removed)
+        XCTAssertFalse(rowState.isAudioRemovable)
+        XCTAssertTrue(rowState.isArtifactFolderAvailable)
         XCTAssertTrue(FileManager.default.fileExists(atPath: folder.path))
         XCTAssertFalse(FileManager.default.fileExists(atPath: audioURL.path))
         XCTAssertFalse(FileManager.default.fileExists(atPath: microphoneURL.path))


### PR DESCRIPTION
## Summary

Meetings rows regressed in v0.7.x because SwiftUI body and eager menu evaluation repeatedly statted meeting audio/finalization files while inline spinner animations invalidated the same deep view and accessibility tree. This moves meeting row filesystem state off the render path and stops inline spinners from scheduling repeat-forever animation, restoring responsive list and export interactions without changing Core finalization semantics or the Meetings UI.

## Design

- Resolve audio availability, finalization-lock removability, and artifact-folder availability off the main actor alongside each Library page load.
- Publish one cached `MeetingRowFileState` per meeting and pass it into row cards, thumbnails, and menu builders as plain values.
- Refresh cached state on persisted row reloads and both single/bulk audio-removal actions; no polling timers were added.
- Keep the Merkaba visual identity, but render the `.inline` preset statically. Card and hero presets retain motion, and the spinner now exposes a plain static `Loading` accessibility label without `.updatesFrequently`.

Before this change, each row body/menu evaluation could perform audio, lock-file, and artifact-folder stats; animation caused those evaluations continuously. After this change, filesystem work occurs once per row load/status refresh off-main, while row rendering is value-only and inline spinners do not start repeat-forever animations.

## Risk surface

The main risk is stale cached file state. Focused coverage proves repeated reads do not re-stat, persisted status reloads refresh the snapshot, and audio removal immediately updates the loaded row. Core audio/finalization, retention, cleanup, and lock-file behavior are deliberately unchanged. Transcript-detail action-bar menus are outside this Meetings-list fix.

## Test evidence

Passed locally:

- `swift build`
- `swift test --filter MeetingAudioFileTests` — 26 tests
- `swift test --filter TranscriptionLibraryViewModelTests` — 44 tests
- `swift test --filter MeetingDeletionCopyTests` — 12 tests
- `swift test` — 4,797 XCTest cases, 16 skipped, 0 failures; 17 Swift Testing cases, 0 failures
- `git diff --check`

Both GitHub `swift-test` checks pass. One duplicate CI attempt initially missed `MeetingRecordingTileTests/testAudioSavedConfirmationAutoClears` under parallel load; that unrelated timing test passed immediately in isolation locally and the failed CI job passed on rerun. Gemini Code Assist reported no findings.

## Author notes

The supplied spindump attributes 629/1001 samples to the SwiftUI layout/accessibility update path and includes `MeetingRowCard.body` plus `MeetingAudioFile.isFinalizationInProgress`. The code path now proves inline spinners pass `animate: false`, so `SpinnerRingView.onAppear` resets static state instead of entering `startAnimation()` and its repeat-forever animations. This has not been re-profiled with Instruments on the reporter workload. Local Greptile CLI and `no-mistakes` were unavailable in this environment; CodeRabbit skipped review because the PR is intentionally draft.

Fixes #787
Fixes #788