### PR TITLE
Keep long transcript loading off the main actor

### DIFF
--- a/Sources/MacParakeet/Views/Transcription/TranscriptBodyLayout.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptBodyLayout.swift
@@ -16,13 +16,17 @@ enum TranscriptBodyLayout {
     /// The #845 reporter case was 964 rows; typical meetings are far smaller.
     static let nonLazyRowLimit = 400
 
+    /// A missing count means the detached segment cache is still building.
+    /// Stay lazy until the exact count arrives so a large first-open cannot
+    /// briefly materialize every timed row.
     static func usesLazyStack(
-        rowCount: Int,
+        rowCount: Int?,
         environment: [String: String] = launchEnvironment
     ) -> Bool {
         if let override = debugOverride(named: "MACPARAKEET_DEBUG_TRANSCRIPT_LAZY", environment: environment) {
             return override
         }
+        guard let rowCount else { return true }
         return rowCount > nonLazyRowLimit
     }
 

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
@@ -64,6 +64,66 @@ private enum TranscriptDisplayMode: String, CaseIterable, Hashable {
     case timed = "Timed"
 }
 
+/// Owns rich-context work so every replacement cancels and invalidates the
+/// previous request. The returned task makes completion observable in tests;
+/// production callers retain it here rather than relying on untracked work.
+@MainActor
+final class TranscriptRichContextLoader {
+    typealias Builder = @Sendable (Transcription, TranscriptAIContextMode) async -> String
+
+    struct Request: Equatable, Sendable {
+        let transcriptionID: UUID
+        let contentRevision: UInt64
+    }
+
+    private let builder: Builder
+    private var generation: UInt64 = 0
+    private var task: Task<Void, Never>?
+
+    init(
+        builder: @escaping Builder = { transcription, mode in
+            await Task.detached(priority: .userInitiated) {
+                TranscriptAIContextFormatter.format(transcription: transcription, mode: mode)
+            }.value
+        }
+    ) {
+        self.builder = builder
+    }
+
+    @discardableResult
+    func schedule(
+        transcription: Transcription,
+        mode: TranscriptAIContextMode,
+        contentRevision: UInt64,
+        apply: @escaping @MainActor (Request, String) -> Void
+    ) -> Task<Void, Never> {
+        invalidate()
+        let request = Request(
+            transcriptionID: transcription.id,
+            contentRevision: contentRevision
+        )
+        let requestGeneration = generation
+        let builder = builder
+        let task = Task { [weak self] in
+            let text = await builder(transcription, mode)
+            guard !Task.isCancelled,
+                let self,
+                self.generation == requestGeneration
+            else { return }
+            apply(request, text)
+            self.task = nil
+        }
+        self.task = task
+        return task
+    }
+
+    func invalidate() {
+        generation &+= 1
+        task?.cancel()
+        task = nil
+    }
+}
+
 /// Records the user's engine choice from the retranscribe popover so the
 /// confirmation alert can be presented in a *separate* render cycle from
 /// the popover dismissal — chaining popover → alert in the same cycle on
@@ -230,12 +290,17 @@ struct TranscriptResultView: View {
     // Cached transcript data — recomputed only when transcription.id changes, not on every playback tick
     @State private var cachedSegments: [TranscriptSegment] = []
     /// Total timed rows (cards' segments or flat segments); drives the lazy/non-lazy choice.
-    @State private var cachedTranscriptRowCount = 0
+    /// `nil` means the detached cache build is still pending, which must use
+    /// the conservative lazy layout so a large first-open never renders eagerly.
+    @State private var cachedTranscriptRowCount: Int?
     @State private var cachedIdentifiedTurnCards: [IdentifiedSpeakerTurn] = []
     @State private var cachedHasSpeakers: Bool = false
     @State private var cachedSpeakerColorMap: [String: Color] = [:]
     @State private var cachedSpeakerLabelMap: [String: String] = [:]
     @State private var cachedSegmentStartMs: [Int] = []  // sorted, for binary search
+    @State private var cachedSpeakerStats: [String: SpeakerStatistics] = [:]
+    @State private var segmentCacheRequestID = UUID()
+    @State private var richContextLoader = TranscriptRichContextLoader()
     @State private var autoScrollPaused = false
     @State private var scrollPauseTask: Task<Void, Never>?
     @State private var scrollMonitor: Any?
@@ -282,13 +347,15 @@ struct TranscriptResultView: View {
                     playerViewModel.loadSubtitleCues(from: words)
                 }
             }
-            rebuildSegmentCache()
-            viewModel.loadPersistedContent()
             syncTranscriptDisplayMode()
+                if transcriptDisplayMode == .timed {
+                    scheduleSegmentCacheRebuild()
+                }
+            viewModel.loadPersistedContent()
             promptResultsViewModel.loadVisiblePrompts()
             promptResultsViewModel.loadPromptResults(transcriptionId: transcription.id)
-            let text = currentAIContextText
-            chatViewModel.loadTranscript(text, transcriptionId: viewModel.currentTranscription?.id)
+                chatViewModel.loadTranscript(transcriptText, transcriptionId: viewModel.currentTranscription?.id)
+                scheduleRichAIContextLoad()
             // Feed the user's typed meeting notes (if any) into chat alongside
             // the transcript. The closure is re-evaluated on every chat-send so
             // a CLI edit to userNotes in another process is visible to the next
@@ -309,7 +376,6 @@ struct TranscriptResultView: View {
                     playerViewModel.loadSubtitleCues(from: words)
                 }
             }
