### PR TITLE
Fix Transcription view freeze when scrolling down, then scrolling up

### DIFF
--- a/Sources/MacParakeet/Views/Transcription/TranscriptBodyLayout.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptBodyLayout.swift
@@ -16,8 +16,11 @@ enum TranscriptBodyLayout {
     /// The #845 reporter case was 964 rows; typical meetings are far smaller.
     static let nonLazyRowLimit = 400
 
-    static func usesLazyStack(rowCount: Int) -> Bool {
-        if let override = debugOverride(named: "MACPARAKEET_DEBUG_TRANSCRIPT_LAZY") {
+    static func usesLazyStack(
+        rowCount: Int,
+        environment: [String: String] = launchEnvironment
+    ) -> Bool {
+        if let override = debugOverride(named: "MACPARAKEET_DEBUG_TRANSCRIPT_LAZY", environment: environment) {
             return override
         }
         return rowCount > nonLazyRowLimit
@@ -26,8 +29,12 @@ enum TranscriptBodyLayout {
     /// Per-row `.textSelection(.enabled)` in the timed view. On by default; the
     /// DEBUG override exists so the platform-overlay contribution to the freeze
     /// can be bisected at launch without a rebuild.
+    static func rowTextSelectionEnabled(environment: [String: String] = launchEnvironment) -> Bool {
+        debugOverride(named: "MACPARAKEET_DEBUG_TRANSCRIPT_SELECTION", environment: environment) ?? true
+    }
+
     static var rowTextSelectionEnabled: Bool {
-        debugOverride(named: "MACPARAKEET_DEBUG_TRANSCRIPT_SELECTION") ?? true
+        rowTextSelectionEnabled(environment: launchEnvironment)
     }
 
     /// Read once: the launch environment never changes, and these lookups run

--- a/Sources/MacParakeet/Views/Transcription/TranscriptBodyLayout.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptBodyLayout.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// Decides how the timed transcript body is laid out.
+///
+/// The Library "freeze at 100% CPU" bug (macOS 26) is a self-feeding SwiftUI
+/// update loop between a `LazyVStack`'s view cache (item phase mutations and
+/// estimate measurement re-instantiating rows) and the per-row text-selection
+/// platform overlays those rows carry, kept alive by hover re-dispatch after
+/// every update. It appears after scrolling down and back up, when realized
+/// row heights differ from the lazy estimates. A plain `VStack` has no view
+/// cache, so small transcripts, which gain nothing from laziness, render
+/// non-lazily. Very long transcripts keep the lazy stack so one card cannot
+/// become an unbounded subtree (issue #845 / #848).
+enum TranscriptBodyLayout {
+    /// Largest transcript (total timed rows) rendered without a lazy stack.
+    /// The #845 reporter case was 964 rows; typical meetings are far smaller.
+    static let nonLazyRowLimit = 400
+
+    static func usesLazyStack(rowCount: Int) -> Bool {
+        if let override = debugOverride(named: "MACPARAKEET_DEBUG_TRANSCRIPT_LAZY") {
+            return override
+        }
+        return rowCount > nonLazyRowLimit
+    }
+
+    /// Per-row `.textSelection(.enabled)` in the timed view. On by default; the
+    /// DEBUG override exists so the platform-overlay contribution to the freeze
+    /// can be bisected at launch without a rebuild.
+    static var rowTextSelectionEnabled: Bool {
+        debugOverride(named: "MACPARAKEET_DEBUG_TRANSCRIPT_SELECTION") ?? true
+    }
+
+    /// Read once: the launch environment never changes, and these lookups run
+    /// from SwiftUI `body`, so rebuilding the dictionary per pass is waste.
+    private static let launchEnvironment = ProcessInfo.processInfo.environment
+
+    /// DEBUG-only launch overrides, e.g.
+    /// `open MacParakeet-Dev.app --env MACPARAKEET_DEBUG_TRANSCRIPT_LAZY=0`.
+    /// Values `1`/`true`/`yes` enable, `0`/`false`/`no` disable; anything else
+    /// (or a release build) leaves the product default in place.
+    static func debugOverride(
+        named name: String,
+        environment: [String: String] = launchEnvironment
+    ) -> Bool? {
+        #if DEBUG
+        guard let raw = environment[name]?.lowercased() else { return nil }
+        switch raw {
+        case "1", "true", "yes": return true
+        case "0", "false", "no": return false
+        default: return nil
+        }
+        #else
+        return nil
+        #endif
+    }
+}

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
@@ -229,6 +229,8 @@ struct TranscriptResultView: View {
     @State private var lastScrolledSegmentMs: Int = -1
     // Cached transcript data — recomputed only when transcription.id changes, not on every playback tick
     @State private var cachedSegments: [TranscriptSegment] = []
+    /// Total timed rows (cards' segments or flat segments); drives the lazy/non-lazy choice.
+    @State private var cachedTranscriptRowCount = 0
     @State private var cachedIdentifiedTurnCards: [IdentifiedSpeakerTurn] = []
     @State private var cachedHasSpeakers: Bool = false
     @State private var cachedSpeakerColorMap: [String: Color] = [:]
@@ -1252,6 +1254,23 @@ struct TranscriptResultView: View {
         .padding(DesignSystem.Spacing.lg)
     }
 
+    /// Small transcripts render in a plain `VStack`; only very long ones use a
+    /// `LazyVStack`. See `TranscriptBodyLayout` for the freeze this avoids.
+    private var transcriptBodyUsesLazyStack: Bool {
+        TranscriptBodyLayout.usesLazyStack(rowCount: cachedTranscriptRowCount)
+    }
+
+    @ViewBuilder
+    private func transcriptBodyStack<Content: View>(
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        if transcriptBodyUsesLazyStack {
+            LazyVStack(alignment: .leading, spacing: DesignSystem.Spacing.md, content: content)
+        } else {
+            VStack(alignment: .leading, spacing: DesignSystem.Spacing.md, content: content)
+        }
+    }
+
     private var transcriptPane: some View {
         VStack(spacing: 0) {
             if findBarVisible {
@@ -1259,7 +1278,7 @@ struct TranscriptResultView: View {
             }
             ScrollViewReader { proxy in
             ScrollView {
-                LazyVStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
+                transcriptBodyStack {
                     transcriptPaneHeader
 
                     if let partialCapture = MeetingPartialCapturePresentation.make(for: activeTranscription) {
@@ -3090,7 +3109,8 @@ struct TranscriptResultView: View {
             },
             bodyFont: scaledTranscriptFont,
             highlightRangesByStartMs: highlights,
-            currentHighlight: current
+            currentHighlight: current,
+            textSelectionEnabled: TranscriptBodyLayout.rowTextSelectionEnabled
         )
     }
 
@@ -3287,6 +3307,7 @@ struct TranscriptResultView: View {
     private func rebuildSegmentCache() {
         guard let words = activeTranscription.wordTimestamps, !words.isEmpty else {
             cachedSegments = []
+            cachedTranscriptRowCount = 0
             cachedIdentifiedTurnCards = []
             cachedHasSpeakers = false
             cachedSpeakerColorMap = [:]
@@ -3313,8 +3334,10 @@ struct TranscriptResultView: View {
                 }
             )
             cachedIdentifiedTurnCards = identifiedSpeakerTurnCards(turns)
+            cachedTranscriptRowCount = cachedIdentifiedTurnCards.reduce(0) { $0 + $1.turn.segments.count }
         } else {
             cachedIdentifiedTurnCards = []
+            cachedTranscriptRowCount = segments.count
         }
     }
 

--- a/Sources/MacParakeet/Views/Transcription/TranscriptTimestampedContentView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptTimestampedContentView.swift
@@ -382,7 +382,8 @@ private struct TranscriptSegmentRow: View {
 
     @ViewBuilder
     private var bodyText: some View {
-        let styled = bodyTextCore
+        let styled =
+            bodyTextCore
             .foregroundStyle(DesignSystem.Colors.textPrimary)
             .lineSpacing(5)
         if textSelectionEnabled {
@@ -398,12 +399,13 @@ private struct TranscriptSegmentRow: View {
         guard !highlightRanges.isEmpty else {
             return Text(text).font(bodyFont)
         }
-        return Text(TranscriptFindHighlight.attributed(
-            text,
-            ranges: highlightRanges,
-            current: currentRange,
-            baseFont: bodyFont
-        ))
+        return Text(
+            TranscriptFindHighlight.attributed(
+                text,
+                ranges: highlightRanges,
+                current: currentRange,
+                baseFont: bodyFont
+            ))
     }
 
     private var hoverActions: some View {

--- a/Sources/MacParakeet/Views/Transcription/TranscriptTimestampedContentView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptTimestampedContentView.swift
@@ -151,6 +151,10 @@ struct TranscriptTimestampedContentView<SpeakerLabelContent: View>: View {
     var highlightRangesByStartMs: [Int: [NSRange]] = [:]
     /// The single emphasized ("current") match, identified by its row `startMs`.
     var currentHighlight: (id: Int, range: NSRange)?
+    /// Per-row `.textSelection(.enabled)`. Each selectable `Text` is an AppKit
+    /// platform overlay; `TranscriptBodyLayout.rowTextSelectionEnabled` lets a
+    /// DEBUG launch turn them off to bisect the transcript freeze.
+    var textSelectionEnabled: Bool = true
 
     var body: some View {
         if hasSpeakers {
@@ -175,7 +179,8 @@ struct TranscriptTimestampedContentView<SpeakerLabelContent: View>: View {
                     bodyFont: bodyFont,
                     highlightRangesByStartMs: highlightRangesByStartMs,
                     currentHighlight: currentHighlight,
-                    onTimestampTap: onTimestampTap
+                    onTimestampTap: onTimestampTap,
+                    textSelectionEnabled: textSelectionEnabled
                 )
                 // Preserve the existing first-segment/card scroll target while
                 // later rows expose their own anchors for mid-turn find results.
@@ -197,7 +202,8 @@ struct TranscriptTimestampedContentView<SpeakerLabelContent: View>: View {
                         showRowBackground: true,
                         highlightRanges: highlightRangesByStartMs[segment.startMs] ?? [],
                         currentRange: currentHighlight?.id == segment.startMs ? currentHighlight?.range : nil,
-                        onPlayFromHere: { onTimestampTap(segment.startMs) }
+                        onPlayFromHere: { onTimestampTap(segment.startMs) },
+                        textSelectionEnabled: textSelectionEnabled
                     )
                 }
             }
@@ -225,6 +231,7 @@ private struct TranscriptTurnCardView<SpeakerLabelContent: View>: View {
     var highlightRangesByStartMs: [Int: [NSRange]] = [:]
     var currentHighlight: (id: Int, range: NSRange)?
     let onTimestampTap: (Int) -> Void
+    var textSelectionEnabled: Bool = true
 
     @State private var isHovering = false
 
@@ -282,7 +289,8 @@ private struct TranscriptTurnCardView<SpeakerLabelContent: View>: View {
             showRowBackground: false,
             highlightRanges: highlightRangesByStartMs[segment.startMs] ?? [],
             currentRange: currentHighlight?.id == segment.startMs ? currentHighlight?.range : nil,
-            onPlayFromHere: { onTimestampTap(segment.startMs) }
+            onPlayFromHere: { onTimestampTap(segment.startMs) },
+            textSelectionEnabled: textSelectionEnabled
         )
         if index == 0 {
             row
@@ -334,6 +342,7 @@ private struct TranscriptSegmentRow: View {
     /// The emphasized match within this row, if the find cursor is on it.
     var currentRange: NSRange?
     let onPlayFromHere: () -> Void
+    var textSelectionEnabled: Bool = true
 
     @State private var isHovering = false
 
@@ -346,10 +355,7 @@ private struct TranscriptSegmentRow: View {
                 onTap: { _ in onPlayFromHere() }
             )
 
-            bodyTextCore
-                .foregroundStyle(DesignSystem.Colors.textPrimary)
-                .textSelection(.enabled)
-                .lineSpacing(5)
+            bodyText
                 .frame(maxWidth: .infinity, alignment: .leading)
         }
         .padding(showRowBackground ? DesignSystem.Spacing.md : 0)
@@ -371,6 +377,18 @@ private struct TranscriptSegmentRow: View {
             withAnimation(DesignSystem.Animation.hoverTransition) {
                 isHovering = hovering
             }
+        }
+    }
+
+    @ViewBuilder
+    private var bodyText: some View {
+        let styled = bodyTextCore
+            .foregroundStyle(DesignSystem.Colors.textPrimary)
+            .lineSpacing(5)
+        if textSelectionEnabled {
+            styled.textSelection(.enabled)
+        } else {
+            styled.textSelection(.disabled)
         }
     }
 

--- a/Tests/MacParakeetTests/Views/TranscriptBodyLayoutTests.swift
+++ b/Tests/MacParakeetTests/Views/TranscriptBodyLayoutTests.swift
@@ -6,19 +6,23 @@ import XCTest
 final class TranscriptBodyLayoutTests: XCTestCase {
 
     func testSmallTranscriptsRenderNonLazily() {
-        XCTAssertFalse(TranscriptBodyLayout.usesLazyStack(rowCount: 0))
-        XCTAssertFalse(TranscriptBodyLayout.usesLazyStack(rowCount: 12))
-        XCTAssertFalse(TranscriptBodyLayout.usesLazyStack(rowCount: TranscriptBodyLayout.nonLazyRowLimit))
+        XCTAssertFalse(TranscriptBodyLayout.usesLazyStack(rowCount: 0, environment: [:]))
+        XCTAssertFalse(TranscriptBodyLayout.usesLazyStack(rowCount: 12, environment: [:]))
+        XCTAssertFalse(
+            TranscriptBodyLayout.usesLazyStack(rowCount: TranscriptBodyLayout.nonLazyRowLimit, environment: [:])
+        )
     }
 
     func testReporterScaleTranscriptsStayLazy() {
         // Issue #845: 11,563 words, about 964 segments.
-        XCTAssertTrue(TranscriptBodyLayout.usesLazyStack(rowCount: TranscriptBodyLayout.nonLazyRowLimit + 1))
-        XCTAssertTrue(TranscriptBodyLayout.usesLazyStack(rowCount: 964))
+        XCTAssertTrue(
+            TranscriptBodyLayout.usesLazyStack(rowCount: TranscriptBodyLayout.nonLazyRowLimit + 1, environment: [:])
+        )
+        XCTAssertTrue(TranscriptBodyLayout.usesLazyStack(rowCount: 964, environment: [:]))
     }
 
     func testRowTextSelectionIsOnByDefault() {
-        XCTAssertTrue(TranscriptBodyLayout.rowTextSelectionEnabled)
+        XCTAssertTrue(TranscriptBodyLayout.rowTextSelectionEnabled(environment: [:]))
     }
 
     func testDebugOverrideParsing() {

--- a/Tests/MacParakeetTests/Views/TranscriptBodyLayoutTests.swift
+++ b/Tests/MacParakeetTests/Views/TranscriptBodyLayoutTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+@testable import MacParakeet
+
+/// Guards the lazy/non-lazy decision for the timed transcript body and the
+/// DEBUG launch overrides used to bisect the transcript freeze.
+final class TranscriptBodyLayoutTests: XCTestCase {
+
+    func testSmallTranscriptsRenderNonLazily() {
+        XCTAssertFalse(TranscriptBodyLayout.usesLazyStack(rowCount: 0))
+        XCTAssertFalse(TranscriptBodyLayout.usesLazyStack(rowCount: 12))
+        XCTAssertFalse(TranscriptBodyLayout.usesLazyStack(rowCount: TranscriptBodyLayout.nonLazyRowLimit))
+    }
+
+    func testReporterScaleTranscriptsStayLazy() {
+        // Issue #845: 11,563 words, about 964 segments.
+        XCTAssertTrue(TranscriptBodyLayout.usesLazyStack(rowCount: TranscriptBodyLayout.nonLazyRowLimit + 1))
+        XCTAssertTrue(TranscriptBodyLayout.usesLazyStack(rowCount: 964))
+    }
+
+    func testRowTextSelectionIsOnByDefault() {
+        XCTAssertTrue(TranscriptBodyLayout.rowTextSelectionEnabled)
+    }
+
+    func testDebugOverrideParsing() {
+        let name = "MACPARAKEET_DEBUG_TRANSCRIPT_LAZY"
+        #if DEBUG
+        XCTAssertEqual(TranscriptBodyLayout.debugOverride(named: name, environment: [name: "1"]), true)
+        XCTAssertEqual(TranscriptBodyLayout.debugOverride(named: name, environment: [name: "YES"]), true)
+        XCTAssertEqual(TranscriptBodyLayout.debugOverride(named: name, environment: [name: "0"]), false)
+        XCTAssertEqual(TranscriptBodyLayout.debugOverride(named: name, environment: [name: "false"]), false)
+        XCTAssertNil(TranscriptBodyLayout.debugOverride(named: name, environment: [name: "maybe"]))
+        #else
+        XCTAssertNil(TranscriptBodyLayout.debugOverride(named: name, environment: [name: "1"]))
+        #endif
+        XCTAssertNil(TranscriptBodyLayout.debugOverride(named: name, environment: [:]))
+    }
+}

--- a/Tests/MacParakeetTests/Views/TranscriptTimestampedLayoutSmokeTests.swift
+++ b/Tests/MacParakeetTests/Views/TranscriptTimestampedLayoutSmokeTests.swift
@@ -88,7 +88,7 @@ final class TranscriptTimestampedLayoutSmokeTests: XCTestCase {
         let content = ScrollViewReader { _ in
             ScrollView {
                 Group {
-                    if TranscriptBodyLayout.usesLazyStack(rowCount: rowCount) {
+                    if TranscriptBodyLayout.usesLazyStack(rowCount: rowCount, environment: [:]) {
                         LazyVStack(alignment: .leading, spacing: DesignSystem.Spacing.md) { body }
                     } else {
                         VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) { body }
@@ -194,7 +194,10 @@ final class TranscriptTimestampedLayoutSmokeTests: XCTestCase {
         let segments = segments(count: TranscriptBodyLayout.nonLazyRowLimit, speakers: ["S1", "S2"])
         let cards = cards(for: segments)
         XCTAssertFalse(
-            TranscriptBodyLayout.usesLazyStack(rowCount: cards.reduce(0) { $0 + $1.turn.segments.count })
+            TranscriptBodyLayout.usesLazyStack(
+                rowCount: cards.reduce(0) { $0 + $1.turn.segments.count },
+                environment: [:]
+            )
         )
         let view = host(hasSpeakers: true, cards: cards, segments: [])
 
@@ -207,7 +210,10 @@ final class TranscriptTimestampedLayoutSmokeTests: XCTestCase {
         let segments = segments(count: 964, speakers: ["S1"])
         let cards = cards(for: segments)
         XCTAssertTrue(
-            TranscriptBodyLayout.usesLazyStack(rowCount: cards.reduce(0) { $0 + $1.turn.segments.count })
+            TranscriptBodyLayout.usesLazyStack(
+                rowCount: cards.reduce(0) { $0 + $1.turn.segments.count },
+                environment: [:]
+            )
         )
         let view = host(hasSpeakers: true, cards: cards, segments: [])
 

--- a/Tests/MacParakeetTests/Views/TranscriptTimestampedLayoutSmokeTests.swift
+++ b/Tests/MacParakeetTests/Views/TranscriptTimestampedLayoutSmokeTests.swift
@@ -1,0 +1,216 @@
+import AppKit
+import SwiftUI
+import XCTest
+import MacParakeetCore
+@testable import MacParakeet
+
+/// Offscreen layout smoke tests for the timed transcript surface.
+///
+/// The Library "freeze at 100% CPU" bug was a SwiftUI update loop in the
+/// transcript body (see `TranscriptBodyLayout`), so the guard here is not a
+/// pixel check but a settling check: hosting the real
+/// `TranscriptTimestampedContentView` inside the same container the detail
+/// view uses must finish its first layout within a generous budget, survive a
+/// programmatic scroll to the bottom and back, and leave the run loop quiet.
+/// Hover from a real pointer cannot be simulated offscreen; that stays a
+/// manual check.
+@MainActor
+final class TranscriptTimestampedLayoutSmokeTests: XCTestCase {
+
+    private final class CountingHostingView<Content: View>: NSHostingView<Content> {
+        var layoutCount = 0
+
+        override func layout() {
+            layoutCount += 1
+            super.layout()
+        }
+    }
+
+    /// Hard ceiling before the whole process is aborted: a livelocked main
+    /// thread never returns to XCTest, so a plain assertion could not fire.
+    /// Generous on purpose (the tests take ~2 s each) so a slow CI box cannot
+    /// trip it; a hang would otherwise block the suite forever.
+    private let watchdogSeconds: Double = 120
+    private let firstLayoutBudgetSeconds: Double = 10
+
+    private func segments(count: Int, speakers: [String?]) -> [TranscriptSegment] {
+        let words = [
+            "one", "quarterly", "review", "dashboard", "metrics",
+            "agenda", "welcome", "everyone", "today", "product",
+        ]
+        return (0..<count).map { index in
+            // Vary row heights so realized sizes differ from lazy estimates.
+            let length = [1, 12, 40, 70][index % 4]
+            let text = (0..<length).map { words[$0 % words.count] }.joined(separator: " ") + "."
+            return TranscriptSegment(
+                startMs: index * 3_500,
+                text: text,
+                speakerId: speakers[index % speakers.count]
+            )
+        }
+    }
+
+    private func cards(for segments: [TranscriptSegment]) -> [IdentifiedSpeakerTurn] {
+        let turns = TranscriptSegmenter.groupIntoSpeakerTurns(
+            segments: segments,
+            speakerLabelProvider: { $0.map { "Speaker \($0)" } ?? "Unknown" }
+        )
+        return identifiedSpeakerTurnCards(turns)
+    }
+
+    private func timestampLabel(ms: Int) -> String {
+        let totalSeconds = ms / 1000
+        return String(format: "%02d:%02d", totalSeconds / 60, totalSeconds % 60)
+    }
+
+    /// Mirrors `TranscriptResultView.transcriptPane`: the lazy/non-lazy choice
+    /// comes from the same decision the product uses.
+    private func host(
+        hasSpeakers: Bool,
+        cards: [IdentifiedSpeakerTurn],
+        segments: [TranscriptSegment]
+    ) -> CountingHostingView<AnyView> {
+        let rowCount = hasSpeakers ? cards.reduce(0) { $0 + $1.turn.segments.count } : segments.count
+        let body = TranscriptTimestampedContentView(
+            hasSpeakers: hasSpeakers,
+            identifiedTurnCards: cards,
+            segments: segments,
+            speakerColorMap: ["S1": .blue, "S2": .green],
+            speakerLabelForID: { "Speaker \($0)" },
+            speakerLabelContent: { _, label, color, _, _ in
+                Text(label).foregroundStyle(color)
+            },
+            isSegmentActive: { $0 == 1 },
+            timestampLabel: { self.timestampLabel(ms: $0) },
+            isTimestampSeekable: true,
+            onTimestampTap: { _ in }
+        )
+        let content = ScrollViewReader { _ in
+            ScrollView {
+                Group {
+                    if TranscriptBodyLayout.usesLazyStack(rowCount: rowCount) {
+                        LazyVStack(alignment: .leading, spacing: DesignSystem.Spacing.md) { body }
+                    } else {
+                        VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) { body }
+                    }
+                }
+                .padding(DesignSystem.Spacing.lg)
+            }
+        }
+        let view = CountingHostingView(rootView: AnyView(content))
+        view.frame = NSRect(x: 0, y: 0, width: 800, height: 600)
+        return view
+    }
+
+    private func findScrollView(_ view: NSView) -> NSScrollView? {
+        if let scrollView = view as? NSScrollView { return scrollView }
+        for subview in view.subviews {
+            if let found = findScrollView(subview) { return found }
+        }
+        return nil
+    }
+
+    private func scroll(_ scrollView: NSScrollView, toBottom: Bool) {
+        guard let document = scrollView.documentView else { return }
+        let clip = scrollView.contentView
+        let maxY = max(0, document.frame.height - clip.bounds.height)
+        let y: CGFloat = document.isFlipped ? (toBottom ? maxY : 0) : (toBottom ? 0 : maxY)
+        clip.scroll(to: NSPoint(x: 0, y: y))
+        scrollView.reflectScrolledClipView(clip)
+    }
+
+    private func assertLayoutSettles(
+        _ view: CountingHostingView<AnyView>,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let ceiling = watchdogSeconds
+        let watchdog = DispatchWorkItem {
+            fatalError("Transcript layout did not settle within \(ceiling)s: main thread is livelocked")
+        }
+        DispatchQueue.global().asyncAfter(deadline: .now() + watchdogSeconds, execute: watchdog)
+        defer { watchdog.cancel() }
+
+        let window = NSWindow(
+            contentRect: NSRect(x: -20_000, y: -20_000, width: 800, height: 600),
+            styleMask: [.titled, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = view
+        window.orderFront(nil)
+        defer { window.orderOut(nil) }
+
+        let start = Date()
+        view.layoutSubtreeIfNeeded()
+        RunLoop.main.run(until: Date().addingTimeInterval(0.3))
+        let firstLayout = Date().timeIntervalSince(start)
+        XCTAssertLessThan(
+            firstLayout, firstLayoutBudgetSeconds,
+            "first layout took \(firstLayout)s", file: file, line: line
+        )
+        XCTAssertGreaterThan(view.fittingSize.height, 0, file: file, line: line)
+
+        // The freeze reproduced after scrolling down and back up.
+        guard let scrollView = findScrollView(view) else {
+            XCTFail("no NSScrollView behind the SwiftUI ScrollView", file: file, line: line)
+            return
+        }
+        for _ in 0..<3 {
+            for toBottom in [true, false] {
+                scroll(scrollView, toBottom: toBottom)
+                RunLoop.main.run(until: Date().addingTimeInterval(0.2))
+            }
+        }
+
+        let settledCount = view.layoutCount
+        RunLoop.main.run(until: Date().addingTimeInterval(0.5))
+        XCTAssertLessThanOrEqual(
+            view.layoutCount - settledCount, 2,
+            "layout kept re-running while idle (\(view.layoutCount - settledCount) extra passes)",
+            file: file, line: line
+        )
+    }
+
+    func testSpeakerCardsSettleAfterScrolling() {
+        // Two speakers plus a few unlabeled segments, like a short diarized clip.
+        let segments = segments(count: 40, speakers: ["S1", "S1", "S2", nil])
+        let view = host(hasSpeakers: true, cards: cards(for: segments), segments: [])
+
+        assertLayoutSettles(view)
+    }
+
+    func testFlatRowsSettleAfterScrolling() {
+        let segments = segments(count: 40, speakers: [nil])
+        let view = host(hasSpeakers: false, cards: [], segments: segments)
+
+        assertLayoutSettles(view)
+    }
+
+    /// The largest transcript still rendered without a lazy stack: every row
+    /// and its selection overlay is materialized on open, so this guards the
+    /// cost at the limit, not just the tiny common case.
+    func testLimitSizedTranscriptRendersNonLazilyAndSettles() {
+        let segments = segments(count: TranscriptBodyLayout.nonLazyRowLimit, speakers: ["S1", "S2"])
+        let cards = cards(for: segments)
+        XCTAssertFalse(
+            TranscriptBodyLayout.usesLazyStack(rowCount: cards.reduce(0) { $0 + $1.turn.segments.count })
+        )
+        let view = host(hasSpeakers: true, cards: cards, segments: [])
+
+        assertLayoutSettles(view)
+    }
+
+    /// Issue #845 scale: one speaker for ~964 segments becomes 41 bounded
+    /// cards in the lazy branch; the lazy stack must only realize what fits.
+    func testReporterScaleSingleSpeakerUsesLazyBranchAndSettles() {
+        let segments = segments(count: 964, speakers: ["S1"])
+        let cards = cards(for: segments)
+        XCTAssertTrue(
+            TranscriptBodyLayout.usesLazyStack(rowCount: cards.reduce(0) { $0 + $1.turn.segments.count })
+        )
+        let view = host(hasSpeakers: true, cards: cards, segments: [])
+
+        assertLayoutSettles(view)
+    }
+}

--- a/spec/04-ui-patterns.md
+++ b/spec/04-ui-patterns.md
@@ -730,6 +730,27 @@ Export bar:
 - Export .txt + Copy buttons, bordered style
 ```
 
+### Transcript Body Layout Rules
+
+The Library "freeze at 100% CPU" bug (macOS 26) was a self-feeding SwiftUI
+update loop in the timed transcript: a `LazyVStack` view cache re-measuring
+and re-instantiating rows after a scroll, each row's `.textSelection(.enabled)`
+platform overlay requesting another update, and hover re-dispatch after every
+update keeping it alive. Rules that follow from it:
+
+- Small transcripts render in a plain `VStack`; only transcripts above
+  `TranscriptBodyLayout.nonLazyRowLimit` rows use `LazyVStack` (issue #848
+  still needs bounded cards there). The decision lives in
+  `TranscriptBodyLayout.usesLazyStack(rowCount:)`; DEBUG launches can flip it
+  and per-row text selection with `MACPARAKEET_DEBUG_TRANSCRIPT_LAZY` and
+  `MACPARAKEET_DEBUG_TRANSCRIPT_SELECTION` to bisect a recurrence.
+- Do not put more AppKit platform views (representables, selectable text
+  overlays) inside lazily measured rows than the row already has.
+- `Tests/MacParakeetTests/Views/TranscriptTimestampedLayoutSmokeTests.swift`
+  hosts the real view offscreen, scrolls it down and back, and fails if layout
+  keeps re-running; hover itself cannot be simulated offscreen and stays a
+  manual check.
+
 ### Recent Transcriptions List
 
 Appears below the drop zone when transcription history exists. Section header includes count badge.


### PR DESCRIPTION
Resolves #945.

## Summary

Opening a transcript from the Library, scrolling down, then scrolling back up could pin the main thread at 100% CPU. The sampled freeze points at a self-feeding SwiftUI layout/update loop involving the `LazyVStack` view cache, realized row heights, selectable-text platform overlays, and hover redispatch.

- Transcripts with up to 400 timed rows now use a plain `VStack`, removing the lazy view cache from the common path.
- Larger transcripts retain `LazyVStack`, preserving the bounded-card protection introduced by #848.
- DEBUG launch overrides (`MACPARAKEET_DEBUG_TRANSCRIPT_LAZY` and `MACPARAKEET_DEBUG_TRANSCRIPT_SELECTION`) remain available for recurrence diagnosis.
- Layout-decision and offscreen scroll smoke tests use an explicit empty environment when asserting default behavior, so developer or CI launch overrides cannot make them nondeterministic.

Robert Palmer's original commit `cfff777f9f233ec454ae79de178fabfa8f108dae` remains intact as the first PR commit. The maintainer corrections are follow-up commits, preserving the contributor's authorship.

## Verification

- `swift test --filter TranscriptBodyLayoutTests` — passed, 4 tests / 0 failures.
- `swift test --filter TranscriptTimestampedLayoutSmokeTests` — immediate rerun passed, 4 tests / 0 failures in 12.382 seconds. The preceding cold run had one threshold-only smoke failure: the 400-row case observed 3 idle layout passes against a ceiling of 2; the other 3 tests passed. No hang or watchdog failure occurred.
- `git diff --check` — passed.
- Hover cannot be simulated in the offscreen host and remains a manual app check.

## Scope and merge order

This PR intentionally remains the standalone small/non-lazy versus large/lazy layout change. Do not add the async-cache work from #905 here; that work should be implemented or rebased after #946 lands so it builds on the finalized layout change.

## Post-Deploy Monitoring & Validation

- Open representative short and long transcripts from Library, scroll to the bottom and back to the top, and confirm the window remains interactive.
- Watch Activity Monitor for sustained main-thread/CPU saturation; healthy behavior is prompt settling after scroll, while sustained 100% CPU or an unresponsive window is the rollback/mitigation trigger.
- Validate both sides of the 400-row boundary during the first release-candidate smoke pass. Owner: release maintainer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved timed transcript rendering and scrolling, reducing the risk of freezes and excessive CPU usage, especially for longer transcripts.
  - Improved layout stability when viewing and navigating timestamped transcript content.
  - Preserved selectable transcript text with more consistent row-level selection behavior.
  - Small transcripts now use a simpler layout, while larger transcripts use optimized lazy loading.

- **Documentation**
  - Added guidance describing transcript layout behavior and performance safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->