### PR TITLE
Silence bundled CLI UserDefaults warning

### DIFF
--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -91,6 +91,9 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
 
 ### Fixed
 
+- Bundled CLI commands no longer emit a Foundation UserDefaults suite warning
+  on otherwise successful invocations. The standalone CLI continues sharing
+  the MacParakeet app's preferences.
 - Local-file titles in `search`, `transcript`, and `cards list` now preserve
   the original media filename unless the user explicitly renamed the
   transcription, matching the Mac app and avoiding transcript-opening words as

--- a/Sources/CLI/Commands/CLIHelpers.swift
+++ b/Sources/CLI/Commands/CLIHelpers.swift
@@ -3,7 +3,6 @@ import Darwin
 import Foundation
 import MacParakeetCore
 
-let macParakeetAppDefaultsSuiteName = "com.macparakeet.MacParakeet"
 let cliValidationMisuseExitCode = ExitCode(2)
 
 struct CLIJSONEnvelopeExit: Error {
@@ -11,8 +10,15 @@ struct CLIJSONEnvelopeExit: Error {
     let originalError: Error
 }
 
-func macParakeetAppDefaults() -> UserDefaults {
-    UserDefaults(suiteName: macParakeetAppDefaultsSuiteName) ?? .standard
+func macParakeetAppDefaults(
+    bundleIdentifier: String? = Bundle.main.bundleIdentifier
+) -> UserDefaults {
+    // The bundled CLI already inherits the app's defaults domain. Reopening it
+    // as a named suite makes Foundation emit a nonsensical-suite warning.
+    if bundleIdentifier == AppPaths.preferencesSuiteName {
+        return .standard
+    }
+    return AppPaths.sharedAppDefaults()
 }
 
 func validateCLISpeechEngineMemoryRequirement(

--- a/Tests/CLITests/CLIHelpersTests.swift
+++ b/Tests/CLITests/CLIHelpersTests.swift
@@ -1,9 +1,17 @@
 import Darwin
+import Foundation
 import XCTest
 @testable import CLI
 @testable import MacParakeetCore
 
 final class CLIHelpersTests: XCTestCase {
+
+    func testBundledCLIUsesStandardDefaultsForAppPreferenceDomain() {
+        XCTAssertTrue(
+            macParakeetAppDefaults(bundleIdentifier: AppPaths.preferencesSuiteName)
+                === UserDefaults.standard
+        )
+    }
 
     func testStandardOutputRedirectionRestoresStdoutPayload() throws {
         let nullFileDescriptor = open("/dev/null", O_WRONLY)


### PR DESCRIPTION
## What changed

- Use UserDefaults.standard when the CLI is running inside the MacParakeet app preference domain.
- Keep the canonical named suite for standalone CLI installations so they continue sharing app preferences.
- Add a focused regression test and document the public CLI fix in the unreleased changelog.

## Why

The bundled CLI inherits the app bundle identifier. Constructing a named UserDefaults suite with that same identifier triggers a Foundation warning on otherwise successful commands, polluting stderr for automation. The standalone CLI does not inherit that identifier, so it still needs the named suite.

This keeps the fix at the existing preference helper: one context check, no command-specific suppression, and no new abstraction.

## Risk and scope

Low. Preference keys and values, stdout, JSON schemas, exit codes, and standalone preference sharing are unchanged. The only intended behavior change is removing the misleading stderr warning in the bundled app context.

## Verification

- swift test --filter CLIHelpersTests: 27 passed
- swift test: 4,904 XCTest cases passed, 20 skipped; 17 Swift Testing cases passed
- Synthetic app-bundle smoke test: bundled --help, health --json, and config get telemetry all exited successfully with zero-byte stderr
- Standalone smoke test: the same commands remained clean and read the same telemetry preference
- Two independent fresh-eye reviews found no remaining correctness or maintainability issues
- git diff --check passed

The optional no-mistakes and local Greptile CLI tools were unavailable on this machine, so this used the documented fallback workflow and hosted PR checks/review.

Fixes #825

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Silences the Foundation UserDefaults suite warning for the bundled CLI by using standard defaults when running inside MacParakeet. Standalone CLI behavior and preference sharing remain unchanged.

- **Bug Fixes**
  - Use `UserDefaults.standard` when the process inherits the app bundle identifier to avoid the suite warning.
  - Keep the named app suite for standalone installs to preserve shared preferences.
  - Add a regression test and update the unreleased changelog.

<sup>Written for commit ba04dd34a5409fcea549c04608c955b61c314e0e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/830?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Bundled CLI commands no longer emit a UserDefaults suite warning during otherwise successful execution.
  - The standalone CLI continues to share preferences with the MacParakeet app.

- **Documentation**
  - Updated the CLI changelog to document the warning fix and preference behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->