### PR TITLE
core: centralize bundle-id-aware UserDefaults resolution in AppPaths

### DIFF
--- a/Sources/CLI/Commands/CLIHelpers.swift
+++ b/Sources/CLI/Commands/CLIHelpers.swift
@@ -10,15 +10,13 @@ struct CLIJSONEnvelopeExit: Error {
     let originalError: Error
 }
 
+/// CLI-local alias for `AppPaths.appDefaults(bundleIdentifier:)`, kept so the
+/// existing call sites across `Sources/CLI/Commands/` don't need to name
+/// the `AppPaths` type at every use.
 func macParakeetAppDefaults(
     bundleIdentifier: String? = Bundle.main.bundleIdentifier
 ) -> UserDefaults {
-    // The bundled CLI already inherits the app's defaults domain. Reopening it
-    // as a named suite makes Foundation emit a nonsensical-suite warning.
-    if bundleIdentifier == AppPaths.preferencesSuiteName {
-        return .standard
-    }
-    return AppPaths.sharedAppDefaults()
+    AppPaths.appDefaults(bundleIdentifier: bundleIdentifier)
 }
 
 func validateCLISpeechEngineMemoryRequirement(

--- a/Sources/MacParakeetCore/Services/AppPaths.swift
+++ b/Sources/MacParakeetCore/Services/AppPaths.swift
@@ -82,8 +82,32 @@ public enum AppPaths {
         return defaultMeetingRecordingsDir(environment: environment)
     }
 
+    /// Opens the named suite (falling back to `.standard` when the suite
+    /// cannot be created), regardless of which process calls it. A
+    /// process whose own bundle identifier equals `preferencesSuiteName`
+    /// (the app itself, or a helper embedded in its bundle) reopening that
+    /// domain as a named suite makes Foundation log a nonsensical-suite
+    /// warning to stderr; such callers should read `appDefaults(bundleIdentifier:)`
+    /// instead, which avoids that self-reopen.
     public static func sharedAppDefaults() -> UserDefaults {
         UserDefaults(suiteName: preferencesSuiteName) ?? .standard
+    }
+
+    /// Resolves the MacParakeet preferences domain the way a caller safely
+    /// can from any process: `.standard` when the current process's own
+    /// bundle identifier already is `preferencesSuiteName` (the running app,
+    /// or an executable embedded in its `.app` bundle — both already read
+    /// and write that domain as their own `.standard` defaults), and the
+    /// named suite otherwise (a standalone binary such as the Homebrew CLI,
+    /// whose own domain differs from the app's and therefore needs to open
+    /// it explicitly to share preferences with the app).
+    public static func appDefaults(
+        bundleIdentifier: String? = Bundle.main.bundleIdentifier
+    ) -> UserDefaults {
+        if bundleIdentifier == preferencesSuiteName {
+            return .standard
+        }
+        return sharedAppDefaults()
     }
 
     public static func normalizedMeetingArtifactsFolder(_ value: String) -> String? {

--- a/Tests/MacParakeetTests/Services/AppPathsTests.swift
+++ b/Tests/MacParakeetTests/Services/AppPathsTests.swift
@@ -161,31 +161,22 @@ final class AppPathsTests: XCTestCase {
         )
     }
 
+    // The two shared-suite cases assert branch selection by identity rather
+    // than writing through the suite: the resolved object not being
+    // `.standard` distinguishes the named-suite branch, and these tests
+    // therefore leave the real preferences domain untouched. Write-through
+    // behavior of the shared suite is covered by the standalone-CLI test in
+    // `CLIHelpersTests`.
     func testAppDefaultsReturnsSharedSuiteWhenBundleIdentifierIsNil() {
-        let key = "AppPathsTests.appDefaults.nilBundle.\(UUID().uuidString)"
-        let value = UUID().uuidString
-        let resolved = AppPaths.appDefaults(bundleIdentifier: nil)
-        let shared = AppPaths.sharedAppDefaults()
-        defer {
-            shared.removeObject(forKey: key)
-        }
-
-        resolved.set(value, forKey: key)
-
-        XCTAssertEqual(shared.string(forKey: key), value)
+        XCTAssertFalse(
+            AppPaths.appDefaults(bundleIdentifier: nil) === UserDefaults.standard
+        )
     }
 
     func testAppDefaultsReturnsSharedSuiteForUnrelatedBundleIdentifier() {
-        let key = "AppPathsTests.appDefaults.otherBundle.\(UUID().uuidString)"
-        let value = UUID().uuidString
-        let resolved = AppPaths.appDefaults(bundleIdentifier: "com.macparakeet.tests.other")
-        let shared = AppPaths.sharedAppDefaults()
-        defer {
-            shared.removeObject(forKey: key)
-        }
-
-        resolved.set(value, forKey: key)
-
-        XCTAssertEqual(shared.string(forKey: key), value)
+        XCTAssertFalse(
+            AppPaths.appDefaults(bundleIdentifier: "com.macparakeet.tests.other")
+                === UserDefaults.standard
+        )
     }
 }

