### PR TITLE
Show indeterminate progress while speech models prepare

### DIFF
--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -89,6 +89,12 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
 
 ## [Unreleased]
 
+### Fixed
+
+- Transcription and retranscription progress now reports
+  `Preparing speech model...` while the local engine loads instead of printing
+  a synthetic 0% update before measurable work begins. JSON stdout is unchanged.
+
 ## [3.0.0] — 2026-07-14
 
 ### Changed

--- a/Sources/CLI/Commands/RetranscribeCommand.swift
+++ b/Sources/CLI/Commands/RetranscribeCommand.swift
@@ -705,6 +705,8 @@ struct RetranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding 
                 printProgressLine("Converting audio...")
             case .downloading(let percent):
                 printProgressLine("Downloading audio... \(percent)%")
+            case .preparingSpeechModel:
+                printProgressLine("Preparing speech model...")
             case .transcribing(let percent):
                 printProgressLine("\(prefix)... \(percent)%")
             case .identifyingSpeakers:

--- a/Sources/CLI/Commands/TranscribeCommand.swift
+++ b/Sources/CLI/Commands/TranscribeCommand.swift
@@ -792,6 +792,7 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
             switch progress {
             case .converting: printProgressLine("Converting audio...")
             case .downloading(let pct): printProgressLine("Downloading audio... \(pct)%")
+            case .preparingSpeechModel: printProgressLine("Preparing speech model...")
             case .transcribing(let pct): printProgressLine("Transcribing... \(pct)%")
             case .identifyingSpeakers: printProgressLine("Identifying speakers...")
             case .finalizing: printProgressLine("Finalizing...")
@@ -832,6 +833,7 @@ struct TranscribeCommand: AsyncParsableCommand, CLITelemetryMetadataProviding {
             switch progress {
             case .converting: line = "Converting audio..."
             case .downloading(let pct): line = "Fetching episode... \(pct)%"
+            case .preparingSpeechModel: line = "Preparing speech model..."
             case .transcribing(let pct): line = "Transcribing... \(pct)%"
             case .identifyingSpeakers: line = "Identifying speakers..."
             case .finalizing: line = "Finalizing..."

--- a/Sources/MacParakeet/Views/Transcription/TranscribeView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscribeView.swift
@@ -505,6 +505,8 @@ struct TranscribeView: View {
             return "arrow.down.circle"
         case .converting:
             return "waveform.path.ecg"
+        case .preparingSpeechModel:
+            return "cpu"
         case .transcribing:
             return "waveform"
         case .identifyingSpeakers:
@@ -531,7 +533,7 @@ struct TranscribeView: View {
             return .download
         case .converting:
             return .convert
-        case .transcribing, .identifyingSpeakers, .finalizing:
+        case .preparingSpeechModel, .transcribing, .identifyingSpeakers, .finalizing:
             return .transcribe
         }
     }

--- a/Sources/MacParakeetCore/Models/TranscriptionProgress.swift
+++ b/Sources/MacParakeetCore/Models/TranscriptionProgress.swift
@@ -5,6 +5,7 @@ import Foundation
 public enum TranscriptionProgress: Sendable {
     case converting
     case downloading(percent: Int)
+    case preparingSpeechModel
     case transcribing(percent: Int)
     case identifyingSpeakers
     case finalizing
@@ -14,7 +15,7 @@ public enum TranscriptionProgress: Sendable {
         switch self {
         case .downloading(let percent), .transcribing(let percent):
             return min(Double(percent), 100) / 100
-        case .converting, .identifyingSpeakers, .finalizing:
+        case .converting, .preparingSpeechModel, .identifyingSpeakers, .finalizing:
             return nil
         }
     }

--- a/Sources/MacParakeetCore/Services/TranscriptionService.swift
+++ b/Sources/MacParakeetCore/Services/TranscriptionService.swift
@@ -1075,7 +1075,6 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
             }
         }
 
-        onProgress?(.transcribing(percent: 0))
         if !keepDownloadedAudio {
             unownedDownloadedAudioURL = nil
         }
@@ -1392,7 +1391,7 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
                 sourceWavURLs[source] = wavURL
 
                 lifecycleStage = .stt
-                onProgress?(.transcribing(percent: Int((Double(index) / Double(max(activeSources.count, 1))) * 100)))
+                onProgress?(.preparingSpeechModel)
                 let result: STTResult
                 meetingFinalizationBenchmarkObserver?.stageDidStart(benchmarkStage)
                 do {
@@ -1588,8 +1587,8 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
                 throw AudioProcessorError.conversionFailed("Failed to produce WAV output")
             }
 
-            onProgress?(.transcribing(percent: 0))
             lifecycleStage = .stt
+            onProgress?(.preparingSpeechModel)
             let sttProgress: (@Sendable (Int, Int) -> Void)? = onProgress.map { callback in
                 { @Sendable current, total in
                     let pct = total > 0 ? Int(Double(current) / Double(total) * 100) : 0

--- a/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
@@ -65,6 +65,7 @@ public final class TranscriptionViewModel {
         case preparing
         case downloading
         case converting
+        case preparingSpeechModel
         case transcribing
         case identifyingSpeakers
         case finalizing
@@ -1106,6 +1107,7 @@ public final class TranscriptionViewModel {
         switch progress {
         case .converting: return .converting
         case .downloading: return .downloading
+        case .preparingSpeechModel: return .preparingSpeechModel
         case .transcribing: return .transcribing
         case .identifyingSpeakers: return .identifyingSpeakers
         case .finalizing: return .finalizing
@@ -1118,6 +1120,8 @@ public final class TranscriptionViewModel {
             return "Converting audio..."
         case .downloading(let percent):
             return "Downloading audio... \(percent)%"
+        case .preparingSpeechModel:
+            return "Preparing speech model..."
         case .transcribing(let percent):
             return "Transcribing... \(percent)%"
         case .identifyingSpeakers:
@@ -1135,6 +1139,8 @@ public final class TranscriptionViewModel {
             return "Fetching source audio"
         case .converting:
             return "Normalizing audio stream"
+        case .preparingSpeechModel:
+            return "Preparing speech model"
         case .transcribing:
             return "Running speech recognition"
         case .identifyingSpeakers:
@@ -1161,6 +1167,10 @@ public final class TranscriptionViewModel {
             case .localFile:
                 return nil
             }
+        case .preparingSpeechModel:
+            return engine == .whisper
+                ? "First use may take several minutes while Core ML optimizes Whisper."
+                : nil
         case .transcribing:
             switch engine {
             case .parakeet:

--- a/Tests/MacParakeetTests/STT/MockSTTClient.swift
+++ b/Tests/MacParakeetTests/STT/MockSTTClient.swift
@@ -53,6 +53,7 @@ public actor MockSTTClient: STTClientProtocol, STTDictationPreviewTranscribing, 
     private var backgroundWarmUpTask: Task<Void, Never>?
     private var queuedTranscribeResults: [STTResult] = []
     private var queuedTranscribeErrors: [Error] = []
+    private var transcribeProgressUpdates: [(current: Int, total: Int)] = []
     private var liveSessionID: UUID?
     private var livePartialHandler: (@Sendable (String) -> Void)?
     private var liveAppendsHeld = false
@@ -99,6 +100,10 @@ public actor MockSTTClient: STTClientProtocol, STTDictationPreviewTranscribing, 
         self.transcribeResult = nil
     }
 
+    public func configureTranscribeProgress(_ updates: [(current: Int, total: Int)]) {
+        transcribeProgressUpdates = updates
+    }
+
     public func configureWarmUp(error: Error? = nil, progressPhases: [String]? = nil) {
         self.warmUpError = error
         self.warmUpProgressPhases = progressPhases
@@ -124,6 +129,10 @@ public actor MockSTTClient: STTClientProtocol, STTDictationPreviewTranscribing, 
         lastJob = job
         audioPaths.append(audioPath)
         jobs.append(job)
+
+        for update in transcribeProgressUpdates {
+            onProgress?(update.current, update.total)
+        }
 
         if !queuedTranscribeErrors.isEmpty {
             throw queuedTranscribeErrors.removeFirst()

--- a/Tests/MacParakeetTests/Services/TranscriptionServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/TranscriptionServiceTests.swift
@@ -333,6 +333,21 @@ final class TranscriptionServiceTests: XCTestCase {
     var promptResultRepo: PromptResultRepository!
     var llmRunRepo: LLMRunRepository!
 
+    private func isConverting(_ progress: TranscriptionProgress) -> Bool {
+        if case .converting = progress { return true }
+        return false
+    }
+
+    private func isPreparingSpeechModel(_ progress: TranscriptionProgress) -> Bool {
+        if case .preparingSpeechModel = progress { return true }
+        return false
+    }
+
+    private func isTranscribing(_ progress: TranscriptionProgress, percent: Int) -> Bool {
+        if case .transcribing(let actual) = progress { return actual == percent }
+        return false
+    }
+
     override func setUp() async throws {
         dbManager = try DatabaseManager()
         mockAudio = MockAudioProcessor()
@@ -381,6 +396,24 @@ final class TranscriptionServiceTests: XCTestCase {
         XCTAssertEqual(fetched?.transcriptSegments?.map(\.text), ["This is a transcription"])
         let indexedText: [String] = try segmentRepo.fetch(transcriptionId: result.id).map(\.text)
         XCTAssertEqual(indexedText, ["This is a transcription"])
+    }
+
+    func testTranscribeFileReportsModelPreparationBeforeEngineProgress() async throws {
+        await mockSTT.configure(result: STTResult(text: "Prepared transcription"))
+        await mockSTT.configureTranscribeProgress([(current: 0, total: 10), (current: 1, total: 10)])
+        let phasesLock = OSAllocatedUnfairLock(initialState: [TranscriptionProgress]())
+
+        _ = try await service.transcribe(fileURL: URL(fileURLWithPath: "/tmp/preparation.wav")) { progress in
+            phasesLock.withLock { $0.append(progress) }
+        }
+
+        let phases = phasesLock.withLock { $0 }
+        XCTAssertGreaterThanOrEqual(phases.count, 4)
+        guard phases.count >= 4 else { return }
+        XCTAssertTrue(isConverting(phases[0]))
+        XCTAssertTrue(isPreparingSpeechModel(phases[1]))
+        XCTAssertTrue(isTranscribing(phases[2], percent: 0))
+        XCTAssertTrue(isTranscribing(phases[3], percent: 10))
     }
 
     func testTranscribeFileUsesDedicatedTranscriptionEngineRoute() async throws {
@@ -1152,7 +1185,11 @@ final class TranscriptionServiceTests: XCTestCase {
         XCTAssertTrue(phases.contains { if case .downloading(7) = $0 { true } else { false } })
         XCTAssertTrue(phases.contains { if case .downloading(42) = $0 { true } else { false } })
         XCTAssertTrue(phases.contains { if case .downloading(100) = $0 { true } else { false } })
-        XCTAssertTrue(phases.contains { if case .transcribing = $0 { true } else { false } })
+        XCTAssertTrue(phases.contains { if case .preparingSpeechModel = $0 { true } else { false } })
+        XCTAssertFalse(
+            phases.contains { if case .transcribing = $0 { true } else { false } },
+            "TranscriptionService should not invent a 0% event before the engine reports measurable progress"
+        )
     }
 
     func testTranscribeURLPassesYouTubeMetadataToPlaybackConversion() async throws {
@@ -1402,7 +1439,10 @@ final class TranscriptionServiceTests: XCTestCase {
             )
         )
 
-        let result = try await service.transcribeMeeting(recording: recording)
+        let phasesLock = OSAllocatedUnfairLock(initialState: [TranscriptionProgress]())
+        let result = try await service.transcribeMeeting(recording: recording) { progress in
+            phasesLock.withLock { $0.append(progress) }
+        }
         let sttCallCount = await mockSTT.transcribeCallCount
         let jobs = await mockSTT.jobs
         let convertCallCount = await mockAudio.convertCallCount
@@ -1429,6 +1469,13 @@ final class TranscriptionServiceTests: XCTestCase {
         XCTAssertEqual(jobs, [.meetingFinalize, .meetingFinalize])
         XCTAssertEqual(convertCallCount, 2)
         XCTAssertEqual(convertURLs, [microphoneURL, systemURL])
+        XCTAssertEqual(
+            phasesLock.withLock { phases in
+                phases.filter { if case .preparingSpeechModel = $0 { true } else { false } }.count
+            },
+            2,
+            "Each separately scheduled meeting source should report indeterminate model preparation"
+        )
 
         let events = telemetry.snapshot()
         let completedEvent = events.reversed().first {

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
@@ -341,6 +341,31 @@ final class TranscriptionViewModelTests: XCTestCase {
         try await waitUntil { !self.viewModel.isTranscribing }
     }
 
+    func testTranscribeFileShowsIndeterminateWhisperModelPreparation() async throws {
+        let suiteName = "TranscriptionViewModelTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        SpeechEnginePreference.whisper.save(to: defaults)
+        viewModel = TranscriptionViewModel(defaults: defaults)
+        await mockService.configureProgress(phases: [.preparingSpeechModel])
+        await mockService.configureDelay(milliseconds: 250)
+        viewModel.configure(transcriptionService: mockService, transcriptionRepo: mockRepo)
+
+        viewModel.transcribeFile(url: URL(fileURLWithPath: "/tmp/myfile.wav"))
+
+        try await waitUntil { self.viewModel.progressPhase == .preparingSpeechModel }
+        XCTAssertEqual(viewModel.progress, "Preparing speech model...")
+        XCTAssertEqual(viewModel.progressHeadline, "Preparing speech model")
+        XCTAssertEqual(
+            viewModel.progressSubline,
+            "First use may take several minutes while Core ML optimizes Whisper."
+        )
+        XCTAssertNil(viewModel.transcriptionProgress)
+
+        viewModel.cancelTranscription()
+        try await waitUntil { !self.viewModel.isTranscribing }
+    }
+
     func testTranscribeFileProgressSublineUsesNemotronVariantSnapshot() async throws {
         let suiteName = "TranscriptionViewModelTests-\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!

--- a/spec/02-features.md
+++ b/spec/02-features.md
@@ -476,6 +476,8 @@ reuses the shared `.alert`-only notification authorization.
 - Local STT input is normalized to 16kHz mono WAV
 - Max file duration: configurable, default 4 hours
 - Large files show progress bar with estimated time remaining
+- Local speech-model preparation is shown as indeterminate; percentage progress
+  begins only when the engine reports measurable transcription work
 - Word-level timestamps preserved for subtitle export (v0.3)
 - Folder expansion + supported-extension filtering + the 200-file cap live in
   `AudioFileEnumerator` (Core); the sequential drain is owned by

--- a/spec/04-ui-patterns.md
+++ b/spec/04-ui-patterns.md
@@ -647,8 +647,8 @@ Uses `SpinnerRingView` plus phase-aware progress feedback.
 │                                                          │
 │                    [merkaba spinner]                     │
 │                                                          │
-│               "Downloading audio... 42%"                │
-│                     [linear 42% bar]                     │
+│                "Preparing speech model..."              │
+│                  [indeterminate bar]                     │
 │                                                          │
 │                    [error if any]                        │
 │                                                          │
@@ -656,11 +656,13 @@ Uses `SpinnerRingView` plus phase-aware progress feedback.
 
 - SpinnerRingView(size: 48, tintColor: .accentColor)
 - Phase icon behind spinner:
-  - Download phase (`"download"` in phase text): `arrow.down.circle`
+  - Download phase: `arrow.down.circle`
+  - Speech-model preparation phase: `cpu`
   - Transcription phase: `waveform`
 - Progress text: body font, secondary color (`viewModel.progress`)
-- Determinate progress bar shown when phase text ends with `%` (parsed from phase string)
-- During download phases without parsable percent, show indeterminate linear bar + helper text
+- Determinate progress bar shown only when the structured phase carries a fraction
+- Speech-model preparation is indeterminate; Whisper explains that first-use
+  Core ML optimization can take several minutes
 - Error text: caption, red (if present)
 ```
 


### PR DESCRIPTION
## Summary

- Add a semantic `preparingSpeechModel` phase between audio conversion and measurable engine progress.
- Show an indeterminate progress bar during that phase, with a Whisper-specific note that first-use Core ML optimization may take several minutes.
- Preserve the centralized STT runtime as the sole owner of engine routing, model preparation, scheduling, and cancellation.
- Keep CLI stderr progress and the feature/UI docs aligned with the app.

## Why

Issue #805 reports Whisper appearing stuck at 0%. The diagnostic evidence is consistent with a cold local model preparation taking minutes before Whisper emits its first measurable transcription update. The previous synthetic 0% event made that active but unmeasurable work look hung.

This changes only progress semantics and presentation; it does not prewarm an engine, add polling or timers, or change transcription behavior.

## Testing

- `swift test --filter "TranscriptionServiceTests|TranscriptionViewModelTests|TranscribeCommandTests|RetranscribeCommandTests"` — 279 passed
- `swift test` — 4,860 passed, 20 skipped, 0 failures; Swift Testing: 17 passed
- Post-review exact-head `swift test --filter TranscriptionServiceTests` — 68 passed
- `git diff --check`
- Fresh manual standards and spec review — no findings

## Local gate notes

The optional `no-mistakes` and Greptile CLIs are not installed in this checkout, so I used the documented manual review fallback. The installed Swift 6.3 formatter reports a large pre-existing repository-wide lint baseline; no formatter churn is included in this PR.

Closes #805

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated **“Preparing speech model…”** stage across the app and CLI during local model loading.
  * Displays **indeterminate progress** while loading, then begins percentage-based transcription only when measurable work starts.
  * Updated the transcription UI visuals (icon/timeline behavior and phase-specific copy, including Whisper-focused subtext).

* **Bug Fixes**
  * Removed misleading initial **0% transcription** progress emissions so progress now matches real work stages.
  * Ensured **stdout JSON output behavior remains unchanged**.

* **Tests**
  * Extended progress-phase coverage with deterministic progress configuration and new UI/state assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->