### PR TITLE
Document the v0.7.3 CLI QA pass

### DIFF
--- a/docs/audits/2026-07-16-v0.7.3-comprehensive-codebase-release-architecture-audit.md
+++ b/docs/audits/2026-07-16-v0.7.3-comprehensive-codebase-release-architecture-audit.md
@@ -370,7 +370,12 @@ Verified bundled asset hashes:
 | node | d36b3d980963d44bd2c5e844fac4cfeee26a167b744287a4e74a9575af9d0559 |
 
 These hashes prove the contents of the audit bundle, not the future signed DMG.
-The final release must re-verify the immutable signed artifact.
+The later exact-head QA build records a different `liblocalvqe` hash because
+the locally built dylib has a different Mach-O UUID and embeds its build-worktree
+path; both builds use the same pinned LocalVQE/ggml commits, architecture,
+install name, version, size, and dependencies. The final release must re-verify
+and record the immutable signed artifact's own dylib hash. The pinned AEC model
+hash remains the stable content gate.
 
 ## 10. Test and compiler evidence
 

--- a/docs/audits/2026-07-16-v0.7.3-comprehensive-codebase-release-architecture-audit.md
+++ b/docs/audits/2026-07-16-v0.7.3-comprehensive-codebase-release-architecture-audit.md
@@ -17,6 +17,9 @@ combines the recent-change review, whole-codebase and architecture deep dive,
 release-candidate evidence, live issue and pull-request interpretation, fixes
 made while auditing, residual risks, and the exact path to publication.
 
+The subsequent automated and CLI-focused execution record is in
+[`2026-07-16-v0.7.3-qa.md`](./2026-07-16-v0.7.3-qa.md).
+
 The app should remain on the **0.7.x** train. The bundled command-line tool has
 its own 3.0 contract version; that does not imply an app 0.8 release.
 

