### PR TITLE
Keep meeting finalization truthful and recoverable

### DIFF
--- a/Sources/MacParakeet/App/AppEnvironment.swift
+++ b/Sources/MacParakeet/App/AppEnvironment.swift
@@ -29,6 +29,7 @@ final class AppEnvironment {
     let sttScheduler: STTScheduler
     let sharedMicStream: SharedMicrophoneStream
     let audioProcessor: AudioProcessor
+    let meetingRecordingLockFileStore: MeetingRecordingLockFileStore
     let meetingRecordingService: MeetingRecordingService
     let meetingRecordingSettlement: MeetingRecordingSettlement
     let meetingRecordingRecoveryService: MeetingRecordingRecoveryService
@@ -152,7 +153,7 @@ final class AppEnvironment {
             // burst into a single warm-engine restart (issue #481).
             warmCaptureRefreshDebounce: 0.5
         )
-        let meetingRecordingLockFileStore = MeetingRecordingLockFileStore()
+        meetingRecordingLockFileStore = MeetingRecordingLockFileStore()
         meetingRecordingService = MeetingRecordingService(
             micProcessingMode: meetingMicProcessingMode,
             audioCaptureService: MeetingAudioCaptureService(

--- a/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
+++ b/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
@@ -326,6 +326,7 @@ final class AppEnvironmentConfigurer {
             llmService: hasLLMConfig ? env.llmService : nil,
             pillViewModel: meetingPillViewModel,
             meetingRecordingSettlement: env.meetingRecordingSettlement,
+            finalizationOwnershipClaimer: env.meetingRecordingLockFileStore,
             onMenuBarIconUpdate: { _ in callbacks.onMenuBarIconUpdate() },
             onTranscriptionReady: { [weak self] transcription in
                 guard let self else { return }
@@ -350,8 +351,11 @@ final class AppEnvironmentConfigurer {
                     callbacks.onOpenMainWindow()
                 }
             },
-            onQueuedTranscriptionFailed: { [weak self] content in
+            onQueuedTranscriptionFailed: { [weak self] transcriptionID, content in
                 guard let self else { return }
+                self.transcriptionViewModel.refreshCurrentTranscriptionIfMatching(
+                    id: transcriptionID
+                )
                 self.libraryViewModel.loadTranscriptions()
                 self.meetingsWorkspaceViewModel.refreshRecentMeetings()
                 TranscriptionCompletionPresenter.presentNotification(content)
@@ -388,7 +392,8 @@ final class AppEnvironmentConfigurer {
                 let protectedIDs = meetingCoordinator.queuedMeetingTranscriptionIDs
                 let reconciled = try await MeetingFinalizationReconciler.reconcileStaleProcessingRows(
                     repository: env.transcriptionRepo,
-                    excludingTranscriptionIDs: protectedIDs
+                    excludingTranscriptionIDs: protectedIDs,
+                    ownershipCoordinator: env.meetingRecordingLockFileStore
                 )
                 guard !reconciled.isEmpty, let self else { return }
                 self.libraryViewModel.loadTranscriptions()

--- a/Sources/MacParakeet/App/MeetingFinalizationReconciler.swift
+++ b/Sources/MacParakeet/App/MeetingFinalizationReconciler.swift
@@ -1,15 +1,43 @@
 import Foundation
 import MacParakeetCore
 
+/// The narrow persistence capability startup reconciliation needs.
+///
+/// `transitionStatus` must compare and update within one database transaction.
+/// A read followed by an unconditional write can regress a row that another
+/// app process completed between those operations.
+protocol MeetingFinalizationStatusRepository: Sendable {
+    func fetchMeetings(
+        withStatus status: Transcription.TranscriptionStatus
+    ) throws -> [Transcription]
+
+    @discardableResult
+    func transitionStatus(
+        id: UUID,
+        from expectedStatus: Transcription.TranscriptionStatus,
+        to status: Transcription.TranscriptionStatus,
+        errorMessage: String?
+    ) throws -> Bool
+}
+
+extension TranscriptionRepository: MeetingFinalizationStatusRepository {}
+
+/// Answers ownership for one canonical meeting-artifact folder.
+protocol MeetingFinalizationOwnershipChecking: Sendable {
+    func hasLiveOwner(folderURL: URL) throws -> Bool
+}
+
+extension MeetingRecordingLockFileStore: MeetingFinalizationOwnershipChecking {}
+
 enum MeetingFinalizationReconciler {
     static let staleProcessingErrorMessage =
         "MacParakeet quit before meeting transcription finished. Your audio is saved."
 
     @discardableResult
     static func reconcileStaleProcessingRows(
-        repository: TranscriptionRepositoryProtocol,
+        repository: any MeetingFinalizationStatusRepository,
         excludingTranscriptionIDs protectedIDs: Set<UUID> = [],
-        lockFileStore: MeetingRecordingLockFileStore = MeetingRecordingLockFileStore()
+        ownershipChecker: any MeetingFinalizationOwnershipChecking = MeetingRecordingLockFileStore()
     ) async throws -> [UUID] {
         try await Task.detached(priority: .utility) {
             let processingRows = try repository.fetchMeetings(withStatus: .processing)
@@ -19,7 +47,7 @@ enum MeetingFinalizationReconciler {
             for row in processingRows {
                 if let folderPath = row.meetingArtifactFolderPath,
                    !folderPath.isEmpty,
-                   try lockFileStore.hasLiveOwner(
+                   try ownershipChecker.hasLiveOwner(
                        folderURL: URL(fileURLWithPath: folderPath, isDirectory: true)
                    ) {
                     continue

--- a/Sources/MacParakeet/App/MeetingFinalizationReconciler.swift
+++ b/Sources/MacParakeet/App/MeetingFinalizationReconciler.swift
@@ -1,5 +1,6 @@
 import Foundation
 import MacParakeetCore
+import OSLog
 
 /// The narrow persistence capability startup reconciliation needs.
 ///
@@ -23,6 +24,11 @@ protocol MeetingFinalizationStatusRepository: Sendable {
 extension TranscriptionRepository: MeetingFinalizationStatusRepository {}
 
 enum MeetingFinalizationReconciler {
+    private static let logger = Logger(
+        subsystem: "com.macparakeet",
+        category: "MeetingFinalizationReconciler"
+    )
+
     static let staleProcessingErrorMessage =
         "MacParakeet quit before meeting transcription finished. Your audio is saved."
 
@@ -39,27 +45,36 @@ enum MeetingFinalizationReconciler {
             var reconciledIDs: [UUID] = []
 
             for row in processingRows {
-                let transition: @Sendable () throws -> Bool = {
-                    try repository.transitionStatus(
-                        id: row.id,
-                        from: .processing,
-                        to: .error,
-                        errorMessage: staleProcessingErrorMessage
+                do {
+                    let transition: @Sendable () throws -> Bool = {
+                        try repository.transitionStatus(
+                            id: row.id,
+                            from: .processing,
+                            to: .error,
+                            errorMessage: staleProcessingErrorMessage
+                        )
+                    }
+                    let didReconcile: Bool
+                    if let folderPath = row.meetingArtifactFolderPath,
+                        !folderPath.isEmpty
+                    {
+                        didReconcile = try ownershipCoordinator.reconcileIfUnowned(
+                            folderURL: URL(fileURLWithPath: folderPath, isDirectory: true),
+                            transition: transition
+                        )
+                    } else {
+                        didReconcile = try transition()
+                    }
+                    if didReconcile {
+                        reconciledIDs.append(row.id)
+                    }
+                } catch {
+                    logger.error(
+                        """
+                        Failed to reconcile stale meeting \(row.id.uuidString, privacy: .public): \
+                        \(error.localizedDescription, privacy: .private)
+                        """
                     )
-                }
-                let didReconcile: Bool
-                if let folderPath = row.meetingArtifactFolderPath,
-                    !folderPath.isEmpty
-                {
-                    didReconcile = try ownershipCoordinator.reconcileIfUnowned(
-                        folderURL: URL(fileURLWithPath: folderPath, isDirectory: true),
-                        transition: transition
-                    )
-                } else {
-                    didReconcile = try transition()
-                }
-                if didReconcile {
-                    reconciledIDs.append(row.id)
                 }
             }
             return reconciledIDs

--- a/Sources/MacParakeet/App/MeetingFinalizationReconciler.swift
+++ b/Sources/MacParakeet/App/MeetingFinalizationReconciler.swift
@@ -46,10 +46,11 @@ enum MeetingFinalizationReconciler {
 
             for row in processingRows {
                 if let folderPath = row.meetingArtifactFolderPath,
-                   !folderPath.isEmpty,
-                   try ownershipChecker.hasLiveOwner(
-                       folderURL: URL(fileURLWithPath: folderPath, isDirectory: true)
-                   ) {
+                    !folderPath.isEmpty,
+                    try ownershipChecker.hasLiveOwner(
+                        folderURL: URL(fileURLWithPath: folderPath, isDirectory: true)
+                    )
+                {
                     continue
                 }
 

--- a/Sources/MacParakeet/App/MeetingFinalizationReconciler.swift
+++ b/Sources/MacParakeet/App/MeetingFinalizationReconciler.swift
@@ -22,13 +22,6 @@ protocol MeetingFinalizationStatusRepository: Sendable {
 
 extension TranscriptionRepository: MeetingFinalizationStatusRepository {}
 
-/// Answers ownership for one canonical meeting-artifact folder.
-protocol MeetingFinalizationOwnershipChecking: Sendable {
-    func hasLiveOwner(folderURL: URL) throws -> Bool
-}
-
-extension MeetingRecordingLockFileStore: MeetingFinalizationOwnershipChecking {}
-
 enum MeetingFinalizationReconciler {
     static let staleProcessingErrorMessage =
         "MacParakeet quit before meeting transcription finished. Your audio is saved."
@@ -37,7 +30,8 @@ enum MeetingFinalizationReconciler {
     static func reconcileStaleProcessingRows(
         repository: any MeetingFinalizationStatusRepository,
         excludingTranscriptionIDs protectedIDs: Set<UUID> = [],
-        ownershipChecker: any MeetingFinalizationOwnershipChecking = MeetingRecordingLockFileStore()
+        ownershipCoordinator: any MeetingFinalizationReconciliationCoordinating =
+            MeetingRecordingLockFileStore()
     ) async throws -> [UUID] {
         try await Task.detached(priority: .utility) {
             let processingRows = try repository.fetchMeetings(withStatus: .processing)
@@ -45,21 +39,25 @@ enum MeetingFinalizationReconciler {
             var reconciledIDs: [UUID] = []
 
             for row in processingRows {
-                if let folderPath = row.meetingArtifactFolderPath,
-                    !folderPath.isEmpty,
-                    try ownershipChecker.hasLiveOwner(
-                        folderURL: URL(fileURLWithPath: folderPath, isDirectory: true)
+                let transition: @Sendable () throws -> Bool = {
+                    try repository.transitionStatus(
+                        id: row.id,
+                        from: .processing,
+                        to: .error,
+                        errorMessage: staleProcessingErrorMessage
                     )
-                {
-                    continue
                 }
-
-                let didReconcile = try repository.transitionStatus(
-                    id: row.id,
-                    from: .processing,
-                    to: .error,
-                    errorMessage: staleProcessingErrorMessage
-                )
+                let didReconcile: Bool
+                if let folderPath = row.meetingArtifactFolderPath,
+                    !folderPath.isEmpty
+                {
+                    didReconcile = try ownershipCoordinator.reconcileIfUnowned(
+                        folderURL: URL(fileURLWithPath: folderPath, isDirectory: true),
+                        transition: transition
+                    )
+                } else {
+                    didReconcile = try transition()
+                }
                 if didReconcile {
                     reconciledIDs.append(row.id)
                 }

--- a/Sources/MacParakeet/App/MeetingFinalizationReconciler.swift
+++ b/Sources/MacParakeet/App/MeetingFinalizationReconciler.swift
@@ -8,19 +8,34 @@ enum MeetingFinalizationReconciler {
     @discardableResult
     static func reconcileStaleProcessingRows(
         repository: TranscriptionRepositoryProtocol,
-        excludingTranscriptionIDs protectedIDs: Set<UUID> = []
+        excludingTranscriptionIDs protectedIDs: Set<UUID> = [],
+        lockFileStore: MeetingRecordingLockFileStore = MeetingRecordingLockFileStore()
     ) async throws -> [UUID] {
         try await Task.detached(priority: .utility) {
-            let staleRows = try repository.fetchMeetings(withStatus: .processing)
+            let processingRows = try repository.fetchMeetings(withStatus: .processing)
                 .filter { !protectedIDs.contains($0.id) }
-            for row in staleRows {
-                try repository.updateStatus(
+            var reconciledIDs: [UUID] = []
+
+            for row in processingRows {
+                if let folderPath = row.meetingArtifactFolderPath,
+                   !folderPath.isEmpty,
+                   try lockFileStore.hasLiveOwner(
+                       folderURL: URL(fileURLWithPath: folderPath, isDirectory: true)
+                   ) {
+                    continue
+                }
+
+                let didReconcile = try repository.transitionStatus(
                     id: row.id,
-                    status: .error,
+                    from: .processing,
+                    to: .error,
                     errorMessage: staleProcessingErrorMessage
                 )
+                if didReconcile {
+                    reconciledIDs.append(row.id)
+                }
             }
-            return staleRows.map(\.id)
+            return reconciledIDs
         }.value
     }
 }

--- a/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
@@ -90,7 +90,7 @@ final class MeetingRecordingFlowCoordinator {
     private let onMenuBarIconUpdate: (BreathWaveIcon.MenuBarState) -> Void
     private let onTranscriptionReady: (Transcription) -> Void
     private let onQueuedTranscriptionReady: (Transcription, Bool) -> Void
-    private let onQueuedTranscriptionFailed: (TranscriptionCompletionNotifier.Content) -> Void
+    private let onQueuedTranscriptionFailed: (UUID, TranscriptionCompletionNotifier.Content) -> Void
     private let onRecordingBegan: () -> Void
     private let onRecordingStopping: () -> Void
     private let onFlowReturnedToIdle: () -> Void
@@ -155,11 +155,13 @@ final class MeetingRecordingFlowCoordinator {
         llmService: LLMServiceProtocol?,
         pillViewModel: MeetingRecordingPillViewModel,
         meetingRecordingSettlement: MeetingRecordingSettlement,
+        finalizationOwnershipClaimer: any MeetingFinalizationOwnershipClaiming =
+            MeetingRecordingLockFileStore(),
         meetingTranscriptionQueue: MeetingTranscriptionQueue? = nil,
         onMenuBarIconUpdate: @escaping (BreathWaveIcon.MenuBarState) -> Void,
         onTranscriptionReady: @escaping (Transcription) -> Void,
         onQueuedTranscriptionReady: ((Transcription, Bool) -> Void)? = nil,
-        onQueuedTranscriptionFailed: ((TranscriptionCompletionNotifier.Content) -> Void)? = nil,
+        onQueuedTranscriptionFailed: ((UUID, TranscriptionCompletionNotifier.Content) -> Void)? = nil,
         onRecordingBegan: @escaping () -> Void = {},
         onRecordingStopping: @escaping () -> Void = {},
         onFlowReturnedToIdle: @escaping () -> Void = {}
@@ -185,7 +187,8 @@ final class MeetingRecordingFlowCoordinator {
             ?? MeetingTranscriptionQueue(
                 transcriptionService: transcriptionService,
                 transcriptionRepo: transcriptionRepo,
-                meetingRecordingSettlement: meetingRecordingSettlement
+                meetingRecordingSettlement: meetingRecordingSettlement,
+                finalizationOwnershipClaimer: finalizationOwnershipClaimer
             )
         self.onMenuBarIconUpdate = onMenuBarIconUpdate
         self.onTranscriptionReady = onTranscriptionReady
@@ -194,7 +197,7 @@ final class MeetingRecordingFlowCoordinator {
                 onTranscriptionReady(transcription)
             }
         self.onQueuedTranscriptionFailed =
-            onQueuedTranscriptionFailed ?? { content in
+            onQueuedTranscriptionFailed ?? { _, content in
                 TranscriptionCompletionPresenter.presentNotification(content)
             }
         self.onRecordingBegan = onRecordingBegan
@@ -1532,7 +1535,13 @@ final class MeetingRecordingFlowCoordinator {
 
     func retryMeetingFinalization(_ transcription: Transcription) async throws {
         let item = try await makeRetryQueueItem(from: transcription)
-        meetingTranscriptionQueue.enqueue(item)
+        guard
+            try await meetingTranscriptionQueue.enqueueClaimingFinalizationOwnership(
+                item
+            )
+        else {
+            throw MeetingFinalizationRetryError.alreadyProcessing
+        }
     }
 
     var queuedMeetingTranscriptionIDs: Set<UUID> {
@@ -1573,7 +1582,10 @@ final class MeetingRecordingFlowCoordinator {
                 liveTranscriptLagged: item.liveTranscriptLagged,
                 errorType: TelemetryErrorClassifier.classify(error)
             )
-            onQueuedTranscriptionFailed(TranscriptionCompletionNotifier.meetingNeedsRetryContent())
+            onQueuedTranscriptionFailed(
+                item.transcriptionID,
+                TranscriptionCompletionNotifier.meetingNeedsRetryContent()
+            )
         }
     }
 

--- a/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
+++ b/Sources/MacParakeet/App/MeetingRecordingFlowCoordinator.swift
@@ -917,7 +917,7 @@ final class MeetingRecordingFlowCoordinator {
                         )
                         self.persistLiveAskConversationIfNeeded(transcriptionID: prepared.id)
                         let enqueueStartedAt = Date()
-                        meetingTranscriptionQueue.enqueue(
+                        await meetingTranscriptionQueue.enqueue(
                             MeetingTranscriptionQueue.Item(
                                 recording: output,
                                 transcriptionID: prepared.id,

--- a/Sources/MacParakeet/App/MeetingTranscriptionQueue.swift
+++ b/Sources/MacParakeet/App/MeetingTranscriptionQueue.swift
@@ -11,6 +11,25 @@ final class MeetingTranscriptionQueue {
         let trigger: TelemetryMeetingOperationTrigger?
         let liveWordCount: Int
         let liveTranscriptLagged: Bool
+        let finalizationOwnershipLease: MeetingFinalizationOwnershipLease?
+
+        init(
+            recording: MeetingRecordingOutput,
+            transcriptionID: UUID,
+            operationContext: ObservabilityOperationContext,
+            trigger: TelemetryMeetingOperationTrigger?,
+            liveWordCount: Int,
+            liveTranscriptLagged: Bool,
+            finalizationOwnershipLease: MeetingFinalizationOwnershipLease? = nil
+        ) {
+            self.recording = recording
+            self.transcriptionID = transcriptionID
+            self.operationContext = operationContext
+            self.trigger = trigger
+            self.liveWordCount = liveWordCount
+            self.liveTranscriptLagged = liveTranscriptLagged
+            self.finalizationOwnershipLease = finalizationOwnershipLease
+        }
 
         func withTranscriptionID(_ transcriptionID: UUID) -> Item {
             Item(
@@ -19,7 +38,22 @@ final class MeetingTranscriptionQueue {
                 operationContext: operationContext,
                 trigger: trigger,
                 liveWordCount: liveWordCount,
-                liveTranscriptLagged: liveTranscriptLagged
+                liveTranscriptLagged: liveTranscriptLagged,
+                finalizationOwnershipLease: finalizationOwnershipLease
+            )
+        }
+
+        func withFinalizationOwnershipLease(
+            _ lease: MeetingFinalizationOwnershipLease
+        ) -> Item {
+            Item(
+                recording: recording,
+                transcriptionID: transcriptionID,
+                operationContext: operationContext,
+                trigger: trigger,
+                liveWordCount: liveWordCount,
+                liveTranscriptLagged: liveTranscriptLagged,
+                finalizationOwnershipLease: lease
             )
         }
     }
@@ -47,6 +81,7 @@ final class MeetingTranscriptionQueue {
     private let transcriptionService: TranscriptionServiceProtocol
     private let transcriptionRepo: TranscriptionRepositoryProtocol
     private let meetingRecordingSettlement: MeetingRecordingSettlement
+    private let finalizationOwnershipClaimer: any MeetingFinalizationOwnershipClaiming
 
     private var pendingItems: [Item] = []
     private var activeItem: Item?
@@ -59,11 +94,14 @@ final class MeetingTranscriptionQueue {
     init(
         transcriptionService: TranscriptionServiceProtocol,
         transcriptionRepo: TranscriptionRepositoryProtocol,
-        meetingRecordingSettlement: MeetingRecordingSettlement
+        meetingRecordingSettlement: MeetingRecordingSettlement,
+        finalizationOwnershipClaimer: any MeetingFinalizationOwnershipClaiming =
+            MeetingRecordingLockFileStore()
     ) {
         self.transcriptionService = transcriptionService
         self.transcriptionRepo = transcriptionRepo
         self.meetingRecordingSettlement = meetingRecordingSettlement
+        self.finalizationOwnershipClaimer = finalizationOwnershipClaimer
     }
 
     var snapshot: Snapshot {
@@ -78,16 +116,29 @@ final class MeetingTranscriptionQueue {
         return ids
     }
 
-    func enqueue(_ item: Item) {
+    @discardableResult
+    func enqueue(_ item: Item) -> Bool {
         guard !containsQueuedTranscription(id: item.transcriptionID) else {
             logger.info(
                 "queued_meeting_transcription_duplicate_dropped id=\(item.transcriptionID.uuidString, privacy: .public)"
             )
-            return
+            restoreFinalizationOwnershipIfNeeded(for: item)
+            return false
         }
         pendingItems.append(item)
         notifyStateChanged()
         startNextIfNeeded()
+        return true
+    }
+
+    func enqueueClaimingFinalizationOwnership(_ item: Item) async throws -> Bool {
+        let ownershipClaimer = finalizationOwnershipClaimer
+        let lease = try await Task.detached(priority: .userInitiated) {
+            try ownershipClaimer.claimFinalizationOwnership(
+                folderURL: item.recording.folderURL
+            )
+        }.value
+        return enqueue(item.withFinalizationOwnershipLease(lease))
     }
 
     func waitUntilIdle() async {
@@ -119,6 +170,7 @@ final class MeetingTranscriptionQueue {
                 logger.info(
                     "queued_meeting_transcription_already_completed id=\(transcription.id.uuidString, privacy: .public)"
                 )
+                restoreFinalizationOwnershipIfNeeded(for: originalItem)
                 finishActiveItem(nil)
                 return
             }
@@ -130,6 +182,7 @@ final class MeetingTranscriptionQueue {
             logger.error(
                 "queued_meeting_transcription_prepare_failed session=\(originalItem.recording.sessionID.uuidString, privacy: .public) error_type=\(TelemetryErrorClassifier.classify(error), privacy: .public) error_detail=\(error.localizedDescription, privacy: .private)"
             )
+            restoreFinalizationOwnershipIfNeeded(for: originalItem)
             finishActiveItem(.failure(item: originalItem, error: error))
             return
         }
@@ -148,6 +201,7 @@ final class MeetingTranscriptionQueue {
                 "queued_meeting_transcription_failed session=\(item.recording.sessionID.uuidString, privacy: .public) error_type=\(TelemetryErrorClassifier.classify(error), privacy: .public) error_detail=\(error.localizedDescription, privacy: .private)"
             )
             await markFailed(item, error: error)
+            restoreFinalizationOwnershipIfNeeded(for: item)
             finishActiveItem(.failure(item: item, error: error))
             return
         }
@@ -162,6 +216,7 @@ final class MeetingTranscriptionQueue {
             logger.error(
                 "queued_meeting_settlement_failed_lock_retained_for_recovery session=\(item.recording.sessionID.uuidString, privacy: .public) error_type=\(TelemetryErrorClassifier.classify(error), privacy: .public) error_detail=\(error.localizedDescription, privacy: .private)"
             )
+            restoreFinalizationOwnershipIfNeeded(for: item)
         }
         finishActiveItem(.success(item: item, transcription: transcription))
     }
@@ -231,6 +286,17 @@ final class MeetingTranscriptionQueue {
 
     private func containsQueuedTranscription(id: UUID) -> Bool {
         activeItem?.transcriptionID == id || pendingItems.contains { $0.transcriptionID == id }
+    }
+
+    private func restoreFinalizationOwnershipIfNeeded(for item: Item) {
+        guard let lease = item.finalizationOwnershipLease else { return }
+        do {
+            try finalizationOwnershipClaimer.releaseFinalizationOwnership(lease)
+        } catch {
+            logger.error(
+                "queued_meeting_ownership_release_failed id=\(item.transcriptionID.uuidString, privacy: .public) error=\(error.localizedDescription, privacy: .private)"
+            )
+        }
     }
 
     private func finishActiveItem(_ completion: Completion?) {

--- a/Sources/MacParakeet/App/MeetingTranscriptionQueue.swift
+++ b/Sources/MacParakeet/App/MeetingTranscriptionQueue.swift
@@ -117,12 +117,12 @@ final class MeetingTranscriptionQueue {
     }
 
     @discardableResult
-    func enqueue(_ item: Item) -> Bool {
+    func enqueue(_ item: Item) async -> Bool {
         guard !containsQueuedTranscription(id: item.transcriptionID) else {
             logger.info(
                 "queued_meeting_transcription_duplicate_dropped id=\(item.transcriptionID.uuidString, privacy: .public)"
             )
-            restoreFinalizationOwnershipIfNeeded(for: item)
+            await restoreFinalizationOwnershipIfNeeded(for: item)
             return false
         }
         pendingItems.append(item)
@@ -138,7 +138,7 @@ final class MeetingTranscriptionQueue {
                 folderURL: item.recording.folderURL
             )
         }.value
-        return enqueue(item.withFinalizationOwnershipLease(lease))
+        return await enqueue(item.withFinalizationOwnershipLease(lease))
     }
 
     func waitUntilIdle() async {
@@ -170,7 +170,7 @@ final class MeetingTranscriptionQueue {
                 logger.info(
                     "queued_meeting_transcription_already_completed id=\(transcription.id.uuidString, privacy: .public)"
                 )
-                restoreFinalizationOwnershipIfNeeded(for: originalItem)
+                await restoreFinalizationOwnershipIfNeeded(for: originalItem)
                 finishActiveItem(nil)
                 return
             }
@@ -182,7 +182,7 @@ final class MeetingTranscriptionQueue {
             logger.error(
                 "queued_meeting_transcription_prepare_failed session=\(originalItem.recording.sessionID.uuidString, privacy: .public) error_type=\(TelemetryErrorClassifier.classify(error), privacy: .public) error_detail=\(error.localizedDescription, privacy: .private)"
             )
-            restoreFinalizationOwnershipIfNeeded(for: originalItem)
+            await restoreFinalizationOwnershipIfNeeded(for: originalItem)
             finishActiveItem(.failure(item: originalItem, error: error))
             return
         }
@@ -201,7 +201,7 @@ final class MeetingTranscriptionQueue {
                 "queued_meeting_transcription_failed session=\(item.recording.sessionID.uuidString, privacy: .public) error_type=\(TelemetryErrorClassifier.classify(error), privacy: .public) error_detail=\(error.localizedDescription, privacy: .private)"
             )
             await markFailed(item, error: error)
-            restoreFinalizationOwnershipIfNeeded(for: item)
+            await restoreFinalizationOwnershipIfNeeded(for: item)
             finishActiveItem(.failure(item: item, error: error))
             return
         }
@@ -216,7 +216,7 @@ final class MeetingTranscriptionQueue {
             logger.error(
                 "queued_meeting_settlement_failed_lock_retained_for_recovery session=\(item.recording.sessionID.uuidString, privacy: .public) error_type=\(TelemetryErrorClassifier.classify(error), privacy: .public) error_detail=\(error.localizedDescription, privacy: .private)"
             )
-            restoreFinalizationOwnershipIfNeeded(for: item)
+            await restoreFinalizationOwnershipIfNeeded(for: item)
         }
         finishActiveItem(.success(item: item, transcription: transcription))
     }
@@ -288,10 +288,13 @@ final class MeetingTranscriptionQueue {
         activeItem?.transcriptionID == id || pendingItems.contains { $0.transcriptionID == id }
     }
 
-    private func restoreFinalizationOwnershipIfNeeded(for item: Item) {
+    private func restoreFinalizationOwnershipIfNeeded(for item: Item) async {
         guard let lease = item.finalizationOwnershipLease else { return }
+        let ownershipClaimer = finalizationOwnershipClaimer
         do {
-            try finalizationOwnershipClaimer.releaseFinalizationOwnership(lease)
+            try await Task.detached(priority: .utility) {
+                try ownershipClaimer.releaseFinalizationOwnership(lease)
+            }.value
         } catch {
             logger.error(
                 "queued_meeting_ownership_release_failed id=\(item.transcriptionID.uuidString, privacy: .public) error=\(error.localizedDescription, privacy: .private)"

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
@@ -143,11 +143,9 @@ struct MeetingTranscriptProcessingPresentation: Equatable {
 
 enum TranscriptDetailActionAvailability {
     static func canEdit(
-        transcriptText: String,
         status: Transcription.TranscriptionStatus
     ) -> Bool {
         status != .processing
-            && !transcriptText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
     static func canRetranscribe(
@@ -1689,7 +1687,6 @@ struct TranscriptResultView: View {
                 .disabled(
                     transcriptDisplayMode != .text
                         || !TranscriptDetailActionAvailability.canEdit(
-                            transcriptText: transcriptText,
                             status: activeTranscription.status
                         )
                 )

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
@@ -1703,7 +1703,7 @@ struct TranscriptResultView: View {
             return "Editing is available after transcription finishes."
         }
         if transcriptText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            return "No transcript text to edit."
+            return "Add transcript text manually."
         }
         return "Edit the transcript text"
     }

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
@@ -122,6 +122,42 @@ struct MeetingTimedTranscriptRecoveryBannerPresentation: Equatable {
     }
 }
 
+struct MeetingTranscriptProcessingPresentation: Equatable {
+    let title: String
+    let message: String
+
+    static func make(
+        sourceType: Transcription.SourceType,
+        status: Transcription.TranscriptionStatus
+    ) -> MeetingTranscriptProcessingPresentation? {
+        guard sourceType == .meeting,
+              status == .processing else {
+            return nil
+        }
+        return MeetingTranscriptProcessingPresentation(
+            title: "Transcribing meeting",
+            message: "Your audio is saved. Final transcription is continuing in the background. You can leave this page and return later."
+        )
+    }
+}
+
+enum TranscriptDetailActionAvailability {
+    static func canEdit(
+        transcriptText: String,
+        status: Transcription.TranscriptionStatus
+    ) -> Bool {
+        status != .processing
+            && !transcriptText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    static func canRetranscribe(
+        hasRetainedAudio: Bool,
+        status: Transcription.TranscriptionStatus
+    ) -> Bool {
+        hasRetainedAudio && status != .processing
+    }
+}
+
 struct TranscriptResultView: View {
     let transcription: Transcription
     @Bindable var viewModel: TranscriptionViewModel
@@ -609,15 +645,18 @@ struct TranscriptResultView: View {
                       : "Meeting artifact folder is not available")
             }
 
-            if onRetranscribe != nil, let filePath = transcription.filePath,
-               FileManager.default.fileExists(atPath: filePath) {
-                let engineOption = viewModel.retranscriptionEngineOption(for: transcription)
+            if onRetranscribe != nil, let filePath = activeTranscription.filePath,
+               TranscriptDetailActionAvailability.canRetranscribe(
+                   hasRetainedAudio: FileManager.default.fileExists(atPath: filePath),
+                   status: activeTranscription.status
+               ) {
+                let engineOption = viewModel.retranscriptionEngineOption(for: activeTranscription)
                 Button {
                     if engineOption != nil {
                         showingRetranscribeOptions.toggle()
                     } else {
                         retranscriptionConfirmation = RetranscriptionConfirmation(
-                            transcriptionID: transcription.id,
+                            transcriptionID: activeTranscription.id,
                             speechEngineOverride: nil
                         )
                     }
@@ -1228,6 +1267,7 @@ struct TranscriptResultView: View {
                     }
 
                     if activeTranscription.sourceType == .meeting,
+                       activeTranscription.status != .processing,
                        !activeTranscription.hasWordTimestamps,
                        let banner = meetingNoWordTimestampsBannerPresentation {
                         meetingNoWordTimestampsBanner(banner)
@@ -1248,6 +1288,10 @@ struct TranscriptResultView: View {
                             .foregroundStyle(DesignSystem.Colors.errorRed)
                     }
 
+                    if let presentation = meetingTranscriptProcessingPresentation {
+                        meetingTranscriptProcessingState(presentation)
+                    }
+
                     if editingTranscript {
                         transcriptEditor
                     } else if transcriptDisplayMode == .timed,
@@ -1257,9 +1301,9 @@ struct TranscriptResultView: View {
                             speakerSummaryPanel(speakers: speakers)
                         }
                         timestampedView(words: timestamps)
-                    } else if !transcriptText.isEmpty {
+                    } else if !transcriptText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                         transcriptTextBlock
-                    } else {
+                    } else if meetingTranscriptProcessingPresentation == nil {
                         Text("No transcript available")
                             .foregroundStyle(DesignSystem.Colors.textSecondary)
                     }
@@ -1642,12 +1686,61 @@ struct TranscriptResultView: View {
                     Label("Edit", systemImage: "pencil")
                 }
                 .parakeetAction(.secondary)
-                .disabled(transcriptDisplayMode != .text)
-                .help(transcriptDisplayMode == .text
-                    ? "Edit the transcript text"
-                    : "Switch to Text to edit. Edits apply to the text transcript; timestamps are preserved.")
+                .disabled(
+                    transcriptDisplayMode != .text
+                        || !TranscriptDetailActionAvailability.canEdit(
+                            transcriptText: transcriptText,
+                            status: activeTranscription.status
+                        )
+                )
+                .help(transcriptEditHelp)
             }
         }
+    }
+
+    private var transcriptEditHelp: String {
+        if transcriptDisplayMode != .text {
+            return "Switch to Text to edit. Edits apply to the text transcript; timestamps are preserved."
+        }
+        if activeTranscription.status == .processing {
+            return "Editing is available after transcription finishes."
+        }
+        if transcriptText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return "No transcript text to edit."
+        }
+        return "Edit the transcript text"
+    }
+
+    private var meetingTranscriptProcessingPresentation: MeetingTranscriptProcessingPresentation? {
+        MeetingTranscriptProcessingPresentation.make(
+            sourceType: activeTranscription.sourceType,
+            status: activeTranscription.status
+        )
+    }
+
+    private func meetingTranscriptProcessingState(
+        _ presentation: MeetingTranscriptProcessingPresentation
+    ) -> some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+            HStack(spacing: DesignSystem.Spacing.sm) {
+                ParakeetSpinner(.inline, tint: DesignSystem.Colors.accent)
+                Text(presentation.title)
+                    .font(DesignSystem.Typography.body.weight(.semibold))
+                    .foregroundStyle(DesignSystem.Colors.textPrimary)
+            }
+
+            Text(presentation.message)
+                .font(DesignSystem.Typography.body)
+                .foregroundStyle(DesignSystem.Colors.textSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(DesignSystem.Spacing.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius)
+                .fill(DesignSystem.Colors.surfaceElevated)
+        )
+        .accessibilityElement(children: .combine)
     }
 
     private var transcriptEditor: some View {

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
@@ -131,12 +131,14 @@ struct MeetingTranscriptProcessingPresentation: Equatable {
         status: Transcription.TranscriptionStatus
     ) -> MeetingTranscriptProcessingPresentation? {
         guard sourceType == .meeting,
-              status == .processing else {
+            status == .processing
+        else {
             return nil
         }
         return MeetingTranscriptProcessingPresentation(
             title: "Transcribing meeting",
-            message: "Your audio is saved. Final transcription is continuing in the background. You can leave this page and return later."
+            message:
+                "Your audio is saved. Final transcription is continuing in the background. You can leave this page and return later."
         )
     }
 }

--- a/Sources/MacParakeetCore/Database/TranscriptionRepository.swift
+++ b/Sources/MacParakeetCore/Database/TranscriptionRepository.swift
@@ -15,13 +15,6 @@ public protocol TranscriptionRepositoryProtocol: Sendable {
     func delete(id: UUID) throws -> Bool
     func deleteAll() throws
     func updateStatus(id: UUID, status: Transcription.TranscriptionStatus, errorMessage: String?) throws
-    @discardableResult
-    func transitionStatus(
-        id: UUID,
-        from expectedStatus: Transcription.TranscriptionStatus,
-        to status: Transcription.TranscriptionStatus,
-        errorMessage: String?
-    ) throws -> Bool
     func updateFileName(id: UUID, fileName: String) throws
     func updateTitleOverride(id: UUID, titleOverride: String?) throws
     func updateChatMessages(id: UUID, chatMessages: [ChatMessage]?) throws
@@ -115,19 +108,6 @@ extension TranscriptionRepositoryProtocol {
         )
     }
     public func clearStoredAudioPathsForURLTranscriptions() throws {}
-    @discardableResult
-    public func transitionStatus(
-        id: UUID,
-        from expectedStatus: Transcription.TranscriptionStatus,
-        to status: Transcription.TranscriptionStatus,
-        errorMessage: String?
-    ) throws -> Bool {
-        guard try fetch(id: id)?.status == expectedStatus else {
-            return false
-        }
-        try updateStatus(id: id, status: status, errorMessage: errorMessage)
-        return true
-    }
     @discardableResult
     public func clearStoredAudioPathsForMeetingTranscriptions(under directoryPath: String) throws -> [UUID] { [] }
     public func updateFileName(id: UUID, fileName: String) throws {}

--- a/Sources/MacParakeetCore/Database/TranscriptionRepository.swift
+++ b/Sources/MacParakeetCore/Database/TranscriptionRepository.swift
@@ -15,6 +15,13 @@ public protocol TranscriptionRepositoryProtocol: Sendable {
     func delete(id: UUID) throws -> Bool
     func deleteAll() throws
     func updateStatus(id: UUID, status: Transcription.TranscriptionStatus, errorMessage: String?) throws
+    @discardableResult
+    func transitionStatus(
+        id: UUID,
+        from expectedStatus: Transcription.TranscriptionStatus,
+        to status: Transcription.TranscriptionStatus,
+        errorMessage: String?
+    ) throws -> Bool
     func updateFileName(id: UUID, fileName: String) throws
     func updateTitleOverride(id: UUID, titleOverride: String?) throws
     func updateChatMessages(id: UUID, chatMessages: [ChatMessage]?) throws
@@ -108,6 +115,19 @@ extension TranscriptionRepositoryProtocol {
         )
     }
     public func clearStoredAudioPathsForURLTranscriptions() throws {}
+    @discardableResult
+    public func transitionStatus(
+        id: UUID,
+        from expectedStatus: Transcription.TranscriptionStatus,
+        to status: Transcription.TranscriptionStatus,
+        errorMessage: String?
+    ) throws -> Bool {
+        guard try fetch(id: id)?.status == expectedStatus else {
+            return false
+        }
+        try updateStatus(id: id, status: status, errorMessage: errorMessage)
+        return true
+    }
     @discardableResult
     public func clearStoredAudioPathsForMeetingTranscriptions(under directoryPath: String) throws -> [UUID] { [] }
     public func updateFileName(id: UUID, fileName: String) throws {}
@@ -466,6 +486,26 @@ public final class TranscriptionRepository: TranscriptionRepositoryProtocol, @un
             transcription.errorMessage = errorMessage
             transcription.updatedAt = Date()
             try transcription.update(db)
+        }
+    }
+
+    @discardableResult
+    public func transitionStatus(
+        id: UUID,
+        from expectedStatus: Transcription.TranscriptionStatus,
+        to status: Transcription.TranscriptionStatus,
+        errorMessage: String? = nil
+    ) throws -> Bool {
+        try dbQueue.write { db in
+            guard var transcription = try Transcription.fetchOne(db, key: id),
+                  transcription.status == expectedStatus else {
+                return false
+            }
+            transcription.status = status
+            transcription.errorMessage = errorMessage
+            transcription.updatedAt = Date()
+            try transcription.update(db)
+            return true
         }
     }
 

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingLockFileStore.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingLockFileStore.swift
@@ -287,6 +287,8 @@ public final class MeetingRecordingLockFileStore:
     MeetingFinalizationReconciliationCoordinating
 {
     private static let finalizationOwnershipMutexFileName = ".finalization-ownership.lock"
+    private static let relinquishedFinalizationLeases =
+        MeetingFinalizationRelinquishedLeaseRegistry()
 
     private let processChecker: any ProcessAliveChecking
     private let processID: Int32
@@ -358,7 +360,10 @@ public final class MeetingRecordingLockFileStore:
                 throw MeetingFinalizationOwnershipError.missingLock
             }
             let currentProcessAlreadyOwnsLease =
-                currentLock.finalizationLeaseId != nil && currentLock.pid == processID
+                currentLock.pid == processID
+                && currentLock.finalizationLeaseId.map {
+                    !Self.relinquishedFinalizationLeases.contains($0)
+                } == true
             let anotherProcessIsAlive =
                 currentLock.pid != processID && processChecker.isAlive(pid: currentLock.pid)
             if currentProcessAlreadyOwnsLease || anotherProcessIsAlive {
@@ -374,6 +379,9 @@ public final class MeetingRecordingLockFileStore:
                 currentLock.withFinalizationOwner(pid: processID, leaseID: lease.id),
                 folderURL: folderURL
             )
+            if let previousLeaseID = currentLock.finalizationLeaseId {
+                Self.relinquishedFinalizationLeases.remove(previousLeaseID)
+            }
             return lease
         }
     }
@@ -381,13 +389,23 @@ public final class MeetingRecordingLockFileStore:
     public func releaseFinalizationOwnership(
         _ lease: MeetingFinalizationOwnershipLease
     ) throws {
-        try withFinalizationOwnershipMutex(folderURL: lease.folderURL) {
-            guard let currentLock = try read(folderURL: lease.folderURL),
-                currentLock.finalizationLeaseId == lease.id
-            else {
-                return
+        do {
+            try withFinalizationOwnershipMutex(folderURL: lease.folderURL) {
+                guard let currentLock = try read(folderURL: lease.folderURL),
+                    currentLock.finalizationLeaseId == lease.id
+                else {
+                    return
+                }
+                try write(lease.previousLock, folderURL: lease.folderURL)
             }
-            try write(lease.previousLock, folderURL: lease.folderURL)
+            Self.relinquishedFinalizationLeases.remove(lease.id)
+        } catch {
+            // The owner has finished even when restoring the prior lock hits a
+            // transient I/O failure. Remember that exact token so a later
+            // retry in this process can replace it without treating abandoned
+            // work as an active same-process finalization.
+            Self.relinquishedFinalizationLeases.insert(lease.id)
+            throw error
         }
     }
 
@@ -496,6 +514,27 @@ public final class MeetingRecordingLockFileStore:
         defer { _ = flock(fileDescriptor, LOCK_UN) }
 
         return try operation()
+    }
+}
+
+private final class MeetingFinalizationRelinquishedLeaseRegistry: @unchecked Sendable {
+    private let lock = NSLock()
+    private var leaseIDs: Set<UUID> = []
+
+    func contains(_ leaseID: UUID) -> Bool {
+        lock.withLock { leaseIDs.contains(leaseID) }
+    }
+
+    func insert(_ leaseID: UUID) {
+        _ = lock.withLock {
+            leaseIDs.insert(leaseID)
+        }
+    }
+
+    func remove(_ leaseID: UUID) {
+        _ = lock.withLock {
+            leaseIDs.remove(leaseID)
+        }
     }
 }
 

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingLockFileStore.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingLockFileStore.swift
@@ -25,6 +25,9 @@ public struct MeetingRecordingLockFile: Codable, Sendable, Equatable {
     public let pid: Int32
     public let displayName: String
     public let state: MeetingRecordingLockState
+    /// Unique token while a retry or crash recovery owns finalization. `nil`
+    /// for the original recording/finalization path and legacy lock files.
+    public let finalizationLeaseId: UUID?
     public let speechEngine: SpeechEngineSelection
     /// Whether `speechEngine` was explicitly persisted by the recording build.
     /// Legacy locks without the field retain the Parakeet decode fallback but
@@ -47,6 +50,7 @@ public struct MeetingRecordingLockFile: Codable, Sendable, Equatable {
         case pid
         case displayName
         case state
+        case finalizationLeaseId
         case speechEngine
         case startContext
         case calendarEventSnapshot
@@ -60,6 +64,7 @@ public struct MeetingRecordingLockFile: Codable, Sendable, Equatable {
         pid: Int32 = ProcessInfo.processInfo.processIdentifier,
         displayName: String,
         state: MeetingRecordingLockState = .recording,
+        finalizationLeaseId: UUID? = nil,
         speechEngine: SpeechEngineSelection = SpeechEngineSelection(engine: .parakeet),
         speechEngineWasCaptured: Bool = true,
         startContext: MeetingStartContext? = nil,
@@ -73,6 +78,7 @@ public struct MeetingRecordingLockFile: Codable, Sendable, Equatable {
         self.pid = pid
         self.displayName = displayName
         self.state = state
+        self.finalizationLeaseId = finalizationLeaseId
         self.speechEngine = speechEngine
         self.speechEngineWasCaptured = speechEngineWasCaptured
         self.startContext = startContext
@@ -89,6 +95,10 @@ public struct MeetingRecordingLockFile: Codable, Sendable, Equatable {
         pid = try container.decode(Int32.self, forKey: .pid)
         displayName = try container.decode(String.self, forKey: .displayName)
         state = try container.decodeIfPresent(MeetingRecordingLockState.self, forKey: .state) ?? .recording
+        finalizationLeaseId = try container.decodeIfPresent(
+            UUID.self,
+            forKey: .finalizationLeaseId
+        )
         let decodedSpeechEngine = try container.decodeIfPresent(SpeechEngineSelection.self, forKey: .speechEngine)
         speechEngine = decodedSpeechEngine ?? SpeechEngineSelection(engine: .parakeet)
         speechEngineWasCaptured = schemaVersion >= 2 && decodedSpeechEngine != nil
@@ -114,6 +124,7 @@ public struct MeetingRecordingLockFile: Codable, Sendable, Equatable {
         try container.encode(pid, forKey: .pid)
         try container.encode(displayName, forKey: .displayName)
         try container.encode(state, forKey: .state)
+        try container.encodeIfPresent(finalizationLeaseId, forKey: .finalizationLeaseId)
         if speechEngineWasCaptured {
             try container.encode(speechEngine, forKey: .speechEngine)
         }
@@ -130,6 +141,7 @@ public struct MeetingRecordingLockFile: Codable, Sendable, Equatable {
             pid: pid,
             displayName: displayName,
             state: state,
+            finalizationLeaseId: finalizationLeaseId,
             speechEngine: speechEngine,
             speechEngineWasCaptured: speechEngineWasCaptured,
             startContext: startContext,
@@ -147,6 +159,7 @@ public struct MeetingRecordingLockFile: Codable, Sendable, Equatable {
             pid: pid,
             displayName: displayName,
             state: state,
+            finalizationLeaseId: finalizationLeaseId,
             speechEngine: speechEngine,
             speechEngineWasCaptured: speechEngineWasCaptured,
             startContext: startContext,
@@ -164,6 +177,28 @@ public struct MeetingRecordingLockFile: Codable, Sendable, Equatable {
             pid: pid,
             displayName: displayName,
             state: state,
+            finalizationLeaseId: finalizationLeaseId,
+            speechEngine: speechEngine,
+            speechEngineWasCaptured: speechEngineWasCaptured,
+            startContext: startContext,
+            calendarEventSnapshot: calendarEventSnapshot,
+            notes: notes,
+            folderURL: folderURL
+        )
+    }
+
+    public func withFinalizationOwner(
+        pid: Int32,
+        leaseID: UUID
+    ) -> MeetingRecordingLockFile {
+        MeetingRecordingLockFile(
+            schemaVersion: schemaVersion,
+            sessionId: sessionId,
+            startedAt: startedAt,
+            pid: pid,
+            displayName: displayName,
+            state: .awaitingTranscription,
+            finalizationLeaseId: leaseID,
             speechEngine: speechEngine,
             speechEngineWasCaptured: speechEngineWasCaptured,
             startContext: startContext,
@@ -179,6 +214,53 @@ public protocol MeetingRecordingLockFileStoring: Sendable {
     func read(folderURL: URL) throws -> MeetingRecordingLockFile?
     func delete(folderURL: URL) throws
     func discoverOrphans(meetingsRoot: URL) throws -> [MeetingRecordingLockFile]
+}
+
+public struct MeetingFinalizationOwnershipLease: Sendable, Equatable {
+    public let id: UUID
+    public let folderURL: URL
+    public let previousLock: MeetingRecordingLockFile
+
+    public init(
+        id: UUID,
+        folderURL: URL,
+        previousLock: MeetingRecordingLockFile
+    ) {
+        self.id = id
+        self.folderURL = folderURL
+        self.previousLock = previousLock
+    }
+}
+
+public enum MeetingFinalizationOwnershipError: Error, LocalizedError, Sendable, Equatable {
+    case missingLock
+    case ownedByLiveProcess(pid: Int32)
+
+    public var errorDescription: String? {
+        switch self {
+        case .missingLock:
+            return "The meeting recovery record is missing. The saved audio was not changed."
+        case .ownedByLiveProcess:
+            return "This meeting is already being transcribed by MacParakeet."
+        }
+    }
+}
+
+public protocol MeetingFinalizationOwnershipClaiming: Sendable {
+    func claimFinalizationOwnership(
+        folderURL: URL
+    ) throws -> MeetingFinalizationOwnershipLease
+    func releaseFinalizationOwnership(_ lease: MeetingFinalizationOwnershipLease) throws
+}
+
+public protocol MeetingFinalizationReconciliationCoordinating: Sendable {
+    /// Runs `transition` only while this folder has no live owner. The
+    /// ownership check and transition are serialized against retry/recovery
+    /// claims by the folder's advisory lock.
+    func reconcileIfUnowned(
+        folderURL: URL,
+        transition: @Sendable () throws -> Bool
+    ) throws -> Bool
 }
 
 public protocol ProcessAliveChecking: Sendable {
@@ -199,11 +281,22 @@ public struct LiveProcessChecker: ProcessAliveChecking {
     }
 }
 
-public final class MeetingRecordingLockFileStore: MeetingRecordingLockFileStoring {
-    private let processChecker: any ProcessAliveChecking
+public final class MeetingRecordingLockFileStore:
+    MeetingRecordingLockFileStoring,
+    MeetingFinalizationOwnershipClaiming,
+    MeetingFinalizationReconciliationCoordinating
+{
+    private static let finalizationOwnershipMutexFileName = ".finalization-ownership.lock"
 
-    public init(processChecker: any ProcessAliveChecking = LiveProcessChecker()) {
+    private let processChecker: any ProcessAliveChecking
+    private let processID: Int32
+
+    public init(
+        processChecker: any ProcessAliveChecking = LiveProcessChecker(),
+        processID: Int32 = ProcessInfo.processInfo.processIdentifier
+    ) {
         self.processChecker = processChecker
+        self.processID = processID
     }
 
     public static func lockFileURL(for folderURL: URL) -> URL {
@@ -252,6 +345,65 @@ public final class MeetingRecordingLockFileStore: MeetingRecordingLockFileStorin
             return false
         }
         return processChecker.isAlive(pid: lockFile.pid)
+    }
+
+    public func claimFinalizationOwnership(
+        folderURL: URL
+    ) throws -> MeetingFinalizationOwnershipLease {
+        guard FileManager.default.fileExists(atPath: folderURL.path) else {
+            throw MeetingFinalizationOwnershipError.missingLock
+        }
+        return try withFinalizationOwnershipMutex(folderURL: folderURL) {
+            guard let currentLock = try read(folderURL: folderURL) else {
+                throw MeetingFinalizationOwnershipError.missingLock
+            }
+            let currentProcessAlreadyOwnsLease =
+                currentLock.finalizationLeaseId != nil && currentLock.pid == processID
+            let anotherProcessIsAlive =
+                currentLock.pid != processID && processChecker.isAlive(pid: currentLock.pid)
+            if currentProcessAlreadyOwnsLease || anotherProcessIsAlive {
+                throw MeetingFinalizationOwnershipError.ownedByLiveProcess(pid: currentLock.pid)
+            }
+
+            let lease = MeetingFinalizationOwnershipLease(
+                id: UUID(),
+                folderURL: folderURL.standardizedFileURL,
+                previousLock: currentLock
+            )
+            try write(
+                currentLock.withFinalizationOwner(pid: processID, leaseID: lease.id),
+                folderURL: folderURL
+            )
+            return lease
+        }
+    }
+
+    public func releaseFinalizationOwnership(
+        _ lease: MeetingFinalizationOwnershipLease
+    ) throws {
+        try withFinalizationOwnershipMutex(folderURL: lease.folderURL) {
+            guard let currentLock = try read(folderURL: lease.folderURL),
+                currentLock.finalizationLeaseId == lease.id
+            else {
+                return
+            }
+            try write(lease.previousLock, folderURL: lease.folderURL)
+        }
+    }
+
+    public func reconcileIfUnowned(
+        folderURL: URL,
+        transition: @Sendable () throws -> Bool
+    ) throws -> Bool {
+        guard FileManager.default.fileExists(atPath: folderURL.path) else {
+            return try transition()
+        }
+        return try withFinalizationOwnershipMutex(folderURL: folderURL) {
+            guard try !hasLiveOwner(folderURL: folderURL) else {
+                return false
+            }
+            return try transition()
+        }
     }
 
     public func delete(folderURL: URL) throws {
@@ -319,6 +471,31 @@ public final class MeetingRecordingLockFileStore: MeetingRecordingLockFileStorin
             }
             return $0.startedAt < $1.startedAt
         }
+    }
+
+    private func withFinalizationOwnershipMutex<T>(
+        folderURL: URL,
+        _ operation: () throws -> T
+    ) throws -> T {
+        let mutexURL = folderURL.appendingPathComponent(
+            Self.finalizationOwnershipMutexFileName
+        )
+        let fileDescriptor = open(
+            mutexURL.path,
+            O_CREAT | O_RDWR,
+            S_IRUSR | S_IWUSR
+        )
+        guard fileDescriptor >= 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        defer { close(fileDescriptor) }
+
+        guard flock(fileDescriptor, LOCK_EX) == 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        defer { _ = flock(fileDescriptor, LOCK_UN) }
+
+        return try operation()
     }
 }
 

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingLockFileStore.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingLockFileStore.swift
@@ -243,6 +243,17 @@ public final class MeetingRecordingLockFileStore: MeetingRecordingLockFileStorin
         }
     }
 
+    /// Whether a readable lock in this exact session folder belongs to a
+    /// process that is still alive. Startup reconciliation uses the per-folder
+    /// check because a meeting row already carries its canonical artifact path;
+    /// scanning a global root would miss custom roots and do unnecessary I/O.
+    public func hasLiveOwner(folderURL: URL) throws -> Bool {
+        guard let lockFile = try read(folderURL: folderURL) else {
+            return false
+        }
+        return processChecker.isAlive(pid: lockFile.pid)
+    }
+
     public func delete(folderURL: URL) throws {
         let lockFileURL = Self.lockFileURL(for: folderURL)
         guard FileManager.default.fileExists(atPath: lockFileURL.path) else {

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingLockFileStore.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingLockFileStore.swift
@@ -105,10 +105,11 @@ public struct MeetingRecordingLockFile: Codable, Sendable, Equatable {
         startContext = (try? container.decodeIfPresent(MeetingStartContext.self, forKey: .startContext)) ?? nil
         // Calendar snapshots are best-effort context. A malformed optional
         // snapshot must not block lock-file recovery of the audio metadata.
-        calendarEventSnapshot = (try? container.decodeIfPresent(
-            MeetingCalendarSnapshot.self,
-            forKey: .calendarEventSnapshot
-        )) ?? nil
+        calendarEventSnapshot =
+            (try? container.decodeIfPresent(
+                MeetingCalendarSnapshot.self,
+                forKey: .calendarEventSnapshot
+            )) ?? nil
         // Notes are decoded independently — see ADR-020 §9. If a future encoder
         // bug or hand-edited file produces a malformed `notes` value, recovery
         // of the audio metadata still succeeds; only the typed notes are lost.
@@ -357,7 +358,8 @@ public final class MeetingRecordingLockFileStore:
             throw MeetingFinalizationOwnershipError.missingLock
         }
         return try withFinalizationOwnershipMutex(folderURL: folderURL) {
-            guard let currentLock = try read(folderURL: folderURL) else {
+            guard let currentLock = try readableOrUnreadablePresentLock(folderURL: folderURL)
+            else {
                 throw MeetingFinalizationOwnershipError.missingLock
             }
             let currentProcessAlreadyOwnsLease =
@@ -488,8 +490,9 @@ public final class MeetingRecordingLockFileStore:
         var matches: [MeetingRecordingLockFile] = []
         for folderURL in sessionFolders {
             guard try folderURL.resourceValues(forKeys: [.isDirectoryKey]).isDirectory == true,
-                  let lockFile = try read(folderURL: folderURL),
-                  predicate(lockFile) else {
+                let lockFile = try read(folderURL: folderURL),
+                predicate(lockFile)
+            else {
                 continue
             }
 
@@ -504,11 +507,38 @@ public final class MeetingRecordingLockFileStore:
         }
     }
 
+    /// Retry must still be able to take over a folder whose `recording.lock`
+    /// is present but unreadable (corrupt JSON, zero-byte, future schema).
+    /// `read` maps those to `nil`, which used to look like a missing lock and
+    /// bricked claim after reconciliation had already marked the row retryable.
+    private func readableOrUnreadablePresentLock(
+        folderURL: URL
+    ) throws -> MeetingRecordingLockFile? {
+        if let readableLock = try read(folderURL: folderURL) {
+            return readableLock
+        }
+        guard
+            FileManager.default.fileExists(
+                atPath: Self.lockFileURL(for: folderURL).path
+            )
+        else {
+            return nil
+        }
+        return MeetingRecordingLockFile(
+            sessionId: UUID(),
+            startedAt: Date(),
+            pid: 0,
+            displayName: folderURL.lastPathComponent,
+            state: .awaitingTranscription
+        )
+    }
+
     private func hasRelinquishedFinalizationLease(
         _ lockFile: MeetingRecordingLockFile
     ) -> Bool {
         guard lockFile.pid == processID,
-              let leaseID = lockFile.finalizationLeaseId else {
+            let leaseID = lockFile.finalizationLeaseId
+        else {
             return false
         }
         return Self.relinquishedFinalizationLeases.contains(leaseID)

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingLockFileStore.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingLockFileStore.swift
@@ -446,14 +446,16 @@ public final class MeetingRecordingLockFileStore:
         }
     }
 
-    /// Lock files in `meetingsRoot` whose owning process is still alive — i.e.
-    /// meetings actively recording or awaiting transcription inside a running
-    /// MacParakeet instance. The inverse of `discoverOrphans`.
+    /// Lock files in `meetingsRoot` whose owning process is still alive, minus
+    /// an exact lease token this process recorded as relinquished after a
+    /// restore failure. The in-process result is the inverse of
+    /// `discoverOrphans`.
     ///
     /// Used by out-of-process callers (the CLI) that cannot observe the GUI's
     /// live recording state but must avoid clobbering an in-progress session's
-    /// folder on disk. Same disk signal the recovery service already trusts:
-    /// `pid` liveness via `ProcessAliveChecking`.
+    /// folder on disk. The relinquishment registry is process-local, so those
+    /// callers conservatively see the same disk signal recovery otherwise
+    /// trusts: `pid` liveness via `ProcessAliveChecking`.
     public func discoverActiveSessions(meetingsRoot: URL) throws -> [MeetingRecordingLockFile] {
         try sortedSessions(meetingsRoot: meetingsRoot) {
             !hasRelinquishedFinalizationLease($0)

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingLockFileStore.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingLockFileStore.swift
@@ -347,6 +347,7 @@ public final class MeetingRecordingLockFileStore:
             return false
         }
         return processChecker.isAlive(pid: lockFile.pid)
+            && !hasRelinquishedFinalizationLease(lockFile)
     }
 
     public func claimFinalizationOwnership(
@@ -373,7 +374,9 @@ public final class MeetingRecordingLockFileStore:
             let lease = MeetingFinalizationOwnershipLease(
                 id: UUID(),
                 folderURL: folderURL.standardizedFileURL,
-                previousLock: currentLock
+                previousLock: currentLock.finalizationLeaseId.flatMap {
+                    Self.relinquishedFinalizationLeases.previousLock(for: $0)
+                } ?? currentLock
             )
             try write(
                 currentLock.withFinalizationOwner(pid: processID, leaseID: lease.id),
@@ -404,7 +407,7 @@ public final class MeetingRecordingLockFileStore:
             // transient I/O failure. Remember that exact token so a later
             // retry in this process can replace it without treating abandoned
             // work as an active same-process finalization.
-            Self.relinquishedFinalizationLeases.insert(lease.id)
+            Self.relinquishedFinalizationLeases.insert(lease)
             throw error
         }
     }
@@ -434,8 +437,13 @@ public final class MeetingRecordingLockFileStore:
 
     public func discoverOrphans(meetingsRoot: URL) throws -> [MeetingRecordingLockFile] {
         // Orphans are crashed sessions: a lock file whose owning process is no
-        // longer alive. Their audio is recoverable, not in active use.
-        try sortedSessions(meetingsRoot: meetingsRoot) { !processChecker.isAlive(pid: $0.pid) }
+        // longer alive, or a same-process finalization lease explicitly
+        // relinquished after lock restoration failed. Their audio is
+        // recoverable, not in active use.
+        try sortedSessions(meetingsRoot: meetingsRoot) {
+            hasRelinquishedFinalizationLease($0)
+                || !processChecker.isAlive(pid: $0.pid)
+        }
     }
 
     /// Lock files in `meetingsRoot` whose owning process is still alive — i.e.
@@ -447,7 +455,10 @@ public final class MeetingRecordingLockFileStore:
     /// folder on disk. Same disk signal the recovery service already trusts:
     /// `pid` liveness via `ProcessAliveChecking`.
     public func discoverActiveSessions(meetingsRoot: URL) throws -> [MeetingRecordingLockFile] {
-        try sortedSessions(meetingsRoot: meetingsRoot) { processChecker.isAlive(pid: $0.pid) }
+        try sortedSessions(meetingsRoot: meetingsRoot) {
+            !hasRelinquishedFinalizationLease($0)
+                && processChecker.isAlive(pid: $0.pid)
+        }
     }
 
     /// Every readable recording lock under `meetingsRoot`, regardless of PID
@@ -491,6 +502,16 @@ public final class MeetingRecordingLockFileStore:
         }
     }
 
+    private func hasRelinquishedFinalizationLease(
+        _ lockFile: MeetingRecordingLockFile
+    ) -> Bool {
+        guard lockFile.pid == processID,
+              let leaseID = lockFile.finalizationLeaseId else {
+            return false
+        }
+        return Self.relinquishedFinalizationLeases.contains(leaseID)
+    }
+
     private func withFinalizationOwnershipMutex<T>(
         folderURL: URL,
         _ operation: () throws -> T
@@ -519,21 +540,25 @@ public final class MeetingRecordingLockFileStore:
 
 private final class MeetingFinalizationRelinquishedLeaseRegistry: @unchecked Sendable {
     private let lock = NSLock()
-    private var leaseIDs: Set<UUID> = []
+    private var previousLocksByLeaseID: [UUID: MeetingRecordingLockFile] = [:]
 
     func contains(_ leaseID: UUID) -> Bool {
-        lock.withLock { leaseIDs.contains(leaseID) }
+        lock.withLock { previousLocksByLeaseID[leaseID] != nil }
     }
 
-    func insert(_ leaseID: UUID) {
-        _ = lock.withLock {
-            leaseIDs.insert(leaseID)
+    func previousLock(for leaseID: UUID) -> MeetingRecordingLockFile? {
+        lock.withLock { previousLocksByLeaseID[leaseID] }
+    }
+
+    func insert(_ lease: MeetingFinalizationOwnershipLease) {
+        lock.withLock {
+            previousLocksByLeaseID[lease.id] = lease.previousLock
         }
     }
 
     func remove(_ leaseID: UUID) {
         _ = lock.withLock {
-            leaseIDs.remove(leaseID)
+            previousLocksByLeaseID.removeValue(forKey: leaseID)
         }
     }
 }

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingLockFileStore.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingLockFileStore.swift
@@ -344,11 +344,22 @@ public final class MeetingRecordingLockFileStore:
     /// check because a meeting row already carries its canonical artifact path;
     /// scanning a global root would miss custom roots and do unnecessary I/O.
     public func hasLiveOwner(folderURL: URL) throws -> Bool {
-        guard let lockFile = try read(folderURL: folderURL) else {
-            return false
+        if let lockFile = try read(folderURL: folderURL) {
+            return processChecker.isAlive(pid: lockFile.pid)
+                && !hasRelinquishedFinalizationLease(lockFile)
         }
-        return processChecker.isAlive(pid: lockFile.pid)
-            && !hasRelinquishedFinalizationLease(lockFile)
+        // `read` maps a newer schema to nil so older builds do not invent
+        // fields they cannot understand. Reconciliation must still honor a
+        // peeked live PID, or an older process will mark the newer build's
+        // in-flight row failed.
+        if let header = peekLockFileHeader(folderURL: folderURL),
+            let schemaVersion = header.schemaVersion,
+            schemaVersion > MeetingRecordingLockFile.currentSchemaVersion,
+            let pid = header.pid
+        {
+            return processChecker.isAlive(pid: pid)
+        }
+        return false
     }
 
     public func claimFinalizationOwnership(
@@ -508,14 +519,25 @@ public final class MeetingRecordingLockFileStore:
     }
 
     /// Retry must still be able to take over a folder whose `recording.lock`
-    /// is present but unreadable (corrupt JSON, zero-byte, future schema).
-    /// `read` maps those to `nil`, which used to look like a missing lock and
-    /// bricked claim after reconciliation had already marked the row retryable.
+    /// is present but unreadable (corrupt JSON, zero-byte). `read` maps those
+    /// to `nil`, which used to look like a missing lock and bricked claim
+    /// after reconciliation had already marked the row retryable.
+    ///
+    /// A newer schema is different: if its peeked PID is still alive, claim
+    /// must refuse rather than overwrite a lock this build cannot interpret.
     private func readableOrUnreadablePresentLock(
         folderURL: URL
     ) throws -> MeetingRecordingLockFile? {
         if let readableLock = try read(folderURL: folderURL) {
             return readableLock
+        }
+        if let header = peekLockFileHeader(folderURL: folderURL),
+            let schemaVersion = header.schemaVersion,
+            schemaVersion > MeetingRecordingLockFile.currentSchemaVersion,
+            let pid = header.pid,
+            processChecker.isAlive(pid: pid)
+        {
+            throw MeetingFinalizationOwnershipError.ownedByLiveProcess(pid: pid)
         }
         guard
             FileManager.default.fileExists(
@@ -531,6 +553,35 @@ public final class MeetingRecordingLockFileStore:
             displayName: folderURL.lastPathComponent,
             state: .awaitingTranscription
         )
+    }
+
+    private struct LockFileHeader {
+        var schemaVersion: Int?
+        var pid: Int32?
+    }
+
+    private func peekLockFileHeader(folderURL: URL) -> LockFileHeader? {
+        let lockFileURL = Self.lockFileURL(for: folderURL)
+        guard FileManager.default.fileExists(atPath: lockFileURL.path),
+            let data = try? Data(contentsOf: lockFileURL),
+            let object = try? JSONSerialization.jsonObject(with: data),
+            let dictionary = object as? [String: Any]
+        else {
+            return nil
+        }
+        let schemaVersion = intValue(in: dictionary, key: "schemaVersion")
+        let pid = intValue(in: dictionary, key: "pid").map(Int32.init)
+        return LockFileHeader(schemaVersion: schemaVersion, pid: pid)
+    }
+
+    private func intValue(in dictionary: [String: Any], key: String) -> Int? {
+        if let value = dictionary[key] as? Int {
+            return value
+        }
+        if let value = dictionary[key] as? NSNumber {
+            return value.intValue
+        }
+        return nil
     }
 
     private func hasRelinquishedFinalizationLease(

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingRecoveryService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingRecoveryService.swift
@@ -189,7 +189,13 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
         var shouldRestoreOwnership = true
         defer {
             if shouldRestoreOwnership {
-                try? lockFileStore.releaseFinalizationOwnership(ownershipLease)
+                do {
+                    try lockFileStore.releaseFinalizationOwnership(ownershipLease)
+                } catch {
+                    logger.error(
+                        "meeting_recovery_ownership_release_failed session=\(lock.sessionId.uuidString, privacy: .public) error=\(error.localizedDescription, privacy: .private)"
+                    )
+                }
             }
         }
 

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingRecoveryService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingRecoveryService.swift
@@ -40,7 +40,7 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
     private let logger = Logger(subsystem: "com.macparakeet.core", category: "MeetingRecordingRecoveryService")
 
     private let meetingsRoot: URL
-    private let lockFileStore: MeetingRecordingLockFileStoring
+    private let lockFileStore: any MeetingRecordingLockFileStoring & MeetingFinalizationOwnershipClaiming
     private let transcriptionService: TranscriptionServiceProtocol
     private let transcriptionRepo: TranscriptionRepositoryProtocol
     private let settlement: MeetingRecordingSettlement
@@ -57,7 +57,9 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
 
     public convenience init(
         meetingsRoot: URL = URL(fileURLWithPath: AppPaths.meetingRecordingsDir, isDirectory: true),
-        lockFileStore: MeetingRecordingLockFileStoring = MeetingRecordingLockFileStore(),
+        lockFileStore:
+            any MeetingRecordingLockFileStoring & MeetingFinalizationOwnershipClaiming =
+            MeetingRecordingLockFileStore(),
         transcriptionService: TranscriptionServiceProtocol,
         transcriptionRepo: TranscriptionRepositoryProtocol,
         audioConverter: AudioFileConverting = AudioFileConverter(),
@@ -80,7 +82,9 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
 
     init(
         meetingsRoot: URL = URL(fileURLWithPath: AppPaths.meetingRecordingsDir, isDirectory: true),
-        lockFileStore: MeetingRecordingLockFileStoring = MeetingRecordingLockFileStore(),
+        lockFileStore:
+            any MeetingRecordingLockFileStoring & MeetingFinalizationOwnershipClaiming =
+            MeetingRecordingLockFileStore(),
         transcriptionService: TranscriptionServiceProtocol,
         transcriptionRepo: TranscriptionRepositoryProtocol,
         settlement: MeetingRecordingSettlement? = nil,
@@ -179,6 +183,15 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
         guard fileManager.fileExists(atPath: folderURL.path) else {
             throw MeetingRecordingRecoveryError.missingSessionFolder
         }
+        let ownershipLease = try lockFileStore.claimFinalizationOwnership(
+            folderURL: folderURL
+        )
+        var shouldRestoreOwnership = true
+        defer {
+            if shouldRestoreOwnership {
+                try? lockFileStore.releaseFinalizationOwnership(ownershipLease)
+            }
+        }
 
         let microphoneAudio = MeetingArtifactAudioFileNames.resolveRawMicrophoneURL(
             in: folderURL,
@@ -190,7 +203,13 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
 
         if let existing = try existingCompletedTranscription(in: folderURL) {
             await writeNotesSidecar(for: lock, folderURL: folderURL)
-            return try await completeExistingTranscription(existing, folderURL: folderURL, lock: lock)
+            let completed = try await completeExistingTranscription(
+                existing,
+                folderURL: folderURL,
+                lock: lock
+            )
+            shouldRestoreOwnership = false
+            return completed
         }
         let incompleteRows = try existingIncompleteTranscriptions(in: folderURL)
         let rowToUpdate = selectedIncompleteTranscription(from: incompleteRows)
@@ -350,7 +369,13 @@ public final class MeetingRecordingRecoveryService: MeetingRecordingRecoveryServ
             } else {
                 transcription = try await transcriptionService.transcribeMeeting(recording: recording, onProgress: nil)
             }
-            return try await completeRecovery(transcription, folderURL: folderURL, lock: lock)
+            let completed = try await completeRecovery(
+                transcription,
+                folderURL: folderURL,
+                lock: lock
+            )
+            shouldRestoreOwnership = false
+            return completed
         } catch {
             logger.error("meeting_recovery_transcription_failed session=\(lock.sessionId.uuidString, privacy: .public) error=\(error.localizedDescription, privacy: .public)")
             throw error

--- a/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
@@ -1230,7 +1230,7 @@ public final class TranscriptionViewModel {
         applyMeetingRetention: Bool = true,
         selectTranscription: Bool = true
     ) {
-        if selectTranscription {
+        if selectTranscription || currentTranscription?.id == transcription.id {
             currentTranscription = transcription
         }
         loadTranscriptions()

--- a/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
@@ -1466,6 +1466,14 @@ public final class TranscriptionViewModel {
         refreshPromptResultStatus()
     }
 
+    public func refreshCurrentTranscriptionIfMatching(id: UUID) {
+        guard currentTranscription?.id == id,
+              let fresh = try? transcriptionRepo?.fetch(id: id) else {
+            return
+        }
+        currentTranscription = fresh
+    }
+
     public func updateConversationStatus(id: UUID, hasConversations: Bool) {
         guard currentTranscription?.id == id else { return }
         self.hasConversations = hasConversations

--- a/Tests/MacParakeetTests/App/MeetingFinalizationReconcilerTests.swift
+++ b/Tests/MacParakeetTests/App/MeetingFinalizationReconcilerTests.swift
@@ -192,7 +192,7 @@ final class MeetingFinalizationReconcilerTests: XCTestCase {
             liveTranscriptLagged: false
         )
 
-        queue.enqueue(item)
+        await queue.enqueue(item)
         try await waitUntil {
             queue.queuedTranscriptionIDs == [transcriptionID]
         }

--- a/Tests/MacParakeetTests/App/MeetingFinalizationReconcilerTests.swift
+++ b/Tests/MacParakeetTests/App/MeetingFinalizationReconcilerTests.swift
@@ -224,7 +224,8 @@ private final class ReconcilerStatusRepository: MeetingFinalizationStatusReposit
     ) throws -> [Transcription] {
         lock.lock()
         defer { lock.unlock() }
-        return rows
+        return
+            rows
             .filter { $0.sourceType == .meeting && $0.status == status }
             .sorted { $0.createdAt > $1.createdAt }
     }

--- a/Tests/MacParakeetTests/App/MeetingFinalizationReconcilerTests.swift
+++ b/Tests/MacParakeetTests/App/MeetingFinalizationReconcilerTests.swift
@@ -44,7 +44,7 @@ final class MeetingFinalizationReconcilerTests: XCTestCase {
         let repo = ReconcilerStatusRepository()
         let folderURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("MeetingFinalizationReconcilerTests-\(UUID().uuidString)")
-        let ownershipChecker = ReconcilerOwnershipChecker(
+        let ownershipCoordinator = ReconcilerOwnershipCoordinator(
             liveFolderPaths: [folderURL.standardizedFileURL.path]
         )
         let processingMeeting = Transcription(
@@ -57,7 +57,7 @@ final class MeetingFinalizationReconcilerTests: XCTestCase {
 
         let reconciledIDs = try await MeetingFinalizationReconciler.reconcileStaleProcessingRows(
             repository: repo,
-            ownershipChecker: ownershipChecker
+            ownershipCoordinator: ownershipCoordinator
         )
 
         XCTAssertTrue(reconciledIDs.isEmpty)
@@ -78,7 +78,7 @@ final class MeetingFinalizationReconcilerTests: XCTestCase {
 
         let reconciledIDs = try await MeetingFinalizationReconciler.reconcileStaleProcessingRows(
             repository: repo,
-            ownershipChecker: ReconcilerOwnershipChecker()
+            ownershipCoordinator: ReconcilerOwnershipCoordinator()
         )
 
         XCTAssertEqual(reconciledIDs, [processingMeeting.id])
@@ -102,6 +102,58 @@ final class MeetingFinalizationReconcilerTests: XCTestCase {
         XCTAssertTrue(reconciledIDs.isEmpty)
         XCTAssertEqual(try repo.fetch(id: processingMeeting.id)?.status, .completed)
         XCTAssertNil(try repo.fetch(id: processingMeeting.id)?.errorMessage)
+    }
+
+    func testReconcileSkipsDeadOwnerMeetingAfterAnotherProcessClaimsRetry() async throws {
+        let manager = try DatabaseManager()
+        let repo = TranscriptionRepository(dbQueue: manager.dbQueue)
+        let folderURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("MeetingFinalizationRetryLease-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: folderURL) }
+        let processChecker = ReconcilerProcessAliveChecker(alivePIDs: [101])
+        let retryStore = MeetingRecordingLockFileStore(
+            processChecker: processChecker,
+            processID: 101
+        )
+        let reconcilingStore = MeetingRecordingLockFileStore(
+            processChecker: processChecker,
+            processID: 202
+        )
+        try retryStore.write(
+            MeetingRecordingLockFile(
+                sessionId: UUID(),
+                startedAt: Date(),
+                pid: 42,
+                displayName: "Retry meeting",
+                state: .awaitingTranscription
+            ),
+            folderURL: folderURL
+        )
+        let retryableMeeting = Transcription(
+            fileName: "Retry meeting",
+            meetingArtifactFolderPath: folderURL.path,
+            status: .error,
+            sourceType: .meeting
+        )
+        try repo.save(retryableMeeting)
+
+        let lease = try retryStore.claimFinalizationOwnership(
+            folderURL: folderURL
+        )
+        defer { try? retryStore.releaseFinalizationOwnership(lease) }
+        try repo.updateStatus(
+            id: retryableMeeting.id,
+            status: .processing,
+            errorMessage: nil
+        )
+
+        let reconciledIDs = try await MeetingFinalizationReconciler.reconcileStaleProcessingRows(
+            repository: repo,
+            ownershipCoordinator: reconcilingStore
+        )
+
+        XCTAssertTrue(reconciledIDs.isEmpty)
+        XCTAssertEqual(try repo.fetch(id: retryableMeeting.id)?.status, .processing)
     }
 
     @MainActor
@@ -262,11 +314,27 @@ private final class ReconcilerStatusRepository: MeetingFinalizationStatusReposit
     }
 }
 
-private struct ReconcilerOwnershipChecker: MeetingFinalizationOwnershipChecking {
+private struct ReconcilerOwnershipCoordinator:
+    MeetingFinalizationReconciliationCoordinating
+{
     var liveFolderPaths: Set<String> = []
 
-    func hasLiveOwner(folderURL: URL) throws -> Bool {
-        liveFolderPaths.contains(folderURL.standardizedFileURL.path)
+    func reconcileIfUnowned(
+        folderURL: URL,
+        transition: @Sendable () throws -> Bool
+    ) throws -> Bool {
+        guard !liveFolderPaths.contains(folderURL.standardizedFileURL.path) else {
+            return false
+        }
+        return try transition()
+    }
+}
+
+private struct ReconcilerProcessAliveChecker: ProcessAliveChecking {
+    let alivePIDs: Set<Int32>
+
+    func isAlive(pid: Int32) -> Bool {
+        alivePIDs.contains(pid)
     }
 }
 

--- a/Tests/MacParakeetTests/App/MeetingFinalizationReconcilerTests.swift
+++ b/Tests/MacParakeetTests/App/MeetingFinalizationReconcilerTests.swift
@@ -85,6 +85,41 @@ final class MeetingFinalizationReconcilerTests: XCTestCase {
         XCTAssertEqual(try repo.fetch(id: processingMeeting.id)?.status, .error)
     }
 
+    func testReconcileContinuesAfterAnotherRowsOwnershipCheckFails() async throws {
+        let repo = ReconcilerStatusRepository()
+        let failingFolderURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("MeetingFinalizationUnreadable-\(UUID().uuidString)")
+        let recoverableFolderURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("MeetingFinalizationRecoverable-\(UUID().uuidString)")
+        let failingMeeting = Transcription(
+            createdAt: Date(timeIntervalSince1970: 2),
+            fileName: "Unreadable meeting",
+            meetingArtifactFolderPath: failingFolderURL.path,
+            status: .processing,
+            sourceType: .meeting
+        )
+        let recoverableMeeting = Transcription(
+            createdAt: Date(timeIntervalSince1970: 1),
+            fileName: "Recoverable meeting",
+            meetingArtifactFolderPath: recoverableFolderURL.path,
+            status: .processing,
+            sourceType: .meeting
+        )
+        try repo.save(failingMeeting)
+        try repo.save(recoverableMeeting)
+
+        let reconciledIDs = try await MeetingFinalizationReconciler.reconcileStaleProcessingRows(
+            repository: repo,
+            ownershipCoordinator: ReconcilerOwnershipCoordinator(
+                failingFolderPaths: [failingFolderURL.standardizedFileURL.path]
+            )
+        )
+
+        XCTAssertEqual(reconciledIDs, [recoverableMeeting.id])
+        XCTAssertEqual(try repo.fetch(id: failingMeeting.id)?.status, .processing)
+        XCTAssertEqual(try repo.fetch(id: recoverableMeeting.id)?.status, .error)
+    }
+
     func testReconcileOmitsRowWhenAtomicTransitionLosesToCompletion() async throws {
         let repo = ReconcilerStatusRepository()
         let processingMeeting = Transcription(
@@ -318,16 +353,25 @@ private struct ReconcilerOwnershipCoordinator:
     MeetingFinalizationReconciliationCoordinating
 {
     var liveFolderPaths: Set<String> = []
+    var failingFolderPaths: Set<String> = []
 
     func reconcileIfUnowned(
         folderURL: URL,
         transition: @Sendable () throws -> Bool
     ) throws -> Bool {
-        guard !liveFolderPaths.contains(folderURL.standardizedFileURL.path) else {
+        let folderPath = folderURL.standardizedFileURL.path
+        if failingFolderPaths.contains(folderPath) {
+            throw ReconcilerOwnershipError.unreadableLock
+        }
+        guard !liveFolderPaths.contains(folderPath) else {
             return false
         }
         return try transition()
     }
+}
+
+private enum ReconcilerOwnershipError: Error {
+    case unreadableLock
 }
 
 private struct ReconcilerProcessAliveChecker: ProcessAliveChecking {

--- a/Tests/MacParakeetTests/App/MeetingFinalizationReconcilerTests.swift
+++ b/Tests/MacParakeetTests/App/MeetingFinalizationReconcilerTests.swift
@@ -41,6 +41,76 @@ final class MeetingFinalizationReconcilerTests: XCTestCase {
         XCTAssertEqual(try repo.fetch(id: processingFile.id)?.status, .processing)
     }
 
+    func testReconcileSkipsProcessingRowOwnedByAnotherLiveProcess() async throws {
+        let repo = MockTranscriptionRepository()
+        let folderURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("MeetingFinalizationReconcilerTests-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: folderURL) }
+        let lockStore = MeetingRecordingLockFileStore(
+            processChecker: ReconcilerProcessAliveChecker(alivePIDs: [42])
+        )
+        try lockStore.write(
+            MeetingRecordingLockFile(
+                sessionId: UUID(),
+                startedAt: Date(),
+                pid: 42,
+                displayName: "Meeting owned by another app process",
+                state: .awaitingTranscription
+            ),
+            folderURL: folderURL
+        )
+        let processingMeeting = Transcription(
+            fileName: "Live meeting",
+            meetingArtifactFolderPath: folderURL.path,
+            status: .processing,
+            sourceType: .meeting
+        )
+        try repo.save(processingMeeting)
+
+        let reconciledIDs = try await MeetingFinalizationReconciler.reconcileStaleProcessingRows(
+            repository: repo,
+            lockFileStore: lockStore
+        )
+
+        XCTAssertTrue(reconciledIDs.isEmpty)
+        XCTAssertEqual(try repo.fetch(id: processingMeeting.id)?.status, .processing)
+    }
+
+    func testReconcileMarksProcessingRowWithDeadLockOwnerFailed() async throws {
+        let repo = MockTranscriptionRepository()
+        let folderURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("MeetingFinalizationReconcilerTests-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: folderURL) }
+        let lockStore = MeetingRecordingLockFileStore(
+            processChecker: ReconcilerProcessAliveChecker(alivePIDs: [])
+        )
+        try lockStore.write(
+            MeetingRecordingLockFile(
+                sessionId: UUID(),
+                startedAt: Date(),
+                pid: 42,
+                displayName: "Interrupted meeting",
+                state: .awaitingTranscription
+            ),
+            folderURL: folderURL
+        )
+        let processingMeeting = Transcription(
+            fileName: "Interrupted meeting",
+            meetingArtifactFolderPath: folderURL.path,
+            status: .processing,
+            sourceType: .meeting
+        )
+        try repo.save(processingMeeting)
+
+        let reconciledIDs = try await MeetingFinalizationReconciler.reconcileStaleProcessingRows(
+            repository: repo,
+            lockFileStore: lockStore
+        )
+
+        XCTAssertEqual(reconciledIDs, [processingMeeting.id])
+        XCTAssertEqual(try repo.fetch(id: processingMeeting.id)?.status, .error)
+    }
+
     @MainActor
     func testReconcileSkipsProcessingRowsOwnedByQueue() async throws {
         let repo = MockTranscriptionRepository()
@@ -139,4 +209,12 @@ private final class ReconcilerRecordingLockFileStore: MeetingRecordingLockFileSt
     func read(folderURL: URL) throws -> MeetingRecordingLockFile? { nil }
     func delete(folderURL: URL) throws {}
     func discoverOrphans(meetingsRoot: URL) throws -> [MeetingRecordingLockFile] { [] }
+}
+
+private struct ReconcilerProcessAliveChecker: ProcessAliveChecking {
+    let alivePIDs: Set<Int32>
+
+    func isAlive(pid: Int32) -> Bool {
+        alivePIDs.contains(pid)
+    }
 }

--- a/Tests/MacParakeetTests/App/MeetingFinalizationReconcilerTests.swift
+++ b/Tests/MacParakeetTests/App/MeetingFinalizationReconcilerTests.swift
@@ -5,7 +5,7 @@ import XCTest
 
 final class MeetingFinalizationReconcilerTests: XCTestCase {
     func testReconcileStaleProcessingRowsMarksOnlyProcessingMeetingsFailed() async throws {
-        let repo = MockTranscriptionRepository()
+        let repo = ReconcilerStatusRepository()
         let staleMeeting = Transcription(
             fileName: "Stale meeting",
             status: .processing,
@@ -29,7 +29,6 @@ final class MeetingFinalizationReconcilerTests: XCTestCase {
             repository: repo
         )
 
-        XCTAssertEqual(repo.fetchMeetingsWithStatusCalls, [.processing])
         XCTAssertEqual(reconciledIDs, [staleMeeting.id])
         let reconciled = try XCTUnwrap(repo.fetch(id: staleMeeting.id))
         XCTAssertEqual(reconciled.status, .error)
@@ -42,22 +41,11 @@ final class MeetingFinalizationReconcilerTests: XCTestCase {
     }
 
     func testReconcileSkipsProcessingRowOwnedByAnotherLiveProcess() async throws {
-        let repo = MockTranscriptionRepository()
+        let repo = ReconcilerStatusRepository()
         let folderURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("MeetingFinalizationReconcilerTests-\(UUID().uuidString)")
-        defer { try? FileManager.default.removeItem(at: folderURL) }
-        let lockStore = MeetingRecordingLockFileStore(
-            processChecker: ReconcilerProcessAliveChecker(alivePIDs: [42])
-        )
-        try lockStore.write(
-            MeetingRecordingLockFile(
-                sessionId: UUID(),
-                startedAt: Date(),
-                pid: 42,
-                displayName: "Meeting owned by another app process",
-                state: .awaitingTranscription
-            ),
-            folderURL: folderURL
+        let ownershipChecker = ReconcilerOwnershipChecker(
+            liveFolderPaths: [folderURL.standardizedFileURL.path]
         )
         let processingMeeting = Transcription(
             fileName: "Live meeting",
@@ -69,7 +57,7 @@ final class MeetingFinalizationReconcilerTests: XCTestCase {
 
         let reconciledIDs = try await MeetingFinalizationReconciler.reconcileStaleProcessingRows(
             repository: repo,
-            lockFileStore: lockStore
+            ownershipChecker: ownershipChecker
         )
 
         XCTAssertTrue(reconciledIDs.isEmpty)
@@ -77,23 +65,9 @@ final class MeetingFinalizationReconcilerTests: XCTestCase {
     }
 
     func testReconcileMarksProcessingRowWithDeadLockOwnerFailed() async throws {
-        let repo = MockTranscriptionRepository()
+        let repo = ReconcilerStatusRepository()
         let folderURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("MeetingFinalizationReconcilerTests-\(UUID().uuidString)")
-        defer { try? FileManager.default.removeItem(at: folderURL) }
-        let lockStore = MeetingRecordingLockFileStore(
-            processChecker: ReconcilerProcessAliveChecker(alivePIDs: [])
-        )
-        try lockStore.write(
-            MeetingRecordingLockFile(
-                sessionId: UUID(),
-                startedAt: Date(),
-                pid: 42,
-                displayName: "Interrupted meeting",
-                state: .awaitingTranscription
-            ),
-            folderURL: folderURL
-        )
         let processingMeeting = Transcription(
             fileName: "Interrupted meeting",
             meetingArtifactFolderPath: folderURL.path,
@@ -104,16 +78,36 @@ final class MeetingFinalizationReconcilerTests: XCTestCase {
 
         let reconciledIDs = try await MeetingFinalizationReconciler.reconcileStaleProcessingRows(
             repository: repo,
-            lockFileStore: lockStore
+            ownershipChecker: ReconcilerOwnershipChecker()
         )
 
         XCTAssertEqual(reconciledIDs, [processingMeeting.id])
         XCTAssertEqual(try repo.fetch(id: processingMeeting.id)?.status, .error)
     }
 
+    func testReconcileOmitsRowWhenAtomicTransitionLosesToCompletion() async throws {
+        let repo = ReconcilerStatusRepository()
+        let processingMeeting = Transcription(
+            fileName: "Finishing meeting",
+            status: .processing,
+            sourceType: .meeting
+        )
+        try repo.save(processingMeeting)
+        repo.completeBeforeNextTransition(id: processingMeeting.id)
+
+        let reconciledIDs = try await MeetingFinalizationReconciler.reconcileStaleProcessingRows(
+            repository: repo
+        )
+
+        XCTAssertTrue(reconciledIDs.isEmpty)
+        XCTAssertEqual(try repo.fetch(id: processingMeeting.id)?.status, .completed)
+        XCTAssertNil(try repo.fetch(id: processingMeeting.id)?.errorMessage)
+    }
+
     @MainActor
     func testReconcileSkipsProcessingRowsOwnedByQueue() async throws {
-        let repo = MockTranscriptionRepository()
+        let manager = try DatabaseManager()
+        let repo = TranscriptionRepository(dbQueue: manager.dbQueue)
         let transcriptionService = MockTranscriptionService()
         await transcriptionService.holdMeetingFinalization()
         await transcriptionService.persistFinalizedMeetings(to: repo)
@@ -204,17 +198,80 @@ final class MeetingFinalizationReconcilerTests: XCTestCase {
     }
 }
 
+private final class ReconcilerStatusRepository: MeetingFinalizationStatusRepository, @unchecked Sendable {
+    private let lock = NSLock()
+    private var rows: [Transcription] = []
+    private var completionBeforeTransitionIDs: Set<UUID> = []
+
+    func save(_ transcription: Transcription) throws {
+        lock.lock()
+        defer { lock.unlock() }
+        if let index = rows.firstIndex(where: { $0.id == transcription.id }) {
+            rows[index] = transcription
+        } else {
+            rows.append(transcription)
+        }
+    }
+
+    func fetch(id: UUID) throws -> Transcription? {
+        lock.lock()
+        defer { lock.unlock() }
+        return rows.first { $0.id == id }
+    }
+
+    func fetchMeetings(
+        withStatus status: Transcription.TranscriptionStatus
+    ) throws -> [Transcription] {
+        lock.lock()
+        defer { lock.unlock() }
+        return rows
+            .filter { $0.sourceType == .meeting && $0.status == status }
+            .sorted { $0.createdAt > $1.createdAt }
+    }
+
+    func completeBeforeNextTransition(id: UUID) {
+        lock.lock()
+        defer { lock.unlock() }
+        completionBeforeTransitionIDs.insert(id)
+    }
+
+    @discardableResult
+    func transitionStatus(
+        id: UUID,
+        from expectedStatus: Transcription.TranscriptionStatus,
+        to status: Transcription.TranscriptionStatus,
+        errorMessage: String?
+    ) throws -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard let index = rows.firstIndex(where: { $0.id == id }) else {
+            return false
+        }
+        if completionBeforeTransitionIDs.remove(id) != nil {
+            rows[index].status = .completed
+            rows[index].errorMessage = nil
+        }
+        guard rows[index].status == expectedStatus else {
+            return false
+        }
+        rows[index].status = status
+        rows[index].errorMessage = errorMessage
+        return true
+    }
+}
+
+private struct ReconcilerOwnershipChecker: MeetingFinalizationOwnershipChecking {
+    var liveFolderPaths: Set<String> = []
+
+    func hasLiveOwner(folderURL: URL) throws -> Bool {
+        liveFolderPaths.contains(folderURL.standardizedFileURL.path)
+    }
+}
+
 private final class ReconcilerRecordingLockFileStore: MeetingRecordingLockFileStoring, @unchecked Sendable {
     func write(_ file: MeetingRecordingLockFile, folderURL: URL) throws {}
     func read(folderURL: URL) throws -> MeetingRecordingLockFile? { nil }
     func delete(folderURL: URL) throws {}
     func discoverOrphans(meetingsRoot: URL) throws -> [MeetingRecordingLockFile] { [] }
-}
-
-private struct ReconcilerProcessAliveChecker: ProcessAliveChecking {
-    let alivePIDs: Set<Int32>
-
-    func isAlive(pid: Int32) -> Bool {
-        alivePIDs.contains(pid)
-    }
 }

--- a/Tests/MacParakeetTests/Database/TranscriptionRepositoryTests.swift
+++ b/Tests/MacParakeetTests/Database/TranscriptionRepositoryTests.swift
@@ -757,6 +757,35 @@ final class TranscriptionRepositoryTests: XCTestCase {
         XCTAssertEqual(try repo.fetch(id: transcription.id)?.status, .cancelled)
     }
 
+    func testTransitionStatusUpdatesOnlyExpectedState() throws {
+        let transcription = Transcription(fileName: "test.mp3")
+        try repo.save(transcription)
+
+        XCTAssertTrue(try repo.transitionStatus(
+            id: transcription.id,
+            from: .processing,
+            to: .error,
+            errorMessage: "Interrupted"
+        ))
+        XCTAssertEqual(try repo.fetch(id: transcription.id)?.status, .error)
+        XCTAssertEqual(try repo.fetch(id: transcription.id)?.errorMessage, "Interrupted")
+    }
+
+    func testTransitionStatusCannotRegressCompletedRow() throws {
+        let transcription = Transcription(fileName: "test.mp3")
+        try repo.save(transcription)
+        try repo.updateStatus(id: transcription.id, status: .completed)
+
+        XCTAssertFalse(try repo.transitionStatus(
+            id: transcription.id,
+            from: .processing,
+            to: .error,
+            errorMessage: "Interrupted"
+        ))
+        XCTAssertEqual(try repo.fetch(id: transcription.id)?.status, .completed)
+        XCTAssertNil(try repo.fetch(id: transcription.id)?.errorMessage)
+    }
+
     func testUpdateFileName() throws {
         let transcription = Transcription(
             fileName: "Meeting Apr 5",

--- a/Tests/MacParakeetTests/Database/TranscriptionRepositoryTests.swift
+++ b/Tests/MacParakeetTests/Database/TranscriptionRepositoryTests.swift
@@ -786,6 +786,53 @@ final class TranscriptionRepositoryTests: XCTestCase {
         XCTAssertNil(try repo.fetch(id: transcription.id)?.errorMessage)
     }
 
+    func testConcurrentCompletionAlwaysWinsOverReconciliationAcrossRepositories() async throws {
+        let directoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TranscriptionRepositoryRace-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+        let databasePath = directoryURL.appendingPathComponent("macparakeet.db").path
+        let firstManager = try DatabaseManager(path: databasePath)
+        let secondManager = try DatabaseManager(path: databasePath)
+        let firstRepository = TranscriptionRepository(dbQueue: firstManager.dbQueue)
+        let secondRepository = TranscriptionRepository(dbQueue: secondManager.dbQueue)
+
+        for iteration in 0..<25 {
+            let transcription = Transcription(
+                fileName: "race-\(iteration).m4a",
+                status: .processing,
+                sourceType: .meeting
+            )
+            try firstRepository.save(transcription)
+
+            let reconciliation = Task.detached {
+                try firstRepository.transitionStatus(
+                    id: transcription.id,
+                    from: .processing,
+                    to: .error,
+                    errorMessage: "Interrupted"
+                )
+            }
+            let completion = Task.detached {
+                try secondRepository.updateStatus(
+                    id: transcription.id,
+                    status: .completed,
+                    errorMessage: nil
+                )
+            }
+
+            _ = try await reconciliation.value
+            try await completion.value
+
+            XCTAssertEqual(
+                try firstRepository.fetch(id: transcription.id)?.status,
+                .completed,
+                "Completion was regressed in iteration \(iteration)"
+            )
+            XCTAssertNil(try firstRepository.fetch(id: transcription.id)?.errorMessage)
+        }
+    }
+
     func testUpdateFileName() throws {
         let transcription = Transcription(
             fileName: "Meeting Apr 5",

--- a/Tests/MacParakeetTests/MeetingRecordingFlow/MeetingRecordingFlowCoordinatorTests.swift
+++ b/Tests/MacParakeetTests/MeetingRecordingFlow/MeetingRecordingFlowCoordinatorTests.swift
@@ -129,6 +129,7 @@ final class MeetingRecordingFlowCoordinatorTests: XCTestCase {
         let settlementHarness = await makeSettlementHarness(transcriptionService: transcriptionService)
 
         var retryNotifications: [TranscriptionCompletionNotifier.Content] = []
+        var failedTranscriptionIDs: [UUID] = []
         let coordinator = MeetingRecordingFlowCoordinator(
             meetingRecordingService: recordingService,
             transcriptionService: transcriptionService,
@@ -142,7 +143,8 @@ final class MeetingRecordingFlowCoordinatorTests: XCTestCase {
             meetingRecordingSettlement: settlementHarness.settlement,
             onMenuBarIconUpdate: { _ in },
             onTranscriptionReady: { _ in },
-            onQueuedTranscriptionFailed: { content in
+            onQueuedTranscriptionFailed: { transcriptionID, content in
+                failedTranscriptionIDs.append(transcriptionID)
                 retryNotifications.append(content)
             }
         )
@@ -158,6 +160,7 @@ final class MeetingRecordingFlowCoordinatorTests: XCTestCase {
         XCTAssertEqual(row.status, .error)
         XCTAssertEqual(row.sourceType, .meeting)
         XCTAssertEqual(row.errorMessage, FlowTestError.finalizationFailed.localizedDescription)
+        XCTAssertEqual(failedTranscriptionIDs, [row.id])
         XCTAssertEqual(retryNotifications, [TranscriptionCompletionNotifier.meetingNeedsRetryContent()])
         XCTAssertTrue(settlementHarness.lockStore.deletes.isEmpty)
     }
@@ -180,6 +183,7 @@ final class MeetingRecordingFlowCoordinatorTests: XCTestCase {
             sourceType: .meeting
         )
         try settlementHarness.transcriptionRepo.save(failed)
+        let ownershipClaimer = FlowFinalizationOwnershipClaimer()
         let coordinator = MeetingRecordingFlowCoordinator(
             meetingRecordingService: MeetingRecordingServiceSpy(output: makeRecordingOutput()),
             transcriptionService: transcriptionService,
@@ -191,6 +195,7 @@ final class MeetingRecordingFlowCoordinatorTests: XCTestCase {
             llmService: nil,
             pillViewModel: MeetingRecordingPillViewModel(),
             meetingRecordingSettlement: settlementHarness.settlement,
+            finalizationOwnershipClaimer: ownershipClaimer,
             onMenuBarIconUpdate: { _ in },
             onTranscriptionReady: { _ in }
         )
@@ -218,6 +223,61 @@ final class MeetingRecordingFlowCoordinatorTests: XCTestCase {
         XCTAssertEqual(snapshot.finalizedMeetingTranscriptionIDs, [failed.id])
         XCTAssertEqual(snapshot.finalizedMeetingRecordings.first?.displayName, failed.fileName)
         XCTAssertEqual(snapshot.finalizedMeetingRecordings.first?.durationSeconds, 12)
+        XCTAssertEqual(ownershipClaimer.claimedFolderURLs, [folderURL.standardizedFileURL])
+    }
+
+    func testRetryMeetingFinalizationDoesNotQueueWithoutOwnership() async throws {
+        let transcriptionService = MockTranscriptionService()
+        let settlementHarness = await makeSettlementHarness(
+            transcriptionService: transcriptionService
+        )
+        let folderURL = try makeArchivedRetryFolder()
+        defer { try? FileManager.default.removeItem(at: folderURL) }
+        let failed = Transcription(
+            fileName: "Retry meeting",
+            filePath: folderURL.appendingPathComponent(
+                MeetingArtifactAudioFileNames.playback
+            ).path,
+            meetingArtifactFolderPath: folderURL.path,
+            status: .error,
+            sourceType: .meeting
+        )
+        try settlementHarness.transcriptionRepo.save(failed)
+        let ownershipClaimer = FlowFinalizationOwnershipClaimer(
+            claimError: MeetingFinalizationOwnershipError.ownedByLiveProcess(pid: 42)
+        )
+        let coordinator = MeetingRecordingFlowCoordinator(
+            meetingRecordingService: MeetingRecordingServiceSpy(output: makeRecordingOutput()),
+            transcriptionService: transcriptionService,
+            permissionService: MockPermissionService(),
+            transcriptionRepo: settlementHarness.transcriptionRepo,
+            conversationRepo: MockChatConversationRepository(),
+            quickPromptRepo: NoOpQuickPromptRepository(),
+            configStore: NoOpLLMConfigStore(),
+            llmService: nil,
+            pillViewModel: MeetingRecordingPillViewModel(),
+            meetingRecordingSettlement: settlementHarness.settlement,
+            finalizationOwnershipClaimer: ownershipClaimer,
+            onMenuBarIconUpdate: { _ in },
+            onTranscriptionReady: { _ in }
+        )
+
+        do {
+            try await coordinator.retryMeetingFinalization(failed)
+            XCTFail("Expected an active owner to refuse retry admission")
+        } catch {
+            XCTAssertEqual(
+                error as? MeetingFinalizationOwnershipError,
+                .ownedByLiveProcess(pid: 42)
+            )
+        }
+
+        let snapshot = await transcriptionService.meetingFlowSnapshot()
+        XCTAssertEqual(snapshot.finalizeMeetingCallCount, 0)
+        XCTAssertEqual(
+            try settlementHarness.transcriptionRepo.fetch(id: failed.id)?.status,
+            .error
+        )
     }
 
     func testCaptureFailureSignalUsesStopTranscribeFlowExactlyOnce() async throws {
@@ -1367,6 +1427,53 @@ private actor MeetingRecordingServiceSpy: MeetingRecordingServiceProtocol {
 
 private final class ProbableCalendarSnapshotHolder: @unchecked Sendable {
     var snapshot: MeetingCalendarSnapshot?
+}
+
+private final class FlowFinalizationOwnershipClaimer:
+    MeetingFinalizationOwnershipClaiming,
+    @unchecked Sendable
+{
+    private let lock = NSLock()
+    private let claimError: Error?
+    private(set) var claimedFolderURLs: [URL] = []
+    private(set) var releasedLeaseIDs: [UUID] = []
+
+    init(claimError: Error? = nil) {
+        self.claimError = claimError
+    }
+
+    func claimFinalizationOwnership(
+        folderURL: URL
+    ) throws -> MeetingFinalizationOwnershipLease {
+        if let claimError {
+            throw claimError
+        }
+        return lock.withLock {
+            let standardizedFolderURL = folderURL.standardizedFileURL
+            claimedFolderURLs.append(standardizedFolderURL)
+            let leaseID = UUID()
+            return MeetingFinalizationOwnershipLease(
+                id: leaseID,
+                folderURL: standardizedFolderURL,
+                previousLock: MeetingRecordingLockFile(
+                    sessionId: UUID(),
+                    startedAt: Date(),
+                    pid: 42,
+                    displayName: "Retry meeting",
+                    state: .awaitingTranscription,
+                    folderURL: standardizedFolderURL
+                )
+            )
+        }
+    }
+
+    func releaseFinalizationOwnership(
+        _ lease: MeetingFinalizationOwnershipLease
+    ) throws {
+        lock.withLock {
+            releasedLeaseIDs.append(lease.id)
+        }
+    }
 }
 
 private final class FlowRecordingLockFileStore: MeetingRecordingLockFileStoring, @unchecked Sendable {

--- a/Tests/MacParakeetTests/MeetingRecordingFlow/MeetingTranscriptionQueueTests.swift
+++ b/Tests/MacParakeetTests/MeetingRecordingFlow/MeetingTranscriptionQueueTests.swift
@@ -37,6 +37,7 @@ final class MeetingTranscriptionQueueTests: XCTestCase {
     func testQueueContinuesAfterFailedFinalize() async throws {
         let transcriptionRepo = MockTranscriptionRepository()
         let lockStore = QueueRecordingLockFileStore()
+        let ownershipClaimer = QueueFinalizationOwnershipClaimer()
         let transcriptionService = QueueTranscriptionServiceSpy(transcriptionRepo: transcriptionRepo)
         let queue = MeetingTranscriptionQueue(
             transcriptionService: transcriptionService,
@@ -44,9 +45,12 @@ final class MeetingTranscriptionQueueTests: XCTestCase {
             meetingRecordingSettlement: MeetingRecordingSettlement(
                 lockFileStore: lockStore,
                 transcriptionRepo: transcriptionRepo
-            )
+            ),
+            finalizationOwnershipClaimer: ownershipClaimer
         )
-        let first = makeItem(name: "A")
+        let originalFirst = makeItem(name: "A")
+        let lease = makeFinalizationOwnershipLease(for: originalFirst)
+        let first = originalFirst.withFinalizationOwnershipLease(lease)
         let second = makeItem(name: "B")
         try persistProcessingRows([first, second], in: transcriptionRepo)
         try createAudioFile(for: first)
@@ -74,11 +78,13 @@ final class MeetingTranscriptionQueueTests: XCTestCase {
         XCTAssertEqual(failed.status, .error)
         XCTAssertNotNil(failed.errorMessage)
         XCTAssertTrue(FileManager.default.fileExists(atPath: first.recording.mixedAudioURL.path))
+        XCTAssertEqual(ownershipClaimer.releasedLeaseIDs, [lease.id])
     }
 
     func testSettlementRefusalAfterFinalizeStillReportsSuccessAndRetainsLock() async throws {
         let transcriptionRepo = MockTranscriptionRepository()
         let lockStore = QueueRecordingLockFileStore()
+        let ownershipClaimer = QueueFinalizationOwnershipClaimer()
         let transcriptionService = QueueTranscriptionServiceSpy(transcriptionRepo: transcriptionRepo)
         let queue = MeetingTranscriptionQueue(
             transcriptionService: transcriptionService,
@@ -86,9 +92,12 @@ final class MeetingTranscriptionQueueTests: XCTestCase {
             meetingRecordingSettlement: MeetingRecordingSettlement(
                 lockFileStore: lockStore,
                 transcriptionRepo: transcriptionRepo
-            )
+            ),
+            finalizationOwnershipClaimer: ownershipClaimer
         )
-        let item = makeItem(name: "A")
+        let originalItem = makeItem(name: "A")
+        let lease = makeFinalizationOwnershipLease(for: originalItem)
+        let item = originalItem.withFinalizationOwnershipLease(lease)
         try persistProcessingRows([item], in: transcriptionRepo)
         await transcriptionService.mismatchSettlementPaths(transcriptionID: item.transcriptionID)
 
@@ -107,6 +116,7 @@ final class MeetingTranscriptionQueueTests: XCTestCase {
 
         XCTAssertEqual(completions, ["success:A"])
         XCTAssertTrue(lockStore.deletes.isEmpty)
+        XCTAssertEqual(ownershipClaimer.releasedLeaseIDs, [lease.id])
     }
 
     func testSnapshotCountsActiveAndPendingItems() async throws {
@@ -285,6 +295,7 @@ final class MeetingTranscriptionQueueTests: XCTestCase {
     func testQueueDoesNotRegressCompletedRowBackToProcessing() async throws {
         let transcriptionRepo = MockTranscriptionRepository()
         let lockStore = QueueRecordingLockFileStore()
+        let ownershipClaimer = QueueFinalizationOwnershipClaimer()
         let transcriptionService = QueueTranscriptionServiceSpy(transcriptionRepo: transcriptionRepo)
         let queue = MeetingTranscriptionQueue(
             transcriptionService: transcriptionService,
@@ -292,9 +303,12 @@ final class MeetingTranscriptionQueueTests: XCTestCase {
             meetingRecordingSettlement: MeetingRecordingSettlement(
                 lockFileStore: lockStore,
                 transcriptionRepo: transcriptionRepo
-            )
+            ),
+            finalizationOwnershipClaimer: ownershipClaimer
         )
-        let item = makeItem(name: "Already Done")
+        let originalItem = makeItem(name: "Already Done")
+        let lease = makeFinalizationOwnershipLease(for: originalItem)
+        let item = originalItem.withFinalizationOwnershipLease(lease)
         try persistRow(status: .completed, item: item, in: transcriptionRepo)
 
         var completions: [MeetingTranscriptionQueue.Completion] = []
@@ -311,6 +325,7 @@ final class MeetingTranscriptionQueueTests: XCTestCase {
         let fetched = try XCTUnwrap(transcriptionRepo.fetch(id: item.transcriptionID))
         XCTAssertEqual(fetched.status, .completed)
         XCTAssertNil(fetched.errorMessage)
+        XCTAssertEqual(ownershipClaimer.releasedLeaseIDs, [lease.id])
     }
 
     private func makeItem(name: String) -> MeetingTranscriptionQueue.Item {
@@ -322,6 +337,23 @@ final class MeetingTranscriptionQueueTests: XCTestCase {
             trigger: .manual,
             liveWordCount: 0,
             liveTranscriptLagged: false
+        )
+    }
+
+    private func makeFinalizationOwnershipLease(
+        for item: MeetingTranscriptionQueue.Item
+    ) -> MeetingFinalizationOwnershipLease {
+        MeetingFinalizationOwnershipLease(
+            id: UUID(),
+            folderURL: item.recording.folderURL,
+            previousLock: MeetingRecordingLockFile(
+                sessionId: item.recording.sessionID,
+                startedAt: Date(timeIntervalSince1970: 1_700_000_000),
+                pid: 42,
+                displayName: item.recording.displayName,
+                state: .awaitingTranscription,
+                folderURL: item.recording.folderURL
+            )
         )
     }
 
@@ -572,6 +604,32 @@ private final class QueueRecordingLockFileStore: MeetingRecordingLockFileStoring
     }
 
     func discoverOrphans(meetingsRoot: URL) throws -> [MeetingRecordingLockFile] { [] }
+}
+
+private final class QueueFinalizationOwnershipClaimer:
+    MeetingFinalizationOwnershipClaiming,
+    @unchecked Sendable
+{
+    private let lock = NSLock()
+    private var releasedIDs: [UUID] = []
+
+    var releasedLeaseIDs: [UUID] {
+        lock.withLock { releasedIDs }
+    }
+
+    func claimFinalizationOwnership(
+        folderURL: URL
+    ) throws -> MeetingFinalizationOwnershipLease {
+        throw QueueTestError.failed
+    }
+
+    func releaseFinalizationOwnership(
+        _ lease: MeetingFinalizationOwnershipLease
+    ) throws {
+        lock.withLock {
+            releasedIDs.append(lease.id)
+        }
+    }
 }
 
 private enum QueueTestError: Error {

--- a/Tests/MacParakeetTests/MeetingRecordingFlow/MeetingTranscriptionQueueTests.swift
+++ b/Tests/MacParakeetTests/MeetingRecordingFlow/MeetingTranscriptionQueueTests.swift
@@ -20,8 +20,8 @@ final class MeetingTranscriptionQueueTests: XCTestCase {
         let second = makeItem(name: "B")
         try persistProcessingRows([first, second], in: transcriptionRepo)
 
-        queue.enqueue(first)
-        queue.enqueue(second)
+        await queue.enqueue(first)
+        await queue.enqueue(second)
         await queue.waitUntilIdle()
 
         let transcriptionSnapshot = await transcriptionService.snapshot()
@@ -66,8 +66,8 @@ final class MeetingTranscriptionQueueTests: XCTestCase {
             }
         }
 
-        queue.enqueue(first)
-        queue.enqueue(second)
+        await queue.enqueue(first)
+        await queue.enqueue(second)
         await queue.waitUntilIdle()
 
         let transcriptionSnapshot = await transcriptionService.snapshot()
@@ -79,6 +79,7 @@ final class MeetingTranscriptionQueueTests: XCTestCase {
         XCTAssertNotNil(failed.errorMessage)
         XCTAssertTrue(FileManager.default.fileExists(atPath: first.recording.mixedAudioURL.path))
         XCTAssertEqual(ownershipClaimer.releasedLeaseIDs, [lease.id])
+        XCTAssertEqual(ownershipClaimer.releaseMainThreadValues, [false])
     }
 
     func testSettlementRefusalAfterFinalizeStillReportsSuccessAndRetainsLock() async throws {
@@ -111,7 +112,7 @@ final class MeetingTranscriptionQueueTests: XCTestCase {
             }
         }
 
-        queue.enqueue(item)
+        await queue.enqueue(item)
         await queue.waitUntilIdle()
 
         XCTAssertEqual(completions, ["success:A"])
@@ -136,8 +137,8 @@ final class MeetingTranscriptionQueueTests: XCTestCase {
         let second = makeItem(name: "B")
         try persistProcessingRows([first, second], in: transcriptionRepo)
 
-        queue.enqueue(first)
-        queue.enqueue(second)
+        await queue.enqueue(first)
+        await queue.enqueue(second)
         try await waitUntil {
             queue.snapshot.activeItem?.transcriptionID == first.transcriptionID
                 && queue.snapshot.pendingCount == 1
@@ -165,7 +166,7 @@ final class MeetingTranscriptionQueueTests: XCTestCase {
         )
         let item = makeItem(name: "Missing Row")
 
-        queue.enqueue(item)
+        await queue.enqueue(item)
         try await waitUntil {
             queue.snapshot.activeItem?.transcriptionID != nil
                 && queue.snapshot.activeItem?.transcriptionID != item.transcriptionID
@@ -211,7 +212,7 @@ final class MeetingTranscriptionQueueTests: XCTestCase {
         try transcriptionRepo.save(failed)
         try createAudioFile(for: item)
 
-        queue.enqueue(item)
+        await queue.enqueue(item)
         await queue.waitUntilIdle()
 
         let fetched = try XCTUnwrap(transcriptionRepo.fetch(id: item.transcriptionID))
@@ -238,7 +239,7 @@ final class MeetingTranscriptionQueueTests: XCTestCase {
         try createAudioFile(for: item)
         await transcriptionService.cancel(transcriptionID: item.transcriptionID)
 
-        queue.enqueue(item)
+        await queue.enqueue(item)
         await queue.waitUntilIdle()
 
         let cancelled = try XCTUnwrap(transcriptionRepo.fetch(id: item.transcriptionID))
@@ -247,7 +248,7 @@ final class MeetingTranscriptionQueueTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: item.recording.mixedAudioURL.path))
 
         await transcriptionService.clearFailures(transcriptionID: item.transcriptionID)
-        queue.enqueue(item)
+        await queue.enqueue(item)
         await queue.waitUntilIdle()
 
         let retried = try XCTUnwrap(transcriptionRepo.fetch(id: item.transcriptionID))
@@ -275,8 +276,8 @@ final class MeetingTranscriptionQueueTests: XCTestCase {
         try persistRow(status: .error, item: item, in: transcriptionRepo)
         try createAudioFile(for: item)
 
-        queue.enqueue(item)
-        queue.enqueue(item)
+        await queue.enqueue(item)
+        await queue.enqueue(item)
         try await waitUntil {
             queue.snapshot.activeItem?.transcriptionID == item.transcriptionID
         }
@@ -316,7 +317,7 @@ final class MeetingTranscriptionQueueTests: XCTestCase {
             completions.append(completion)
         }
 
-        queue.enqueue(item)
+        await queue.enqueue(item)
         await queue.waitUntilIdle()
 
         XCTAssertTrue(completions.isEmpty)
@@ -612,9 +613,14 @@ private final class QueueFinalizationOwnershipClaimer:
 {
     private let lock = NSLock()
     private var releasedIDs: [UUID] = []
+    private var releaseWasOnMainThread: [Bool] = []
 
     var releasedLeaseIDs: [UUID] {
         lock.withLock { releasedIDs }
+    }
+
+    var releaseMainThreadValues: [Bool] {
+        lock.withLock { releaseWasOnMainThread }
     }
 
     func claimFinalizationOwnership(
@@ -628,6 +634,7 @@ private final class QueueFinalizationOwnershipClaimer:
     ) throws {
         lock.withLock {
             releasedIDs.append(lease.id)
+            releaseWasOnMainThread.append(Thread.isMainThread)
         }
     }
 }

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingLockFileStoreTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingLockFileStoreTests.swift
@@ -88,9 +88,10 @@ final class MeetingRecordingLockFileStoreTests: XCTestCase {
         )
 
         XCTAssertFalse(try store.hasLiveOwner(folderURL: deadFolderURL))
-        XCTAssertFalse(try store.hasLiveOwner(
-            folderURL: tempRoot.appendingPathComponent("missing-session")
-        ))
+        XCTAssertFalse(
+            try store.hasLiveOwner(
+                folderURL: tempRoot.appendingPathComponent("missing-session")
+            ))
     }
 
     func testFinalizationOwnershipClaimRewritesAndReleaseRestoresDeadOwner() throws {
@@ -166,6 +167,41 @@ final class MeetingRecordingLockFileStoreTests: XCTestCase {
         XCTAssertEqual(claimed.pid, 101)
         XCTAssertEqual(claimed.finalizationLeaseId, replacementLease.id)
         XCTAssertNotEqual(claimed.finalizationLeaseId, staleLeaseID)
+    }
+
+    func testFinalizationOwnershipClaimTreatsUnreadablePresentLockAsDeadEvidence() throws {
+        let folderURL = tempRoot.appendingPathComponent("corrupt-claim-session")
+        try FileManager.default.createDirectory(at: folderURL, withIntermediateDirectories: true)
+        try Data("{not-json".utf8).write(
+            to: MeetingRecordingLockFileStore.lockFileURL(for: folderURL)
+        )
+        let claimingStore = MeetingRecordingLockFileStore(
+            processChecker: MockProcessAliveChecker(alivePIDs: [101]),
+            processID: 101
+        )
+
+        let lease = try claimingStore.claimFinalizationOwnership(folderURL: folderURL)
+
+        let claimed = try XCTUnwrap(claimingStore.read(folderURL: folderURL))
+        XCTAssertEqual(claimed.pid, 101)
+        XCTAssertEqual(claimed.finalizationLeaseId, lease.id)
+        XCTAssertEqual(claimed.state, .awaitingTranscription)
+    }
+
+    func testFinalizationOwnershipClaimTreatsZeroByteLockAsDeadEvidence() throws {
+        let folderURL = tempRoot.appendingPathComponent("zero-byte-claim-session")
+        try FileManager.default.createDirectory(at: folderURL, withIntermediateDirectories: true)
+        try Data().write(to: MeetingRecordingLockFileStore.lockFileURL(for: folderURL))
+        let claimingStore = MeetingRecordingLockFileStore(
+            processChecker: MockProcessAliveChecker(alivePIDs: [101]),
+            processID: 101
+        )
+
+        let lease = try claimingStore.claimFinalizationOwnership(folderURL: folderURL)
+
+        let claimed = try XCTUnwrap(claimingStore.read(folderURL: folderURL))
+        XCTAssertEqual(claimed.pid, 101)
+        XCTAssertEqual(claimed.finalizationLeaseId, lease.id)
     }
 
     func testFailedOwnershipReleaseCanBeReclaimedBySameProcess() throws {
@@ -271,9 +307,10 @@ final class MeetingRecordingLockFileStoreTests: XCTestCase {
 
         try store.delete(folderURL: folderURL)
 
-        XCTAssertFalse(FileManager.default.fileExists(
-            atPath: MeetingRecordingLockFileStore.lockFileURL(for: folderURL).path
-        ))
+        XCTAssertFalse(
+            FileManager.default.fileExists(
+                atPath: MeetingRecordingLockFileStore.lockFileURL(for: folderURL).path
+            ))
     }
 
     func testDiscoverOrphansSkipsLiveOwners() throws {
@@ -407,10 +444,12 @@ final class MeetingRecordingLockFileStoreTests: XCTestCase {
 
         XCTAssertEqual(sessions.map(\.sessionId), [live.sessionId, deadAwaiting.sessionId])
         XCTAssertEqual(sessions.map(\.state), [.recording, .awaitingTranscription])
-        XCTAssertEqual(sessions.map { $0.folderURL?.standardizedFileURL }, [
-            liveFolderURL.standardizedFileURL,
-            deadFolderURL.standardizedFileURL,
-        ])
+        XCTAssertEqual(
+            sessions.map { $0.folderURL?.standardizedFileURL },
+            [
+                liveFolderURL.standardizedFileURL,
+                deadFolderURL.standardizedFileURL,
+            ])
     }
 
     // MARK: - ADR-020 §9 — notes field
@@ -445,15 +484,15 @@ final class MeetingRecordingLockFileStoreTests: XCTestCase {
         let folderURL = tempRoot.appendingPathComponent("session")
         try FileManager.default.createDirectory(at: folderURL, withIntermediateDirectories: true)
         let json = """
-        {
-            "schemaVersion": 1,
-            "sessionId": "11111111-2222-3333-4444-555555555555",
-            "startedAt": "2026-04-25T12:00:00Z",
-            "pid": 123,
-            "displayName": "Old Session",
-            "state": "recording"
-        }
-        """
+            {
+                "schemaVersion": 1,
+                "sessionId": "11111111-2222-3333-4444-555555555555",
+                "startedAt": "2026-04-25T12:00:00Z",
+                "pid": 123,
+                "displayName": "Old Session",
+                "state": "recording"
+            }
+            """
         try Data(json.utf8).write(to: MeetingRecordingLockFileStore.lockFileURL(for: folderURL))
 
         let readLockFile = try XCTUnwrap(store.read(folderURL: folderURL))
@@ -495,16 +534,16 @@ final class MeetingRecordingLockFileStoreTests: XCTestCase {
         let folderURL = tempRoot.appendingPathComponent("session")
         try FileManager.default.createDirectory(at: folderURL, withIntermediateDirectories: true)
         let json = """
-        {
-            "schemaVersion": 1,
-            "sessionId": "11111111-2222-3333-4444-555555555555",
-            "startedAt": "2026-04-25T12:00:00Z",
-            "pid": 123,
-            "displayName": "Recoverable Session",
-            "state": "recording",
-            "notes": 42
-        }
-        """
+            {
+                "schemaVersion": 1,
+                "sessionId": "11111111-2222-3333-4444-555555555555",
+                "startedAt": "2026-04-25T12:00:00Z",
+                "pid": 123,
+                "displayName": "Recoverable Session",
+                "state": "recording",
+                "notes": 42
+            }
+            """
         try Data(json.utf8).write(to: MeetingRecordingLockFileStore.lockFileURL(for: folderURL))
 
         let readLockFile = try XCTUnwrap(store.read(folderURL: folderURL))
@@ -516,19 +555,19 @@ final class MeetingRecordingLockFileStoreTests: XCTestCase {
         let folderURL = tempRoot.appendingPathComponent("session-start-context")
         try FileManager.default.createDirectory(at: folderURL, withIntermediateDirectories: true)
         let json = """
-        {
-            "schemaVersion": 1,
-            "sessionId": "11111111-2222-3333-4444-555555555555",
-            "startedAt": "2026-04-25T12:00:00Z",
-            "pid": 123,
-            "displayName": "Recoverable Session",
-            "state": "recording",
-            "startContext": {
-                "triggerKind": "future_trigger",
-                "sourceMode": "microphone_only"
+            {
+                "schemaVersion": 1,
+                "sessionId": "11111111-2222-3333-4444-555555555555",
+                "startedAt": "2026-04-25T12:00:00Z",
+                "pid": 123,
+                "displayName": "Recoverable Session",
+                "state": "recording",
+                "startContext": {
+                    "triggerKind": "future_trigger",
+                    "sourceMode": "microphone_only"
+                }
             }
-        }
-        """
+            """
         try Data(json.utf8).write(to: MeetingRecordingLockFileStore.lockFileURL(for: folderURL))
 
         let readLockFile = try XCTUnwrap(store.read(folderURL: folderURL))
@@ -541,16 +580,16 @@ final class MeetingRecordingLockFileStoreTests: XCTestCase {
         let folderURL = tempRoot.appendingPathComponent("session-calendar-snapshot")
         try FileManager.default.createDirectory(at: folderURL, withIntermediateDirectories: true)
         let json = """
-        {
-            "schemaVersion": 1,
-            "sessionId": "11111111-2222-3333-4444-555555555555",
-            "startedAt": "2026-04-25T12:00:00Z",
-            "pid": 123,
-            "displayName": "Recoverable Session",
-            "state": "recording",
-            "calendarEventSnapshot": 42
-        }
-        """
+            {
+                "schemaVersion": 1,
+                "sessionId": "11111111-2222-3333-4444-555555555555",
+                "startedAt": "2026-04-25T12:00:00Z",
+                "pid": 123,
+                "displayName": "Recoverable Session",
+                "state": "recording",
+                "calendarEventSnapshot": 42
+            }
+            """
         try Data(json.utf8).write(to: MeetingRecordingLockFileStore.lockFileURL(for: folderURL))
 
         let readLockFile = try XCTUnwrap(store.read(folderURL: folderURL))

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingLockFileStoreTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingLockFileStoreTests.swift
@@ -174,12 +174,13 @@ final class MeetingRecordingLockFileStoreTests: XCTestCase {
             processChecker: MockProcessAliveChecker(alivePIDs: [101]),
             processID: 101
         )
+        let original = makeLockFile(
+            pid: 42,
+            state: .awaitingTranscription,
+            folderURL: folderURL
+        )
         try claimingStore.write(
-            makeLockFile(
-                pid: 42,
-                state: .awaitingTranscription,
-                folderURL: folderURL
-            ),
+            original,
             folderURL: folderURL
         )
         let abandonedLease = try claimingStore.claimFinalizationOwnership(
@@ -195,6 +196,15 @@ final class MeetingRecordingLockFileStoreTests: XCTestCase {
         )
 
         try claimingStore.write(claimedLock, folderURL: folderURL)
+        XCTAssertFalse(try claimingStore.hasLiveOwner(folderURL: folderURL))
+        XCTAssertEqual(
+            try claimingStore.discoverOrphans(meetingsRoot: tempRoot).map(\.sessionId),
+            [original.sessionId]
+        )
+        XCTAssertTrue(
+            try claimingStore.discoverActiveSessions(meetingsRoot: tempRoot).isEmpty
+        )
+
         let replacementLease = try claimingStore.claimFinalizationOwnership(
             folderURL: folderURL
         )
@@ -205,6 +215,14 @@ final class MeetingRecordingLockFileStoreTests: XCTestCase {
         )
         XCTAssertEqual(replacementLock.pid, 101)
         XCTAssertEqual(replacementLock.finalizationLeaseId, replacementLease.id)
+
+        try claimingStore.releaseFinalizationOwnership(replacementLease)
+        XCTAssertEqual(try claimingStore.read(folderURL: folderURL), original)
+
+        let thirdLease = try claimingStore.claimFinalizationOwnership(
+            folderURL: folderURL
+        )
+        XCTAssertNotEqual(thirdLease.id, replacementLease.id)
     }
 
     func testConcurrentFinalizationOwnershipClaimsAdmitOneProcess() async throws {

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingLockFileStoreTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingLockFileStoreTests.swift
@@ -188,6 +188,57 @@ final class MeetingRecordingLockFileStoreTests: XCTestCase {
         XCTAssertEqual(claimed.state, .awaitingTranscription)
     }
 
+    func testHasLiveOwnerHonorsPeekedPIDOnNewerSchemaLock() throws {
+        let folderURL = tempRoot.appendingPathComponent("future-schema-live")
+        let liveStore = MeetingRecordingLockFileStore(
+            processChecker: MockProcessAliveChecker(alivePIDs: [42])
+        )
+        try writeRawLockFile(makeLockFile(schemaVersion: 999, pid: 42), folderURL: folderURL)
+
+        XCTAssertNil(try liveStore.read(folderURL: folderURL))
+        XCTAssertTrue(try liveStore.hasLiveOwner(folderURL: folderURL))
+        XCTAssertFalse(
+            try MeetingRecordingLockFileStore(
+                processChecker: MockProcessAliveChecker(alivePIDs: [])
+            ).hasLiveOwner(folderURL: folderURL)
+        )
+    }
+
+    func testFinalizationOwnershipClaimRefusesLiveNewerSchemaLock() throws {
+        let folderURL = tempRoot.appendingPathComponent("future-schema-claim")
+        try writeRawLockFile(makeLockFile(schemaVersion: 999, pid: 42), folderURL: folderURL)
+        let claimingStore = MeetingRecordingLockFileStore(
+            processChecker: MockProcessAliveChecker(alivePIDs: [42, 101]),
+            processID: 101
+        )
+
+        XCTAssertThrowsError(
+            try claimingStore.claimFinalizationOwnership(folderURL: folderURL)
+        ) { error in
+            XCTAssertEqual(
+                error as? MeetingFinalizationOwnershipError,
+                .ownedByLiveProcess(pid: 42)
+            )
+        }
+        XCTAssertNil(try claimingStore.read(folderURL: folderURL))
+    }
+
+    func testFinalizationOwnershipClaimReplacesDeadNewerSchemaLock() throws {
+        let folderURL = tempRoot.appendingPathComponent("future-schema-dead")
+        try writeRawLockFile(makeLockFile(schemaVersion: 999, pid: 42), folderURL: folderURL)
+        let claimingStore = MeetingRecordingLockFileStore(
+            processChecker: MockProcessAliveChecker(alivePIDs: [101]),
+            processID: 101
+        )
+
+        let lease = try claimingStore.claimFinalizationOwnership(folderURL: folderURL)
+
+        let claimed = try XCTUnwrap(claimingStore.read(folderURL: folderURL))
+        XCTAssertEqual(claimed.pid, 101)
+        XCTAssertEqual(claimed.finalizationLeaseId, lease.id)
+        XCTAssertEqual(claimed.schemaVersion, MeetingRecordingLockFile.currentSchemaVersion)
+    }
+
     func testFinalizationOwnershipClaimTreatsZeroByteLockAsDeadEvidence() throws {
         let folderURL = tempRoot.appendingPathComponent("zero-byte-claim-session")
         try FileManager.default.createDirectory(at: folderURL, withIntermediateDirectories: true)

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingLockFileStoreTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingLockFileStoreTests.swift
@@ -93,6 +93,121 @@ final class MeetingRecordingLockFileStoreTests: XCTestCase {
         ))
     }
 
+    func testFinalizationOwnershipClaimRewritesAndReleaseRestoresDeadOwner() throws {
+        let folderURL = tempRoot.appendingPathComponent("claim-session")
+        let original = makeLockFile(
+            pid: 42,
+            state: .awaitingTranscription,
+            folderURL: folderURL
+        )
+        let claimingStore = MeetingRecordingLockFileStore(
+            processChecker: MockProcessAliveChecker(alivePIDs: [101]),
+            processID: 101
+        )
+        try claimingStore.write(original, folderURL: folderURL)
+
+        let lease = try claimingStore.claimFinalizationOwnership(
+            folderURL: folderURL
+        )
+
+        let claimed = try XCTUnwrap(claimingStore.read(folderURL: folderURL))
+        XCTAssertEqual(claimed.pid, 101)
+        XCTAssertEqual(claimed.state, .awaitingTranscription)
+        XCTAssertEqual(claimed.finalizationLeaseId, lease.id)
+
+        try claimingStore.releaseFinalizationOwnership(lease)
+
+        XCTAssertEqual(try claimingStore.read(folderURL: folderURL), original)
+    }
+
+    func testFinalizationOwnershipClaimRefusesLiveOwner() throws {
+        let folderURL = tempRoot.appendingPathComponent("live-claim-session")
+        let claimingStore = MeetingRecordingLockFileStore(
+            processChecker: MockProcessAliveChecker(alivePIDs: [42, 101]),
+            processID: 101
+        )
+        let original = makeLockFile(
+            pid: 42,
+            state: .awaitingTranscription,
+            folderURL: folderURL
+        )
+        try claimingStore.write(original, folderURL: folderURL)
+
+        XCTAssertThrowsError(
+            try claimingStore.claimFinalizationOwnership(folderURL: folderURL)
+        ) { error in
+            XCTAssertEqual(
+                error as? MeetingFinalizationOwnershipError,
+                .ownedByLiveProcess(pid: 42)
+            )
+        }
+        XCTAssertEqual(try claimingStore.read(folderURL: folderURL), original)
+    }
+
+    func testFinalizationOwnershipClaimReplacesDeadProcessLease() throws {
+        let folderURL = tempRoot.appendingPathComponent("stale-lease-session")
+        let staleLeaseID = UUID()
+        let staleLock = makeLockFile(
+            pid: 42,
+            state: .awaitingTranscription,
+            folderURL: folderURL
+        ).withFinalizationOwner(pid: 42, leaseID: staleLeaseID)
+        let claimingStore = MeetingRecordingLockFileStore(
+            processChecker: MockProcessAliveChecker(alivePIDs: [101]),
+            processID: 101
+        )
+        try claimingStore.write(staleLock, folderURL: folderURL)
+
+        let replacementLease = try claimingStore.claimFinalizationOwnership(
+            folderURL: folderURL
+        )
+
+        let claimed = try XCTUnwrap(claimingStore.read(folderURL: folderURL))
+        XCTAssertEqual(claimed.pid, 101)
+        XCTAssertEqual(claimed.finalizationLeaseId, replacementLease.id)
+        XCTAssertNotEqual(claimed.finalizationLeaseId, staleLeaseID)
+    }
+
+    func testConcurrentFinalizationOwnershipClaimsAdmitOneProcess() async throws {
+        let folderURL = tempRoot.appendingPathComponent("concurrent-claim-session")
+        let processChecker = MockProcessAliveChecker(alivePIDs: [101, 202])
+        let firstStore = MeetingRecordingLockFileStore(
+            processChecker: processChecker,
+            processID: 101
+        )
+        let secondStore = MeetingRecordingLockFileStore(
+            processChecker: processChecker,
+            processID: 202
+        )
+        let original = makeLockFile(
+            pid: 42,
+            state: .awaitingTranscription,
+            folderURL: folderURL
+        )
+
+        for iteration in 0..<25 {
+            try firstStore.write(original, folderURL: folderURL)
+            let firstTask = Task.detached {
+                try? firstStore.claimFinalizationOwnership(folderURL: folderURL)
+            }
+            let secondTask = Task.detached {
+                try? secondStore.claimFinalizationOwnership(folderURL: folderURL)
+            }
+            let firstLease = await firstTask.value
+            let secondLease = await secondTask.value
+            let leases = [firstLease, secondLease].compactMap { $0 }
+
+            XCTAssertEqual(
+                leases.count,
+                1,
+                "Expected one finalization owner in iteration \(iteration)"
+            )
+            if let lease = leases.first {
+                try firstStore.releaseFinalizationOwnership(lease)
+            }
+        }
+    }
+
     func testDeleteRemovesFile() throws {
         let folderURL = tempRoot.appendingPathComponent("session")
         try store.write(makeLockFile(), folderURL: folderURL)

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingLockFileStoreTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingLockFileStoreTests.swift
@@ -67,6 +67,32 @@ final class MeetingRecordingLockFileStoreTests: XCTestCase {
         XCTAssertEqual(readLockFile.folderURL?.standardizedFileURL, folderURL.standardizedFileURL)
     }
 
+    func testHasLiveOwnerUsesReadableLockPID() throws {
+        let folderURL = tempRoot.appendingPathComponent("session")
+        let liveStore = MeetingRecordingLockFileStore(
+            processChecker: MockProcessAliveChecker(alivePIDs: [42])
+        )
+        try liveStore.write(
+            makeLockFile(pid: 42, state: .awaitingTranscription),
+            folderURL: folderURL
+        )
+
+        XCTAssertTrue(try liveStore.hasLiveOwner(folderURL: folderURL))
+    }
+
+    func testHasLiveOwnerReturnsFalseForDeadOrMissingOwner() throws {
+        let deadFolderURL = tempRoot.appendingPathComponent("dead-session")
+        try store.write(
+            makeLockFile(pid: 42, state: .awaitingTranscription),
+            folderURL: deadFolderURL
+        )
+
+        XCTAssertFalse(try store.hasLiveOwner(folderURL: deadFolderURL))
+        XCTAssertFalse(try store.hasLiveOwner(
+            folderURL: tempRoot.appendingPathComponent("missing-session")
+        ))
+    }
+
     func testDeleteRemovesFile() throws {
         let folderURL = tempRoot.appendingPathComponent("session")
         try store.write(makeLockFile(), folderURL: folderURL)

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingLockFileStoreTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingLockFileStoreTests.swift
@@ -168,6 +168,45 @@ final class MeetingRecordingLockFileStoreTests: XCTestCase {
         XCTAssertNotEqual(claimed.finalizationLeaseId, staleLeaseID)
     }
 
+    func testFailedOwnershipReleaseCanBeReclaimedBySameProcess() throws {
+        let folderURL = tempRoot.appendingPathComponent("failed-release-session")
+        let claimingStore = MeetingRecordingLockFileStore(
+            processChecker: MockProcessAliveChecker(alivePIDs: [101]),
+            processID: 101
+        )
+        try claimingStore.write(
+            makeLockFile(
+                pid: 42,
+                state: .awaitingTranscription,
+                folderURL: folderURL
+            ),
+            folderURL: folderURL
+        )
+        let abandonedLease = try claimingStore.claimFinalizationOwnership(
+            folderURL: folderURL
+        )
+        let claimedLock = try XCTUnwrap(
+            claimingStore.read(folderURL: folderURL)
+        )
+
+        try FileManager.default.removeItem(at: folderURL)
+        XCTAssertThrowsError(
+            try claimingStore.releaseFinalizationOwnership(abandonedLease)
+        )
+
+        try claimingStore.write(claimedLock, folderURL: folderURL)
+        let replacementLease = try claimingStore.claimFinalizationOwnership(
+            folderURL: folderURL
+        )
+
+        XCTAssertNotEqual(replacementLease.id, abandonedLease.id)
+        let replacementLock = try XCTUnwrap(
+            claimingStore.read(folderURL: folderURL)
+        )
+        XCTAssertEqual(replacementLock.pid, 101)
+        XCTAssertEqual(replacementLock.finalizationLeaseId, replacementLease.id)
+    }
+
     func testConcurrentFinalizationOwnershipClaimsAdmitOneProcess() async throws {
         let folderURL = tempRoot.appendingPathComponent("concurrent-claim-session")
         let processChecker = MockProcessAliveChecker(alivePIDs: [101, 202])

--- a/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingRecoveryServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/MeetingRecording/MeetingRecordingRecoveryServiceTests.swift
@@ -300,7 +300,11 @@ final class MeetingRecordingRecoveryServiceTests: XCTestCase {
             _ = try await recoveryService.recover(fixture.lock)
             XCTFail("Expected recovery to throw")
         } catch {
-            XCTAssertNotNil(try lockStore.read(folderURL: fixture.folderURL))
+            let restoredLock = try XCTUnwrap(
+                lockStore.read(folderURL: fixture.folderURL)
+            )
+            XCTAssertEqual(restoredLock, fixture.lock)
+            XCTAssertNil(restoredLock.finalizationLeaseId)
         }
     }
 
@@ -1219,7 +1223,11 @@ private struct RecoveryProcessChecker: ProcessAliveChecking {
     func isAlive(pid: Int32) -> Bool { alivePIDs.contains(pid) }
 }
 
-private final class RecoveryRecordingLockFileStore: MeetingRecordingLockFileStoring, @unchecked Sendable {
+private final class RecoveryRecordingLockFileStore:
+    MeetingRecordingLockFileStoring,
+    MeetingFinalizationOwnershipClaiming,
+    @unchecked Sendable
+{
     private let delegate: MeetingRecordingLockFileStore
     private let lock = NSLock()
     var deleteErrorsRemaining = 0
@@ -1250,6 +1258,18 @@ private final class RecoveryRecordingLockFileStore: MeetingRecordingLockFileStor
 
     func discoverOrphans(meetingsRoot: URL) throws -> [MeetingRecordingLockFile] {
         try delegate.discoverOrphans(meetingsRoot: meetingsRoot)
+    }
+
+    func claimFinalizationOwnership(
+        folderURL: URL
+    ) throws -> MeetingFinalizationOwnershipLease {
+        try delegate.claimFinalizationOwnership(folderURL: folderURL)
+    }
+
+    func releaseFinalizationOwnership(
+        _ lease: MeetingFinalizationOwnershipLease
+    ) throws {
+        try delegate.releaseFinalizationOwnership(lease)
     }
 }
 

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
@@ -1303,6 +1303,54 @@ final class TranscriptionViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.currentTranscription?.id, displayed.id)
     }
 
+    func testQueuedFailureRefreshesMatchingProcessingDetailInPlace() {
+        let id = UUID()
+        let processing = Transcription(
+            id: id,
+            fileName: "failed meeting",
+            status: .processing,
+            sourceType: .meeting
+        )
+        let failed = Transcription(
+            id: id,
+            fileName: "failed meeting",
+            status: .error,
+            errorMessage: "Speech model failed",
+            sourceType: .meeting
+        )
+        mockRepo.transcriptions = [failed]
+        viewModel.configure(transcriptionService: mockService, transcriptionRepo: mockRepo)
+        viewModel.currentTranscription = processing
+        viewModel.selectedTab = .chat
+
+        viewModel.refreshCurrentTranscriptionIfMatching(id: id)
+
+        XCTAssertEqual(viewModel.currentTranscription?.status, .error)
+        XCTAssertEqual(viewModel.currentTranscription?.errorMessage, "Speech model failed")
+        XCTAssertEqual(viewModel.selectedTab, .chat)
+    }
+
+    func testQueuedFailureDoesNotRefreshUnrelatedDetail() {
+        let displayed = Transcription(
+            fileName: "displayed meeting",
+            rawTranscript: "Keep this detail open.",
+            status: .completed,
+            sourceType: .meeting
+        )
+        let failed = Transcription(
+            fileName: "failed meeting",
+            status: .error,
+            sourceType: .meeting
+        )
+        mockRepo.transcriptions = [displayed, failed]
+        viewModel.configure(transcriptionService: mockService, transcriptionRepo: mockRepo)
+        viewModel.currentTranscription = displayed
+
+        viewModel.refreshCurrentTranscriptionIfMatching(id: failed.id)
+
+        XCTAssertEqual(viewModel.currentTranscription?.id, displayed.id)
+    }
+
     func testRefreshingSameTranscriptionDoesNotResetSelectedTab() {
         let id = UUID()
         let first = Transcription(id: id, fileName: "first.mp3", rawTranscript: "First", status: .completed)

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
@@ -1238,6 +1238,71 @@ final class TranscriptionViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.hasConversations)
     }
 
+    func testQueuedCompletionRefreshesMatchingDetailWithoutSelectingDuringAnotherMeeting() {
+        let id = UUID()
+        let processing = Transcription(
+            id: id,
+            fileName: "first meeting",
+            status: .processing,
+            sourceType: .meeting
+        )
+        let completed = Transcription(
+            id: id,
+            fileName: "first meeting",
+            rawTranscript: "Finished while another meeting was recording.",
+            status: .completed,
+            sourceType: .meeting
+        )
+        mockRepo.transcriptions = [completed]
+        viewModel.configure(transcriptionService: mockService, transcriptionRepo: mockRepo)
+        viewModel.currentTranscription = processing
+        viewModel.selectedTab = .chat
+        viewModel.hasConversations = true
+
+        viewModel.presentCompletedTranscription(
+            completed,
+            autoSave: false,
+            runAutoPrompts: false,
+            selectTranscription: false
+        )
+
+        XCTAssertEqual(viewModel.currentTranscription?.id, id)
+        XCTAssertEqual(viewModel.currentTranscription?.status, .completed)
+        XCTAssertEqual(
+            viewModel.currentTranscription?.rawTranscript,
+            "Finished while another meeting was recording."
+        )
+        XCTAssertEqual(viewModel.selectedTab, .chat)
+        XCTAssertTrue(viewModel.hasConversations)
+    }
+
+    func testQueuedCompletionDoesNotReplaceUnrelatedDetailWhenSelectionIsSuppressed() {
+        let displayed = Transcription(
+            fileName: "displayed meeting",
+            rawTranscript: "Keep this detail open.",
+            status: .completed,
+            sourceType: .meeting
+        )
+        let completed = Transcription(
+            fileName: "background meeting",
+            rawTranscript: "Completed in the background.",
+            status: .completed,
+            sourceType: .meeting
+        )
+        mockRepo.transcriptions = [displayed, completed]
+        viewModel.configure(transcriptionService: mockService, transcriptionRepo: mockRepo)
+        viewModel.currentTranscription = displayed
+
+        viewModel.presentCompletedTranscription(
+            completed,
+            autoSave: false,
+            runAutoPrompts: false,
+            selectTranscription: false
+        )
+
+        XCTAssertEqual(viewModel.currentTranscription?.id, displayed.id)
+    }
+
     func testRefreshingSameTranscriptionDoesNotResetSelectedTab() {
         let id = UUID()
         let first = Transcription(id: id, fileName: "first.mp3", rawTranscript: "First", status: .completed)

--- a/Tests/MacParakeetTests/ViewModels/ViewModelMocks.swift
+++ b/Tests/MacParakeetTests/ViewModels/ViewModelMocks.swift
@@ -482,7 +482,7 @@ actor MockTranscriptionService: SpeechEngineOverrideTranscriptionService {
         meetingFinalizationHeld = true
     }
 
-    func persistFinalizedMeetings(to repository: MockTranscriptionRepository) {
+    func persistFinalizedMeetings(to repository: any TranscriptionRepositoryProtocol) {
         preparedMeetingSaveHook = { transcription in
             try? repository.save(transcription)
         }

--- a/Tests/MacParakeetTests/Views/MeetingTranscriptProcessingPresentationTests.swift
+++ b/Tests/MacParakeetTests/Views/MeetingTranscriptProcessingPresentationTests.swift
@@ -32,7 +32,6 @@ final class MeetingTranscriptProcessingPresentationTests: XCTestCase {
     func testActionsStayUnavailableWhileMeetingFinalizationIsProcessing() {
         XCTAssertFalse(
             TranscriptDetailActionAvailability.canEdit(
-                transcriptText: "",
                 status: .processing
             ))
         XCTAssertFalse(
@@ -45,7 +44,6 @@ final class MeetingTranscriptProcessingPresentationTests: XCTestCase {
     func testCompletedTranscriptRetainsExistingActionAvailability() {
         XCTAssertTrue(
             TranscriptDetailActionAvailability.canEdit(
-                transcriptText: "Finished transcript",
                 status: .completed
             ))
         XCTAssertTrue(
@@ -53,9 +51,8 @@ final class MeetingTranscriptProcessingPresentationTests: XCTestCase {
                 hasRetainedAudio: true,
                 status: .completed
             ))
-        XCTAssertFalse(
+        XCTAssertTrue(
             TranscriptDetailActionAvailability.canEdit(
-                transcriptText: " \n ",
                 status: .completed
             ))
     }

--- a/Tests/MacParakeetTests/Views/MeetingTranscriptProcessingPresentationTests.swift
+++ b/Tests/MacParakeetTests/Views/MeetingTranscriptProcessingPresentationTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+import MacParakeetCore
+@testable import MacParakeet
+
+final class MeetingTranscriptProcessingPresentationTests: XCTestCase {
+    func testEmptyProcessingMeetingExplainsDurableBackgroundWork() throws {
+        let presentation = try XCTUnwrap(
+            MeetingTranscriptProcessingPresentation.make(
+                sourceType: .meeting,
+                status: .processing
+            ))
+
+        XCTAssertEqual(presentation.title, "Transcribing meeting")
+        XCTAssertTrue(presentation.message.contains("audio is saved"))
+        XCTAssertTrue(presentation.message.contains("background"))
+        XCTAssertTrue(presentation.message.contains("leave this page"))
+    }
+
+    func testPresentationIsLimitedToProcessingMeetings() {
+        XCTAssertNil(
+            MeetingTranscriptProcessingPresentation.make(
+                sourceType: .meeting,
+                status: .completed
+            ))
+        XCTAssertNil(
+            MeetingTranscriptProcessingPresentation.make(
+                sourceType: .file,
+                status: .processing
+            ))
+    }
+
+    func testActionsStayUnavailableWhileMeetingFinalizationIsProcessing() {
+        XCTAssertFalse(
+            TranscriptDetailActionAvailability.canEdit(
+                transcriptText: "",
+                status: .processing
+            ))
+        XCTAssertFalse(
+            TranscriptDetailActionAvailability.canRetranscribe(
+                hasRetainedAudio: true,
+                status: .processing
+            ))
+    }
+
+    func testCompletedTranscriptRetainsExistingActionAvailability() {
+        XCTAssertTrue(
+            TranscriptDetailActionAvailability.canEdit(
+                transcriptText: "Finished transcript",
+                status: .completed
+            ))
+        XCTAssertTrue(
+            TranscriptDetailActionAvailability.canRetranscribe(
+                hasRetainedAudio: true,
+                status: .completed
+            ))
+        XCTAssertFalse(
+            TranscriptDetailActionAvailability.canEdit(
+                transcriptText: " \n ",
+                status: .completed
+            ))
+    }
+}

--- a/spec/04-ui-patterns.md
+++ b/spec/04-ui-patterns.md
@@ -133,8 +133,10 @@ state, Text mode permits Edit even when transcription produced no text so the
 user can enter it manually; Retranscribe still requires retained audio. If the
 matching detail page is already open when background finalization finishes, it
 refreshes in place on either success or terminal failure, even while another
-meeting is recording. That refresh must not navigate, activate a window, or
-replace an unrelated open detail page.
+meeting is recording. That in-place refresh must not navigate, activate a
+window, or replace an unrelated open detail page. Recorder-idle queued
+completion may still present the finished meeting, matching the existing
+queued-completion behavior.
 
 ### Local Transcription Rename
 

--- a/spec/04-ui-patterns.md
+++ b/spec/04-ui-patterns.md
@@ -123,6 +123,15 @@ The tile body is informational. Only the visible Start and Stop capsules are rea
 
 When `Library.filter == .meeting`, the view renders a date-grouped list (`Today` / `Yesterday` / `Previous 7 Days` / `Previous 30 Days` / `{Month Year}`) using `MeetingDateGroupHeader` + `MeetingRowCard` instead of the thumbnail grid the other filters use. Meeting rows surface saved-audio state directly (`Audio saved`, `Audio removed`, or `Audio missing`) so playback/retranscription expectations are visible before the user opens a menu.
 
+Opening an empty processing meeting row must preserve that same lifecycle
+truth. The transcript pane shows an indeterminate "Transcribing meeting"
+surface, states that the audio is saved and final transcription continues in
+the background, and tells the user they may leave and return later. It must not
+use the terminal "No transcript available" empty state. Edit and Retranscribe
+are unavailable while the row is processing; they become available according
+to their existing text/audio predicates after the row reaches a terminal
+state.
+
 ### Local Transcription Rename
 
 Local transcription rows expose `Rename...` with a `pencil` symbol in the same Library card/context menu as `Open`, placed before selection and destructive actions. The dialog is compact, prefilled with the effective display title, and rejects blank titles. Until the user explicitly renames it, a Local row's effective title is its original media filename rather than transcript-derived opening words. Rename is a display-metadata operation only: the original source filename/path remain unchanged, and copy-on-import/media-retention behavior is not implied.

--- a/spec/04-ui-patterns.md
+++ b/spec/04-ui-patterns.md
@@ -132,8 +132,9 @@ are unavailable while the row is processing. After the row reaches a terminal
 state, Text mode permits Edit even when transcription produced no text so the
 user can enter it manually; Retranscribe still requires retained audio. If the
 matching detail page is already open when background finalization finishes, it
-refreshes in place even while another meeting is recording. That refresh must
-not navigate, activate a window, or replace an unrelated open detail page.
+refreshes in place on either success or terminal failure, even while another
+meeting is recording. That refresh must not navigate, activate a window, or
+replace an unrelated open detail page.
 
 ### Local Transcription Rename
 

--- a/spec/04-ui-patterns.md
+++ b/spec/04-ui-patterns.md
@@ -128,9 +128,12 @@ truth. The transcript pane shows an indeterminate "Transcribing meeting"
 surface, states that the audio is saved and final transcription continues in
 the background, and tells the user they may leave and return later. It must not
 use the terminal "No transcript available" empty state. Edit and Retranscribe
-are unavailable while the row is processing; they become available according
-to their existing text/audio predicates after the row reaches a terminal
-state.
+are unavailable while the row is processing. After the row reaches a terminal
+state, Text mode permits Edit even when transcription produced no text so the
+user can enter it manually; Retranscribe still requires retained audio. If the
+matching detail page is already open when background finalization finishes, it
+refreshes in place even while another meeting is recording. That refresh must
+not navigate, activate a window, or replace an unrelated open detail page.
 
 ### Local Transcription Rename
 

--- a/spec/05-audio-pipeline.md
+++ b/spec/05-audio-pipeline.md
@@ -322,6 +322,12 @@ B can start only after Meeting A's source audio, mixed playback artifact,
 `awaitingTranscription` lock, and processing Library row are durable. Meeting
 A's final STT then continues in the queue-owned background path.
 
+On app startup, processing-row reconciliation excludes both finalizations in
+the current process's queue and rows whose exact artifact folder has a readable
+lock owned by another live process. An unowned row becomes retryable error only
+if its persisted status is still `processing` at the atomic update boundary;
+this prevents startup cleanup from regressing a concurrently completed row.
+
 This is a recorder-availability guarantee, not an instant-transcript guarantee.
 Queued meeting finalization still uses the shared `STTScheduler` background
 slot. If file, folder, YouTube, podcast, or media URL STT is already running,

--- a/spec/05-audio-pipeline.md
+++ b/spec/05-audio-pipeline.md
@@ -327,6 +327,11 @@ the current process's queue and rows whose exact artifact folder has a readable
 lock owned by another live process. An unowned row becomes retryable error only
 if its persisted status is still `processing` at the atomic update boundary;
 this prevents startup cleanup from regressing a concurrently completed row.
+Retry and crash recovery first claim that folder by rewriting the lock with
+their PID and a unique lease token. The claim and startup reconciliation share
+a per-folder advisory mutex, so the ownership check and compare-and-set cannot
+race a newly admitted finalization. Failed admission restores the prior lock;
+successful settlement deletes it.
 
 This is a recorder-availability guarantee, not an instant-transcript guarantee.
 Queued meeting finalization still uses the shared `STTScheduler` background
@@ -365,9 +370,10 @@ Full meeting deletion is the path that removes the session folder.
 Scheduled retention only detaches audio for completed meeting rows with stored
 audio paths. It skips any session folder that still has `recording.lock`, live
 or dead PID, because those files are active or recoverable recording input.
-Crash-recovered meetings are protected while recovery runs; once the lock is
-removed and the recovered row is completed, normal retention applies. The same
-lock guard protects manual cleanup: both `TranscriptionAssetCleanup` and the
+Crash-recovered meetings are protected while recovery runs by the claiming
+process PID and finalization lease; once the lock is removed and the recovered
+row is completed, normal retention applies. The same lock guard protects
+manual cleanup: both `TranscriptionAssetCleanup` and the
 `clear-meeting-audio` CLI refuse to remove a session folder while a
 `recording.lock` is present, including dead-owner `awaitingTranscription` locks
 whose audio is still queued for background transcription (back-to-back meeting

--- a/spec/adr/014-meeting-recording.md
+++ b/spec/adr/014-meeting-recording.md
@@ -103,7 +103,11 @@ durable boundary, not transcript completion. Opening the processing row shows
 an indeterminate transcription state that explicitly says the audio is saved
 and background work is continuing. Transcript editing and manual
 retranscription stay unavailable until that queued finalization reaches a
-terminal state.
+terminal state. If the detail is already open, both completion and terminal
+failure refresh that same row in place without navigating or stealing focus.
+Manual retry and crash recovery claim the session lock with the current PID and
+a unique lease before admission; startup reconciliation shares the same
+per-folder mutex so it cannot mark newly claimed work as interrupted.
 
 Stop is durable even in `starting`. It immediately enters `stopping` and runs
 the normal stop-and-queue effect instead of waiting for a `recordingStarted`

--- a/spec/adr/014-meeting-recording.md
+++ b/spec/adr/014-meeting-recording.md
@@ -98,6 +98,12 @@ It marks the durable stop boundary: source audio, `meeting-playback.m4a`,
 `recording.lock(state=awaitingTranscription)`, and the processing Library row
 exist on disk, so the recorder returns to idle and another meeting can start.
 Final STT runs through `MeetingTranscriptionQueue` and updates that row later.
+The green completion check and "Saved to Library" copy acknowledge this
+durable boundary, not transcript completion. Opening the processing row shows
+an indeterminate transcription state that explicitly says the audio is saved
+and background work is continuing. Transcript editing and manual
+retranscription stay unavailable until that queued finalization reaches a
+terminal state.
 
 Stop is durable even in `starting`. It immediately enters `stopping` and runs
 the normal stop-and-queue effect instead of waiting for a `recordingStarted`

--- a/spec/adr/014-meeting-recording.md
+++ b/spec/adr/014-meeting-recording.md
@@ -105,6 +105,7 @@ and background work is continuing. Transcript editing and manual
 retranscription stay unavailable until that queued finalization reaches a
 terminal state. If the detail is already open, both completion and terminal
 failure refresh that same row in place without navigating or stealing focus.
+Recorder-idle queued completion may still present the finished meeting.
 Manual retry and crash recovery claim the session lock with the current PID and
 a unique lease before admission; startup reconciliation shares the same
 per-folder mutex so it cannot mark newly claimed work as interrupted.

--- a/spec/adr/019-crash-resilient-meeting-recording.md
+++ b/spec/adr/019-crash-resilient-meeting-recording.md
@@ -179,6 +179,14 @@ Declining the prompt **keeps** the lock file and audio — the user
 can retry recovery later from a Settings affordance ("Pending
 recovery: 1 partial recording").
 
+Startup also reconciles processing meeting rows left behind by an interrupted
+finalization. That reconciliation must distinguish a stale row from work owned
+by another live MacParakeet process: a readable lock at the row's artifact
+folder with a live PID protects the row, even when the new process has no local
+queue entry for it. An unowned processing row may move to a retryable error
+only through an atomic compare-and-set from `processing`, so a concurrent
+successful finalization cannot be overwritten.
+
 ### 3. Schema version on the lock file
 
 The original lock file embedded `schemaVersion: 1`; schema v2 distinguishes an

--- a/spec/adr/019-crash-resilient-meeting-recording.md
+++ b/spec/adr/019-crash-resilient-meeting-recording.md
@@ -187,9 +187,11 @@ queue entry for it. An unowned processing row may move to a retryable error
 only through an atomic compare-and-set from `processing`, so a concurrent
 successful finalization cannot be overwritten. Retry and recovery first claim
 the folder by rewriting the lock with their PID and a unique optional
-`finalizationLeaseId`. Claiming and reconciliation share a per-folder advisory
-mutex; only one can win, and failed finalization restores the prior lock only
-if the same lease still owns it.
+`finalizationLeaseId`. A present but unreadable lock (corrupt, zero-byte, or
+future schema) is treated as dead evidence so Retry is not bricked. Claiming
+and reconciliation share a per-folder advisory mutex; only one can win, and
+failed finalization restores the prior lock only if the same lease still owns
+it.
 
 ### 3. Schema version on the lock file
 

--- a/spec/adr/019-crash-resilient-meeting-recording.md
+++ b/spec/adr/019-crash-resilient-meeting-recording.md
@@ -187,8 +187,9 @@ queue entry for it. An unowned processing row may move to a retryable error
 only through an atomic compare-and-set from `processing`, so a concurrent
 successful finalization cannot be overwritten. Retry and recovery first claim
 the folder by rewriting the lock with their PID and a unique optional
-`finalizationLeaseId`. A present but unreadable lock (corrupt, zero-byte, or
-future schema) is treated as dead evidence so Retry is not bricked. Claiming
+`finalizationLeaseId`. A present but unreadable lock (corrupt or zero-byte) is treated as
+dead evidence so Retry is not bricked. A future-schema lock whose
+peeked PID is still alive is left alone. Claiming
 and reconciliation share a per-folder advisory mutex; only one can win, and
 failed finalization restores the prior lock only if the same lease still owns
 it.

--- a/spec/adr/019-crash-resilient-meeting-recording.md
+++ b/spec/adr/019-crash-resilient-meeting-recording.md
@@ -185,7 +185,11 @@ by another live MacParakeet process: a readable lock at the row's artifact
 folder with a live PID protects the row, even when the new process has no local
 queue entry for it. An unowned processing row may move to a retryable error
 only through an atomic compare-and-set from `processing`, so a concurrent
-successful finalization cannot be overwritten.
+successful finalization cannot be overwritten. Retry and recovery first claim
+the folder by rewriting the lock with their PID and a unique optional
+`finalizationLeaseId`. Claiming and reconciliation share a per-folder advisory
+mutex; only one can win, and failed finalization restores the prior lock only
+if the same lease still owns it.
 
 ### 3. Schema version on the lock file
 

--- a/spec/contracts/meeting-recovery-retention.md
+++ b/spec/contracts/meeting-recovery-retention.md
@@ -116,6 +116,11 @@ compare-and-set on the persisted status. If another process completed or
 otherwise settled the row after the startup read, reconciliation leaves the
 newer state intact and does not report the row as reconciled.
 
+Ownership inspection and transition failures are isolated per row. The affected
+row remains unchanged and the failure is logged, while reconciliation continues
+with unrelated processing meetings; one unreadable lock cannot wedge recovery
+for every other meeting at startup.
+
 The live-owner check and compare-and-set run while holding a per-session
 advisory mutex. Retry and crash recovery claim ownership under that same mutex
 by atomically rewriting the lock with their PID and a unique

--- a/spec/contracts/meeting-recovery-retention.md
+++ b/spec/contracts/meeting-recovery-retention.md
@@ -65,9 +65,15 @@ metadata.
 `finalizationLeaseId` is a backward-compatible optional ownership token.
 Normal stop-and-queue locks and older locks omit it. Retry and crash-recovery
 flows write a fresh token together with the claiming process PID before they
-touch the transcript row or start STT. A missing token decodes as `nil`; a
-malformed token makes the structural lock unreadable rather than silently
-discarding ownership evidence.
+touch the transcript row or start STT. A missing token decodes as `nil`. A
+malformed token, zero-byte file, or future schema makes `read` return `nil`
+(the same as today's corrupt-JSON path). Reconciliation then treats the row as
+unowned and marks it retryable; claim treats a *present but unreadable* lock
+as dead evidence and writes a fresh ownership lock so Retry is not bricked.
+
+A second file, `.finalization-ownership.lock`, is an advisory mutex created
+inside the session folder. It is not user data, is hidden from folder
+enumeration, and is not a retention barrier.
 
 Speech-engine provenance is versioned because schema v1 writers always encoded
 the former shared engine route. A v1 `speechEngine` therefore does not prove
@@ -185,7 +191,12 @@ not final-transcription completion:
 
 ## Non-Stable Fields
 
-- PID liveness is process-local and time-sensitive.
+- PID liveness is process-local and time-sensitive. `kill(pid, 0)` cannot
+  distinguish MacParakeet from a later process that reused the same PID. A
+  long-lived reused PID can leave a `.processing` row looking owned, which
+  suppresses reconciliation, recovery, and Retry until that PID exits. This
+  remaining hole is accepted; do not add a schema bump or process-birth
+  discriminator in this change.
 - `startedAt` and folder paths vary by session.
 - Preview-engine provenance is intentionally not part of the lock. It is
   additive archived metadata only; recovery needs the authoritative final route.

--- a/spec/contracts/meeting-recovery-retention.md
+++ b/spec/contracts/meeting-recovery-retention.md
@@ -17,6 +17,9 @@ actions, and protect folders from automatic destructive sweeps.
   delete `recording.lock` after final transcription.
 - `MeetingRecordingRecoveryService`: reads orphaned locks, recovers audio, and
   routes completed-session lock cleanup through settlement.
+- `MeetingFinalizationReconciler`: uses queue ownership, the row's artifact
+  lock, and an atomic status transition to identify interrupted processing
+  rows without clobbering work in another live app process.
 - `MeetingAudioRetentionSweeper`: detaches completed meeting audio after the
   configured retention window.
 - `history clear-meeting-audio`: refuses clear-all when any readable lock
@@ -26,6 +29,7 @@ actions, and protect folders from automatic destructive sweeps.
 
 - Launch/settings recovery UI.
 - Background meeting finalization.
+- Startup processing-row reconciliation.
 - CLI clear-audio safeguards.
 - Meeting audio retention sweeps.
 - Support diagnostics and future smoke tests.
@@ -73,6 +77,8 @@ accept supported older versions and reject newer, unknown versions.
 Use the narrow predicate that matches the operation:
 
 - Recovery orphan discovery: valid/readable lock plus dead owner PID.
+- Processing-row reconciliation protection: a current-process queue entry or
+  a valid/readable lock at the row's artifact folder plus live owner PID.
 - Active-session CLI refusal: valid/readable lock plus live owner PID, or
   stricter readable-session checks for clear-all operations.
 - Automatic destructive sweep safety: any file named `recording.lock` in the
@@ -81,6 +87,20 @@ Use the narrow predicate that matches the operation:
 `discoverActiveSessions(...)` is PID-live only. It is not a generic "safe to
 mutate" predicate. A dead-owner `awaitingTranscription` lock can still point at
 valid audio that has not been finalized into a completed transcript.
+
+## Processing Row Reconciliation
+
+At startup, a processing meeting row is stale only when no current-process
+queue item owns its transcription id and no readable lock at its
+`meetingArtifactFolderPath` has a live owner PID. The per-folder check is
+intentional: it supports custom artifact roots and avoids treating the new
+process's empty in-memory queue as global truth.
+
+After those ownership checks, reconciliation changes the row from `processing`
+to a retryable `error` with an audio-saved explanation. That write is a
+compare-and-set on the persisted status. If another process completed or
+otherwise settled the row after the startup read, reconciliation leaves the
+newer state intact and does not report the row as reconciled.
 
 ## Retention Rule
 
@@ -149,6 +169,8 @@ retention barrier.
 ## Tests that enforce this
 
 - `MeetingRecordingLockFileStoreTests`
+- `MeetingFinalizationReconcilerTests`
+- `TranscriptionRepositoryTests`
 - `MeetingRecordingSettlementTests`
 - `MeetingRecordingRecoveryServiceTests`
 - `MeetingTranscriptionQueueTests`
@@ -156,14 +178,15 @@ retention barrier.
 - `MeetingAudioRetentionSweeperTests`
 - `MeetingRecordingServiceTests`
 
-Focused coverage pins dead-PID `awaitingTranscription` reads, the distinction
-between active-session discovery and retention safety, completed recovery lock
-cleanup, and retention sweeps skipping valid, zero-byte, corrupt, and
-future-schema lock files. Settlement coverage pins refusal for missing or
-non-completed rows, rethrown delete I/O failure (including discard surfacing a
-retained lock and staying retryable), queue success/failure lock behavior, and
-crash-point convergence for awaiting locks with no row, processing rows, and
-completed rows whose lock is still present.
+Focused coverage pins dead-PID `awaitingTranscription` reads, live-owner
+processing-row protection across app processes, atomic refusal to regress a
+completed row, the distinction between active-session discovery and retention
+safety, completed recovery lock cleanup, and retention sweeps skipping valid,
+zero-byte, corrupt, and future-schema lock files. Settlement coverage pins
+refusal for missing or non-completed rows, rethrown delete I/O failure
+(including discard surfacing a retained lock and staying retryable), queue
+success/failure lock behavior, and crash-point convergence for awaiting locks
+with no row, processing rows, and completed rows whose lock is still present.
 
 ## When this changes
 

--- a/spec/contracts/meeting-recovery-retention.md
+++ b/spec/contracts/meeting-recovery-retention.md
@@ -116,7 +116,10 @@ by atomically rewriting the lock with their PID and a unique
 `finalizationLeaseId`. This closes the check-to-write race: startup
 reconciliation and finalization admission cannot both win. A failed or
 duplicate admission restores the exact prior lock only when its lease token
-still matches; successful settlement deletes the lock instead.
+still matches; successful settlement deletes the lock instead. If restoring
+the prior lock hits an I/O error, that exact relinquished token may be replaced
+by a later claim in the same process; unrelated and still-active lease tokens
+remain protected.
 
 ## Retention Rule
 

--- a/spec/contracts/meeting-recovery-retention.md
+++ b/spec/contracts/meeting-recovery-retention.md
@@ -94,9 +94,13 @@ Use the narrow predicate that matches the operation:
 - Automatic destructive sweep safety: any file named `recording.lock` in the
   session folder, whether it is parseable or not.
 
-`discoverActiveSessions(...)` is PID-live only. It is not a generic "safe to
-mutate" predicate. A dead-owner `awaitingTranscription` lock can still point at
-valid audio that has not been finalized into a completed transcript.
+`discoverActiveSessions(...)` is PID-live except that the process which
+recorded an exact lease token as relinquished excludes that token from its
+active results and exposes it through orphan discovery instead. The registry
+is process-local, so out-of-process callers such as the CLI conservatively
+remain PID-live only. Active discovery is not a generic "safe to mutate"
+predicate. A dead-owner `awaitingTranscription` lock can still point at valid
+audio that has not been finalized into a completed transcript.
 
 ## Processing Row Reconciliation
 

--- a/spec/contracts/meeting-recovery-retention.md
+++ b/spec/contracts/meeting-recovery-retention.md
@@ -66,10 +66,13 @@ metadata.
 Normal stop-and-queue locks and older locks omit it. Retry and crash-recovery
 flows write a fresh token together with the claiming process PID before they
 touch the transcript row or start STT. A missing token decodes as `nil`. A
-malformed token, zero-byte file, or future schema makes `read` return `nil`
-(the same as today's corrupt-JSON path). Reconciliation then treats the row as
-unowned and marks it retryable; claim treats a *present but unreadable* lock
-as dead evidence and writes a fresh ownership lock so Retry is not bricked.
+malformed token or zero-byte file makes `read` return `nil` (the same as
+today's corrupt-JSON path). Reconciliation then treats that row as unowned
+and marks it retryable; claim treats a *present but unreadable* lock as dead
+evidence and writes a fresh ownership lock so Retry is not bricked. A future
+schema is also unreadable to this build, but a peeked live PID still counts
+as a live owner so an older process cannot fail the newer build's in-flight
+work. A future-schema lock whose peeked PID is dead remains claimable.
 
 A second file, `.finalization-ownership.lock`, is an advisory mutex created
 inside the session folder. It is not user data, is hidden from folder

--- a/spec/contracts/meeting-recovery-retention.md
+++ b/spec/contracts/meeting-recovery-retention.md
@@ -84,7 +84,9 @@ accept supported older versions and reject newer, unknown versions.
 
 Use the narrow predicate that matches the operation:
 
-- Recovery orphan discovery: valid/readable lock plus dead owner PID.
+- Recovery orphan discovery: valid/readable lock plus dead owner PID, or an
+  exact same-process lease token recorded as relinquished after restoration
+  failed.
 - Processing-row reconciliation protection: a current-process queue entry or
   a valid/readable lock at the row's artifact folder plus live owner PID.
 - Active-session CLI refusal: valid/readable lock plus live owner PID, or
@@ -119,7 +121,10 @@ duplicate admission restores the exact prior lock only when its lease token
 still matches; successful settlement deletes the lock instead. If restoring
 the prior lock hits an I/O error, that exact relinquished token may be replaced
 by a later claim in the same process; unrelated and still-active lease tokens
-remain protected.
+remain protected. The replacement inherits the relinquished lease's original
+pre-claim lock, so repeated fail/retry cycles cannot restore an abandoned lease
+or wedge the next retry. A relinquished token is not a live owner and remains
+visible to recovery discovery even while its former process PID is alive.
 
 ## Retention Rule
 

--- a/spec/contracts/meeting-recovery-retention.md
+++ b/spec/contracts/meeting-recovery-retention.md
@@ -48,6 +48,7 @@ Stable lock fields:
 - `pid`
 - `displayName`
 - `state`
+- `finalizationLeaseId`
 - `speechEngine`
 - `notes`
 
@@ -60,6 +61,13 @@ Stable states:
 `notes` is a backward-compatible additive field. Missing values decode to safe
 defaults, and malformed `notes` does not block recovery of the structural lock
 metadata.
+
+`finalizationLeaseId` is a backward-compatible optional ownership token.
+Normal stop-and-queue locks and older locks omit it. Retry and crash-recovery
+flows write a fresh token together with the claiming process PID before they
+touch the transcript row or start STT. A missing token decodes as `nil`; a
+malformed token makes the structural lock unreadable rather than silently
+discarding ownership evidence.
 
 Speech-engine provenance is versioned because schema v1 writers always encoded
 the former shared engine route. A v1 `speechEngine` therefore does not prove
@@ -102,6 +110,14 @@ compare-and-set on the persisted status. If another process completed or
 otherwise settled the row after the startup read, reconciliation leaves the
 newer state intact and does not report the row as reconciled.
 
+The live-owner check and compare-and-set run while holding a per-session
+advisory mutex. Retry and crash recovery claim ownership under that same mutex
+by atomically rewriting the lock with their PID and a unique
+`finalizationLeaseId`. This closes the check-to-write race: startup
+reconciliation and finalization admission cannot both win. A failed or
+duplicate admission restores the exact prior lock only when its lease token
+still matches; successful settlement deletes the lock instead.
+
 ## Retention Rule
 
 Automatic retention-like deletion must skip a meeting folder whenever
@@ -134,7 +150,8 @@ failed cleanup (for example, discard must not report success while
 can re-settle the completed row on a later scan. On the transcription-queue
 path a settlement error after a successful finalize is caught by the queue:
 the completed transcript is already durably saved, so the queue still reports
-success and leaves the lock for recovery to re-settle.
+success and restores any retry ownership lease to the prior protective lock so
+recovery can re-settle it later.
 
 The non-settlement deletion paths are intentionally limited to flows that are
 not final-transcription completion:
@@ -178,8 +195,9 @@ retention barrier.
 - `MeetingAudioRetentionSweeperTests`
 - `MeetingRecordingServiceTests`
 
-Focused coverage pins dead-PID `awaitingTranscription` reads, live-owner
-processing-row protection across app processes, atomic refusal to regress a
+Focused coverage pins dead-PID `awaitingTranscription` reads, serialized
+single-owner retry/recovery admission, live-owner processing-row protection
+across app processes, atomic refusal to regress a
 completed row, the distinction between active-session discovery and retention
 safety, completed recovery lock cleanup, and retention sweeps skipping valid,
 zero-byte, corrupt, and future-schema lock files. Settlement coverage pins


### PR DESCRIPTION
Walkthrough: https://macparakeet.com/dev/pr/869

## Summary

A completed recording currently moves to a green saved state as soon as its audio is durable and final transcription is queued. Opening it during the longer model pass can therefore show the terminal “No transcript available” state even though transcription is still healthy. A second MacParakeet process can also misclassify that active work as abandoned because startup reconciliation previously trusted only its own in-memory queue.

This change makes that lifecycle truthful end to end: processing meetings show an explicit background-transcription state, terminal actions remain unavailable until processing settles, and an already-open matching detail refreshes in place on success or failure. It also gives each artifact folder an advisory finalization mutex plus an exact PID/lease owner, so startup reconciliation, retry, and recovery cannot overwrite live work from another process.

## Design

- The green check remains the durable saved/queued boundary; it does not pretend that final STT has completed.
- `.processing` is a first-class transcript presentation state. It cannot fall through to empty-terminal UI or expose Edit/Retranscribe.
- If the matching detail is already open, completion and terminal failure refresh that row in place without navigating or replacing an unrelated detail — even while another meeting is recording. Recorder-idle queued completion may still present the finished meeting.
- Startup reconciliation checks the artifact folder’s exact live owner and performs a database compare-and-set from `processing` to `error`.
- Reconciliation failures are isolated per row: an unreadable lock remains unchanged and is logged without blocking recovery of unrelated meetings.
- Retry/recovery ownership is serialized per folder and represented by the existing v2 lock format with an optional unique lease ID, preserving backward compatibility.
- Failed physical lock cleanup is represented as a locally relinquished lease so it remains immediately and repeatedly recoverable without weakening out-of-process PID checks.
- A present-but-unreadable `recording.lock` is treated as dead evidence on claim, so Retry is not bricked after reconciliation marked the row retryable.

The governing UI, audio-pipeline, crash-recovery ADR, and recovery-retention contract are updated with the same semantics.

## How it works

```mermaid
sequenceDiagram
    participant U as User
    participant F as Recording flow
    participant Q as Finalization queue
    participant D as Meeting detail
    participant R as Startup/recovery
    U->>F: Stop recording
    F->>Q: Save audio + enqueue final STT
    Q-->>D: status = processing
    D-->>U: Transcribing meeting (safe to leave)
    R->>Q: Acquire folder mutex
    R->>R: Check exact PID + lease owner
    alt owner is live
        R-->>R: Preserve processing row
    else owner is dead or relinquished
        R->>Q: Claim or CAS to recoverable error
    end
    alt STT succeeds
        Q-->>D: Refresh matching open detail with transcript
    else STT fails
        Q-->>D: Refresh matching open detail with retryable error
    end
```

## Risk surface

The sensitive paths are cross-process ownership, cleanup after cancellation/failure, and database state transitions. Review should focus on lease restoration across every exit path and on the rule that only the matching open detail refreshes in place.

Deliberately unchanged:

- No STT engine, model, or diarization algorithm changes.
- No database migration.
- No meeting audio or transcript deletion.
- No lock schema-version bump; the lease field is optional.
- PID reuse via `kill(pid, 0)` remains an accepted limitation and is now documented in the recovery contract.

## Test evidence

- Hosted CI passed twice on `b495326f`, including release build, CLI/bundle smoke, concurrency safety, Swift 6 language mode, and all 5,097 tests.
- Local focused suites on the review worktree: **302/302**, including two new tests that claim a corrupt JSON lock and a zero-byte lock.
- Independent adversarial review (Cursor CLI Fable xhigh, GPT-5.6 Sol xhigh, plus in-session correctness / reliability / data-integrity / simplicity / standards / spec). No remaining merge blockers after `ec9d1622`.
- Hosted CodeRabbit identified the per-row reconciliation gap on an earlier head; it was fixed in `b495326f`. Greptile was 5/5 on that head.
- `xcrun swift-format lint --strict` passed for the lock-store follow-up.
- `no-mistakes` CLI was not on PATH in this checkout; the PR remote exists. Greptile CLI was not installed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clearer in-place status updates when background meeting transcription completes or fails.
  - Added a dedicated “Transcribing meeting” state with guidance while processing.
  - Editing and retranscription actions are now appropriately restricted during processing.

- **Bug Fixes**
  - Improved meeting finalization retry and crash recovery to prevent duplicate processing and protect active work.
  - Failed queued transcriptions now refresh only the affected meeting.

- **Documentation**
  - Clarified meeting processing, recovery, ownership, retention, and transcript action behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->