### PR TITLE
Make completed meetings copyable as one unit

### DIFF
--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
@@ -536,16 +536,7 @@ struct TranscriptResultView: View {
 
     private var actionBar: some View {
         HStack(spacing: DesignSystem.Spacing.sm) {
-            Button {
-                copyToClipboard()
-            } label: {
-                Label(
-                    copied ? "Copied!" : "Copy",
-                    systemImage: copied ? "checkmark" : "doc.on.clipboard"
-                )
-                .foregroundStyle(copied ? DesignSystem.Colors.successGreen : .primary)
-            }
-            .parakeetAction(.secondary)
+            copyAction
 
             Button {
                 showingExportOptions.toggle()
@@ -713,6 +704,42 @@ struct TranscriptResultView: View {
         .popover(item: $exportConfirmation, arrowEdge: .top) { confirmation in
             exportConfirmationPopover(confirmation)
         }
+    }
+
+    @ViewBuilder
+    private var copyAction: some View {
+        if activeTranscription.sourceType == .meeting {
+            Menu {
+                Button {
+                    copyTranscriptToClipboard()
+                } label: {
+                    Label("Copy Transcript", systemImage: "doc.plaintext")
+                }
+            } label: {
+                copyActionLabel(title: copied ? "Copied!" : "Copy Meeting")
+            } primaryAction: {
+                copyMeetingToClipboard()
+            }
+            .parakeetAction(.secondary)
+            .help("Copy the meeting title, notes, and transcript. Use the menu to copy only the transcript.")
+            .accessibilityLabel("Copy meeting")
+            .accessibilityValue(copied ? "Copied" : "")
+        } else {
+            Button {
+                copyTranscriptToClipboard()
+            } label: {
+                copyActionLabel(title: copied ? "Copied!" : "Copy")
+            }
+            .parakeetAction(.secondary)
+        }
+    }
+
+    private func copyActionLabel(title: String) -> some View {
+        Label(
+            title,
+            systemImage: copied ? "checkmark" : "doc.on.clipboard"
+        )
+        .foregroundStyle(copied ? DesignSystem.Colors.successGreen : .primary)
     }
 
     private var isRetranscriptionConfirmationPresented: Binding<Bool> {
@@ -3298,9 +3325,20 @@ struct TranscriptResultView: View {
 
     // MARK: - Actions
 
-    private func copyToClipboard() {
-        let text = transcriptText
-        TranscriptResultActions.copyText(text)
+    private func copyMeetingToClipboard() {
+        let markdown = MeetingMarkdownRenderer().renderForClipboard(
+            transcription: activeTranscription
+        )
+        TranscriptResultActions.copyText(markdown, source: .meeting)
+        showCopiedFeedback()
+    }
+
+    private func copyTranscriptToClipboard() {
+        TranscriptResultActions.copyText(transcriptText)
+        showCopiedFeedback()
+    }
+
+    private func showCopiedFeedback() {
         copiedResetTask?.cancel()
         withAnimation(DesignSystem.Animation.hoverTransition) { copied = true }
         copiedResetTask = Task { @MainActor in

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingMarkdownRenderer.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingMarkdownRenderer.swift
@@ -135,6 +135,18 @@ public struct MeetingMarkdownRenderer: Sendable {
 
     public init() {}
 
+    public func renderForClipboard(transcription: Transcription) -> String {
+        let transcript = renderedTranscript(transcription)
+        var sections = ["# \(transcription.fileName)"]
+
+        if let notes = normalizedNonEmptyText(transcription.userNotes) {
+            sections.append("## Notes\n\n\(notes)")
+        }
+
+        sections.append("## Transcript\n\n\(transcript.text)")
+        return sections.joined(separator: "\n\n") + "\n"
+    }
+
     public func render(
         transcription: Transcription,
         promptResults: [PromptResult],

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingMarkdownRenderer.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingMarkdownRenderer.swift
@@ -137,13 +137,10 @@ public struct MeetingMarkdownRenderer: Sendable {
 
     public func renderForClipboard(transcription: Transcription) -> String {
         let transcript = renderedTranscript(transcription)
-        var sections = ["# \(transcription.fileName)"]
-
-        if let notes = normalizedNonEmptyText(transcription.userNotes) {
-            sections.append("## Notes\n\n\(notes)")
-        }
-
-        sections.append("## Transcript\n\n\(transcript.text)")
+        let sections = meetingContentSections(
+            transcription: transcription,
+            transcript: transcript.text
+        )
         return sections.joined(separator: "\n\n") + "\n"
     }
 
@@ -153,21 +150,18 @@ public struct MeetingMarkdownRenderer: Sendable {
         artifactPaths: MeetingMarkdownArtifactPaths = .init()
     ) -> String {
         let transcript = renderedTranscript(transcription)
-        var sections: [String] = [
+        var sections = [
             frontmatter(
                 transcription: transcription,
                 artifactPaths: artifactPaths,
                 speakerLabelsIncluded: transcript.speakerLabelsIncluded,
                 promptResultCount: promptResults.count
-            ),
-            "# \(transcription.fileName)",
+            )
         ]
-
-        if let notes = normalizedNonEmptyText(transcription.userNotes) {
-            sections.append("## Notes\n\n\(notes)")
-        }
-
-        sections.append("## Transcript\n\n\(transcript.text)")
+        sections.append(contentsOf: meetingContentSections(
+            transcription: transcription,
+            transcript: transcript.text
+        ))
 
         if !promptResults.isEmpty {
             sections.append(promptResultsSection(promptResults, artifactPaths: artifactPaths))
@@ -178,6 +172,20 @@ public struct MeetingMarkdownRenderer: Sendable {
         }
 
         return sections.joined(separator: "\n\n") + "\n"
+    }
+
+    private func meetingContentSections(
+        transcription: Transcription,
+        transcript: String
+    ) -> [String] {
+        var sections = ["# \(transcription.fileName)"]
+
+        if let notes = normalizedNonEmptyText(transcription.userNotes) {
+            sections.append("## Notes\n\n\(notes)")
+        }
+
+        sections.append("## Transcript\n\n\(transcript)")
+        return sections
     }
 
     private func frontmatter(

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingMarkdownRendererClipboardTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingMarkdownRendererClipboardTests.swift
@@ -1,0 +1,107 @@
+import XCTest
+@testable import MacParakeetCore
+
+final class MeetingMarkdownRendererClipboardTests: XCTestCase {
+    func testRenderForClipboardIncludesTitleNotesAndPreferredTranscript() {
+        let transcription = Transcription(
+            fileName: "Weekly Product Sync",
+            rawTranscript: "Unedited transcript.",
+            cleanTranscript: "Edited transcript.",
+            status: .completed,
+            sourceType: .meeting,
+            userNotes: "  Decision: Ship Friday.\nOwner: Dana.  "
+        )
+
+        let markdown = MeetingMarkdownRenderer().renderForClipboard(
+            transcription: transcription
+        )
+
+        XCTAssertEqual(
+            markdown,
+            """
+            # Weekly Product Sync
+
+            ## Notes
+
+            Decision: Ship Friday.
+            Owner: Dana.
+
+            ## Transcript
+
+            Edited transcript.
+
+            """
+        )
+    }
+
+    func testRenderForClipboardOmitsBlankNotesAndFallsBackToRawTranscript() {
+        let transcription = Transcription(
+            fileName: "Customer Call",
+            rawTranscript: "Raw transcript.",
+            cleanTranscript: "  \n",
+            status: .completed,
+            sourceType: .meeting,
+            userNotes: " \n\t "
+        )
+
+        let markdown = MeetingMarkdownRenderer().renderForClipboard(
+            transcription: transcription
+        )
+
+        XCTAssertEqual(
+            markdown,
+            """
+            # Customer Call
+
+            ## Transcript
+
+            Raw transcript.
+
+            """
+        )
+    }
+
+    func testRenderForClipboardIncludesReliableSpeakerLabels() {
+        let transcription = Transcription(
+            fileName: "Design Review",
+            rawTranscript: "Ship it.",
+            wordTimestamps: [
+                WordTimestamp(
+                    word: "Ship",
+                    startMs: 0,
+                    endMs: 400,
+                    confidence: 0.9,
+                    speakerId: "S1"
+                ),
+                WordTimestamp(
+                    word: "it.",
+                    startMs: 450,
+                    endMs: 800,
+                    confidence: 0.9,
+                    speakerId: "S1"
+                ),
+            ],
+            speakers: [SpeakerInfo(id: "S1", label: "Dana")],
+            status: .completed,
+            sourceType: .meeting
+        )
+
+        let markdown = MeetingMarkdownRenderer().renderForClipboard(
+            transcription: transcription
+        )
+
+        XCTAssertEqual(
+            markdown,
+            """
+            # Design Review
+
+            ## Transcript
+
+            **Dana**
+
+            Ship it.
+
+            """
+        )
+    }
+}

--- a/spec/02-features.md
+++ b/spec/02-features.md
@@ -1678,6 +1678,7 @@ final transcripts remain plain text without word timestamps or speaker labels.
 - [x] Notes round-trip through crash recovery via lock-file `notes` (additive, decoded with `decodeIfPresent`, decoded independently so a malformed notes value doesn't block audio recovery)
 - [x] Soft-cap warning footer at 7,500 words; notes themselves are never truncated (cap applies only at prompt-assembly time)
 - [x] `MeetingNotesViewModel.notesText` is `private(set)` and bound exclusively to the editor — code-level enforcement of the "notes are user-authored only" invariant (ADR-020 §11)
+- [x] Completed meeting detail uses **Copy Meeting** as its primary copy action, producing compact Markdown with title, non-empty personal notes, and the preferred transcript; its split menu retains **Copy Transcript**, while the live Transcript-tab Copy action remains transcript-only
 
 ### F37: Memo-Steered Summaries
 


### PR DESCRIPTION
## Summary

Completed meetings now expose Copy Meeting as the primary copy action. One click places compact, human-readable Markdown on the clipboard with the meeting title, non-empty personal notes, and preferred transcript; the adjacent split menu preserves Copy Transcript for users who want only the transcript.

Closes #841.

## Design

The clipboard format reuses the existing meeting Markdown renderer and its canonical edited-transcript fallback and reliable speaker-label rules. A private shared section builder keeps title, notes, and transcript content aligned between clipboard output and durable Markdown export, while clipboard output deliberately omits frontmatter, prompt results, and artifact paths.

No preference or new export model is introduced. The completed meeting detail is the only changed surface.

| Surface | Before | After |
|---|---|---|
| Completed meeting primary copy | Transcript only | Title, notes, and transcript |
| Completed meeting alternate copy | None | Copy Transcript in the split menu |
| Live meeting Transcript tab | Transcript only | Unchanged |
| Non-meeting transcript detail | Transcript only | Unchanged |

## Risk surface

The main risk is clipboard content selection: blank notes must disappear, edited text must beat raw text, and stale speaker alignment must not override an edited transcript. Focused tests cover the formatter behavior and existing renderer regressions. Clipboard telemetry remains content-free and records only the existing meeting source category.

Out of scope: copying prompt results, artifact paths, audio metadata, or adding configurable copy templates.

## Test evidence

Passed locally:

- swift test --filter MeetingMarkdownRendererClipboardTests — 3 tests
- swift test --filter TranscriptExportOptionsTests — 14 tests
- Swift 6 compilation of MacParakeet, including the SwiftUI split control
- git diff --check

Clean GitHub CI passed twice on exact head ff958900, including release build, CLI and release-bundle smoke, Swift concurrency safety, Swift 6 language mode, and the full 4,933-test suite. One initial duplicate CI attempt hit the unrelated timing-sensitive MeetingRecordingServiceTests.testDuplicateCaptureFailuresEmitOneSignal; the simultaneous clean lane and the failed-job rerun both passed it.

The single local full swift test invocation also hit two broad-suite failures outside the focused changed area; terminal truncation did not retain their names. The two clean CI passes provide the authoritative isolated result.

no-mistakes and the local Greptile CLI were unavailable in this environment. The committed standards/spec review was completed manually, and the GitHub Greptile review finished at 5/5 with no findings.