### PR TITLE
Fix Local transcription filename regression

### DIFF
--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -91,6 +91,10 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
 
 ### Fixed
 
+- Local-file titles in `search`, `transcript`, and `cards list` now preserve
+  the original media filename unless the user explicitly renamed the
+  transcription, matching the Mac app and avoiding transcript-opening words as
+  unstable source identifiers. JSON field names and shapes are unchanged.
 - Transcription and retranscription progress now reports
   `Preparing speech model...` while the local engine loads instead of printing
   a synthetic 0% update before measurable work begins. JSON stdout is unchanged.

--- a/Sources/MacParakeetCore/Database/SegmentRepository.swift
+++ b/Sources/MacParakeetCore/Database/SegmentRepository.swift
@@ -480,16 +480,8 @@ public final class SegmentRepository: SegmentRepositoryProtocol, @unchecked Send
         (0x41...0x5A).contains(value) ? value + 0x20 : value
     }
 
-    private static let titleExpression = """
-        CASE
-            WHEN t.sourceType = 'meeting' THEN t.fileName
-            ELSE COALESCE(
-                NULLIF(TRIM(t.titleOverride), ''),
-                NULLIF(TRIM(t.derivedTitle), ''),
-                t.fileName
-            )
-        END
-        """
+    private static let titleExpression =
+        TranscriptionRepository.effectiveDisplayTitleExpression(tableAlias: "t")
 
     private static let urlSourceTypeLiterals = [
         Transcription.SourceType.youtube,

--- a/Sources/MacParakeetCore/Database/TranscriptionRepository.swift
+++ b/Sources/MacParakeetCore/Database/TranscriptionRepository.swift
@@ -136,14 +136,13 @@ public final class TranscriptionRepository: TranscriptionRepositoryProtocol, @un
                 ELSE NULLIF(TRIM(\(prefix)titleOverride), '')
             END,
             CASE
-                WHEN \(prefix)sourceType IN ('meeting', 'file')
-                    THEN NULLIF(TRIM(\(prefix)fileName), '')
-                ELSE COALESCE(
-                    NULLIF(TRIM(\(prefix)derivedTitle), ''),
-                    NULLIF(TRIM(\(prefix)fileName), '')
+                WHEN \(prefix)sourceType = 'meeting' THEN COALESCE(
+                    NULLIF(TRIM(\(prefix)fileName), ''),
+                    \(prefix)fileName
                 )
-            END,
-            \(prefix)fileName
+                WHEN \(prefix)sourceType = 'file' THEN \(prefix)fileName
+                ELSE COALESCE(NULLIF(TRIM(\(prefix)derivedTitle), ''), \(prefix)fileName)
+            END
         )
         """
     }

--- a/Sources/MacParakeetCore/Database/TranscriptionRepository.swift
+++ b/Sources/MacParakeetCore/Database/TranscriptionRepository.swift
@@ -125,19 +125,28 @@ extension TranscriptionRepositoryProtocol {
 // advertise Swift Sendable conformance.
 public final class TranscriptionRepository: TranscriptionRepositoryProtocol, @unchecked Sendable {
     private let dbQueue: DatabaseQueue
-    private static let libraryDisplayTitleExpression = """
+    private static let libraryDisplayTitleExpression = effectiveDisplayTitleExpression()
+
+    static func effectiveDisplayTitleExpression(tableAlias: String? = nil) -> String {
+        let prefix = tableAlias.map { "\($0)." } ?? ""
+        return """
         COALESCE(
             CASE
-                WHEN sourceType = 'meeting' THEN NULL
-                ELSE NULLIF(TRIM(titleOverride), '')
+                WHEN \(prefix)sourceType = 'meeting' THEN NULL
+                ELSE NULLIF(TRIM(\(prefix)titleOverride), '')
             END,
             CASE
-                WHEN sourceType = 'meeting' THEN NULLIF(TRIM(fileName), '')
-                ELSE COALESCE(NULLIF(TRIM(derivedTitle), ''), NULLIF(TRIM(fileName), ''))
+                WHEN \(prefix)sourceType IN ('meeting', 'file')
+                    THEN NULLIF(TRIM(\(prefix)fileName), '')
+                ELSE COALESCE(
+                    NULLIF(TRIM(\(prefix)derivedTitle), ''),
+                    NULLIF(TRIM(\(prefix)fileName), '')
+                )
             END,
-            fileName
+            \(prefix)fileName
         )
         """
+    }
 
     public init(dbQueue: DatabaseQueue) {
         self.dbQueue = dbQueue

--- a/Sources/MacParakeetCore/Models/Transcription.swift
+++ b/Sources/MacParakeetCore/Models/Transcription.swift
@@ -199,6 +199,9 @@ extension Transcription {
         if let titleOverride = normalizedTitleOverride {
             return titleOverride
         }
+        if sourceType == .file {
+            return fileName
+        }
         if let derived = derivedTitle?.trimmingCharacters(in: .whitespacesAndNewlines),
            !derived.isEmpty {
             return derived

--- a/Sources/MacParakeetCore/Services/TranscriptionService.swift
+++ b/Sources/MacParakeetCore/Services/TranscriptionService.swift
@@ -658,9 +658,9 @@ public actor TranscriptionService: SpeechEngineOverrideTranscriptionService {
             : .empty
         let fileName = Self.firstNonEmpty(
             displayFileName,
-            embeddedMetadata.title,
             storedFileURL?.lastPathComponent,
-            fileURL.lastPathComponent
+            fileURL.lastPathComponent,
+            embeddedMetadata.title
         ) ?? fileURL.lastPathComponent
         let fileSize = storedFileURL.flatMap {
             (try? FileManager.default.attributesOfItem(atPath: $0.path)[.size] as? Int).flatMap { $0 }

--- a/Sources/MacParakeetCore/TextProcessing/TranscriptDerivers.swift
+++ b/Sources/MacParakeetCore/TextProcessing/TranscriptDerivers.swift
@@ -1,13 +1,13 @@
 import Foundation
 
 /// Pure-function deriver that produces a display-ready title string from a raw
-/// transcript. The first substantive sentence (filler-stripped) becomes the
-/// headline for file/YouTube rows in the Library thumbnail grid — sources that
-/// have no inherent title. Meeting rows use their own editable meeting name
-/// (`Transcription.fileName`) instead; for meetings this derived value only
-/// feeds the snippet preview and the "Save Audio As…" export-filename helper.
-/// Falls back through several tiers so even short or filler-heavy transcripts
-/// get a usable title.
+/// transcript. The first substantive sentence (filler-stripped) can become the
+/// headline for URL rows that lack useful source metadata. Imported local files
+/// retain their original filename unless the user explicitly renames them, while
+/// meeting rows use their own editable meeting name (`Transcription.fileName`).
+/// The derived value remains searchable metadata for local files and feeds
+/// meeting audio export naming. Falls back through several tiers so even short
+/// or filler-heavy transcripts get a usable semantic title.
 ///
 /// Deterministic and synchronous — runs on the transcription completion path
 /// and persists into `Transcription.derivedTitle`.

--- a/Tests/CLITests/CardsCommandTests.swift
+++ b/Tests/CLITests/CardsCommandTests.swift
@@ -42,6 +42,7 @@ final class CardsCommandTests: XCTestCase {
         XCTAssertTrue(actions[0]["owner"] is NSNull)
 
         let file = try XCTUnwrap(rows.first { ($0["source"] as? String) == "file" })
+        XCTAssertEqual(file["title"] as? String, "notes.m4a")
         XCTAssertTrue(file["durationMs"] is NSNull)
         XCTAssertTrue(file["attendees"] is NSNull)
         XCTAssertEqual((file["decisions"] as? [Any])?.count, 0)
@@ -161,7 +162,8 @@ final class CardsCommandTests: XCTestCase {
             durationMs: nil,
             rawTranscript: "File notes.",
             status: .completed,
-            sourceType: .file
+            sourceType: .file,
+            derivedTitle: "Spoken Local Opening"
         )
         for transcription in [meeting, file] {
             try transcriptions.save(transcription)

--- a/Tests/CLITests/SearchCommandTests.swift
+++ b/Tests/CLITests/SearchCommandTests.swift
@@ -115,6 +115,7 @@ final class SearchCommandTests: XCTestCase {
         let hit = try XCTUnwrap(hits.first)
         let searchKeys: Set<String> = Set(hit.keys)
         XCTAssertEqual(searchKeys, Self.searchHitKeys)
+        XCTAssertEqual(hit["title"] as? String, "legacy.m4a")
         XCTAssertTrue(hit["startMs"] is NSNull)
         XCTAssertTrue(hit["speaker"] is NSNull)
 
@@ -123,6 +124,7 @@ final class SearchCommandTests: XCTestCase {
         ])
         let transcriptOutput = try await captureStandardOutput { try await transcript.run() }
         let payload: [String: Any] = try decodeJSON(transcriptOutput)
+        XCTAssertEqual(payload["title"] as? String, "legacy.m4a")
         let rows = try XCTUnwrap(payload["segments"] as? [[String: Any]])
         let row = try XCTUnwrap(rows.first)
         let transcriptKeys: Set<String> = Set(row.keys)

--- a/Tests/CLITests/SearchCommandTests.swift
+++ b/Tests/CLITests/SearchCommandTests.swift
@@ -79,6 +79,7 @@ final class SearchCommandTests: XCTestCase {
         let output = try await captureStandardOutput { try await command.run() }
         let payload: [String: Any] = try decodeJSON(output)
         XCTAssertEqual(payload["transcriptionId"] as? String, fixture.fileID.uuidString)
+        XCTAssertEqual(payload["title"] as? String, "notes.m4a")
         XCTAssertEqual(payload["source"] as? String, "file")
         let segments = try XCTUnwrap(payload["segments"] as? [[String: Any]])
         XCTAssertEqual(segments.first?["seq"] as? Int, 0)
@@ -100,7 +101,8 @@ final class SearchCommandTests: XCTestCase {
             fileName: "legacy.m4a",
             rawTranscript: "Legacy untimed evidence.",
             status: .completed,
-            sourceType: .file
+            sourceType: .file,
+            derivedTitle: "Spoken Local Opening"
         )
         try TranscriptionRepository(dbQueue: manager.dbQueue).save(transcription)
         try SegmentRepository(dbQueue: manager.dbQueue).replaceSegments(for: transcription)

--- a/Tests/MacParakeetTests/Database/SegmentRepositoryTests.swift
+++ b/Tests/MacParakeetTests/Database/SegmentRepositoryTests.swift
@@ -335,6 +335,42 @@ final class SegmentRepositoryTests: XCTestCase {
         XCTAssertTrue(afterDelete.isEmpty)
     }
 
+    func testSearchUsesSourceAwareDisplayTitles() throws {
+        let local = Transcription(
+            fileName: "source-recording.m4a",
+            rawTranscript: "shared naming marker",
+            status: .completed,
+            sourceType: .file,
+            derivedTitle: "Spoken Local Opening"
+        )
+        let renamedLocal = Transcription(
+            fileName: "renamed-source.m4a",
+            rawTranscript: "shared naming marker",
+            status: .completed,
+            sourceType: .file,
+            titleOverride: "Customer Interview",
+            derivedTitle: "Spoken Renamed Opening"
+        )
+        let url = Transcription(
+            fileName: "Published Video Title",
+            rawTranscript: "shared naming marker",
+            status: .completed,
+            sourceType: .youtube,
+            derivedTitle: "Spoken URL Opening"
+        )
+
+        for transcription in [local, renamedLocal, url] {
+            try transcriptions.save(transcription)
+            try segments.replaceSegments(for: transcription)
+        }
+
+        let hits = try segments.search(SegmentSearchQuery(query: "naming", limit: 10))
+        let titlesByID = Dictionary(uniqueKeysWithValues: hits.map { ($0.transcriptionId, $0.title) })
+        XCTAssertEqual(titlesByID[local.id], "source-recording.m4a")
+        XCTAssertEqual(titlesByID[renamedLocal.id], "Customer Interview")
+        XCTAssertEqual(titlesByID[url.id], "Spoken URL Opening")
+    }
+
     func testCJKFallbackAndGraphemeSafeSnippet() throws {
         XCTAssertTrue(SegmentRepository.requiresSubstringFallback("\u{20000}"))
         XCTAssertTrue(SegmentRepository.requiresSubstringFallback("\u{FF76}"), "halfwidth Katakana")

--- a/Tests/MacParakeetTests/Database/SegmentRepositoryTests.swift
+++ b/Tests/MacParakeetTests/Database/SegmentRepositoryTests.swift
@@ -337,7 +337,7 @@ final class SegmentRepositoryTests: XCTestCase {
 
     func testSearchUsesSourceAwareDisplayTitles() throws {
         let local = Transcription(
-            fileName: "source-recording.m4a",
+            fileName: " source-recording .m4a",
             rawTranscript: "shared naming marker",
             status: .completed,
             sourceType: .file,
@@ -366,7 +366,7 @@ final class SegmentRepositoryTests: XCTestCase {
 
         let hits = try segments.search(SegmentSearchQuery(query: "naming", limit: 10))
         let titlesByID = Dictionary(uniqueKeysWithValues: hits.map { ($0.transcriptionId, $0.title) })
-        XCTAssertEqual(titlesByID[local.id], "source-recording.m4a")
+        XCTAssertEqual(titlesByID[local.id], " source-recording .m4a")
         XCTAssertEqual(titlesByID[renamedLocal.id], "Customer Interview")
         XCTAssertEqual(titlesByID[url.id], "Spoken URL Opening")
     }

--- a/Tests/MacParakeetTests/Database/TranscriptionRepositoryTests.swift
+++ b/Tests/MacParakeetTests/Database/TranscriptionRepositoryTests.swift
@@ -137,6 +137,12 @@ final class TranscriptionRepositoryTests: XCTestCase {
             derivedTitle: "Derived Topic"
         )
         let localWithoutDerived = Transcription(fileName: "source-file.m4a", status: .completed)
+        let urlWithDerived = Transcription(
+            fileName: "Published Video Title",
+            status: .completed,
+            sourceType: .youtube,
+            derivedTitle: "Transcript Topic"
+        )
         let meeting = Transcription(
             fileName: "Weekly Sync",
             status: .completed,
@@ -145,9 +151,10 @@ final class TranscriptionRepositoryTests: XCTestCase {
             derivedTitle: "Transcript-Derived Meeting Topic"
         )
 
-        XCTAssertEqual(localWithDerived.effectiveDisplayTitle, "Transcript Topic")
-        XCTAssertEqual(localWithBlankOverride.effectiveDisplayTitle, "Derived Topic")
+        XCTAssertEqual(localWithDerived.effectiveDisplayTitle, "source-file.m4a")
+        XCTAssertEqual(localWithBlankOverride.effectiveDisplayTitle, "blank-override.m4a")
         XCTAssertEqual(localWithoutDerived.effectiveDisplayTitle, "source-file.m4a")
+        XCTAssertEqual(urlWithDerived.effectiveDisplayTitle, "Transcript Topic")
         XCTAssertEqual(meeting.effectiveDisplayTitle, "Weekly Sync")
     }
 
@@ -623,7 +630,7 @@ final class TranscriptionRepositoryTests: XCTestCase {
         )
         let newer = Transcription(
             createdAt: Date(timeIntervalSinceReferenceDate: 200),
-            fileName: "Apple.mp3",
+            fileName: "Zulu.mp3",
             status: .completed,
             derivedTitle: "Aardvark Topic",
             updatedAt: Date(timeIntervalSinceReferenceDate: 200)
@@ -650,7 +657,7 @@ final class TranscriptionRepositoryTests: XCTestCase {
         )
         XCTAssertEqual(
             try repo.fetchLibraryPage(query: TranscriptionLibraryQuery(sortOrder: .titleAscending, limit: 10)).items.map(\.id),
-            [newer.id, meeting.id, older.id]
+            [meeting.id, older.id, newer.id]
         )
     }
 
@@ -758,7 +765,7 @@ final class TranscriptionRepositoryTests: XCTestCase {
 
         let fetched = try XCTUnwrap(repo.fetch(id: transcription.id))
         XCTAssertNil(fetched.titleOverride)
-        XCTAssertEqual(fetched.effectiveDisplayTitle, "Derived Topic")
+        XCTAssertEqual(fetched.effectiveDisplayTitle, "IMG_1942.m4a")
         XCTAssertEqual(fetched.fileName, "IMG_1942.m4a")
         XCTAssertEqual(fetched.filePath, "/tmp/IMG_1942.m4a")
         XCTAssertEqual(fetched.derivedTitle, "Derived Topic")

--- a/Tests/MacParakeetTests/Services/TranscriptionServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/TranscriptionServiceTests.swift
@@ -648,7 +648,7 @@ final class TranscriptionServiceTests: XCTestCase {
         XCTAssertEqual(try transcriptionRepo.fetch(id: result.id)?.durationMs, 5000)
     }
 
-    func testTranscribeFilePersistsEmbeddedMediaMetadataAndArtwork() async throws {
+    func testTranscribeDragDropPreservesOriginalFilenameAndEmbeddedMediaMetadata() async throws {
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("transcription-metadata-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
@@ -679,15 +679,15 @@ final class TranscriptionServiceTests: XCTestCase {
             ]
         ))
 
-        let result = try await service.transcribe(fileURL: fileURL)
+        let result = try await service.transcribe(fileURL: fileURL, source: .dragDrop)
         let fetched = try XCTUnwrap(transcriptionRepo.fetch(id: result.id))
         let cachedThumbnail = try XCTUnwrap(thumbnailCache.cachedThumbnail(for: result.id))
 
-        XCTAssertEqual(result.fileName, "Episode Title")
+        XCTAssertEqual(result.fileName, "downloaded.m4a")
         XCTAssertEqual(result.channelName, "Show Host")
         XCTAssertEqual(result.videoDescription, "Episode notes")
         XCTAssertEqual(result.durationMs, 12_000)
-        XCTAssertEqual(fetched.fileName, "Episode Title")
+        XCTAssertEqual(fetched.fileName, "downloaded.m4a")
         XCTAssertEqual(fetched.channelName, "Show Host")
         XCTAssertEqual(fetched.videoDescription, "Episode notes")
         XCTAssertEqual(fetched.durationMs, 12_000)

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionLibraryViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionLibraryViewModelTests.swift
@@ -263,11 +263,11 @@ final class TranscriptionLibraryViewModelTests: XCTestCase {
         await load()
 
         vm.renameTranscriptionTitle(vm.transcriptions[0], to: "   ")
-        vm.renameTranscriptionTitle(vm.transcriptions[0], to: "Auto Derived Title")
+        vm.renameTranscriptionTitle(vm.transcriptions[0], to: "IMG_1942.m4a")
 
         let loaded = try XCTUnwrap(vm.transcriptions.first)
         XCTAssertNil(loaded.titleOverride)
-        XCTAssertEqual(loaded.effectiveDisplayTitle, "Auto Derived Title")
+        XCTAssertEqual(loaded.effectiveDisplayTitle, "IMG_1942.m4a")
         XCTAssertNil(try repo.fetch(id: transcription.id)?.titleOverride)
     }
 

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
@@ -2128,10 +2128,10 @@ final class TranscriptionViewModelTests: XCTestCase {
         viewModel.currentTranscription = t
 
         viewModel.renameCurrentTranscriptionTitle(to: "   ")
-        viewModel.renameCurrentTranscriptionTitle(to: "Auto Derived Title")
+        viewModel.renameCurrentTranscriptionTitle(to: "IMG_1942.m4a")
 
         XCTAssertNil(viewModel.currentTranscription?.titleOverride)
-        XCTAssertEqual(viewModel.currentTranscription?.effectiveDisplayTitle, "Auto Derived Title")
+        XCTAssertEqual(viewModel.currentTranscription?.effectiveDisplayTitle, "IMG_1942.m4a")
         XCTAssertTrue(mockRepo.updateTitleOverrideCalls.isEmpty)
     }
 

--- a/Tests/MacParakeetTests/Views/TranscriptResultActionsTests.swift
+++ b/Tests/MacParakeetTests/Views/TranscriptResultActionsTests.swift
@@ -88,6 +88,29 @@ final class TranscriptResultActionsTests: XCTestCase {
         XCTAssertEqual(result.exportedURLs.map(\.lastPathComponent), ["Q3 Vendor Notes.txt"])
     }
 
+    func testBulkExportUsesOriginalFilenameForUnrenamedLocalFile() async throws {
+        let transcription = Transcription(
+            fileName: "my_video.mp4",
+            rawTranscript: "Welcome to the first few spoken words.",
+            status: .completed,
+            sourceType: .file,
+            derivedTitle: "Welcome to the first few spoken words"
+        )
+
+        let result = try await TranscriptResultActions.exportTranscriptsToDirectory(
+            transcriptions: [transcription],
+            format: .txt,
+            options: TranscriptExportOptions(
+                includeTimestamps: false,
+                includeSpeakerLabels: false,
+                includeMetadata: false
+            ),
+            directory: tempDir
+        )
+
+        XCTAssertEqual(result.exportedURLs.map(\.lastPathComponent), ["my_video.txt"])
+    }
+
     func testBulkExportCompleteSuccessRequiresEveryRequestedFile() {
         let result = BulkTranscriptExportResult(
             directory: tempDir,

--- a/spec/01-data-model.md
+++ b/spec/01-data-model.md
@@ -177,7 +177,7 @@ CREATE INDEX idx_transcriptions_status_created_at ON transcriptions(status, crea
 - `engine` / `engineVariant` record the STT engine attribution for Parakeet, Nemotron Beta, Cohere, and optional WhisperKit paths. Added in v0.8; legacy rows keep `NULL`.
 - `calendarEventSnapshot` is a JSON blob for meeting rows only. It stores `confidence` (`confirmed` for calendar auto-start, `probable` for manual starts matched against the current poll cache), EventKit `eventIdentifier`, optional `externalId`, event title, scheduled start/end, attendee names/emails, organizer name/email, meeting URL/service, and capture timestamp. This is local user data and must not be sent in telemetry, including attendee counts. Added in v0.25.
 - `titleOverride` stores a user-authored display title for non-meeting transcription rows. It is app metadata only: it does not rename/move `filePath`, replace the original `fileName`, or participate in meeting artifact naming. Blank titles are normalized to `NULL`. Added in v0.26.
-- `derivedTitle` / `derivedSnippet` cache display copy derived from the completed transcript. Added in v0.9 so Library cards do not need to recompute preview text on every render.
+- `derivedTitle` / `derivedSnippet` cache semantic display copy derived from the completed transcript. Local file rows retain the original `fileName` as their default visible title, but the derived copy remains available for search and preview-related behavior. Added in v0.9 so Library surfaces do not need to recompute derived text on every render.
 - The legacy `summary` column was migrated into `summaries` in v0.7 and dropped in v0.7.6.
 - No FTS on transcriptions in v0.1. Search by filename or scroll the list. Revisit if the list grows large.
 
@@ -713,7 +713,7 @@ struct Transcription: Codable, Identifiable {
     var engineVariant: String?          // v0.8 — Engine-specific model variant
     var calendarEventSnapshot: MeetingCalendarSnapshot? // v0.25 — Local calendar context snapshot
     var titleOverride: String?          // v0.26 — User-authored non-meeting display title override
-    var derivedTitle: String?           // v0.9 — Display title derived from transcript text
+    var derivedTitle: String?           // v0.9 — Semantic title derived from transcript text
     var derivedSnippet: String?         // v0.9 — Display preview snippet derived from transcript text
     var updatedAt: Date
 
@@ -1288,7 +1288,7 @@ migrator.registerMigration("v0.7-prompts-and-summaries") { db in
 | `dictations.engineVariant` | v0.8 | Engine-specific variant id; `NULL` for engines without variants and legacy rows |
 | `transcriptions.engine` | v0.8 | STT engine that produced the transcription; `NULL` for legacy rows |
 | `transcriptions.engineVariant` | v0.8 | Engine-specific variant id; `NULL` for engines without variants and legacy rows |
-| `transcriptions.derivedTitle` | v0.9 | Cached display title derived from transcript content |
+| `transcriptions.derivedTitle` | v0.9 | Cached semantic title derived from transcript content |
 | `transcriptions.derivedSnippet` | v0.9 | Cached display preview snippet derived from transcript content |
 | `quick_prompts` | v0.10 | User-customizable live Ask tab shortcut pills; v0.6 product feature |
 | `idx_transcriptions_source_type_created_at` / `idx_transcriptions_favorite_created_at` / `idx_transcriptions_status_created_at` | v0.10 | Library filter/sort indexes for source type, favorites, and status |

--- a/spec/02-features.md
+++ b/spec/02-features.md
@@ -1566,7 +1566,7 @@ Embedded video/audio playback, split-pane detail view, synced transcript highlig
 - [x] Multi-select cleanup with `Select Many...`, `Select All`, clear/cancel, and contextual destructive confirmations
 - [x] Meeting cleanup supports both full deletion and `Remove Audio Only...`; optional notes, AI results, and chats are removed only by full meeting deletion
 
-Visible transcription titles resolve in this order: meeting `fileName` for meeting rows; otherwise non-empty user `titleOverride`, non-empty `derivedTitle`, then original `fileName`. Library cards, detail headers, search, title sort, and GUI export filename suggestions use that effective title. Public CLI lookup/output remains tied to the existing CLI contract unless explicitly updated with CLI docs and tests.
+Visible transcription titles are source-aware. Meeting rows use their meeting `fileName`. Local file rows use a non-empty user `titleOverride` when explicitly renamed, then the original media `fileName`; transcript-derived opening words never replace that source identity. URL rows retain the non-empty `titleOverride`, `derivedTitle`, then `fileName` fallback. Library cards, detail headers, title sort, agent-facing title fields, and GUI export filename suggestions use that effective title. Search still matches the override, original filename, derived title, and transcript content. Public CLI exact-name lookup and export defaults remain tied to the existing CLI contract.
 
 ### F27: Home Page Redesign
 

--- a/spec/04-ui-patterns.md
+++ b/spec/04-ui-patterns.md
@@ -125,7 +125,7 @@ When `Library.filter == .meeting`, the view renders a date-grouped list (`Today`
 
 ### Local Transcription Rename
 
-Local transcription rows expose `Rename...` with a `pencil` symbol in the same Library card/context menu as `Open`, placed before selection and destructive actions. The dialog is compact, prefilled with the effective display title, and rejects blank titles. Rename is a display-metadata operation only: the original source filename/path remain unchanged, and copy-on-import/media-retention behavior is not implied.
+Local transcription rows expose `Rename...` with a `pencil` symbol in the same Library card/context menu as `Open`, placed before selection and destructive actions. The dialog is compact, prefilled with the effective display title, and rejects blank titles. Until the user explicitly renames it, a Local row's effective title is its original media filename rather than transcript-derived opening words. Rename is a display-metadata operation only: the original source filename/path remain unchanged, and copy-on-import/media-retention behavior is not implied.
 
 The transcript detail header uses the same effective title as the Library. The pencil affordance is available for supported title-editing sources: meetings through the existing meeting title path, and local file transcriptions through the persisted title override path.
 

--- a/spec/05-audio-pipeline.md
+++ b/spec/05-audio-pipeline.md
@@ -82,7 +82,7 @@ Input File → FFmpeg → 16kHz mono WAV → selected local STT engine → Trans
 
 ```
 User selects file
-    → Extract embedded media metadata (title, author, artwork, duration) when present
+    → Preserve the original filename and extract embedded author, description, artwork, and duration when present
     → Validate format (check extension + probe with FFmpeg)
     → Validate duration <= max (4 hours default)
     → Convert to 16kHz mono WAV via FFmpeg

--- a/spec/contracts/cli-json-v1.md
+++ b/spec/contracts/cli-json-v1.md
@@ -41,14 +41,17 @@ with human progress/status kept off stdout.
 - `search --json` returns an array of segment hits with `transcriptionId`,
   `title`, ISO-8601 `recordedAt`, `source`, `seq`, nullable `startMs` and
   `speaker`, `snippet`, and nullable `rank`. CJK substring-fallback hits use
-  `rank: null`.
+  `rank: null`. Local-file `title` values use an explicit title override when
+  present, otherwise the original media filename; transcript-derived opening
+  words do not replace the source filename.
 - For `search --since/--until`, a bare `yyyy-MM-dd` is interpreted in the
   user's local calendar and time zone: `--since` starts at local midnight and
   `--until` includes the full local day. Full ISO-8601 timestamps with `Z` or
   an explicit offset retain that stated zone.
 - `transcript --json` returns one object with transcription metadata and an
   ordered `segments` array. Segment objects contain `seq`, nullable timing and
-  speaker fields, `text`, and `segmenterVersion`.
+  speaker fields, `text`, and `segmenterVersion`. Its Local-file `title` follows
+  the same override-then-original-filename rule as search results.
 - `cards list --json` returns an array; `--ndjson` returns the same card objects
   one compact object per line. Each object has exactly `transcriptionId`,
   `title`, `date`, nullable `durationMs`, `source`, nullable `attendees`, the
@@ -58,6 +61,7 @@ with human progress/status kept off stdout.
   are explicit `null`. File/URL decision and action arrays are empty. Cards
   whose transcript hash, segmenter version, prompt version, or card schema
   version is stale are suppressed; list output contains current cards only.
+  Local-file card titles follow the same override-then-original-filename rule.
 - `cards generate --json` returns selection and progress counts, nullable
   prompt/completion/total token totals, explicit `estimatedCostUSD: null`, and
   per-recording failures. Human progress remains on stderr. Any failed item


### PR DESCRIPTION
## Summary

- restore original media filenames as the default title for Local file transcriptions
- keep explicit Local renames authoritative while leaving URL-derived and meeting naming unchanged
- use the same source-aware title policy for Library sorting, search results, GUI exports, cards, and transcript JSON
- keep derived Local titles searchable without showing them as the source identity

## Why

Issue #809 identified a regression: imported files such as `my_video.mp4` were being displayed and exported under their first spoken words instead of the original filename. This restores the earlier behavior directly; it does not add a preference or database migration.

## Verification

- focused naming and neighboring-surface suite: 261 tests, 0 failures
- full `swift test` on current `origin/main`: 4,903 tests, 20 skipped, 0 failures
- `git diff --check`
- standards review: no findings
- issue/spec review: no findings

The optional local `no-mistakes` and `greptile` CLIs were not installed, so the documented standard review path and full local suite were used; GitHub CI remains the remote gate.

Fixes #809

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores original media filenames as the default title and export stem for Local transcriptions, and fixes drag‑and‑drop imports to keep the path filename even when embedded titles exist. URL and meeting naming stay the same; fixes #809.

- **Bug Fixes**
  - Local file titles now use the original filename across the Library, CLI JSON (`search`, `transcript`, `cards list`), and GUI exports.
  - Drag‑and‑drop imports preserve the path filename; embedded author/description/artwork/duration are still saved.
  - User `titleOverride` remains authoritative; derived titles stay searchable but are not shown for Local files.
  - Bulk export uses the original filename for unrenamed Local files.

- **Refactors**
  - Centralized a source‑aware SQL title expression via `effectiveDisplayTitleExpression(tableAlias:)`; shared by Library sort/search and `SegmentRepository`, matching model behavior (including whitespace handling).
  - Updated `effectiveDisplayTitle` to prefer `fileName` for `.file` sources.
  - Clarified CLI JSON contract/specs and added tests for Local filename behavior; no schema changes or migrations.

<sup>Written for commit cf2229c4ecec604ad59a8b03005f74a57f26899d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/815?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Local file transcriptions now consistently display and export using the original filename unless explicitly renamed.
  * Search results, transcript output, and card listings now apply consistent source-aware title behavior.
  * Renaming a transcription to its existing filename is treated as a no-op.

* **Documentation**
  * Clarified title behavior across the library, search, exports, and CLI JSON output.
  * Clarified the meaning of transcript-derived metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->