--- a/Tests/MacParakeetTests/Services/AppPathsTests.swift
+++ b/Tests/MacParakeetTests/Services/AppPathsTests.swift
@@ -151,4 +151,41 @@ final class AppPathsTests: XCTestCase {
         // (it may create real dirs, but those are expected app directories)
         try AppPaths.ensureDirectories()
     }
+
+    // MARK: - appDefaults(bundleIdentifier:)
+
+    func testAppDefaultsReturnsStandardWhenBundleIdentifierMatchesSuite() {
+        XCTAssertTrue(
+            AppPaths.appDefaults(bundleIdentifier: AppPaths.preferencesSuiteName)
+                === UserDefaults.standard
+        )
+    }
+
+    func testAppDefaultsReturnsSharedSuiteWhenBundleIdentifierIsNil() {
+        let key = "AppPathsTests.appDefaults.nilBundle.\(UUID().uuidString)"
+        let value = UUID().uuidString
+        let resolved = AppPaths.appDefaults(bundleIdentifier: nil)
+        let shared = AppPaths.sharedAppDefaults()
+        defer {
+            shared.removeObject(forKey: key)
+        }
+
+        resolved.set(value, forKey: key)
+
+        XCTAssertEqual(shared.string(forKey: key), value)
+    }
+
+    func testAppDefaultsReturnsSharedSuiteForUnrelatedBundleIdentifier() {
+        let key = "AppPathsTests.appDefaults.otherBundle.\(UUID().uuidString)"
+        let value = UUID().uuidString
+        let resolved = AppPaths.appDefaults(bundleIdentifier: "com.macparakeet.tests.other")
+        let shared = AppPaths.sharedAppDefaults()
+        defer {
+            shared.removeObject(forKey: key)
+        }
+
+        resolved.set(value, forKey: key)
+
+        XCTAssertEqual(shared.string(forKey: key), value)
+    }
 }

--- a/Tests/MacParakeetTests/Services/AppPathsTests.swift
+++ b/Tests/MacParakeetTests/Services/AppPathsTests.swift
@@ -161,22 +161,40 @@ final class AppPathsTests: XCTestCase {
         )
     }
 
