### PR TITLE
Release macparakeet-cli 3.1.0 for Homebrew

### DIFF
--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -89,6 +89,8 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
 
 ## [Unreleased]
 
+## [3.1.0] — 2026-07-19
+
 ### Added
 
 - `transcribe --audio-track <N>` selects a one-based embedded audio track for
@@ -101,6 +103,9 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
   deterministic reading paragraphs with at most one timestamp per paragraph;
   Markdown stdout uses the same formatting. SRT, VTT, and JSON output are
   unchanged.
+- Bundled CLI commands no longer emit a Foundation UserDefaults suite warning
+  on otherwise successful invocations. The standalone CLI continues sharing
+  the MacParakeet app's preferences.
 - Native OpenAI LLM calls omit `temperature` for GPT-5.x reasoning-tier
   models (e.g. `gpt-5.5`, `gpt-5.4-mini`), preventing HTTP 400 responses
   from model and reasoning-effort combinations that do not accept non-default

--- a/Sources/CLI/Commands/CLIHelpers.swift
+++ b/Sources/CLI/Commands/CLIHelpers.swift
@@ -3,7 +3,6 @@ import Darwin
 import Foundation
 import MacParakeetCore
 
-let macParakeetAppDefaultsSuiteName = "com.macparakeet.MacParakeet"
 let cliValidationMisuseExitCode = ExitCode(2)
 
 struct CLIJSONEnvelopeExit: Error {
@@ -11,8 +10,15 @@ struct CLIJSONEnvelopeExit: Error {
     let originalError: Error
 }
 
-func macParakeetAppDefaults() -> UserDefaults {
-    UserDefaults(suiteName: macParakeetAppDefaultsSuiteName) ?? .standard
+func macParakeetAppDefaults(
+    bundleIdentifier: String? = Bundle.main.bundleIdentifier
+) -> UserDefaults {
+    // The bundled CLI already inherits the app's defaults domain. Reopening it
+    // as a named suite makes Foundation emit a nonsensical-suite warning.
+    if bundleIdentifier == AppPaths.preferencesSuiteName {
+        return .standard
+    }
+    return AppPaths.sharedAppDefaults()
 }
 
 func validateCLISpeechEngineMemoryRequirement(

--- a/Sources/CLI/Commands/SpecCommand.swift
+++ b/Sources/CLI/Commands/SpecCommand.swift
@@ -203,6 +203,9 @@ private extension CLISpecCommand {
                     "--podcast", valueName: "QUERY",
                     summary: "Search Apple Podcasts by show/episode text and transcribe the selected episode."),
                 CLISpecParameter.option(
+                    "--audio-track", valueName: "N",
+                    summary: "Select a one-based embedded audio track for local files and folders."),
+                CLISpecParameter.option(
                     "--output-dir", valueName: "DIR",
                     summary: "Write one transcript file per input to this directory; implies batch mode."),
                 CLISpecParameter.option(

--- a/Sources/CLI/MacParakeetCLI.swift
+++ b/Sources/CLI/MacParakeetCLI.swift
@@ -8,7 +8,7 @@ struct CLI: AsyncParsableCommand {
     /// distinguishable from synthesized Bundle.main values (the bare executable
     /// has no Info.plist and macOS otherwise reports an SDK marker like "16.0").
     /// Bump in lockstep with `Sources/CLI/CHANGELOG.md`.
-    static let cliVersion = "3.0.0"
+    static let cliVersion = "3.1.0"
 
     static let configuration = CommandConfiguration(
         commandName: "macparakeet-cli",

--- a/Tests/CLITests/CLIHelpersTests.swift
+++ b/Tests/CLITests/CLIHelpersTests.swift
@@ -1,9 +1,32 @@
 import Darwin
+import Foundation
 import XCTest
 @testable import CLI
 @testable import MacParakeetCore
 
 final class CLIHelpersTests: XCTestCase {
+
+    func testBundledCLIUsesStandardDefaultsForAppPreferenceDomain() {
+        XCTAssertTrue(
+            macParakeetAppDefaults(bundleIdentifier: AppPaths.preferencesSuiteName)
+                === UserDefaults.standard
+        )
+    }
+
+    func testStandaloneCLIUsesSharedAppPreferenceDomain() {
+        let key = "CLIHelpersTests.standaloneDefaults.\(UUID().uuidString)"
+        let value = UUID().uuidString
+        let standaloneDefaults = macParakeetAppDefaults(bundleIdentifier: "com.macparakeet.cli-tests")
+        let sharedDefaults = AppPaths.sharedAppDefaults()
+        defer {
+            standaloneDefaults.removeObject(forKey: key)
+            sharedDefaults.removeObject(forKey: key)
+        }
+
+        standaloneDefaults.set(value, forKey: key)
+
+        XCTAssertEqual(sharedDefaults.string(forKey: key), value)
+    }
 
     func testStandardOutputRedirectionRestoresStdoutPayload() throws {
         let nullFileDescriptor = open("/dev/null", O_WRONLY)

--- a/Tests/CLITests/SpecCommandTests.swift
+++ b/Tests/CLITests/SpecCommandTests.swift
@@ -309,6 +309,7 @@ final class SpecCommandTests: XCTestCase {
         let options = try XCTUnwrap(transcribe["options"] as? [[String: Any]])
         let optionNames = Set(options.compactMap { $0["name"] as? String })
         XCTAssertTrue(optionNames.contains("--podcast"))
+        XCTAssertTrue(optionNames.contains("--audio-track"))
         XCTAssertTrue(optionNames.contains("--output-dir"))
         XCTAssertTrue(optionNames.contains("--format"))
         XCTAssertTrue(optionNames.contains("--mode"))
@@ -325,6 +326,12 @@ final class SpecCommandTests: XCTestCase {
         XCTAssertEqual(engine["valueName"] as? String, "parakeet|nemotron|whisper|cohere|app-default")
         let format = try XCTUnwrap(options.first { ($0["name"] as? String) == "--format" })
         XCTAssertEqual(format["valueName"] as? String, "text|transcript|json|srt|vtt")
+        let audioTrack = try XCTUnwrap(options.first { ($0["name"] as? String) == "--audio-track" })
+        XCTAssertEqual(audioTrack["valueName"] as? String, "N")
+        XCTAssertEqual(
+            audioTrack["summary"] as? String,
+            "Select a one-based embedded audio track for local files and folders."
+        )
         let parakeetModel = try XCTUnwrap(options.first { ($0["name"] as? String) == "--parakeet-model" })
         XCTAssertEqual(
             parakeetModel["summary"] as? String,

--- a/docs/cli-testing.md
+++ b/docs/cli-testing.md
@@ -617,11 +617,11 @@ when its server-side authentication is enabled.
 
 | Provider | Default Model | API Key Required |
 |----------|--------------|-----------------|
-| `anthropic` | claude-sonnet-4-6 | Yes |
-| `openai` | gpt-5.5 | Yes |
+| `anthropic` | claude-sonnet-5 | Yes |
+| `openai` | gpt-4.1 | Yes |
 | `openai-compatible` | user-selected endpoint/model | Optional |
-| `gemini` | gemini-3.5-flash | Yes |
-| `openrouter` | anthropic/claude-sonnet-4.6 | Yes |
+| `gemini` | gemini-2.5-flash | Yes |
+| `openrouter` | anthropic/claude-sonnet-5 | Yes |
 | `ollama` | qwen3.5:4b | No (local) |
 | `lmstudio` | user-selected in LM Studio | Optional (local) |
 | `cli` | N/A (tool decides) | No (tool manages auth) |

--- a/scripts/dist/homebrew-tap-scaffold/README.md
+++ b/scripts/dist/homebrew-tap-scaffold/README.md
@@ -32,34 +32,38 @@ macparakeet-cli transcribe ~/Downloads/audio.mp3 --format json
 
 **Requirements:** macOS 14.2+ (Sonoma) on Apple Silicon (M1, M2, M3, M4).
 
-**First run downloads ~6&nbsp;GB of CoreML speech models** to
-`~/Library/Application Support/MacParakeet/models/`. Subsequent runs are
-fully offline.
+The first transcription with a local engine downloads the selected CoreML
+model. Parakeet, Nemotron, and Cohere models are cached under
+`~/Library/Application Support/FluidAudio/Models/`; optional Whisper models
+use `~/Library/Application Support/MacParakeet/models/stt/whisper/`.
+Subsequent transcription with that model is fully offline.
 
-**Source code:** <https://github.com/moona3k/macparakeet>
+**Source:** <https://github.com/moona3k/macparakeet>
 **Compatibility policy (semver):** [`Sources/CLI/CHANGELOG.md`](https://github.com/moona3k/macparakeet/blob/main/Sources/CLI/CHANGELOG.md)
 **Agent integration docs:** [`integrations/README.md`](https://github.com/moona3k/macparakeet/tree/main/integrations)
 **For agent operators:** <https://macparakeet.com/agents>
 
-## Available casks
+> Why a tap and not homebrew-core? `macparakeet-cli` ships as a signed,
+> precompiled Apple-Silicon binary, and homebrew-core only accepts formulae
+> that build from source (or produce cross-platform binaries). A tap is the
+> correct permanent home for it.
 
-### `macparakeet`
+## Mac app — now in the official Homebrew cask
 
-The full MacParakeet macOS app — system-wide dictation, file
-transcription, and meeting recording. The same DMG distributed at
-<https://macparakeet.com>, but installable via brew.
+The MacParakeet macOS app no longer ships from this tap. It graduated to the
+official **[`homebrew/cask`](https://github.com/Homebrew/homebrew-cask/blob/HEAD/Casks/m/macparakeet.rb)**
+on 2026-06-06, so no tap is required:
 
 ```bash
-brew tap moona3k/tap
 brew install --cask macparakeet
 ```
 
-**Requirements:** macOS 14.2+ on Apple Silicon. The app self-updates
-via Sparkle (`auto_updates true` in the cask), so brew won't fight
-with in-app updates after install.
+Homebrew keeps the official cask up to date automatically (BrewTestBot
+autobump). Existing app installs from this tap are redirected to the official
+cask automatically via [`tap_migrations.json`](tap_migrations.json) on the
+next `brew update`.
 
 ## License
 
-The formulae and casks in this tap are MIT-licensed. The packages they
-install have their own licenses (`macparakeet-cli` and `macparakeet` are
-both GPL-3.0 — see source).
+The formulae in this tap are MIT-licensed. The packages they install have
+their own licenses (`macparakeet-cli` is GPL-3.0 — see source).

--- a/scripts/dist/homebrew-tap-scaffold/macparakeet-cli.rb
+++ b/scripts/dist/homebrew-tap-scaffold/macparakeet-cli.rb
@@ -39,8 +39,11 @@ class MacparakeetCli < Formula
 
   def caveats
     <<~EOS
-      First run downloads the Parakeet TDT speech model (~6 GB) to:
-        ~/Library/Application Support/MacParakeet/models/
+      Local Parakeet, Nemotron, and Cohere models are cached by FluidAudio at:
+        ~/Library/Application Support/FluidAudio/Models/
+
+      Optional Whisper models are stored at:
+        ~/Library/Application Support/MacParakeet/models/stt/whisper/
 
       The CLI shares its database with the macOS app at:
         ~/Library/Application Support/MacParakeet/macparakeet.db


### PR DESCRIPTION
## What changed

- promotes the accumulated additive CLI work to 3.1.0
- eliminates the bundled CLI UserDefaults warning while preserving shared standalone preferences
- catalogs `transcribe --audio-track` in `spec --json`
- refreshes provider defaults and Homebrew model/cache and cask guidance

## Why

The tap is still publishing CLI 2.3.1 even though the public integration docs rely on the 3.x automation surface. This prepares an exact, current release commit before signing, notarization, GitHub publication, and tap update.

## Risk and scope

The runtime change is limited to selecting the correct UserDefaults object for bundled versus standalone execution. JSON shapes and exit-code meanings are unchanged; the spec change exposes an already-shipped additive flag.

`no-mistakes` is not installed in this checkout, so the documented PR workflow is being used directly.

## Verification

- 479 CLITests passed before the final rebase
- 68 focused version/helpers/spec/provider tests passed after rebasing onto current `origin/main`
- live debug binary reports 3.1.0
- `spec --json` is parseable and includes `--audio-track`
- changed Swift files linted with the repo swift-format configuration (pre-existing warnings only)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release `macparakeet-cli` 3.1.0 to the Homebrew tap to match the 3.x integration docs. Removes the bundled UserDefaults warning, updates the JSON spec, and refreshes tap guidance.

- **New Features**
  - `spec --json` now catalogs `transcribe --audio-track`.
  - Provider defaults refreshed to current runtime.
  - Tap README and formula caveats updated with FluidAudio and Whisper cache paths; Mac app now via `homebrew/cask` with tap migration.

- **Bug Fixes**
  - Bundled CLI uses standard defaults to avoid the Foundation suite warning; standalone CLI continues sharing the app’s preferences.

<sup>Written for commit 19359c7f223250335c1bc627f9eee237036840bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/847?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

