### PR TITLE
Omit temperature for GPT-5.x reasoning-tier OpenAI models

### DIFF
--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -91,6 +91,12 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
 
 ### Fixed
 
+- Native OpenAI LLM calls omit `temperature` for GPT-5.x reasoning-tier
+  models (e.g. `gpt-5.5`, `gpt-5.4-mini`), preventing HTTP 400
+  "unsupported temperature" responses from models that only accept the
+  default sampling temperature. Chat-tier variants (`gpt-5.3-chat-latest`)
+  and pre-5.x models retain the caller's temperature, matching the existing
+  o-series handling and the Anthropic adapter's behavior.
 - Local-file titles in `search`, `transcript`, and `cards list` now preserve
   the original media filename unless the user explicitly renamed the
   transcription, matching the Mac app and avoiding transcript-opening words as

--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -95,8 +95,8 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
   models (e.g. `gpt-5.5`, `gpt-5.4-mini`), preventing HTTP 400 responses
   from model and reasoning-effort combinations that do not accept non-default
   sampling temperatures. Chat-tier variants (`gpt-5.3-chat-latest`) and
-  pre-5.x models retain the caller's temperature, matching the existing
-  o-series handling and the Anthropic adapter's behavior.
+  non-o-series pre-5.x models retain the caller's temperature; o-series
+  reasoning models continue using their existing omission behavior.
 - Local-file titles in `search`, `transcript`, and `cards list` now preserve
   the original media filename unless the user explicitly renamed the
   transcription, matching the Mac app and avoiding transcript-opening words as

--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -92,10 +92,10 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
 ### Fixed
 
 - Native OpenAI LLM calls omit `temperature` for GPT-5.x reasoning-tier
-  models (e.g. `gpt-5.5`, `gpt-5.4-mini`), preventing HTTP 400
-  "unsupported temperature" responses from models that only accept the
-  default sampling temperature. Chat-tier variants (`gpt-5.3-chat-latest`)
-  and pre-5.x models retain the caller's temperature, matching the existing
+  models (e.g. `gpt-5.5`, `gpt-5.4-mini`), preventing HTTP 400 responses
+  from model and reasoning-effort combinations that do not accept non-default
+  sampling temperatures. Chat-tier variants (`gpt-5.3-chat-latest`) and
+  pre-5.x models retain the caller's temperature, matching the existing
   o-series handling and the Anthropic adapter's behavior.
 - Local-file titles in `search`, `transcript`, and `cards list` now preserve
   the original media filename unless the user explicitly renamed the

