### PR TITLE
fix(audio): stabilize mic prep and trace system recovery

### DIFF
--- a/Sources/MacParakeetCore/Audio/MeetingAudioCaptureService.swift
+++ b/Sources/MacParakeetCore/Audio/MeetingAudioCaptureService.swift
@@ -55,6 +55,7 @@ extension SystemAudioStream: MeetingSystemAudioCapturing {}
 public actor MeetingAudioCaptureService {
     public typealias EventHandler = @Sendable (MeetingAudioCaptureEvent) -> Void
     typealias MeetingMicrophoneCaptureFactory = @Sendable () -> any MeetingMicrophoneCapturing
+    typealias DiagnosticSink = @Sendable (String) -> Void
 
     // Route changes can leave ScreenCaptureKit without buffers while Core Audio
     // settles for many seconds. Keep retries bounded, but cover that transition
@@ -76,6 +77,7 @@ public actor MeetingAudioCaptureService {
     private let micProcessingMode: MeetingMicProcessingMode
     private let sourceModeProvider: @Sendable () -> MeetingAudioSourceMode
     private let systemAudioRecoveryDelays: [Duration]
+    private let diagnosticSink: DiagnosticSink
     private let micHealthObserver: MeetingMicHealthTelemetryObserver
     private let systemAudioCallbackGate = SystemAudioCallbackGate()
 
@@ -120,6 +122,7 @@ public actor MeetingAudioCaptureService {
         self.micProcessingMode = micProcessingMode
         self.sourceModeProvider = sourceModeProvider
         self.systemAudioRecoveryDelays = Self.productionSystemAudioRecoveryDelays
+        self.diagnosticSink = { AudioCaptureDiagnostics.append($0) }
         self.micHealthObserver = MeetingMicHealthTelemetryObserver()
         self.systemAudioCaptureFactory = {
             guard #available(macOS 14.2, *) else {
@@ -137,7 +140,8 @@ public actor MeetingAudioCaptureService {
         micHealthConfig: MeetingMicHealthMonitor.Config = .default,
         micHealthNowProvider: @escaping @Sendable () -> Date = { Date() },
         micHealthFeatureEnabled: Bool = AppFeatures.meetingCaptureReliabilityEnabled,
-        systemAudioRecoveryDelays: [Duration]? = nil
+        systemAudioRecoveryDelays: [Duration]? = nil,
+        diagnosticSink: @escaping DiagnosticSink = { AudioCaptureDiagnostics.append($0) }
     ) {
         self.microphoneCapture = microphoneCaptureFactory()
         self.systemAudioCaptureFactory = systemAudioCaptureFactory
@@ -146,6 +150,7 @@ public actor MeetingAudioCaptureService {
         self.systemAudioRecoveryDelays =
             systemAudioRecoveryDelays
             ?? Self.productionSystemAudioRecoveryDelays
+        self.diagnosticSink = diagnosticSink
         self.micHealthObserver = MeetingMicHealthTelemetryObserver(
             config: micHealthConfig,
             nowProvider: micHealthNowProvider,
@@ -161,7 +166,8 @@ public actor MeetingAudioCaptureService {
         micHealthConfig: MeetingMicHealthMonitor.Config = .default,
         micHealthNowProvider: @escaping @Sendable () -> Date = { Date() },
         micHealthFeatureEnabled: Bool = AppFeatures.meetingCaptureReliabilityEnabled,
-        systemAudioRecoveryDelays: [Duration]? = nil
+        systemAudioRecoveryDelays: [Duration]? = nil,
+        diagnosticSink: @escaping DiagnosticSink = { AudioCaptureDiagnostics.append($0) }
     ) {
         self.microphoneCapture = microphoneCapture
         self.systemAudioCaptureFactory = systemAudioCaptureFactory
@@ -170,6 +176,7 @@ public actor MeetingAudioCaptureService {
         self.systemAudioRecoveryDelays =
             systemAudioRecoveryDelays
             ?? Self.productionSystemAudioRecoveryDelays
+        self.diagnosticSink = diagnosticSink
         self.micHealthObserver = MeetingMicHealthTelemetryObserver(
             config: micHealthConfig,
             nowProvider: micHealthNowProvider,
@@ -526,10 +533,19 @@ public actor MeetingAudioCaptureService {
         }
 
         logger.warning("system_audio_recovery_started recovery_id=\(recoveryID, privacy: .public)")
+        diagnosticSink(
+            "system_audio_recovery_started recovery_id=\(recoveryID) \(AudioCaptureDiagnostics.errorFields(originalError))"
+        )
         await stalledCapture.stop()
 
         for (attemptIndex, delay) in systemAudioRecoveryDelays.enumerated() {
+            let attempt = attemptIndex + 1
             guard isSystemAudioRecoveryCurrent(recoveryID: recoveryID, attemptID: attemptID) else {
+                logSystemAudioRecoveryCancellation(
+                    recoveryID: recoveryID,
+                    attempt: attempt,
+                    phase: "before_attempt"
+                )
                 return
             }
 
@@ -537,12 +553,26 @@ public actor MeetingAudioCaptureService {
                 try await Task.sleep(for: delay)
                 try Task.checkCancellation()
             } catch {
+                logSystemAudioRecoveryCancellation(
+                    recoveryID: recoveryID,
+                    attempt: attempt,
+                    phase: "retry_delay"
+                )
                 return
             }
 
             guard isSystemAudioRecoveryCurrent(recoveryID: recoveryID, attemptID: attemptID) else {
+                logSystemAudioRecoveryCancellation(
+                    recoveryID: recoveryID,
+                    attempt: attempt,
+                    phase: "before_factory"
+                )
                 return
             }
+
+            diagnosticSink(
+                "system_audio_recovery_attempt_started recovery_id=\(recoveryID) attempt=\(attempt)"
+            )
 
             let replacement: any MeetingSystemAudioCapturing
             do {
@@ -550,6 +580,9 @@ public actor MeetingAudioCaptureService {
             } catch {
                 logger.warning(
                     "system_audio_recovery_factory_failed recovery_id=\(recoveryID, privacy: .public) attempt=\(attemptIndex + 1, privacy: .public) error=\(error.localizedDescription, privacy: .private)"
+                )
+                diagnosticSink(
+                    "system_audio_recovery_factory_failed recovery_id=\(recoveryID) attempt=\(attempt) \(AudioCaptureDiagnostics.errorFields(error))"
                 )
                 continue
             }
@@ -573,6 +606,9 @@ public actor MeetingAudioCaptureService {
                 logger.warning(
                     "system_audio_recovery_start_failed recovery_id=\(recoveryID, privacy: .public) attempt=\(attemptIndex + 1, privacy: .public) error=\(error.localizedDescription, privacy: .private)"
                 )
+                diagnosticSink(
+                    "system_audio_recovery_start_failed recovery_id=\(recoveryID) attempt=\(attempt) \(AudioCaptureDiagnostics.errorFields(error))"
+                )
                 if let ownedCapture = takeSystemAudioCapture(generation: replacementGeneration) {
                     await ownedCapture.stop()
                 }
@@ -583,6 +619,11 @@ public actor MeetingAudioCaptureService {
                 if let ownedCapture = takeSystemAudioCapture(generation: replacementGeneration) {
                     await ownedCapture.stop()
                 }
+                logSystemAudioRecoveryCancellation(
+                    recoveryID: recoveryID,
+                    attempt: attempt,
+                    phase: "after_start"
+                )
                 return
             }
 
@@ -601,12 +642,20 @@ public actor MeetingAudioCaptureService {
                     if let ownedCapture = takeSystemAudioCapture(generation: replacementGeneration) {
                         await ownedCapture.stop()
                     }
+                    logSystemAudioRecoveryCancellation(
+                        recoveryID: recoveryID,
+                        attempt: attempt,
+                        phase: "first_buffer_promotion"
+                    )
                     return
                 }
                 switch signal.promoteAfterFirstBuffer() {
                 case .failed(let error):
                     logger.warning(
                         "system_audio_recovery_attempt_failed_after_first_buffer recovery_id=\(recoveryID, privacy: .public) attempt=\(attemptIndex + 1, privacy: .public) error=\(error.localizedDescription, privacy: .private)"
+                    )
+                    diagnosticSink(
+                        "system_audio_recovery_attempt_failed_after_first_buffer recovery_id=\(recoveryID) attempt=\(attempt) \(AudioCaptureDiagnostics.errorFields(error))"
                     )
                     if let ownedCapture = takeSystemAudioCapture(generation: replacementGeneration) {
                         await ownedCapture.stop()
@@ -632,15 +681,26 @@ public actor MeetingAudioCaptureService {
                     if let ownedCapture = takeSystemAudioCapture(generation: replacementGeneration) {
                         await ownedCapture.stop()
                     }
+                    logSystemAudioRecoveryCancellation(
+                        recoveryID: recoveryID,
+                        attempt: attempt,
+                        phase: "first_buffer_unavailable"
+                    )
                     return
                 case .ready:
                     break
                 }
+                diagnosticSink(
+                    "system_audio_recovery_first_buffer recovery_id=\(recoveryID) attempt=\(attempt)"
+                )
                 // Promotion is now atomic with callback classification: any
                 // subsequent failure is routed as a fresh running-source loss.
                 finishSystemAudioRecoveryIfOwned(recoveryID: recoveryID)
                 logger.info(
                     "system_audio_recovery_succeeded recovery_id=\(recoveryID, privacy: .public) attempt=\(attemptIndex + 1, privacy: .public)"
+                )
+                diagnosticSink(
+                    "system_audio_recovery_succeeded recovery_id=\(recoveryID) attempt=\(attempt)"
                 )
                 eventTarget.emit(.sourceRecovered(source: .system))
                 return
@@ -648,6 +708,9 @@ public actor MeetingAudioCaptureService {
             case .failure(let error):
                 logger.warning(
                     "system_audio_recovery_attempt_stalled recovery_id=\(recoveryID, privacy: .public) attempt=\(attemptIndex + 1, privacy: .public) error=\(error.localizedDescription, privacy: .private)"
+                )
+                diagnosticSink(
+                    "system_audio_recovery_attempt_stalled recovery_id=\(recoveryID) attempt=\(attempt) \(AudioCaptureDiagnostics.errorFields(error))"
                 )
                 if let ownedCapture = takeSystemAudioCapture(generation: replacementGeneration) {
                     await ownedCapture.stop()
@@ -673,6 +736,11 @@ public actor MeetingAudioCaptureService {
                 if let ownedCapture = takeSystemAudioCapture(generation: replacementGeneration) {
                     await ownedCapture.stop()
                 }
+                logSystemAudioRecoveryCancellation(
+                    recoveryID: recoveryID,
+                    attempt: attempt,
+                    phase: "waiting_for_first_buffer"
+                )
                 return
             }
         }
@@ -681,10 +749,24 @@ public actor MeetingAudioCaptureService {
             return
         }
         logger.error("system_audio_recovery_exhausted recovery_id=\(recoveryID, privacy: .public)")
+        diagnosticSink(
+            "system_audio_recovery_exhausted recovery_id=\(recoveryID) attempts=\(systemAudioRecoveryDelays.count) \(AudioCaptureDiagnostics.errorFields(originalError))"
+        )
         emitTerminalSystemAudioFailure(
             originalError,
             sourceMode: sourceMode,
             eventTarget: eventTarget
+        )
+    }
+
+    private func logSystemAudioRecoveryCancellation(
+        recoveryID: Int,
+        attempt: Int,
+        phase: String
+    ) {
+        guard Task.isCancelled else { return }
+        diagnosticSink(
+            "system_audio_recovery_cancelled recovery_id=\(recoveryID) attempt=\(attempt) phase=\(phase)"
         )
     }
 

--- a/Sources/MacParakeetCore/Audio/MicrophoneEnginePlatform.swift
+++ b/Sources/MacParakeetCore/Audio/MicrophoneEnginePlatform.swift
@@ -427,6 +427,23 @@ public final class AVAudioEngineMicrophonePlatform: MicrophoneEnginePlatform, @u
     private var prepared = false
     private var preparedAttempt: MeetingInputDeviceAttempt?
     private var preparedRouteSnapshot: [MeetingInputDeviceAttempt]?
+    private struct InputConfigurationSnapshot: Equatable {
+        let sampleRate: Double
+        let channelCount: AVAudioChannelCount
+        let commonFormat: AVAudioCommonFormat
+        let isInterleaved: Bool
+
+        init?(_ format: AVAudioFormat?) {
+            guard let format, format.sampleRate > 0, format.channelCount > 0 else {
+                return nil
+            }
+            sampleRate = format.sampleRate
+            channelCount = format.channelCount
+            commonFormat = format.commonFormat
+            isInterleaved = format.isInterleaved
+        }
+    }
+    private var preparedInputConfiguration: InputConfigurationSnapshot?
     private var preparedVPIO = false
     private var preparedBufferSize: AVAudioFrameCount = 0
     private var tapHandlerBox: MutableMicrophoneTapHandler?
@@ -678,6 +695,7 @@ public final class AVAudioEngineMicrophonePlatform: MicrophoneEnginePlatform, @u
             } catch {
                 prepared = false
                 preparedRouteSnapshot = nil
+                preparedInputConfiguration = nil
                 AudioCaptureDiagnostics.append(
                     "shared_mic_engine_prepare_failed \(AudioCaptureDiagnostics.errorFields(error))"
                 )
@@ -1165,6 +1183,9 @@ public final class AVAudioEngineMicrophonePlatform: MicrophoneEnginePlatform, @u
     ) {
         prepared = true
         preparedAttempt = attempt
+        preparedInputConfiguration = InputConfigurationSnapshot(
+            UncheckedSendableAudioEngine(audioEngine).inputFormat()
+        )
         preparedVPIO = vpioEnabled
         preparedBufferSize = bufferSize
         // AVAudioEngine can emit a configuration-change notification as a
@@ -1258,6 +1279,7 @@ public final class AVAudioEngineMicrophonePlatform: MicrophoneEnginePlatform, @u
         tapHandlerBox.completeStartupConfigurationTracking()
         prepared = false
         preparedRouteSnapshot = nil
+        preparedInputConfiguration = nil
         installConfigurationChangeObserverLocked()
         installRouteChangeObserversLocked()
         armCallbackLivenessTimerLocked(tapHandler: tapHandlerBox)
@@ -1271,6 +1293,7 @@ public final class AVAudioEngineMicrophonePlatform: MicrophoneEnginePlatform, @u
         cancelCallbackLivenessTimerLocked()
         prepared = false
         preparedRouteSnapshot = nil
+        preparedInputConfiguration = nil
         preparedConfigurationGeneration = 0
         tapHandlerBox?.clear()
         tapHandlerBox = nil
@@ -1312,6 +1335,7 @@ public final class AVAudioEngineMicrophonePlatform: MicrophoneEnginePlatform, @u
         cancelCallbackLivenessTimerLocked()
         prepared = false
         preparedRouteSnapshot = nil
+        preparedInputConfiguration = nil
         preparedConfigurationGeneration = 0
         tapHandlerBox?.clear()
         tapHandlerBox = nil
@@ -1369,6 +1393,28 @@ public final class AVAudioEngineMicrophonePlatform: MicrophoneEnginePlatform, @u
                     "shared_mic_engine_configuration_changed sr=\(snapshot.sr, privacy: .public) ch=\(snapshot.ch, privacy: .public) isRunning=\(snapshot.isRunning, privacy: .public) engine_is_running=\(snapshot.engineIsRunning, privacy: .public)"
                 )
                 self.refreshActiveTapSignalPolicyLocked()
+                if self.prepared,
+                    self.deviceAttemptsBuilder?() == self.preparedRouteSnapshot,
+                    Self.preparedAttemptIsSafe(
+                        self.preparedAttempt,
+                        bluetoothInputState: self.bluetoothInputState
+                    ),
+                    let preparedInputConfiguration = self.preparedInputConfiguration,
+                    InputConfigurationSnapshot(format) == preparedInputConfiguration
+                {
+                    // Device selection / prepare can post its own notification
+                    // after markPreparedLocked has installed the observer. If
+                    // the resolved route and negotiated input configuration are
+                    // still identical, absorb that delayed setup echo into the
+                    // existing generation snapshot. A later real mutation still
+                    // fails these checks and follows the invalidation path.
+                    self.preparedConfigurationGeneration =
+                        self.configurationChangeGeneration.withLock { $0 }
+                    AudioCaptureDiagnostics.append(
+                        "shared_mic_engine_configuration_change_ignored reason=unchanged_prepared_setup"
+                    )
+                    return
+                }
                 // The device ID can stay constant while a Bluetooth aggregate
                 // changes transport/profile. Route consumers must re-evaluate
                 // warm-capture eligibility for configuration changes too, not

--- a/Tests/MacParakeetTests/Audio/MeetingAudioCaptureServiceTests.swift
+++ b/Tests/MacParakeetTests/Audio/MeetingAudioCaptureServiceTests.swift
@@ -77,6 +77,19 @@ private final class CompletionFlag: @unchecked Sendable {
     }
 }
 
+private final class MeetingAudioDiagnosticRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var events: [String] = []
+
+    func record(_ event: String) {
+        lock.withLock { events.append(event) }
+    }
+
+    func snapshot() -> [String] {
+        lock.withLock { events }
+    }
+}
+
 private final class MeetingAudioTelemetrySpy: TelemetryServiceProtocol, @unchecked Sendable {
     private let lock = NSLock()
     private var events: [TelemetryEventSpec] = []
@@ -1213,6 +1226,7 @@ final class MeetingAudioCaptureServiceTests: XCTestCase {
         let readyReplacement = MockMeetingSystemAudioCapture(
             startExpectation: readyReplacementStarted
         )
+        let diagnostics = MeetingAudioDiagnosticRecorder()
         let captures = SystemAudioCaptureFactorySequence([
             stalledCapture,
             silentReplacement,
@@ -1221,7 +1235,8 @@ final class MeetingAudioCaptureServiceTests: XCTestCase {
         let service = MeetingAudioCaptureService(
             microphoneCapture: MockMeetingMicrophoneCapture(),
             systemAudioCaptureFactory: { try captures.make() },
-            systemAudioRecoveryDelays: [.zero, .zero]
+            systemAudioRecoveryDelays: [.zero, .zero],
+            diagnosticSink: { event in diagnostics.record(event) }
         )
         addTeardownBlock {
             await service.stop()
@@ -1261,6 +1276,20 @@ final class MeetingAudioCaptureServiceTests: XCTestCase {
         XCTAssertEqual(stalledCapture.stopCallCount, 1)
         XCTAssertEqual(silentReplacement.stopCallCount, 1)
         XCTAssertEqual(readyReplacement.stopCallCount, 0)
+        XCTAssertEqual(
+            diagnostics.snapshot().map { $0.split(separator: " ").first.map(String.init) },
+            [
+                "system_audio_recovery_started",
+                "system_audio_recovery_attempt_started",
+                "system_audio_recovery_attempt_stalled",
+                "system_audio_recovery_attempt_started",
+                "system_audio_recovery_first_buffer",
+                "system_audio_recovery_succeeded",
+            ]
+        )
+        XCTAssertTrue(diagnostics.snapshot().contains { $0.contains("attempt=1") })
+        XCTAssertTrue(diagnostics.snapshot().contains { $0.contains("attempt=2") })
+        XCTAssertTrue(diagnostics.snapshot().contains { $0.contains("error_type=") })
     }
 
     func testEmitsTerminalSystemInterruptionOnlyAfterRecoveryAttemptsAreExhausted() async throws {
@@ -1275,12 +1304,15 @@ final class MeetingAudioCaptureServiceTests: XCTestCase {
         let stalledCapture = MockMeetingSystemAudioCapture()
         let firstFailedCapture = MockMeetingSystemAudioCapture(
             startExpectation: firstAttemptStarted,
-            startError: .systemAudioCaptureFailed("route is still changing")
+            startError: .systemAudioCaptureFailed(
+                "route is still changing at /Users/alex/private/meeting.wav via https://example.com/private"
+            )
         )
         let secondFailedCapture = MockMeetingSystemAudioCapture(
             startExpectation: secondAttemptStarted,
             startError: .systemAudioCaptureFailed("route is still changing")
         )
+        let diagnostics = MeetingAudioDiagnosticRecorder()
         let captures = SystemAudioCaptureFactorySequence([
             stalledCapture,
             firstFailedCapture,
@@ -1289,7 +1321,8 @@ final class MeetingAudioCaptureServiceTests: XCTestCase {
         let service = MeetingAudioCaptureService(
             microphoneCapture: microphone,
             systemAudioCaptureFactory: { try captures.make() },
-            systemAudioRecoveryDelays: [.zero, .zero]
+            systemAudioRecoveryDelays: [.zero, .zero],
+            diagnosticSink: { event in diagnostics.record(event) }
         )
         addTeardownBlock {
             await service.stop()
@@ -1326,6 +1359,22 @@ final class MeetingAudioCaptureServiceTests: XCTestCase {
         XCTAssertEqual(firstFailedCapture.stopCallCount, 1)
         XCTAssertEqual(secondFailedCapture.stopCallCount, 1)
         XCTAssertEqual(microphone.stopCallCount, 0)
+        XCTAssertEqual(
+            diagnostics.snapshot().map { $0.split(separator: " ").first.map(String.init) },
+            [
+                "system_audio_recovery_started",
+                "system_audio_recovery_attempt_started",
+                "system_audio_recovery_start_failed",
+                "system_audio_recovery_attempt_started",
+                "system_audio_recovery_start_failed",
+                "system_audio_recovery_exhausted",
+            ]
+        )
+        XCTAssertTrue(
+            diagnostics.snapshot().last?.contains("attempts=2 error_type=") == true
+        )
+        XCTAssertFalse(diagnostics.snapshot().joined().contains("/Users/alex"))
+        XCTAssertFalse(diagnostics.snapshot().joined().contains("https://example.com"))
     }
 
     func testCoalescesDuplicateSystemStallSignalsIntoOneRecovery() async throws {
@@ -1456,10 +1505,12 @@ final class MeetingAudioCaptureServiceTests: XCTestCase {
         ])
         let retiredSessionEvents = FactoryInvocationBox()
         let nextSessionBuffers = FactoryInvocationBox()
+        let diagnostics = MeetingAudioDiagnosticRecorder()
         let service = MeetingAudioCaptureService(
             microphoneCapture: MockMeetingMicrophoneCapture(),
             systemAudioCaptureFactory: { try captures.make() },
-            systemAudioRecoveryDelays: [.zero]
+            systemAudioRecoveryDelays: [.zero],
+            diagnosticSink: { event in diagnostics.record(event) }
         )
 
         _ = try await service.start(sourceMode: .systemOnly) { event in
@@ -1503,6 +1554,11 @@ final class MeetingAudioCaptureServiceTests: XCTestCase {
         nextSessionCapture.emit(buffer: buffer, time: AVAudioTime(hostTime: 46))
         XCTAssertEqual(nextSessionBuffers.get(), 1)
         XCTAssertEqual(captures.makeCallCount, 3)
+        XCTAssertTrue(
+            diagnostics.snapshot().contains(
+                "system_audio_recovery_cancelled recovery_id=1 attempt=1 phase=waiting_for_first_buffer"
+            )
+        )
         await service.stop()
     }
 

--- a/Tests/MacParakeetTests/Audio/MicrophoneEnginePlatformConfigChangeRecoveryTests.swift
+++ b/Tests/MacParakeetTests/Audio/MicrophoneEnginePlatformConfigChangeRecoveryTests.swift
@@ -21,6 +21,108 @@ import XCTest
 /// returns.
 final class MicrophoneEnginePlatformConfigChangeRecoveryTests: XCTestCase {
 
+    /// Device selection and `AVAudioEngine.prepare()` can enqueue their own
+    /// configuration notification after preparation has already been marked.
+    /// When the resolved route and input format are unchanged, that delayed
+    /// setup echo must leave the prepared engine reusable instead of starting
+    /// the discard -> route-notification -> reprepare loop from issue #928.
+    func testDelayedConfigurationChangeWithUnchangedRouteKeepsPreparedEngine() throws {
+        let attempt = MeetingInputDeviceAttempt(source: .builtIn, deviceID: 10)
+        let startedEngine = OSAllocatedUnfairLock<AVAudioEngine?>(initialState: nil)
+        let buffer = UncheckedSendableAudioPCMBuffer(makeRecoveryTestBuffer())
+        let platform = AVAudioEngineMicrophonePlatform(
+            deviceAttemptsBuilder: { [attempt] },
+            inputDeviceSetter: { _, _ in true },
+            bluetoothInputState: { _ in false },
+            engineStarter: { engine, _, _, tapHandler in
+                startedEngine.withLock { $0 = engine }
+                tapHandler(buffer.buffer, AVAudioTime(hostTime: 1))
+            }
+        )
+        defer { platform.stopEngine() }
+
+        platform.prepare(
+            vpioEnabled: false,
+            bufferSize: 256,
+            tapHandler: { _, _ in }
+        )
+        let before = platform.preparedEngineStateForTesting
+        XCTAssertTrue(before.prepared)
+
+        NotificationCenter.default.post(
+            name: .AVAudioEngineConfigurationChange,
+            object: before.engine
+        )
+        _ = platform.isEngineRunning  // flush the queued observer handling
+
+        let after = platform.preparedEngineStateForTesting
+        XCTAssertTrue(
+            after.prepared,
+            "an unchanged delayed setup notification must not discard preparation"
+        )
+        XCTAssertTrue(
+            before.engine === after.engine,
+            "an unchanged delayed setup notification must retain the prepared engine"
+        )
+
+        try platform.configureAndStart(
+            vpioEnabled: false,
+            bufferSize: 256,
+            tapHandler: { _, _ in }
+        )
+        XCTAssertTrue(
+            startedEngine.withLock { $0 } === before.engine,
+            "the next capture must use the prepared engine instead of reconfiguring a fresh one"
+        )
+    }
+
+    func testPreparedConfigurationChangeWithDifferentRouteDiscardsAndNotifies() throws {
+        let originalAttempt = MeetingInputDeviceAttempt.implicitSystemDefault(
+            resolvedDeviceID: 10
+        )
+        let changedAttempt = MeetingInputDeviceAttempt.implicitSystemDefault(
+            resolvedDeviceID: 20
+        )
+        let route = OSAllocatedUnfairLock(initialState: [originalAttempt])
+        let routeChange = expectation(description: "route consumers are notified")
+        let token = NotificationCenter.default.addObserver(
+            forName: .macParakeetMicrophoneSelectionDidChange,
+            object: nil,
+            queue: nil
+        ) { _ in
+            routeChange.fulfill()
+        }
+        defer { NotificationCenter.default.removeObserver(token) }
+
+        let platform = AVAudioEngineMicrophonePlatform(
+            deviceAttemptsBuilder: { route.withLock { $0 } },
+            inputDeviceSetter: { _, _ in true },
+            bluetoothInputState: { _ in false },
+            engineStarter: { _, _, _, _ in }
+        )
+        defer { platform.stopEngine() }
+
+        platform.prepare(
+            vpioEnabled: false,
+            bufferSize: 256,
+            tapHandler: { _, _ in }
+        )
+        let before = platform.preparedEngineStateForTesting
+        XCTAssertTrue(before.prepared)
+
+        route.withLock { $0 = [changedAttempt] }
+        NotificationCenter.default.post(
+            name: .AVAudioEngineConfigurationChange,
+            object: before.engine
+        )
+        _ = platform.isEngineRunning
+
+        wait(for: [routeChange], timeout: 0.5)
+        let after = platform.preparedEngineStateForTesting
+        XCTAssertFalse(after.prepared)
+        XCTAssertFalse(before.engine === after.engine)
+    }
+
     func testRunningConfigurationChangeNotifiesInputRouteConsumers() throws {
         let routeChange = expectation(description: "route consumers are notified")
         let buffer = UncheckedSendableAudioPCMBuffer(makeRecoveryTestBuffer())

--- a/Tests/MacParakeetTests/Audio/MicrophoneEngineRealPlatformTests.swift
+++ b/Tests/MacParakeetTests/Audio/MicrophoneEngineRealPlatformTests.swift
@@ -147,10 +147,9 @@ final class MicrophoneEngineRealPlatformTests: XCTestCase {
         )
     }
 
-    /// Core Audio can renegotiate the input chain while a stopped engine is
-    /// waiting for key-down. The configuration observer must discard that
-    /// preparation so the next start cannot reuse a stale tap format.
-    func testConfigurationChangeDiscardsPreparedEngine() throws {
+    /// Some devices deliver the setup notification after `prepare()` returns.
+    /// If the actual route and format stayed unchanged, keep the prepared graph.
+    func testDelayedUnchangedConfigurationChangeKeepsPreparedEngine() throws {
         platform.stopEngine()
         platform = try makePreparablePlatform()
 
@@ -169,10 +168,10 @@ final class MicrophoneEngineRealPlatformTests: XCTestCase {
         _ = platform.isEngineRunning  // queue sync flushes observer invalidation
 
         let after = platform.preparedEngineStateForTesting
-        XCTAssertFalse(after.prepared)
-        XCTAssertFalse(
+        XCTAssertTrue(after.prepared)
+        XCTAssertTrue(
             before.engine === after.engine,
-            "A configuration change must replace the stale prepared engine."
+            "An unchanged delayed setup notification must keep the prepared engine."
         )
     }
 


### PR DESCRIPTION
## Summary

Prepared microphone capture now keeps a reusable engine when Core Audio delivers a delayed configuration notification but the resolved route, transport safety, and input format are unchanged. System-audio recovery also writes sanitized lifecycle markers to the opt-in audio diagnostic log, so future failures can be distinguished without changing ScreenCaptureKit recovery behavior.

## Design

- Snapshot the prepared input configuration alongside the resolved device attempt, then absorb only notifications that still match both snapshots and remain safe for prewarming.
- Preserve the existing discard, route-notification, and bounded recovery paths for actual route, transport, or format changes.
- Mirror recovery start, attempt, first-buffer, failure, cancellation, success, and exhaustion states into the existing diagnostic sink with bounded IDs and attempt counts.

## Risk and privacy scope

- The behavior change is limited to unchanged delayed notifications while an `AVAudioEngine` is prepared but stopped. Running-engine recovery and real prepared-route invalidation remain unchanged.
- System-audio recovery behavior is unchanged; this slice adds observability only.
- Diagnostic errors use the existing sanitizer. Focused tests verify that user paths and URLs are not written. No audio or transcript content is added to diagnostics.

## Validation

- `swift test --filter MicrophoneEnginePlatformConfigChangeRecoveryTests` — 20 passed, 0 failed.
- `swift test --filter MicrophoneEnginePrewarmRoutingTests` — 8 passed, 0 failed.
- `swift test --filter MeetingAudioCaptureServiceTests` — 36 passed, 0 failed.
- `xcrun swift-format lint --strict --no-color-diagnostics --configuration .swift-format <five changed Swift files>` — zero diagnostics on both `origin/main` and this branch; no branch-introduced signatures.
- `git diff --check origin/main...HEAD` — clean.

## Hardware gap

No physical USB/Bluetooth route transition or live Microsoft Teams capture was exercised in this worktree. The deterministic suites cover unchanged setup echoes, real route mutation, prewarm transport safety, recovery lifecycle logging, cancellation, and diagnostic redaction; hardware confirmation remains a release/review gate.

## Related

Fixes #928.

Related: #943 — observability prerequisite only. This PR does not fix the intermittent silent Teams capture, and #943 should remain open.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a delayed configuration notification from discarding a prepared microphone engine when route and format are unchanged, and adds opt-in lifecycle diagnostics for system-audio recovery.

**Microphone prep**
- Snapshots the prepared input format alongside the resolved device attempt.
- Absorbs delayed setup echoes that still match both snapshots and remain safe for prewarming.
- Real route, transport, or format changes keep the existing discard, route-notification, and bounded recovery paths.

**System-audio diagnostics**
- Writes recovery start, attempt, first-buffer, failure, cancellation, success, and exhaustion states to the existing diagnostic sink.
- Uses sanitized errors and bounded IDs/attempt counts; no recovery behavior changes.

Fixes #928.

<sup>Written for commit 3c3ba966b82162d49586cec321f2511230a6cb5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/950?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved microphone capture reliability when audio configuration updates arrive during setup.
  * Preserved prepared microphone sessions when the audio route and input format remain unchanged, reducing unnecessary reinitialization.
  * Improved system-audio recovery reporting to support clearer troubleshooting of recovery attempts, failures, cancellations, and successful recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->