### PR TITLE
fix: never let the retention sweeper delete audio for delete-immediately

### DIFF
--- a/Sources/MacParakeet/App/MeetingAudioRetentionSweepCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingAudioRetentionSweepCoordinator.swift
@@ -136,7 +136,9 @@ final class MeetingAudioRetentionSweepCoordinator {
     }
 
     private func logSweepResult(_ result: MeetingAudioRetentionSweepResult) {
-        logger.info(
+        // .notice persists to the unified log store (.info is memory-only);
+        // sweeps delete user audio, so they must be reconstructable later.
+        logger.notice(
             "meeting_audio_retention_sweep_completed evaluated=\(result.evaluatedCount, privacy: .public) eligible=\(result.eligibleCount, privacy: .public) detached=\(result.detachedCount, privacy: .public) locked=\(result.skippedLockedCount, privacy: .public) unmanaged=\(result.skippedUnmanagedCount, privacy: .public) failed=\(result.failedCount, privacy: .public)"
         )
     }

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -1846,7 +1846,7 @@ struct SettingsView: View {
         case .deleteAfterDays(let days):
             return "MacParakeet will remove saved meeting audio older than \(MeetingAudioRetention.normalizedDeleteAfterDays(days)) days. Transcripts stay, and notes, AI results, and chats stay if they exist. Playback and re-transcription will no longer be available, and MacParakeet cannot detect or backfill speakers for swept meetings."
         case .deleteImmediately:
-            return "MacParakeet will remove saved audio after each final transcript is saved. The meeting stays with its transcript, and notes, AI results, and chats stay if they exist. Playback and re-transcription will no longer be available, and MacParakeet cannot detect or backfill speakers for swept meetings."
+            return "New recordings will not keep audio after each final transcript is saved. Audio already saved from past meetings is kept. The meeting stays with its transcript, and notes, AI results, and chats stay if they exist. Playback and re-transcription will no longer be available for new recordings, and MacParakeet cannot detect or backfill speakers for them."
         }
     }
 

--- a/Sources/MacParakeetCore/AppRuntimePreferences.swift
+++ b/Sources/MacParakeetCore/AppRuntimePreferences.swift
@@ -497,7 +497,6 @@ public final class UserDefaultsAppRuntimePreferences: AppRuntimePreferencesProto
     public static let saveMeetingAudioKey = "saveMeetingAudio"
     public static let meetingAudioRetentionKey = "meetingAudioRetention"
     public static let meetingAudioRetentionDeleteAfterDaysKey = "meetingAudioRetentionDeleteAfterDays"
