### PR TITLE
Release readiness: fix Meetings panel and advance CLI to 3.0

### DIFF
--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -89,6 +89,8 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
 
 ## [Unreleased]
 
+## [3.0.0] — 2026-07-14
+
 ### Changed
 
 - Inline Anthropic and OpenRouter LLM commands now default to Claude Sonnet 5.
@@ -97,14 +99,15 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
 
 - **Breaking:** removed the `prefer-built-in-mic-bluetooth-output` configuration
   key because capture no longer rewrites microphone routing based on the audio
-  output device. Existing stored values are ignored. Per the CLI compatibility
-  policy, this change must ship in the next major CLI release.
+  output device. Existing stored values are ignored. This breaking removal is
+  the reason for the 3.0.0 major release.
 
 ### Fixed
 
-- Native Anthropic LLM calls no longer send the deprecated `temperature`
-  parameter, preventing HTTP 400 responses from newer Claude models. The
-  `--model` help example now references Claude Sonnet 5.
+- Native Anthropic LLM calls omit `temperature` for newer and unknown Claude
+  models, preventing HTTP 400 responses from models that reject non-default
+  sampling parameters. Known compatible legacy models retain the caller's
+  temperature. The `--model` help example now references Claude Sonnet 5.
 - Cohere Transcribe CLI paths now enforce the same 16 GB memory floor recorded
   in the speech-engine capability registry. `config set speech-engine cohere`,
   `models download cohere-transcribe`, `models select cohere-transcribe`, and