-            rebuildSegmentCache()
             headerExpanded = false
             speakerOverviewExpanded = true
             editingTitle = false
@@ -335,27 +401,46 @@ struct TranscriptResultView: View {
             viewModel.selectedTab = .transcript
             viewModel.loadPersistedContent()
             syncTranscriptDisplayMode()
+                if transcriptDisplayMode == .timed {
+                    scheduleSegmentCacheRebuild()
+                } else {
+                    applyEmptySegmentCache()
+                }
             promptResultsViewModel.loadPromptResults(transcriptionId: transcription.id)
-            let text = currentAIContextText
-            chatViewModel.loadTranscript(text, transcriptionId: viewModel.currentTranscription?.id)
+                chatViewModel.loadTranscript(transcriptText, transcriptionId: viewModel.currentTranscription?.id)
+                scheduleRichAIContextLoad()
         }
         .onChange(of: activeTranscription.speakers) {
-            rebuildSegmentCache()
+                if transcriptDisplayMode == .timed {
+                    scheduleSegmentCacheRebuild()
+                }
             if findBarVisible { rebuildFindBlocks() }
         }
         .onChange(of: activeTranscription.wordTimestamps) {
-            rebuildSegmentCache()
+                if transcriptDisplayMode == .timed {
+                    scheduleSegmentCacheRebuild()
+                }
             if findBarVisible { rebuildFindBlocks() }
         }
         .onChange(of: activeTranscription.diarizationSegments) {
-            rebuildSegmentCache()
+                if transcriptDisplayMode == .timed {
+                    scheduleSegmentCacheRebuild()
+                }
             if findBarVisible { rebuildFindBlocks() }
         }
         .onChange(of: transcriptText) {
             if findBarVisible { rebuildFindBlocks() }
         }