-    // The two shared-suite cases assert branch selection by identity rather
-    // than writing through the suite: the resolved object not being
-    // `.standard` distinguishes the named-suite branch, and these tests
-    // therefore leave the real preferences domain untouched. Write-through
-    // behavior of the shared suite is covered by the standalone-CLI test in
-    // `CLIHelpersTests`.
+    // The two shared-suite cases verify the resolved instance against
+    // `sharedAppDefaults()` by writing through it, which targets the real
+    // `com.macparakeet.MacParakeet` domain: that is the only way to observe
+    // which suite an opaque `UserDefaults` wraps. The keys carry the
+    // `macparakeet.tests.` prefix so any leftover from a killed test run is
+    // identifiable, and the `defer` cleanup does not run on SIGKILL/abort.
+    private func assertResolvesToSharedSuite(
+        _ resolved: UserDefaults,
+        _ message: String
+    ) {
+        let key = "macparakeet.tests.AppPathsTests.\(UUID().uuidString)"
+        let value = UUID().uuidString
+        let shared = AppPaths.sharedAppDefaults()
+        defer {
+            shared.removeObject(forKey: key)
+        }
+
+        resolved.set(value, forKey: key)
+
+        XCTAssertFalse(resolved === UserDefaults.standard, message)
+        XCTAssertEqual(shared.string(forKey: key), value, message)
+    }
+
     func testAppDefaultsReturnsSharedSuiteWhenBundleIdentifierIsNil() {
-        XCTAssertFalse(
-            AppPaths.appDefaults(bundleIdentifier: nil) === UserDefaults.standard
+        assertResolvesToSharedSuite(
+            AppPaths.appDefaults(bundleIdentifier: nil),
+            "nil bundle identifier resolves to the shared suite"
         )
     }
 
     func testAppDefaultsReturnsSharedSuiteForUnrelatedBundleIdentifier() {
-        XCTAssertFalse(
-            AppPaths.appDefaults(bundleIdentifier: "com.macparakeet.tests.other")
-                === UserDefaults.standard
+        assertResolvesToSharedSuite(
+            AppPaths.appDefaults(bundleIdentifier: "com.macparakeet.tests.other"),
+            "unrelated bundle identifier resolves to the shared suite"
         )
     }
 }


### PR DESCRIPTION
Follow-up to #825.

While preparing a fix for the stderr warning reported there, I found it no longer reproduces: c1ef0c80 (CLI 3.1.0) already guards the bundled case in `macParakeetAppDefaults()`. I verified with a bundled-layout harness (the CLI binary placed in an app-bundle skeleton whose `CFBundleIdentifier` is `com.macparakeet.MacParakeet`, matching `scripts/dist/build_app_bundle.sh`), running `health --json` and `config get`/`set`. Current main prints nothing to stderr; reverting the guard reproduces the exact warning from the issue. So #825 looks fixed since CLI 3.1.0 and can probably just be closed.

This PR keeps the verification and moves the guard where it can't be missed:

- `AppPaths.appDefaults(bundleIdentifier:)` is now the canonical accessor for the shared preferences domain, next to `preferencesSuiteName` in Core. It returns `.standard` when the caller's own bundle identifier equals the suite name, and the named suite otherwise.
- The CLI's `macParakeetAppDefaults()` delegates to it instead of carrying its own copy of the check, so the ~30 CLI call sites are unchanged.
- Three new tests in `AppPathsTests` pin the bundled, standalone (nil bundle id), and foreign-bundle-id cases, with the suite domains cleaned up in teardown.

No behavior change for the app or the standalone CLI; the bundled CLI keeps the no-warning behavior it has had since 3.1.0, now regression-tested.

CLITests (484) and AppPathsTests (18) pass, and the full suite was run once before submission.

Drafted with AI assistance (Claude); the diff was human-reviewed and verified locally with the full suite before submission.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes bundle-ID-aware `UserDefaults` resolution in `AppPaths` to avoid Foundation’s “nonsensical suite” stderr warning in bundled layouts. The CLI’s local guard is replaced by `AppPaths.appDefaults(bundleIdentifier:)`; behavior is unchanged for the app, standalone CLI, and bundled CLI.

- Add `AppPaths.appDefaults(bundleIdentifier:)`: returns `.standard` when the caller’s bundle ID equals `preferencesSuiteName`, otherwise opens the shared suite via `sharedAppDefaults()`.
- Keep `sharedAppDefaults()` behavior and document that callers should prefer `appDefaults(bundleIdentifier:)`.
- Update `macParakeetAppDefaults(...)` to delegate to `AppPaths.appDefaults(...)`, leaving CLI call sites unchanged.
- Tests: cover bundled, nil bundle ID, and foreign bundle ID cases; verify the shared-suite branch by writing through the resolved instance and reading back via `sharedAppDefaults()`, using `macparakeet.tests.`-prefixed keys and cleaning them up in `defer`.

<sup>Written for commit ac49433a34dc9b7072e59ddba0dfb54ac4be6bc6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/918?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved preference selection across the main app, embedded helpers, and standalone processes.
  - Matching application identifiers now use standard preferences, while other contexts consistently use shared preferences.
  - Preference values are now resolved more reliably across supported application contexts.

- **Tests**
  - Added coverage for matching, missing, and unrelated application identifiers.
  - Verified consistent shared-preference suite selection across supported contexts.
  - Added cleanup and validation for shared preference values during testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->