### PR TITLE
Skip AI formatting for empty transcripts

### DIFF
--- a/Sources/MacParakeetCore/TextProcessing/TranscriptFormatter.swift
+++ b/Sources/MacParakeetCore/TextProcessing/TranscriptFormatter.swift
@@ -24,6 +24,10 @@ struct TranscriptFormatter: Sendable {
             return .skipped
         }
 
+        guard text.contains(where: { !$0.isWhitespace }) else {
+            return .skipped
+        }
+
         // The formatter rewrites the full text, so output length tracks input
         // length; past the cap slow providers can stall finalization until
         // timeout before falling back anyway (issue #493).

--- a/Tests/MacParakeetTests/Services/TranscriptionServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/TranscriptionServiceTests.swift
@@ -1800,6 +1800,51 @@ final class TranscriptionServiceTests: XCTestCase {
         XCTAssertEqual(fetched.id, stub.id)
     }
 
+    func testTranscribeMeetingSkipsAIFormatterWhenRawTranscriptIsEmpty() async throws {
+        await mockSTT.configure(result: STTResult(text: ""))
+        let llm = MockLLMService()
+        let assistantReply = "Please provide the raw transcript you would like me to clean."
+        llm.formatTranscriptResult = assistantReply
+        let service = TranscriptionService(
+            audioProcessor: mockAudio,
+            sttTranscriber: mockSTT,
+            transcriptionRepo: transcriptionRepo,
+            llmService: llm,
+            llmRunRepo: llmRunRepo,
+            shouldUseAIFormatter: { true },
+            meetingAutomationHookRunner: nil
+        )
+        let recording = try makeOneSourceMeetingRecording(displayName: "Silent Meeting")
+        defer { try? FileManager.default.removeItem(at: recording.folderURL) }
+
+        let result = try await service.transcribeMeeting(recording: recording)
+
+        XCTAssertEqual(result.rawTranscript, "")
+        XCTAssertNil(result.cleanTranscript)
+        XCTAssertEqual(llm.formatTranscriptCallCount, 0)
+        XCTAssertTrue(try llmRunRepo.fetchForTranscription(id: result.id).isEmpty)
+
+        let persisted = try XCTUnwrap(transcriptionRepo.fetch(id: result.id))
+        XCTAssertEqual(persisted.rawTranscript, "")
+        XCTAssertNil(persisted.cleanTranscript)
+
+        let transcriptURL = recording.folderURL.appendingPathComponent(
+            MeetingArtifactStore.transcriptFileName
+        )
+        let transcriptData = try Data(contentsOf: transcriptURL)
+        let transcriptJSON = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: transcriptData) as? [String: Any]
+        )
+        XCTAssertEqual(transcriptJSON["transcript"] as? String, "")
+
+        let markdownURL = recording.folderURL.appendingPathComponent(
+            MeetingArtifactStore.markdownFileName
+        )
+        let markdown = try String(contentsOf: markdownURL, encoding: .utf8)
+        XCTAssertTrue(markdown.contains("## Transcript"))
+        XCTAssertFalse(markdown.contains(assistantReply))
+    }
+
     func testTranscribeMeetingAppliesEnabledCustomWordsToTextAndWordTokens() async throws {
         // Seed the user's Vocabulary with company-context corrections (issue #550).
         let dbManager = try DatabaseManager()

--- a/Tests/MacParakeetTests/TextProcessing/TranscriptFormatterTests.swift
+++ b/Tests/MacParakeetTests/TextProcessing/TranscriptFormatterTests.swift
@@ -17,6 +17,51 @@ final class TranscriptFormatterTests: XCTestCase {
         XCTAssertEqual(mockLLMService.formatTranscriptCallCount, 0)
     }
 
+    func testSkippedWhenInputIsWhitespaceOnlyDoesNotCallLLM() async throws {
+        let mockLLMService = MockLLMService()
+        let formatter = makeFormatter(llmService: mockLLMService)
+        let promptResolved = expectation(description: "prompt not resolved")
+        promptResolved.isInverted = true
+        let started = expectation(description: "formatter start not posted")
+        started.isInverted = true
+        let finished = expectation(description: "formatter finish not posted")
+        finished.isInverted = true
+        let startObserver = NotificationCenter.default.addObserver(
+            forName: .macParakeetAIFormatterDidStart,
+            object: nil,
+            queue: nil
+        ) { _ in
+            started.fulfill()
+        }
+        let finishObserver = NotificationCenter.default.addObserver(
+            forName: .macParakeetAIFormatterDidFinish,
+            object: nil,
+            queue: nil
+        ) { _ in
+            finished.fulfill()
+        }
+        defer {
+            NotificationCenter.default.removeObserver(startObserver)
+            NotificationCenter.default.removeObserver(finishObserver)
+        }
+
+        let outcome = try await formatter.format(
+            " \n\t ",
+            runSource: LLMRunSource(dictationId: UUID()),
+            lane: .dictation,
+            resolvePrompt: {
+                promptResolved.fulfill()
+                return (AIFormatter.defaultPromptTemplate, nil)
+            }
+        )
+
+        await fulfillment(of: [promptResolved, started, finished], timeout: 0.1)
+        XCTAssertNil(outcome.text)
+        XCTAssertNil(outcome.run)
+        XCTAssertNil(outcome.resolution)
+        XCTAssertEqual(mockLLMService.formatTranscriptCallCount, 0)
+    }
+
     func testTranscriptionLaneSkipsWhenInputExceedsMaxInputChars() async throws {
         let mockLLMService = MockLLMService()
         let formatter = makeFormatter(llmService: mockLLMService)

--- a/spec/02-features.md
+++ b/spec/02-features.md
@@ -939,6 +939,7 @@ Important constraints:
 - formatter is a separate toggle, not a dictation mode
 - formatter uses the shared `LLMService`
 - formatter runs for dictation, file/URL, and meeting transcription flows — every transcription finalization path shares `completeTranscription`, which invokes the formatter (`TelemetryFormatterSource` emits `.dictation` and `.transcription`; meetings report as `.transcription`)
+- formatter skips empty or whitespace-only input before prompt resolution or any provider call, so a model response can never become transcript content when STT produces no transcript text (#855)
 - formatter routing is per-surface: "Use for transcripts" (file/URL/meeting, default on) and "Use for dictation" (default off) toggles in AI settings, each ANDed with provider availability (#408, #493)
 - transcription formatter input is capped at `AIFormatter.maxTranscriptionInputChars` (20k chars); longer transcripts (hour-long meetings) skip straight to deterministic cleanup because a full-rewrite response can stall slow providers until timeout (#493)
 - dictation formatter prompts route through local exact-app profiles, local coarse-category profiles, built-in coarse-category smart defaults, and then the fallback formatter prompt


### PR DESCRIPTION
## Summary

- Skip the shared AI transcript formatter when its input is empty or whitespace-only.
- Prevent provider clarification replies from becoming canonical meeting transcript content in the database, `transcript.json`, or `meeting.md`.
- Cover the shared formatter invariant and the complete meeting finalization/persistence/artifact path.
- Document the formatter precondition in the governing feature spec.

## Root cause

`TranscriptFormatter` guarded configuration and oversized transcription input, but it had no lower-bound validity check. Meeting finalization correctly passed an empty finalized transcript into that shared module. The provider then returned a plausible request for transcript input, and `completeTranscription` correctly treated any successful formatter result as `cleanTranscript`; every downstream surface consistently preferred that clean value.

The fault is therefore at the formatter interface, not in persistence or rendering.

## Design

The fix enforces one invariant at the existing shared formatter seam: text without any non-whitespace content is not format-able. The skip occurs before prompt resolution, lifecycle notifications, provider calls, or formatter-run persistence, so all callers inherit the protection.

Deliberate non-goals:

- No minimum-word/token threshold. Short speech such as “yes” is legitimate and should remain format-able.
- No model-output phrase heuristic. Provider wording varies and filtering after the call would duplicate a weaker rule downstream.
- No new persisted “no speech” state. Empty text can result from silence, mute, or capture failure; existing UI already renders the empty-transcript state, while machine artifacts now remain truthfully empty.

## Verification

- `swift test --filter TranscriptFormatterTests` — 9 passed
- `swift test --filter TranscriptionServiceTests/testTranscribeMeetingSkipsAIFormatterWhenRawTranscriptIsEmpty` — 1 passed
- `swift test` — 4,951 passed, 20 environment-gated skipped, 0 failures
- `git diff --check`
- Changed-line `swift-format` lint review found no new formatting findings

Local `no-mistakes` and Greptile CLIs were unavailable in this checkout, so hosted CI and review are the remaining merge gates.

Closes #855

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip the transcript formatter when the input is empty or whitespace so a provider’s clarification message can’t be saved as transcript content. Fixes #855 and keeps the DB row, `transcript.json`, and `meeting.md` empty for silent recordings.

- **Bug Fixes**
  - Add a lower-bound check in `TranscriptFormatter` to return `.skipped` for empty/whitespace input before prompt resolution, lifecycle notifications, provider calls, or persistence.
  - Add tests for the full meeting finalization path (DB row, LLM ledger, `transcript.json`, and `meeting.md` with no assistant reply) and a whitespace-only invariant; update the feature spec.

<sup>Written for commit 3b9877d569154b7f78898b8e05c399bb25a982bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/856?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * AI formatting now skips empty or whitespace-only transcription input.
  * Prevents blank recordings from triggering AI processing or producing incorrect transcript content.
  * Exports now preserve an empty transcript correctly in JSON and Markdown (including omitting the formatter’s assistant reply).
* **Tests**
  * Added coverage to confirm AI formatting and related persistence are bypassed for empty/whitespace input.
* **Documentation**
  * Updated the AI Formatter spec to document the new empty-input behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->