### PR TITLE
Clean up persistent UserDefaults domains in tests

### DIFF
--- a/Tests/MacParakeetTests/App/AppHotkeyCoordinatorTests.swift
+++ b/Tests/MacParakeetTests/App/AppHotkeyCoordinatorTests.swift
@@ -9,7 +9,9 @@ final class AppHotkeyCoordinatorTests: XCTestCase {
     private func makeViewModel(functionName: String = #function) -> SettingsViewModel {
         let suiteName = "AppHotkeyCoordinatorTests.\(functionName).\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!
-        defaults.removePersistentDomain(forName: suiteName)
+        addTeardownBlock {
+            UserDefaults(suiteName: suiteName)?.removePersistentDomain(forName: suiteName)
+        }
         return SettingsViewModel(defaults: defaults)
     }
 

--- a/Tests/MacParakeetTests/App/MeetingAudioRetentionSweepCoordinatorTests.swift
+++ b/Tests/MacParakeetTests/App/MeetingAudioRetentionSweepCoordinatorTests.swift
@@ -99,7 +99,9 @@ final class MeetingAudioRetentionSweepCoordinatorTests: XCTestCase {
     private func makeDefaults() -> UserDefaults {
         let suite = "meeting-audio-retention-sweep-\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suite)!
-        defaults.removePersistentDomain(forName: suite)
+        addTeardownBlock {
+            UserDefaults(suiteName: suite)?.removePersistentDomain(forName: suite)
+        }
         return defaults
     }
 

--- a/Tests/MacParakeetTests/AppRuntimePreferencesTests.swift
+++ b/Tests/MacParakeetTests/AppRuntimePreferencesTests.swift
@@ -5,9 +5,12 @@ import XCTest
 
 final class AppRuntimePreferencesTests: XCTestCase {
     private func makePreferences() -> UserDefaultsAppRuntimePreferences {
-        UserDefaultsAppRuntimePreferences(
-            defaults: UserDefaults(suiteName: "app-runtime-prefs-\(UUID().uuidString)")!
-        )
+        let suite = "app-runtime-prefs-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        addTeardownBlock {
+            UserDefaults(suiteName: suite)?.removePersistentDomain(forName: suite)
+        }
+        return UserDefaultsAppRuntimePreferences(defaults: defaults)
     }
 
     func testMarkFirstDictationCompletedReturnsTrueOnlyOnFirstTransition() {
@@ -33,6 +36,7 @@ final class AppRuntimePreferencesTests: XCTestCase {
     func testKeepDictationOnClipboardReadsStoredValue() {
         let suite = "app-runtime-prefs-\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
         defaults.set(true, forKey: UserDefaultsAppRuntimePreferences.keepDictationOnClipboardKey)
 
         let preferences = UserDefaultsAppRuntimePreferences(defaults: defaults)
@@ -111,6 +115,7 @@ final class AppRuntimePreferencesTests: XCTestCase {
     func testVoiceReturnTriggersAreDisabledWhenToggleIsOff() {
         let suite = "app-runtime-prefs-\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
         defaults.set(["press return"], forKey: UserDefaultsAppRuntimePreferences.voiceReturnTriggersKey)
 
         let preferences = UserDefaultsAppRuntimePreferences(defaults: defaults)
@@ -121,6 +126,7 @@ final class AppRuntimePreferencesTests: XCTestCase {
     func testVoiceReturnTriggersDefaultWhenEnabledWithoutStoredValue() {
         let suite = "app-runtime-prefs-\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
         defaults.set(true, forKey: UserDefaultsAppRuntimePreferences.voiceReturnEnabledKey)
 
         let preferences = UserDefaultsAppRuntimePreferences(defaults: defaults)
@@ -131,6 +137,7 @@ final class AppRuntimePreferencesTests: XCTestCase {
     func testVoiceReturnTriggersReadLegacySingleTrigger() {
         let suite = "app-runtime-prefs-\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
         defaults.set(true, forKey: UserDefaultsAppRuntimePreferences.voiceReturnEnabledKey)
         defaults.set(" zatwierdź ", forKey: UserDefaultsAppRuntimePreferences.voiceReturnTriggerKey)
 
@@ -142,6 +149,7 @@ final class AppRuntimePreferencesTests: XCTestCase {
     func testVoiceReturnTriggersNormalizeStoredList() {
         let suite = "app-runtime-prefs-\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
         defaults.set(true, forKey: UserDefaultsAppRuntimePreferences.voiceReturnEnabledKey)
         defaults.set(
             [" press return ", "PRESS RETURN", "", "zatwierdź"],
@@ -155,6 +163,7 @@ final class AppRuntimePreferencesTests: XCTestCase {
     func testVoiceReturnTriggersFallBackToLegacyWhenStoredListNormalizesEmpty() {
         let suite = "app-runtime-prefs-\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
         defaults.set(true, forKey: UserDefaultsAppRuntimePreferences.voiceReturnEnabledKey)
         defaults.set([" ", ""], forKey: UserDefaultsAppRuntimePreferences.voiceReturnTriggersKey)
         defaults.set(" zatwierdź ", forKey: UserDefaultsAppRuntimePreferences.voiceReturnTriggerKey)
@@ -166,6 +175,7 @@ final class AppRuntimePreferencesTests: XCTestCase {
     func testVoiceReturnTriggersFallBackToDefaultWhenStoredValuesNormalizeEmpty() {
         let suite = "app-runtime-prefs-\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
         defaults.set(true, forKey: UserDefaultsAppRuntimePreferences.voiceReturnEnabledKey)
         defaults.set([" ", ""], forKey: UserDefaultsAppRuntimePreferences.voiceReturnTriggersKey)
         defaults.set(" ", forKey: UserDefaultsAppRuntimePreferences.voiceReturnTriggerKey)
@@ -187,7 +197,9 @@ final class AppRuntimePreferencesTests: XCTestCase {
 
     func testDictationUndoCountdownRoundTripsStoredValue() {
         for countdown in DictationUndoCountdown.allCases {
-            let defaults = UserDefaults(suiteName: "app-runtime-prefs-\(UUID().uuidString)")!
+            let suite = "app-runtime-prefs-\(UUID().uuidString)"
+            let defaults = UserDefaults(suiteName: suite)!
+            defer { defaults.removePersistentDomain(forName: suite) }
             defaults.set(
                 countdown.rawValue,
                 forKey: UserDefaultsAppRuntimePreferences.dictationUndoCountdownKey
@@ -197,7 +209,9 @@ final class AppRuntimePreferencesTests: XCTestCase {
     }
 
     func testDictationUndoCountdownFallsBackForUnknownValue() {
-        let defaults = UserDefaults(suiteName: "app-runtime-prefs-\(UUID().uuidString)")!
+        let suite = "app-runtime-prefs-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
         defaults.set(
             "not-a-real-value",
             forKey: UserDefaultsAppRuntimePreferences.dictationUndoCountdownKey
@@ -392,6 +406,7 @@ final class AppRuntimePreferencesTests: XCTestCase {
     func testFirstDictationFlagPersistsAcrossInstances() {
         let suite = "app-runtime-prefs-\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
 
         let first = UserDefaultsAppRuntimePreferences(defaults: defaults)
         XCTAssertTrue(first.markFirstDictationCompleted())

--- a/Tests/MacParakeetTests/Calendar/MeetingAutoStartCoordinatorTests.swift
+++ b/Tests/MacParakeetTests/Calendar/MeetingAutoStartCoordinatorTests.swift
@@ -9,6 +9,7 @@ final class MeetingAutoStartCoordinatorTests: XCTestCase {
     // MARK: - Fixtures
 
     private var defaults: UserDefaults!
+    private var defaultsSuiteName: String!
     private var settingsViewModel: SettingsViewModel!
     private var calendarService: MockCalendarService!
 
@@ -23,9 +24,8 @@ final class MeetingAutoStartCoordinatorTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        let suite = "com.macparakeet.tests.coordinator.\(UUID().uuidString)"
-        defaults = UserDefaults(suiteName: suite)!
-        defaults.removePersistentDomain(forName: suite)
+        defaultsSuiteName = "com.macparakeet.tests.coordinator.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: defaultsSuiteName)!
         // Tests seed defaults before constructing SettingsViewModel via
         // `seedSettings(...)` so VM init reads the right values without
         // firing `didSet` (which under `.notify`/`.autoStart` would call
@@ -54,6 +54,8 @@ final class MeetingAutoStartCoordinatorTests: XCTestCase {
     }
 
     override func tearDown() {
+        defaults.removePersistentDomain(forName: defaultsSuiteName)
+        defaultsSuiteName = nil
         defaults = nil
         settingsViewModel = nil
         calendarService = nil

--- a/Tests/MacParakeetTests/DictationFlow/DictationFlowCoordinatorLoadCaptionTests.swift
+++ b/Tests/MacParakeetTests/DictationFlow/DictationFlowCoordinatorLoadCaptionTests.swift
@@ -391,7 +391,11 @@ final class DictationFlowCoordinatorLoadCaptionTests: XCTestCase {
             transcribeGate: transcribeGate
         )
         let repo = DictationRepository(dbQueue: dbManager.dbQueue)
-        let preferencesDefaults = UserDefaults(suiteName: "load-caption-\(UUID().uuidString)")!
+        let preferencesSuiteName = "load-caption-\(UUID().uuidString)"
+        let preferencesDefaults = UserDefaults(suiteName: preferencesSuiteName)!
+        addTeardownBlock {
+            UserDefaults(suiteName: preferencesSuiteName)?.removePersistentDomain(forName: preferencesSuiteName)
+        }
         preferencesDefaults.set(keepDictationOnClipboard, forKey: UserDefaultsAppRuntimePreferences.keepDictationOnClipboardKey)
         preferencesDefaults.set(
             dictationInsertionStyle.rawValue,
@@ -413,7 +417,11 @@ final class DictationFlowCoordinatorLoadCaptionTests: XCTestCase {
             }
         )
 
-        let settingsDefaults = UserDefaults(suiteName: "load-caption-settings-\(UUID().uuidString)")!
+        let settingsSuiteName = "load-caption-settings-\(UUID().uuidString)"
+        let settingsDefaults = UserDefaults(suiteName: settingsSuiteName)!
+        addTeardownBlock {
+            UserDefaults(suiteName: settingsSuiteName)?.removePersistentDomain(forName: settingsSuiteName)
+        }
         settingsDefaults.set(false, forKey: UserDefaultsAppRuntimePreferences.showIdlePillKey)
         let settings = SettingsViewModel(defaults: settingsDefaults)
 

--- a/Tests/MacParakeetTests/STT/CohereTranscribeEngineTests.swift
+++ b/Tests/MacParakeetTests/STT/CohereTranscribeEngineTests.swift
@@ -383,7 +383,9 @@ final class CohereTranscribeEngineTests: XCTestCase {
     }
 
     func testCohereDefaultLanguageRoundTrips() throws {
-        let defaults = try XCTUnwrap(UserDefaults(suiteName: "cohere-lang-test-\(UUID().uuidString)"))
+        let suiteName = "cohere-lang-test-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
         XCTAssertNil(SpeechEnginePreference.cohereDefaultLanguage(defaults: defaults))
         SpeechEnginePreference.saveCohereDefaultLanguage("ja", defaults: defaults)
         XCTAssertEqual(SpeechEnginePreference.cohereDefaultLanguage(defaults: defaults), "ja")

--- a/Tests/MacParakeetTests/Services/Dictation/DictationServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/Dictation/DictationServiceTests.swift
@@ -1223,7 +1223,9 @@ final class DictationServiceTests: XCTestCase {
     }
 
     func testFirstDictationFlagFlipsAfterSuccessfulSave() async throws {
-        let defaults = UserDefaults(suiteName: "dictation-first-success-\(UUID().uuidString)")!
+        let suiteName = "dictation-first-success-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
         let preferences = UserDefaultsAppRuntimePreferences(defaults: defaults)
         XCTAssertFalse(preferences.hasCompletedFirstDictation)
 
@@ -1250,7 +1252,9 @@ final class DictationServiceTests: XCTestCase {
     }
 
     func testFirstDictationFlagDoesNotFlipOnFailedDictation() async throws {
-        let defaults = UserDefaults(suiteName: "dictation-first-failure-\(UUID().uuidString)")!
+        let suiteName = "dictation-first-failure-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
         let preferences = UserDefaultsAppRuntimePreferences(defaults: defaults)
 
         service = DictationService(

--- a/Tests/MacParakeetTests/Services/LLM/LLMExecutionContextResolverTests.swift
+++ b/Tests/MacParakeetTests/Services/LLM/LLMExecutionContextResolverTests.swift
@@ -4,9 +4,12 @@ import XCTest
 final class LLMExecutionContextResolverTests: XCTestCase {
     func testStoredResolverReturnsNilWithoutProviderConfig() throws {
         let configStore = MockLLMConfigStore()
+        let suiteName = "test.llm.context.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
         let resolver = StoredLLMExecutionContextResolver(
             configStore: configStore,
-            cliConfigStore: LocalCLIConfigStore(defaults: UserDefaults(suiteName: "test.llm.context.\(UUID().uuidString)")!)
+            cliConfigStore: LocalCLIConfigStore(defaults: defaults)
         )
 
         XCTAssertNil(try resolver.resolveContext())
@@ -16,9 +19,12 @@ final class LLMExecutionContextResolverTests: XCTestCase {
         let configStore = MockLLMConfigStore()
         configStore.config = .openai(apiKey: "sk-test", model: "gpt-5.4")
 
+        let suiteName = "test.llm.context.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
         let resolver = StoredLLMExecutionContextResolver(
             configStore: configStore,
-            cliConfigStore: LocalCLIConfigStore(defaults: UserDefaults(suiteName: "test.llm.context.\(UUID().uuidString)")!)
+            cliConfigStore: LocalCLIConfigStore(defaults: defaults)
         )
 
         let context = try resolver.resolveContext()
@@ -30,7 +36,9 @@ final class LLMExecutionContextResolverTests: XCTestCase {
         let configStore = MockLLMConfigStore()
         configStore.config = .localCLI()
 
-        let defaults = UserDefaults(suiteName: "test.llm.context.\(UUID().uuidString)")!
+        let suiteName = "test.llm.context.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
         let cliConfigStore = LocalCLIConfigStore(defaults: defaults)
         try cliConfigStore.save(
             LocalCLIConfig(

--- a/Tests/MacParakeetTests/Services/LLM/LocalCLIExecutorTests.swift
+++ b/Tests/MacParakeetTests/Services/LLM/LocalCLIExecutorTests.swift
@@ -64,7 +64,9 @@ final class LocalCLIExecutorTests: XCTestCase {
     // MARK: - Config Store
 
     func testConfigStoreRoundTrip() throws {
-        let defaults = UserDefaults(suiteName: "test.localcli.\(UUID().uuidString)")!
+        let suiteName = "test.localcli.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
         let store = LocalCLIConfigStore(defaults: defaults)
 
         XCTAssertNil(store.load())
@@ -89,7 +91,9 @@ final class LocalCLIExecutorTests: XCTestCase {
     }
 
     func testConfigStoreMigratesLegacyDefaultTimeoutOnFirstLoad() throws {
-        let defaults = UserDefaults(suiteName: "test.localcli.\(UUID().uuidString)")!
+        let suiteName = "test.localcli.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
         let store = LocalCLIConfigStore(defaults: defaults)
 
         // Simulate a pre-#478 store: a config saved with the old 45s default,
@@ -113,7 +117,9 @@ final class LocalCLIExecutorTests: XCTestCase {
     }
 
     func testConfigStoreDoesNotMigrateNonDefaultLegacyTimeout() throws {
-        let defaults = UserDefaults(suiteName: "test.localcli.\(UUID().uuidString)")!
+        let suiteName = "test.localcli.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
         let store = LocalCLIConfigStore(defaults: defaults)
 
         try store.save(
@@ -124,7 +130,9 @@ final class LocalCLIExecutorTests: XCTestCase {
     }
 
     func testConfigStoreEmptyLoadConsumesMigrationWindow() throws {
-        let defaults = UserDefaults(suiteName: "test.localcli.\(UUID().uuidString)")!
+        let suiteName = "test.localcli.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
         let store = LocalCLIConfigStore(defaults: defaults)
 
         // A load with no stored config marks the store as post-#478: a 45

--- a/Tests/MacParakeetTests/TelemetryServiceTests.swift
+++ b/Tests/MacParakeetTests/TelemetryServiceTests.swift
@@ -1478,12 +1478,16 @@ final class TelemetryServiceTests: XCTestCase {
     // MARK: - AppPreferences
 
     func testTelemetryEnabledDefault() {
-        let defaults = UserDefaults(suiteName: "test-telemetry-\(UUID().uuidString)")!
+        let suiteName = "test-telemetry-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
         XCTAssertTrue(AppPreferences.isTelemetryEnabled(defaults: defaults))
     }
 
     func testTelemetryEnabledRespectsUserChoice() {
-        let defaults = UserDefaults(suiteName: "test-telemetry-\(UUID().uuidString)")!
+        let suiteName = "test-telemetry-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
         defaults.set(false, forKey: AppPreferences.telemetryEnabledKey)
         XCTAssertFalse(AppPreferences.isTelemetryEnabled(defaults: defaults))
     }

--- a/Tests/MacParakeetTests/ViewModels/LLMSettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/LLMSettingsViewModelTests.swift
@@ -1309,7 +1309,9 @@ final class LLMSettingsViewModelTests: XCTestCase {
     }
 
     func testHasUnsavedChangesTracksLocalCLIConfigDraft() throws {
-        let defaults = UserDefaults(suiteName: "test.vm.\(UUID().uuidString)")!
+        let suiteName = "test.vm.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
         let cliStore = LocalCLIConfigStore(defaults: defaults)
         try cliStore.save(
             LocalCLIConfig(commandTemplate: "claude -p --model haiku", timeoutSeconds: 90)
@@ -1594,7 +1596,9 @@ final class LLMSettingsViewModelTests: XCTestCase {
     }
 
     func testLoadsExistingLocalCLIConfigRehydratesPresetSelection() throws {
-        let defaults = UserDefaults(suiteName: "test.vm.\(UUID().uuidString)")!
+        let suiteName = "test.vm.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
         let cliStore = LocalCLIConfigStore(defaults: defaults)
         try cliStore.save(
             LocalCLIConfig(
@@ -1613,7 +1617,10 @@ final class LLMSettingsViewModelTests: XCTestCase {
     }
 
     func testLocalCLICanSaveWithCommand() {
-        let cliStore = LocalCLIConfigStore(defaults: UserDefaults(suiteName: "test.vm.\(UUID().uuidString)")!)
+        let suiteName = "test.vm.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let cliStore = LocalCLIConfigStore(defaults: defaults)
         viewModel.configure(configStore: mockConfigStore, llmClient: mockClient, cliConfigStore: cliStore)
         viewModel.selectedProviderID = .localCLI
         viewModel.commandTemplate = "claude -p --model haiku"
@@ -1637,7 +1644,9 @@ final class LLMSettingsViewModelTests: XCTestCase {
     }
 
     func testLocalCLISaveDuringConnectionTestDoesNotRestoreStaleCommand() async throws {
-        let defaults = UserDefaults(suiteName: "test.vm.\(UUID().uuidString)")!
+        let suiteName = "test.vm.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
         let cliStore = LocalCLIConfigStore(defaults: defaults)
         try cliStore.save(LocalCLIConfig(commandTemplate: "echo OLD", timeoutSeconds: 10))
 
@@ -1657,7 +1666,9 @@ final class LLMSettingsViewModelTests: XCTestCase {
     }
 
     func testClearKeepsSavedLocalCLIConfigAfterUnsavedProviderSwitch() throws {
-        let defaults = UserDefaults(suiteName: "test.vm.\(UUID().uuidString)")!
+        let suiteName = "test.vm.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
         let cliStore = LocalCLIConfigStore(defaults: defaults)
         try cliStore.save(
             LocalCLIConfig(

--- a/Tests/MacParakeetTests/ViewModels/MediaPlayerViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/MediaPlayerViewModelTests.swift
@@ -426,11 +426,15 @@ final class MediaPlayerViewModelTests: XCTestCase {
     }
 }
 
-private func isolatedPlaybackDefaults() -> UserDefaults {
-    let suiteName = "com.macparakeet.tests.playback-rate.\(UUID().uuidString)"
-    let defaults = UserDefaults(suiteName: suiteName)!
-    defaults.removePersistentDomain(forName: suiteName)
-    return defaults
+private extension MediaPlayerViewModelTests {
+    func isolatedPlaybackDefaults() -> UserDefaults {
+        let suiteName = "com.macparakeet.tests.playback-rate.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        addTeardownBlock {
+            UserDefaults(suiteName: suiteName)?.removePersistentDomain(forName: suiteName)
+        }
+        return defaults
+    }
 }
 
 /// Reference-type capture wrapper. Closures that have to mutate state can

--- a/Tests/MacParakeetTests/ViewModels/OnboardingViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/OnboardingViewModelTests.swift
@@ -212,8 +212,9 @@ final class OnboardingViewModelTests: XCTestCase {
         let perms = MockPermissionService()
         perms.microphonePermission = .notDetermined
         let stt = MockSTTClient()
-        let defaults = UserDefaults(suiteName: "com.macparakeet.tests.\(UUID().uuidString)")!
-        defaults.removePersistentDomain(forName: defaults.volatileDomainNames.first ?? "")
+        let suite = "com.macparakeet.tests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
 
         let vm = makeViewModel(permissionService: perms, sttClient: stt, defaults: defaults)
         vm.jump(to: .microphone)
@@ -234,8 +235,9 @@ final class OnboardingViewModelTests: XCTestCase {
         let perms = MockPermissionService()
         perms.accessibilityPermission = false
         let stt = MockSTTClient()
-        let defaults = UserDefaults(suiteName: "com.macparakeet.tests.\(UUID().uuidString)")!
-        defaults.removePersistentDomain(forName: defaults.volatileDomainNames.first ?? "")
+        let suite = "com.macparakeet.tests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
 
         let vm = makeViewModel(permissionService: perms, sttClient: stt, defaults: defaults)
         vm.jump(to: .accessibility)
@@ -259,7 +261,9 @@ final class OnboardingViewModelTests: XCTestCase {
         perms.accessibilityPermission = false
         perms.requestAccessibilityResult = false
         let stt = MockSTTClient()
-        let defaults = UserDefaults(suiteName: "com.macparakeet.tests.\(UUID().uuidString)")!
+        let suite = "com.macparakeet.tests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
 
         let vm = makeViewModel(permissionService: perms, sttClient: stt, defaults: defaults)
         vm.jump(to: .accessibility)
@@ -294,7 +298,9 @@ final class OnboardingViewModelTests: XCTestCase {
         perms.accessibilityPermission = false
         perms.requestAccessibilityResult = false
         let stt = MockSTTClient()
-        let defaults = UserDefaults(suiteName: "com.macparakeet.tests.\(UUID().uuidString)")!
+        let suite = "com.macparakeet.tests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
 
         let vm = makeViewModel(permissionService: perms, sttClient: stt, defaults: defaults)
         vm.jump(to: .accessibility)
@@ -323,7 +329,9 @@ final class OnboardingViewModelTests: XCTestCase {
         perms.accessibilityPermission = false
         perms.requestAccessibilityResult = false
         let stt = MockSTTClient()
-        let defaults = UserDefaults(suiteName: "com.macparakeet.tests.\(UUID().uuidString)")!
+        let suite = "com.macparakeet.tests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
 
         let vm = makeViewModel(permissionService: perms, sttClient: stt, defaults: defaults)
         vm.jump(to: .accessibility)
@@ -347,7 +355,9 @@ final class OnboardingViewModelTests: XCTestCase {
         let perms = DelayedMicrophonePermissionService()
         perms.accessibilityPermission = false
         let stt = MockSTTClient()
-        let defaults = UserDefaults(suiteName: "com.macparakeet.tests.\(UUID().uuidString)")!
+        let suite = "com.macparakeet.tests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
 
         let vm = makeViewModel(permissionService: perms, sttClient: stt, defaults: defaults)
         vm.refresh()
@@ -384,7 +394,7 @@ final class OnboardingViewModelTests: XCTestCase {
         let stt = MockSTTClient()
         let suite = "com.macparakeet.tests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suite)!
-        defaults.removePersistentDomain(forName: suite)
+        defer { defaults.removePersistentDomain(forName: suite) }
 
         let vm = makeViewModel(permissionService: perms, sttClient: stt, defaults: defaults)
         XCTAssertEqual(vm.step, .welcome)
@@ -409,7 +419,7 @@ final class OnboardingViewModelTests: XCTestCase {
         let stt = MockSTTClient()
         let suite = "com.macparakeet.tests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suite)!
-        defaults.removePersistentDomain(forName: suite)
+        defer { defaults.removePersistentDomain(forName: suite) }
 
         let vm = makeViewModel(permissionService: perms, sttClient: stt, defaults: defaults)
         vm.jump(to: .done)
@@ -440,7 +450,7 @@ final class OnboardingViewModelTests: XCTestCase {
         let stt = MockSTTClient()
         let suite = "com.macparakeet.tests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suite)!
-        defaults.removePersistentDomain(forName: suite)
+        defer { defaults.removePersistentDomain(forName: suite) }
 
         let vm = makeViewModel(permissionService: perms, sttClient: stt, defaults: defaults)
 
@@ -462,7 +472,7 @@ final class OnboardingViewModelTests: XCTestCase {
         let stt = MockSTTClient()
         let suite = "com.macparakeet.tests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suite)!
-        defaults.removePersistentDomain(forName: suite)
+        defer { defaults.removePersistentDomain(forName: suite) }
         defaults.set("2026-01-01T00:00:00Z", forKey: OnboardingViewModel.onboardingCompletedKey)
 
         let vm = makeViewModel(permissionService: perms, sttClient: stt, defaults: defaults)
@@ -474,7 +484,7 @@ final class OnboardingViewModelTests: XCTestCase {
         let stt = MockSTTClient()
         let suite = "com.macparakeet.tests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suite)!
-        defaults.removePersistentDomain(forName: suite)
+        defer { defaults.removePersistentDomain(forName: suite) }
         defaults.set("2026-01-01T00:00:00Z", forKey: OnboardingViewModel.onboardingCompletedKey)
 
         let vm = makeViewModel(permissionService: perms, sttClient: stt, defaults: defaults)
@@ -494,7 +504,7 @@ final class OnboardingViewModelTests: XCTestCase {
         let stt = MockSTTClient()
         let suite = "com.macparakeet.tests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suite)!
-        defaults.removePersistentDomain(forName: suite)
+        defer { defaults.removePersistentDomain(forName: suite) }
         let clock = OnboardingTestClock(Date(timeIntervalSince1970: 100))
 
         let vm = makeViewModel(
@@ -556,7 +566,9 @@ final class OnboardingViewModelTests: XCTestCase {
     func testPermissionPollingLifecycleStopsAfterCancellation() async throws {
         let perms = PollingPermissionService()
         let stt = MockSTTClient()
-        let defaults = UserDefaults(suiteName: "com.macparakeet.tests.\(UUID().uuidString)")!
+        let suite = "com.macparakeet.tests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
         let vm = makeViewModel(
             permissionService: perms,
             sttClient: stt,
@@ -588,8 +600,9 @@ final class OnboardingViewModelTests: XCTestCase {
     func testEngineWarmUpTransitionsToReady() async throws {
         let perms = MockPermissionService()
         let stt = MockSTTClient()
-        let defaults = UserDefaults(suiteName: "com.macparakeet.tests.\(UUID().uuidString)")!
-        defaults.removePersistentDomain(forName: defaults.volatileDomainNames.first ?? "")
+        let suite = "com.macparakeet.tests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
 
         let vm = makeViewModel(permissionService: perms, sttClient: stt, defaults: defaults)
         vm.jump(to: .engine)
@@ -613,7 +626,7 @@ final class OnboardingViewModelTests: XCTestCase {
         await stt.configureWarmUpHangIndefinitely()
         let suite = "com.macparakeet.tests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suite)!
-        defaults.removePersistentDomain(forName: suite)
+        defer { defaults.removePersistentDomain(forName: suite) }
 
         let vm = makeViewModel(
             permissionService: perms,
@@ -651,7 +664,7 @@ final class OnboardingViewModelTests: XCTestCase {
         let stt = MockSTTClient()
         let suite = "com.macparakeet.tests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suite)!
-        defaults.removePersistentDomain(forName: suite)
+        defer { defaults.removePersistentDomain(forName: suite) }
 
         let vm = makeViewModel(
             permissionService: perms,
@@ -684,7 +697,7 @@ final class OnboardingViewModelTests: XCTestCase {
         await stt.configureWarmUpHangIndefinitely()
         let suite = "com.macparakeet.tests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suite)!
-        defaults.removePersistentDomain(forName: suite)
+        defer { defaults.removePersistentDomain(forName: suite) }
 
         let vm = makeViewModel(permissionService: perms, sttClient: stt, defaults: defaults)
         XCTAssertEqual(vm.step, .welcome, "head-start fires while still on Welcome")
@@ -709,7 +722,7 @@ final class OnboardingViewModelTests: XCTestCase {
         await stt.configureWarmUpHangIndefinitely()
         let suite = "com.macparakeet.tests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suite)!
-        defaults.removePersistentDomain(forName: suite)
+        defer { defaults.removePersistentDomain(forName: suite) }
 
         let vm = makeViewModel(permissionService: perms, sttClient: stt, defaults: defaults)
         vm.startEngineWarmUp()
@@ -729,7 +742,7 @@ final class OnboardingViewModelTests: XCTestCase {
         await stt.configureWarmUpHangIndefinitely()
         let suite = "com.macparakeet.tests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suite)!
-        defaults.removePersistentDomain(forName: suite)
+        defer { defaults.removePersistentDomain(forName: suite) }
 
         let vm = makeViewModel(permissionService: perms, sttClient: stt, defaults: defaults)
 
@@ -767,7 +780,7 @@ final class OnboardingViewModelTests: XCTestCase {
         await stt.configureWarmUp(error: STTError.engineStartFailed("boom"))
         let suite = "com.macparakeet.tests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suite)!
-        defaults.removePersistentDomain(forName: suite)
+        defer { defaults.removePersistentDomain(forName: suite) }
 
         let vm = makeViewModel(permissionService: perms, sttClient: stt, defaults: defaults)
         vm.jump(to: .engine)
@@ -803,7 +816,7 @@ final class OnboardingViewModelTests: XCTestCase {
         await stt.configureWarmUp(error: STTError.engineStartFailed("boom"))
         let suite = "com.macparakeet.tests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suite)!
-        defaults.removePersistentDomain(forName: suite)
+        defer { defaults.removePersistentDomain(forName: suite) }
 
         let vm = makeViewModel(permissionService: perms, sttClient: stt, defaults: defaults)
         XCTAssertEqual(vm.step, .welcome)
@@ -841,7 +854,7 @@ final class OnboardingViewModelTests: XCTestCase {
         let stt = MockSTTClient()
         let suite = "com.macparakeet.tests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suite)!
-        defaults.removePersistentDomain(forName: suite)
+        defer { defaults.removePersistentDomain(forName: suite) }
 
         let vm = makeViewModel(
             permissionService: perms,
@@ -866,7 +879,7 @@ final class OnboardingViewModelTests: XCTestCase {
         let stt = MockSTTClient()
         let suite = "com.macparakeet.tests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suite)!
-        defaults.removePersistentDomain(forName: suite)
+        defer { defaults.removePersistentDomain(forName: suite) }
 
         let vm = makeViewModel(permissionService: perms, sttClient: stt, defaults: defaults)
         vm.jump(to: .engine)
@@ -893,7 +906,7 @@ final class OnboardingViewModelTests: XCTestCase {
         let stt = MockSTTClient()
         let suite = "com.macparakeet.tests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suite)!
-        defaults.removePersistentDomain(forName: suite)
+        defer { defaults.removePersistentDomain(forName: suite) }
 
         let vm = makeViewModel(
             permissionService: perms,
@@ -931,7 +944,7 @@ final class OnboardingViewModelTests: XCTestCase {
         await diarization.configureReady(false)
         let suite = "com.macparakeet.tests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suite)!
-        defaults.removePersistentDomain(forName: suite)
+        defer { defaults.removePersistentDomain(forName: suite) }
 
         let vm = makeViewModel(
             permissionService: perms,
@@ -961,7 +974,7 @@ final class OnboardingViewModelTests: XCTestCase {
         let downloadSpy = WhisperDownloadSpy()
         let suite = "com.macparakeet.tests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suite)!
-        defaults.removePersistentDomain(forName: suite)
+        defer { defaults.removePersistentDomain(forName: suite) }
 
         let vm = makeViewModel(
             permissionService: perms,
@@ -1002,7 +1015,9 @@ final class OnboardingViewModelTests: XCTestCase {
     func testEngineWarmUpFailsWhisperPreflightWhenCJKLocaleAndOffline() async throws {
         let perms = MockPermissionService()
         let stt = MockSTTClient()
-        let defaults = UserDefaults(suiteName: "com.macparakeet.tests.\(UUID().uuidString)")!
+        let suite = "com.macparakeet.tests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
 
         let vm = makeViewModel(
             permissionService: perms,
@@ -1030,8 +1045,9 @@ final class OnboardingViewModelTests: XCTestCase {
         let perms = MockPermissionService()
         let stt = MockSTTClient()
         let diarization = MockDiarizationService()
-        let defaults = UserDefaults(suiteName: "com.macparakeet.tests.\(UUID().uuidString)")!
-        defaults.removePersistentDomain(forName: defaults.volatileDomainNames.first ?? "")
+        let suite = "com.macparakeet.tests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
 
         let vm = makeViewModel(
             permissionService: perms,
@@ -1054,8 +1070,9 @@ final class OnboardingViewModelTests: XCTestCase {
         let stt = MockSTTClient()
         let diarization = MockDiarizationService()
         await diarization.configurePrepareModels(error: STTError.modelDownloadFailed)
-        let defaults = UserDefaults(suiteName: "com.macparakeet.tests.\(UUID().uuidString)")!
-        defaults.removePersistentDomain(forName: defaults.volatileDomainNames.first ?? "")
+        let suite = "com.macparakeet.tests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
 
         let vm = makeViewModel(
             permissionService: perms,
@@ -1077,7 +1094,7 @@ final class OnboardingViewModelTests: XCTestCase {
         let stt = MockSTTClient()
         let suite = "com.macparakeet.tests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suite)!
-        defaults.removePersistentDomain(forName: suite)
+        defer { defaults.removePersistentDomain(forName: suite) }
 
         let vm = makeViewModel(permissionService: perms, sttClient: stt, defaults: defaults)
         XCTAssertFalse(vm.hasCompletedOnboarding)
@@ -1094,7 +1111,7 @@ final class OnboardingViewModelTests: XCTestCase {
         let stt = MockSTTClient()
         let suite = "com.macparakeet.tests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suite)!
-        defaults.removePersistentDomain(forName: suite)
+        defer { defaults.removePersistentDomain(forName: suite) }
         let clock = OnboardingTestClock(Date(timeIntervalSince1970: 100))
 
         let vm = makeViewModel(
@@ -1134,7 +1151,7 @@ final class OnboardingViewModelTests: XCTestCase {
         let stt = MockSTTClient()
         let suite = "com.macparakeet.tests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suite)!
-        defaults.removePersistentDomain(forName: suite)
+        defer { defaults.removePersistentDomain(forName: suite) }
         let clock = OnboardingTestClock(Date(timeIntervalSince1970: 100))
 
         let vm = makeViewModel(
@@ -1170,7 +1187,7 @@ final class OnboardingViewModelTests: XCTestCase {
         let stt = MockSTTClient()
         let suite = "com.macparakeet.tests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suite)!
-        defaults.removePersistentDomain(forName: suite)
+        defer { defaults.removePersistentDomain(forName: suite) }
         let clock = OnboardingTestClock(Date(timeIntervalSince1970: 100))
 
         let vm = makeViewModel(
@@ -1213,7 +1230,7 @@ final class OnboardingViewModelTests: XCTestCase {
         let stt = MockSTTClient()
         let suite = "com.macparakeet.tests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suite)!
-        defaults.removePersistentDomain(forName: suite)
+        defer { defaults.removePersistentDomain(forName: suite) }
         let clock = OnboardingTestClock(Date(timeIntervalSince1970: 10))
 
         let vm = makeViewModel(
@@ -1266,7 +1283,9 @@ final class OnboardingViewModelTests: XCTestCase {
             "Downloading speech model (571 MB)... 50%",
             "Loading model into memory...",
         ])
-        let defaults = UserDefaults(suiteName: "com.macparakeet.tests.\(UUID().uuidString)")!
+        let suite = "com.macparakeet.tests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
 
         let vm = makeViewModel(permissionService: perms, sttClient: stt, defaults: defaults)
         vm.jump(to: .engine)
@@ -1304,7 +1323,9 @@ final class OnboardingViewModelTests: XCTestCase {
         let perms = MockPermissionService()
         let stt = MockSTTClient()
         await stt.configureWarmUpFailuresBeforeSuccess(2)
-        let defaults = UserDefaults(suiteName: "com.macparakeet.tests.\(UUID().uuidString)")!
+        let suite = "com.macparakeet.tests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
 
         let vm = makeViewModel(permissionService: perms, sttClient: stt, defaults: defaults)
         vm.jump(to: .engine)
@@ -1321,7 +1342,9 @@ final class OnboardingViewModelTests: XCTestCase {
         let perms = MockPermissionService()
         let stt = MockSTTClient()
         await stt.configureWarmUp(error: STTError.modelDownloadFailed)
-        let defaults = UserDefaults(suiteName: "com.macparakeet.tests.\(UUID().uuidString)")!
+        let suite = "com.macparakeet.tests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
 
         let vm = makeViewModel(permissionService: perms, sttClient: stt, defaults: defaults)
         vm.jump(to: .engine)
@@ -1341,7 +1364,9 @@ final class OnboardingViewModelTests: XCTestCase {
     func testEngineWarmUpFailsPreflightWhenOfflineOnFirstSetup() async throws {
         let perms = MockPermissionService()
         let stt = MockSTTClient()
-        let defaults = UserDefaults(suiteName: "com.macparakeet.tests.\(UUID().uuidString)")!
+        let suite = "com.macparakeet.tests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
 
         let vm = makeViewModel(
             permissionService: perms,
@@ -1370,7 +1395,9 @@ final class OnboardingViewModelTests: XCTestCase {
         let diarization = MockDiarizationService()
         await diarization.configureCachedModels(false)
         await diarization.configureReady(false)
-        let defaults = UserDefaults(suiteName: "com.macparakeet.tests.\(UUID().uuidString)")!
+        let suite = "com.macparakeet.tests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
 
         let vm = makeViewModel(
             permissionService: perms,
@@ -1400,7 +1427,9 @@ final class OnboardingViewModelTests: XCTestCase {
         let diarization = MockDiarizationService()
         await diarization.configureCachedModels(true)
         await diarization.configureReady(false)
-        let defaults = UserDefaults(suiteName: "com.macparakeet.tests.\(UUID().uuidString)")!
+        let suite = "com.macparakeet.tests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
 
         let vm = makeViewModel(
             permissionService: perms,
@@ -1422,7 +1451,9 @@ final class OnboardingViewModelTests: XCTestCase {
     func testEngineWarmUpFailsPreflightWhenDiskTooLowOnFirstSetup() async throws {
         let perms = MockPermissionService()
         let stt = MockSTTClient()
-        let defaults = UserDefaults(suiteName: "com.macparakeet.tests.\(UUID().uuidString)")!
+        let suite = "com.macparakeet.tests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
 
         let vm = makeViewModel(
             permissionService: perms,
@@ -1448,7 +1479,9 @@ final class OnboardingViewModelTests: XCTestCase {
     func testEngineWarmUpFailsPreflightWhenRuntimeUnsupported() async throws {
         let perms = MockPermissionService()
         let stt = MockSTTClient()
-        let defaults = UserDefaults(suiteName: "com.macparakeet.tests.\(UUID().uuidString)")!
+        let suite = "com.macparakeet.tests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
 
         let vm = makeViewModel(
             permissionService: perms,

--- a/Tests/MacParakeetTests/ViewModels/TranscriptChatViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptChatViewModelTests.swift
@@ -233,7 +233,9 @@ final class TranscriptChatViewModelTests: XCTestCase {
     }
 
     func testRefreshModelInfoShowsLocalCLIPresetName() throws {
-        let defaults = UserDefaults(suiteName: "test.chat.localcli.\(UUID().uuidString)")!
+        let suiteName = "test.chat.localcli.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
         let cliStore = LocalCLIConfigStore(defaults: defaults)
         try cliStore.save(
             LocalCLIConfig(commandTemplate: "codex exec --skip-git-repo-check --model gpt-5.4-mini")
@@ -259,7 +261,9 @@ final class TranscriptChatViewModelTests: XCTestCase {
     }
 
     func testRefreshModelInfoShowsCustomCLILabel() throws {
-        let defaults = UserDefaults(suiteName: "test.chat.customcli.\(UUID().uuidString)")!
+        let suiteName = "test.chat.customcli.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
         let cliStore = LocalCLIConfigStore(defaults: defaults)
         try cliStore.save(LocalCLIConfig(commandTemplate: "python llm_wrapper.py"))
 


### PR DESCRIPTION
## Summary

Tests create UUID-suffixed `UserDefaults` suites for isolation, but several suites were never removed after execution. Because named suites are persistent preference domains, repeated local test runs leave stale plist files in `~/Library/Preferences`.

This tests-only change updates 14 test files to remove their persistent UUID `UserDefaults` domains after each test. It changes no files under `Sources/` and does not alter production behavior.

Closes #892.

## Design

The cleanup follows three patterns already used elsewhere in the test suite:

- Fixture helpers register an `addTeardownBlock` that captures the suite name.
- Tests that mint suites inline use `defer { defaults.removePersistentDomain(forName: suiteName) }`.
- `MeetingAutoStartCoordinatorTests` stores the suite name created in `setUp()` and removes that domain in `tearDown()`.

Pre-existing cleanup calls that ran before any test write, or that used `volatileDomainNames` instead of the named suite, are replaced because they did not remove the persistent UUID domain. `AutoSaveServiceTests` remains out of scope because it already removes its stored suite name correctly.

## Risk surface

- The diff is confined to `Tests/MacParakeetTests`; there are no source, product behavior, public API, persistence-schema, privacy, or release changes.
- The review-sensitive detail is teardown lifetime: each callback or `defer` must retain the exact suite name used to construct its `UserDefaults` instance and must run after the test's final write.
- A teardown mistake could leave test preferences behind or clear a test suite too early, but cannot target the app's standard defaults because every affected suite name is test-specific and UUID-suffixed.

## Test evidence

Focused verification on head `44aa13e5bac78b187bec9fcffd857f84b127f144`:

```bash
swift test --filter 'AppHotkeyCoordinatorTests|MeetingAudioRetentionSweepCoordinatorTests|AppRuntimePreferencesTests|MeetingAutoStartCoordinatorTests|DictationFlowCoordinatorLoadCaptionTests|CohereTranscribeEngineTests|DictationServiceTests|LLMExecutionContextResolverTests|LocalCLIExecutorTests|TelemetryServiceTests|LLMSettingsViewModelTests|MediaPlayerViewModelTests|OnboardingViewModelTests|TranscriptChatViewModelTests'
```

Result: 544 tests executed, 0 failures, 1 skipped. The skipped Cohere end-to-end test requires `COHERE_E2E_CLIP` and is unrelated to this cleanup.

The contributor also reported a local full-suite run of 5,073 tests with 0 failures before submission; that full-suite claim was not rerun while preparing this PR for independent review.

## Scope

- 14 test files
- 190 additions, 83 deletions
- Tests-only cleanup of persistent UUID `UserDefaults` domains
- No contributor code, commits, branch, or authorship changed while preparing the PR description

Drafted with AI assistance (Claude); the contributor reported that the diff was human-reviewed and verified locally before submission.
