### PR TITLE
Sync macparakeet-cli 3.1.0 Homebrew formula

### DIFF
--- a/scripts/dist/homebrew-tap-scaffold/macparakeet-cli.rb
+++ b/scripts/dist/homebrew-tap-scaffold/macparakeet-cli.rb
@@ -11,12 +11,14 @@
 #
 # See HOWTO.md for CLI release instructions.
 
+require "json"
+
 class MacparakeetCli < Formula
   desc "Local STT, transcription, and prompt automation for Apple Silicon"
   homepage "https://macparakeet.com"
-  url "https://github.com/moona3k/macparakeet/releases/download/cli-v2.3.1/macparakeet-cli-2.3.1-darwin-arm64.tar.gz"
-  version "2.3.1"
-  sha256 "4250a6d8ad2f829ba00ab6dd4514764e6fa3bb28d6607e5547263fe554be2b6d"
+  url "https://github.com/moona3k/macparakeet/releases/download/cli-v3.1.0/macparakeet-cli-3.1.0-darwin-arm64.tar.gz"
+  version "3.1.0"
+  sha256 "05d0cb95ac4fb26bc18c5adecb7bb19d2a1892a42dd69bd5fce388f2138426bc"
   license "GPL-3.0-or-later"
 
   # Apple Silicon only — the Neural Engine is the entire performance story
@@ -24,13 +26,16 @@ class MacparakeetCli < Formula
   # Runtime media deps (bundled inside MacParakeet.app, but the standalone
   # CLI install needs them on PATH).
   depends_on "ffmpeg"
+  depends_on :macos
+  depends_on "yt-dlp"
 
   # macOS 14.2+ (Sonoma) — required by FluidAudio + Swift 6 runtime.
   # Homebrew's `depends_on macos:` only accepts major-version symbols, so
   # `:sonoma` covers 14.0+; the patch-level floor (14.2) is enforced at
   # install time via the `odie` check below.
-  depends_on macos: :sonoma
-  depends_on "yt-dlp"
+  on_macos do
+    depends_on macos: :sonoma
+  end
 
   def install
     odie "macparakeet-cli requires macOS 14.2 or later" if MacOS.version < "14.2"
@@ -61,5 +66,7 @@ class MacparakeetCli < Formula
 
   test do
     assert_match version.to_s, shell_output("#{bin}/macparakeet-cli --version")
+    spec = JSON.parse(shell_output("#{bin}/macparakeet-cli spec --json"))
+    assert_equal version.to_s, spec.fetch("cliVersion")
   end
 end


### PR DESCRIPTION
## Summary
- sync the repository formula reference to the published `cli-v3.1.0` asset and verified SHA-256
- require macOS explicitly in addition to ARM64/Sonoma
- make the formula test validate `spec --json` reports the installed CLI version

## Verification
- live `moona3k/tap` formula passes `brew style` and `brew audit --strict --online`
- reference formula body is byte-identical to the live tap formula
- public tarball SHA-256: `05d0cb95ac4fb26bc18c5adecb7bb19d2a1892a42dd69bd5fce388f2138426bc`
- fresh Homebrew install and `brew test` pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs the `macparakeet-cli` Homebrew formula to v3.1.0 (updated URL and SHA-256). Adds an explicit macOS requirement (Sonoma+) and updates the test to parse `spec --json` and verify the installed CLI version.

<sup>Written for commit 6306ceaf25649b6d77b7cff1a7528ad24d340da3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/849?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