--- a/Sources/CLI/MacParakeetCLI.swift
+++ b/Sources/CLI/MacParakeetCLI.swift
@@ -8,7 +8,7 @@ struct CLI: AsyncParsableCommand {
     /// distinguishable from synthesized Bundle.main values (the bare executable
     /// has no Info.plist and macOS otherwise reports an SDK marker like "16.0").
     /// Bump in lockstep with `Sources/CLI/CHANGELOG.md`.
-    static let cliVersion = "2.14.0"
+    static let cliVersion = "3.0.0"
 
     static let configuration = CommandConfiguration(
         commandName: "macparakeet-cli",

--- a/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
@@ -929,6 +929,7 @@ final class MeetingRecordingFlowCoordinator {
             pendingTitle = nil
             pendingCalendarEventSnapshot = nil
             pendingAudioSourceMode = nil
+            pendingLivePanelPresentation = false
             pendingStartContext = nil
             actionTask?.cancel()
             actionTask = Task { @MainActor in

--- a/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
@@ -658,6 +658,7 @@ final class MeetingRecordingFlowCoordinator {
             pendingTitle = nil
             pendingCalendarEventSnapshot = nil
             pendingAudioSourceMode = nil
+            pendingLivePanelPresentation = false
             pendingStartContext = nil
             let operationContext = currentMeetingOperationContext ?? ObservabilityOperationContext()
             currentMeetingOperationContext = operationContext
@@ -1638,6 +1639,7 @@ extension MeetingRecordingFlowCoordinator {
         pendingTitle = nil
         pendingCalendarEventSnapshot = nil
         pendingAudioSourceMode = nil
+        pendingLivePanelPresentation = false
         pendingStartContext = nil
         _ = stateMachine.handle(.startRequested)
         _ = stateMachine.handle(.permissionsGranted(generation: stateMachine.generation))

--- a/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
@@ -131,6 +131,7 @@ final class MeetingRecordingFlowCoordinator {
     private var currentMeetingOperationContext: ObservabilityOperationContext?
     private var currentMeetingTrigger: TelemetryMeetingOperationTrigger?
     private var pendingAudioSourceMode: MeetingAudioSourceMode?
+    private var pendingLivePanelPresentation = false
 
     init(
         meetingRecordingService: MeetingRecordingServiceProtocol,
@@ -276,11 +277,13 @@ final class MeetingRecordingFlowCoordinator {
     @discardableResult
     func startRecording(
         title: String? = nil,
-        trigger: TelemetryMeetingRecordingTrigger = .manual
+        trigger: TelemetryMeetingRecordingTrigger = .manual,
+        presentLivePanelWhenReady: Bool = false
     ) -> Int? {
         guard stateMachine.state == .idle else { return nil }
         let resolvedTrigger = pendingTrigger ?? trigger
         let sourceMode = meetingAudioSourceModeProvider()
+        pendingLivePanelPresentation = presentLivePanelWhenReady
         pendingTrigger = resolvedTrigger
         pendingTitle = title
         pendingAudioSourceMode = sourceMode
@@ -400,6 +403,7 @@ final class MeetingRecordingFlowCoordinator {
         pendingCalendarEventSnapshot = calendarEventSnapshot
         let sourceMode = meetingAudioSourceModeProvider()
         pendingAudioSourceMode = sourceMode
+        pendingLivePanelPresentation = false
         pendingStartContext = makeStartContext(trigger: .calendarAutoStart, sourceMode: sourceMode)
         currentMeetingOperationContext = ObservabilityOperationContext()
         sendEvent(.startRequested)
@@ -416,6 +420,7 @@ final class MeetingRecordingFlowCoordinator {
         pendingTitle = title
         let sourceMode = meetingAudioSourceModeProvider()
         pendingAudioSourceMode = sourceMode
+        pendingLivePanelPresentation = false
         pendingStartContext = makeStartContext(trigger: .calendarAutoStart, sourceMode: sourceMode)
         pendingCalendarEventSnapshot = nil
         currentMeetingOperationContext = ObservabilityOperationContext()
@@ -442,6 +447,7 @@ final class MeetingRecordingFlowCoordinator {
         pendingTitle = nil
         pendingCalendarEventSnapshot = nil
         pendingAudioSourceMode = nil
+        pendingLivePanelPresentation = false
         pendingStartContext = nil
         currentMeetingOperationContext = nil
         currentMeetingTrigger = nil
@@ -627,6 +633,10 @@ final class MeetingRecordingFlowCoordinator {
                     self?.hideMeetingPanel()
                 }
                 panelController = controller
+            }
+            if pendingLivePanelPresentation {
+                pendingLivePanelPresentation = false
+                showMeetingPanel()
             }
             refreshFloatingPillVisibility()
             startPillPolling()
@@ -1085,6 +1095,7 @@ final class MeetingRecordingFlowCoordinator {
         panelController?.close()
         panelController = nil
         panelViewModel = nil
+        pendingLivePanelPresentation = false
     }
 
     private func confirmAndCancelRecording() {
@@ -1671,5 +1682,9 @@ extension MeetingRecordingFlowCoordinator {
 
     var testHook_isFloatingPillVisible: Bool {
         pillController?.isVisible == true
+    }
+
+    var testHook_isMeetingPanelVisible: Bool {
+        panelController?.isVisible == true
     }
 }

--- a/Sources/MacParakeet/AppDelegate.swift
+++ b/Sources/MacParakeet/AppDelegate.swift
@@ -842,7 +842,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
 
-        meetingRecordingFlowCoordinator?.startRecording(trigger: .manual)
+        meetingRecordingFlowCoordinator?.startRecording(
+            trigger: .manual,
+            presentLivePanelWhenReady: true
+        )
     }
 
     private func presentActiveMeetingQuitAlert() -> NSApplication.TerminateReply {

--- a/Tests/MacParakeetTests/MeetingRecordingFlow/MeetingRecordingFlowCoordinatorTests.swift
+++ b/Tests/MacParakeetTests/MeetingRecordingFlow/MeetingRecordingFlowCoordinatorTests.swift
@@ -789,6 +789,18 @@ final class MeetingRecordingFlowCoordinatorTests: XCTestCase {
         XCTAssertTrue(coordinator.isMeetingRecordingActive)
         XCTAssertTrue(coordinator.testHook_hasFloatingPillController)
         XCTAssertFalse(coordinator.testHook_isFloatingPillVisible)
+        XCTAssertFalse(coordinator.testHook_isMeetingPanelVisible)
+    }
+
+    func testStartRecordingCanPresentLivePanelWhenReady() async throws {
+        let recordingService = MeetingRecordingServiceSpy(output: makeRecordingOutput())
+        let coordinator = makeQuitTeardownCoordinator(recordingService: recordingService)
+
+        XCTAssertNotNil(coordinator.startRecording(presentLivePanelWhenReady: true))
+        try await waitForStartCall(on: recordingService, coordinator: coordinator)
+
+        XCTAssertEqual(coordinator.testHook_state, .recording)
+        XCTAssertTrue(coordinator.testHook_isMeetingPanelVisible)
     }
 
     func testRefreshingFloatingPillVisibilityDoesNotDisturbRecordingFlow() async throws {

--- a/docs/audits/2026-07-14-post-0.7.2-release-readiness.md
+++ b/docs/audits/2026-07-14-post-0.7.2-release-readiness.md
@@ -1,0 +1,137 @@
+# Post-0.7.2 Release Readiness Audit — 2026-07-14
+
+## Verdict
+
+The post-0.7.2 code line is a credible release candidate after two concrete
+blockers found in this audit are landed:
+
+1. Starting a meeting from the Meetings workspace did not present the live
+   notes/chat/transcript panel after its asynchronous permission setup
+   ([#792](https://github.com/moona3k/macparakeet/issues/792)).
+2. The bundled CLI had removed a stable configuration key but still reported
+   version `2.14.0`, contrary to the CLI's published semver contract. The next
+   release must identify that surface as CLI `3.0.0`.
+
+This audit branch fixes both issues and corrects two documentation drifts. Do
+not publish a new app release until the branch is merged, exact merged-`main`
+CI is green, and the short signed-app/manual matrix below is complete.
+
+## Scope And Baseline
+
+- Stable baseline: app `v0.7.2`, tag `afc2eff9dd0c388f6833f801dad139a8b09bfc0a`.
+- Audited development head: `d1f611812064da2c4c8058fab77a93f7cd07e399`.
+- Range: 35 commits, 82 files, +3,945/-979 relative to `v0.7.2`.
+- The audit ran from a clean detached `origin/main` worktree. The caller's
+  existing dirty worktree was not modified.
+- Exact-head CI run
+  [29369638072](https://github.com/moona3k/macparakeet/actions/runs/29369638072)
+  was green before audit fixes: release build, CLI contract smoke, release
+  bundle smoke, strict concurrency, Swift 6, and the full test suite.
+- All GitHub review threads on the five merged PRs were resolved: 28 resolved,
+  0 unresolved.
+
+## Recently Merged PR Review
+
+| PR | Review | Verdict |
+|---|---|---|
+| [#801](https://github.com/moona3k/macparakeet/pull/801) — restore implicit System Default microphone routing | Restores the safe `named -> implicit System Default -> distinct built-in fallback` chain and removes the output-device-driven input rewrite implicated by #796. Input routing no longer changes because a Bluetooth output is active. The removal of `prefer-built-in-mic-bluetooth-output` is correctly called breaking, but the CLI version was not advanced. | Audio fix is sound. Release-blocking CLI version omission fixed by this audit. Reporter confirmation on #796 remains desirable, not a code gate. |
+| [#783](https://github.com/moona3k/macparakeet/pull/783) — separate dictation and transcription engines | Keeps one shared scheduler/runtime while separating workflow preferences. File/URL work snapshots its route at operation entry; meeting sessions pin their route into recovery schema v2. Focused tests cover scheduler arbitration, settings independence, recovery compatibility, and retranscription. | Merge-ready architecture and behavior. Corrected one stale contract sentence that still called the current lock schema v1. |
+| [#775](https://github.com/moona3k/macparakeet/pull/775) — in-app CLI installer | Uses a narrow actor-owned symlink installer, refuses non-symlink conflicts, requires confirmation for stale links, and rejects App Translocation. The app bundle remains the source of truth for the installed command. | Code-ready. A signed app in `/Applications` still needs one manual install/upgrade/conflict pass. |
+| [#795](https://github.com/moona3k/macparakeet/pull/795) — Anthropic sampling compatibility and model refresh | Uses a conservative legacy allow-list for `temperature`; newer and unknown Claude IDs omit it. Current IDs and sampling constraints were checked against Anthropic's [model IDs](https://platform.claude.com/docs/en/about-claude/models/model-ids-and-versions), [Sonnet 5 notes](https://platform.claude.com/docs/en/about-claude/models/whats-new-sonnet-5), and [deprecation policy](https://platform.claude.com/docs/en/about-claude/models/model-deprecations); [OpenRouter's Anthropic catalog](https://openrouter.ai/anthropic) also exposes the selected model. | Code-ready. Corrected changelog wording that had inaccurately implied all Anthropic requests omit `temperature`. |
+| [#785](https://github.com/moona3k/macparakeet/pull/785) — dictation cold-start clipping | Prepares the real input route while stopped, invalidates stale preparations on configuration changes, preserves single-engine subscriber arbitration, and keeps the Bluetooth idle-warm suppression separate. Deterministic and real-microphone tests cover cold start, prepared start, VPIO transitions, concurrent subscribers, and repeated cycles. | Code-ready on the tested host. Route-change/USB/Bluetooth/sleep-wake signed-app QA remains a release-operation gate. |
+
+The two direct post-tag commits only add the screenshots attached to #796;
+they do not alter runtime behavior.
+
+## Findings Fixed By This Audit
+
+### Meetings workspace start did not open the live panel
+
+`AppDelegate.startMeetingRecordingFromWorkspace()` started the coordinator but
+did not preserve an intent to open the live panel. An immediate presentation
+attempt would also have been racy because the panel controller is only created
+after asynchronous permission checks.
+
+The fix carries a one-start `presentLivePanelWhenReady` intent into the
+coordinator and consumes it immediately after panel creation. Default,
+hotkey, and calendar starts retain the compact floating-pill behavior. A
+regression test asserts both the requested visible-panel path and the unchanged
+default-hidden path.
+
+### Breaking CLI surface reported the old version
+
+`prefer-built-in-mic-bluetooth-output` was a public `config` key and is absent
+from both command handling and `spec --json` on current `main`. The app bundle
+always includes that CLI, so shipping another app without a CLI major bump
+would distribute a breaking binary that still claimed `2.14.0`.
+
+The audit promotes the pending CLI changes to `3.0.0`, updates
+`CLI.cliVersion`, and clarifies in the contract that removing stable catalog
+entries requires a CLI major even when the `macparakeet.cli.spec` envelope can
+remain schema v1.
+
+## Live Issue Triage
+
+- [#792](https://github.com/moona3k/macparakeet/issues/792): confirmed release
+  blocker; fixed and regression-tested by this audit.
+- [#796](https://github.com/moona3k/macparakeet/issues/796): v0.7.2 M5 Pro
+  input failure with a successful 0.6.24 downgrade. #801 directly removes the
+  intervening route policy implicated by logs and restores the successful
+  implicit-default fallback. Keep open until the reporter verifies a build.
+- [#798](https://github.com/moona3k/macparakeet/issues/798): intermittent
+  second-dictation failure on v0.7.1 with Instant Dictation enabled. No logs or
+  reproduction are attached. Current real-hardware cold/cycle/VPIO tests pass,
+  and #785 changes the affected start path. Treat as a field-verification item,
+  not a proven current-main blocker; request diagnostics if it reproduces.
+- [#786](https://github.com/moona3k/macparakeet/issues/786): mixed-language
+  Parakeet output. This is a model/language-control limitation rather than a
+  post-0.7.2 code regression; it should remain a product follow-up.
+
+## Open PR Merge Readiness
+
+Neither currently open PR is merge-ready or part of this release candidate:
+
+- [#537](https://github.com/moona3k/macparakeet/pull/537) is `DIRTY`, based on
+  June 15 state, and needs a rebase plus a fresh architecture/quality review.
+- [#363](https://github.com/moona3k/macparakeet/pull/363) is `DIRTY`, based on
+  May 26 state, and needs a product-scope decision, rebase, and fresh review.
+
+They should not be merged opportunistically into the release branch.
+
+## Verification
+
+- `git diff --check`: pass.
+- 104 contract/coordinator tests: pass.
+- Every test class changed by PRs #801, #783, #775, #795, and #785: 1,043
+  tests passed, 0 failed.
+- Real microphone suite: 10 active tests passed, 0 failed, with the three
+  explicitly gated cases skipped. The three-minute idle case was then run
+  separately and passed in 180.651 seconds. Default-input mutation and the
+  50-cycle stress case remain physical release-matrix operations.
+- Full `swift test`: 4,854 XCTest tests passed, 20 explicitly skipped, 0
+  failed; all 17 Swift Testing checks also passed.
+- CI-style SwiftPM release bundle (helper downloads disabled and the CI FFmpeg
+  placeholder supplied): pass, including Sparkle trust-anchor and dSYM checks.
+- Rebuilt bundle with the portable FFmpeg from the installed release: pass.
+  Its embedded CLI reported `3.0.0`; `spec --json` parsed as
+  `macparakeet.cli.spec` schema v1 with 89 commands.
+- End-to-end release demo smoke against that real-FFmpeg bundle: pass for
+  synthesized audio conversion, Parakeet Unified transcription, isolated
+  database persistence, and Markdown export. A deliberate run against the CI
+  `/usr/bin/true` FFmpeg placeholder failed conversion as expected; the same
+  optimized CLI passed standalone, proving that result was fixture packaging,
+  not a product regression.
+- Exact merged-`main` CI: pending merge.
+
+## Remaining Release Operations
+
+1. Merge the audit fixes and require exact merged-`main` CI to pass.
+2. Build the signed release candidate and test CLI install, stale-link upgrade,
+   and non-symlink conflict from `/Applications`.
+3. Run the short physical audio matrix: Instant Dictation on/off, five cycles,
+   route change, USB mic, Bluetooth default input, explicit built-in input with
+   Bluetooth output, and sleep/wake.
+4. Ask #796 and #798 reporters to verify the candidate when practical.
+5. If the standalone Homebrew CLI is published, release `cli-v3.0.0`, update
+   the tap formula/checksum, and verify a fresh Homebrew install separately
+   from the app/Sparkle release.

--- a/spec/contracts/cli-json-v1.md
+++ b/spec/contracts/cli-json-v1.md
@@ -147,9 +147,12 @@ misuse.
 ## Versioning And Compatibility
 
 The current CLI spec schema is `macparakeet.cli.spec` v1. Additive catalog
-fields are v1-compatible. Removing or renaming failure-envelope fields,
-changing exit-code meanings, or moving JSON-mode status text to stdout is a
-breaking contract change and requires explicit version/changelog treatment.
+fields are v1-compatible. Removing a stable catalog entry such as a command,
+option, or configuration key is a breaking CLI-surface change and requires a
+new CLI major even when the catalog envelope stays schema v1. Removing or
+renaming failure-envelope fields, changing exit-code meanings, or moving
+JSON-mode status text to stdout is also breaking and requires explicit
+version/changelog treatment.
 
 ## Tests that enforce this
 

--- a/spec/contracts/meeting-recovery-retention.md
+++ b/spec/contracts/meeting-recovery-retention.md
@@ -135,10 +135,11 @@ not final-transcription completion:
 
 ## Versioning And Compatibility
 
-Lock schema v1 accepts older/equal versions and rejects newer versions as
-opaque. Additive optional fields can stay v1 when older readers either ignore
-them or decode with defaults. Required structural changes need a schema bump and
-must preserve the file-presence retention barrier.
+Lock schema v2 accepts supported older/equal versions and rejects newer
+versions as opaque. Additive optional fields can stay at the current schema
+version when older readers either ignore them or decode with defaults. Required
+structural changes need a schema bump and must preserve the file-presence
+retention barrier.
 
 ## Tests that enforce this
 


### PR DESCRIPTION
## Summary

- fix #792 by carrying the Meetings-workspace presentation intent through asynchronous permission setup and showing the live notes/transcript/chat panel once its controller exists
- preserve compact-pill behavior for hotkey, calendar, and ordinary recording starts
- advance the bundled CLI to 3.0.0 because #801 removed the stable `prefer-built-in-mic-bluetooth-output` config key
- clarify CLI semver and meeting-recovery schema contracts
- add a durable post-v0.7.2 review covering merged PRs #801, #783, #775, #795, and #785; live issues; open-PR readiness; and remaining ship operations

Closes #792.

## Review verdict

All five post-v0.7.2 PRs are code-ready after these fixes. All 28 review threads are resolved. Open PRs #537 and #363 remain dirty/stale and are explicitly excluded from this release candidate.

The detailed review is in [docs/audits/2026-07-14-post-0.7.2-release-readiness.md](https://github.com/moona3k/macparakeet/blob/codex/release-readiness-20260714/docs/audits/2026-07-14-post-0.7.2-release-readiness.md).

## Verification

- 104 coordinator/contract tests passed
- 1,043 tests across every class touched by the five merged PRs passed
- real-microphone suite: 10 active tests passed; separately gated three-minute idle test passed in 180.651s
- full suite: 4,854 XCTest tests passed, 20 explicitly skipped, 0 failed; all 17 Swift Testing checks passed
- SwiftPM release bundle passed Sparkle trust-anchor and dSYM checks
- embedded CLI reports 3.0.0 and emits valid `macparakeet.cli.spec` schema v1 (89 commands)
- bundled synthesized-audio -> Parakeet Unified -> isolated SQLite -> Markdown export smoke passed with the portable release FFmpeg
- `git diff --check` passed

## Remaining release operations

After merge, require CI on the exact merged `main` SHA. Before publishing, run the signed `/Applications` CLI installer upgrade/conflict checks and the short physical audio matrix (Instant Dictation, repeated starts, route change, USB, Bluetooth, explicit built-in input, sleep/wake). Reporter verification for #796 and #798 remains desirable.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Meetings workspace Start so the live notes/transcript/chat panel opens after permissions complete. Also bumps the bundled `macparakeet-cli` to 3.0.0 after a breaking config key removal.

- **Bug Fixes**
  - Meetings workspace Start now opens the live panel once its controller exists; hotkey, calendar, and regular starts keep the compact pill. Closes #792.
  - Adds a one-start `presentLivePanelWhenReady` flag in the coordinator, cleared on reset/teardown and all cancellation paths; includes a new test and a visibility test hook.

- **Dependencies**
  - Advance embedded `macparakeet-cli` to `3.0.0` due to removal of `prefer-built-in-mic-bluetooth-output`; update `CHANGELOG.md` and `cliVersion`.
  - Clarify `macparakeet.cli.spec` semver (removing stable catalog entries requires a CLI major) and correct meeting-recovery lock schema to v2; add a post-0.7.2 release readiness audit.

<sup>Written for commit d5b982cb9e66fc164a0743bdae15e68d8948a7c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/802?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The Meetings workspace can now present the live meeting panel automatically once recording is ready.
* **Bug Fixes**
  * Improved compatibility with newer Claude models by omitting `temperature` for native Anthropic requests when required.
* **CLI**
  * Bumped the bundled CLI major version to **3.0.0** and refreshed changelog/versioning for breaking-change framing.
* **Documentation**
  * Updated CLI JSON contract guidance and meeting-recovery lock schema compatibility (Lock schema v2).
  * Added a post-release readiness audit document.
* **Tests**
  * Extended coordinator tests to verify live panel visibility and the new “present when ready” behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->