### PR TITLE
docs: record the completed 0.7.3 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@
 
 ---
 
-MacParakeet runs NVIDIA's Parakeet TDT on Apple's Neural Engine via [FluidAudio](https://github.com/FluidInference/FluidAudio) CoreML. The current stable release includes system-wide dictation, file/URL transcription, meeting recording with selectable microphone/system capture and echo-suppressed finalization, meeting calendar support, Parakeet v3/v2/Unified model selection, optional local Nemotron Beta, Cohere Transcribe, and WhisperKit recognition, and Transforms for selected-text rewrites. Current `main` adds post-v0.7.2 microphone-routing, capture-lifecycle, speech-engine routing, CLI, and workflow fixes. All speech recognition happens on your Mac.
+MacParakeet runs NVIDIA's Parakeet TDT on Apple's Neural Engine via [FluidAudio](https://github.com/FluidInference/FluidAudio) CoreML. The current stable release includes system-wide dictation, file/URL transcription, meeting recording with selectable microphone/system capture and echo-suppressed finalization, meeting calendar support, Parakeet v3/v2/Unified model selection, optional local Nemotron Beta, Cohere Transcribe, and WhisperKit recognition, and Transforms for selected-text rewrites. Version 0.7.3 adds System Default microphone-routing repair, separate live/final speech-engine routes, bounded meeting-capture lifecycle handling, meeting auto-save feedback, and bundled CLI 3.0. All speech recognition happens on your Mac.
 
 ## Release status
 
@@ -63,8 +63,8 @@ The [notarized DMG](https://downloads.macparakeet.com/MacParakeet.dmg) is the st
 
 | Channel | Status | Includes |
 |---------|--------|----------|
-| Stable DMG `0.7.2` | Recommended for normal use | Dictation, file/video/media URL and podcast transcription, meeting recording with selectable mic/system capture, cleaned-mic finalization and audio-retention controls, meeting calendar reminders and opt-in auto-start/auto-stop, Transforms, VAD-guided meeting live-preview chunking, Parakeet v3/v2/Unified model selection, optional Nemotron Beta, Cohere, and WhisperKit, exports, vocabulary, AI features |
-| `main` branch | Development | Latest stable release plus System Default microphone-routing repair, separate live/final speech-engine routes, bounded meeting-capture lifecycle handling, meeting auto-save feedback, CLI 3.0, and other post-v0.7.2 fixes; developer-gated in-process MLX local LLM groundwork remains compiled/tested but hidden from normal users |
+| Stable DMG `0.7.3` | Recommended for normal use | Dictation, file/video/media URL and podcast transcription, meeting recording with selectable mic/system capture, cleaned-mic finalization and audio-retention controls, meeting calendar reminders and opt-in auto-start/auto-stop, System Default microphone routing, separate live/final speech-engine routes, bounded meeting-capture lifecycle handling, Transforms, VAD-guided meeting live-preview chunking, Parakeet v3/v2/Unified model selection, optional Nemotron Beta, Cohere, and WhisperKit, bundled CLI 3.0, exports, vocabulary, AI features |
+| `main` branch | Development | Current `0.7.3` source plus subsequent reviewed development; developer-gated in-process MLX local LLM groundwork remains compiled/tested but hidden from normal users |
 
 Meeting calendar support is live in the stable DMG. MacParakeet reads upcoming meetings from the local macOS Calendar store through EventKit, can show reminders, and can optionally start a recording after a countdown. Auto-start defaults to `.off` and must be opted into. Recordings stop manually unless the separate activity-based auto-stop setting is enabled; that setting also defaults off.
 

--- a/docs/audits/2026-07-16-release-readiness-audit.md
+++ b/docs/audits/2026-07-16-release-readiness-audit.md
@@ -7,6 +7,9 @@
 > Fixed point: public release `v0.7.2` at `afc2eff9`
 >
 > Candidate version: `0.7.3`
+>
+> Published release: `v0.7.3` at
+> `d6321f87dccecf29bd4792113f522bb0c98d1f35`, build `20260717011712`
 
 Canonical consolidated record:
 [`2026-07-16-v0.7.3-comprehensive-codebase-release-architecture-audit.md`](./2026-07-16-v0.7.3-comprehensive-codebase-release-architecture-audit.md).
@@ -17,13 +20,16 @@ contract version does not require a new minor app version.
 
 ## Verdict
 
-The post-v0.7.2 code is a credible `0.7.3` release candidate. The reviewed
-implementation has no known code-level release blocker after the dependency,
-release-tooling, and canonical-documentation fixes in this audit branch.
+Version `0.7.3` was published after the reviewed code was rebuilt from the
+merged CLI-installer revert, exact-main CI passed, and the signed/notarized
+installed candidate, bundled CLI demo, R2 object, Sparkle feed, and GitHub asset
+were verified. The immutable DMG is 148,896,323 bytes with SHA-256
+`0c4ccb1b6f0cedae0f7994afce393094596aacdd8548af374ae18ae500ecdd8a`.
 
-This is **code ready**, not yet **ship complete**. A signed/notarized candidate
-still needs the physical audio-route and long-meeting matrix in this document
-before publishing the DMG, appcast, GitHub release, and Homebrew asset.
+The longer hardware/audio matrix below remains useful ongoing physical QA; the
+publication record does not claim scenarios that were not rerun against the
+exact final build. Full artifact and notarization evidence is in the canonical
+consolidated record linked above.
 
 ## Scope
 
@@ -73,8 +79,11 @@ recent merged implementation plans are marked for archival rather than open.
 
 ## Recent-change review
 
-No new correctness, privacy, persistence, concurrency, or CLI-contract defect
-was found in PRs #775, #783, #785, #795, #801, #802, or #810-#822.
+Signed-candidate QA later found that PR #775's in-app CLI PATH-link installer
+could not write the normal root-owned `/usr/local/bin`; PR #827 removed it
+before publication. Apart from that superseded installer, no new correctness,
+privacy, persistence, concurrency, or CLI-contract defect was found in PRs
+#783, #785, #795, #801, #802, or #810-#822.
 
 The highest-risk paths have explicit ownership and bounded state transitions:
 
@@ -161,8 +170,10 @@ Run from a notarized app copied to `/Applications`, not from the DMG volume:
    auto-save feedback, and no stuck recording state.
 4. **No-headphones AEC:** run Zoom, Google Meet, and Teams samples; compare raw
    microphone, system audio, playback, cleaned microphone, and final transcript.
-5. **Installed CLI:** run installer/permissions checks and the release demo smoke
-   against `/Applications/MacParakeet.app/Contents/MacOS/macparakeet-cli`.
+5. **Installed CLI:** verify the bundled executable, record Terminal PATH
+   resolution separately, and run the release demo smoke against
+   `/Applications/MacParakeet.app/Contents/MacOS/macparakeet-cli`. Do not modify
+   Homebrew-owned links as part of app QA.
 
 ## Non-blocking follow-ups
 

--- a/docs/audits/2026-07-16-release-readiness-audit.md
+++ b/docs/audits/2026-07-16-release-readiness-audit.md
@@ -82,8 +82,8 @@ recent merged implementation plans are marked for archival rather than open.
 Signed-candidate QA later found that PR #775's in-app CLI PATH-link installer
 could not write the normal root-owned `/usr/local/bin`; PR #827 removed it
 before publication. Apart from that superseded installer, no new correctness,
-privacy, persistence, concurrency, or CLI-contract defect was found in PRs
-#783, #785, #795, #801, #802, or #810-#822.
+privacy, persistence, concurrency, or CLI-contract defect was found in the
+remaining reviewed PR set (#783, #785, #795, #801, #802, and #810-#822).
 
 The highest-risk paths have explicit ownership and bounded state transitions:
 

--- a/docs/audits/2026-07-16-v0.7.3-comprehensive-codebase-release-architecture-audit.md
+++ b/docs/audits/2026-07-16-v0.7.3-comprehensive-codebase-release-architecture-audit.md
@@ -21,7 +21,7 @@ made while auditing, residual risks, and the exact path to publication.
 The app should remain on the **0.7.x** train. The bundled command-line tool has
 its own 3.0 contract version; that does not imply an app 0.8 release.
 
-### Post-release publication record
+## Post-release publication record
 
 Version 0.7.3 was published on 2026-07-16 after PR #827 removed the in-app CLI
 PATH-link installer and exact-main CI passed. The original candidate verdicts
@@ -126,16 +126,17 @@ content.
 
 ### Current public release
 
-- Latest GitHub release: **v0.7.2**
-- Release name: **MacParakeet 0.7.2**
-- Published: **2026-07-12 20:27:06 UTC**
+- Latest GitHub release: **v0.7.3**
+- Release name: **MacParakeet 0.7.3**
+- Published: **2026-07-17 01:44:51 UTC**
 - Draft/prerelease: **no / no**
-- Dereferenced release commit: **afc2eff9dd0c388f6833f801dad139a8b09bfc0a**
+- Dereferenced release commit: **d6321f87dccecf29bd4792113f522bb0c98d1f35**
 
 The canonical Sparkle feed is **https://macparakeet.com/appcast.xml**. Its
-newest item is 0.7.2, build 20260712195419, minimum macOS 14.2. The enclosure
-length is 148,685,155 bytes and the remote DMG reports the same content length.
-The feed contains an EdDSA signature.
+newest item is 0.7.3, build 20260717011712, minimum macOS 14.2. The enclosure
+length is 148,896,323 bytes and a cache-busted full remote download has the
+same length and SHA-256 as the immutable release DMG. Sparkle's verifier
+accepts the feed's EdDSA signature against that remote file.
 
 ### Audited development head
 
@@ -722,7 +723,7 @@ These are bounded follow-ups, not reasons to expand the release patch:
 10. Evaluate WhisperKit 1.x independently; remove the Swift 6 skip only after
     proving compatibility.
 
-## 15. Required signed-candidate physical QA
+## 15. Ongoing physical QA not claimed as 0.7.3 release evidence
 
 Run these checks from a notarized app copied to **/Applications**, not from the
 DMG volume.

--- a/docs/audits/2026-07-16-v0.7.3-comprehensive-codebase-release-architecture-audit.md
+++ b/docs/audits/2026-07-16-v0.7.3-comprehensive-codebase-release-architecture-audit.md
@@ -8,7 +8,8 @@
 >
 > Stable release fixed point: **v0.7.2**, commit **afc2eff9dd0c388f6833f801dad139a8b09bfc0a**
 >
-> Candidate: **MacParakeet 0.7.3**
+> Released version: **MacParakeet 0.7.3**, commit
+> **d6321f87dccecf29bd4792113f522bb0c98d1f35**
 >
 > Audit branch: **codex/release-readiness-20260716**
 
@@ -19,6 +20,46 @@ made while auditing, residual risks, and the exact path to publication.
 
 The app should remain on the **0.7.x** train. The bundled command-line tool has
 its own 3.0 contract version; that does not imply an app 0.8 release.
+
+### Post-release publication record
+
+Version 0.7.3 was published on 2026-07-16 after PR #827 removed the in-app CLI
+PATH-link installer and exact-main CI passed. The original candidate verdicts
+below describe the review state before publication; this record supersedes the
+old "not ship complete" status.
+
+| Surface | Published evidence |
+|---|---|
+| Source and tag | Release commit and lightweight tag `v0.7.3`: `d6321f87dccecf29bd4792113f522bb0c98d1f35` |
+| App metadata | Version `0.7.3`, build `20260717011712`, embedded commit `d6321f87dcce` |
+| Immutable DMG | 148,896,323 bytes; SHA-256 `0c4ccb1b6f0cedae0f7994afce393094596aacdd8548af374ae18ae500ecdd8a` |
+| Apple notarization | App submission `9bacbfec-398a-4a37-a83d-509808e3b838`; DMG submission `e5c4eabb-2e0a-41f0-9315-d92982f782ae`; both accepted and stapled |
+| Sparkle | EdDSA `gxVsSar1BqbILQHiwBvbRr0nuJLxSbX/Ldw80ao8yyn0RpHrlr9R8f3Bkgy+ExaoIpkAcsKggx+VXvfgIieECA==`; live appcast build, URL, length, and signature match the artifact |
+| CI | Exact merged-main run `29547029677` passed the release build, CLI and bundle smoke, concurrency and Swift 6 gates, and full suite |
+| Installed candidate | Gatekeeper accepted the app as Notarized Developer ID; deep codesign and app/DMG staples validated; installed version/build/commit and bundled CLI 3.0 matched; release-demo smoke passed |
+| CLI installer removal | Installed Settings and application menus contain no installer surface; source/tests contain no installer symbols; the existing Homebrew link at `/opt/homebrew/bin/macparakeet-cli` was not changed |
+| R2 and GitHub | A cache-busted full download from R2 and the GitHub release asset were each byte-for-byte identical to the local DMG; GitHub release `v0.7.3` targets the exact release commit |
+
+Initial R2 file-body upload attempts failed locally with Wrangler `fetch failed`
+and left the old public object intact. Wrangler's streaming `--pipe` path
+completed the same authenticated upload; a full public re-download, byte count,
+SHA-256, and `cmp` then proved the remote object before the appcast was
+deployed. The website appcast commit is `1385cd2`.
+
+The exact final candidate was launched from `/Applications`; its Settings view
+and application menu were inspected, and the bundled CLI demo was exercised.
+This publication record does not overclaim the longer Bluetooth, sleep/wake,
+real-call AEC, and long-meeting scenarios in section 15; those remain useful
+ongoing physical QA rather than evidence fabricated after release.
+
+The installed CLI `health` command also surfaced one unknown migration in this
+maintainer machine's long-lived development database:
+`v0.10.1-quick-prompts-pin`. Read-only inspection showed the current migration
+ledger through `v0.28-cards` was present, while that one identifier was absent
+from current source, reachable Git history, and active worktrees. The database
+was not modified. Because the isolated final CLI release-demo smoke passed,
+this was classified as orphan development-database history rather than a 0.7.3
+app/CLI schema mismatch or release blocker.
 
 ## 1. Executive verdict
 
@@ -32,10 +73,11 @@ or a broad architectural rewrite.
 
 ### Shipping verdict
 
-The candidate is **code ready, not ship complete**. It still needs a
-Developer-ID-signed, notarized, installed-app candidate and the physical audio
-matrix in section 15. The audit deliberately did not tag, sign, notarize,
-upload, alter the appcast, publish a GitHub release, or update Homebrew.
+**Superseded by the post-release publication record above.** The audit branch
+itself did not publish; the final release workflow subsequently rebuilt from
+the merged CLI-installer revert, signed and notarized the app and DMG, verified
+the installed candidate and bundled CLI, and published one immutable artifact
+through R2, Sparkle, and GitHub.
 
 ### Architecture verdict
 
@@ -156,8 +198,9 @@ The first-parent sequence reviewed was:
 | PR #819, ef9d2509 | Adds the current Engine settings surface. |
 | PR #822, 6599603c | Clarifies the Advanced transcription-engine option, keeps errors visible, and makes Settings search expand/scroll to the control. |
 
-No new correctness, privacy, persistence, or public-contract defect was found
-in those merged changes. The highest-risk flows have explicit ownership:
+Apart from the PR #775 installer defect described immediately below, no new
+correctness, privacy, persistence, or public-contract defect was found in the
+other merged changes. The highest-risk flows have explicit ownership:
 
 - ScreenCaptureKit startup exposes partial ownership to Stop immediately.
 - A late startup completion cannot revive or erase a stopped meeting.
@@ -219,6 +262,12 @@ The final product boundary is simpler:
 - The shell user owns PATH, aliases, and manually created links.
 - The app does not modify shell profiles, write package-manager paths, or offer
   a privileged PATH-link installer.
+
+PR #827 merged the removal before release. Issue #595 was closed as not planned
+with the bundled-path and ownership explanation; release-readiness issue #824
+was closed with the correction that its earlier installer-ready claim had been
+superseded. This preserves the useful request history without representing the
+removed convenience surface as a shipped fix.
 
 The release fix therefore reverts PR #775 in full, including the menu item,
 Settings row, installer service, and their dedicated tests. It does not remove
@@ -399,7 +448,7 @@ A replay with GIT_EXEC_PATH explicitly removed passed the strict bundle.
 
 ### 8.3 Canonical release and feature truth
 
-README/spec/ADR surfaces now say:
+At audit time, README/spec/ADR surfaces were corrected to say:
 
 - v0.7.2 is the current public stable release.
 - The post-v0.7.2 reliability train is a 0.7.3 candidate.
@@ -407,6 +456,9 @@ README/spec/ADR surfaces now say:
   live dictation preview shipped in the v0.7 line with their actual flags and
   defaults.
 - The recent merged implementation plans are no longer described as open.
+
+After publication, the canonical README/spec release blocks were advanced to
+stable 0.7.3. The statements above remain the dated pre-publication checkpoint.
 
 ## 9. Candidate artifact evidence
 
@@ -732,7 +784,8 @@ From the installed app:
 
 ## 16. Release publication sequence
 
-Only after section 15 passes:
+The final release followed this order after the maintainer approved
+publication:
 
 1. Select the exact approved Git SHA and record it.
 2. Confirm origin/main still contains reviewed PR #822 at or after 6599603c.
@@ -751,6 +804,11 @@ Only after section 15 passes:
 
 Do not rebuild between signing, Sparkle signing, GitHub upload, and appcast
 publication. Those surfaces must all describe the same bytes.
+
+Completed result: all three public surfaces describe build `20260717011712`
+and the same 148,896,323-byte DMG. Sparkle verification succeeded against full
+downloads from both R2 and GitHub. The broader physical scenarios in section
+15 remain explicitly unclaimed, as noted in the post-release record.
 
 ## 17. Audit branch inventory
 

--- a/spec/README.md
+++ b/spec/README.md
@@ -62,8 +62,8 @@ These decisions are final. Do not second-guess them.
 
 | Channel | Status | Notes |
 |---------|--------|-------|
-| Stable DMG `0.7.2` | User-facing release, recommended for normal use | Dictation, file/media URL transcription, meeting recording with cleaned-mic finalization, calendar auto-start and activity-based auto-stop (both opt-in, default off), Transforms, VAD-guided meeting live-preview chunking, optional Nemotron Beta, Cohere, and WhisperKit, exports, vocabulary, AI features |
-| `main` | Development | Latest stable release plus System Default microphone-routing repair, separate live/final speech-engine routes, bounded meeting-capture lifecycle handling, meeting auto-save feedback, CLI 3.0, and other post-v0.7.2 fixes; developer-gated in-process MLX local LLM groundwork remains compiled/tested but hidden from normal users |
+| Stable DMG `0.7.3` | User-facing release, recommended for normal use | Dictation, file/media URL transcription, System Default microphone routing, separate live/final speech-engine routes, meeting recording with cleaned-mic finalization and bounded capture lifecycle, calendar auto-start and activity-based auto-stop (both opt-in, default off), Transforms, VAD-guided meeting live-preview chunking, optional Nemotron Beta, Cohere, and WhisperKit, bundled CLI 3.0, exports, vocabulary, AI features |
+| `main` | Development | Current `0.7.3` source plus subsequent reviewed development; developer-gated in-process MLX local LLM groundwork remains compiled/tested but hidden from normal users |
 
 Current `main` feature gates in `Sources/MacParakeetCore/AppFeatures.swift`:
 
@@ -127,7 +127,7 @@ All ADRs live in `spec/adr/`. These are locked -- they record decisions already 
 | v0.4 | Polish & Launch | Diarization, custom hotkey, non-blocking progress, direct distribution | **Implemented** |
 | v0.5 | Data, UI & Prompts | Private dictation, favorites, video player, split-pane detail, library grid, prompt library, multi-summary | **Implemented** |
 | v0.6 | Meeting Recording + Multilingual STT + Transforms | System audio + mic capture, concurrent with dictation, local transcription, VAD-guided live-preview chunking, library integration, optional Nemotron Beta and WhisperKit engines, system-wide selected-text rewrites, calendar auto-start | **Implemented** |
-| v0.7 | Post-v0.6 polish | Activity-based auto-stop (ADR-023, per-user default off), meeting reliability (ADR-025 Phase A behind a default-on kill switch), activity-based detection groundwork (ADR-024 Phases A+B behind a default-off flag), optional Cohere Transcribe, display-only live dictation transcript preview, meeting echo-cancellation/cleaned-mic artifacts, meeting audio N-day retention, System Default microphone-routing repair, split live/final speech-engine routes, bounded meeting-capture lifecycle, CLI 3.0, developer-gated local MLX groundwork, and follow-up polish | **Implemented; stable 0.7.2, 0.7.3 release candidate on `main`** |
+| v0.7 | Post-v0.6 polish | Activity-based auto-stop (ADR-023, per-user default off), meeting reliability (ADR-025 Phase A behind a default-on kill switch), activity-based detection groundwork (ADR-024 Phases A+B behind a default-off flag), optional Cohere Transcribe, display-only live dictation transcript preview, meeting echo-cancellation/cleaned-mic artifacts, meeting audio N-day retention, System Default microphone-routing repair, split live/final speech-engine routes, bounded meeting-capture lifecycle, CLI 3.0, developer-gated local MLX groundwork, and follow-up polish | **Implemented; stable 0.7.3** |
 
 ## Version Progress
 


### PR DESCRIPTION
## Summary

- advance canonical README/spec release truth to stable 0.7.3
- record the exact published commit, artifact metadata, notarization, CI, Sparkle, R2, GitHub, and installed-candidate evidence
- document the PR #775/#595 issue-triage oversight and clean PR #827 removal without claiming the installer shipped
- preserve the longer hardware matrix as ongoing QA rather than overclaiming release evidence

## Verification

- `git diff --check`
- `./scripts/check-readme-references.sh`
- live R2 and GitHub DMGs previously downloaded and compared byte-for-byte to the signed local artifact
- live appcast previously compared byte-for-byte to the deployed appcast commit and verified with Sparkle

The `v0.7.3` tag intentionally remains on the exact shipped source commit (`d6321f87dccecf29bd4792113f522bb0c98d1f35`); this PR is the post-release truth sync.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Advance README and spec to stable 0.7.3 and record the exact release in the audits: build, notarization, Sparkle signature, CI run, immutable DMG hash/size, and byte-for-byte verification across R2 and GitHub. Clarify that the in-app CLI PATH-link installer was removed pre-release, update the live-release details to the actual 0.7.3 GitHub/Sparkle state, label the hardware matrix as ongoing QA, and fix minor Markdown structure issues.

<sup>Written for commit 8d9950e4c60dd7e32caa74c3acd523a6d4845ad6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/828?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated release materials to mark **0.7.3** as the latest stable version, including refreshed “includes” details.
  - Synced release-channel and roadmap documentation to align **Stable** and **main** with **0.7.3**.
  - Refreshed release-readiness and release-architecture audit documents with final publication/verification records and artifact integrity details.
  - Documented the resolution of a CLI installer path-writing issue prior to publication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->