+        .onChange(of: viewModel.currentTranscriptionRevision) {
+                guard viewModel.currentTranscription?.id == transcription.id else {
+                    richContextLoader.invalidate()
+                    return
+                }
+                chatViewModel.updateTranscriptText(transcriptText)
+                scheduleRichAIContextLoad()
+        }
         .onChange(of: transcriptAIContextModeRaw) {
-            chatViewModel.loadTranscript(currentAIContextText, transcriptionId: viewModel.currentTranscription?.id)
+                scheduleRichAIContextLoad()
         }
         .onChange(of: viewModel.selectedTab) {
             if case .result(let id) = viewModel.selectedTab {
@@ -363,6 +448,7 @@ struct TranscriptResultView: View {
             }
         }
         .onDisappear {
+                richContextLoader.invalidate()
             playerViewModel.cleanup()
             if let monitor = scrollMonitor {
                 NSEvent.removeMonitor(monitor)
@@ -898,7 +984,7 @@ struct TranscriptResultView: View {
     }
 
     private var transcriptWordCount: Int {
-        if transcriptDisplayMode == .timed,
+        if !hasEditedTranscript,
            let wordTimestamps = activeTranscription.wordTimestamps, !wordTimestamps.isEmpty {
             return wordTimestamps.count
         }
@@ -1370,6 +1456,9 @@ struct TranscriptResultView: View {
         )
         .background { transcriptFindShortcuts }
         .onChange(of: transcriptDisplayMode) {
+            if transcriptDisplayMode == .timed {
+                scheduleSegmentCacheRebuild()
+            }
             if findBarVisible { rebuildFindBlocks() }
         }
         .onChange(of: editingTranscript) {
@@ -3118,11 +3207,7 @@ struct TranscriptResultView: View {
 
     @ViewBuilder
     private func speakerSummaryPanel(speakers: [SpeakerInfo]) -> some View {
-        let colorMap = buildSpeakerColorMap()
-        let speakerStats = TranscriptSegmenter.computeSpeakerStats(
-            diarizationSegments: activeTranscription.diarizationSegments,
-            wordTimestamps: activeTranscription.wordTimestamps
-        )
+        let colorMap = cachedSpeakerColorMap.isEmpty ? buildSpeakerColorMap() : cachedSpeakerColorMap
 
         VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
             Button {
@@ -3163,7 +3248,7 @@ struct TranscriptResultView: View {
 
             if speakerOverviewExpanded {
                 ForEach(speakers, id: \.id) { speaker in
-                    let stats = speakerStats[speaker.id]
+                    let stats = cachedSpeakerStats[speaker.id]
                     HStack(spacing: DesignSystem.Spacing.md) {
                         Circle()
                             .fill(colorMap[speaker.id] ?? DesignSystem.Colors.textTertiary)
@@ -3278,7 +3363,9 @@ struct TranscriptResultView: View {
         let trimmed = editingSpeakerLabel.trimmingCharacters(in: .whitespacesAndNewlines)
         if !trimmed.isEmpty {
             viewModel.renameSpeaker(id: speakerId, to: trimmed)
-            rebuildSegmentCache()
+            if transcriptDisplayMode == .timed {
+                scheduleSegmentCacheRebuild()
+            }
         }
         cancelSpeakerRename()
     }
@@ -3303,42 +3390,78 @@ struct TranscriptResultView: View {
 
     // MARK: - Segment Cache
 
-    /// Rebuild cached segment data. Called once on appear and when transcription.id changes.
-    private func rebuildSegmentCache() {
-        guard let words = activeTranscription.wordTimestamps, !words.isEmpty else {
-            cachedSegments = []
-            cachedTranscriptRowCount = 0
-            cachedIdentifiedTurnCards = []
-            cachedHasSpeakers = false
-            cachedSpeakerColorMap = [:]
-            cachedSpeakerLabelMap = [:]
-            cachedSegmentStartMs = []
+    private func scheduleRichAIContextLoad() {
+        let transcription = activeTranscription
+        let mode = currentAIContextMode
+        let revision = viewModel.currentTranscriptionRevision
+        let viewModel = viewModel
+        let chatViewModel = chatViewModel
+        richContextLoader.schedule(
+            transcription: transcription,
+            mode: mode,
+            contentRevision: revision
+        ) { request, text in
+            guard viewModel.currentTranscriptionRevision == request.contentRevision else { return }
+            guard viewModel.currentTranscription?.id == request.transcriptionID else { return }
+            chatViewModel.updateTranscriptText(text)
+        }
+    }
+
+    private func scheduleSegmentCacheRebuild() {
+        let words = activeTranscription.wordTimestamps
+        let speakers = activeTranscription.speakers
+        let diarizationSegments = activeTranscription.diarizationSegments
+        let transcriptionID = activeTranscription.id
+        let requestID = UUID()
+        segmentCacheRequestID = requestID
+
+        guard let words, !words.isEmpty else {
+            applyEmptySegmentCache()
             return
         }
 
-        let segments = TranscriptSegmenter.groupIntoSegments(words: words)
-        let hasSpeakers = words.contains { $0.speakerId != nil }
+        cachedTranscriptRowCount = nil
 
-        cachedSegments = segments
-        cachedHasSpeakers = hasSpeakers
-        cachedSpeakerColorMap = buildSpeakerColorMap()
-        cachedSpeakerLabelMap = buildSpeakerLabelMap()
-        cachedSegmentStartMs = segments.map(\.startMs)
-
-        if hasSpeakers {
-            let turns = TranscriptSegmenter.groupIntoSpeakerTurns(
-                segments: segments,
-                speakerLabelProvider: { speakerID in
-                    guard let speakerID else { return "Unknown" }
-                    return cachedSpeakerLabelMap[speakerID] ?? "Unknown"
-                }
-            )
-            cachedIdentifiedTurnCards = identifiedSpeakerTurnCards(turns)
-            cachedTranscriptRowCount = cachedIdentifiedTurnCards.reduce(0) { $0 + $1.turn.segments.count }
-        } else {
-            cachedIdentifiedTurnCards = []
-            cachedTranscriptRowCount = segments.count
+        Task {
+            let payload = await Task.detached(priority: .userInitiated) {
+                TranscriptSegmentCachePayload.make(
+                    words: words,
+                    speakers: speakers,
+                    diarizationSegments: diarizationSegments
+                )
+            }.value
+            guard segmentCacheRequestID == requestID else { return }
+            guard activeTranscription.id == transcriptionID else { return }
+            applySegmentCache(payload)
         }
+    }
+
+    private func applySegmentCache(_ payload: TranscriptSegmentCachePayload) {
+        cachedSegments = payload.segments
+        cachedHasSpeakers = payload.hasSpeakers
+        cachedSpeakerLabelMap = payload.speakerLabelMap
+        cachedSpeakerStats = payload.speakerStats
+        cachedTranscriptRowCount = payload.rowCount
+        cachedSegmentStartMs = payload.segments.map(\.startMs)
+        cachedSpeakerColorMap = buildSpeakerColorMap()
+        cachedIdentifiedTurnCards =
+            payload.hasSpeakers
+            ? identifiedSpeakerTurnCards(payload.speakerTurns)
+            : []
+        if findBarVisible { rebuildFindBlocks() }
+    }
+
+    private func applyEmptySegmentCache() {
+        segmentCacheRequestID = UUID()
+        cachedSegments = []
+        cachedTranscriptRowCount = 0
+        cachedIdentifiedTurnCards = []
+        cachedHasSpeakers = false
+        cachedSpeakerColorMap = [:]
+        cachedSpeakerLabelMap = [:]
+        cachedSpeakerStats = [:]
+        cachedSegmentStartMs = []
+        if findBarVisible { rebuildFindBlocks() }
     }
 
     // MARK: - Binary Search Helpers
@@ -3451,7 +3574,8 @@ struct TranscriptResultView: View {
             return
         }
 
-        chatViewModel.loadTranscript(currentAIContextText, transcriptionId: viewModel.currentTranscription?.id)
+        chatViewModel.loadTranscript(transcriptText, transcriptionId: viewModel.currentTranscription?.id)
+        scheduleRichAIContextLoad()
         transcriptDraft = ""
         transcriptEditError = nil
         editingTranscript = false
@@ -3462,7 +3586,8 @@ struct TranscriptResultView: View {
 
     private func revertTranscriptEdit() {
         guard viewModel.revertCurrentTranscriptToOriginal() else { return }
-        chatViewModel.loadTranscript(currentAIContextText, transcriptionId: viewModel.currentTranscription?.id)
+        chatViewModel.loadTranscript(transcriptText, transcriptionId: viewModel.currentTranscription?.id)
+        scheduleRichAIContextLoad()
         transcriptDraft = ""
         transcriptEditError = nil
         editingTranscript = false
@@ -4049,6 +4174,53 @@ private struct EngineBadge: View {
                 Capsule(style: .continuous)
                     .stroke(tint.opacity(0.28), lineWidth: 0.5)
             )
+    }
+}
+
+private struct TranscriptSegmentCachePayload: Sendable {
+    let segments: [TranscriptSegment]
+    let speakerTurns: [SpeakerTurn]
+    let speakerStats: [String: SpeakerStatistics]
+    let rowCount: Int
+    let hasSpeakers: Bool
+    let speakerLabelMap: [String: String]
+
+    static func make(
+        words: [WordTimestamp],
+        speakers: [SpeakerInfo]?,
+        diarizationSegments: [DiarizationSegmentRecord]?
+    ) -> TranscriptSegmentCachePayload {
+        let segments = TranscriptSegmenter.groupIntoSegments(words: words)
+        let hasSpeakers = words.contains { $0.speakerId != nil }
+        var speakerLabelMap: [String: String] = [:]
+        if let speakers {
+            for speaker in speakers {
+                speakerLabelMap[speaker.id] = speaker.label
+            }
+        }
+        let speakerTurns =
+            hasSpeakers
+            ? TranscriptSegmenter.groupIntoSpeakerTurns(
+                segments: segments,
+                speakerLabelProvider: { speakerID in
+                    guard let speakerID else { return "Unknown" }
+                    return speakerLabelMap[speakerID] ?? "Unknown"
+                }
+            )
+            : []
+        return TranscriptSegmentCachePayload(
+            segments: segments,
+            speakerTurns: speakerTurns,
+            speakerStats: TranscriptSegmenter.computeSpeakerStats(
+                diarizationSegments: diarizationSegments,
+                wordTimestamps: words
+            ),
+            rowCount: hasSpeakers
+                ? speakerTurns.reduce(0) { $0 + $1.segments.count }
+                : segments.count,
+            hasSpeakers: hasSpeakers,
+            speakerLabelMap: speakerLabelMap
+        )
     }
 }
 

--- a/Sources/MacParakeet/Views/Transcription/TranscriptTimestampedContentView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptTimestampedContentView.swift
@@ -399,13 +399,12 @@ private struct TranscriptSegmentRow: View {
         guard !highlightRanges.isEmpty else {
             return Text(text).font(bodyFont)
         }
-        return Text(
-            TranscriptFindHighlight.attributed(
-                text,
-                ranges: highlightRanges,
-                current: currentRange,
-                baseFont: bodyFont
-            ))
+        return Text(TranscriptFindHighlight.attributed(
+            text,
+            ranges: highlightRanges,
+            current: currentRange,
+            baseFont: bodyFont
+        ))
     }
 
     private var hoverActions: some View {

--- a/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionViewModel.swift
@@ -95,8 +95,13 @@ public final class TranscriptionViewModel {
     }
 
     public var transcriptions: [Transcription] = []
+    /// Monotonic identity for the selected transcript snapshot. Views use this
+    /// to reject asynchronous derivations that finished after a same-row edit,
+    /// retranscription, refresh, or metadata update.
+    public private(set) var currentTranscriptionRevision: UInt64 = 0
     public var currentTranscription: Transcription? {
         didSet {
+            currentTranscriptionRevision &+= 1
             let transcriptionChanged = oldValue?.id != currentTranscription?.id
             if transcriptionChanged {
                 selectedTab = .transcript
@@ -1458,11 +1463,12 @@ public final class TranscriptionViewModel {
         }
     }
 
+    /// Refreshes prompt-result tab chrome for the already-selected row.
+    ///
+    /// Library and Meetings already hand a fully decoded `Transcription`.
+    /// Re-fetching the row here would JSON-decode word timestamps on the
+    /// main actor before the detail view's first frame.
     public func loadPersistedContent() {
-        if let id = currentTranscription?.id,
-           let fresh = try? transcriptionRepo?.fetch(id: id) {
-            currentTranscription = fresh
-        }
         refreshPromptResultStatus()
     }
 

--- a/Tests/MacParakeetTests/ViewModels/TranscriptChatViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptChatViewModelTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+@testable import MacParakeet
 @testable import MacParakeetCore
 @testable import MacParakeetViewModels
 
@@ -169,6 +170,115 @@ final class TranscriptChatViewModelTests: XCTestCase {
 
         XCTAssertTrue(viewModel.messages.isEmpty)
         XCTAssertEqual(viewModel.inputText, "")
+    }
+
+    func testUpdateTranscriptTextPreservesHistoryAndIsUsedOnNextSend() async throws {
+        let transcriptionId = UUID()
+        let conv = ChatConversation(
+            transcriptionId: transcriptionId,
+            title: "Restored",
+            messages: [
+                ChatMessage(role: .user, content: "Question"),
+                ChatMessage(role: .assistant, content: "Answer"),
+            ]
+        )
+        mockConversationRepo.conversations = [conv]
+        viewModel.loadTranscript("Plain transcript", transcriptionId: transcriptionId)
+
+        XCTAssertEqual(viewModel.messages.count, 2)
+        XCTAssertEqual(viewModel.conversations.count, 1)
+
+        viewModel.updateTranscriptText("Rich upgraded context")
+
+        XCTAssertEqual(viewModel.messages.count, 2)
+        XCTAssertEqual(viewModel.messages[0].content, "Question")
+        XCTAssertEqual(viewModel.conversations.count, 1)
+        XCTAssertEqual(viewModel.currentConversation?.id, conv.id)
+        XCTAssertEqual(viewModel.inputText, "")
+
+        mockService.streamTokens = ["ok"]
+        viewModel.inputText = "Follow up"
+        viewModel.sendMessage()
+        try await Task.sleep(nanoseconds: 200_000_000)
+
+        XCTAssertEqual(mockService.lastChatTranscript, "Rich upgraded context")
+        XCTAssertEqual(viewModel.messages.count, 4)
+    }
+
+    func testEditRichContextUpgradeReturnsBeforeBuildCompletes() async {
+        let builder = ControlledRichContextBuilder()
+        let loader = TranscriptRichContextLoader { transcription, mode in
+            await builder.build(transcription, mode)
+        }
+        let transcription = Transcription(
+            fileName: "edited.mp3",
+            rawTranscript: "original",
+            cleanTranscript: "edited",
+            status: .completed
+        )
+        var applied: [String] = []
+
+        let task = loader.schedule(
+            transcription: transcription,
+            mode: .richTranscript,
+            contentRevision: 1
+        ) { _, text in
+            applied.append(text)
+        }
+
+        await builder.waitUntilStarted("edited")
+        XCTAssertTrue(applied.isEmpty, "Scheduling must not synchronously build long rich context.")
+
+        await builder.finish("edited", with: "rich edited context")
+        await task.value
+        XCTAssertEqual(applied, ["rich edited context"])
+    }
+
+    func testRevertRichContextUpgradeRejectsOlderEditCompletion() async {
+        let builder = ControlledRichContextBuilder()
+        let loader = TranscriptRichContextLoader { transcription, mode in
+            await builder.build(transcription, mode)
+        }
+        let transcriptionID = UUID()
+        let edited = Transcription(
+            id: transcriptionID,
+            fileName: "edited.mp3",
+            rawTranscript: "original",
+            cleanTranscript: "edited",
+            status: .completed
+        )
+        let reverted = Transcription(
+            id: transcriptionID,
+            fileName: "edited.mp3",
+            rawTranscript: "original",
+            status: .completed
+        )
+        var applied: [String] = []
+
+        let editedTask = loader.schedule(
+            transcription: edited,
+            mode: .richTranscript,
+            contentRevision: 1
+        ) { _, text in
+            applied.append(text)
+        }
+        await builder.waitUntilStarted("edited")
+
+        let revertedTask = loader.schedule(
+            transcription: reverted,
+            mode: .richTranscript,
+            contentRevision: 2
+        ) { _, text in
+            applied.append(text)
+        }
+        await builder.waitUntilStarted("original")
+
+        await builder.finish("original", with: "reverted context")
+        await revertedTask.value
+        await builder.finish("edited", with: "stale edited context")
+        await editedTask.value
+
+        XCTAssertEqual(applied, ["reverted context"])
     }
 
     // MARK: - Cancel Streaming
@@ -1048,6 +1158,34 @@ final class TranscriptChatViewModelTests: XCTestCase {
         try await Task.sleep(nanoseconds: 200_000_000)
 
         XCTAssertEqual(mockService.lastChatSource, .meetingAsk)
+    }
+}
+
+private actor ControlledRichContextBuilder {
+    private var started: Set<String> = []
+    private var startWaiters: [String: [CheckedContinuation<Void, Never>]] = [:]
+    private var buildContinuations: [String: CheckedContinuation<String, Never>] = [:]
+
+    func build(_ transcription: Transcription, _ mode: TranscriptAIContextMode) async -> String {
+        let key = transcription.cleanTranscript ?? transcription.rawTranscript ?? ""
+        started.insert(key)
+        for waiter in startWaiters.removeValue(forKey: key) ?? [] {
+            waiter.resume()
+        }
+        return await withCheckedContinuation { continuation in
+            buildContinuations[key] = continuation
+        }
+    }
+
+    func waitUntilStarted(_ key: String) async {
+        guard !started.contains(key) else { return }
+        await withCheckedContinuation { continuation in
+            startWaiters[key, default: []].append(continuation)
+        }
+    }
+
+    func finish(_ key: String, with result: String) {
+        buildContinuations.removeValue(forKey: key)?.resume(returning: result)
     }
 }
 

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionViewModelTests.swift
@@ -2400,20 +2400,27 @@ final class TranscriptionViewModelTests: XCTestCase {
 
     // MARK: - Persisted Content
 
-    func testLoadPersistedContentRefreshesCurrentTranscriptionFromDB() {
-        let t = Transcription(fileName: "test.mp3", status: .completed)
-        mockRepo.transcriptions = [t]
+    func testLoadPersistedContentRefreshesPromptResultTabsWithoutRefetchingRow() {
+        let handed = Transcription(
+            fileName: "handed.mp3",
+            rawTranscript: "already loaded from Library",
+            status: .completed
+        )
+        var stored = handed
+        stored.rawTranscript = "stale or different DB copy"
+        stored.fileName = "from-db.mp3"
+        mockRepo.transcriptions = [stored]
 
         viewModel.configure(
             transcriptionService: mockService,
             transcriptionRepo: mockRepo,
             promptResultRepo: mockPromptResultRepo
         )
-        viewModel.currentTranscription = t
+        viewModel.currentTranscription = handed
 
         mockPromptResultRepo.promptResults = [
             PromptResult(
-                transcriptionId: t.id,
+                transcriptionId: handed.id,
                 promptName: "Concise Summary",
                 promptContent: Prompt.defaultPrompt.content,
                 content: "Migrated summary"
@@ -2423,6 +2430,30 @@ final class TranscriptionViewModelTests: XCTestCase {
         viewModel.loadPersistedContent()
 
         XCTAssertTrue(viewModel.hasPromptResultTabs)
+        XCTAssertEqual(viewModel.currentTranscription?.rawTranscript, "already loaded from Library")
+        XCTAssertEqual(viewModel.currentTranscription?.fileName, "handed.mp3")
+    }
+
+    func testCurrentTranscriptionRevisionAdvancesForSelectionEditAndRevert() {
+        let transcription = Transcription(
+            fileName: "editable.mp3",
+            rawTranscript: "Original transcript",
+            status: .completed
+        )
+        mockRepo.transcriptions = [transcription]
+        viewModel.configure(transcriptionService: mockService, transcriptionRepo: mockRepo)
+
+        let beforeSelection = viewModel.currentTranscriptionRevision
+        viewModel.currentTranscription = transcription
+        let afterSelection = viewModel.currentTranscriptionRevision
+
+        XCTAssertGreaterThan(afterSelection, beforeSelection)
+        XCTAssertTrue(viewModel.updateCurrentTranscriptText(to: "Edited transcript"))
+        let afterEdit = viewModel.currentTranscriptionRevision
+        XCTAssertGreaterThan(afterEdit, afterSelection)
+
+        XCTAssertTrue(viewModel.revertCurrentTranscriptToOriginal())
+        XCTAssertGreaterThan(viewModel.currentTranscriptionRevision, afterEdit)
     }
 
     // MARK: - Retranscribe

--- a/Tests/MacParakeetTests/Views/MandalaDataTests.swift
+++ b/Tests/MacParakeetTests/Views/MandalaDataTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+@testable import MacParakeet
+@testable import MacParakeetCore
+
+final class MandalaDataTests: XCTestCase {
+    func testWordTimestampSamplingAlwaysReturnsTwentyFourPoints() {
+        XCTAssertEqual(MandalaData.from(wordTimestamps: []).radialPoints.count, 24)
+
+        let one = [WordTimestamp(word: "hi", startMs: 0, endMs: 100, confidence: 0.9)]
+        XCTAssertEqual(MandalaData.from(wordTimestamps: one).radialPoints.count, 24)
+
+        let twentyThree = (0..<23).map { index in
+            WordTimestamp(word: "w", startMs: index, endMs: index + 1, confidence: 0.5)
+        }
+        XCTAssertEqual(MandalaData.from(wordTimestamps: twentyThree).radialPoints.count, 24)
+
+        let many = (0..<2_000).map { index in
+            WordTimestamp(
+                word: "w",
+                startMs: index,
+                endMs: index + 1,
+                confidence: Double(index) / 2_000
+            )
+        }
+        let sampled = MandalaData.from(wordTimestamps: many)
+        XCTAssertEqual(sampled.radialPoints.count, 24)
+        XCTAssertEqual(sampled.radialPoints[0], 0, accuracy: 0.0001)
+    }
+
+    func testTextSamplingDoesNotRequireTheFullString() {
+        let short = MandalaData.from(text: "abc", durationMs: 1_000)
+        XCTAssertEqual(short.radialPoints.count, 24)
+
+        let long = String(repeating: "word ", count: 20_000)
+        let fromLong = MandalaData.from(text: long, durationMs: 7_200_000)
+        XCTAssertEqual(fromLong.radialPoints.count, 24)
+    }
+}

--- a/Tests/MacParakeetTests/Views/TranscriptBodyLayoutTests.swift
+++ b/Tests/MacParakeetTests/Views/TranscriptBodyLayoutTests.swift
@@ -21,6 +21,10 @@ final class TranscriptBodyLayoutTests: XCTestCase {
         XCTAssertTrue(TranscriptBodyLayout.usesLazyStack(rowCount: 964, environment: [:]))
     }
 
+    func testPendingRowCountStaysLazyUntilDetachedCacheFinishes() {
+        XCTAssertTrue(TranscriptBodyLayout.usesLazyStack(rowCount: nil, environment: [:]))
+    }
+
     func testRowTextSelectionIsOnByDefault() {
         XCTAssertTrue(TranscriptBodyLayout.rowTextSelectionEnabled(environment: [:]))
     }


### PR DESCRIPTION
## Summary

Opening a long Library recording no longer performs transcript-sized SQLite/JSON, rich-context, timed-segment, and mandala work synchronously before the first frame. The PR now sits on current `main`, includes the final async revision guards from independent review, and preserves the small/non-lazy versus large/lazy layout policy merged in #946.

Fixes #905.

## Before / after

| Hot path | Before | After |
| --- | --- | --- |
| Initial Library open | Re-fetched and decoded the already-loaded full transcription row. | Refreshes only prompt-result tab chrome. |
| Chat context | Built rich transcript context on the main actor before interaction. | Loads cheap transcript text first, then upgrades rich context off-main. |
| Timed transcript data | Grouped transcript-sized segment structures eagerly. | Builds detached cache payloads only when timed mode needs them; pending row count stays lazy. |
| Edits / retranscription | An older detached result could replace newer content. | `currentTranscriptionRevision` and transcription-ID checks discard stale results. |
| Mandala | Mapped every word confidence on each render. | Samples a fixed 24 points. |

## Review map

- `Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift`: initial-load cutover, async rich-context/timed-cache ownership, cancellation and stale-result guards, bounded mandala data.
- `Sources/MacParakeetViewModels/TranscriptionViewModel.swift`: monotonic current-transcription revision.
- `Sources/MacParakeet/Views/Transcription/TranscriptBodyLayout.swift`: optional pending row count remains lazy until detached cache completion.
- `Sources/MacParakeet/Views/Transcription/TranscriptTimestampedContentView.swift`: environment propagation retained from #946.
- Changed tests cover prompt-only reloads, revision changes, async return-before-build, stale navigation/edit results, pending cache layout, and fixed-size sampling.

## Correctness invariants

- Never publish detached work unless both transcription ID and content revision still match.
- Cancel/invalidate in-flight work when the active transcription changes or the view disappears.
- Keep the large-transcript lazy layout while cache row count is unknown.
- Preserve text selection and explicit environment overrides from #946.
- Do not alter persistence or public CLI contracts.

## Verification

- `swift test --filter 'TranscriptChatViewModelTests|TranscriptionViewModelTests|MandalaDataTests|TranscriptBodyLayoutTests'`: 193 tests passed, 0 failures.
- The first focused attempt exposed an omitted `TranscriptionViewModel.currentTranscriptionRevision` source delta while rebuilding the PR on current main; adding that source file fixed compilation, and the complete focused set then passed.
- `git diff --check`: passed.
- The semantically equivalent integrated branch previously passed 5,124 XCTest tests plus 17 Swift Testing tests with 0 failures.
- GitHub CI is the final full-suite/release gate for this rewritten head.

## Limitations

- Actual-app long-recording smoke was unavailable because the local app launch path is blocked by the installed Git client lacking `submodule` support.
- No physical two-hour media artifact was opened in this preparation pass; focused tests cover cancellation, stale-result rejection, and bounded work contracts.