### PR TITLE
fix: clarify onboarding recovery and align feedback input

### DIFF
--- a/Sources/MacParakeet/Views/Feedback/FeedbackView.swift
+++ b/Sources/MacParakeet/Views/Feedback/FeedbackView.swift
@@ -14,6 +14,11 @@ struct FeedbackView: View {
     @State private var isLogRowHovered = false
     @FocusState private var messageFocused: Bool
 
+    /// Single source of truth for the message editor's content inset, shared
+    /// by the `TextEditor` and its overlaid placeholder so the insertion
+    /// point and placeholder text always start from the same position.
+    private let messageContentInset = DesignSystem.Spacing.sm
+
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: DesignSystem.Spacing.lg) {
@@ -184,7 +189,7 @@ struct FeedbackView: View {
                         .scrollContentBackground(.hidden)
                         .tint(DesignSystem.Colors.accent)
                         .focused($messageFocused)
-                        .padding(DesignSystem.Spacing.sm)
+                        .padding(messageContentInset)
                         .frame(minHeight: 120)
                         .background(
                             RoundedRectangle(cornerRadius: DesignSystem.Layout.rowCornerRadius)
@@ -205,7 +210,7 @@ struct FeedbackView: View {
                         Text(placeholderText)
                             .font(DesignSystem.Typography.body)
                             .foregroundStyle(.tertiary)
-                            .padding(DesignSystem.Spacing.sm + 5)
+                            .padding(messageContentInset)
                             .allowsHitTesting(false)
                     }
                 }

--- a/Sources/MacParakeet/Views/Feedback/FeedbackView.swift
+++ b/Sources/MacParakeet/Views/Feedback/FeedbackView.swift
@@ -14,10 +14,11 @@ struct FeedbackView: View {
     @State private var isLogRowHovered = false
     @FocusState private var messageFocused: Bool
 
-    /// Single source of truth for the message editor's content inset, shared
-    /// by the `TextEditor` and its overlaid placeholder so the insertion
-    /// point and placeholder text always start from the same position.
+    /// Outer inset shared by the editor and the placeholder's vertical axis.
     private let messageContentInset = DesignSystem.Spacing.sm
+
+    /// NSTextView adds this horizontal line-fragment inset inside TextEditor.
+    private let textEditorLineFragmentPadding: CGFloat = 5
 
     var body: some View {
         ScrollView {
@@ -210,7 +211,8 @@ struct FeedbackView: View {
                         Text(placeholderText)
                             .font(DesignSystem.Typography.body)
                             .foregroundStyle(.tertiary)
-                            .padding(messageContentInset)
+                            .padding(.horizontal, messageContentInset + textEditorLineFragmentPadding)
+                            .padding(.vertical, messageContentInset)
                             .allowsHitTesting(false)
                     }
                 }

--- a/Sources/MacParakeet/Views/Onboarding/OnboardingFlowView.swift
+++ b/Sources/MacParakeet/Views/Onboarding/OnboardingFlowView.swift
@@ -1024,6 +1024,14 @@ struct OnboardingFlowView: View {
     private func engineRecoveryTips(for message: String) -> [String] {
         let lower = message.lowercased()
 
+        if lower.contains("speaker diarization") || lower.contains("speaker models") {
+            return [
+                "Make the required speaker diarization models available, then retry setup.",
+                "If this Mac cannot download models, copy the complete local model cache from another Mac, then retry.",
+                "Setup remains blocked until the required local speaker models are present."
+            ]
+        }
+
         if lower.contains("network") || lower.contains("internet") || lower.contains("timed out") {
             return [
                 "Check your internet connection, then retry setup.",

--- a/Sources/MacParakeet/Views/Onboarding/OnboardingFlowView.swift
+++ b/Sources/MacParakeet/Views/Onboarding/OnboardingFlowView.swift
@@ -1028,7 +1028,7 @@ struct OnboardingFlowView: View {
             return [
                 "Make the required speaker diarization models available, then retry setup.",
                 "If this Mac cannot download models, copy the complete local model cache from another Mac, then retry.",
-                "Setup remains blocked until the required local speaker models are present."
+                "Setup remains blocked until the required local speaker models are present.",
             ]
         }
 

--- a/Sources/MacParakeetViewModels/OnboardingViewModel.swift
+++ b/Sources/MacParakeetViewModels/OnboardingViewModel.swift
@@ -732,6 +732,8 @@ public final class OnboardingViewModel {
                     self.engineState = .working(message: "Speaker models: \(message)", progress: nil)
                 }
             })
+        } catch is CancellationError {
+            throw CancellationError()
         } catch {
             logger.error("diarization_model_prep_failed error=\(error.localizedDescription, privacy: .public)")
             Telemetry.send(.errorOccurred(
@@ -739,7 +741,9 @@ public final class OnboardingViewModel {
                 code: "model_prep_failed",
                 description: TelemetryErrorClassifier.errorDetail(error)
             ))
-            throw error
+            throw STTError.engineStartFailed(
+                "Speaker diarization model preparation failed. Make the required speaker models available, then retry setup."
+            )
         }
     }
 

--- a/Tests/MacParakeetTests/ViewModels/OnboardingViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/OnboardingViewModelTests.swift
@@ -1070,9 +1070,10 @@ final class OnboardingViewModelTests: XCTestCase {
 
         XCTAssertEqual(
             vm.engineState,
-            .failed(message: STTError.engineStartFailed(
-                "Speaker diarization model preparation failed. Make the required speaker models available, then retry setup."
-            ).localizedDescription)
+            .failed(
+                message: STTError.engineStartFailed(
+                    "Speaker diarization model preparation failed. Make the required speaker models available, then retry setup."
+                ).localizedDescription)
         )
         XCTAssertFalse(vm.canContinueFromCurrentStep())
     }
@@ -1105,9 +1106,10 @@ final class OnboardingViewModelTests: XCTestCase {
 
         XCTAssertEqual(
             vm.engineState,
-            .failed(message: STTError.engineStartFailed(
-                "Speaker diarization model preparation failed. Make the required speaker models available, then retry setup."
-            ).localizedDescription)
+            .failed(
+                message: STTError.engineStartFailed(
+                    "Speaker diarization model preparation failed. Make the required speaker models available, then retry setup."
+                ).localizedDescription)
         )
         XCTAssertFalse(vm.engineBusy)
         XCTAssertFalse(vm.canContinueFromCurrentStep())

--- a/Tests/MacParakeetTests/ViewModels/OnboardingViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/OnboardingViewModelTests.swift
@@ -1068,8 +1068,54 @@ final class OnboardingViewModelTests: XCTestCase {
         vm.startEngineWarmUp()
         try await Task.sleep(for: .milliseconds(150))
 
-        XCTAssertEqual(vm.engineState, .failed(message: STTError.modelDownloadFailed.localizedDescription))
+        XCTAssertEqual(
+            vm.engineState,
+            .failed(message: STTError.engineStartFailed(
+                "Speaker diarization model preparation failed. Make the required speaker models available, then retry setup."
+            ).localizedDescription)
+        )
         XCTAssertFalse(vm.canContinueFromCurrentStep())
+    }
+
+    func testMissingDiarizationModelsSurfaceActionableFailureAndRetryAfterModelsBecomeAvailable() async throws {
+        let perms = MockPermissionService()
+        let stt = MockSTTClient()
+        let diarization = MockDiarizationService()
+        await diarization.configureCachedModels(false)
+        await diarization.configureReady(false)
+        await diarization.configurePrepareModels(error: STTError.modelDownloadFailed)
+        let defaults = UserDefaults(suiteName: "com.macparakeet.tests.\(UUID().uuidString)")!
+
+        let vm = makeViewModel(
+            permissionService: perms,
+            sttClient: stt,
+            diarizationService: diarization,
+            defaults: defaults,
+            isSpeechModelCached: { true }
+        )
+        vm.jump(to: .engine)
+
+        vm.startEngineWarmUp()
+        try await waitUntil {
+            if case .failed = vm.engineState { return true }
+            return false
+        }
+
+        XCTAssertEqual(
+            vm.engineState,
+            .failed(message: STTError.engineStartFailed(
+                "Speaker diarization model preparation failed. Make the required speaker models available, then retry setup."
+            ).localizedDescription)
+        )
+        XCTAssertFalse(vm.engineBusy)
+        XCTAssertFalse(vm.canContinueFromCurrentStep())
+
+        await diarization.configurePrepareModels(error: nil)
+        await diarization.configureCachedModels(true)
+        vm.retryEngineWarmUp()
+        try await waitUntil { vm.engineState == .ready }
+
+        XCTAssertTrue(vm.canContinueFromCurrentStep())
     }
 
     func testMarkOnboardingCompletedPersistsToDefaults() {

--- a/Tests/MacParakeetTests/ViewModels/OnboardingViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/OnboardingViewModelTests.swift
@@ -1084,7 +1084,9 @@ final class OnboardingViewModelTests: XCTestCase {
         await diarization.configureCachedModels(false)
         await diarization.configureReady(false)
         await diarization.configurePrepareModels(error: STTError.modelDownloadFailed)
-        let defaults = UserDefaults(suiteName: "com.macparakeet.tests.\(UUID().uuidString)")!
+        let suite = "com.macparakeet.tests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
 
         let vm = makeViewModel(
             permissionService: perms,


### PR DESCRIPTION
## Summary

- Make speaker-diarization model preparation failures actionable and retryable during onboarding, including the offline copied-cache path.
- Align the Feedback placeholder with the TextEditor caret on both axes: both use the same 8-point vertical inset, while the placeholder adds the 5-point horizontal compensation for NSTextView's intrinsic line-fragment padding.

## Design

| Area | Before | After | Review focus |
| --- | --- | --- | --- |
| Diarization setup | Preparation failures exposed the underlying download error without a local-model recovery path. | The failure names the required speaker models, preserves cancellation, blocks engine selection until preparation succeeds, and supports retry after models become available. | State restoration, navigation, cancellation, retry semantics. |
| Feedback editor | One uniform placeholder padding could not match both TextEditor's intrinsic horizontal inset and its vertical origin. | TextEditor keeps an 8-point outer inset; placeholder uses 13 points horizontally and 8 vertically. | NSTextView's 5-point line-fragment padding and visual-evidence limitations. |

## Review map

- `Sources/MacParakeetViewModels/OnboardingViewModel.swift`: diarization preparation error wrapping and state behavior.
- `Sources/MacParakeet/Views/Onboarding/OnboardingFlowView.swift`: recovery guidance and retry UI.
- `Tests/MacParakeetTests/ViewModels/OnboardingViewModelTests.swift`: missing-model, retry, cancellation, and restoration coverage.
- `Sources/MacParakeet/Views/Feedback/FeedbackView.swift`: axis-specific placeholder compensation.

## Independent-review correction

Fresh-eye review found that the first Feedback revision removed NSTextView's established 5-point horizontal compensation. Commit `af748b87` restores that compensation on the horizontal axis only while keeping the vertical origins equal. The production target was rebuilt after this correction.

## Verification

- `swift test --filter OnboardingViewModelTests`: 51 tests passed, 0 failures.
- `swift build --target MacParakeet`: passed after `af748b87`; FeedbackView compiled.
- Strict formatter-signature comparison for the prepared branch: 0 branch-introduced diagnostics.
- `git diff --check`: passed.
- Full suite: not rerun here; the integrated semantic branch previously passed 5,124 XCTest tests plus 17 Swift Testing tests with 0 failures.

## Limitations

- Actual-app cursor/placeholder visual smoke was unavailable because the local app launch path is blocked by the installed Git client lacking `submodule` support.
- There is no automated SwiftUI geometry assertion for the caret origin; the alignment follows the existing LiveNotesPaneView and DiscoverView NSTextView compensation pattern.

Closes #663
Closes #872

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved alignment between feedback placeholder text and the text insertion point.
  * Added clearer guidance when speaker diarization models are unavailable or engine setup fails.
  * Engine setup errors now provide actionable recovery steps instead of generic messages.
  * Retrying engine setup after required models become available can now successfully continue onboarding.
  * Cancellation during setup remains handled without displaying an unnecessary failure message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->