### PR TITLE
Make Discover optional at compile time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ journal/
 # Xcode
 .build/
 .build-swift6-no-whisper/
+.build-swift6-no-discover/
 DerivedData/
 /dist/
 *.xcodeproj/xcuserdata/

--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,7 @@ import Foundation
 
 let skipWhisperKit = ProcessInfo.processInfo.environment["MACPARAKEET_SKIP_WHISPERKIT"] == "1"
 let enableMLXLocalLLM = ProcessInfo.processInfo.environment["MACPARAKEET_ENABLE_MLX_LOCAL_LLM"] == "1"
+let disableDiscover = ProcessInfo.processInfo.environment["MACPARAKEET_DISABLE_DISCOVER"] == "1"
 
 let packageDependencies: [Package.Dependency] = [
     // GRDB for SQLite (dictation history + transcription records)
@@ -53,6 +54,43 @@ let whisperKitSwiftSettings: [SwiftSetting] = skipWhisperKit ? [] : [
 let mlxLocalLLMSwiftSettings: [SwiftSetting] = enableMLXLocalLLM ? [
     .define("MACPARAKEET_HAS_MLX_LOCAL_LLM")
 ] : []
+
+let discoverSwiftSettings: [SwiftSetting] = disableDiscover ? [
+    .define("MACPARAKEET_DISABLE_DISCOVER")
+] : []
+
+let discoverAppExcludes = disableDiscover ? [
+    "Resources/discover-fallback.json",
+    "Views/Discover",
+] : []
+
+let discoverCoreExcludes = disableDiscover ? [
+    "Models/DiscoverContent.swift",
+    "Services/Discover",
+] : []
+
+let discoverViewModelExcludes = disableDiscover ? [
+    "DiscoverViewModel.swift"
+] : []
+
+let discoverTestExcludes = disableDiscover ? [
+    "Models/DiscoverContentTests.swift",
+    "Services/Discover",
+] : []
+
+let appTargetSwiftSettings: [SwiftSetting] = mlxLocalLLMSwiftSettings + discoverSwiftSettings
+let coreTargetExcludes: [String] = [
+    "Audio/README.md",
+    "Database/README.md",
+    "Licensing/README.md",
+    "Resources",
+    "Services/System/README.md",
+    "STT/README.md",
+    "TextProcessing/README.md",
+] + discoverCoreExcludes
+let coreTargetSwiftSettings: [SwiftSetting] = whisperKitSwiftSettings + discoverSwiftSettings
+let testTargetSwiftSettings: [SwiftSetting] =
+    whisperKitSwiftSettings + mlxLocalLLMSwiftSettings + discoverSwiftSettings
 
 let appDependencies: [Target.Dependency] = [
     "MacParakeetCore",
@@ -106,8 +144,9 @@ let package = Package(
             name: "MacParakeet",
             dependencies: appDependencies,
             path: "Sources/MacParakeet",
+            exclude: discoverAppExcludes,
             resources: [.process("Resources")],
-            swiftSettings: mlxLocalLLMSwiftSettings
+            swiftSettings: appTargetSwiftSettings
         ),
         // macparakeet-cli — versioned public surface (semver, Sources/CLI/CHANGELOG.md).
         // Consumed by the macOS app, scripted callers, and downstream agent skills
@@ -135,29 +174,24 @@ let package = Package(
             name: "MacParakeetCore",
             dependencies: coreDependencies,
             path: "Sources/MacParakeetCore",
-            exclude: [
-                "Audio/README.md",
-                "Database/README.md",
-                "Licensing/README.md",
-                "Resources",
-                "Services/System/README.md",
-                "STT/README.md",
-                "TextProcessing/README.md",
-            ],
-            swiftSettings: whisperKitSwiftSettings
+            exclude: coreTargetExcludes,
+            swiftSettings: coreTargetSwiftSettings
         ),
         // ViewModels library (testable, depends on Core + AppKit/SwiftUI)
         .target(
             name: "MacParakeetViewModels",
             dependencies: ["MacParakeetCore"],
-            path: "Sources/MacParakeetViewModels"
+            path: "Sources/MacParakeetViewModels",
+            exclude: discoverViewModelExcludes,
+            swiftSettings: discoverSwiftSettings
         ),
         // Tests
         .testTarget(
             name: "MacParakeetTests",
             dependencies: appTestDependencies,
             path: "Tests/MacParakeetTests",
-            swiftSettings: whisperKitSwiftSettings + mlxLocalLLMSwiftSettings
+            exclude: discoverTestExcludes,
+            swiftSettings: testTargetSwiftSettings
         ),
         .testTarget(
             name: "CLITests",

--- a/README.md
+++ b/README.md
@@ -169,6 +169,13 @@ scripts/dev/run_app.sh    # build, sign, launch
 
 The dev script creates a signed `.app` bundle so macOS grants mic and accessibility permissions. It disables target-level Xcode signing, then signs the finished bundle with the best available local identity. Override with `MACPARAKEET_CODESIGN_IDENTITY="Your Identity"` if needed.
 
+Discover is included by default. To compile a local app without any Discover
+code, fallback content, UI, cache setup, or network endpoints:
+
+```bash
+MACPARAKEET_DISABLE_DISCOVER=1 scripts/dev/run_app.sh
+```
+
 ## Command line and agent automation
 
 `macparakeet-cli` is the public automation surface for MacParakeet: the canonical Swift-native interface to Parakeet TDT on Apple Silicon, plus the scriptable entry point for MacParakeet's local library, model cache, prompts, meetings, and JSON contracts. Use [`integrations/README.md`](integrations/README.md) for the agent-facing automation guide and [`Sources/CLI/CHANGELOG.md`](Sources/CLI/CHANGELOG.md) for compatibility notes.
@@ -283,7 +290,7 @@ All speech recognition runs locally. Parakeet uses the Neural Engine; optional N
 - **Opt-out telemetry.** Non-identifying usage analytics and crash reporting go to a self-hosted endpoint only when telemetry is enabled. No persistent IDs, no IP storage, and no transcript/audio content is transmitted. [Source code is right here](Sources/MacParakeetCore/Services/Telemetry/TelemetryService.swift) — verify it yourself.
 - **User-controlled retention.** Temporary working audio is cleaned up by its owning flow. Saved dictation, file/media, and meeting audio follows the relevant storage setting; meeting audio is kept by default. Deleting audio does not imply deleting the transcript.
 
-**What does use the network:** Configured LLM features (including opted-in automatic prompts, formatter, titles, and knowledge cards) send text context to the chosen provider, or whatever service a configured CLI tool uses. Model setup downloads required assets; Sparkle checks for app updates. Media imports use yt-dlp, the public iTunes directory/RSS feeds, and episode downloads. Telemetry/crash reports go to our self-hosted endpoint unless you opt out. **Discover independently requests `https://macparakeet.com/api/discover.json` at app launch**, even when telemetry is disabled and the Discover page is unopened; it falls back to cached/bundled content offline. Explicit feedback and Discover thought submissions also use the network. Core capture and local transcription work offline after model setup, but there is no global no-network toggle.
+**What does use the network:** Configured LLM features (including opted-in automatic prompts, formatter, titles, and knowledge cards) send text context to the chosen provider, or whatever service a configured CLI tool uses. Model setup downloads required assets; Sparkle checks for app updates. Media imports use yt-dlp, the public iTunes directory/RSS feeds, and episode downloads. Telemetry/crash reports go to our self-hosted endpoint unless you opt out. **Discover independently requests `https://macparakeet.com/api/discover.json` at app launch**, even when telemetry is disabled and the Discover page is unopened; it falls back to cached/bundled content offline. Builds compiled with `MACPARAKEET_DISABLE_DISCOVER=1` contain neither Discover endpoint. Explicit feedback and Discover thought submissions also use the network. Core capture and local transcription work offline after model setup, but there is no global no-network toggle.
 
 **Note:** Builds from source also send telemetry by default. Opt out in Settings or set `MACPARAKEET_TELEMETRY_URL` to override.
 

--- a/Sources/MacParakeet/App/AppFeatureDependencies.swift
+++ b/Sources/MacParakeet/App/AppFeatureDependencies.swift
@@ -1,0 +1,8 @@
+import MacParakeetViewModels
+
+@MainActor
+struct AppFeatureDependencies {
+    #if !MACPARAKEET_DISABLE_DISCOVER
+    let discoverViewModel = DiscoverViewModel()
+    #endif
+}

--- a/Sources/MacParakeet/App/AppWindowCoordinator.swift
+++ b/Sources/MacParakeet/App/AppWindowCoordinator.swift
@@ -19,7 +19,7 @@ final class AppWindowCoordinator: NSObject, NSWindowDelegate {
     private let textSnippetsViewModel: TextSnippetsViewModel
     private let vocabularyBackupViewModel: VocabularyBackupViewModel
     private let feedbackViewModel: FeedbackViewModel
-    private let discoverViewModel: DiscoverViewModel
+    private let featureDependencies: AppFeatureDependencies
     private let libraryViewModel: TranscriptionLibraryViewModel
     private let meetingsWorkspaceViewModel: MeetingsWorkspaceViewModel
     private let meetingPillViewModel: MeetingRecordingPillViewModel
@@ -47,7 +47,7 @@ final class AppWindowCoordinator: NSObject, NSWindowDelegate {
         textSnippetsViewModel: TextSnippetsViewModel,
         vocabularyBackupViewModel: VocabularyBackupViewModel,
         feedbackViewModel: FeedbackViewModel,
-        discoverViewModel: DiscoverViewModel,
+        featureDependencies: AppFeatureDependencies,
         libraryViewModel: TranscriptionLibraryViewModel,
         meetingsWorkspaceViewModel: MeetingsWorkspaceViewModel,
         meetingPillViewModel: MeetingRecordingPillViewModel,
@@ -72,7 +72,7 @@ final class AppWindowCoordinator: NSObject, NSWindowDelegate {
         self.textSnippetsViewModel = textSnippetsViewModel
         self.vocabularyBackupViewModel = vocabularyBackupViewModel
         self.feedbackViewModel = feedbackViewModel
-        self.discoverViewModel = discoverViewModel
+        self.featureDependencies = featureDependencies
         self.libraryViewModel = libraryViewModel
         self.meetingsWorkspaceViewModel = meetingsWorkspaceViewModel
         self.meetingPillViewModel = meetingPillViewModel
@@ -184,7 +184,7 @@ final class AppWindowCoordinator: NSObject, NSWindowDelegate {
             textSnippetsViewModel: textSnippetsViewModel,
             vocabularyBackupViewModel: vocabularyBackupViewModel,
             feedbackViewModel: feedbackViewModel,
-            discoverViewModel: discoverViewModel,
+            featureDependencies: featureDependencies,
             libraryViewModel: libraryViewModel,
             meetingsWorkspaceViewModel: meetingsWorkspaceViewModel,
             meetingPillViewModel: meetingPillViewModel,

--- a/Sources/MacParakeet/AppDelegate.swift
+++ b/Sources/MacParakeet/AppDelegate.swift
@@ -66,7 +66,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private let textSnippetsViewModel = TextSnippetsViewModel()
     private let vocabularyBackupViewModel = VocabularyBackupViewModel()
     private let feedbackViewModel = FeedbackViewModel()
-    private let discoverViewModel = DiscoverViewModel()
+    private let featureDependencies = AppFeatureDependencies()
     private let libraryViewModel = TranscriptionLibraryViewModel()
     private let meetingsLibraryViewModel = TranscriptionLibraryViewModel(scope: .meetings)
     private let llmSettingsViewModel = LLMSettingsViewModel()
@@ -200,7 +200,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         textSnippetsViewModel: textSnippetsViewModel,
         vocabularyBackupViewModel: vocabularyBackupViewModel,
         feedbackViewModel: feedbackViewModel,
-        discoverViewModel: discoverViewModel,
+        featureDependencies: featureDependencies,
         libraryViewModel: libraryViewModel,
         meetingsWorkspaceViewModel: meetingsWorkspaceViewModel,
         meetingPillViewModel: meetingPillViewModel,
@@ -367,7 +367,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         menuBarCoordinator.setupMenuBar()
         settingsObserverCoordinator.startObserving()
         windowCoordinator.applyActivationPolicyFromSettings()
+        #if !MACPARAKEET_DISABLE_DISCOVER
         setupDiscoverContent()
+        #endif
         #if DEBUG
         showDebugDictationPreviewQAIfRequested()
         #endif
@@ -630,15 +632,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         NSApp.terminate(nil)
     }
 
+    #if !MACPARAKEET_DISABLE_DISCOVER
     private func setupDiscoverContent() {
         guard let fallbackURL = Bundle.module.url(forResource: "discover-fallback", withExtension: "json"),
               let data = try? Data(contentsOf: fallbackURL) else { return }
 
         let service = DiscoverService(fallbackData: data)
-        discoverViewModel.configure(service: service)
-        discoverViewModel.loadCached()
-        discoverViewModel.refreshInBackground()
+        featureDependencies.discoverViewModel.configure(service: service)
+        featureDependencies.discoverViewModel.loadCached()
+        featureDependencies.discoverViewModel.refreshInBackground()
     }
+    #endif
 
     // MARK: - Disk Image Guard
 

--- a/Sources/MacParakeet/Views/Components/SacredGeometry.swift
+++ b/Sources/MacParakeet/Views/Components/SacredGeometry.swift
@@ -22,6 +22,63 @@ struct TriangleShape: Shape {
     }
 }
 
+// MARK: - Static Merkaba Shape
+
+/// Static Merkaba ornament used by non-Discover surfaces such as the prompt library.
+///
+/// Keep this shared shape separate from the animated Merkaba views below: callers
+/// use it as a lightweight stroked background and own its color, line width, and
+/// transforms.
+struct MerkabaShape: Shape {
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        let center = CGPoint(x: rect.midX, y: rect.midY)
+        let radius = min(rect.width, rect.height) * 0.42
+
+        addTriangle(to: &path, center: center, radius: radius, angleOffset: -.pi / 2)
+        addTriangle(to: &path, center: center, radius: radius, angleOffset: .pi / 2)
+
+        let innerRadius = radius * 0.5
+        for index in 0..<6 {
+            let angle = CGFloat(index) * .pi / 3
+            let point = CGPoint(
+                x: center.x + innerRadius * Foundation.cos(angle),
+                y: center.y + innerRadius * Foundation.sin(angle)
+            )
+            if index == 0 { path.move(to: point) } else { path.addLine(to: point) }
+        }
+        path.closeSubpath()
+
+        path.addEllipse(
+            in: CGRect(
+                x: center.x - radius,
+                y: center.y - radius,
+                width: radius * 2,
+                height: radius * 2
+            )
+        )
+
+        return path
+    }
+
+    private func addTriangle(
+        to path: inout Path,
+        center: CGPoint,
+        radius: CGFloat,
+        angleOffset: CGFloat
+    ) {
+        for index in 0..<3 {
+            let angle = CGFloat(index) * 2 * .pi / 3 + angleOffset
+            let point = CGPoint(
+                x: center.x + radius * Foundation.cos(angle),
+                y: center.y + radius * Foundation.sin(angle)
+            )
+            if index == 0 { path.move(to: point) } else { path.addLine(to: point) }
+        }
+        path.closeSubpath()
+    }
+}
+
 // MARK: - Spinner Ring (Compact Merkaba)
 
 /// Merkaba-inspired spinner — two counter-rotating triangles with glowing vertices

--- a/Sources/MacParakeet/Views/Discover/DiscoverView.swift
+++ b/Sources/MacParakeet/Views/Discover/DiscoverView.swift
@@ -37,7 +37,7 @@ struct DiscoverView: View {
                 Text("Discover")
                     .font(DesignSystem.Typography.heroTitle)
                     .foregroundStyle(DesignSystem.Colors.textPrimary)
-                
+
                 RoundedRectangle(cornerRadius: 1)
                     .fill(DesignSystem.Colors.accent)
                     .frame(width: 32, height: 3)
@@ -65,7 +65,7 @@ struct DiscoverView: View {
     private func discoverCard(_ item: DiscoverItem) -> some View {
         let isHovered = hoveredItemId == item.id
         let isCopied = copiedItemId == item.id
-        
+
         return ZStack(alignment: .bottomTrailing) {
             // Sacred geometry watermark
             SacredGeometryView(
@@ -115,7 +115,7 @@ struct DiscoverView: View {
                         Rectangle()
                             .fill(DesignSystem.Colors.accent.opacity(0.4))
                             .frame(width: 12, height: 1)
-                        
+
                         Text(attribution)
                             .font(DesignSystem.Typography.caption)
                             .foregroundStyle(DesignSystem.Colors.textTertiary)
@@ -188,7 +188,7 @@ struct DiscoverView: View {
                     Image(systemName: "hand.thumbsup.fill")
                         .font(.system(size: 18))
                         .foregroundStyle(DesignSystem.Colors.successGreen)
-                    
+
                     VStack(alignment: .leading, spacing: 2) {
                         Text("Sent successfully")
                             .font(DesignSystem.Typography.bodySmall)
@@ -237,9 +237,9 @@ struct DiscoverView: View {
                                 .font(DesignSystem.Typography.caption)
                                 .foregroundStyle(DesignSystem.Colors.errorRed)
                         }
-                        
+
                         Spacer()
-                        
+
                         Button {
                             submitThought()
                         } label: {

--- a/Sources/MacParakeet/Views/Discover/SacredGeometryShapes.swift
+++ b/Sources/MacParakeet/Views/Discover/SacredGeometryShapes.swift
@@ -245,48 +245,6 @@ struct VesicaPiscisShape: Shape {
     }
 }
 
-// MARK: - Merkaba
-// Star tetrahedron — two interlocking equilateral triangles (2D projection)
-
-struct MerkabaShape: Shape {
-    func path(in rect: CGRect) -> Path {
-        var path = Path()
-        let cx = rect.midX
-        let cy = rect.midY
-        let r = min(rect.width, rect.height) * 0.42
-
-        // Upward triangle
-        for i in 0..<3 {
-            let a = CGFloat(i) * 2.0 * .pi / 3.0 - .pi / 2.0
-            let pt = CGPoint(x: cx + r * ccos(a), y: cy + r * ssin(a))
-            if i == 0 { path.move(to: pt) } else { path.addLine(to: pt) }
-        }
-        path.closeSubpath()
-
-        // Downward triangle
-        for i in 0..<3 {
-            let a = CGFloat(i) * 2.0 * .pi / 3.0 + .pi / 2.0
-            let pt = CGPoint(x: cx + r * ccos(a), y: cy + r * ssin(a))
-            if i == 0 { path.move(to: pt) } else { path.addLine(to: pt) }
-        }
-        path.closeSubpath()
-
-        // Inner hexagon
-        let ir = r * 0.5
-        for i in 0..<6 {
-            let a = CGFloat(i) * .pi / 3.0
-            let pt = CGPoint(x: cx + ir * ccos(a), y: cy + ir * ssin(a))
-            if i == 0 { path.move(to: pt) } else { path.addLine(to: pt) }
-        }
-        path.closeSubpath()
-
-        // Outer circle
-        path.addEllipse(in: circleRect(center: CGPoint(x: cx, y: cy), radius: r))
-
-        return path
-    }
-}
-
 // MARK: - Golden Spiral
 // Fibonacci spiral — logarithmic growth from center outward
 

--- a/Sources/MacParakeet/Views/MainWindowView.swift
+++ b/Sources/MacParakeet/Views/MainWindowView.swift
@@ -12,7 +12,9 @@ enum SidebarItem: String, CaseIterable, Identifiable {
     case vocabulary = "Vocabulary"
     case feedback = "Feedback"
     case settings = "Settings"
+    #if !MACPARAKEET_DISABLE_DISCOVER
     case discover = "Discover"
+    #endif
 
     var id: String { rawValue }
 
@@ -26,7 +28,9 @@ enum SidebarItem: String, CaseIterable, Identifiable {
         case .vocabulary: return "book.fill"
         case .feedback: return "bubble.left.and.text.bubble.right"
         case .settings: return "gearshape"
+        #if !MACPARAKEET_DISABLE_DISCOVER
         case .discover: return "sparkles"
+        #endif
         }
     }
 
@@ -51,8 +55,10 @@ enum SidebarItem: String, CaseIterable, Identifiable {
         return items
     }
 
-    /// Note: `.discover` is intentionally excluded from the arrays above.
-    /// It renders as a pinned card below the sidebar list via `safeAreaInset`.
+    #if !MACPARAKEET_DISABLE_DISCOVER
+    /// `.discover` is intentionally excluded from the arrays above. It renders
+    /// as a pinned card below the sidebar list via `safeAreaInset`.
+    #endif
 }
 
 struct MainWindowView: View {
@@ -71,7 +77,7 @@ struct MainWindowView: View {
     let textSnippetsViewModel: TextSnippetsViewModel
     let vocabularyBackupViewModel: VocabularyBackupViewModel
     let feedbackViewModel: FeedbackViewModel
-    let discoverViewModel: DiscoverViewModel
+    let featureDependencies: AppFeatureDependencies
     let libraryViewModel: TranscriptionLibraryViewModel
     let meetingsWorkspaceViewModel: MeetingsWorkspaceViewModel
     let meetingPillViewModel: MeetingRecordingPillViewModel
@@ -103,13 +109,15 @@ struct MainWindowView: View {
                 }
                 .listStyle(.sidebar)
                 .tint(DesignSystem.Colors.accent)
+                #if !MACPARAKEET_DISABLE_DISCOVER
                 .safeAreaInset(edge: .bottom, spacing: 0) {
                     DiscoverSidebarCard(
-                        viewModel: discoverViewModel,
+                        viewModel: featureDependencies.discoverViewModel,
                         isSelected: state.selectedItem == .discover,
                         onTap: { state.selectedItem = .discover }
                     )
                 }
+                #endif
                 .navigationSplitViewColumnWidth(min: 170, ideal: DesignSystem.Layout.sidebarMinWidth, max: 240)
             } detail: {
                 Group {
@@ -266,8 +274,13 @@ struct MainWindowView: View {
                             },
                             onHotkeyRecordingStateChanged: onHotkeyRecordingStateChanged
                         )
+                    #if !MACPARAKEET_DISABLE_DISCOVER
                     case .discover:
-                        DiscoverView(viewModel: discoverViewModel, thoughtsService: DiscoverThoughtsService())
+                        DiscoverView(
+                            viewModel: featureDependencies.discoverViewModel,
+                            thoughtsService: DiscoverThoughtsService()
+                        )
+                    #endif
                     }
                 }
             }

--- a/Sources/MacParakeetCore/Services/AppPaths.swift
+++ b/Sources/MacParakeetCore/Services/AppPaths.swift
@@ -216,9 +216,11 @@ public enum AppPaths {
     }
 
     /// Cached discover feed
+    #if !MACPARAKEET_DISABLE_DISCOVER
     public static var discoverCachePath: String {
         "\(appSupportDir)/discover-cache.json"
     }
+    #endif
 
     /// Thumbnail cache directory
     public static var thumbnailsDir: String {

--- a/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
+++ b/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
@@ -250,7 +250,9 @@ public enum TelemetryCopySource: String, Sendable, Equatable {
     case transcription
     case history
     case meeting
+    #if !MACPARAKEET_DISABLE_DISCOVER
     case discover
+    #endif
 }
 
 public enum TelemetryFormatterSource: String, Sendable, Equatable {

--- a/Tests/MacParakeetTests/Views/SpinnerRingViewTests.swift
+++ b/Tests/MacParakeetTests/Views/SpinnerRingViewTests.swift
@@ -4,6 +4,16 @@ import XCTest
 
 @MainActor
 final class SpinnerRingViewTests: XCTestCase {
+    func testStaticMerkabaShapeRetainsExpectedBounds() {
+        let path = MerkabaShape().path(in: CGRect(x: 0, y: 0, width: 100, height: 100))
+
+        XCTAssertFalse(path.isEmpty)
+        XCTAssertEqual(path.boundingRect.minX, 8, accuracy: 0.001)
+        XCTAssertEqual(path.boundingRect.minY, 8, accuracy: 0.001)
+        XCTAssertEqual(path.boundingRect.maxX, 92, accuracy: 0.001)
+        XCTAssertEqual(path.boundingRect.maxY, 92, accuracy: 0.001)
+    }
+
     func testAnimatedSpinnerUsesCoreAnimationLayers() {
         let view = SpinnerRingNSView(frame: NSRect(x: 0, y: 0, width: 14, height: 14))
 

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -19,6 +19,15 @@ This creates `dist/MacParakeet.app` and bundles:
 - Standalone helper binaries (FFmpeg, yt-dlp helper seed, and optional Node runtime) into `Contents/Resources/` when configured by the build scripts
 - No Python runtime or `uv` bootstrap is bundled (FluidAudio/CoreML STT is native Swift)
 
+Discover is included by default. Set `MACPARAKEET_DISABLE_DISCOVER=1` to
+exclude its sources and bundled fallback feed from a local release build. The
+bundle script uses a separate Xcode derived-data directory and fails if a
+Discover resource or endpoint survives in the assembled app:
+
+```bash
+MACPARAKEET_DISABLE_DISCOVER=1 VERSION=X.Y.Z scripts/dist/build_app_bundle.sh
+```
+
 `build_app_bundle.sh` automatically downloads a **statically-linked FFmpeg** from [ffmpeg.martin-riedl.de](https://ffmpeg.martin-riedl.de/) (macOS arm64, SHA256-verified). No Homebrew dependency. To use a custom binary instead, set `FFMPEG_PATH`:
 
 ```bash

--- a/scripts/dev/run_app.sh
+++ b/scripts/dev/run_app.sh
@@ -6,7 +6,11 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 # optimized build (e.g. to feel-test true STT latency — Debug Swift is ~10x
 # slower for the Cohere decoder's per-step work).
 CONFIG="${MACPARAKEET_CONFIG:-Debug}"
-DERIVED_DATA_DIR="$ROOT_DIR/.build/xcode-dev"
+DISCOVER_BUILD_SUFFIX=""
+if [[ "${MACPARAKEET_DISABLE_DISCOVER:-0}" == "1" ]]; then
+  DISCOVER_BUILD_SUFFIX="-no-discover"
+fi
+DERIVED_DATA_DIR="$ROOT_DIR/.build/xcode-dev${DISCOVER_BUILD_SUFFIX}"
 PRODUCT_DIR="$DERIVED_DATA_DIR/Build/Products/$CONFIG"
 APP_BIN="$PRODUCT_DIR/MacParakeet"
 APP_BUNDLE="$PRODUCT_DIR/MacParakeet-Dev.app"

--- a/scripts/dist/build_app_bundle.sh
+++ b/scripts/dist/build_app_bundle.sh
@@ -24,6 +24,8 @@ set -euo pipefail
 #   SKIP_BUILD          (default: 0) reuse existing Release binary if 1
 #   BUILD_SYSTEM        (default: xcodebuild) 'xcodebuild' or 'swiftpm'
 #   XCODE_DERIVED_DATA  (default: .build/xcode-dist) derived data path for xcodebuild
+#   SWIFTPM_BUILD_PATH  (default: .build, or .build-no-discover-dist when Discover is disabled)
+#   MACPARAKEET_DISABLE_DISCOVER (default: 0) exclude Discover code and fallback content when 1
 #   FFMPEG_PATH         (default: auto-download static build) source ffmpeg binary to bundle
 #   FFMPEG_VERSION      (default: release) 'release' or 'snapshot' from ffmpeg.martin-riedl.de
 #   ALLOW_NON_PORTABLE_FFMPEG (default: 0) allow bundling ffmpeg with non-system dylib deps
@@ -58,7 +60,12 @@ UNIVERSAL="${UNIVERSAL:-0}"
 SKIP_BUILD="${SKIP_BUILD:-0}"
 BUILD_SYSTEM="${BUILD_SYSTEM:-xcodebuild}"
 BUILD_SOURCE="${BUILD_SOURCE:-dist-${BUILD_SYSTEM}-release}"
-XCODE_DERIVED_DATA="${XCODE_DERIVED_DATA:-$ROOT_DIR/.build/xcode-dist}"
+DISCOVER_BUILD_SUFFIX=""
+if [[ "${MACPARAKEET_DISABLE_DISCOVER:-0}" == "1" ]]; then
+  DISCOVER_BUILD_SUFFIX="-no-discover"
+fi
+XCODE_DERIVED_DATA="${XCODE_DERIVED_DATA:-$ROOT_DIR/.build/xcode-dist${DISCOVER_BUILD_SUFFIX}}"
+SWIFTPM_BUILD_PATH="${SWIFTPM_BUILD_PATH:-$ROOT_DIR/.build${DISCOVER_BUILD_SUFFIX:+-no-discover-dist}}"
 
 APP_DIR="$DIST_DIR/${APP_NAME}.app"
 CONTENTS_DIR="$APP_DIR/Contents"
@@ -91,11 +98,11 @@ build_swiftpm() {
 
   pushd "$ROOT_DIR" >/dev/null
   if [[ "$UNIVERSAL" == "1" ]]; then
-    swift build -c release --arch arm64 --arch x86_64 --product MacParakeet
-    swift build -c release --arch arm64 --arch x86_64 --product macparakeet-cli
+    swift build --scratch-path "$SWIFTPM_BUILD_PATH" -c release --arch arm64 --arch x86_64 --product MacParakeet
+    swift build --scratch-path "$SWIFTPM_BUILD_PATH" -c release --arch arm64 --arch x86_64 --product macparakeet-cli
   else
-    swift build -c release --product MacParakeet
-    swift build -c release --product macparakeet-cli
+    swift build --scratch-path "$SWIFTPM_BUILD_PATH" -c release --product MacParakeet
+    swift build --scratch-path "$SWIFTPM_BUILD_PATH" -c release --product macparakeet-cli
   fi
   popd >/dev/null
 }
@@ -107,9 +114,9 @@ build_cli_swiftpm() {
 
   pushd "$ROOT_DIR" >/dev/null
   if [[ "$UNIVERSAL" == "1" ]]; then
-    swift build -c release --arch arm64 --arch x86_64 --product macparakeet-cli
+    swift build --scratch-path "$SWIFTPM_BUILD_PATH" -c release --arch arm64 --arch x86_64 --product macparakeet-cli
   else
-    swift build -c release --product macparakeet-cli
+    swift build --scratch-path "$SWIFTPM_BUILD_PATH" -c release --product macparakeet-cli
   fi
   popd >/dev/null
 }
@@ -211,9 +218,9 @@ copy_resource_bundles() {
 swiftpm_release_bin_dir() {
   pushd "$ROOT_DIR" >/dev/null
   if [[ "$UNIVERSAL" == "1" ]]; then
-    swift build -c release --arch arm64 --arch x86_64 --product "$1" --show-bin-path
+    swift build --scratch-path "$SWIFTPM_BUILD_PATH" -c release --arch arm64 --arch x86_64 --product "$1" --show-bin-path
   else
-    swift build -c release --product "$1" --show-bin-path
+    swift build --scratch-path "$SWIFTPM_BUILD_PATH" -c release --product "$1" --show-bin-path
   fi
   popd >/dev/null
 }
@@ -247,12 +254,16 @@ if [[ "$BUILD_SYSTEM" == "swiftpm" ]]; then
   echo "[2/4] Assembling app bundle…"
   cp "$BIN_PATH" "$MACOS_DIR/$APP_NAME"
   chmod +x "$MACOS_DIR/$APP_NAME"
+  copy_resource_bundles "$BIN_DIR"
 else
   build_xcodebuild
   echo "[2/4] Assembling app bundle…"
 fi
 
 copy_cli_binary
+
+bash "$ROOT_DIR/scripts/dist/verify_discover_bundle_mode.sh" \
+  "$APP_DIR" "${MACPARAKEET_DISABLE_DISCOVER:-0}" "$APP_NAME"
 
 # Bundle FFmpeg (required at runtime for media demux/conversion).
 #

--- a/scripts/dist/test_verify_discover_bundle_mode.sh
+++ b/scripts/dist/test_verify_discover_bundle_mode.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+scratch="$(mktemp -d)"
+trap 'rm -rf "$scratch"' EXIT
+app_dir="$scratch/MacParakeet.app"
+mkdir -p "$app_dir/Contents/Resources" "$app_dir/Contents/MacOS"
+app_binary="$app_dir/Contents/MacOS/MacParakeet"
+cli_binary="$app_dir/Contents/MacOS/macparakeet-cli"
+printf '%s\n' 'no feature endpoints' > "$app_binary"
+cp "$app_binary" "$cli_binary"
+
+verify() {
+  bash "$script_dir/verify_discover_bundle_mode.sh" "$app_dir" "$1" > "$scratch/result.log" 2>&1
+}
+
+expect_failure() {
+  if verify "$1"; then
+    echo "Expected verification to reject: $2" >&2
+    exit 1
+  fi
+  grep -F "$2" "$scratch/result.log" > /dev/null
+}
+
+verify 1
+expect_failure 0 'missing discover-fallback.json'
+touch "$app_dir/Contents/Resources/discover-fallback.json"
+verify 0
+expect_failure 1 'unexpectedly contains:'
+rm "$app_dir/Contents/Resources/discover-fallback.json"
+
+# A match near the beginning of output larger than the pipe buffer reproduces
+# the previous SIGPIPE false negative, for both binaries and each pattern.
+for binary in "$app_binary" "$cli_binary"; do
+  for marker in '/api/discover.json' '/api/discover-thoughts' 'MACPARAKEET_DISCOVER_URL'; do
+    awk -v marker="$marker" 'BEGIN {
+      print marker
+      for (i = 0; i < 100000; i++) print "non_secret_padding_for_pipe_buffer"
+    }' > "$binary"
+    expect_failure 1 'contains Discover endpoints or overrides'
+  done
+  printf '%s\n' 'no feature endpoints' > "$binary"
+done
+verify 1
+echo 'Discover bundle verification tests passed.'

--- a/scripts/dist/verify_discover_bundle_mode.sh
+++ b/scripts/dist/verify_discover_bundle_mode.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Inspect the assembled bundle without rebuilding or launching it.
+app_dir="${1:?Usage: verify_discover_bundle_mode.sh APP_DIR [DISABLED] [APP_NAME]}"
+disabled="${2:-0}"
+app_name="${3:-MacParakeet}"
+resources_dir="$app_dir/Contents/Resources"
+macos_dir="$app_dir/Contents/MacOS"
+discover_resource="$(find "$resources_dir" -name 'discover-fallback.json' -print -quit)"
+
+if [[ "$disabled" == "1" ]]; then
+  if [[ -n "$discover_resource" ]]; then
+    echo "Discover-disabled build unexpectedly contains: $discover_resource" >&2
+    exit 1
+  fi
+  for bundled_binary in "$macos_dir/$app_name" "$macos_dir/macparakeet-cli"; do
+    # Consume all strings: grep -q exits on the first match and can give
+    # strings SIGPIPE, making this condition false under pipefail.
+    if [[ -f "$bundled_binary" ]] && strings "$bundled_binary" | grep -E '/api/discover(\.json|-thoughts)|MACPARAKEET_DISCOVER_' > /dev/null; then
+      echo "Discover-disabled build unexpectedly contains Discover endpoints or overrides: $bundled_binary" >&2
+      exit 1
+    fi
+  done
+  echo "Verified Discover is absent from the app bundle."
+elif [[ -z "$discover_resource" ]]; then
+  echo "Discover-enabled build is missing discover-fallback.json." >&2
+  exit 1
+fi

--- a/spec/03-architecture.md
+++ b/spec/03-architecture.md
@@ -165,10 +165,10 @@ The UI layer. Thin shell over MacParakeetCore. No business logic lives here.
 
 #### Main Window
 
-**Responsibility:** Primary in-app navigation shell. Hosts the Transcribe capture hub, Library, Dictations, Vocabulary, Transforms, Feedback, Settings, and Discover surfaces. File/URL transcription, meeting recording, transcript browse, dictation history, prompt actions, Transforms, and settings all route through this window.
+**Responsibility:** Primary in-app navigation shell. Hosts the Transcribe capture hub, Library, Dictations, Vocabulary, Transforms, Feedback, Settings, and (unless excluded at compile time) Discover surfaces. File/URL transcription, meeting recording, transcript browse, dictation history, prompt actions, Transforms, and settings all route through this window.
 
 **Key Types:**
-- `MainWindowView` — `NavigationSplitView` sidebar (Transcribe / Library / Dictations / Vocabulary / Transforms / Feedback / Settings) plus pinned Discover card and a global transcription progress bar
+- `MainWindowView` — `NavigationSplitView` sidebar (Transcribe / Library / Dictations / Vocabulary / Transforms / Feedback / Settings), a global transcription progress bar, and a pinned Discover card unless `MACPARAKEET_DISABLE_DISCOVER=1` excludes that feature from the build
 - `TranscribeView` — YouTube card, file drop card, Meeting Recording tile, and transcript detail / progress surfaces
 - `TranscriptionLibraryView` — file, YouTube, meeting, and favorite transcript browse with search/sort/filter support
 - `TranscriptResultView` — Scrollable text with optional word-level timestamps

--- a/spec/04-ui-patterns.md
+++ b/spec/04-ui-patterns.md
@@ -1092,17 +1092,11 @@ Button to re-run onboarding flow: "Run Onboarding Again..."
 
 ## Discover (v0.4)
 
-A curated content feed displayed as a sidebar item with a full-page content view. Discover surfaces tips, quotes, affirmations, and sponsored items fetched from a remote JSON feed (`macparakeet.com/api/discover.json`) with local cache fallback and a bundled default.
-
-The refresh is started unconditionally by app launch, not by selecting this
-page, and is independent of the telemetry setting. The app does not provide a
-Discover visibility/network toggle; release-readiness work leaves that product
-behavior unchanged. Cached/bundled content supports offline display, not an
-opt-out from the launch request.
+A curated content feed displayed as a sidebar item with a full-page content view. Discover surfaces tips, quotes, affirmations, and sponsored items fetched from a remote JSON feed (`macparakeet.com/api/discover.json`) with local cache fallback and a bundled default. The feature is included by default; setting `MACPARAKEET_DISABLE_DISCOVER=1` at compile time excludes its code, resources, and UI.
 
 ### Sidebar Card
 
-The Discover item is **not** part of the regular sidebar `List`. It renders as a pinned card below the sidebar list via `.safeAreaInset(edge: .bottom)`. This keeps it visually distinct and always visible regardless of scroll position.
+When compiled in, the Discover item is **not** part of the regular sidebar `List`. It renders as a pinned card below the sidebar list via `.safeAreaInset(edge: .bottom)`. This keeps it visually distinct and always visible regardless of scroll position.
 
 ```
 ┌──────────────────┐

--- a/spec/04-ui-patterns.md
+++ b/spec/04-ui-patterns.md
@@ -1094,6 +1094,11 @@ Button to re-run onboarding flow: "Run Onboarding Again..."
 
 A curated content feed displayed as a sidebar item with a full-page content view. Discover surfaces tips, quotes, affirmations, and sponsored items fetched from a remote JSON feed (`macparakeet.com/api/discover.json`) with local cache fallback and a bundled default. The feature is included by default; setting `MACPARAKEET_DISABLE_DISCOVER=1` at compile time excludes its code, resources, and UI.
 
+When Discover is compiled in, refresh starts at app launch, independently of
+page selection and the telemetry setting. There is no runtime visibility or
+network toggle. Cached and bundled content supports offline display; it does
+not disable the launch request.
+
 ### Sidebar Card
 
 When compiled in, the Discover item is **not** part of the regular sidebar `List`. It renders as a pinned card below the sidebar list via `.safeAreaInset(edge: .bottom)`. This keeps it visually distinct and always visible regardless of scroll position.

--- a/spec/README.md
+++ b/spec/README.md
@@ -86,6 +86,10 @@ Implementation status is not release verification. Candidate hardware capture,
 long-transcript interaction, signed upgrade, and full-suite evidence must be
 reported separately; a source/doc review does not establish those gates.
 
+Discover is included in normal builds. `MACPARAKEET_DISABLE_DISCOVER=1` is a
+manifest-level local build option that excludes the Discover sources, fallback
+feed, UI wiring, cache path, and network endpoints; it is not a runtime setting.
+
 ## Architecture Decision Records (ADRs)
 
 All ADRs live in `spec/adr/`. These are locked -- they record decisions already made.


### PR DESCRIPTION
## Why this is useful

Some local builds should omit the Discover feed entirely. This adds `MACPARAKEET_DISABLE_DISCOVER=1` as a build-time choice while keeping Discover enabled in normal builds. A disabled build excludes its views, services, models, telemetry source case and bundled fallback JSON; the shared Merkaba artwork remains available to the rest of the app.

The distribution scripts isolate build directories by mode and inspect the assembled app and CLI for Discover resources/endpoints. The verifier consumes the complete `strings` output, so a large binary cannot hide a detected endpoint behind a SIGPIPE false negative.

```mermaid
flowchart LR
    F{Disable Discover?} -->|No, default| D[Normal targets and fallback resource]
    F -->|Yes| E[Exclude Discover sources and resources]
    D --> B[Assemble app and CLI]
    E --> B
    B --> V[Verify bundle matches requested mode]
```

## Screenshots

Captured from the corrected integrated app with fictional demonstration data. Navigation may differ from the independent feature branches.

![Default build: Discover remains available.](https://raw.githubusercontent.com/alfred-sa/macparakeet/ed1828c790a3ff5296157ed80a2945ea22d74c98/screenshots/955-discover-default.png)

*Default build: Discover remains available.*

![Build with MACPARAKEET_DISABLE_DISCOVER=1: Discover is omitted from navigation.](https://raw.githubusercontent.com/alfred-sa/macparakeet/ed1828c790a3ff5296157ed80a2945ea22d74c98/screenshots/955-discover-disabled.png)

*Build with MACPARAKEET_DISABLE_DISCOVER=1: Discover is omitted from navigation.*

## Scope and review focus

This is an independent extraction from the fork, based on upstream `1159dfca8ae53a15ffcc1562b1efb9220f95cd88`. It contains no prompt, meeting, Markdown or Library layout changes. It is a compile-time distribution option; the existing upstream proposal for a runtime network preference addresses a different use case.

Review both build modes, SwiftPM source/resource exclusion, shared artwork, and packaging checks. Disabled builds must not retain a fallback file, service endpoint or environment override string. The default build must retain its fallback resource.

## Validation

- `bash scripts/dist/test_verify_discover_bundle_mode.sh`: passed on this extracted branch, including app/CLI markers and output larger than a pipe buffer.
- `git diff --check`: passed.
- `MACPARAKEET_DISABLE_DISCOVER=1 swift test --filter 'SpinnerRingViewTests|MainWindowStateTests'`: built this extracted branch and passed all 14 tests.
- The corrected integrated series passed its focused selection: 1,579 tests, one skipped, zero failures. Independent review found no remaining actionable issue in the eight corrections made across the series. This is integrated evidence, not a replacement for both distribution-mode checks above.

Upstream CI currently requires maintainer action (`action_required`), and CodeRabbit skipped review while the PR was a draft. Those checks are not represented as passed.

Local `no-mistakes` and Greptile CLIs are unavailable. The website walkthrough repository referenced by the contributor guide is inaccessible to this account (GitHub returns 404), so the explanation and diagram are included here.


Both corrected Xcode GUI configurations (Discover enabled and `MACPARAKEET_DISABLE_DISCOVER=1`) built and launched successfully for the local visual comparison.

Cubic review follow-up: restored the explicit default-build contract that Discover refresh starts at launch independently of telemetry, with no runtime opt-out. This is a documentation clarification; runtime behavior is unchanged.
