### PR TITLE
Fix live preview after Pause Media pre-roll reset

### DIFF
--- a/Sources/MacParakeetCore/Services/Dictation/DictationService.swift
+++ b/Sources/MacParakeetCore/Services/Dictation/DictationService.swift
@@ -65,10 +65,18 @@ private struct LiveDictationTranscriptionState: Sendable {
     }
 }
 
+private struct DictationDisplayPreviewSamples: Sendable {
+    let samples: [Float]
+    /// Identifies the pre-roll epoch this chunk belongs to so buffered samples
+    /// from before a reset cannot enter the next preview tail.
+    let generation: Int
+}
+
 private struct DictationDisplayPreviewState: Sendable {
     let dictationSessionID: Int
     let previewSessionID: UUID
-    let sampleContinuation: AsyncStream<[Float]>.Continuation
+    let sampleContinuation: AsyncStream<DictationDisplayPreviewSamples>.Continuation
+    let resetGeneration: OSAllocatedUnfairLock<Int>
     let task: Task<Void, Never>
 }
 
@@ -566,8 +574,8 @@ public actor DictationService: DictationServiceProtocol {
         if let state = liveTranscriptionState, state.dictationSessionID == activeSessionID {
             state.markDegraded(reason: "preroll_discarded")
         }
+        resetDisplayPreview(sessionID: activeSessionID)
         clearLiveTranscript()
-        await cancelDisplayPreview(sessionID: activeSessionID, clearText: true)
         await audioProcessor.discardPreRollForActiveCapture()
     }
 
