### PR TITLE
fix(settings): make meeting hotkey searchable

### DIFF
--- a/Sources/MacParakeetViewModels/SettingsSearchIndex.swift
+++ b/Sources/MacParakeetViewModels/SettingsSearchIndex.swift
@@ -86,6 +86,7 @@ public enum SettingsSearchIndex {
     /// that won't render.
     private static let meetingGatedIds: Set<String> = [
         "meeting",
+        "meeting.hotkey",
         "meeting.floatingControls",
         "meeting.speakerDetection",
         "meeting.autoStop",
@@ -235,6 +236,19 @@ public enum SettingsSearchIndex {
             title: "Meeting Recording",
             subtitle: "Dedicated controls for meeting audio capture.",
             keywords: ["meeting", "system audio", "screen recording", "meeting capture", "core audio taps"],
+            cardAnchor: "meeting"
+        ),
+        SettingsSearchEntry(
+            id: "meeting.hotkey",
+            tab: .capture,
+            title: "Meeting hotkey",
+            subtitle: "in Meeting Recording",
+            keywords: [
+                "hotkey", "shortcut", "keyboard shortcut", "meeting shortcut",
+                "change hotkey", "change shortcut", "remove hotkey", "remove shortcut",
+                "disable hotkey", "unmap", "remap",
+                "cmd shift m", "cmd+shift+m", "command shift m", "command+shift+m", "⌘⇧m"
+            ],
             cardAnchor: "meeting"
         ),
         SettingsSearchEntry(

--- a/Tests/MacParakeetTests/ViewModels/SettingsSearchIndexTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/SettingsSearchIndexTests.swift
@@ -99,6 +99,32 @@ final class SettingsSearchIndexTests: XCTestCase {
         XCTAssertTrue(results.contains(where: { $0.id == "system.storage" }))
     }
 
+    func testMeetingHotkeyQueriesFindMeetingHotkeySetting() throws {
+        if AppFeatures.meetingRecordingEnabled {
+            let entry = try XCTUnwrap(
+                SettingsSearchIndex.entries.first { $0.id == "meeting.hotkey" }
+            )
+            XCTAssertEqual(entry.tab, .capture)
+            XCTAssertEqual(entry.title, "Meeting hotkey")
+            XCTAssertEqual(entry.subtitle, "in Meeting Recording")
+            XCTAssertEqual(entry.cardAnchor, "meeting")
+
+            for query in [
+                "meeting hotkey", "meeting shortcut", "change hotkey",
+                "remove shortcut", "disable hotkey", "CMD+Shift+M",
+                "Command Shift M", "⌘⇧M"
+            ] {
+                let ids = Set(SettingsSearchIndex.matches(query).map(\.id))
+                XCTAssertTrue(ids.contains("meeting.hotkey"), "Query \(query) should find the meeting hotkey")
+            }
+        } else {
+            XCTAssertFalse(
+                SettingsSearchIndex.entries.contains { $0.id == "meeting.hotkey" },
+                "Meeting hotkey search should stay hidden with meeting recording disabled"
+            )
+        }
+    }
+
     func testTranscriptOnlyQueryFindsStorageRetention() {
         let results = SettingsSearchIndex.matches("transcript only")
 
@@ -255,6 +281,7 @@ final class SettingsSearchIndexTests: XCTestCase {
         // change. Ids: card + sub-card + cross-tab permission row.
         let meetingGatedIds: Set<String> = [
             "meeting",
+            "meeting.hotkey",
             "meeting.floatingControls",
             "meeting.speakerDetection",
             "meeting.autoStop",


### PR DESCRIPTION
## Summary

Before this change, Settings search could not take users looking for the meeting shortcut—including the reported ⌘⇧M collision and change/remove/disable language—to the control that already existed. Search now returns a dedicated Meeting hotkey result and routes directly to the existing Meeting Recording card. The entry follows the meeting feature flag; hotkey defaults, registration, persistence, and controls are unchanged.

Fixes #835

## Test evidence

- Test-first verification: the new focused test failed before the search entry existed and passed after implementation.
- `swift test --filter SettingsSearchIndexTests` — 31 tests passed.
- `swift test` — 4,909 tests passed, 20 skipped, 0 failures.
- `git diff --check` — clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the meeting shortcut searchable in Settings (fixes #835). Adds a feature-gated "Meeting hotkey" result that routes to the Meeting Recording card and matches queries like change/remove/disable and common Command-Shift-M/⌘⇧M spellings; hotkey registration, defaults, and persistence are unchanged.

<sup>Written for commit c6cf8229aa7573079a4d467c6bc187aa66b183f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/837?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “Meeting hotkey” to Settings search, including relevant keywords and navigation.

* **Bug Fixes**
  * The Meeting hotkey setting is now hidden from search when meeting recording is disabled.

* **Tests**
  * Added coverage for finding the setting with multiple search queries and verifying feature-based visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->