### PR TITLE
Preserve multilingual um in Clean processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ You choose between two **processing modes**:
 
 **The Clean pipeline** applies these steps in order:
 
-1. **Filler removal** — Strips "um", "uh", and sentence-start fillers like "so", "well", "like"
+1. **Filler removal** — Strips the conservative hesitation spellings "uh", "umm", and "uhh"
 2. **Custom words** — Applies your word replacement rules (e.g., "aye pee eye" becomes "API", or "kubernetes" gets capitalized to "Kubernetes"). Case-insensitive, whole-word matching. Words can be toggled on/off without deleting.
 3. **Voice Return** — If you've defined one or more trigger phrases (e.g., "press return" or "zatwierdź") and speak one at the end of a dictation, it's stripped from the output and a Return keypress is simulated after paste
 4. **Snippet expansion** — Replaces short trigger phrases with longer text (e.g., "my signature" expands to "Best regards, David"). Triggers are natural language phrases because that's what the speech engine outputs. Matched longest-first to prevent collisions.

--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -95,6 +95,8 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
   the original media filename unless the user explicitly renamed the
   transcription, matching the Mac app and avoiding transcript-opening words as
   unstable source identifiers. JSON field names and shapes are unchanged.
+- Clean processing now preserves `um` because it carries meaning in supported
+  languages such as Portuguese and German.
 - Transcription and retranscription progress now reports
   `Preparing speech model...` while the local engine loads instead of printing
   a synthetic 0% update before measurable work begins. JSON stdout is unchanged.

