### PR TITLE
Report meeting recordings whose system track is silent

### DIFF
--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
@@ -169,6 +169,11 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         var microphoneSystemDominantDrops = 0
         var backpressureDrops = 0
         var transcriptionFailures = 0
+        // Highest per-buffer level seen on each source while recording, on the
+        // same 0...1 scale as `AVAudioPCMBuffer.rmsLevel`. A system peak of zero
+        // after a full meeting means the tap only ever delivered silence.
+        var microphonePeakLevel: Float = 0
+        var systemPeakLevel: Float = 0
     }
 
     private struct Session: Sendable {
@@ -1145,6 +1150,10 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
                 captureReport: captureReport
             )
         )
+        emitSystemAudioSilenceWarningIfNeeded(
+            session: session,
+            durationSeconds: captureElapsedDurationSeconds
+        )
         AudioCaptureDiagnostics.append(
             echoSuppressionSummaryLine(session: session)
         )
@@ -1370,6 +1379,10 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
                 recordCaptureMetrics(for: .microphone, time: time)
                 if handling == .recordAndProcess {
                     latestLevels.microphone = muted ? 0 : recordingBuffer.rmsLevel
+                    captureHealthMetrics.microphonePeakLevel = max(
+                        captureHealthMetrics.microphonePeakLevel,
+                        latestLevels.microphone
+                    )
                     updateMicrophoneRms(with: latestLevels.microphone)
                     if let samples = AudioChunker.extractAndResample(from: recordingBuffer) {
                         await ingestResampledSamples(
@@ -1395,6 +1408,10 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
                 recordCaptureMetrics(for: .system, time: time)
                 if handling == .recordAndProcess {
                     latestLevels.system = buffer.rmsLevel
+                    captureHealthMetrics.systemPeakLevel = max(
+                        captureHealthMetrics.systemPeakLevel,
+                        latestLevels.system
+                    )
                     updateSystemRms(with: latestLevels.system)
                     if let samples = AudioChunker.extractAndResample(from: buffer) {
                         await ingestResampledSamples(
@@ -1944,6 +1961,48 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         )
     }
 
+    private var systemAudioSignalVerdict: MeetingSystemAudioSignalVerdict {
+        MeetingSystemAudioSignalVerdict.evaluate(
+            capturesSystemAudio: captureHealthMetrics.sourceMode?.capturesSystemAudio ?? false,
+            systemFirstBufferSeen: captureHealthMetrics.systemFirstBufferSeen,
+            systemPeakLevel: captureHealthMetrics.systemPeakLevel
+        )
+    }
+
+    /// Surface a system track that stayed at digital silence for a whole meeting.
+    ///
+    /// Nothing else notices this: the stream reports a first buffer, writes frames
+    /// for the full duration, and every stop stage succeeds, so the user only finds
+    /// out by reading a transcript with the other party missing from it.
+    private func emitSystemAudioSilenceWarningIfNeeded(
+        session: Session,
+        durationSeconds: TimeInterval
+    ) {
+        let verdict = systemAudioSignalVerdict
+        guard
+            MeetingSystemAudioSignalVerdict.shouldWarn(
+                verdict: verdict,
+                microphonePeakLevel: captureHealthMetrics.microphonePeakLevel,
+                durationSeconds: durationSeconds
+            )
+        else { return }
+        let sessionID = session.id.uuidString
+        let durationLabel = String(format: "%.3f", durationSeconds)
+        let micPeakLabel = String(format: "%.3f", captureHealthMetrics.microphonePeakLevel)
+        logger.warning(
+            "meeting_system_audio_silent session=\(sessionID, privacy: .public) duration_s=\(durationLabel, privacy: .public)"
+        )
+        AudioCaptureDiagnostics.append(
+            [
+                "meeting_system_audio_silent",
+                "session=\(sessionID)",
+                "duration_s=\(durationLabel)",
+                "mic_peak_level=\(micPeakLabel)",
+                "detail=system_audio_tap_delivered_only_silence",
+            ].joined(separator: " ")
+        )
+    }
+
     private func captureHealthSummaryLine(
         session: Session,
         durationSeconds: TimeInterval,
@@ -1966,6 +2025,9 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         }
         func statusLabel(for source: AudioSource) -> String {
             captureReport?.source(for: source)?.status.rawValue ?? "unknown"
+        }
+        func levelLabel(_ level: Float) -> String {
+            String(format: "%.3f", level)
         }
         return [
             "meeting_recording_health",
@@ -1993,6 +2055,9 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
             "mic_chunks_low_signal_dropped=\(captureHealthMetrics.microphoneLowSignalDrops)",
             "system_chunks_low_signal_dropped=\(captureHealthMetrics.systemLowSignalDrops)",
             "mic_chunks_system_dominant_dropped=\(captureHealthMetrics.microphoneSystemDominantDrops)",
+            "mic_peak_level=\(levelLabel(captureHealthMetrics.microphonePeakLevel))",
+            "system_peak_level=\(levelLabel(captureHealthMetrics.systemPeakLevel))",
+            "system_signal=\(systemAudioSignalVerdict.rawValue)",
             "backpressure_drops=\(captureHealthMetrics.backpressureDrops)",
             "transcription_failures=\(captureHealthMetrics.transcriptionFailures)",
             "interrupted_sources=\(interruptedSourceLabel.isEmpty ? "none" : interruptedSourceLabel)",

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
@@ -174,6 +174,9 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         // after a full meeting means the tap only ever delivered silence.
         var microphonePeakLevel: Float = 0
         var systemPeakLevel: Float = 0
+        // Set for every system buffer that reaches the recording, unlike
+        // `systemFirstBufferSeen`, which needs a valid host time.
+        var systemBufferObserved = false
     }
 
     private struct Session: Sendable {
@@ -1411,6 +1414,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
                 )
                 recordCaptureMetrics(for: .system, time: time)
                 let systemLevel = buffer.rmsLevel
+                captureHealthMetrics.systemBufferObserved = true
                 captureHealthMetrics.systemPeakLevel = max(
                     captureHealthMetrics.systemPeakLevel,
                     systemLevel
@@ -1969,7 +1973,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
     private var systemAudioSignalVerdict: MeetingSystemAudioSignalVerdict {
         MeetingSystemAudioSignalVerdict.evaluate(
             capturesSystemAudio: captureHealthMetrics.sourceMode?.capturesSystemAudio ?? false,
-            systemFirstBufferSeen: captureHealthMetrics.systemFirstBufferSeen,
+            systemBufferObserved: captureHealthMetrics.systemBufferObserved,
             systemPeakLevel: captureHealthMetrics.systemPeakLevel
         )
     }

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
@@ -1377,12 +1377,16 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
                     timelineTimeSeconds: pauseAdjustedHostTimeSeconds(for: time)
                 )
                 recordCaptureMetrics(for: .microphone, time: time)
+                // Peak tracks every buffer that reaches the file, including the
+                // pre-pause buffers `preserveAudioOnly` writes without processing,
+                // so the reported level always describes the recorded audio.
+                let microphoneLevel = muted ? 0 : recordingBuffer.rmsLevel
+                captureHealthMetrics.microphonePeakLevel = max(
+                    captureHealthMetrics.microphonePeakLevel,
+                    microphoneLevel
+                )
                 if handling == .recordAndProcess {
-                    latestLevels.microphone = muted ? 0 : recordingBuffer.rmsLevel
-                    captureHealthMetrics.microphonePeakLevel = max(
-                        captureHealthMetrics.microphonePeakLevel,
-                        latestLevels.microphone
-                    )
+                    latestLevels.microphone = microphoneLevel
                     updateMicrophoneRms(with: latestLevels.microphone)
                     if let samples = AudioChunker.extractAndResample(from: recordingBuffer) {
                         await ingestResampledSamples(
@@ -1406,12 +1410,13 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
                     timelineTimeSeconds: pauseAdjustedHostTimeSeconds(for: time)
                 )
                 recordCaptureMetrics(for: .system, time: time)
+                let systemLevel = buffer.rmsLevel
+                captureHealthMetrics.systemPeakLevel = max(
+                    captureHealthMetrics.systemPeakLevel,
+                    systemLevel
+                )
                 if handling == .recordAndProcess {
-                    latestLevels.system = buffer.rmsLevel
-                    captureHealthMetrics.systemPeakLevel = max(
-                        captureHealthMetrics.systemPeakLevel,
-                        latestLevels.system
-                    )
+                    latestLevels.system = systemLevel
                     updateSystemRms(with: latestLevels.system)
                     if let samples = AudioChunker.extractAndResample(from: buffer) {
                         await ingestResampledSamples(

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingRecordingService.swift
@@ -174,9 +174,6 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
         // after a full meeting means the tap only ever delivered silence.
         var microphonePeakLevel: Float = 0
         var systemPeakLevel: Float = 0
-        // Set for every system buffer that reaches the recording, unlike
-        // `systemFirstBufferSeen`, which needs a valid host time.
-        var systemBufferObserved = false
     }
 
     private struct Session: Sendable {
@@ -1414,7 +1411,6 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
                 )
                 recordCaptureMetrics(for: .system, time: time)
                 let systemLevel = buffer.rmsLevel
-                captureHealthMetrics.systemBufferObserved = true
                 captureHealthMetrics.systemPeakLevel = max(
                     captureHealthMetrics.systemPeakLevel,
                     systemLevel
@@ -1746,16 +1742,19 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
                 asOf: now
             )
         }
+        // A buffer reaching this point has been written, so the source has
+        // produced audio regardless of whether its host time is usable. Only
+        // the host-time metrics below depend on that.
+        switch source {
+        case .microphone:
+            captureHealthMetrics.microphoneFirstBufferSeen = true
+        case .system:
+            captureHealthMetrics.systemFirstBufferSeen = true
+        }
         guard time.isHostTimeValid else { return }
         var metrics = sourceCaptureMetrics[source] ?? SourceCaptureMetrics()
         if metrics.firstHostTime == nil {
             metrics.firstHostTime = time.hostTime
-            switch source {
-            case .microphone:
-                captureHealthMetrics.microphoneFirstBufferSeen = true
-            case .system:
-                captureHealthMetrics.systemFirstBufferSeen = true
-            }
         }
         metrics.lastHostTime = time.hostTime
         sourceCaptureMetrics[source] = metrics
@@ -1973,7 +1972,7 @@ public actor MeetingRecordingService: MeetingRecordingServiceProtocol {
     private var systemAudioSignalVerdict: MeetingSystemAudioSignalVerdict {
         MeetingSystemAudioSignalVerdict.evaluate(
             capturesSystemAudio: captureHealthMetrics.sourceMode?.capturesSystemAudio ?? false,
-            systemBufferObserved: captureHealthMetrics.systemBufferObserved,
+            systemBufferObserved: captureHealthMetrics.systemFirstBufferSeen,
             systemPeakLevel: captureHealthMetrics.systemPeakLevel
         )
     }

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingSystemAudioSignalVerdict.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingSystemAudioSignalVerdict.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// Whether the system-audio tap actually carried any signal during a meeting.
+///
+/// ScreenCaptureKit can keep a healthy-looking stream running while every sample
+/// it hands back is zero. Buffers keep arriving, frames keep being written, and
+/// the stall watchdogs in `SystemAudioStream` stay quiet because they only look
+/// for buffers going *absent*, never for buffers being *empty*. The far side of
+/// the call is lost for the whole meeting and every stop stage still reports
+/// success.
+///
+/// The per-buffer level is already computed on the capture path, so the highest
+/// one seen over a session is enough to tell the two cases apart after the fact.
+public enum MeetingSystemAudioSignalVerdict: String, Sendable, Equatable {
+    /// System audio was not part of this recording, or never produced a buffer.
+    case notCaptured = "not_captured"
+    /// The system track carried signal at some point.
+    case present
+    /// The system track was digital silence from start to finish.
+    case silent
+
+    public static func evaluate(
+        capturesSystemAudio: Bool,
+        systemFirstBufferSeen: Bool,
+        systemPeakLevel: Float
+    ) -> Self {
+        guard capturesSystemAudio, systemFirstBufferSeen else { return .notCaptured }
+        return systemPeakLevel > 0 ? .present : .silent
+    }
+
+    /// A silent system track is only worth warning about when the recording ran
+    /// long enough to be a real meeting and the microphone did carry signal.
+    ///
+    /// Both guards exist to keep quiet about the innocent cases: a few seconds of
+    /// testing, or a session where nothing was audible on either side, is not
+    /// evidence that the tap broke.
+    public static func shouldWarn(
+        verdict: Self,
+        microphonePeakLevel: Float,
+        durationSeconds: TimeInterval,
+        minimumDurationSeconds: TimeInterval = defaultMinimumWarningDurationSeconds
+    ) -> Bool {
+        verdict == .silent
+            && microphonePeakLevel > 0
+            && durationSeconds >= minimumDurationSeconds
+    }
+
+    public static let defaultMinimumWarningDurationSeconds: TimeInterval = 30
+}

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingSystemAudioSignalVerdict.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingSystemAudioSignalVerdict.swift
@@ -19,12 +19,17 @@ public enum MeetingSystemAudioSignalVerdict: String, Sendable, Equatable {
     /// The system track was digital silence from start to finish.
     case silent
 
+    /// - Parameter systemBufferObserved: whether any system buffer reached the
+    ///   recording. Deliberately not `systemFirstBufferSeen`, which is only set
+    ///   for buffers carrying a valid host time; tying the verdict to timestamp
+    ///   validity would report a broken tap as `notCaptured` and swallow the
+    ///   warning this type exists to raise.
     public static func evaluate(
         capturesSystemAudio: Bool,
-        systemFirstBufferSeen: Bool,
+        systemBufferObserved: Bool,
         systemPeakLevel: Float
     ) -> Self {
-        guard capturesSystemAudio, systemFirstBufferSeen else { return .notCaptured }
+        guard capturesSystemAudio, systemBufferObserved else { return .notCaptured }
         return systemPeakLevel > 0 ? .present : .silent
     }
 

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingSystemAudioSignalVerdict.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingSystemAudioSignalVerdict.swift
@@ -20,9 +20,8 @@ public enum MeetingSystemAudioSignalVerdict: String, Sendable, Equatable {
     case silent
 
     /// - Parameter systemBufferObserved: whether any system buffer reached the
-    ///   recording. Deliberately not `systemFirstBufferSeen`, which is only set
-    ///   for buffers carrying a valid host time; tying the verdict to timestamp
-    ///   validity would report a broken tap as `notCaptured` and swallow the
+    ///   recording. This must not be conditioned on host-time validity: a
+    ///   broken tap would then be reported as `notCaptured`, swallowing the
     ///   warning this type exists to raise.
     public static func evaluate(
         capturesSystemAudio: Bool,

--- a/Tests/MacParakeetTests/MeetingRecordingFlow/MeetingSystemAudioSignalVerdictTests.swift
+++ b/Tests/MacParakeetTests/MeetingRecordingFlow/MeetingSystemAudioSignalVerdictTests.swift
@@ -1,0 +1,126 @@
+import XCTest
+
+@testable import MacParakeetCore
+
+final class MeetingSystemAudioSignalVerdictTests: XCTestCase {
+    private typealias Verdict = MeetingSystemAudioSignalVerdict
+
+    // MARK: - evaluate
+
+    func testMicrophoneOnlyRecordingIsNotCaptured() {
+        XCTAssertEqual(
+            Verdict.evaluate(
+                capturesSystemAudio: false,
+                systemFirstBufferSeen: false,
+                systemPeakLevel: 0
+            ),
+            .notCaptured
+        )
+    }
+
+    func testStreamThatNeverDeliveredABufferIsNotCaptured() {
+        XCTAssertEqual(
+            Verdict.evaluate(
+                capturesSystemAudio: true,
+                systemFirstBufferSeen: false,
+                systemPeakLevel: 0
+            ),
+            .notCaptured
+        )
+    }
+
+    func testStreamWithSignalIsPresent() {
+        XCTAssertEqual(
+            Verdict.evaluate(
+                capturesSystemAudio: true,
+                systemFirstBufferSeen: true,
+                systemPeakLevel: 0.42
+            ),
+            .present
+        )
+    }
+
+    func testVeryQuietButNonZeroSignalIsStillPresent() {
+        XCTAssertEqual(
+            Verdict.evaluate(
+                capturesSystemAudio: true,
+                systemFirstBufferSeen: true,
+                systemPeakLevel: .leastNormalMagnitude
+            ),
+            .present
+        )
+    }
+
+    func testStreamThatDeliveredOnlyZeroSamplesIsSilent() {
+        XCTAssertEqual(
+            Verdict.evaluate(
+                capturesSystemAudio: true,
+                systemFirstBufferSeen: true,
+                systemPeakLevel: 0
+            ),
+            .silent
+        )
+    }
+
+    // MARK: - shouldWarn
+
+    func testWarnsOnALongSilentMeetingWhereTheMicrophoneHadSignal() {
+        XCTAssertTrue(
+            Verdict.shouldWarn(
+                verdict: .silent,
+                microphonePeakLevel: 0.3,
+                durationSeconds: 2_400
+            )
+        )
+    }
+
+    func testDoesNotWarnWhenTheSystemTrackHadSignal() {
+        XCTAssertFalse(
+            Verdict.shouldWarn(
+                verdict: .present,
+                microphonePeakLevel: 0.3,
+                durationSeconds: 2_400
+            )
+        )
+    }
+
+    func testDoesNotWarnWhenSystemAudioWasNotPartOfTheRecording() {
+        XCTAssertFalse(
+            Verdict.shouldWarn(
+                verdict: .notCaptured,
+                microphonePeakLevel: 0.3,
+                durationSeconds: 2_400
+            )
+        )
+    }
+
+    func testDoesNotWarnWhenNothingWasAudibleOnEitherSide() {
+        XCTAssertFalse(
+            Verdict.shouldWarn(
+                verdict: .silent,
+                microphonePeakLevel: 0,
+                durationSeconds: 2_400
+            )
+        )
+    }
+
+    func testDoesNotWarnOnAShortClip() {
+        XCTAssertFalse(
+            Verdict.shouldWarn(
+                verdict: .silent,
+                microphonePeakLevel: 0.3,
+                durationSeconds: 5
+            )
+        )
+    }
+
+    func testWarnsExactlyAtTheMinimumDuration() {
+        XCTAssertTrue(
+            Verdict.shouldWarn(
+                verdict: .silent,
+                microphonePeakLevel: 0.3,
+                durationSeconds: Verdict.defaultMinimumWarningDurationSeconds
+            )
+        )
+    }
+}

--- a/Tests/MacParakeetTests/MeetingRecordingFlow/MeetingSystemAudioSignalVerdictTests.swift
+++ b/Tests/MacParakeetTests/MeetingRecordingFlow/MeetingSystemAudioSignalVerdictTests.swift
@@ -11,7 +11,7 @@ final class MeetingSystemAudioSignalVerdictTests: XCTestCase {
         XCTAssertEqual(
             Verdict.evaluate(
                 capturesSystemAudio: false,
-                systemFirstBufferSeen: false,
+                systemBufferObserved: false,
                 systemPeakLevel: 0
             ),
             .notCaptured
@@ -22,7 +22,7 @@ final class MeetingSystemAudioSignalVerdictTests: XCTestCase {
         XCTAssertEqual(
             Verdict.evaluate(
                 capturesSystemAudio: true,
-                systemFirstBufferSeen: false,
+                systemBufferObserved: false,
                 systemPeakLevel: 0
             ),
             .notCaptured
@@ -33,7 +33,7 @@ final class MeetingSystemAudioSignalVerdictTests: XCTestCase {
         XCTAssertEqual(
             Verdict.evaluate(
                 capturesSystemAudio: true,
-                systemFirstBufferSeen: true,
+                systemBufferObserved: true,
                 systemPeakLevel: 0.42
             ),
             .present
@@ -44,7 +44,7 @@ final class MeetingSystemAudioSignalVerdictTests: XCTestCase {
         XCTAssertEqual(
             Verdict.evaluate(
                 capturesSystemAudio: true,
-                systemFirstBufferSeen: true,
+                systemBufferObserved: true,
                 systemPeakLevel: .leastNormalMagnitude
             ),
             .present
@@ -55,7 +55,7 @@ final class MeetingSystemAudioSignalVerdictTests: XCTestCase {
         XCTAssertEqual(
             Verdict.evaluate(
                 capturesSystemAudio: true,
-                systemFirstBufferSeen: true,
+                systemBufferObserved: true,
                 systemPeakLevel: 0
             ),
             .silent


### PR DESCRIPTION
Closes nothing on its own; this is the detection half of #912.

Thanks again for MacParakeet. I hit #912 on my own machine (a 40 minute call
recorded with the far side as pure digital silence) and wanted to contribute
the part I was confident about rather than just report it.

## What this changes

Nothing about capture behavior. Only reporting.

`SystemAudioStream` watches for buffers going *absent*
(`armSilentBufferWatchdogIfRunning`, `checkHeartbeat`). It has no notion of
buffers arriving *empty*, so an all-zero `SCStream` looks perfectly healthy:
first buffer seen, frames written for the full duration, every stop stage
green, `capture_failed=false`. That is how a whole meeting can lose the other
party with no signal anywhere.

The per-buffer level is already computed on the capture path
(`latestLevels.system = buffer.rmsLevel`), so this keeps the highest one seen
per source and turns it into a verdict.

- `meeting_recording_health` gains `mic_peak_level`, `system_peak_level`, and
  `system_signal` (`present` / `silent` / `not_captured`).
- A silent system track logs a distinct `meeting_system_audio_silent` warning
  at stop.

Before, on a failing session of mine:

```
system_first_buffer=true system_frames=23871360 system_chunks_enqueued=0
interrupted_sources=none capture_failed=false
```

After, the same session would also carry `system_peak_level=0.000
system_signal=silent` plus the warning line.

## Keeping it quiet on the innocent cases

Silence is normal, so the warning needs two more things to be true: the
microphone carried signal, and the recording ran at least 30 seconds. A short
test clip, or a session where nothing was audible on either side, does not
trip it. `MeetingSystemAudioSignalVerdict.shouldWarn` is where that lives, and
the threshold is injectable for tests.

Exact zero is the trigger rather than a floor, deliberately. A real tap on a
quiet call still returns tiny nonzero values; only a broken tap returns
literal zeros for an entire meeting. There is a test pinning that
(`testVeryQuietButNonZeroSignalIsStillPresent`).

## Deliberately not in this PR

Two things from #912 that felt like your call, not mine:

1. **Surfacing it in the UI.** Right now the user still has to read the log.
   Happy to add this if you tell me where it belongs.
2. **Mid-meeting recovery.** `MeetingAudioCaptureService` already treats
   `.systemAudioStalled` as recoverable and rebuilds the stream with backoff,
   so a new `MeetingSystemAudioStall` case would plug straight in. I did not
   do it because I could not find a safe mid-call trigger: a genuinely quiet
   stretch is indistinguishable from a dead tap from inside the tap, and I did
   not want to churn streams during real meetings. Detection first seemed like
   the honest order.

## Testing

Full suite run locally against Xcode 26.6, this branch and `upstream/main`
back to back on the same machine:

| | tests | skipped | failures |
|---|---|---|---|
| `upstream/main` @ 5f745a1 | 5106 | 20 | 0 |
| this branch | 5117 | 20 | 0 |

The 11 extra tests are the ones this PR adds
(`MeetingSystemAudioSignalVerdictTests`). Nothing regressed.

## Root cause, still open

This PR does not explain *why* the tap goes to zeros. What I know from my own
machine, in case it helps:

- Screen recording permission was granted the whole time.
- A standalone SCK probe with the same configuration captured real audio on
  the same machine minutes after a failure, so the OS side was healthy.
- Three good recordings and three silent ones came from one app process that
  had been running seven days. Quitting and relaunching the app fixed it.
- Not display sleep: ten display sleeps happened between two runs that both
  captured fine.
- Single built-in display, no virtual displays, output device unchanged
  throughout.

Suggests the `SCStream` (or something it holds) goes bad inside a long-lived
process. Happy to dig further if that is useful to you.
