### PR TITLE
Fix long single-speaker transcript performance

### DIFF
--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
@@ -194,7 +194,7 @@ struct TranscriptResultView: View {
     // Cached transcript data — recomputed only when transcription.id changes, not on every playback tick
     @State private var cachedSegments: [TranscriptSegment] = []
     @State private var cachedTurns: [SpeakerTurn] = []
-    @State private var cachedIdentifiedTurns: [IdentifiedSpeakerTurn] = []
+    @State private var cachedIdentifiedTurnCards: [IdentifiedSpeakerTurn] = []
     @State private var cachedHasSpeakers: Bool = false
     @State private var cachedSpeakerColorMap: [String: Color] = [:]
     @State private var cachedSpeakerLabelMap: [String: String] = [:]
@@ -2932,7 +2932,7 @@ struct TranscriptResultView: View {
         let current = findCurrentHighlight
         TranscriptTimestampedContentView(
             hasSpeakers: cachedHasSpeakers,
-            identifiedTurns: cachedIdentifiedTurns,
+            identifiedTurnCards: cachedIdentifiedTurnCards,
             segments: cachedSegments,
             speakerColorMap: cachedSpeakerColorMap,
             speakerLabelForID: { cachedSpeakerLabelMap[$0] ?? "Unknown" },
@@ -3158,7 +3158,7 @@ struct TranscriptResultView: View {
         guard let words = activeTranscription.wordTimestamps, !words.isEmpty else {
             cachedSegments = []
             cachedTurns = []
-            cachedIdentifiedTurns = []
+            cachedIdentifiedTurnCards = []
             cachedHasSpeakers = false
             cachedSpeakerColorMap = [:]
             cachedSpeakerLabelMap = [:]
@@ -3184,10 +3184,10 @@ struct TranscriptResultView: View {
                 }
             )
             cachedTurns = turns
-            cachedIdentifiedTurns = identifiedSpeakerTurns(turns)
+            cachedIdentifiedTurnCards = identifiedSpeakerTurnCards(turns)
         } else {
             cachedTurns = []
-            cachedIdentifiedTurns = []
+            cachedIdentifiedTurnCards = []
         }
     }
 

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
@@ -193,7 +193,6 @@ struct TranscriptResultView: View {
     @State private var lastScrolledSegmentMs: Int = -1
     // Cached transcript data — recomputed only when transcription.id changes, not on every playback tick
     @State private var cachedSegments: [TranscriptSegment] = []
-    @State private var cachedTurns: [SpeakerTurn] = []
     @State private var cachedIdentifiedTurnCards: [IdentifiedSpeakerTurn] = []
     @State private var cachedHasSpeakers: Bool = false
     @State private var cachedSpeakerColorMap: [String: Color] = [:]
@@ -3157,7 +3156,6 @@ struct TranscriptResultView: View {
     private func rebuildSegmentCache() {
         guard let words = activeTranscription.wordTimestamps, !words.isEmpty else {
             cachedSegments = []
-            cachedTurns = []
             cachedIdentifiedTurnCards = []
             cachedHasSpeakers = false
             cachedSpeakerColorMap = [:]
@@ -3183,10 +3181,8 @@ struct TranscriptResultView: View {
                     return cachedSpeakerLabelMap[speakerID] ?? "Unknown"
                 }
             )
-            cachedTurns = turns
             cachedIdentifiedTurnCards = identifiedSpeakerTurnCards(turns)
         } else {
-            cachedTurns = []
             cachedIdentifiedTurnCards = []
         }
     }
@@ -3224,15 +3220,13 @@ struct TranscriptResultView: View {
         return activeIdx == segmentIndex
     }
 
-    /// Find the scroll target ID (segment startMs) for the given playback time using binary search.
+    /// Find the scroll target ID (segment startMs) for the given playback time.
     private func autoScrollTarget(for currentMs: Int) -> Int? {
         if cachedHasSpeakers {
-            // Find the last turn whose first segment starts at or before currentMs
-            for turn in cachedTurns.reversed() {
-                if let first = turn.segments.first, first.startMs <= currentMs {
-                    return first.startMs
-                }
-            }
+            return speakerTurnCardScrollTarget(
+                for: currentMs,
+                in: cachedIdentifiedTurnCards
+            )
         } else {
             if let idx = activeSegmentIndex(for: currentMs) {
                 return cachedSegmentStartMs[idx]

--- a/Sources/MacParakeet/Views/Transcription/TranscriptTimestampedContentView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptTimestampedContentView.swift
@@ -100,6 +100,19 @@ func identifiedSpeakerTurnCards(_ turns: [SpeakerTurn]) -> [IdentifiedSpeakerTur
     return identifySpeakerTurns(cardTurns)
 }
 
+func speakerTurnCardScrollTarget(
+    for currentMs: Int,
+    in cards: [IdentifiedSpeakerTurn]
+) -> Int? {
+    for card in cards.reversed() {
+        if let firstStartMs = card.turn.segments.first?.startMs,
+           firstStartMs <= currentMs {
+            return firstStartMs
+        }
+    }
+    return nil
+}
+
 private func identifySpeakerTurns(_ turns: [SpeakerTurn]) -> [IdentifiedSpeakerTurn] {
     var duplicateCounts: [SpeakerTurnIdentityBase: Int] = [:]
     return turns.map { turn in

--- a/Sources/MacParakeet/Views/Transcription/TranscriptTimestampedContentView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptTimestampedContentView.swift
@@ -68,7 +68,39 @@ struct IdentifiedSpeakerTurn: Identifiable {
     }
 }
 
-func identifiedSpeakerTurns(_ turns: [SpeakerTurn]) -> [IdentifiedSpeakerTurn] {
+/// Keep each lazy speaker card to a small, predictable amount of view work.
+/// Twenty-four transcript segments is typically a few minutes of speech: large
+/// enough to preserve the visual rhythm of speaker turns, but small enough that
+/// a single-speaker recording cannot become one unbounded SwiftUI subtree.
+let maximumSpeakerTurnSegmentsPerCard = 24
+
+func identifiedSpeakerTurnCards(_ turns: [SpeakerTurn]) -> [IdentifiedSpeakerTurn] {
+    let cardTurns = turns.flatMap { turn -> [SpeakerTurn] in
+        guard turn.segments.count > maximumSpeakerTurnSegmentsPerCard else {
+            return [turn]
+        }
+
+        return stride(
+            from: 0,
+            to: turn.segments.count,
+            by: maximumSpeakerTurnSegmentsPerCard
+        ).map { startIndex in
+            let endIndex = min(
+                startIndex + maximumSpeakerTurnSegmentsPerCard,
+                turn.segments.count
+            )
+            return SpeakerTurn(
+                speakerId: turn.speakerId,
+                speakerLabel: turn.speakerLabel,
+                segments: Array(turn.segments[startIndex..<endIndex])
+            )
+        }
+    }
+
+    return identifySpeakerTurns(cardTurns)
+}
+
+private func identifySpeakerTurns(_ turns: [SpeakerTurn]) -> [IdentifiedSpeakerTurn] {
     var duplicateCounts: [SpeakerTurnIdentityBase: Int] = [:]
     return turns.map { turn in
         let base = SpeakerTurnIdentityBase(
@@ -90,7 +122,7 @@ func identifiedSpeakerTurns(_ turns: [SpeakerTurn]) -> [IdentifiedSpeakerTurn] {
 
 struct TranscriptTimestampedContentView<SpeakerLabelContent: View>: View {
     let hasSpeakers: Bool
-    let identifiedTurns: [IdentifiedSpeakerTurn]
+    let identifiedTurnCards: [IdentifiedSpeakerTurn]
     let segments: [TranscriptSegment]
     let speakerColorMap: [String: Color]
     let speakerLabelForID: (String) -> String
@@ -109,7 +141,7 @@ struct TranscriptTimestampedContentView<SpeakerLabelContent: View>: View {
 
     var body: some View {
         if hasSpeakers {
-            ForEach(identifiedTurns) { identified in
+            ForEach(identifiedTurnCards) { identified in
                 let turn = identified.turn
                 let speakerLabel = speakerLabelForID(turn.speakerId)
                 let speakerColor = speakerColorMap[turn.speakerId] ?? DesignSystem.Colors.textTertiary

--- a/Tests/MacParakeetTests/Views/SpeakerTurnIdentityTests.swift
+++ b/Tests/MacParakeetTests/Views/SpeakerTurnIdentityTests.swift
@@ -72,4 +72,21 @@ final class SpeakerTurnIdentityTests: XCTestCase {
         )
         XCTAssertEqual(Set(cards.map(\.id)).count, cards.count)
     }
+
+    func testAutoScrollTargetAdvancesAcrossContinuationCards() {
+        let segments = (0..<(maximumSpeakerTurnSegmentsPerCard * 2 + 1)).map {
+            segment($0 * 1000)
+        }
+        let cards = identifiedSpeakerTurnCards([turn(segments: segments)])
+
+        XCTAssertNil(speakerTurnCardScrollTarget(for: -1, in: cards))
+        XCTAssertEqual(speakerTurnCardScrollTarget(for: 1000, in: cards), 0)
+        XCTAssertEqual(
+            speakerTurnCardScrollTarget(
+                for: maximumSpeakerTurnSegmentsPerCard * 1000 + 1000,
+                in: cards
+            ),
+            maximumSpeakerTurnSegmentsPerCard * 1000
+        )
+    }
 }

--- a/Tests/MacParakeetTests/Views/SpeakerTurnIdentityTests.swift
+++ b/Tests/MacParakeetTests/Views/SpeakerTurnIdentityTests.swift
@@ -16,17 +16,24 @@ final class SpeakerTurnIdentityTests: XCTestCase {
         SpeakerTurn(speakerId: speaker, speakerLabel: speaker, segments: segments)
     }
 
-    /// A live turn keeps its identity as new segments are appended. Before the
-    /// fix the identity carried `lastStartMs`/`segmentCount`, so every appended
-    /// word produced a "new" identity and SwiftUI rebuilt the growing card.
-    func testIdentityStaysStableWhileTurnGrows() {
-        let small = turn(segments: [segment(1000)])
-        let grown = turn(segments: [segment(1000), segment(2000), segment(3000)])
+    /// The first card keeps its identity when a growing turn crosses the card
+    /// boundary, so SwiftUI adds a continuation card without replacing the
+    /// content already on screen.
+    func testIdentityStaysStableWhenTurnOutgrowsFirstCard() {
+        let small = turn(
+            segments: (0..<maximumSpeakerTurnSegmentsPerCard).map {
+                segment($0 * 1000)
+            })
+        let grown = turn(
+            segments: (0...maximumSpeakerTurnSegmentsPerCard).map {
+                segment($0 * 1000)
+            })
 
-        let smallID = identifiedSpeakerTurns([small])[0].id
-        let grownID = identifiedSpeakerTurns([grown])[0].id
+        let smallCards = identifiedSpeakerTurnCards([small])
+        let grownCards = identifiedSpeakerTurnCards([grown])
 
-        XCTAssertEqual(smallID, grownID)
+        XCTAssertEqual(smallCards[0].id, grownCards[0].id)
+        XCTAssertEqual(grownCards.count, 2)
     }
 
     /// Two turns that share `(speakerId, firstStartMs)` still receive distinct
@@ -35,9 +42,34 @@ final class SpeakerTurnIdentityTests: XCTestCase {
         let a = turn(segments: [segment(1000)])
         let b = turn(segments: [segment(1000), segment(2000)])
 
-        let ids = identifiedSpeakerTurns([a, b]).map(\.id)
+        let ids = identifiedSpeakerTurnCards([a, b]).map(\.id)
 
         XCTAssertEqual(ids.count, 2)
         XCTAssertNotEqual(ids[0], ids[1])
+    }
+
+    func testLongTurnIsSplitIntoBoundedCardsWithoutChangingContent() {
+        // Issue #845 contained 11,563 words, or about 964 typical segments.
+        let reporterScaleSegmentCount = 964
+        let segments = (0..<reporterScaleSegmentCount).map {
+            segment($0 * 1000)
+        }
+
+        let cards = identifiedSpeakerTurnCards([turn(segments: segments)])
+
+        XCTAssertEqual(
+            cards.count,
+            (reporterScaleSegmentCount + maximumSpeakerTurnSegmentsPerCard - 1)
+                / maximumSpeakerTurnSegmentsPerCard
+        )
+        XCTAssertTrue(
+            cards.allSatisfy {
+                $0.turn.segments.count <= maximumSpeakerTurnSegmentsPerCard
+            })
+        XCTAssertEqual(
+            cards.flatMap { $0.turn.segments.map(\.startMs) },
+            segments.map(\.startMs)
+        )
+        XCTAssertEqual(Set(cards.map(\.id)).count, cards.count)
     }
 }


### PR DESCRIPTION
## Summary

- cap speaker-aware Timed transcript cards at 24 segments so `LazyVStack` always has a bounded unit of work
- use those bounded cards as speaker-mode playback auto-scroll targets, including for long one-speaker recordings
- preserve speaker labels, rename controls, timestamps, seek/copy actions, selection behavior, and segment identities across continuation cards
- add a deterministic reporter-scale regression using the approximate 964-segment shape from #845

## Root cause

Diarization correctly groups consecutive segments from one speaker into one semantic turn. The Timed transcript UI also used that turn as one SwiftUI card containing an eager inner `VStack`. A 1.5-hour, one-speaker transcript therefore became one card with nearly a thousand timestamp rows, which defeated the surrounding lazy stack and caused the high CPU, slow scrolling, copy, and export-menu interaction reported in #845.

This fix separates semantic grouping from presentation cards. Transcript data stays unchanged, while rendering and speaker-mode auto-scroll use the same bounded card boundaries.

## UX

Continuation cards reuse the same speaker treatment and begin with their own timestamp, so a user scrolling through a long monologue retains speaker and time context. Short and ordinary multi-speaker turns render exactly as before.

## Validation

- `swift test` — 4,946 tests, 20 skipped, 0 failures
- focused transcript/speaker tests — 49 tests, 0 failures
- retained 964-segment regression verifies bounded cards, full ordered content preservation, and unique stable identities
- temporary offscreen SwiftUI benchmark at issue scale: 1.587s unbounded → 0.054s bounded (about 29x faster, 41 cards)
- offscreen visual inspection confirmed the existing card, speaker, timestamp, and row affordances remain coherent across the continuation boundary
- sequential standards and issue-spec reviews converged cleanly; hosted Greptile rated the reviewed implementation 5/5 and safe to merge

`no-mistakes` and the Greptile CLI were unavailable in the clean worktree, so this used the documented local review fallback plus the full test suite.

Closes #845


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Long speaker turns are now split into manageable transcript cards for improved readability and navigation.
  - Scrolling and timestamp navigation now target the appropriate card, including continuation cards.

- **Bug Fixes**
  - Improved stability of card identities as transcript turns grow, helping prevent unnecessary UI updates.

- **Tests**
  - Added coverage for card splitting, unique identities, preserved segment ordering, and accurate scrolling across continuation cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->