@@ -923,18 +931,20 @@ public actor DictationService: DictationServiceProtocol {
         guard previewSpeechEngine.capabilities.supportsTailPreview else { return nil }
         let speechEngine = previewSpeechEngine.selection
 
-        var continuation: AsyncStream<[Float]>.Continuation?
-        let stream = AsyncStream<[Float]>(bufferingPolicy: .bufferingNewest(120)) {
+        var continuation: AsyncStream<DictationDisplayPreviewSamples>.Continuation?
+        let stream = AsyncStream<DictationDisplayPreviewSamples>(bufferingPolicy: .bufferingNewest(120)) {
             continuation = $0
         }
         guard let sampleContinuation = continuation else { return nil }
 
         let previewSessionID = UUID()
+        let resetGeneration = OSAllocatedUnfairLock(initialState: 0)
         let interval = dictationPreviewInterval
         let windowSampleCount = dictationPreviewWindowSampleCount
         let task = Task { [weak self, previewTranscriber] in
             var tailSamples: [Float] = []
             var tailStartIndex = 0
+            var generation = 0
             let clock = ContinuousClock()
             var lastPass = clock.now
             func appendTailSamples(_ samples: [Float]) {
@@ -953,9 +963,19 @@ public actor DictationService: DictationServiceProtocol {
                 return Array(tailSamples[tailStartIndex...])
             }
 
-            for await samples in stream {
+            for await input in stream {
                 guard !Task.isCancelled else { break }
+                let samples = input.samples
                 guard !samples.isEmpty else { continue }
+                let latestGeneration = resetGeneration.withLock { $0 }
+                // A reset can happen while this task is awaiting inference, so
+                // drop any older chunks that remained buffered in the stream.
+                guard input.generation == latestGeneration else { continue }
+                if input.generation != generation {
+                    tailSamples.removeAll(keepingCapacity: true)
+                    tailStartIndex = 0
+                    generation = input.generation
+                }
                 appendTailSamples(samples)
 
                 let now = clock.now
@@ -980,7 +1000,8 @@ public actor DictationService: DictationServiceProtocol {
                     await self?.updateDisplayPreview(
                         result.text,
                         sessionID: sessionID,
-                        previewSessionID: previewSessionID
+                        previewSessionID: previewSessionID,
+                        generation: generation
                     )
                 } catch is CancellationError {
                     break
@@ -996,6 +1017,7 @@ public actor DictationService: DictationServiceProtocol {
             dictationSessionID: sessionID,
             previewSessionID: previewSessionID,
             sampleContinuation: sampleContinuation,
+            resetGeneration: resetGeneration,
             task: task
         )
         AudioCaptureDiagnostics.append("dictation_preview_started engine=\(speechEngine.engine.rawValue)")
@@ -1003,7 +1025,10 @@ public actor DictationService: DictationServiceProtocol {
         return DictationAudioSampleSink(
             onSamples: { samples in
                 guard !samples.isEmpty else { return }
-                sampleContinuation.yield(samples)
+                sampleContinuation.yield(DictationDisplayPreviewSamples(
+                    samples: samples,
+                    generation: resetGeneration.withLock { $0 }
+                ))
             },
             onFinish: {
                 sampleContinuation.finish()
@@ -1027,13 +1052,30 @@ public actor DictationService: DictationServiceProtocol {
         setLiveTranscript(raw: partial)
     }
 
-    private func updateDisplayPreview(_ preview: String, sessionID: Int, previewSessionID: UUID) {
-        guard displayPreviewState?.dictationSessionID == sessionID,
-              displayPreviewState?.previewSessionID == previewSessionID,
+    private func updateDisplayPreview(
+        _ preview: String,
+        sessionID: Int,
+        previewSessionID: UUID,
+        generation: Int
+    ) {
+        guard let state = displayPreviewState,
+              state.dictationSessionID == sessionID,
+              state.previewSessionID == previewSessionID,
+              // Reject a pre-reset pass that completed after Pause Media.
+              state.resetGeneration.withLock({ $0 }) == generation,
               case .recording = _state else {
             return
         }
         setLiveTranscript(raw: preview)
+    }
+
+    private func resetDisplayPreview(sessionID: Int) {
+        guard let state = displayPreviewState,
+              state.dictationSessionID == sessionID else {
+            return
+        }
+        state.resetGeneration.withLock { $0 += 1 }
+        AudioCaptureDiagnostics.append("dictation_preview_reset reason=preroll_discarded")
     }
 
     /// Feed a raw preview transcript through the stabilizer and publish the

--- a/Tests/MacParakeetTests/STT/MockSTTClient.swift
+++ b/Tests/MacParakeetTests/STT/MockSTTClient.swift
@@ -1,6 +1,12 @@
 import Foundation
 @testable import MacParakeetCore
 
+private struct PreviewCallWaiter {
+    let id: UUID
+    let minimumCount: Int
+    let continuation: CheckedContinuation<Bool, Never>
+}
+
 public actor MockSTTClient: STTClientProtocol, STTDictationPreviewTranscribing, SpeechEngineRoutedTranscribing, STTLiveDictationTranscribing, SpeechEngineSwitching, SpeechEngineTelemetryAttributing, SpeechEngineRoutedWarmUpManaging {
     public var transcribeResult: STTResult?
     public var transcribeError: Error?
@@ -62,10 +68,7 @@ public actor MockSTTClient: STTClientProtocol, STTDictationPreviewTranscribing, 
     private var previewHeld = false
     private var previewReleasesOnCancel = true
     private var previewHoldContinuations: [CheckedContinuation<Void, Never>] = []
-    private var previewCallWaiters: [(
-        minimumCount: Int,
-        continuation: CheckedContinuation<Void, Never>
-    )] = []
+    private var previewCallWaiters: [PreviewCallWaiter] = []
 
     public init() {}
 
@@ -178,14 +181,61 @@ public actor MockSTTClient: STTClientProtocol, STTDictationPreviewTranscribing, 
         resetPreviewTracking()
     }
 
-    public func waitForPreviewCallCount(_ minimumCount: Int) async {
-        guard previewCallCount < minimumCount else { return }
-        await withCheckedContinuation { continuation in
-            previewCallWaiters.append((minimumCount, continuation))
+    public func waitForPreviewCallCount(
+        _ minimumCount: Int,
+        timeout: Duration = .seconds(2)
+    ) async -> Bool {
+        guard previewCallCount < minimumCount else { return true }
+
+        let id = UUID()
+        return await withTaskGroup(of: Bool.self) { group in
+            group.addTask {
+                await self.registerPreviewCallWaiter(id: id, minimumCount: minimumCount)
+            }
+            group.addTask {
+                try? await Task.sleep(for: timeout)
+                return await self.timeOutPreviewCallWaiter(id: id, minimumCount: minimumCount)
+            }
+
+            let result = await group.next() ?? false
+            group.cancelAll()
+            return result
         }
     }
 
+    private func registerPreviewCallWaiter(id: UUID, minimumCount: Int) async -> Bool {
+        guard previewCallCount < minimumCount else { return true }
+
+        return await withCheckedContinuation { continuation in
+            if previewCallCount >= minimumCount {
+                continuation.resume(returning: true)
+            } else {
+                previewCallWaiters.append(
+                    PreviewCallWaiter(
+                        id: id,
+                        minimumCount: minimumCount,
+                        continuation: continuation,
+                    ))
+            }
+        }
+    }
+
+    private func timeOutPreviewCallWaiter(id: UUID, minimumCount: Int) -> Bool {
+        guard previewCallCount < minimumCount else { return true }
+        guard let index = previewCallWaiters.firstIndex(where: { $0.id == id }) else {
+            return previewCallCount >= minimumCount
+        }
+        let waiter = previewCallWaiters.remove(at: index)
+        waiter.continuation.resume(returning: false)
+        return false
+    }
+
     private func resetPreviewTracking() {
+        let waiters = previewCallWaiters
+        previewCallWaiters = []
+        for waiter in waiters {
+            waiter.continuation.resume(returning: false)
+        }
         previewCallCount = 0
         previewCancelCallCount = 0
         previewSamples = []
@@ -221,7 +271,7 @@ public actor MockSTTClient: STTClientProtocol, STTDictationPreviewTranscribing, 
         let ready = previewCallWaiters.filter { $0.minimumCount <= previewCallCount }
         previewCallWaiters.removeAll { $0.minimumCount <= previewCallCount }
         for waiter in ready {
-            waiter.continuation.resume()
+            waiter.continuation.resume(returning: true)
         }
     }
 

--- a/Tests/MacParakeetTests/STT/MockSTTClient.swift
+++ b/Tests/MacParakeetTests/STT/MockSTTClient.swift
@@ -214,7 +214,7 @@ public actor MockSTTClient: STTClientProtocol, STTDictationPreviewTranscribing, 
                     PreviewCallWaiter(
                         id: id,
                         minimumCount: minimumCount,
-                        continuation: continuation,
+                        continuation: continuation
                     ))
             }
         }

--- a/Tests/MacParakeetTests/STT/MockSTTClient.swift
+++ b/Tests/MacParakeetTests/STT/MockSTTClient.swift
@@ -53,6 +53,7 @@ public actor MockSTTClient: STTClientProtocol, STTDictationPreviewTranscribing, 
     private var backgroundWarmUpTask: Task<Void, Never>?
     private var queuedTranscribeResults: [STTResult] = []
     private var queuedTranscribeErrors: [Error] = []
+    private var queuedPreviewResults: [STTResult] = []
     private var transcribeProgressUpdates: [(current: Int, total: Int)] = []
     private var liveSessionID: UUID?
     private var livePartialHandler: (@Sendable (String) -> Void)?
@@ -61,6 +62,10 @@ public actor MockSTTClient: STTClientProtocol, STTDictationPreviewTranscribing, 
     private var previewHeld = false
     private var previewReleasesOnCancel = true
     private var previewHoldContinuations: [CheckedContinuation<Void, Never>] = []
+    private var previewCallWaiters: [(
+        minimumCount: Int,
+        continuation: CheckedContinuation<Void, Never>
+    )] = []
 
     public init() {}
 
@@ -162,6 +167,25 @@ public actor MockSTTClient: STTClientProtocol, STTDictationPreviewTranscribing, 
     public func configurePreview(result: STTResult? = nil, error: Error? = nil) {
         previewResult = result
         previewError = error
+        queuedPreviewResults = []
+        resetPreviewTracking()
+    }
+
+    public func configurePreview(results: [STTResult]) {
+        previewResult = nil
+        previewError = nil
+        queuedPreviewResults = results
+        resetPreviewTracking()
+    }
+
+    public func waitForPreviewCallCount(_ minimumCount: Int) async {
+        guard previewCallCount < minimumCount else { return }
+        await withCheckedContinuation { continuation in
+            previewCallWaiters.append((minimumCount, continuation))
+        }
+    }
+
+    private func resetPreviewTracking() {
         previewCallCount = 0
         previewCancelCallCount = 0
         previewSamples = []
@@ -177,6 +201,7 @@ public actor MockSTTClient: STTClientProtocol, STTDictationPreviewTranscribing, 
         previewCallCount += 1
         previewSamples.append(samples)
         previewSelections.append(speechEngine)
+        resumePreviewCallWaiters()
         if previewHeld {
             await withCheckedContinuation { continuation in
                 previewHoldContinuations.append(continuation)
@@ -186,7 +211,18 @@ public actor MockSTTClient: STTClientProtocol, STTDictationPreviewTranscribing, 
         if let previewError {
             throw previewError
         }
+        if !queuedPreviewResults.isEmpty {
+            return queuedPreviewResults.removeFirst()
+        }
         return previewResult ?? STTResult(text: "preview", words: [], engine: speechEngine.engine)
+    }
+
+    private func resumePreviewCallWaiters() {
+        let ready = previewCallWaiters.filter { $0.minimumCount <= previewCallCount }
+        previewCallWaiters.removeAll { $0.minimumCount <= previewCallCount }
+        for waiter in ready {
+            waiter.continuation.resume()
+        }
     }
 
     public func holdPreviewTranscription(releaseOnCancel: Bool = true) {

--- a/Tests/MacParakeetTests/Services/Dictation/DictationServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/Dictation/DictationServiceTests.swift
@@ -1016,7 +1016,7 @@ final class DictationServiceTests: XCTestCase {
         await mockSTT.releasePreviewTranscription()
     }
 
-    func testPreRollDiscardClearsDisplayPreviewAndStillUsesRecordedFileFinal() async throws {
+    func testPreRollDiscardResetsDisplayPreviewAndStillUsesRecordedFileFinal() async throws {
         service = DictationService(
             audioProcessor: mockAudio,
             sttTranscriber: mockSTT,
@@ -1041,22 +1041,83 @@ final class DictationServiceTests: XCTestCase {
         }
         XCTAssertTrue(cleared, "Expected pre-roll discard to clear display preview")
         let previewCancelCallCount = await mockSTT.previewCancelCallCount
-        XCTAssertEqual(previewCancelCallCount, 1)
+        XCTAssertEqual(
+            previewCancelCallCount,
+            0,
+            "Pre-roll discard should reset the active preview instead of cancelling it"
+        )
 
         await mockAudio.emitLiveSamples([0.3, 0.4])
-        try await Task.sleep(for: .milliseconds(50))
-        let previewCallCount = await mockSTT.previewCallCount
+        await mockAudio.emitLiveSamples([0.5])
+        await mockSTT.waitForPreviewCallCount(3)
+        let previewSamples = await mockSTT.previewSamples
         XCTAssertEqual(
-            previewCallCount,
-            1,
-            "Preview should stop after pre-roll discard so stale pre-roll samples cannot re-enter the visible tail"
+            previewSamples,
+            [[0.1, 0.2], [0.3, 0.4], [0.3, 0.4, 0.5]],
+            "Post-reset preview passes should exclude all pre-roll samples"
+        )
+        let resumedTranscript = await service.liveTranscript
+        XCTAssertEqual(
+            resumedTranscript,
+            "preview tail",
+            "Display preview should publish post-reset speech"
         )
 
         let result = try await service.stopRecording()
 
-        XCTAssertEqual(result.dictation.rawTranscript, "file final")
+        XCTAssertEqual(
+            result.dictation.rawTranscript,
+            "file final",
+            "Final dictation should remain recorded-file authoritative"
+        )
+        let finalPreviewCancelCallCount = await mockSTT.previewCancelCallCount
         let discardCallCount = await mockAudio.discardPreRollCallCount
-        XCTAssertEqual(discardCallCount, 1)
+        XCTAssertEqual(finalPreviewCancelCallCount, 1, "Stopping should still cancel display preview")
+        XCTAssertEqual(discardCallCount, 1, "Expected the recorder pre-roll to be discarded once")
+    }
+
+    func testPreRollDiscardDropsQueuedPreviewAudioAndInFlightResult() async throws {
+        service = DictationService(
+            audioProcessor: mockAudio,
+            sttTranscriber: mockSTT,
+            dictationRepo: dictationRepo,
+            dictationPreviewSpeechEngine: { Self.previewSpeechEngine(.parakeet(.v3)) },
+            dictationPreviewInterval: .zero
+        )
+        await mockSTT.configure(result: STTResult(text: "file final", words: [], engine: .parakeet))
+        await mockSTT.configurePreview(results: [
+            STTResult(text: "stale pre-roll preview", words: [], engine: .parakeet),
+            STTResult(text: "", words: [], engine: .parakeet),
+            STTResult(text: "", words: [], engine: .parakeet),
+        ])
+        await mockSTT.holdPreviewTranscription()
+
+        try await service.startRecording()
+        await mockAudio.emitLiveSamples([0.1])
+        await mockSTT.waitForPreviewCallCount(1)
+
+        await mockAudio.emitLiveSamples([0.2])
+        await service.discardPreRollForActiveCapture(sessionID: nil)
+        await mockAudio.emitLiveSamples([0.3, 0.4])
+        await mockAudio.emitLiveSamples([0.5])
+        await mockSTT.releasePreviewTranscription()
+
+        await mockSTT.waitForPreviewCallCount(3)
+        let previewSamples = await mockSTT.previewSamples
+        XCTAssertEqual(
+            previewSamples,
+            [[0.1], [0.3, 0.4], [0.3, 0.4, 0.5]],
+            "Queued pre-roll audio should be dropped before post-reset passes"
+        )
+        let liveTranscript = await service.liveTranscript
+        XCTAssertEqual(liveTranscript, "", "An in-flight pre-roll result must not reappear after reset")
+
+        let result = try await service.stopRecording()
+        XCTAssertEqual(
+            result.dictation.rawTranscript,
+            "file final",
+            "Final dictation should remain recorded-file authoritative"
+        )
     }
 
     func testStopRecordingCancelsLiveSessionWhenCaptureIsTooShort() async throws {

--- a/Tests/MacParakeetTests/Services/Dictation/DictationServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/Dictation/DictationServiceTests.swift
@@ -1049,13 +1049,16 @@ final class DictationServiceTests: XCTestCase {
 
         await mockAudio.emitLiveSamples([0.3, 0.4])
         await mockAudio.emitLiveSamples([0.5])
-        await mockSTT.waitForPreviewCallCount(3)
+        let previewCallReached = await mockSTT.waitForPreviewCallCount(3)
+        XCTAssertTrue(previewCallReached, "Expected post-reset preview passes")
         let previewSamples = await mockSTT.previewSamples
         XCTAssertEqual(
             previewSamples,
             [[0.1, 0.2], [0.3, 0.4], [0.3, 0.4, 0.5]],
             "Post-reset preview passes should exclude all pre-roll samples"
         )
+        // Preview passes are serial. Entering pass 3 proves pass 2 returned and
+        // its updateDisplayPreview call completed before this assertion.
         let resumedTranscript = await service.liveTranscript
         XCTAssertEqual(
             resumedTranscript,
@@ -1094,7 +1097,8 @@ final class DictationServiceTests: XCTestCase {
 
         try await service.startRecording()
         await mockAudio.emitLiveSamples([0.1])
-        await mockSTT.waitForPreviewCallCount(1)
+        let initialPreviewCallReached = await mockSTT.waitForPreviewCallCount(1)
+        XCTAssertTrue(initialPreviewCallReached, "Expected the held pre-reset preview pass")
 
         await mockAudio.emitLiveSamples([0.2])
         await service.discardPreRollForActiveCapture(sessionID: nil)
@@ -1102,7 +1106,8 @@ final class DictationServiceTests: XCTestCase {
         await mockAudio.emitLiveSamples([0.5])
         await mockSTT.releasePreviewTranscription()
 
-        await mockSTT.waitForPreviewCallCount(3)
+        let postResetPreviewCallsReached = await mockSTT.waitForPreviewCallCount(3)
+        XCTAssertTrue(postResetPreviewCallsReached, "Expected post-reset preview passes")
         let previewSamples = await mockSTT.previewSamples
         XCTAssertEqual(
             previewSamples,


### PR DESCRIPTION
## Summary

- reset the tail-preview audio epoch instead of permanently cancelling preview when Pause Media confirms playback
- tag buffered preview chunks and reject stale in-flight results across a pre-roll reset
- preserve hard preview cancellation on Stop/Cancel and recorded-file authority for final text

## Root cause

Pause Media confirms playback shortly after dictation capture starts. Its pre-roll cleanup called the same hard cancellation used for true session teardown, so the tail-preview worker exited before its first preview pass and was never restarted. Final WAV transcription uses a separate path, which is why text still appeared after Stop/Paste.

## Verification

- Test-first regression: the focused test failed on the previous implementation because preview was cancelled and never resumed
- Race regression: stale buffered audio and an in-flight pre-reset result cannot repopulate the transcript after reset
- swift test --filter DictationServiceTests — 53 passed
- swift test --filter DictationMediaPauseCoordinatorTests — 10 passed
- swift build --target MacParakeet — passed
- swift test — 4,909 XCTest cases passed, 20 skipped; 17 Swift Testing cases passed
- git diff --check — clean
- Claude Fable 5 adversarial review — approved, no blocking findings
- exact-head standards/spec review — no findings

The optional no-mistakes executable was unavailable, so this used the documented fallback review workflow.

Closes #603

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes live preview being cancelled after Pause Media discards pre-roll. Preview now continues immediately after the pause while dropping pre-roll audio and rejecting stale results. Closes #603.

- **Bug Fixes**
  - Reset preview audio epoch on pre-roll discard to keep the worker alive.
  - Tag sample chunks with a generation; reject pre-reset buffered audio and in-flight results via a generation lock; gate `updateDisplayPreview` to publish only post-reset passes.
  - Add bounded preview call waiters with timeout (Swift 5.9 compatible). Preserve hard cancel on Stop/Cancel; final text remains recorded-file authoritative.

<sup>Written for commit 6381532e1277ff6d87cbaefc993a1828a1bc8cbe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/838?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dictation display previews when pre-roll audio is discarded by properly resetting the active preview state.
  * Prevented older/stale preview text and buffered preview content from reappearing after a preview reset.
  * Ensured that final dictation output remains based on the recorded audio when preview is reset.
* **Tests**
  * Added support in the preview transcription mock for queued results and deterministic call-count coordination.
  * Strengthened dictation preview reset tests, including queued pre-roll scenarios and ensuring in-flight preview results don’t surface after reset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->