-    public static let meetingAudioRetentionAutoDeleteConfirmedKey = "meetingAudioRetentionAutoDeleteConfirmed"
     public static let lastMeetingAudioRetentionSweepAtKey = "lastMeetingAudioRetentionSweepAt"
     public static let autoGenerateMeetingTitlesKey = "autoGenerateMeetingTitles"
     public static let youtubeAudioQualityKey = "youtubeAudioQuality"

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingAudioRetentionPolicy.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingAudioRetentionPolicy.swift
@@ -28,9 +28,13 @@ public enum MeetingAudioRetentionPolicy {
         config: MeetingAudioRetention,
         now: Date
     ) -> [UUID] {
-        guard config.automaticallyDeletesAudio else { return [] }
+        // Age-based cleanup only. `.deleteImmediately` is enforced at capture
+        // time (fresh audio is never persisted); treating it as "cutoff = now"
+        // here retroactively destroyed a whole library's saved audio when the
+        // mode was merely selected in Settings (2026-07-16 incident).
+        guard config.mode == .deleteAfterDays else { return [] }
 
-        let retentionInterval = TimeInterval(config == .deleteImmediately ? 0 : config.deleteAfterDays * 24 * 60 * 60)
+        let retentionInterval = TimeInterval(config.deleteAfterDays * 24 * 60 * 60)
         return candidates.compactMap { candidate in
             guard candidate.hasAudioOnDisk,
                   candidate.isCompleted,

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingAudioRetentionSweeper.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingAudioRetentionSweeper.swift
@@ -30,7 +30,11 @@ public final class MeetingAudioRetentionSweeper: @unchecked Sendable {
         retention: MeetingAudioRetention,
         now: Date = Date()
     ) throws -> MeetingAudioRetentionSweepResult {
-        guard retention.automaticallyDeletesAudio else {
+        // Only the age-based mode sweeps saved audio. `.deleteImmediately`
+        // applies at capture time to new recordings and must never
+        // retroactively remove previously saved audio (see
+        // spec/contracts/meeting-artifacts-v1.md).
+        guard retention.mode == .deleteAfterDays else {
             return MeetingAudioRetentionSweepResult(
                 evaluatedCount: 0,
                 eligibleCount: 0,
@@ -41,7 +45,7 @@ public final class MeetingAudioRetentionSweeper: @unchecked Sendable {
             )
         }
 
-        let cutoff = cutoffDate(for: retention, now: now)
+        let cutoff = now.addingTimeInterval(-TimeInterval(retention.deleteAfterDays * 24 * 60 * 60))
         let transcriptions = try repository.fetchMeetingAudioRetentionCandidates(createdAtOrBefore: cutoff)
         var candidates: [MeetingAudioRetentionPolicy.Candidate] = []
         var skippedLockedCount = 0
@@ -95,17 +99,6 @@ public final class MeetingAudioRetentionSweeper: @unchecked Sendable {
             skippedUnmanagedCount: skippedUnmanagedCount,
             failedCount: failedCount
         )
-    }
-
-    private func cutoffDate(for retention: MeetingAudioRetention, now: Date) -> Date {
-        switch retention {
-        case .keepForever:
-            return now
-        case .deleteAfterDays(let days):
-            return now.addingTimeInterval(-TimeInterval(days * 24 * 60 * 60))
-        case .deleteImmediately:
-            return now
-        }
     }
 
     private func hasAnyRecordingLock(forAudioPath filePath: String) -> Bool {

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -860,14 +860,17 @@ public final class SettingsViewModel {
         )
     }
 
+    /// Every mode transition into an auto-deleting retention mode requires
+    /// confirmation — each time, not once per install. A one-time "confirmed"
+    /// flag let a later six-second pass through "Remove audio after
+    /// transcription" silently trigger audio deletion (2026-07-16 incident).
+    /// Day tweaks within delete-after-days stay alert-free (stepper UX).
     public func requiresMeetingAudioRetentionConfirmation(for retention: MeetingAudioRetention) -> Bool {
         retention.automaticallyDeletesAudio
-            && !meetingAudioRetention.automaticallyDeletesAudio
-            && !defaults.bool(forKey: UserDefaultsAppRuntimePreferences.meetingAudioRetentionAutoDeleteConfirmedKey)
+            && retention.mode != meetingAudioRetention.mode
     }
 
     public func confirmMeetingAudioRetentionChange(_ retention: MeetingAudioRetention) {
-        defaults.set(true, forKey: UserDefaultsAppRuntimePreferences.meetingAudioRetentionAutoDeleteConfirmedKey)
         setMeetingAudioRetention(retention)
     }
 

--- a/Tests/MacParakeetTests/App/MeetingAudioRetentionSweepCoordinatorTests.swift
+++ b/Tests/MacParakeetTests/App/MeetingAudioRetentionSweepCoordinatorTests.swift
@@ -51,7 +51,7 @@ final class MeetingAudioRetentionSweepCoordinatorTests: XCTestCase {
         )
         coordinator.schedulePreferenceChangeSweep(
             repository: repository,
-            retention: .deleteImmediately
+            retention: .deleteAfterDays(7)
         )
 
         try? await Task.sleep(for: .milliseconds(100))
@@ -61,7 +61,7 @@ final class MeetingAudioRetentionSweepCoordinatorTests: XCTestCase {
 
         let didFetchAfterRecovery = await waitForFetch(repository)
         XCTAssertTrue(didFetchAfterRecovery)
-        XCTAssertEqual(repository.cutoffs.first, sweepNow)
+        XCTAssertEqual(repository.cutoffs.first, sweepNow.addingTimeInterval(-7 * 24 * 60 * 60))
     }
 
     func testForegroundSweepWaitsForPendingLaunchRecovery() async {

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingAudioRetentionPolicyTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingAudioRetentionPolicyTests.swift
@@ -30,17 +30,21 @@ final class MeetingAudioRetentionPolicyTests: XCTestCase {
         )
     }
 
-    func testDeleteImmediatelySweepsExistingCompletedAudio() {
-        let alreadySaved = candidate(id: UUID(), ageDays: 0, extraSeconds: 1)
-        let justCreated = candidate(id: UUID(), ageDays: 0)
+    func testDeleteImmediatelyNeverSweepsSavedAudio() {
+        // "Remove audio after transcription" applies at capture time (fresh
+        // audio is never persisted). The sweeper must never retroactively
+        // delete audio that was saved under an earlier retention setting —
+        // that destroyed a real user library on 2026-07-16.
+        let old = candidate(id: UUID(), ageDays: 90)
+        let recent = candidate(id: UUID(), ageDays: 0, extraSeconds: 1)
 
         XCTAssertEqual(
             MeetingAudioRetentionPolicy.sweep(
-                [alreadySaved, justCreated],
+                [old, recent],
                 config: .deleteImmediately,
                 now: now
             ),
-            [alreadySaved.id]
+            []
         )
     }
 

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingAudioRetentionSweeperTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingAudioRetentionSweeperTests.swift
@@ -54,6 +54,26 @@ final class MeetingAudioRetentionSweeperTests: XCTestCase {
         XCTAssertEqual(try repo.fetch(id: lockedAwaiting.transcription.id)?.filePath, lockedAwaiting.audioURL.path)
     }
 
+    func testSweepWithDeleteImmediatelyLeavesSavedAudioUntouched() throws {
+        // `.deleteImmediately` is enforced at capture time; the sweeper must
+        // not use it to retroactively destroy previously saved audio.
+        let old = try makeMeeting(ageDays: 90)
+        let recent = try makeMeeting(ageDays: 0)
+        try repo.save(old.transcription)
+        try repo.save(recent.transcription)
+
+        let result = try MeetingAudioRetentionSweeper(repository: repo)
+            .sweep(retention: .deleteImmediately, now: now)
+
+        XCTAssertEqual(result.evaluatedCount, 0)
+        XCTAssertEqual(result.eligibleCount, 0)
+        XCTAssertEqual(result.detachedCount, 0)
+        for meeting in [old, recent] {
+            XCTAssertTrue(FileManager.default.fileExists(atPath: meeting.audioURL.path))
+            XCTAssertEqual(try repo.fetch(id: meeting.transcription.id)?.filePath, meeting.audioURL.path)
+        }
+    }
+
     func testSweepSkipsUnmanagedMeetingAudioPath() throws {
         let externalPath = FileManager.default.temporaryDirectory
             .appendingPathComponent("external-meeting-\(UUID().uuidString).m4a")

--- a/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
@@ -978,14 +978,28 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.meetingAudioRetention, .deleteAfterDays(14))
     }
 
-    func testMeetingAudioRetentionConfirmationRequiredOnlyForFirstAutoDeleteTransition() {
+    func testMeetingAudioRetentionConfirmationRequiredForEveryAutoDeleteModeTransition() {
+        // The one-time "confirmed" flag allowed later destructive switches to
+        // apply silently (the 2026-07-16 audio-loss incident). Every mode
+        // transition into an auto-deleting mode must confirm, every time.
         XCTAssertTrue(viewModel.requiresMeetingAudioRetentionConfirmation(for: .deleteAfterDays(30)))
 
         viewModel.confirmMeetingAudioRetentionChange(.deleteAfterDays(30))
-
         XCTAssertEqual(viewModel.meetingAudioRetention, .deleteAfterDays(30))
+
+        // Confirming once must NOT suppress future confirmations.
         viewModel.setMeetingAudioRetention(.keepForever)
-        XCTAssertFalse(viewModel.requiresMeetingAudioRetentionConfirmation(for: .deleteImmediately))
+        XCTAssertTrue(viewModel.requiresMeetingAudioRetentionConfirmation(for: .deleteImmediately))
+        XCTAssertTrue(viewModel.requiresMeetingAudioRetentionConfirmation(for: .deleteAfterDays(30)))
+
+        // Mode transitions between the two auto-deleting modes also confirm.
+        viewModel.confirmMeetingAudioRetentionChange(.deleteAfterDays(30))
+        XCTAssertTrue(viewModel.requiresMeetingAudioRetentionConfirmation(for: .deleteImmediately))
+
+        // Day tweaks within delete-after-days do not re-confirm (stepper UX),
+        // and returning to keep-forever is never destructive.
+        XCTAssertFalse(viewModel.requiresMeetingAudioRetentionConfirmation(for: .deleteAfterDays(14)))
+        XCTAssertFalse(viewModel.requiresMeetingAudioRetentionConfirmation(for: .keepForever))
     }
 
     func testSettingYouTubeAudioQualityPersists() {

--- a/spec/contracts/meeting-artifacts-v1.md
+++ b/spec/contracts/meeting-artifacts-v1.md
@@ -186,7 +186,11 @@ with a migration and conflict-resolution rule.
 
 Audio retention and "Remove Audio Only" clear `transcriptions.filePath` but
 must preserve `transcriptions.meetingArtifactFolderPath` and leave the folder's
-non-audio artifact files in place. Bulk meeting-audio cleanup removes top-level
+non-audio artifact files in place. The retention sweeper acts only on the
+age-based `delete_after_days` mode. `delete_immediately` ("Remove audio after
+transcription") applies at capture/finalization to new recordings and must
+never retroactively remove previously saved audio — selecting it in Settings
+is not consent to delete the existing library. Bulk meeting-audio cleanup removes top-level
 app-managed audio files in the session folder, including canonical filenames
 and other managed audio extensions, while preserving JSON/Markdown artifacts.
 Full meeting deletion removes the artifact folder even when retained audio was


### PR DESCRIPTION
## The incident

On 2026-07-16 at 21:24 PDT, while browsing Settings on a fresh v0.7.3 install, the meeting-audio retention picker passed through **"Remove audio after transcription"** for six seconds before landing on "Remove after 14 days" (telemetry: `meeting_audio_retention=delete_immediately` at 04:24:35Z → `delete_after_days` at 04:24:41Z). The preference-change forced sweep ran inside that window and **irreversibly deleted the saved audio of every completed meeting that still had any** — 11 meetings aged 1–8 days (DB `updatedAt` burst 04:24:36.153–.350Z). A matching burst on Jul 8 from a dev build took 23 more. No confirmation fired: the alert was gated on a one-time `meetingAudioRetentionAutoDeleteConfirmed` flag consumed on Jun 19, the day the feature shipped.

The app's own alert copy already promised prospective semantics ("MacParakeet will remove saved audio **after each final transcript is saved**") — the sweeper contradicted it by treating `.deleteImmediately` as `cutoff = now`.

## The fix (three layers)

1. **Sweeper semantics** (`MeetingAudioRetentionPolicy`, `MeetingAudioRetentionSweeper`): retention sweeps act only on the age-based `deleteAfterDays` mode. `.deleteImmediately` is enforced at capture time (`shouldSaveFreshAudio` — fresh audio is never persisted), so the sweeper now never touches saved audio for it. Even a transient pass through the mode is harmless.
2. **Confirmation every time** (`SettingsViewModel`): every mode transition into an auto-deleting mode shows the confirmation alert — the one-time flag is removed. Day tweaks within delete-after-days stay alert-free (they arrive per-click from the TextField/Stepper).
3. **Observability** (`MeetingAudioRetentionSweepCoordinator`): sweep results log at `.notice` (persisted) instead of `.info` (memory-only) — during the incident the sweep left no recoverable trace.

Plus: honest alert copy for delete-immediately ("Audio already saved from past meetings is kept"), and the invariant codified in `spec/contracts/meeting-artifacts-v1.md`.

## Behavior table

| Scenario | Before | After |
|---|---|---|
| Select "Remove audio after transcription" (flag consumed) | All completed meetings' audio deleted within ms, silently | Confirmation alert; on confirm, existing audio untouched, only future recordings affected |
| Sweep under `delete_after_days(N)` | Deletes audio older than N days | Unchanged |
| Days stepper changes | No alert | Unchanged (no alert) |
| Sweep forensics | `.info` log, unrecoverable | `.notice`, persisted in unified log |

## Tests

Failing-first: the old `testDeleteImmediatelySweepsExistingCompletedAudio` explicitly encoded the destructive semantics and is replaced by `testDeleteImmediatelyNeverSweepsSavedAudio`. New sweeper integration test proves saved audio + DB pointers survive a `.deleteImmediately` sweep. Settings test proves confirmation is required on every destructive mode transition. Focused retention + settings suites pass locally; full suite running + CI.

## Out of scope (follow-ups)

- **Recovery**: 489 of 525 session folders still contain audio while their rows lost `filePath` (pre-Jun-19 clearing) — a re-link tool can restore most of the library.
- Meetings list shows stale amber "Audio missing" chips after background sweeps (needs post-sweep refresh).
- `no-mistakes` gate skipped — binary still missing on this machine; documented PR workflow used instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents retroactive deletion of saved meeting audio when switching to “Remove audio after transcription.” The sweeper now only deletes by age, confirmations show on each destructive mode change, and sweep results are persisted.

- **Bug Fixes**
  - Sweeper acts only on delete-after-days; never sweeps saved audio for delete-immediately (that mode is enforced at capture time).
  - Show confirmation on every transition into an auto-deleting mode; remove the one-time confirmed flag. Day tweaks within delete-after-days stay alert-free.
  - Persist sweep logs by moving from .info to .notice.
  - Clarify Settings copy for delete-immediately and codify the invariant in spec/contracts/meeting-artifacts-v1.md.

<sup>Written for commit 338e5538263f15fd76e740d9e44f025da48e7e04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/832?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - “Delete immediately” now applies only to newly recorded audio and no longer removes audio from past meetings.
  - Age-based retention cleanup runs only when “Delete after days” is selected.
  - Retention settings now request confirmation whenever switching into an auto-deleting mode.

- **Documentation**
  - Clarified audio retention behavior and preservation of non-audio meeting artifacts.

- **Improvements**
  - Retention cleanup completion events are now recorded more durably for later review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->