--- a/docs/audits/2026-07-16-v0.7.3-qa.md
+++ b/docs/audits/2026-07-16-v0.7.3-qa.md
@@ -1,0 +1,527 @@
+# MacParakeet v0.7.3 QA Report
+
+> Date: 2026-07-16
+>
+> Release candidate: MacParakeet 0.7.3
+>
+> Audited pull request: #823
+>
+> Exact candidate head: `96990768e13544ce570d80aed2f53882395db9a3`
+>
+> Bundled CLI contract: `3.0.0`
+
+This report is the durable execution record for the automated and
+hardware-independent QA performed after the comprehensive release and
+architecture audit. It concentrates on the public CLI, database compatibility,
+the strict release bundle, release-script behavior, and final automated test
+gates. It does not duplicate the architecture analysis in the canonical
+[`v0.7.3` audit](./2026-07-16-v0.7.3-comprehensive-codebase-release-architecture-audit.md).
+
+## 1. Verdict
+
+### CLI verdict: pass with two non-blocking issues recorded
+
+The candidate CLI is release-quality at its public behavior boundary:
+
+- It builds as a standalone Release executable and as the executable embedded
+  in `MacParakeet.app`.
+- Its contract reports version `3.0.0`, schema `macparakeet.cli.spec` version
+  `1`, and 89 advertised command paths.
+- Every advertised command path accepts `--help`.
+- Focused CLI, installer, local-CLI, and telemetry-privacy tests pass.
+- Real local Parakeet transcription, persistence, search, transcript retrieval,
+  and export pass against isolated databases.
+- JSON stdout remains parseable and success/failure exit behavior matches the
+  documented contract.
+- A database created by the installed 0.7.1 app's bundled CLI upgrades cleanly
+  and remains queryable with the 0.7.3 candidate CLI.
+- Standalone and bundled forms share preferences correctly in an isolated
+  cross-process round trip.
+
+Two genuine but non-blocking CLI issues were filed:
+
+1. [#824: CLI installer can report ready while an older Homebrew CLI wins on PATH](https://github.com/moona3k/macparakeet/issues/824).
+2. [#825: Bundled CLI emits a misleading UserDefaults suite warning on successful commands](https://github.com/moona3k/macparakeet/issues/825).
+
+Neither issue corrupts user data, invalidates JSON stdout, breaks the bundled
+CLI, or prevents an explicit path from invoking CLI 3.0.0. Issue #824 is an
+installation/status accuracy problem for users with an existing Homebrew CLI;
+issue #825 is successful-command stderr noise. They should be fixed in a
+bounded follow-up rather than expanding the release patch while the signed
+candidate is being prepared.
+
+### Code and unsigned-bundle verdict: pass
+
+The full automated test suite passes. The exact PR head also completes the
+strict `0.7.3` release bundle path with required meeting echo assets and the
+Xcode Git-helper repair active. Bundle metadata, architectures, helper versions,
+checksums, privacy strings, update trust, Mach-O dependencies, and dSYM identity
+are coherent.
+
+### Ship verdict: still pending signed and physical QA
+
+This QA pass did not find a signed/notarized 0.7.3 artifact owned by the release
+agent. The only signed bundle in the archive checkout was an old 0.6.23
+artifact, and `/Applications/MacParakeet.app` remained 0.7.1. Do not mistake
+either for the candidate.
+
+Publication remains gated on the final Developer-ID-signed, notarized, stapled,
+installed 0.7.3 app/DMG plus the physical microphone, Bluetooth, dictation,
+meeting, and AEC matrix. Those gates cannot be replaced by this automated pass.
+
+## 2. Isolation and safety
+
+QA ran in a detached worktree at:
+
+`/private/tmp/macparakeet-073-qa-20260716.ZxxaU6`
+
+The worktree was moved only between reviewed PR heads. The active application,
+release-agent worktree, `/Applications` bundle, Homebrew installation, real
+database, real preferences, microphone routes, model caches, and user meeting
+artifacts were not mutated.
+
+Where a command could write, it used a temporary database or a temporary
+`CFFIXED_USER_HOME`. The running debug app at the audited-main commit was not
+stopped or relaunched. No signing, notarization, tag, appcast, release, upload,
+Homebrew update, or `/usr/local/bin` change was performed.
+
+## 3. Candidate and branch drift handling
+
+QA initially froze PR #823 at `fea4cc7124670a6ef1b90838a88f2f19c7197c8e`.
+During the pass, review fixes advanced the PR to the final audited head
+`96990768e13544ce570d80aed2f53882395db9a3`:
+
+- `fa11895d`: make release Git capability checks checkout-independent.
+- `55fb4361`: honor a configured `GIT_EXEC_PATH`.
+- `96990768`: tighten release-audit qualifications.
+
+The advance changed only the bundle helper and documentation. A direct diff
+confirmed no change to `Sources/**/*.swift`, `Tests/**/*.swift`, `Package.swift`,
+or `Package.resolved`. The full Swift suite therefore covers an identical
+Swift/package tree. Because the release helper did change, the strict bundle
+was rebuilt from exact head `96990768` and passed again.
+
+## 4. CLI build and contract QA
+
+### Release build and linkage
+
+Command:
+
+```bash
+swift build -c release --product macparakeet-cli
+```
+
+Result: pass. A fresh dependency resolution and Release build completed in
+222.76 seconds. Relevant resolved versions included FluidAudio 0.15.4, Argmax
+0.18.0, GRDB 7.10.0, Sparkle 2.9.0, and swift-argument-parser 1.7.1.
+
+`otool -L` found only system libraries/frameworks for the standalone CLI. No
+Homebrew, user-worktree, or temporary-build path is a runtime dependency.
+
+The only build warning was FluidAudio's upstream unhandled
+`Sources/FluidAudio/ASR/Parakeet/Unified/benchmark.md` file.
+
+### Runtime discovery surface
+
+The standalone Release CLI reported:
+
+| Probe | Result |
+|---|---|
+| `--version` | `3.0.0` |
+| `--help` | pass |
+| `spec --json` | valid JSON, schema `macparakeet.cli.spec`, schema version 1 |
+| Advertised command paths | 89 |
+| Advertised paths accepting `--help` | 89 of 89 |
+| `health --json` | valid JSON; clean stderr for standalone CLI |
+| `models list --json` | valid JSON; 7 model entries; clean stderr |
+| `models status --json` | valid JSON; clean stderr |
+| `config list --json` | valid JSON; 22 keys; clean stderr |
+
+Evidence directory:
+
+`/private/tmp/macparakeet-cli-qa.kPwEp3`
+
+### Focused automated tests
+
+Command:
+
+```bash
+swift test --filter CLITests
+```
+
+Result: 474 tests, zero failures.
+
+Additional command:
+
+```bash
+swift test --filter \
+  'CLIOperationPrivacyTests|CommandLineToolInstallServiceTests|LocalCLIExecutorTests|LocalCLILLMClientTests'
+```
+
+Result: 50 XCTest cases plus 3 Swift Testing cases, zero failures.
+
+The additional matrix covered:
+
+- CLI-operation telemetry key/value privacy.
+- Matching, missing, stale, conflicting, translocated, and missing-bundle CLI
+  installer states.
+- Local CLI process execution, environment handling, stdin, stdout/stderr,
+  cancellation, timeouts, and child-process cleanup.
+- Local CLI LLM adapter request/response and failure behavior.
+
+## 5. Real CLI workflow QA
+
+### Standalone Release CLI smoke
+
+The release-demo smoke generated a local TTS fixture with `/usr/bin/say`,
+converted it to WAV, ran real local Parakeet transcription, persisted to an
+isolated SQLite database, emitted JSON, and exported Markdown.
+
+Result: pass.
+
+Transcript:
+
+> Mac Parakeet Release Demo Smoke Fixture. This short local audio proves
+> transcription and export.
+
+Evidence:
+
+`/private/tmp/macparakeet-073-cli-smoke-source.WUpu7j`
+
+### Exact-head bundled CLI smoke
+
+The same real workflow was repeated against:
+
+`dist/MacParakeet.app/Contents/MacOS/macparakeet-cli`
+
+from exact candidate head `96990768`.
+
+Result: pass. The output record ID was
+`672EF335-298D-4770-A63C-851C68A39AC5`; health and transcription stdout both
+parsed as JSON, and the exported Markdown contained the expected transcript.
+
+Evidence:
+
+`/private/tmp/macparakeet-073-cli-smoke-exact-head.ELRdUL`
+
+### Search, history, transcript, export, and failure semantics
+
+Against the isolated source-smoke database, the candidate CLI completed:
+
+- `history transcriptions --json`: one saved row.
+- `search-reindex --json`: one transcription and one segment indexed.
+- `search 'release AND demo' --json`: one result.
+- `transcript <id> --around-seq 0 --context 2 --json`: one durable segment.
+- `export <id> --format json --stdout`: matching record ID.
+
+Every successful machine-readable stdout value parsed as JSON. Stderr was empty
+for these read/index/export checks.
+
+Error behavior also matched the contract:
+
+| Case | Exit | Stdout | Stderr |
+|---|---:|---|---|
+| Missing transcript after successful parsing | 1 | JSON failure envelope with `errorType: lookup` | empty |
+| Mutually exclusive `--json --envelope` | 2 | empty | ArgumentParser misuse text |
+| Unknown root flag | 2 | empty | ArgumentParser misuse text |
+
+Evidence:
+
+`/private/tmp/macparakeet-cli-contract-qa.OigjpJ`
+
+### Preference sharing across standalone and bundled forms
+
+Using a temporary `CFFIXED_USER_HOME`, QA performed this round trip:
+
+1. Standalone CLI set `telemetry=off`.
+2. Bundled CLI read `off`.
+3. Bundled CLI set `telemetry=on`.
+4. Standalone CLI read `on`.
+
+All four JSON outputs parsed and contained the expected values. This proves the
+bundled warning tracked in #825 is not evidence that shared preference values
+are currently lost.
+
+Evidence:
+
+`/private/tmp/macparakeet-cli-defaults-crossmode.wmam2F`
+
+## 6. Database compatibility QA
+
+The installed 0.7.1 app bundles CLI 2.12.0. That older CLI successfully ran the
+same real transcription/export smoke against a new isolated database. The
+candidate CLI then opened and migrated that database:
+
+| Check | Result |
+|---|---|
+| Pre-candidate migration count | 43 |
+| Candidate migration count | 45 |
+| Unknown candidate migration identifiers | 0 |
+| Saved history row readable | yes |
+| Segment reindex | 1 transcription / 1 segment |
+| Transcript segment readable | yes |
+
+The upgrade retained the expected transcript and word timestamps. This is a
+direct supported-version upgrade proof, not only an empty-database migration
+test.
+
+Evidence:
+
+- `/private/tmp/macparakeet-cli-071-upgrade-smoke.IHISXI`
+- `/private/tmp/macparakeet-cli-upgrade-qa.jBFpQf`
+
+### Developer database schema-skew observation
+
+A non-mutating candidate `health --json` against the maintainer's current real
+database reports:
+
+```text
+database.status = schema_skew
+unknown migration = v0.10.1-quick-prompts-pin
+```
+
+The current source migration ledger has 45 identifiers and intentionally folds
+the pin column into `v0.10-quick-prompts`; the real developer database has 46
+rows because it also retains the orphaned `v0.10.1-quick-prompts-pin` identifier.
+The string was not found in reachable source history or other current
+worktrees. The clean 0.7.1-to-candidate upgrade above has zero unknown
+identifiers.
+
+Classification: developer/prerelease database contamination, not evidence of a
+public 0.7.1/0.7.2 upgrade failure. The CLI correctly refuses to call the
+database healthy. Do not delete or rewrite the real migration ledger as part of
+release QA; reconcile it only through an explicit user-data-safe recovery task.
+
+Evidence:
+
+`/private/tmp/macparakeet-cli-live-health.AHUfB5`
+
+## 7. Machine-level CLI installation QA
+
+The current shell resolves:
+
+```text
+/opt/homebrew/bin/macparakeet-cli -> Homebrew Cellar 2.3.1
+```
+
+The current local tap formula is also 2.3.1 and reports the installation as not
+outdated. `/opt/homebrew/bin` precedes `/usr/local/bin` on this machine. The
+installed 0.7.1 app's internal CLI is 2.12.0; the candidate internal CLI is
+3.0.0.
+
+The app-managed installer owns `/usr/local/bin/macparakeet-cli` and reports a
+matching link as installed and “ready in Terminal.” It does not account for a
+higher-priority Homebrew executable. Therefore installing the app link can
+leave a normal shell invoking 2.3.1 while the UI reports success. Issue #824
+records this behavior. The real links were not changed during QA.
+
+Separate release gate: CLI 3.0.0 is not fully published until its signed
+standalone archive, `cli-v3.0.0` release, updated tap formula/checksum, fresh
+Homebrew reinstall, `--version`, `health --json`, and `brew test` all pass.
+
+## 8. Full automated suite
+
+One final full suite was run, matching the repository rule:
+
+```bash
+swift test --parallel
+```
+
+Result:
+
+- 4,919 XCTest invocations completed.
+- 17 Swift Testing tests in 3 suites completed.
+- Total observed: 4,936 tests.
+- Exit status: 0.
+- Failure markers: none.
+
+Log:
+
+`/private/tmp/macparakeet-073-full-suite-20260716.log`
+
+As described in section 3, the subsequent exact-head changes did not alter the
+Swift/package/test tree. The exact-head strict bundle and bundled CLI smoke were
+then rerun separately.
+
+## 9. Exact-head strict bundle QA
+
+Command:
+
+```bash
+env -u GIT_EXEC_PATH \
+  REQUIRE_MEETING_ECHO_ASSETS=1 \
+  LOCALVQE_CMAKE_BUILD_JOBS=1 \
+  VERSION=0.7.3 \
+  scripts/dist/build_app_bundle.sh
+```
+
+Result: pass from `96990768e13544ce570d80aed2f53882395db9a3`.
+
+The script detected that Xcode's Git lacks `git-submodule`, selected the
+Homebrew Git helper directory, and completed package resolution. The production
+helper function was also exercised directly in three cases:
+
+- valid configured `GIT_EXEC_PATH`: pass and preserved.
+- invalid configured path with shell-Git fallback: pass.
+- `GIT_EXEC_PATH` unset with shell-Git fallback: pass.
+
+### Bundle identity
+
+| Property | Verified value |
+|---|---|
+| Version | 0.7.3 |
+| Build | 20260716212019 |
+| Embedded commit | `96990768e135` |
+| Build source | `dist-xcodebuild-release` |
+| App architecture | arm64 |
+| Bundled CLI | 3.0.0, arm64 |
+| App executable UUID | `1CBB50D6-0111-348A-8451-6E7FEDE745EB` |
+| dSYM UUID | `1CBB50D6-0111-348A-8451-6E7FEDE745EB` |
+| Bundle bytes (`du`) | 355,393,536 |
+| Regular files | 122 |
+| Sparkle | 2.9.0 build 2053, universal |
+| Feed | `https://macparakeet.com/appcast.xml` |
+| Public update key | present and matched |
+| Legal files | 2 |
+| Quarantine attributes | none |
+
+`verify_release_version.sh`, its negative fixture tests, Info.plist lint, strict
+meeting-echo asset verification, update-trust checks, and dSYM matching all
+passed.
+
+### Bundled helpers and checksums
+
+| Artifact | Version/architecture | SHA-256 |
+|---|---|---|
+| Meeting echo model | LocalVQE v1.4 AEC model | `b6e43138588a83bfe903ab5e143b4020b91c1e1629f5a575ac5855ff0003c731` |
+| `liblocalvqe.dylib` | arm64 | `71ede2df141f371ea406b8cad8b63a7a101ba6993a99dec8644057d11a85b32a` |
+| FFmpeg | 8.1.2, arm64 | `eaf91238e104dd0e262bc6510e25061855cc99a6955a721b0ac99660d58c473d` |
+| yt-dlp | 2026.07.04, universal | `498bd0dae17855c599d371d68ec5bafc439a9d8640e838be25c765a9792f261b` |
+| Node | 24.13.1, arm64 | `d36b3d980963d44bd2c5e844fac4cfeee26a167b744287a4e74a9575af9d0559` |
+
+Every bundled Mach-O was inventoried. No dependency referenced `/private/tmp`,
+`/Users`, `/opt/homebrew`, or `/usr/local`. `liblocalvqe.dylib` links only its
+own `@rpath` identity and Apple system libraries/frameworks. The app includes
+the expected executable and Frameworks rpaths.
+
+The privacy surface contains non-empty microphone, system-audio, and full
+calendar usage descriptions. The expected signed-app entitlements request
+audio input, calendars, and outbound network access. The signing pipeline also
+has dedicated hardened-runtime entitlements for Node and yt-dlp.
+
+### Expected pre-sign state
+
+`codesign --verify --deep --strict` fails on the assembled unsigned bundle with:
+
+```text
+code has no resources but signature indicates they must be present
+```
+
+This is expected before the final signing pass: Xcode's linker signature is
+stale after resources, helpers, frameworks, and Info.plist are assembled. The
+release script signs nested Sparkle XPC services/apps/executables, helper
+binaries, dylibs, the CLI, and the outer app inside-out, then requires:
+
+- deep strict code-sign verification;
+- signing team and authority validation;
+- signed privacy entitlements;
+- signed meeting echo runtime validation;
+- app notarization, stapling, and Gatekeeper acceptance;
+- DMG signing, notarization, and stapling.
+
+The unsigned QA app must not be distributed.
+
+## 10. Successful-command diagnostics
+
+### Bundled UserDefaults warning
+
+The bundled CLI emits this message on stderr:
+
+```text
+Using your own bundle identifier as an NSUserDefaults suite name does not make sense and will not work.
+```
+
+It appears on `health --json`, transcription, and config commands because the
+executable runs inside the app bundle. Standalone CLI stderr is clean. The
+preference round trip in section 5 proves values currently work; issue #825
+tracks eliminating the misleading warning.
+
+### CoreML E5RT diagnostic on the short fixture
+
+Both real transcription smokes completed successfully but the very short
+fixture caused CoreML E5RT to write a `slice_by_index: zero shape error`
+diagnostic to stderr near 99% progress. Transcript text, JSON stdout,
+persistence, and export were correct. MacParakeet already quarantines native
+STT diagnostics away from stdout, and benchmark/release tooling anticipates
+E5RT diagnostics. This observation is not classified as a candidate defect
+without a failed or incorrect transcription.
+
+## 11. Live PR review and CI state
+
+At the last code-bearing candidate snapshot:
+
+- PR #823 was open and not a draft.
+- Exact head was `96990768e13544ce570d80aed2f53882395db9a3`.
+- Merge state was clean.
+- All five review threads were resolved.
+- Greptile Review: success.
+- CodeRabbit: success.
+- Cubic: neutral/no blocking finding.
+- Exact-head hosted CI run `29535334278`: success in 24 minutes 16 seconds.
+  It passed Release build, CLI contract smoke, Release bundle smoke,
+  concurrency-warning scan, first-party Swift 6 language mode with WhisperKit
+  excluded from that one language-mode check, the full parallel suite, and log
+  upload.
+
+This QA report itself is a documentation-only successor to that tested
+code-bearing SHA. The release agent must still use the final exact head and
+require its hosted CI to be green before merge/release. If any later change is
+not documentation-only, reconcile the diff and repeat proportional QA; do not
+treat this fixed SHA's evidence as automatically covering new code.
+
+## 12. Remaining release-agent matrix
+
+### Signed/notarized artifact gates
+
+From the one immutable candidate app/DMG:
+
+1. Verify embedded version, build, and Git SHA match the approved head.
+2. Run `codesign --verify --deep --strict` on the app.
+3. Run the signed privacy-surface and meeting-echo verifiers.
+4. Verify Developer ID authority/team, hardened runtime, and helper
+   entitlements.
+5. Run `xcrun stapler validate` and `spctl --assess` on the app.
+6. Verify and mount the DMG read-only; confirm the app and `/Applications`
+   symlink, version, signature, and stapled ticket.
+7. Copy to `/Applications` and run the bundled CLI release-demo smoke there.
+8. Verify `health --json`, CLI version 3.0.0, config sharing, and installer
+   status from the installed app.
+9. Publish the standalone CLI 3.0.0 channel and verify a fresh Homebrew install
+   separately.
+
+### Physical GUI/audio gates
+
+1. System Default input with Bluetooth output, explicit built-in input,
+   AirPods, USB mic, and multichannel USB input.
+2. Instant Dictation after idle, repeated cycles, off/on, route change, and
+   sleep/wake; verify no idle orange mic indicator when disabled.
+3. Meeting start/stop during startup and normal capture; a meeting longer than
+   the #808 failure window; finalization, recovery, artifact, and auto-save
+   feedback.
+4. Zoom, Google Meet, and Teams without headphones; compare raw mic, system,
+   playback, cleaned mic, and final transcript for AEC quality.
+5. App update discovery and validation from the final deployed appcast/DMG.
+
+## 13. Release recommendation
+
+The exact code-bearing PR head is a credible 0.7.3 candidate. Automated CLI,
+database, package, and unsigned-bundle QA found no release-blocking functional
+defect, and exact-head hosted CI is green. Proceed with merge and
+signed-candidate preparation once the documentation-only QA report commit is
+also accepted by branch policy. Do not publish until the signed/notarized
+installed-artifact and physical audio matrices pass.
+
+Treat #824 and #825 as known, bounded CLI follow-ups. During the 0.7.3/CLI 3.0
+release, explicitly verify which `macparakeet-cli` the shell resolves and do not
+describe the standalone CLI as released until the tap is upgraded from 2.3.1
+and a fresh Homebrew installation passes.

--- a/docs/audits/2026-07-16-v0.7.3-qa.md
+++ b/docs/audits/2026-07-16-v0.7.3-qa.md
@@ -48,9 +48,9 @@ CLI, or prevents an explicit path from invoking CLI 3.0.0. Issue #824 is an
 installation/status accuracy problem for users with an existing Homebrew CLI;
 issue #825 is successful-command stderr noise. They should be fixed in a
 bounded follow-up rather than expanding the release patch while the signed
-candidate is being prepared.
+candidate proceeds through physical and publication QA.
 
-### Code and unsigned-bundle verdict: pass
+### Code, bundle, and automated signed-artifact verdict: pass
 
 The full automated test suite passes. The exact PR head also completes the
 strict `0.7.3` release bundle path with required meeting echo assets and the
@@ -58,16 +58,19 @@ Xcode Git-helper repair active. Bundle metadata, architectures, helper versions,
 checksums, privacy strings, update trust, Mach-O dependencies, and dSYM identity
 are coherent.
 
-### Ship verdict: still pending signed and physical QA
+After PR #823 merged, the release agent rebuilt from merged `main` at
+`5232855c96b3b99943871b378d87de69aadf095e`. Independent QA of that
+Developer-ID-signed and notarized app/DMG passed the automated distribution
+gates and a real signed bundled-CLI transcription/export smoke.
 
-This QA pass did not find a signed/notarized 0.7.3 artifact owned by the release
-agent. The only signed bundle in the archive checkout was an old 0.6.23
-artifact, and `/Applications/MacParakeet.app` remained 0.7.1. Do not mistake
-either for the candidate.
+### Ship verdict: pending installed, physical, and publication QA
 
-Publication remains gated on the final Developer-ID-signed, notarized, stapled,
-installed 0.7.3 app/DMG plus the physical microphone, Bluetooth, dictation,
-meeting, and AEC matrix. Those gates cannot be replaced by this automated pass.
+The signed artifact is technically coherent, but it was not copied over the
+existing `/Applications/MacParakeet.app`; that installed app remained 0.7.1.
+Publication remains gated on installed-app validation, the physical microphone,
+Bluetooth, dictation, meeting, and AEC matrix, standalone CLI 3.0 Homebrew
+publication, and remote DMG/appcast/GitHub-asset consistency. Those gates cannot
+be replaced by this automated pass.
 
 ## 2. Isolation and safety
 
@@ -449,7 +452,93 @@ binaries, dylibs, the CLI, and the outer app inside-out, then requires:
 
 The unsigned QA app must not be distributed.
 
-## 10. Successful-command diagnostics
+## 10. Merged-main signed and notarized candidate QA
+
+The release agent rebuilt, signed, notarized, and stapled a candidate from the
+merged release commit. QA did not run or modify the signing workflow; it waited
+for the release-owned process to exit, then independently inspected the
+finished artifacts read-only.
+
+### Signed artifact identity
+
+| Property | Verified value |
+|---|---|
+| Source commit | `5232855c96b3b99943871b378d87de69aadf095e` |
+| Version | 0.7.3 |
+| Build | 20260716214441 |
+| Build source | `dist-xcodebuild-release` |
+| Bundled CLI | 3.0.0 |
+| App/dSYM UUID | `AB1EA062-17D0-3176-896B-2B77BEA31C39` |
+| DMG bytes | 148,933,259 |
+| DMG SHA-256 | `bda4d3e5087d7bc156cd4f5c9fd1fde9b332a9ac838305c09a334cd115d7ee26` |
+
+Final signed code hashes for this candidate are:
+
+| Artifact | SHA-256 |
+|---|---|
+| App executable | `e5b53c4e6b18ec70157aaa7e6d1761d03e3900ceeceb186236893dade8c9d966` |
+| Bundled CLI | `926120f906707fac5da30fa237b4dbce08678a0356475711d968032f72ecc9a8` |
+| `liblocalvqe.dylib` | `c55b74b73d35b9259aae4278d08fc0e3fa88e3f160df51ef3629655102106bb0` |
+| Meeting echo model | `b6e43138588a83bfe903ab5e143b4020b91c1e1629f5a575ac5855ff0003c731` |
+| FFmpeg | `0bae845a433eda70a6687ee3b9480988b9e494e23c0c6d1de48925bd79cf67ba` |
+| yt-dlp | `3b9aa61907e38ed3c7803ab65ec84d143cfe2098e7ba6d27cab8dda9770ccd93` |
+| Node | `da2515cf80afeea6697a2207d5da170eedf227960ee1742f9223cd59b1d746dd` |
+
+Signing changes executable hashes, so these intentionally differ from the
+pre-sign hashes in section 9. The pinned model content remains unchanged.
+
+### Distribution security gates
+
+All of the following passed:
+
+- `verify_release_version.sh` against the signed app.
+- `codesign --verify --deep --strict` on the signed app and on the app mounted
+  from the final DMG.
+- Signed privacy-surface verification: expected bundle ID, Developer ID
+  authority, team `FYAF2ZD7RM`, usage strings, and app entitlements.
+- Signed meeting-echo model/runtime verification.
+- `xcrun stapler validate` for both app and DMG.
+- `spctl --assess` for both app execution and DMG opening; both report
+  `source=Notarized Developer ID`.
+- `syspolicy_check distribution`, which reports the app ready for
+  distribution.
+- `hdiutil verify`, with a valid DMG checksum.
+
+Every signed code object inventoried in the app carries team
+`FYAF2ZD7RM`: the app, CLI, FFmpeg, yt-dlp, Node, LocalVQE dylib, Sparkle
+framework, Autoupdate, Updater app, and Downloader/Installer XPC services.
+
+The final entitlements are the intended narrow surfaces:
+
+- App: microphone input, outbound network client, and calendars.
+- Node: JIT.
+- yt-dlp: disabled library validation for the signed PyInstaller runtime.
+
+### DMG contents and signed CLI smoke
+
+The DMG mounted read-only and contained exactly the expected
+`MacParakeet.app` plus an `Applications -> /Applications` symlink. The mounted
+app reports version 0.7.3 and commit `5232855c96b3`; its Info.plist, app
+executable, and CLI are byte-identical to the signed source app. Deep signature
+and stapler validation pass from the mounted volume.
+
+The real release-demo smoke then ran against the signed bundled CLI. It
+generated the local fixture, transcribed it with Parakeet, persisted it to an
+isolated database, emitted valid JSON, and exported Markdown. Result: pass.
+
+Evidence:
+
+`/private/tmp/macparakeet-073-cli-smoke-signed.LIHZr0`
+
+Transcript:
+
+> Mac Parakeet Release Demo Smoke Fixture. This short local audio proves
+> transcription and export.
+
+This proves the signed CLI executable runs correctly from the release-owned
+app. It does not replace a final smoke after copying the app to `/Applications`.
+
+## 11. Successful-command diagnostics
 
 ### Bundled UserDefaults warning
 
@@ -474,13 +563,12 @@ STT diagnostics away from stdout, and benchmark/release tooling anticipates
 E5RT diagnostics. This observation is not classified as a candidate defect
 without a failed or incorrect transcription.
 
-## 11. Live PR review and CI state
+## 12. Live PR review and CI state
 
-At the last code-bearing candidate snapshot:
+The release code PR reached this final state:
 
-- PR #823 was open and not a draft.
-- Exact head was `96990768e13544ce570d80aed2f53882395db9a3`.
-- Merge state was clean.
+- PR #823 merged at head `96990768e13544ce570d80aed2f53882395db9a3`.
+- Merge commit: `5232855c96b3b99943871b378d87de69aadf095e`.
 - All five review threads were resolved.
 - Greptile Review: success.
 - CodeRabbit: success.
@@ -491,31 +579,41 @@ At the last code-bearing candidate snapshot:
   excluded from that one language-mode check, the full parallel suite, and log
   upload.
 
-This QA report itself is a documentation-only successor to that tested
-code-bearing SHA. The release agent must still use the final exact head and
-require its hosted CI to be green before merge/release. If any later change is
-not documentation-only, reconcile the diff and repeat proportional QA; do not
-treat this fixed SHA's evidence as automatically covering new code.
+The signed candidate was correctly rebuilt from the merge commit, not the
+pre-merge PR head. This report lives in separate documentation-only PR #826.
+If any later release change is not documentation-only, reconcile the diff and
+repeat proportional QA; do not treat this fixed evidence as automatically
+covering new code.
 
-## 12. Remaining release-agent matrix
+## 13. Remaining release-agent matrix
 
-### Signed/notarized artifact gates
+### Completed signed/notarized artifact gates
 
-From the one immutable candidate app/DMG:
+The signed candidate has completed:
 
-1. Verify embedded version, build, and Git SHA match the approved head.
-2. Run `codesign --verify --deep --strict` on the app.
-3. Run the signed privacy-surface and meeting-echo verifiers.
-4. Verify Developer ID authority/team, hardened runtime, and helper
+1. Embedded version, build, and Git SHA verification.
+2. Deep strict code-sign verification.
+3. Signed privacy-surface and meeting-echo verification.
+4. Developer ID authority/team, hardened runtime, and helper
    entitlements.
-5. Run `xcrun stapler validate` and `spctl --assess` on the app.
-6. Verify and mount the DMG read-only; confirm the app and `/Applications`
+5. Stapler, Gatekeeper, and system distribution checks.
+6. Read-only DMG verification/mount; app and `/Applications`
    symlink, version, signature, and stapled ticket.
-7. Copy to `/Applications` and run the bundled CLI release-demo smoke there.
-8. Verify `health --json`, CLI version 3.0.0, config sharing, and installer
-   status from the installed app.
-9. Publish the standalone CLI 3.0.0 channel and verify a fresh Homebrew install
-   separately.
+7. Real release-demo smoke against the signed bundled CLI in the release
+   worktree.
+
+### Remaining installed and publication gates
+
+1. Preserve one immutable DMG; verify its SHA-256 remains
+   `bda4d3e5087d7bc156cd4f5c9fd1fde9b332a9ac838305c09a334cd115d7ee26`
+   through upload, appcast signing, GitHub attachment, and remote retrieval.
+2. Copy to `/Applications` and repeat bundled CLI release-demo smoke.
+3. Verify installed-app `health --json`, CLI version 3.0.0, preference sharing,
+   installer status, and the shell-resolved CLI path/version.
+4. Publish the standalone CLI 3.0.0 channel and verify a fresh Homebrew
+   reinstall, `health --json`, and `brew test` separately.
+5. Verify appcast version/build/signature/length, remote DMG checksum/size,
+   GitHub asset name, update discovery, and Homebrew cask availability.
 
 ### Physical GUI/audio gates
 
@@ -530,14 +628,13 @@ From the one immutable candidate app/DMG:
    playback, cleaned mic, and final transcript for AEC quality.
 5. App update discovery and validation from the final deployed appcast/DMG.
 
-## 13. Release recommendation
+## 14. Release recommendation
 
-The exact code-bearing PR head is a credible 0.7.3 candidate. Automated CLI,
-database, package, and unsigned-bundle QA found no release-blocking functional
-defect, and exact-head hosted CI is green. Proceed with merge and
-signed-candidate preparation once the documentation-only QA report commit is
-also accepted by branch policy. Do not publish until the signed/notarized
-installed-artifact and physical audio matrices pass.
+The merged code and automated signed artifact are credible 0.7.3 release
+candidates. Automated CLI, database, package, bundle, signing, notarization,
+DMG, and signed-CLI QA found no release-blocking functional defect, and hosted
+CI is green. Do not publish until the installed-app, physical audio, standalone
+Homebrew CLI, and remote publication-consistency matrices pass.
 
 Treat #824 and #825 as known, bounded CLI follow-ups. During the 0.7.3/CLI 3.0
 release, explicitly verify which `macparakeet-cli` the shell resolves and do not

--- a/docs/audits/2026-07-16-v0.7.3-qa.md
+++ b/docs/audits/2026-07-16-v0.7.3-qa.md
@@ -280,17 +280,22 @@ database.status = schema_skew
 unknown migration = v0.10.1-quick-prompts-pin
 ```
 
-The current source migration ledger has 45 identifiers and intentionally folds
-the pin column into `v0.10-quick-prompts`; the real developer database has 46
-rows because it also retains the orphaned `v0.10.1-quick-prompts-pin` identifier.
-The string was not found in reachable source history or other current
-worktrees. The clean 0.7.1-to-candidate upgrade above has zero unknown
-identifiers.
+The current source migration ledger has 45 identifiers; its
+`v0.10-quick-prompts` migration creates the `isPinned` column directly. The
+real developer database has 46 rows because it also retains the separate
+`v0.10.1-quick-prompts-pin` identifier. That identifier was not found in
+reachable source history or other current worktrees. Its provenance is
+therefore unresolved; the current schema shape alone does not prove when or
+where the separate identifier ran.
 
-Classification: developer/prerelease database contamination, not evidence of a
-public 0.7.1/0.7.2 upgrade failure. The CLI correctly refuses to call the
-database healthy. Do not delete or rewrite the real migration ledger as part of
-release QA; reconcile it only through an explicit user-data-safe recovery task.
+The clean 0.7.1-to-candidate upgrade above has zero unknown identifiers, so the
+supported public upgrade path tested here does not reproduce the skew. Treat
+this as a developer-database-specific observation, not proof that a customer
+database cannot contain the same identifier. The CLI correctly refuses to call
+the database healthy. If the identifier appears in a customer database, handle
+it as a real compatibility investigation. Do not delete or rewrite any real
+migration ledger as part of release QA; reconcile it only through an explicit
+user-data-safe recovery task.
 
 Evidence:
 
@@ -391,13 +396,26 @@ passed.
 
 ### Bundled helpers and checksums
 
-| Artifact | Version/architecture | SHA-256 |
+| Artifact | Version/architecture | SHA-256 for this exact-head QA build |
 |---|---|---|
 | Meeting echo model | LocalVQE v1.4 AEC model | `b6e43138588a83bfe903ab5e143b4020b91c1e1629f5a575ac5855ff0003c731` |
 | `liblocalvqe.dylib` | arm64 | `71ede2df141f371ea406b8cad8b63a7a101ba6993a99dec8644057d11a85b32a` |
 | FFmpeg | 8.1.2, arm64 | `eaf91238e104dd0e262bc6510e25061855cc99a6955a721b0ac99660d58c473d` |
 | yt-dlp | 2026.07.04, universal | `498bd0dae17855c599d371d68ec5bafc439a9d8640e838be25c765a9792f261b` |
 | Node | 24.13.1, arm64 | `d36b3d980963d44bd2c5e844fac4cfeee26a167b744287a4e74a9575af9d0559` |
+
+The LocalVQE dylib checksum is intentionally recorded as artifact identity,
+not as a reproducible source trust anchor. The earlier pre-#822 audit build
+recorded `20355fc08cea119fad38abc17659795412054587ae8fcfd79cbfac5d37cb3e85`;
+this exact-head build records
+`71ede2df141f371ea406b8cad8b63a7a101ba6993a99dec8644057d11a85b32a`.
+Both are 1,657,728-byte arm64 dylibs built from LocalVQE commit
+`35b116d5eb059d552fa46fac3ce2963ed13ce153` and ggml commit
+`c044a8eeae2591faa0950c8b5e514cbc4bbfc4ca`, with the same install name,
+version, and runtime dependencies. They have different Mach-O UUIDs and embed
+their different absolute build-worktree paths, so byte-for-byte hashes differ.
+The pinned AEC model hash is the stable content gate; the release agent must
+record and verify the final signed candidate's own dylib hash.
 
 Every bundled Mach-O was inventoried. No dependency referenced `/private/tmp`,
 `/Users`, `/opt/homebrew`, or `/usr/local`. `liblocalvqe.dylib` links only its


### PR DESCRIPTION
## Summary

- add the durable automated and CLI-focused QA record for the 0.7.3 candidate merged in #823
- document focused and full-suite test counts, real transcription/search/export evidence, 0.7.1 database upgrade proof, exact-head strict bundle metadata/checksums, signed/notarized distribution verification, and remaining installed/physical/publication gates
- record the two non-blocking CLI findings filed as #824 and #825
- link the QA addendum from the canonical comprehensive audit

## Verification

- QA covers code-bearing head `96990768e13544ce570d80aed2f53882395db9a3`, merged by #823 as `5232855c96b3b99943871b378d87de69aadf095e`
- exact-head hosted CI run `29535334278`: success
- local full suite: 4,919 XCTest invocations plus 17 Swift Testing tests, zero failures
- exact-head strict unsigned 0.7.3 bundle: pass
- exact-head bundled CLI real transcription/export smoke: pass
- merged-main Developer-ID signing, notarization, stapling, Gatekeeper, system distribution, and DMG verification: pass
- signed bundled CLI real transcription/export smoke: pass
- `git diff --check origin/main...HEAD`: pass

Documentation only; no release code or artifact is changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the v0.7.3 CLI QA report and links it from the audit, now also recording signed app/DMG QA (Developer ID + notarization/Gatekeeper pass, recorded hashes, signed bundled‑CLI smoke). Keeps the full‑suite and workflow evidence (transcription/search/export, 0.7.1→0.7.3 upgrade), notes #824/#825, and explains the exact‑head `liblocalvqe` hash difference while requiring re‑verifying the final signed dylib (AEC model hash is the gate).

<sup>Written for commit 25b8270eb68b49dc288ac0051aa411a1df4ecaf3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/826?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