--- a/Sources/MacParakeetCore/Services/LLM/OpenAICompatibleLLMHTTPAdapter.swift
+++ b/Sources/MacParakeetCore/Services/LLM/OpenAICompatibleLLMHTTPAdapter.swift
@@ -256,10 +256,19 @@ struct OpenAICompatibleLLMHTTPAdapter: LLMHTTPAdapter {
         let lowered = model.lowercased()
         if isOpenAIReasoningModelID(lowered) { return true }
         if lowered.contains("chat") { return false }
-        if lowered.hasPrefix("gpt-"), let digit = lowered.dropFirst(4).first, let version = digit.wholeNumberValue, version >= 5 {
+        if let version = gptMajorVersion(lowered), version >= 5 {
             return true
         }
         return false
+    }
+
+    /// Major version of a "gpt-<n>..." model ID ("gpt-5.5" → 5, "gpt-10" → 10),
+    /// or nil for IDs without a gpt- numeric prefix. Reads all leading digits so
+    /// future multi-digit major versions compare correctly.
+    static func gptMajorVersion(_ loweredModel: String) -> Int? {
+        guard loweredModel.hasPrefix("gpt-") else { return nil }
+        let digits = loweredModel.dropFirst(4).prefix(while: { $0.isNumber })
+        return Int(digits)
     }
 
     /// OpenAI models that require max_completion_tokens instead of max_tokens.
@@ -268,7 +277,7 @@ struct OpenAICompatibleLLMHTTPAdapter: LLMHTTPAdapter {
         let lowered = model.lowercased()
         if isOpenAIReasoningModel(lowered) { return true }
         // GPT-5.x and beyond reject max_tokens
-        if lowered.hasPrefix("gpt-"), let digit = lowered.dropFirst(4).first, let version = digit.wholeNumberValue, version >= 5 {
+        if let version = gptMajorVersion(lowered), version >= 5 {
             return true
         }
         return false

--- a/Sources/MacParakeetCore/Services/LLM/OpenAICompatibleLLMHTTPAdapter.swift
+++ b/Sources/MacParakeetCore/Services/LLM/OpenAICompatibleLLMHTTPAdapter.swift
@@ -209,14 +209,14 @@ struct OpenAICompatibleLLMHTTPAdapter: LLMHTTPAdapter {
             request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         }
 
-        // OpenAI reasoning models reject temperature AND max_tokens. That
-        // includes the GPT-5.x reasoning tier (gpt-5.5, gpt-5.4-mini, ...),
-        // which only accepts the default temperature; their "-chat" variants
-        // still accept explicit values. Newer models also require
+        // OpenAI reasoning models reject max_tokens. Explicit temperature
+        // support varies by model and reasoning effort, so omit it for the
+        // GPT-5.x reasoning tier (gpt-5.5, gpt-5.4-mini, ...); its "-chat"
+        // variants still accept explicit values. Newer models also require
         // max_completion_tokens instead of max_tokens.
-        let rejectsTemperature = config.id == .openai && Self.openAIRejectsTemperature(config.modelName)
+        let shouldOmitTemperature = config.id == .openai && Self.openAIShouldOmitTemperature(config.modelName)
         let needsNewTokenParam = config.id == .openai && Self.openAIRequiresMaxCompletionTokens(config.modelName)
-        let temperature = rejectsTemperature ? nil : options.temperature
+        let temperature = shouldOmitTemperature ? nil : options.temperature
         let maxTokens = needsNewTokenParam ? nil : options.maxTokens
         let maxCompletionTokens = needsNewTokenParam ? options.maxTokens : nil
 
@@ -249,10 +249,10 @@ struct OpenAICompatibleLLMHTTPAdapter: LLMHTTPAdapter {
         isOpenAIReasoningModelID(model.lowercased())
     }
 
-    /// OpenAI models that reject non-default `temperature`: the o-series and
-    /// the GPT-5.x+ reasoning tier. Chat-tier variants (gpt-5.3-chat-latest)
-    /// and pre-5.x models accept explicit temperature values.
-    static func openAIRejectsTemperature(_ model: String) -> Bool {
+    /// OpenAI models for which MacParakeet omits explicit `temperature`: the
+    /// o-series and GPT-5.x+ reasoning tier. Chat-tier variants
+    /// (gpt-5.3-chat-latest) and pre-5.x models keep the caller's value.
+    static func openAIShouldOmitTemperature(_ model: String) -> Bool {
         let lowered = model.lowercased()
         if isOpenAIReasoningModelID(lowered) { return true }
         if lowered.contains("chat") { return false }

--- a/Sources/MacParakeetCore/Services/LLM/OpenAICompatibleLLMHTTPAdapter.swift
+++ b/Sources/MacParakeetCore/Services/LLM/OpenAICompatibleLLMHTTPAdapter.swift
@@ -209,12 +209,14 @@ struct OpenAICompatibleLLMHTTPAdapter: LLMHTTPAdapter {
             request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         }
 
-        // OpenAI reasoning models reject temperature AND max_tokens.
-        // Newer OpenAI models (gpt-5.x) reject max_tokens but accept temperature.
-        // All of them require max_completion_tokens instead of max_tokens.
-        let isReasoningModel = config.id == .openai && Self.isOpenAIReasoningModel(config.modelName)
+        // OpenAI reasoning models reject temperature AND max_tokens. That
+        // includes the GPT-5.x reasoning tier (gpt-5.5, gpt-5.4-mini, ...),
+        // which only accepts the default temperature; their "-chat" variants
+        // still accept explicit values. Newer models also require
+        // max_completion_tokens instead of max_tokens.
+        let rejectsTemperature = config.id == .openai && Self.openAIRejectsTemperature(config.modelName)
         let needsNewTokenParam = config.id == .openai && Self.openAIRequiresMaxCompletionTokens(config.modelName)
-        let temperature = isReasoningModel ? nil : options.temperature
+        let temperature = rejectsTemperature ? nil : options.temperature
         let maxTokens = needsNewTokenParam ? nil : options.maxTokens
         let maxCompletionTokens = needsNewTokenParam ? options.maxTokens : nil
 
@@ -245,6 +247,19 @@ struct OpenAICompatibleLLMHTTPAdapter: LLMHTTPAdapter {
     /// OpenAI reasoning models that reject temperature and max_tokens parameters.
     static func isOpenAIReasoningModel(_ model: String) -> Bool {
         isOpenAIReasoningModelID(model.lowercased())
+    }
+
+    /// OpenAI models that reject non-default `temperature`: the o-series and
+    /// the GPT-5.x+ reasoning tier. Chat-tier variants (gpt-5.3-chat-latest)
+    /// and pre-5.x models accept explicit temperature values.
+    static func openAIRejectsTemperature(_ model: String) -> Bool {
+        let lowered = model.lowercased()
+        if isOpenAIReasoningModelID(lowered) { return true }
+        if lowered.contains("chat") { return false }
+        if lowered.hasPrefix("gpt-"), let digit = lowered.dropFirst(4).first, let version = digit.wholeNumberValue, version >= 5 {
+            return true
+        }
+        return false
     }
 
     /// OpenAI models that require max_completion_tokens instead of max_tokens.

--- a/Tests/MacParakeetTests/Services/LLM/LLMClientTests.swift
+++ b/Tests/MacParakeetTests/Services/LLM/LLMClientTests.swift
@@ -879,7 +879,7 @@ final class LLMClientTests: XCTestCase {
         XCTAssertNil(capturedBody?["temperature"])
     }
 
-    func testGPT5UsesMaxCompletionTokensButKeepsTemperature() async throws {
+    func testGPT5ReasoningTierUsesMaxCompletionTokensAndOmitsTemperature() async throws {
         var capturedBody: [String: Any]?
 
         MockURLProtocol.handler = { request in
@@ -899,7 +899,31 @@ final class LLMClientTests: XCTestCase {
         // GPT-5.x requires max_completion_tokens, not max_tokens
         XCTAssertNil(capturedBody?["max_tokens"])
         XCTAssertEqual(capturedBody?["max_completion_tokens"] as? Int, 500)
-        // But GPT-5.x still accepts temperature (unlike reasoning models)
+        // GPT-5.x reasoning tier only accepts the default temperature
+        XCTAssertNil(capturedBody?["temperature"])
+    }
+
+    func testGPT5ChatTierUsesMaxCompletionTokensAndKeepsTemperature() async throws {
+        var capturedBody: [String: Any]?
+
+        MockURLProtocol.handler = { request in
+            if let body = self.extractBody(from: request) {
+                capturedBody = body
+            }
+            return (self.okResponse(for: request), self.validResponseData())
+        }
+
+        let config = LLMProviderConfig.openai(apiKey: "sk-test", model: "gpt-5.3-chat-latest")
+        _ = try await llmClient.chatCompletion(
+            messages: [ChatMessage(role: .user, content: "Hi")],
+            config: config,
+            options: ChatCompletionOptions(temperature: 0.7, maxTokens: 500)
+        )
+
+        // GPT-5.x requires max_completion_tokens, not max_tokens
+        XCTAssertNil(capturedBody?["max_tokens"])
+        XCTAssertEqual(capturedBody?["max_completion_tokens"] as? Int, 500)
+        // Chat-tier GPT-5.x variants still accept explicit temperature
         XCTAssertEqual(capturedBody?["temperature"] as? Double, 0.7)
     }
 

--- a/Tests/MacParakeetTests/Services/LLM/LLMClientTests.swift
+++ b/Tests/MacParakeetTests/Services/LLM/LLMClientTests.swift
@@ -899,7 +899,7 @@ final class LLMClientTests: XCTestCase {
         // GPT-5.x requires max_completion_tokens, not max_tokens
         XCTAssertNil(capturedBody?["max_tokens"])
         XCTAssertEqual(capturedBody?["max_completion_tokens"] as? Int, 500)
-        // GPT-5.x reasoning tier only accepts the default temperature
+        // MacParakeet omits temperature for the GPT-5.x reasoning tier
         XCTAssertNil(capturedBody?["temperature"])
     }
 

--- a/Tests/MacParakeetTests/Services/LLM/LLMHTTPAdapterTests.swift
+++ b/Tests/MacParakeetTests/Services/LLM/LLMHTTPAdapterTests.swift
@@ -76,6 +76,69 @@ final class LLMHTTPAdapterTests: XCTestCase {
         )
     }
 
+    func testOpenAIAdapterOmitsTemperatureForGPT5ReasoningTierModels() async throws {
+        var capturedRequest: URLRequest?
+
+        AdapterRequestURLProtocol.handler = { request in
+            capturedRequest = request
+            return (self.okResponse(for: request), self.validOpenAIResponseData())
+        }
+
+        _ = try await openAIAdapter.chatCompletion(
+            messages: goldenMessages,
+            config: .openai(apiKey: "sk-golden", model: "gpt-5.5"),
+            options: ChatCompletionOptions(temperature: 0.25, maxTokens: 123)
+        )
+
+        let request = try XCTUnwrap(capturedRequest)
+        XCTAssertEqual(
+            try canonicalJSONBody(from: request),
+            """
+            {"max_completion_tokens":123,"messages":[{"content":"System","role":"system"},{"content":"Hello","role":"user"}],"model":"gpt-5.5","stream":false}
+            """
+        )
+    }
+
+    func testOpenAIAdapterKeepsTemperatureForGPT5ChatTierModels() async throws {
+        var capturedRequest: URLRequest?
+
+        AdapterRequestURLProtocol.handler = { request in
+            capturedRequest = request
+            return (self.okResponse(for: request), self.validOpenAIResponseData())
+        }
+
+        _ = try await openAIAdapter.chatCompletion(
+            messages: goldenMessages,
+            config: .openai(apiKey: "sk-golden", model: "gpt-5.3-chat-latest"),
+            options: ChatCompletionOptions(temperature: 0.25, maxTokens: 123)
+        )
+
+        let request = try XCTUnwrap(capturedRequest)
+        XCTAssertEqual(
+            try canonicalJSONBody(from: request),
+            """
+            {"max_completion_tokens":123,"messages":[{"content":"System","role":"system"},{"content":"Hello","role":"user"}],"model":"gpt-5.3-chat-latest","stream":false,"temperature":0.25}
+            """
+        )
+    }
+
+    func testOpenAIRejectsTemperatureModelMatrix() {
+        let rejecting = ["o3", "o4-mini", "gpt-5.5", "gpt-5.4", "gpt-5.4-nano", "GPT-5.4-Mini"]
+        for model in rejecting {
+            XCTAssertTrue(
+                OpenAICompatibleLLMHTTPAdapter.openAIRejectsTemperature(model),
+                "\(model) should reject temperature"
+            )
+        }
+        let accepting = ["gpt-5.3-chat-latest", "gpt-4.1", "gpt-4.1-mini", "gpt-4o", "chatgpt-4o-latest"]
+        for model in accepting {
+            XCTAssertFalse(
+                OpenAICompatibleLLMHTTPAdapter.openAIRejectsTemperature(model),
+                "\(model) should accept temperature"
+            )
+        }
+    }
+
     func testOpenAICompatibleAdapterEncodesNullableKnowledgeCardOwnerSchema() async throws {
         var capturedRequest: URLRequest?
 

--- a/Tests/MacParakeetTests/Services/LLM/LLMHTTPAdapterTests.swift
+++ b/Tests/MacParakeetTests/Services/LLM/LLMHTTPAdapterTests.swift
@@ -122,19 +122,19 @@ final class LLMHTTPAdapterTests: XCTestCase {
         )
     }
 
-    func testOpenAIRejectsTemperatureModelMatrix() {
+    func testOpenAIShouldOmitTemperatureModelMatrix() {
         let rejecting = ["o3", "o4-mini", "gpt-5.5", "gpt-5.4", "gpt-5.4-nano", "GPT-5.4-Mini", "gpt-10"]
         for model in rejecting {
             XCTAssertTrue(
-                OpenAICompatibleLLMHTTPAdapter.openAIRejectsTemperature(model),
-                "\(model) should reject temperature"
+                OpenAICompatibleLLMHTTPAdapter.openAIShouldOmitTemperature(model),
+                "\(model) should omit temperature"
             )
         }
         let accepting = ["gpt-5.3-chat-latest", "gpt-4.1", "gpt-4.1-mini", "gpt-4o", "chatgpt-4o-latest"]
         for model in accepting {
             XCTAssertFalse(
-                OpenAICompatibleLLMHTTPAdapter.openAIRejectsTemperature(model),
-                "\(model) should accept temperature"
+                OpenAICompatibleLLMHTTPAdapter.openAIShouldOmitTemperature(model),
+                "\(model) should keep temperature"
             )
         }
     }

--- a/Tests/MacParakeetTests/Services/LLM/LLMHTTPAdapterTests.swift
+++ b/Tests/MacParakeetTests/Services/LLM/LLMHTTPAdapterTests.swift
@@ -123,7 +123,7 @@ final class LLMHTTPAdapterTests: XCTestCase {
     }
 
     func testOpenAIRejectsTemperatureModelMatrix() {
-        let rejecting = ["o3", "o4-mini", "gpt-5.5", "gpt-5.4", "gpt-5.4-nano", "GPT-5.4-Mini"]
+        let rejecting = ["o3", "o4-mini", "gpt-5.5", "gpt-5.4", "gpt-5.4-nano", "GPT-5.4-Mini", "gpt-10"]
         for model in rejecting {
             XCTAssertTrue(
                 OpenAICompatibleLLMHTTPAdapter.openAIRejectsTemperature(model),


### PR DESCRIPTION
## Problem

Transform hotkeys fail with `Provider error: Unsupported value: 'temperature' does not support 0.7 with this model. Only the default (1) value is supported.` for most models in the OpenAI picker — gpt-5.5 (the default), gpt-5.4, gpt-5.4-mini, and gpt-5.4-nano. Switching between those models doesn't help, which makes the feature look broken rather than misconfigured.

## Root cause

Transforms (and other `ChatCompletionOptions.default` call sites) always send `temperature: 0.7`. `OpenAICompatibleLLMHTTPAdapter` previously stripped `temperature` only for o-series reasoning models (`o1`, `o3`, …). OpenAI's parameter support now varies by model and reasoning effort: GPT-5.5 defaults to medium reasoning and rejects the caller's non-default temperature, while chat-tier variants such as `gpt-5.3-chat-latest` accept it. OpenAI's [GPT-5.4 guidance](https://developers.openai.com/api/docs/guides/latest-model?model=gpt-5.4#parameter-compatibility) likewise makes temperature conditional on reasoning effort.

The Anthropic adapter already handles this class of problem with model-aware temperature omission (see the 3.0.0 CLI changelog entry); this PR gives the OpenAI adapter the same conservative compatibility treatment.

## Fix

New `openAIShouldOmitTemperature(_:)` predicate: o-series models, plus `gpt-5`+ prefixed models without `chat` in the name, omit `temperature`. Chat-tier variants and pre-5.x models keep the caller's value. This is deliberately a compatibility policy rather than a claim that every matched model rejects the field in every reasoning configuration. The request-builder behavior remains one line; `max_completion_tokens` handling is unchanged.

## Verification

- **New tests**: golden-request tests asserting `gpt-5.5` omits `temperature` while `gpt-5.3-chat-latest` keeps it, plus a predicate matrix test (o3, o4-mini, gpt-5.5, gpt-5.4-nano, GPT-5.4-Mini reject; chat tier, gpt-4.1, gpt-4o, chatgpt-4o-latest accept).
- **Updated test**: `testGPT5UsesMaxCompletionTokensButKeepsTemperature` asserted the buggy behavior; split into reasoning-tier (omits) and chat-tier (keeps) variants.
- **Full `swift test` suite passes locally**: 4,907 tests, 0 failures, 20 skipped (macOS 27, Apple Silicon).
- **Wire-level A/B** against a local mock enforcing the real API's rule: the released 0.7.2 CLI sends `temperature=0.7` for gpt-5.5 and gets the 400; this branch omits the key and succeeds; chat tier still sends `0.7` and succeeds.
- **Manual end-to-end**: transform hotkey with OpenAI/gpt-5.5 reproduces the failure on released 0.7.2 and succeeds on this branch's dev build with a real key.

## Notes for reviewers

- `Sources/CLI/CHANGELOG.md` gets an Unreleased → Fixed entry mirroring the 3.0.0 Anthropic temperature entry.
- `no-mistakes` isn't installed in the environment this was authored in, so this followed the documented PR workflow directly (per AGENTS.md fallback).
- The final helper extraction removes the duplicated long version-gate line; the changed hunks add no new swift-format findings beyond the repository baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop sending `temperature` for GPT-5.x reasoning-tier and non-chat GPT-5+ OpenAI models to prevent 400s; chat-tier variants keep `temperature`. Also handle multi-digit GPT versions (e.g., `gpt-10`) for both temperature and token params; changelog now clarifies the pre-5.x vs o-series exception.

- **Bug Fixes**
  - Omit `temperature` for o-series and non-chat `gpt-5+` models (e.g., `gpt-5.5`, `gpt-5.4-mini`, future `gpt-10`); keep it for chat-tier (`gpt-5.3-chat-latest`) and pre-5.x models. `max_completion_tokens` remains the token param for 5+.
  - Added `gptMajorVersion` to parse multi-digit versions; updated tests (golden requests, matrix incl. `gpt-10`) and refined changelog to distinguish pre-5.x (keeps temperature) from o-series (omits).

<sup>Written for commit eb5144d5a293166ab26199e4b599c6cf44eae030. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/831?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with OpenAI GPT-5 reasoning-tier models by omitting `temperature` when unsupported, preventing request failures.
  * Continued honoring caller-provided `temperature` for GPT-5 chat-tier models and older compatible models.
  * Updated GPT-5 requests to use `max_completion_tokens` instead of `max_tokens`.

* **Tests**
  * Added/updated coverage to verify GPT-5 request payload differences (reasoning vs chat), including `temperature` inclusion/omission and the correct token parameter.

* **Documentation**
  * Updated the changelog to reflect the GPT-5 reasoning-tier `temperature` behavior change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
