### PR TITLE
Point agents at macparakeet.com/dev walkthroughs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,3 +166,8 @@ for significant work, not ceremony for every typo.
 - Active/completed plans: [`plans/README.md`](./plans/README.md)
 - Distribution/release steps: [`docs/distribution.md`](./docs/distribution.md)
 - CLI automation contract: [`integrations/README.md`](./integrations/README.md)
+- Human-readable PR/issue walkthroughs: publish self-contained HTML at
+  `https://macparakeet.com/dev/pr/<number>` or
+  `/dev/issue/<number>`. Conventions live in the website repo
+  [`public/dev/README.md`](https://github.com/moona3k/macparakeet-website/blob/main/public/dev/README.md).
+  Link the live URL from the GitHub thread. Skip for typos and one-line fixes.

--- a/docs/pr-review-workflow.md
+++ b/docs/pr-review-workflow.md
@@ -158,6 +158,11 @@ Write it for a smart reader who wasn't in the room.
       changelog when public-facing, and AGENTS.md/CLAUDE.md only when agent
       workflow guidance changes
 - [ ] PR description is audience-friendly and complete
+- [ ] For substantial reviews, a self-contained HTML walkthrough is
+      published at `https://macparakeet.com/dev/pr/<number>` (or
+      `/dev/issue/<number>`) and linked from the GitHub thread. Skip
+      for typos and one-line fixes. See the website
+      [`public/dev/README.md`](https://github.com/moona3k/macparakeet-website/blob/main/public/dev/README.md).
 - [ ] Merged into `main`; branch deleted
 
 ## Anti-patterns


### PR DESCRIPTION
## Summary
- Records the permalink scheme for substantial PR/issue HTML companions: `https://macparakeet.com/dev/pr/<number>` or `/dev/issue/<number>`
- Checklist item in the PR review workflow; skip for typos and one-line fixes

## Test plan
- [ ] Confirm the links in AGENTS.md resolve after the website `/dev` page is live


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes human-readable PR/issue walkthroughs by documenting canonical permalinks at macparakeet.com/dev and adding a review checklist item to require them for substantial changes. Previously walkthroughs had no canonical home; now publish self-contained HTML at `https://macparakeet.com/dev/pr/<number>` or `/dev/issue/<number>` and link it in the GitHub thread; trivial fixes are exempt.

**Rollout**
- Docs-only update in `AGENTS.md` and `docs/pr-review-workflow.md`; no runtime impact.
- Required: for substantial PRs/issues, publish the HTML companion in the website repo (see `public/dev/README.md`) and link the live URL from the GitHub thread; skip for typos and one-line fixes.
- After `/dev` pages go live, verify the links resolve.

<sup>Written for commit d164806ea6619eafeb871d9b51117c0229da368d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/909?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for creating self-contained HTML walkthroughs for substantial pull requests and issues.
  * Updated the merge-ready checklist to require linking walkthroughs for substantial reviews.
  * Clarified that typos and one-line fixes are exempt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->