### PR TITLE
Fix merged words in Nemotron timed transcripts

### DIFF
--- a/Sources/MacParakeetCore/STT/STTWordTimingBuilder.swift
+++ b/Sources/MacParakeetCore/STT/STTWordTimingBuilder.swift
@@ -35,10 +35,18 @@ enum STTWordTimingBuilder {
 
         for timing in tokenTimings {
             let normalizedToken = timing.token.replacingOccurrences(of: "▁", with: " ")
+            let startsNewWord = normalizedToken.first?.isWhitespace == true
             let trimmedToken = normalizedToken.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !trimmedToken.isEmpty else { continue }
+            guard !trimmedToken.isEmpty else {
+                // Multilingual Nemotron can emit the SentencePiece boundary as
+                // its own token, so it still terminates the preceding word.
+                if startsNewWord {
+                    flushCurrentWord()
+                }
+                continue
+            }
 
-            if normalizedToken.first?.isWhitespace == true {
+            if startsNewWord {
                 flushCurrentWord()
                 currentWord = trimmedToken
                 currentStartTime = timing.startTime

--- a/Tests/MacParakeetTests/STT/STTWordTimingBuilderTests.swift
+++ b/Tests/MacParakeetTests/STT/STTWordTimingBuilderTests.swift
@@ -33,6 +33,19 @@ final class STTWordTimingBuilderTests: XCTestCase {
         XCTAssertEqual(words[0].endMs, 320)
     }
 
+    func testWordsPreserveStandaloneSentencePieceBoundary() {
+        let words = STTWordTimingBuilder.words(from: [
+            TokenTiming(token: "▁improve", tokenId: 1, startTime: 0.00, endTime: 0.12, confidence: 0.9),
+            TokenTiming(token: "▁", tokenId: 2, startTime: 0.12, endTime: 0.16, confidence: 0.9),
+            TokenTiming(token: "based", tokenId: 3, startTime: 0.16, endTime: 0.28, confidence: 0.9),
+            TokenTiming(token: "▁on", tokenId: 4, startTime: 0.28, endTime: 0.40, confidence: 0.9),
+        ])
+
+        XCTAssertEqual(words.map(\.word), ["improve", "based", "on"])
+        XCTAssertEqual(words.map(\.startMs), [0, 160, 280])
+        XCTAssertEqual(words.map(\.endMs), [120, 280, 400])
+    }
+
     func testWordsStartPlainFirstTokenAsWord() {
         let words = STTWordTimingBuilder.words(from: [
             TokenTiming(token: "hello", tokenId: 1, startTime: 0.04, endTime: 0.20, confidence: 0.7),


### PR DESCRIPTION
## What changed

- Treat a standalone SentencePiece word-boundary token as a real boundary when building timestamped words.
- Add a regression for the observed `improve` + standalone boundary + `based` sequence.

## Root cause

Multilingual Nemotron's decoded text retained spaces, but its token timing stream can emit `▁` as a standalone token. `STTWordTimingBuilder` trimmed that token to an empty string and skipped it without closing the current word, so the next token was appended to the preceding word (`improvebasedon`, `theenvironmentside`, and similar). Live meeting preview, timed transcript segments, and interleaved final meeting text consume those timestamped words and inherited the corruption.

A model-backed replay of a 10-second excerpt from the reported recording confirmed the boundary: before the fix, decoded text was correct while timestamped words included `primarilelibraries`, `whichkind`, `ofgohandinhand`, `bothon`, `theenvironmentside`, and `pastfew`; after the fix, the timestamped words match the decoded text.

## Scope

- Fixes future Nemotron timed-word output across live meeting chunks and finalized file/meeting transcription.
- Does not change acoustic mic/system duplication behavior.
- Does not rewrite existing saved transcripts; they can be retranscribed from preserved audio.
- No CLI, persistence schema, privacy, or ADR contract changes.

## Verification

- `swift test --filter STTWordTimingBuilderTests` (6 passed)
- `swift test --filter MeetingTranscriptSourceReconcilerTests` (9 passed)
- `swift test --filter TranscriptionServiceTests` (67 passed)
- Model-backed replay against the saved production-audio excerpt
- `swift test` (4,858 XCTest + 17 Swift Testing passed; 20 skipped; 0 failures)
- `xcrun swift-format lint` on changed Swift files
- `git diff --check`

`no-mistakes` and the local Greptile CLI were unavailable in this environment, so this PR uses the documented fallback review path plus GitHub CI/review bots.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes merged words in Nemotron timed transcripts by treating a standalone SentencePiece boundary token as a real word break. Live preview and finalized transcripts now match the model’s decoded spacing.

- **Bug Fixes**
  - Flush the current word when a whitespace-only boundary token (`▁`) appears in token timings.
  - Add a regression test for the “improve” + boundary + “based” sequence.

<sup>Written for commit 44d4389d06f3ea4f241db2d295195035bcb17032. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/811?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved word timing and segmentation for speech-to-text results containing standalone sentence boundaries.
  * Corrected word splitting and timing around whitespace-only transcription tokens.

* **Tests**
  * Added coverage confirming accurate word boundaries and timestamps for standalone sentence boundary markers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->