### PR TITLE
fix(audio): prevent meeting-stop callback stack overflow

### DIFF
--- a/Sources/MacParakeetCore/Audio/MicrophoneEnginePlatform.swift
+++ b/Sources/MacParakeetCore/Audio/MicrophoneEnginePlatform.swift
@@ -63,28 +63,54 @@ public extension MicrophoneEnginePlatform {
 
 /// The tap is installed during idle preparation, but the callback requested by
 /// the eventual capture may be a newer closure. Keep that callback replaceable
-/// without reinstalling the tap; copy it under the lock and invoke it after the
-/// lock is released on the audio render thread.
-private final class MutableMicrophoneTapHandler: @unchecked Sendable {
+/// without reinstalling the tap; snapshot its target under the lock and invoke
+/// it after the lock is released on the audio render thread.
+final class MutableMicrophoneTapHandler: @unchecked Sendable {
     typealias Handler = @Sendable (AVAudioPCMBuffer, AVAudioTime) -> Void
 
-    private let handler: OSAllocatedUnfairLock<Handler?>
+    /// Keep the function behind a stable reference. Repeatedly copying a
+    /// function stored directly as `OSAllocatedUnfairLock` state can build a
+    /// deep chain of Swift reabstraction thunks; destroying that function on
+    /// stop then recursively releases the chain and can overflow the stack.
+    private final class Target: Sendable {
+        let handler: Handler
+
+        init(_ handler: @escaping Handler) {
+            self.handler = handler
+        }
+    }
+
+    private let target: OSAllocatedUnfairLock<Target?>
 
     init(_ handler: @escaping Handler) {
-        self.handler = OSAllocatedUnfairLock(initialState: handler)
+        self.target = OSAllocatedUnfairLock(initialState: Target(handler))
     }
 
     func replace(with handler: @escaping Handler) {
-        self.handler.withLock { $0 = handler }
+        let replacement = Target(handler)
+        let previous = target.withLock { current in
+            let previous = current
+            current = replacement
+            return previous
+        }
+        // Destroy the old function after leaving the lock's critical section.
+        withExtendedLifetime(previous) {}
     }
 
     func invoke(buffer: AVAudioPCMBuffer, time: AVAudioTime) {
-        let current = handler.withLock { $0 }
-        current?(buffer, time)
+        let current = target.withLock { $0 }
+        current?.handler(buffer, time)
     }
 
     func clear() {
-        handler.withLock { $0 = nil }
+        let previous = target.withLock { current in
+            let previous = current
+            current = nil
+            return previous
+        }
+        // An in-flight invocation retains its own Target. Future invocations
+        // see nil, while the detached function is destroyed outside the lock.
+        withExtendedLifetime(previous) {}
     }
 }
 

--- a/Tests/MacParakeetTests/Audio/MutableMicrophoneTapHandlerTests.swift
+++ b/Tests/MacParakeetTests/Audio/MutableMicrophoneTapHandlerTests.swift
@@ -1,0 +1,63 @@
+import AVFoundation
+import os
+import XCTest
+@testable import MacParakeetCore
+
+final class MutableMicrophoneTapHandlerTests: XCTestCase {
+    func testReplaceRoutesFutureBuffersToTheNewHandler() throws {
+        let (buffer, time) = try makeBufferAndTime()
+        let initialCount = OSAllocatedUnfairLock(initialState: 0)
+        let replacementCount = OSAllocatedUnfairLock(initialState: 0)
+        let handler = MutableMicrophoneTapHandler { _, _ in
+            initialCount.withLock { $0 += 1 }
+        }
+
+        handler.invoke(buffer: buffer, time: time)
+        handler.replace { _, _ in
+            replacementCount.withLock { $0 += 1 }
+        }
+        handler.invoke(buffer: buffer, time: time)
+
+        XCTAssertEqual(initialCount.withLock { $0 }, 1)
+        XCTAssertEqual(replacementCount.withLock { $0 }, 1)
+    }
+
+    func testClearStopsFutureBufferDelivery() throws {
+        let (buffer, time) = try makeBufferAndTime()
+        let invocationCount = OSAllocatedUnfairLock(initialState: 0)
+        let handler = MutableMicrophoneTapHandler { _, _ in
+            invocationCount.withLock { $0 += 1 }
+        }
+
+        handler.clear()
+        handler.invoke(buffer: buffer, time: time)
+
+        XCTAssertEqual(invocationCount.withLock { $0 }, 0)
+    }
+
+    func testClearAfterSustainedDeliveryDoesNotOverflowTheStack() throws {
+        let (buffer, time) = try makeBufferAndTime()
+        let invocationCount = OSAllocatedUnfairLock(initialState: 0)
+        let handler = MutableMicrophoneTapHandler { _, _ in
+            invocationCount.withLock { $0 += 1 }
+        }
+
+        for _ in 0..<50_000 {
+            handler.invoke(buffer: buffer, time: time)
+        }
+
+        XCTAssertEqual(invocationCount.withLock { $0 }, 50_000)
+        handler.clear()
+    }
+
+    private func makeBufferAndTime() throws -> (AVAudioPCMBuffer, AVAudioTime) {
+        let format = try XCTUnwrap(
+            AVAudioFormat(standardFormatWithSampleRate: 48_000, channels: 1)
+        )
+        let buffer = try XCTUnwrap(
+            AVAudioPCMBuffer(pcmFormat: format, frameCapacity: 4_096)
+        )
+        let time = AVAudioTime(sampleTime: 0, atRate: format.sampleRate)
+        return (buffer, time)
+    }
+}


### PR DESCRIPTION
## Summary

Ending a several-minute meeting could crash MacParakeet while the shared microphone engine cleared its tap callback. Two live reproductions ended with a stack overflow on `com.macparakeet.shared-mic-platform`; the second stopped after 3,440 callbacks and produced 3,014 recursive ARC/reabstraction frames.

This change keeps the prepared `AVAudioEngine` tap and latest-handler routing, but places the Swift function behind a stable immutable target object. Meeting stop now releases ordinary object references instead of recursively destroying a function-wrapper chain accumulated during sustained delivery.

## Design

| Callback lifetime | Before | After |
|---|---|---|
| Lock state | `Handler?` function value | `Target?` object reference |
| Render-thread snapshot | Copy/reabstract the function through generic lock state | Retain one immutable target reference |
| Replace / clear | Destroy the previous function during locked state mutation | Detach under lock; destroy after leaving the critical section |
| Tap lifecycle | Prepared tap routes to the latest capture handler | Unchanged |

This is deliberately narrow: no new queue, task, engine, public API, meeting state, or teardown ordering. The temporary diagnostic counters used to isolate the crash are not included.

## Root cause

`MutableMicrophoneTapHandler` stored its `@Sendable` function directly as `OSAllocatedUnfairLock<Handler?>` state and copied that function out on every audio callback. Sustained copies accumulated Swift reabstraction wrappers. Clearing the final stored function recursively released the wrapper chain until the 544 KB platform-queue thread stack overflowed.

The trigger is callback count, not an in-flight callback race:

- 71-second run: 702 callbacks, zero in flight at clear, stop succeeded.
- 5m44s run: 3,440 callbacks, zero in flight at clear, stack overflow before clear completed.
- Standalone pre-fix stress: 10,000 deliveries cleared successfully; 50,000 died during clear with exit code 132.
- Focused pre-fix XCTest: died during clear with unexpected signal 11.

## Risk surface

The changed code is on the audio render-thread callback path. Review should focus on latest-handler routing, stopped-delivery privacy, and object lifetime across concurrent clear/invoke. Each invocation retains the immutable target under the existing unfair lock, releases the lock, and invokes the function; an in-flight invocation therefore owns its target while future invocations see `nil` after clear.

Whisper model load performance and meeting transcription behavior are explicitly out of scope.

## Test evidence

Passed locally:

```bash
swift test --filter MutableMicrophoneTapHandlerTests
# 3 tests, including 50,000 deliveries + clear

swift test --filter 'MutableMicrophoneTapHandlerTests|MicrophoneEnginePrewarmRoutingTests|MicrophoneEnginePlatformConfigChangeRecoveryTests|SharedMicrophoneStreamTests'
# 47 tests

MACPARAKEET_HARDWARE_TESTS=1 swift test \
  --filter MicrophoneEngineRealPlatformTests/testPreparedStartDeliversBuffers
# 1 real-microphone integration test

xcrun swift-format lint \
  Sources/MacParakeetCore/Audio/MicrophoneEnginePlatform.swift \
  Tests/MacParakeetTests/Audio/MutableMicrophoneTapHandlerTests.swift

swift test
# 4,857 tests passed; 20 gated tests skipped; 0 failures
```

GitHub review converged at Greptile 5/5 with no actionable findings, and both exact-head Swift CI runs passed. A fixed-binary meeting beyond the observed failure duration is the remaining manual QA gate.

## Official API references

- [Apple: `OSAllocatedUnfairLock`](https://developer.apple.com/documentation/os/osallocatedunfairlock) documents protected state and scoped `withLock` access.
- [Apple: `AVAudioNode`](https://developer.apple.com/documentation/avfaudio/avaudionode) documents the existing install/remove tap lifecycle. This PR leaves that lifecycle unchanged.

## Tooling note

The local Greptile CLI and `no-mistakes` command were unavailable on this machine, so this branch uses the documented fallback workflow and GitHub-hosted reviewers/checks.