--- a/Sources/MacParakeet/Views/Vocabulary/VocabularyView.swift
+++ b/Sources/MacParakeet/Views/Vocabulary/VocabularyView.swift
@@ -127,7 +127,7 @@ struct VocabularyView: View {
                 pipelineStep(
                     number: 1,
                     title: "Remove fillers",
-                    detail: "um, uh, umm, uhh",
+                    detail: "uh, umm, uhh",
                     actionTitle: nil,
                     action: nil
                 )

--- a/Sources/MacParakeetCore/TextProcessing/README.md
+++ b/Sources/MacParakeetCore/TextProcessing/README.md
@@ -46,7 +46,7 @@ mode.
 
 **The five pipeline steps run in this fixed order:**
 
-1. **Filler removal.** Strip pure hesitation sounds (`um`, `uh`,
+1. **Filler removal.** Strip conservative hesitation spellings (`uh`,
    `umm`, `uhh`) only. Word-boundary regex, case-insensitive,
    pre-compiled at type level. The list is intentionally short —
    anything longer ("like", "you know", "kind of") changes meaning
@@ -69,12 +69,10 @@ mode.
    while preserving acronyms, camelCase, custom vocabulary, and expanded
    snippet casing.
 
-**The order is load-bearing.** Filler removal before custom words
-prevents a custom rule from accidentally matching `"um"` as a
-substring. Action extraction before snippet expansion prevents a
-plain-text snippet from consuming the action trigger. Don't reorder
-without writing a test that exercises every adjacent-step
-interaction.
+**The order is load-bearing.** Action extraction before snippet
+expansion prevents a plain-text snippet from consuming the action
+trigger. Don't reorder without writing a test that exercises every
+adjacent-step interaction.
 
 **The pipeline is a pure function.** No I/O, no side effects, no
 state. This makes it trivial to test exhaustively (see
@@ -84,8 +82,9 @@ it at the call site, not inside the pipeline.
 
 **Filler removal is intentionally narrow.** Any expansion of the
 `alwaysSafeFillers` list needs a thoughtful test case demonstrating
-it doesn't change meaning. "I want to like Slack the team" must not
-become "I want to Slack the team."
+it doesn't change meaning in every supported language. Portuguese and
+German use `um` semantically, so it is preserved even though English
+speakers may use the same spelling as a hesitation.
 
 **The AI formatter is a different code path.** `TextRefinementService`
 does not call an LLM. It returns deterministic cleanup (plus any

--- a/Sources/MacParakeetCore/TextProcessing/TextProcessingPipeline.swift
+++ b/Sources/MacParakeetCore/TextProcessing/TextProcessingPipeline.swift
@@ -68,9 +68,9 @@ public struct TextProcessingPipeline: Sendable {
     // MARK: - Step 1: Filler Removal
 
     /// Always-safe fillers (always removed)
-    /// Only pure hesitation sounds — words that never carry meaning.
+    /// Conservative hesitation spellings that do not conflict with supported languages.
     private static let alwaysSafeFillers = [
-        "um", "uh", "umm", "uhh"
+        "uh", "umm", "uhh",
     ]
 
     /// Pre-compiled filler regexes — avoids recompilation on every dictation.

--- a/Tests/MacParakeetTests/DictationFlow/DictationFlowCoordinatorLoadCaptionTests.swift
+++ b/Tests/MacParakeetTests/DictationFlow/DictationFlowCoordinatorLoadCaptionTests.swift
@@ -347,7 +347,7 @@ final class DictationFlowCoordinatorLoadCaptionTests: XCTestCase {
         let harness = try makeHarness(
             isReady: true,
             transcribeDelayMs: 5,
-            transcribeText: "um",
+            transcribeText: "uh",
             keepDictationOnClipboard: true,
             processingMode: .clean
         )

--- a/Tests/MacParakeetTests/TextProcessing/TextProcessingPipelineTests.swift
+++ b/Tests/MacParakeetTests/TextProcessing/TextProcessingPipelineTests.swift
@@ -21,7 +21,7 @@ final class TextProcessingPipelineTests: XCTestCase {
         ]
 
         let result = pipeline.process(
-            text: "um kubernetes is great my signature",
+            text: "uh kubernetes is great my signature",
             customWords: words,
             snippets: snippets
         )
@@ -35,25 +35,29 @@ final class TextProcessingPipelineTests: XCTestCase {
         XCTAssertEqual(result.text, "Hello world")
     }
 
+    func testPipelinePreservesPortugueseUmWhenCounting() {
+        let result = pipeline.process(text: "um, dois, três", customWords: [], snippets: [])
+        XCTAssertEqual(result.text, "Um, dois, três")
+    }
+
     // MARK: - Step 1: Filler Removal
 
     func testAlwaysSafeFillerRemoval() {
-        let result = pipeline.removeFillers(from: "um hello uh world")
+        let result = pipeline.removeFillers(from: "uh hello uhh world")
         // After filler removal, we get "  hello  world" — whitespace cleanup is separate
-        XCTAssertFalse(result.contains("um"))
         XCTAssertFalse(result.contains("uh"))
+        XCTAssertFalse(result.contains("uhh"))
     }
 
     func testFillerRemovalPreservesPartialWords() {
-        // Word boundaries prevent "um" from matching inside "umbrella"
-        let result = pipeline.removeFillers(from: "umbrella this is humble")
-        XCTAssertTrue(result.contains("umbrella"))
-        XCTAssertTrue(result.contains("humble"))
+        // Word boundaries prevent active fillers from matching inside longer words.
+        let result = pipeline.removeFillers(from: "huh summer")
+        XCTAssertEqual(result, "huh summer")
     }
 
     func testFillerRemovalCaseInsensitive() {
-        let result = pipeline.removeFillers(from: "UM hello UHH world")
-        XCTAssertFalse(result.lowercased().contains("um"))
+        let result = pipeline.removeFillers(from: "UH hello UHH world")
+        XCTAssertFalse(result.lowercased().contains("uh"))
         XCTAssertFalse(result.lowercased().contains("uhh"))
     }
 
@@ -558,11 +562,11 @@ final class TextProcessingPipelineTests: XCTestCase {
     }
 
     func testMultiWordTriggerWithFillerGap() {
-        // Filler removal can leave double spaces: "press um return" → "press  return"
+        // Filler removal can leave double spaces: "press uh return" → "press  return"
         let snippets = [
             TextSnippet(trigger: "press return", expansion: "return", action: .returnKey)
         ]
-        let result = pipeline.process(text: "git status press um return", customWords: [], snippets: snippets)
+        let result = pipeline.process(text: "git status press uh return", customWords: [], snippets: snippets)
         XCTAssertEqual(result.text, "Git status")
         XCTAssertEqual(result.postPasteAction, .returnKey)
     }

--- a/Tests/MacParakeetTests/TextProcessing/TextRefinementServiceTests.swift
+++ b/Tests/MacParakeetTests/TextProcessing/TextRefinementServiceTests.swift
@@ -5,7 +5,7 @@ final class TextRefinementServiceTests: XCTestCase {
     func testCleanModeReturnsDeterministicText() async {
         let service = TextRefinementService()
         let result = await service.refine(
-            rawText: "um hello world",
+            rawText: "uh hello world",
             mode: .clean,
             customWords: [],
             snippets: []

--- a/spec/02-features.md
+++ b/spec/02-features.md
@@ -798,7 +798,7 @@ Audio → local STT → raw transcript → clean pipeline → paste
 
 **Step 1: Filler removal**
 
-Conservative defaults: only pure hesitation sounds (`um`, `uh`, `umm`, `uhh`) are removed. False negatives are better than false positives, so words like `like`, `so`, `right`, and phrases like `you know` are not stripped by default.
+Conservative defaults: only hesitation spellings that do not conflict with supported languages (`uh`, `umm`, `uhh`) are removed. False negatives are better than false positives, so semantic words such as Portuguese and German `um`, along with words like `like`, `so`, `right`, and phrases like `you know`, are not stripped by default.
 
 **Step 2: Custom word replacements**
 

--- a/spec/03-architecture.md
+++ b/spec/03-architecture.md
@@ -373,7 +373,7 @@ protocol TextProcessingPipelineProtocol {
 }
 
 // Pipeline stages (executed in order):
-// 1. Filler removal (verbal fillers: um, uh, you know, etc.)
+// 1. Filler removal (conservative hesitation spellings: uh, umm, uhh)
 // 2. Custom word replacements (vocabulary anchors + corrections)
 // 3. Snippet expansion (trigger → expansion)
 // 4. Whitespace cleanup (collapse spaces, fix punctuation, capitalize)

--- a/spec/04-ui-patterns.md
+++ b/spec/04-ui-patterns.md
@@ -800,7 +800,7 @@ The Vocabulary sidebar item is a dedicated panel for managing the text processin
 │                                                           │
 │  HOW IT WORKS                                             │
 │  ─────────────────────────────────────────────────────    │
-│  1. Filler Removal — Strips um, uh, like, you know       │
+│  1. Filler Removal — Strips uh, umm, uhh                │
 │  2. Custom Words — Fixes domain terms STT gets wrong      │
 │  3. Text Snippets — Expands trigger phrases to full text  │
 │  4. Whitespace Cleanup — Normalizes spacing/punctuation   │

--- a/spec/04-ui-patterns.md
+++ b/spec/04-ui-patterns.md
@@ -800,7 +800,7 @@ The Vocabulary sidebar item is a dedicated panel for managing the text processin
 │                                                           │
 │  HOW IT WORKS                                             │
 │  ─────────────────────────────────────────────────────    │
-│  1. Filler Removal — Strips uh, umm, uhh                │
+│  1. Filler Removal — Strips uh, umm, uhh                 │
 │  2. Custom Words — Fixes domain terms STT gets wrong      │
 │  3. Text Snippets — Expands trigger phrases to full text  │
 │  4. Whitespace Cleanup — Normalizes spacing/punctuation   │

--- a/spec/07-text-processing.md
+++ b/spec/07-text-processing.md
@@ -18,9 +18,9 @@ Raw STT Text → Filler Removal → Custom Words → Trailing Action Extraction 
 
 Removes only always-safe hesitation sounds:
 
-- "um", "uh", "umm", "uhh"
+- "uh", "umm", "uhh"
 
-Implementation uses `NSRegularExpression` with word boundaries (`\b`) to avoid partial matches. Words like "like", "so", "right", and phrases like "you know" are intentionally not stripped by default because they can carry meaning.
+Implementation uses `NSRegularExpression` with word boundaries (`\b`) to avoid partial matches. Portuguese and German `um`, words like "like", "so", "right", and phrases like "you know" are intentionally not stripped by default because they can carry meaning.
 
 ### Step 2: Custom Word Replacements
 
@@ -139,7 +139,7 @@ Stores trigger-to-expansion mappings.
 
 ```bash
 # Run clean processing on text
-macparakeet-cli vocab process "um hello kubernetes is great"
+macparakeet-cli vocab process "uh hello kubernetes is great"
 # → "Hello Kubernetes is great."
 
 # Process and copy to clipboard

--- a/spec/adr/004-deterministic-pipeline.md
+++ b/spec/adr/004-deterministic-pipeline.md
@@ -27,7 +27,7 @@ Use a **deterministic 5-step pipeline** for the default "clean" processing mode.
 
 | Step | What It Does | Example |
 |------|-------------|---------|
-| 1. Filler removal | Strip only always-safe hesitation sounds | "um the API" -> "the API" |
+| 1. Filler removal | Strip only always-safe hesitation sounds | "uh the API" -> "the API" |
 | 2. Custom word replacement | User-defined vocabulary anchors and corrections | "kube" -> "Kubernetes", "mac parakeet" -> "MacParakeet" |
 | 3. Trailing action extraction | Strip terminal action-snippet triggers and surface a post-paste action | "send this press return" -> text plus Return action |
 | 4. Snippet expansion | Trigger phrase text expansion | "my address" -> "123 Main St, Springfield, IL 62704" |


### PR DESCRIPTION
## Summary

- preserve `um` in Clean processing because it carries semantic meaning in Portuguese and German
- continue removing the unambiguous hesitation spellings `uh`, `umm`, and `uhh`
- align the Clean pipeline UI, documentation, CLI changelog, and test fixtures with the narrower default

This deliberately changes the default filler list rather than adding a one-off setting or configuration surface.

Fixes #774

## Verification

- `swift test --filter TextProcessingPipelineTests` — 62 passed
- affected refinement and dictation-flow regression tests — passed
- CLI smoke: `um, dois, três` → `Um, dois, três`; `uh hello umm world uhh` → `Hello world`
- one full `swift test` run executed 4,902 tests and identified only three assertions in two fixtures that still used `um` as removable input; both fixtures were corrected to `uh` and their focused tests pass
- `git diff --check`
- independent standards and issue-spec reviews — pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the word "um" in Clean processing for Portuguese and German speakers while still stripping "uh", "umm", and "uhh", and updates UI copy, docs/specs (including the Clean pipeline diagram), tests, and the CLI changelog to match. Fixes #774.

- **Bug Fixes**
  - Remove "um" from the always-safe filler list; keep removing "uh", "umm", and "uhh".
  - Add a Portuguese counting regression test ("um, dois, três" → "Um, dois, três") and update fixtures to use "uh".

- **Migration**
  - If you relied on "um" being removed, update tests or expectations; no new setting was added.

<sup>Written for commit 2a54ce1ec42dd558e3633ea3a8ea9c8e66406a3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/817?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

