### PR TITLE
Render rich Markdown in streaming results, Chat and live Ask

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,9 +95,9 @@ jobs:
           PY
 
       - name: Release Bundle Smoke
-        timeout-minutes: 15
+        timeout-minutes: 25
         env:
-          BUILD_SYSTEM: swiftpm
+          BUILD_SYSTEM: xcodebuild
           BUNDLE_YTDLP: "0"
           BUNDLE_NODE: "0"
           FFMPEG_PATH: /usr/bin/true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,18 @@ jobs:
           mkdir -p .ci-logs
           set -o pipefail
           ./scripts/dist/build_app_bundle.sh 2>&1 | tee .ci-logs/release-bundle-smoke.log
+          swift - dist/MacParakeet.app/Contents/Resources/SwiftStreamingMarkdown_SwiftStreamingMarkdown.bundle <<'SWIFT'
+          import AppKit
+          guard let bundle = Bundle(path: CommandLine.arguments[1]),
+                bundle.bundleIdentifier != nil,
+                bundle.url(forResource: "Assets", withExtension: "car") != nil,
+                NSColor(named: "Colors/Copilot/Theme/Foreground/Primary/450", bundle: bundle) != nil,
+                bundle.image(forResource: "Copy") != nil,
+                bundle.image(forResource: "downloadArrow") != nil else {
+              fatalError("Packaged Markdown colors and action icons must resolve without build-directory resources")
+          }
+          print("Packaged Markdown assets resolve")
+          SWIFT
 
       - name: Swift Concurrency Safety
         timeout-minutes: 15

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,8 +49,8 @@ the `EquatableMacros` plugin, so Xcode builds must keep
 `-skipMacroValidation`; otherwise dependency resolution stops with
 `Macro “EquatableMacros” ... must be enabled before it can be used`. The dev
 script owns this flag. Do not install another Markdown renderer or edit the
-package checkout to work around the error. The script must also stop every
-running MacParakeet process before it rebuilds or re-signs the Dev bundle.
+package checkout to work around the error. The script must confirm this worktree’s replaced dev executables have exited
+before it rebuilds or re-signs their bundle; preserve unrelated app instances.
 Re-signing a bundle in place while macOS is executing it can cause a delayed
 `SIGKILL (Code Signature Invalid)` when a menu or sheet loads another page.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,17 @@ swift run macparakeet-cli --help
 swift run macparakeet-cli health
 ```
 
+For a testable GUI build, use `scripts/dev/run_app.sh` instead of copying its
+`xcodebuild` command by hand. `SwiftStreamingMarkdown` depends transitively on
+the `EquatableMacros` plugin, so Xcode builds must keep
+`-skipMacroValidation`; otherwise dependency resolution stops with
+`Macro “EquatableMacros” ... must be enabled before it can be used`. The dev
+script owns this flag. Do not install another Markdown renderer or edit the
+package checkout to work around the error. The script must also stop every
+running MacParakeet process before it rebuilds or re-signs the Dev bundle.
+Re-signing a bundle in place while macOS is executing it can cause a delayed
+`SIGKILL (Code Signature Invalid)` when a menu or sheet loads another page.
+
 Iterate on focused tests ONLY (`swift test --filter <AreaTests>` for the
 areas the diff touches). Run the full `swift test` suite AT MOST ONCE per
 task, as the final gate before declaring code-change work complete — never

--- a/Package.resolved
+++ b/Package.resolved
@@ -147,7 +147,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/alfred-sa/SwiftStreamingMarkdown",
       "state" : {
-        "revision" : "17507bfe99e90b89f5cae65b78b92dade91e0d30"
+        "revision" : "1f10d5286985349b63145e1193f4f6ad5f7fdfe1"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -10,6 +10,15 @@
       }
     },
     {
+      "identity" : "equatable",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ordo-one/equatable",
+      "state" : {
+        "revision" : "597c2bb34af0c51331eb3b5e705f942d8ee20daa",
+        "version" : "1.4.1"
+      }
+    },
+    {
       "identity" : "fluidaudio",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/FluidInference/FluidAudio",
@@ -25,6 +34,22 @@
       "state" : {
         "revision" : "36e30a6f1ef10e4194f6af0cff90888526f0c115",
         "version" : "7.10.0"
+      }
+    },
+    {
+      "identity" : "highlightswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/appstefan/highlightswift",
+      "state" : {
+        "revision" : "99c431b38a1444a5fd6a4978307fbbefe3a7af53"
+      }
+    },
+    {
+      "identity" : "iosmath",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/junyan72/iosMath",
+      "state" : {
+        "revision" : "ba9ab7729b151329c54fd895a7c1859981d9484c"
       }
     },
     {
@@ -55,6 +80,15 @@
       }
     },
     {
+      "identity" : "swift-cmark",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-cmark.git",
+      "state" : {
+        "revision" : "924936d0427cb25a61169739a7660230bffa6ea6",
+        "version" : "0.8.0"
+      }
+    },
+    {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
@@ -82,12 +116,47 @@
       }
     },
     {
+      "identity" : "swift-markdown",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-markdown.git",
+      "state" : {
+        "revision" : "7d9a5ce307528578dfa777d505496bd5f544ad94",
+        "version" : "0.7.3"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
+      "state" : {
+        "revision" : "79e4b74a295b6eb74a8b585e3a39d29e70c1dbd1",
+        "version" : "603.0.2"
+      }
+    },
+    {
       "identity" : "swift-transformers",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-transformers.git",
       "state" : {
         "revision" : "150169bfba0889c229a2ce7494cf8949f18e6906",
         "version" : "1.1.9"
+      }
+    },
+    {
+      "identity" : "swiftstreamingmarkdown",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/alfred-sa/SwiftStreamingMarkdown",
+      "state" : {
+        "revision" : "17507bfe99e90b89f5cae65b78b92dade91e0d30"
+      }
+    },
+    {
+      "identity" : "swiftui-shimmer",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/markiv/SwiftUI-Shimmer",
+      "state" : {
+        "revision" : "0226e21f9bf355d40e07e5f5e1c33679d50e167f",
+        "version" : "1.5.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -14,11 +14,11 @@ let streamingMarkdownPackageDependencies: [Package.Dependency] = skipStreamingMa
     // Shared SwiftUI renderer for static and streaming LLM Markdown output.
     // v0.7.0 transitively pins two dependencies by revision, so SwiftPM rejects
     // the stable-version requirement. The fork removes one trailing argument
-    // comma that Swift 6.0 / Xcode 16.1 cannot parse; keep this immutable pin
-    // until upstream supports the repository's CI toolchain.
+    // comma that Swift 6.0 / Xcode 16.1 cannot parse and restores selectable
+    // macOS table cells with named actions. Keep these fixes immutably pinned.
     .package(
         url: "https://github.com/alfred-sa/SwiftStreamingMarkdown",
-        revision: "17507bfe99e90b89f5cae65b78b92dade91e0d30"
+        revision: "1f10d5286985349b63145e1193f4f6ad5f7fdfe1"
     )
 ]
 

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,23 @@ import PackageDescription
 import Foundation
 
 let skipWhisperKit = ProcessInfo.processInfo.environment["MACPARAKEET_SKIP_WHISPERKIT"] == "1"
+// The existing no-WhisperKit mode is the repository's first-party Swift 6
+// compatibility build. Omit the Swift 5-only Markdown dependency graph there
+// as well; normal release, concurrency, and test builds still compile it.
+let skipStreamingMarkdown = skipWhisperKit
 let enableMLXLocalLLM = ProcessInfo.processInfo.environment["MACPARAKEET_ENABLE_MLX_LOCAL_LLM"] == "1"
+
+let streamingMarkdownPackageDependencies: [Package.Dependency] = skipStreamingMarkdown ? [] : [
+    // Shared SwiftUI renderer for static and streaming LLM Markdown output.
+    // v0.7.0 transitively pins two dependencies by revision, so SwiftPM rejects
+    // the stable-version requirement. The fork removes one trailing argument
+    // comma that Swift 6.0 / Xcode 16.1 cannot parse; keep this immutable pin
+    // until upstream supports the repository's CI toolchain.
+    .package(
+        url: "https://github.com/alfred-sa/SwiftStreamingMarkdown",
+        revision: "17507bfe99e90b89f5cae65b78b92dade91e0d30"
+    )
+]
 
 let packageDependencies: [Package.Dependency] = [
     // GRDB for SQLite (dictation history + transcription records)
@@ -24,7 +40,7 @@ let packageDependencies: [Package.Dependency] = [
     // as a target dependency for the first-party Swift 6 syntax/concurrency
     // compile check without removing its lockfile pins.
     .package(url: "https://github.com/argmaxinc/argmax-oss-swift", exact: "0.18.0")
-] + (enableMLXLocalLLM ? [
+] + streamingMarkdownPackageDependencies + (enableMLXLocalLLM ? [
     // Opt-in only. mlx-swift-lm currently needs Swift tools 6.1 and Xcode-built
     // Metal shaders, so plain `swift build` / `swift test` / CI must not resolve it.
     .package(url: "https://github.com/ml-explore/mlx-swift-lm", exact: "3.31.4"),
@@ -54,11 +70,14 @@ let mlxLocalLLMSwiftSettings: [SwiftSetting] = enableMLXLocalLLM ? [
     .define("MACPARAKEET_HAS_MLX_LOCAL_LLM")
 ] : []
 
+let streamingMarkdownTargetDependencies: [Target.Dependency] = skipStreamingMarkdown ? [] : [
+    .product(name: "SwiftStreamingMarkdown", package: "SwiftStreamingMarkdown")
+]
 let appDependencies: [Target.Dependency] = [
     "MacParakeetCore",
     "MacParakeetViewModels",
-    .product(name: "Sparkle", package: "Sparkle")
-] + (enableMLXLocalLLM ? [
+    .product(name: "Sparkle", package: "Sparkle"),
+] + streamingMarkdownTargetDependencies + (enableMLXLocalLLM ? [
     "MacParakeetLocalLLM"
 ] : [])
 
@@ -66,8 +85,8 @@ let appTestDependencies: [Target.Dependency] = [
     "MacParakeet",
     "MacParakeetCore",
     "MacParakeetViewModels",
-    "MacParakeetObjCShims"
-] + (enableMLXLocalLLM ? [
+    "MacParakeetObjCShims",
+] + streamingMarkdownTargetDependencies + (enableMLXLocalLLM ? [
     "MacParakeetLocalLLM"
 ] : [])
 

--- a/Sources/MacParakeet/Resources/Legal/MarkdownDependencies.txt
+++ b/Sources/MacParakeet/Resources/Legal/MarkdownDependencies.txt
@@ -1,0 +1,1564 @@
+MacParakeet Markdown dependency notices
+======================================
+
+This file contains verbatim upstream legal material for the exact revisions
+indexed below. Equatable and swift-syntax are macro/build support; including
+their licenses does not assert that the macro executables ship in the app.
+The complete upstream swift-cmark COPYING is retained, including its upstream
+test notices; this does not assert that CommonMark tests ship in MacParakeet.
+Latin Modern Math font files are redistributed unchanged from iosMath.
+The bundled font resources are a subset of the Latin Modern Math distribution;
+the font binary itself is unmodified. The complete, unmodified version 1.959,
+including its manifest and documentation, is available from the font maintainers:
+https://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip
+Project/download page: https://www.gust.org.pl/projects/e-foundry/lm-math/download
+
+
+===== SwiftStreamingMarkdown | 1f10d5286985349b63145e1193f4f6ad5f7fdfe1 | LICENSE =====
+Source: https://raw.githubusercontent.com/alfred-sa/SwiftStreamingMarkdown/1f10d5286985349b63145e1193f4f6ad5f7fdfe1/LICENSE
+
+    MIT License
+
+    Copyright (c) Microsoft Corporation.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE
+
+
+===== swift-markdown | 7d9a5ce307528578dfa777d505496bd5f544ad94 | LICENSE.txt =====
+Source: https://raw.githubusercontent.com/swiftlang/swift-markdown/7d9a5ce307528578dfa777d505496bd5f544ad94/LICENSE.txt
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+    1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+    2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+    3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+    4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+    5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+    6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+    7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+    8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+    9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+    END OF TERMS AND CONDITIONS
+
+    APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+    Copyright [yyyy] [name of copyright owner]
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+
+
+### Runtime Library Exception to the Apache 2.0 License: ###
+
+
+    As an exception, if you use this Software to compile your source code and
+    portions of this Software are embedded into the binary product as a result,
+    you may redistribute such product without providing attribution as would
+    otherwise be required by Sections 4(a), 4(b) and 4(d) of the License.
+
+
+===== swift-markdown | 7d9a5ce307528578dfa777d505496bd5f544ad94 | NOTICE.txt =====
+Source: https://raw.githubusercontent.com/swiftlang/swift-markdown/7d9a5ce307528578dfa777d505496bd5f544ad94/NOTICE.txt
+
+
+                            The Swift Markdown Project
+                            ==========================
+
+Please visit the Swift Markdown web site for more information:
+
+  * https://github.com/apple/swift-markdown
+
+Copyright (c) 2021 Apple Inc. and the Swift project authors
+
+The Swift Project licenses this file to you under the Apache License,
+version 2.0 (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at:
+
+  https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+-------------------------------------------------------------------------------
+
+This product contains Swift Argument Parser.
+
+  * LICENSE (Apache License 2.0):
+    * https://www.apache.org/licenses/LICENSE-2.0
+  * HOMEPAGE:
+    * https://github.com/apple/swift-argument-parser
+
+---
+
+This product contains a derivation of the cmark-gfm project, available at
+https://github.com/apple/swift-cmark.
+
+  * LICENSE (BSD-2):
+    * https://opensource.org/licenses/BSD-2-Clause
+  * HOMEPAGE:
+    * https://github.com/github/cmark-gfm
+
+
+
+===== HighlightSwift | 99c431b38a1444a5fd6a4978307fbbefe3a7af53 | LICENSE.md =====
+Source: https://raw.githubusercontent.com/appstefan/highlightswift/99c431b38a1444a5fd6a4978307fbbefe3a7af53/LICENSE.md
+
+MIT License
+
+Copyright (c) 2023 Stefan Britton
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+===== Highlight.js (HighlightSwift resource) | 99c431b38a1444a5fd6a4978307fbbefe3a7af53 | Sources/HighlightSwift/HighlightJS/LICENSE.md =====
+Source: https://raw.githubusercontent.com/appstefan/highlightswift/99c431b38a1444a5fd6a4978307fbbefe3a7af53/Sources/HighlightSwift/HighlightJS/LICENSE.md
+
+BSD 3-Clause License
+
+Copyright (c) 2006, Ivan Sagalaev.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+===== iosMath | ba9ab7729b151329c54fd895a7c1859981d9484c | LICENSE =====
+Source: https://raw.githubusercontent.com/junyan72/iosMath/ba9ab7729b151329c54fd895a7c1859981d9484c/LICENSE
+
+The MIT License (MIT)
+
+Copyright (c) 2013 MathChat
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+===== Latin Modern Math (iosMath resource) | ba9ab7729b151329c54fd895a7c1859981d9484c | iosMath/fonts/GUST-FONT-LICENSE.txt =====
+Source: https://raw.githubusercontent.com/junyan72/iosMath/ba9ab7729b151329c54fd895a7c1859981d9484c/iosMath/fonts/GUST-FONT-LICENSE.txt
+
+% This is a preliminary version (2006-09-30), barring acceptance from
+% the LaTeX Project Team and other feedback, of the GUST Font License.
+% (GUST is the Polish TeX Users Group, http://www.gust.org.pl)
+%
+% For the most recent version of this license see
+% http://www.gust.org.pl/fonts/licenses/GUST-FONT-LICENSE.txt
+% or
+% http://tug.org/fonts/licenses/GUST-FONT-LICENSE.txt
+%
+% This work may be distributed and/or modified under the conditions
+% of the LaTeX Project Public License, either version 1.3c of this
+% license or (at your option) any later version.
+% 
+% Please also observe the following clause:
+% 1) it is requested, but not legally required, that derived works be
+%    distributed only after changing the names of the fonts comprising this
+%    work and given in an accompanying "manifest", and that the
+%    files comprising the Work, as listed in the manifest, also be given
+%    new names. Any exceptions to this request are also given in the
+%    manifest.
+%    
+%    We recommend the manifest be given in a separate file named
+%    MANIFEST-<fontid>.txt, where <fontid> is some unique identification
+%    of the font family. If a separate "readme" file accompanies the Work, 
+%    we recommend a name of the form README-<fontid>.txt.
+%
+% The latest version of the LaTeX Project Public License is in
+% http://www.latex-project.org/lppl.txt and version 1.3c or later
+% is part of all distributions of LaTeX version 2006/05/20 or later.
+
+
+
+===== Latin Modern Math (iosMath resource) | ba9ab7729b151329c54fd895a7c1859981d9484c | iosMath/fonts/README-Latin-Modern-Math.txt =====
+Source: https://raw.githubusercontent.com/junyan72/iosMath/ba9ab7729b151329c54fd895a7c1859981d9484c/iosMath/fonts/README-Latin-Modern-Math.txt
+
+###########################################################################
+############          Latin Modern Collection of Fonts         ############
+###########################################################################
+
+Font: Latin Modern Math
+Authors: Bogus\l{}aw Jackowski, Piotr Strzelczyk and Piotr Pianowski
+Version: 1.959
+Date: 5 IX 2014
+
+License:
+  % Copyright 2012--2014 for the Latin Modern math extensions by B. Jackowski,
+  % P. Strzelczyk and P. Pianowski (on behalf of TeX Users Groups).
+  %
+  % This work can be freely used and distributed under
+  % the GUST Font License (GFL -- see GUST-FONT-LICENSE.txt)
+  % which is actually an instance of the LaTeX Project Public License
+  % (LPPL -- see http://www.latex-project.org/lppl.txt).
+  %
+  % This work has the maintenance status "maintained". The Current Maintainer
+  % of this work is Bogus\l{}aw Jackowski, Piotr Strzelczyk and Piotr Pianowski.
+  %
+  % This work consists of the files listed
+  % in the MANIFEST-Latin-Modern-Math.txt file.
+ 
+###########################################################################
+############          A BRIEF DESCRIPTION OF THE FONT          ############
+###########################################################################
+
+Latin Modern Math is a math companion for the Latin Modern family
+of fonts (see http://www.gust.org.pl/projects/e-foundry/latin-modern) in
+the OpenType format.
+
+The math OTF fonts should contain a special table, MATH, described in the 
+confidential Microsoft document "The MATH table and OpenType Features 
+for Math Processing". Moreover, they should contain a broad collection
+of special characters (see "Draft Unicode Technical Report #25.
+UNICODE SUPPORT FOR MATHEMATICS" by Barbara Beeton, Asmus Freytag,
+and Murray Sargent III). In particular, math OTF fonts are expected
+to contain the following scripts: a basic serif script (regular, bold, 
+italic and bold italic), a calligraphic script (regular and bold), 
+a double-struck script, a fraktur script (regular and bold), a sans-serif 
+script (regular, bold, oblique and bold oblique), and a monospaced script.
+
+The basic script is, obviously, Latin Modern. Some scripts, however,
+are borrowed from other fonts (the current selection, however, may
+be subject to change), belonging, however, to the "TeX circle":
+
+  * the calligraphic and fraktur alphabets are excerpted from the renowned
+    Euler family (http://en.wikipedia.org/wiki/AMS_Euler);
+
+  * the double struck script is excerpted from Alan Jeffrey's bbold font
+    (http://www.tug.org/texlive/Contents/live/texmf-dist/doc/latex/bbold/bbold.pdf)
+
+  * the sans serif and monospaced alphabets are excerpted from 
+    the Latin Modern Sans and Latin Modern Mono fonts
+    (http://www.gust.org.pl/projects/e-foundry/latin-modern);
+    sans serif bold Greek symbols (required by the already mentioned
+    "Unicode Technical Report #25") were prepared using D.E. Knuth's
+    font sources with some manual tuning
+
+The main math component, that is, the math extension, was programmed
+from scratch, with an attempt to retain the visual compatiblility
+with the original D.E. Knuth's fonts. In particular, all symbols
+(with a few exceptions) appearing in the D.E. Knuth's "canonical" fonts
+have the same width (rounded) as the corresponding Knuthian ones.
+
+Note that the members of all the mentioned alphabets, except
+the main roman alphabet, should be considerd symbols, not letters;
+symbols are not expected to occur in a text stream; instead,
+they are expected to appear lonely, perhaps with some embellishments
+like subscripts, superscripts, primes, dots above and below, etc.
+
+To produce the font, MetaType1 and the FontForge library were used:
+the Type1 PostScript font containing all relevant characters was
+generated with the MetaType1 engine, and the result was converted
+into the OTF format with all the necessary data structures by
+a Python script employing the FontForge library.
+
+Recent changes (ver. 1.958 --> ver. 1.959) comprised
+mainly interline settings in OTF tables (HHEA and
+OS/2) and the correction of unicode slots assigned to
+the contour integrals (glyphs `clockwise contour
+integral', u+2232, and `anticlockwise contour
+integral', u+2233, used to have swapped slots).
+
+                   *    *    *
+
+The TeX Gyre Math Project was launched and is supported by
+TeX USERS GROUPS (CS TUG, DANTE eV, GUST, NTG, TUG India, TUG, UK TUG).
+Hearty thanks to the representatives of these groups and also
+to all people who helped with their work, comments, ideas,
+remarks, bug reports, objections, hints, consolations, etc.
+
+
+===== Equatable (macro build support) | 597c2bb34af0c51331eb3b5e705f942d8ee20daa | LICENSE =====
+Source: https://raw.githubusercontent.com/ordo-one/equatable/597c2bb34af0c51331eb3b5e705f942d8ee20daa/LICENSE
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+===== SwiftUI-Shimmer | 0226e21f9bf355d40e07e5f5e1c33679d50e167f | LICENSE =====
+Source: https://raw.githubusercontent.com/markiv/SwiftUI-Shimmer/0226e21f9bf355d40e07e5f5e1c33679d50e167f/LICENSE
+
+MIT License
+
+Copyright (c) 2021 Vikram Kriplaney
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+===== swift-cmark | 924936d0427cb25a61169739a7660230bffa6ea6 | COPYING =====
+Source: https://raw.githubusercontent.com/swiftlang/swift-cmark/924936d0427cb25a61169739a7660230bffa6ea6/COPYING
+
+Copyright (c) 2014, John MacFarlane
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+-----
+
+houdini.h, houdini_href_e.c, houdini_html_e.c, houdini_html_u.c
+
+derive from https://github.com/vmg/houdini (with some modifications)
+
+Copyright (C) 2012 Vicent Martí
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+-----
+
+buffer.h, buffer.c, chunk.h
+
+are derived from code (C) 2012 Github, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+-----
+
+utf8.c and utf8.c
+
+are derived from utf8proc
+(<http://www.public-software-group.org/utf8proc>),
+(C) 2009 Public Software Group e. V., Berlin, Germany.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+-----
+
+The normalization code in normalize.py was derived from the
+markdowntest project, Copyright 2013 Karl Dubost:
+
+The MIT License (MIT)
+
+Copyright (c) 2013 Karl Dubost
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+-----
+
+The CommonMark spec (test/spec.txt) is
+
+Copyright (C) 2014-15 John MacFarlane
+
+Released under the Creative Commons CC-BY-SA 4.0 license:
+<http://creativecommons.org/licenses/by-sa/4.0/>.
+
+-----
+
+The test software in test/ is
+
+Copyright (c) 2014, John MacFarlane
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+===== swift-syntax (macro build support) | 79e4b74a295b6eb74a8b585e3a39d29e70c1dbd1 | LICENSE.txt =====
+Source: https://raw.githubusercontent.com/swiftlang/swift-syntax/79e4b74a295b6eb74a8b585e3a39d29e70c1dbd1/LICENSE.txt
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+    1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+    2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+    3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+    4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+    5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+    6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+    7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+    8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+    9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+    END OF TERMS AND CONDITIONS
+
+    APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+    Copyright [yyyy] [name of copyright owner]
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+
+
+## Runtime Library Exception to the Apache 2.0 License: ##
+
+
+    As an exception, if you use this Software to compile your source code and
+    portions of this Software are embedded into the binary product as a result,
+    you may redistribute such product without providing attribution as would
+    otherwise be required by Sections 4(a), 4(b) and 4(d) of the License.
+
+
+===== LaTeX Project Public License 1.3c (GUST Font License terms) =====
+Source: https://www.latex-project.org/lppl/lppl-1-3c.txt
+
+The LaTeX Project Public License
+=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+
+LPPL Version 1.3c  2008-05-04
+
+Copyright 1999 2002-2008 LaTeX3 Project
+    Everyone is allowed to distribute verbatim copies of this
+    license document, but modification of it is not allowed.
+
+
+PREAMBLE
+========
+
+The LaTeX Project Public License (LPPL) is the primary license under
+which the LaTeX kernel and the base LaTeX packages are distributed.
+
+You may use this license for any work of which you hold the copyright
+and which you wish to distribute.  This license may be particularly
+suitable if your work is TeX-related (such as a LaTeX package), but 
+it is written in such a way that you can use it even if your work is 
+unrelated to TeX.
+
+The section `WHETHER AND HOW TO DISTRIBUTE WORKS UNDER THIS LICENSE',
+below, gives instructions, examples, and recommendations for authors
+who are considering distributing their works under this license.
+
+This license gives conditions under which a work may be distributed
+and modified, as well as conditions under which modified versions of
+that work may be distributed.
+
+We, the LaTeX3 Project, believe that the conditions below give you
+the freedom to make and distribute modified versions of your work
+that conform with whatever technical specifications you wish while
+maintaining the availability, integrity, and reliability of
+that work.  If you do not see how to achieve your goal while
+meeting these conditions, then read the document `cfgguide.tex'
+and `modguide.tex' in the base LaTeX distribution for suggestions.
+
+
+DEFINITIONS
+===========
+
+In this license document the following terms are used:
+
+   `Work'
+    Any work being distributed under this License.
+    
+   `Derived Work'
+    Any work that under any applicable law is derived from the Work.
+
+   `Modification' 
+    Any procedure that produces a Derived Work under any applicable
+    law -- for example, the production of a file containing an
+    original file associated with the Work or a significant portion of
+    such a file, either verbatim or with modifications and/or
+    translated into another language.
+
+   `Modify'
+    To apply any procedure that produces a Derived Work under any
+    applicable law.
+    
+   `Distribution'
+    Making copies of the Work available from one person to another, in
+    whole or in part.  Distribution includes (but is not limited to)
+    making any electronic components of the Work accessible by
+    file transfer protocols such as FTP or HTTP or by shared file
+    systems such as Sun's Network File System (NFS).
+
+   `Compiled Work'
+    A version of the Work that has been processed into a form where it
+    is directly usable on a computer system.  This processing may
+    include using installation facilities provided by the Work,
+    transformations of the Work, copying of components of the Work, or
+    other activities.  Note that modification of any installation
+    facilities provided by the Work constitutes modification of the Work.
+
+   `Current Maintainer'
+    A person or persons nominated as such within the Work.  If there is
+    no such explicit nomination then it is the `Copyright Holder' under
+    any applicable law.
+
+   `Base Interpreter' 
+    A program or process that is normally needed for running or
+    interpreting a part or the whole of the Work.    
+
+    A Base Interpreter may depend on external components but these
+    are not considered part of the Base Interpreter provided that each
+    external component clearly identifies itself whenever it is used
+    interactively.  Unless explicitly specified when applying the
+    license to the Work, the only applicable Base Interpreter is a
+    `LaTeX-Format' or in the case of files belonging to the 
+    `LaTeX-format' a program implementing the `TeX language'.
+
+
+
+CONDITIONS ON DISTRIBUTION AND MODIFICATION
+===========================================
+
+1.  Activities other than distribution and/or modification of the Work
+are not covered by this license; they are outside its scope.  In
+particular, the act of running the Work is not restricted and no
+requirements are made concerning any offers of support for the Work.
+
+2.  You may distribute a complete, unmodified copy of the Work as you
+received it.  Distribution of only part of the Work is considered
+modification of the Work, and no right to distribute such a Derived
+Work may be assumed under the terms of this clause.
+
+3.  You may distribute a Compiled Work that has been generated from a
+complete, unmodified copy of the Work as distributed under Clause 2
+above, as long as that Compiled Work is distributed in such a way that
+the recipients may install the Compiled Work on their system exactly
+as it would have been installed if they generated a Compiled Work
+directly from the Work.
+
+4.  If you are the Current Maintainer of the Work, you may, without
+restriction, modify the Work, thus creating a Derived Work.  You may
+also distribute the Derived Work without restriction, including
+Compiled Works generated from the Derived Work.  Derived Works
+distributed in this manner by the Current Maintainer are considered to
+be updated versions of the Work.
+
+5.  If you are not the Current Maintainer of the Work, you may modify
+your copy of the Work, thus creating a Derived Work based on the Work,
+and compile this Derived Work, thus creating a Compiled Work based on
+the Derived Work.
+
+6.  If you are not the Current Maintainer of the Work, you may
+distribute a Derived Work provided the following conditions are met
+for every component of the Work unless that component clearly states
+in the copyright notice that it is exempt from that condition.  Only
+the Current Maintainer is allowed to add such statements of exemption 
+to a component of the Work. 
+
+  a. If a component of this Derived Work can be a direct replacement
+     for a component of the Work when that component is used with the
+     Base Interpreter, then, wherever this component of the Work
+     identifies itself to the user when used interactively with that
+     Base Interpreter, the replacement component of this Derived Work
+     clearly and unambiguously identifies itself as a modified version
+     of this component to the user when used interactively with that
+     Base Interpreter.
+     
+  b. Every component of the Derived Work contains prominent notices
+     detailing the nature of the changes to that component, or a
+     prominent reference to another file that is distributed as part
+     of the Derived Work and that contains a complete and accurate log
+     of the changes.
+  
+  c. No information in the Derived Work implies that any persons,
+     including (but not limited to) the authors of the original version
+     of the Work, provide any support, including (but not limited to)
+     the reporting and handling of errors, to recipients of the
+     Derived Work unless those persons have stated explicitly that
+     they do provide such support for the Derived Work.
+
+  d. You distribute at least one of the following with the Derived Work:
+
+       1. A complete, unmodified copy of the Work; 
+          if your distribution of a modified component is made by
+          offering access to copy the modified component from a
+          designated place, then offering equivalent access to copy
+          the Work from the same or some similar place meets this
+          condition, even though third parties are not compelled to
+          copy the Work along with the modified component;
+
+       2. Information that is sufficient to obtain a complete,
+          unmodified copy of the Work.
+
+7.  If you are not the Current Maintainer of the Work, you may
+distribute a Compiled Work generated from a Derived Work, as long as
+the Derived Work is distributed to all recipients of the Compiled
+Work, and as long as the conditions of Clause 6, above, are met with
+regard to the Derived Work.
+
+8.  The conditions above are not intended to prohibit, and hence do not
+apply to, the modification, by any method, of any component so that it
+becomes identical to an updated version of that component of the Work as
+it is distributed by the Current Maintainer under Clause 4, above.
+
+9.  Distribution of the Work or any Derived Work in an alternative
+format, where the Work or that Derived Work (in whole or in part) is
+then produced by applying some process to that format, does not relax or
+nullify any sections of this license as they pertain to the results of
+applying that process.
+     
+10. a. A Derived Work may be distributed under a different license
+       provided that license itself honors the conditions listed in
+       Clause 6 above, in regard to the Work, though it does not have
+       to honor the rest of the conditions in this license.
+      
+    b. If a Derived Work is distributed under a different license, that
+       Derived Work must provide sufficient documentation as part of
+       itself to allow each recipient of that Derived Work to honor the 
+       restrictions in Clause 6 above, concerning changes from the Work.
+
+11. This license places no restrictions on works that are unrelated to
+the Work, nor does this license place any restrictions on aggregating
+such works with the Work by any means.
+
+12.  Nothing in this license is intended to, or may be used to, prevent
+complete compliance by all parties with all applicable laws.
+
+
+NO WARRANTY
+===========
+
+There is no warranty for the Work.  Except when otherwise stated in
+writing, the Copyright Holder provides the Work `as is', without
+warranty of any kind, either expressed or implied, including, but not
+limited to, the implied warranties of merchantability and fitness for a
+particular purpose.  The entire risk as to the quality and performance
+of the Work is with you.  Should the Work prove defective, you assume
+the cost of all necessary servicing, repair, or correction.
+
+In no event unless required by applicable law or agreed to in writing
+will The Copyright Holder, or any author named in the components of the
+Work, or any other party who may distribute and/or modify the Work as
+permitted above, be liable to you for damages, including any general,
+special, incidental or consequential damages arising out of any use of
+the Work or out of inability to use the Work (including, but not limited
+to, loss of data, data being rendered inaccurate, or losses sustained by
+anyone as a result of any failure of the Work to operate with any other
+programs), even if the Copyright Holder or said author or said other
+party has been advised of the possibility of such damages.
+
+
+MAINTENANCE OF THE WORK
+=======================
+
+The Work has the status `author-maintained' if the Copyright Holder
+explicitly and prominently states near the primary copyright notice in
+the Work that the Work can only be maintained by the Copyright Holder
+or simply that it is `author-maintained'.
+
+The Work has the status `maintained' if there is a Current Maintainer
+who has indicated in the Work that they are willing to receive error
+reports for the Work (for example, by supplying a valid e-mail
+address). It is not required for the Current Maintainer to acknowledge
+or act upon these error reports.
+
+The Work changes from status `maintained' to `unmaintained' if there
+is no Current Maintainer, or the person stated to be Current
+Maintainer of the work cannot be reached through the indicated means
+of communication for a period of six months, and there are no other
+significant signs of active maintenance.
+
+You can become the Current Maintainer of the Work by agreement with
+any existing Current Maintainer to take over this role.
+
+If the Work is unmaintained, you can become the Current Maintainer of
+the Work through the following steps:
+
+ 1.  Make a reasonable attempt to trace the Current Maintainer (and
+     the Copyright Holder, if the two differ) through the means of
+     an Internet or similar search.
+
+ 2.  If this search is successful, then enquire whether the Work
+     is still maintained.
+
+  a. If it is being maintained, then ask the Current Maintainer
+     to update their communication data within one month.
+     
+  b. If the search is unsuccessful or no action to resume active
+     maintenance is taken by the Current Maintainer, then announce
+     within the pertinent community your intention to take over
+     maintenance.  (If the Work is a LaTeX work, this could be
+     done, for example, by posting to comp.text.tex.)
+
+ 3a. If the Current Maintainer is reachable and agrees to pass
+     maintenance of the Work to you, then this takes effect
+     immediately upon announcement.
+     
+  b. If the Current Maintainer is not reachable and the Copyright
+     Holder agrees that maintenance of the Work be passed to you,
+     then this takes effect immediately upon announcement.  
+    
+ 4.  If you make an `intention announcement' as described in 2b. above
+     and after three months your intention is challenged neither by
+     the Current Maintainer nor by the Copyright Holder nor by other
+     people, then you may arrange for the Work to be changed so as
+     to name you as the (new) Current Maintainer.
+     
+ 5.  If the previously unreachable Current Maintainer becomes
+     reachable once more within three months of a change completed
+     under the terms of 3b) or 4), then that Current Maintainer must
+     become or remain the Current Maintainer upon request provided
+     they then update their communication data within one month.
+
+A change in the Current Maintainer does not, of itself, alter the fact
+that the Work is distributed under the LPPL license.
+
+If you become the Current Maintainer of the Work, you should
+immediately provide, within the Work, a prominent and unambiguous
+statement of your status as Current Maintainer.  You should also
+announce your new status to the same pertinent community as
+in 2b) above.
+
+
+WHETHER AND HOW TO DISTRIBUTE WORKS UNDER THIS LICENSE
+======================================================
+
+This section contains important instructions, examples, and
+recommendations for authors who are considering distributing their
+works under this license.  These authors are addressed as `you' in
+this section.
+
+Choosing This License or Another License
+----------------------------------------
+
+If for any part of your work you want or need to use *distribution*
+conditions that differ significantly from those in this license, then
+do not refer to this license anywhere in your work but, instead,
+distribute your work under a different license.  You may use the text
+of this license as a model for your own license, but your license
+should not refer to the LPPL or otherwise give the impression that
+your work is distributed under the LPPL.
+
+The document `modguide.tex' in the base LaTeX distribution explains
+the motivation behind the conditions of this license.  It explains,
+for example, why distributing LaTeX under the GNU General Public
+License (GPL) was considered inappropriate.  Even if your work is
+unrelated to LaTeX, the discussion in `modguide.tex' may still be
+relevant, and authors intending to distribute their works under any
+license are encouraged to read it.
+
+A Recommendation on Modification Without Distribution
+-----------------------------------------------------
+
+It is wise never to modify a component of the Work, even for your own
+personal use, without also meeting the above conditions for
+distributing the modified component.  While you might intend that such
+modifications will never be distributed, often this will happen by
+accident -- you may forget that you have modified that component; or
+it may not occur to you when allowing others to access the modified
+version that you are thus distributing it and violating the conditions
+of this license in ways that could have legal implications and, worse,
+cause problems for the community.  It is therefore usually in your
+best interest to keep your copy of the Work identical with the public
+one.  Many works provide ways to control the behavior of that work
+without altering any of its licensed components.
+
+How to Use This License
+-----------------------
+
+To use this license, place in each of the components of your work both
+an explicit copyright notice including your name and the year the work
+was authored and/or last substantially modified.  Include also a
+statement that the distribution and/or modification of that
+component is constrained by the conditions in this license.
+
+Here is an example of such a notice and statement:
+
+  %% pig.dtx
+  %% Copyright 2008 M. Y. Name
+  %
+  % This work may be distributed and/or modified under the
+  % conditions of the LaTeX Project Public License, either version 1.3
+  % of this license or (at your option) any later version.
+  % The latest version of this license is in
+  %   https://www.latex-project.org/lppl.txt
+  % and version 1.3c or later is part of all distributions of LaTeX
+  % version 2008 or later.
+  %
+  % This work has the LPPL maintenance status `maintained'.
+  % 
+  % The Current Maintainer of this work is M. Y. Name.
+  %
+  % This work consists of the files pig.dtx and pig.ins
+  % and the derived file pig.sty.
+
+Given such a notice and statement in a file, the conditions
+given in this license document would apply, with the `Work' referring
+to the three files `pig.dtx', `pig.ins', and `pig.sty' (the last being
+generated from `pig.dtx' using `pig.ins'), the `Base Interpreter'
+referring to any `LaTeX-Format', and both `Copyright Holder' and
+`Current Maintainer' referring to the person `M. Y. Name'.
+
+If you do not want the Maintenance section of LPPL to apply to your
+Work, change `maintained' above into `author-maintained'.  
+However, we recommend that you use `maintained', as the Maintenance
+section was added in order to ensure that your Work remains useful to
+the community even when you can no longer maintain and support it
+yourself.
+
+Derived Works That Are Not Replacements
+---------------------------------------
+
+Several clauses of the LPPL specify means to provide reliability and
+stability for the user community. They therefore concern themselves
+with the case that a Derived Work is intended to be used as a
+(compatible or incompatible) replacement of the original Work. If
+this is not the case (e.g., if a few lines of code are reused for a
+completely different task), then clauses 6b and 6d shall not apply.
+
+
+Important Recommendations
+-------------------------
+
+ Defining What Constitutes the Work
+
+   The LPPL requires that distributions of the Work contain all the
+   files of the Work.  It is therefore important that you provide a
+   way for the licensee to determine which files constitute the Work.
+   This could, for example, be achieved by explicitly listing all the
+   files of the Work near the copyright notice of each file or by
+   using a line such as:
+
+    % This work consists of all files listed in manifest.txt.
+   
+   in that place.  In the absence of an unequivocal list it might be
+   impossible for the licensee to determine what is considered by you
+   to comprise the Work and, in such a case, the licensee would be
+   entitled to make reasonable conjectures as to which files comprise
+   the Work.
+

--- a/Sources/MacParakeet/Views/Components/MarkdownContentView.swift
+++ b/Sources/MacParakeet/Views/Components/MarkdownContentView.swift
@@ -15,6 +15,7 @@ struct MarkdownContentView: View {
     private let baseFontSize: CGFloat
     private let isStreaming: Bool
     @StateObject private var streamingSource: MarkdownSnapshotSource
+    @State private var renderedDocument: RenderableDocument = .empty
 
     init(
         _ content: String,
@@ -29,29 +30,23 @@ struct MarkdownContentView: View {
         )
     }
 
-    @ViewBuilder
     var body: some View {
-        Group {
-            if isStreaming {
-                StreamedMarkdownView(
-                    source: streamingSource,
-                    config: renderConfiguration,
-                    listener: MarkdownContentInteractionListener.shared
-                )
-                .onAppear {
-                    // Refresh the retained source after hidden/static content
-                    // changes; every renderer subscription replays its latest value.
-                    streamingSource.send(content)
-                }
-                .onChange(of: content) { _, newContent in
-                    streamingSource.send(newContent)
-                }
-            } else {
-                MarkdownView(
-                    text: content,
-                    config: renderConfiguration,
-                    listener: MarkdownContentInteractionListener.shared
-                )
+        DocumentView(
+            renderableDocument: renderedDocument,
+            config: renderConfiguration,
+            listener: MarkdownContentInteractionListener.shared
+        )
+        .onAppear {
+            streamingSource.send(content)
+        }
+        .onChange(of: content) { _, newContent in
+            streamingSource.send(newContent)
+        }
+        .task(id: baseFontSize) {
+            // SwiftUI owns this consumer's lifetime. A cancelled parse cannot
+            // publish after a replacement consumer returns to the same pane.
+            await MarkdownSnapshotRenderer.render(source: streamingSource, config: renderConfiguration) {
+                renderedDocument = $0
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -76,7 +71,7 @@ struct MarkdownContentView: View {
 /// A retained snapshot store, with a separate stream for each renderer task.
 /// Cancelling a consumer terminates its AsyncStream permanently, so the source
 /// must create a fresh subscription when the same SwiftUI view reappears.
-final class MarkdownSnapshotSource: ObservableObject, StreamedMarkdownSource, @unchecked Sendable {
+final class MarkdownSnapshotSource: ObservableObject, @unchecked Sendable {
     // The renderer subscribes/cancels from tasks while SwiftUI sends snapshots.
     // All mutable state, including replay ordering, is protected by this lock.
     private let lock = NSLock()
@@ -119,6 +114,27 @@ final class MarkdownSnapshotSource: ObservableObject, StreamedMarkdownSource, @u
         // No strong reference to the source survives into termination handlers.
         for continuation in subscribers.values {
             continuation.finish()
+        }
+    }
+}
+
+/// Serial parsing keeps only the newest waiting snapshot, even when generation
+/// outpaces rendering. Publication stays on the UI actor after cancellation checks.
+enum MarkdownSnapshotRenderer {
+    @MainActor
+    static func render(
+        source: MarkdownSnapshotSource,
+        config: MarkdownRenderConfig,
+        parse: @MainActor (String, MarkdownRenderConfig) async -> RenderableDocument = { text, config in
+            await MarkdownParserImpl().parse(text: text, config: config)
+        },
+        publish: (RenderableDocument) -> Void
+    ) async {
+        for await text in source.text {
+            guard !Task.isCancelled else { return }
+            let document = await parse(text, config)
+            guard !Task.isCancelled else { return }
+            publish(document)
         }
     }
 }
@@ -222,7 +238,7 @@ enum MarkdownContentConfiguration {
     }
 }
 
-/// Writes the unchanged Markdown source without blocking the UI actor.
+/// Writes the renderer's normalized table Markdown without blocking the UI actor.
 enum MarkdownTableExporter {
     static func write(_ content: String, to destination: URL) async throws {
         try await Task.detached(priority: .userInitiated) {

--- a/Sources/MacParakeet/Views/Components/MarkdownContentView.swift
+++ b/Sources/MacParakeet/Views/Components/MarkdownContentView.swift
@@ -222,6 +222,15 @@ enum MarkdownContentConfiguration {
     }
 }
 
+/// Writes the unchanged Markdown source without blocking the UI actor.
+enum MarkdownTableExporter {
+    static func write(_ content: String, to destination: URL) async throws {
+        try await Task.detached(priority: .userInitiated) {
+            try content.write(to: destination, atomically: true, encoding: .utf8)
+        }.value
+    }
+}
+
 private final class MarkdownContentInteractionListener: MarkdownListener {
     static let shared = MarkdownContentInteractionListener()
 
@@ -235,13 +244,26 @@ private final class MarkdownContentInteractionListener: MarkdownListener {
     }
 
     func onTableDownloadTap(content: String) async {
-        await MainActor.run {
+        let destination = await MainActor.run { () -> URL? in
             let panel = NSSavePanel()
             panel.title = "Export Markdown table"
             panel.nameFieldStringValue = "table.md"
             panel.allowedContentTypes = [.plainText]
-            guard panel.runModal() == .OK, let url = panel.url else { return }
-            try? content.write(to: url, atomically: true, encoding: .utf8)
+            guard panel.runModal() == .OK else { return nil }
+            return panel.url
+        }
+        guard let destination else { return }
+        do {
+            try await MarkdownTableExporter.write(content, to: destination)
+        } catch {
+            await MainActor.run {
+                let alert = NSAlert()
+                alert.alertStyle = .warning
+                alert.messageText = "Export Failed"
+                alert.informativeText = error.localizedDescription
+                alert.addButton(withTitle: "OK")
+                alert.runModal()
+            }
         }
     }
 

--- a/Sources/MacParakeet/Views/Components/MarkdownContentView.swift
+++ b/Sources/MacParakeet/Views/Components/MarkdownContentView.swift
@@ -1,488 +1,250 @@
-import SwiftUI
 import AppKit
+#if canImport(SwiftStreamingMarkdown)
+import SwiftStreamingMarkdown
+#endif
+import SwiftUI
 
-/// Block-level element parsed from a markdown string.
-private enum MarkdownBlock {
-    case heading(level: Int, content: String)
-    case paragraph(content: String)
-    case unorderedList(items: [String])
-    case orderedList(items: [String])
-    case codeBlock(language: String?, code: String)
-    case blockquote(content: String)
-    case thematicBreak
-}
-
-/// Renders markdown in a single NSTextView for full text selection and drag support.
-/// Inline formatting (bold, italic, code, links, strikethrough) is handled within each block
-/// via NSAttributedString markdown parsing.
-struct MarkdownContentView: NSViewRepresentable {
+#if canImport(SwiftStreamingMarkdown)
+/// Canonical renderer for LLM-authored Markdown throughout the app.
+///
+/// The source string remains the artifact of record; this view only changes its
+/// presentation. Remote/local images stay disabled, while links are restricted
+/// to web URLs before SwiftUI hands them to the system browser.
+struct MarkdownContentView: View {
     let content: String
-    let baseFont: Font
     private let baseFontSize: CGFloat
+    private let isStreaming: Bool
+    @StateObject private var streamingSource: MarkdownSnapshotSource
 
-    init(_ content: String, font: Font = DesignSystem.Typography.body) {
+    init(
+        _ content: String,
+        font: Font = DesignSystem.Typography.body,
+        isStreaming: Bool = false
+    ) {
         self.content = content
-        self.baseFont = font
-        if font == DesignSystem.Typography.bodyLarge {
-            self.baseFontSize = 15
-        } else {
-            self.baseFontSize = 14
-        }
-    }
-
-    func makeNSView(context: Context) -> SelfSizingTextView {
-        let wrapper = SelfSizingTextView()
-        let textView = wrapper.textView
-        textView.isEditable = false
-        textView.isSelectable = true
-        textView.drawsBackground = false
-        textView.isRichText = true
-        textView.usesAdaptiveColorMappingForDarkAppearance = true
-        textView.textContainerInset = .zero
-        textView.isVerticallyResizable = true
-        textView.isHorizontallyResizable = false
-        textView.textContainer?.lineFragmentPadding = 0
-        textView.textContainer?.widthTracksTextView = true
-        textView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
-
-        context.coordinator.wrapper = wrapper
-        updateContent(wrapper)
-
-        return wrapper
-    }
-
-    func updateNSView(_ wrapper: SelfSizingTextView, context: Context) {
-        if content != context.coordinator.lastContent {
-            context.coordinator.lastContent = content
-            updateContent(wrapper)
-        }
-    }
-
-    func makeCoordinator() -> Coordinator {
-        Coordinator()
-    }
-
-    final class Coordinator {
-        var lastContent: String?
-        weak var wrapper: SelfSizingTextView?
-    }
-
-    private func updateContent(_ wrapper: SelfSizingTextView) {
-        let blocks = Self.parse(content)
-        let attributed = buildAttributedString(blocks: blocks)
-        wrapper.textView.textStorage?.setAttributedString(attributed)
-        wrapper.invalidateIntrinsicContentSize()
-    }
-
-    // MARK: - Attributed String Building
-
-    private func buildAttributedString(blocks: [MarkdownBlock]) -> NSAttributedString {
-        let result = NSMutableAttributedString()
-
-        // Bridge SwiftUI design tokens into appearance-aware NSColors. The
-        // `NSColor(_ swiftuiColor:)` initializer preserves the dynamic light/dark
-        // resolution of `Color(light:dark:)`.
-        let textColor = NSColor(DesignSystem.Colors.textPrimary)
-        let secondaryColor = NSColor(DesignSystem.Colors.textSecondary)
-        let tertiaryColor = NSColor(DesignSystem.Colors.textTertiary)
-        let accentColor = NSColor(DesignSystem.Colors.accent)
-
-        let bodyFont = NSFont.systemFont(ofSize: baseFontSize)
-        let bodyParagraphStyle = NSMutableParagraphStyle()
-        bodyParagraphStyle.lineSpacing = 4
-        bodyParagraphStyle.paragraphSpacing = 10
-
-        for (index, block) in blocks.enumerated() {
-            switch block {
-            case let .heading(level, text):
-                let font: NSFont
-                switch level {
-                case 1: font = NSFont.systemFont(ofSize: 22, weight: .semibold)
-                case 2: font = NSFont.systemFont(ofSize: 17, weight: .semibold)
-                case 3: font = NSFont.systemFont(ofSize: 15, weight: .semibold)
-                default: font = NSFont.systemFont(ofSize: 14, weight: .semibold)
-                }
-                let style = NSMutableParagraphStyle()
-                style.paragraphSpacing = 6
-                if index > 0 { style.paragraphSpacingBefore = level <= 2 ? 12 : 8 }
-
-                let headingStr = inlineAttributedString(text, baseFont: font, color: textColor)
-                headingStr.addAttribute(.paragraphStyle, value: style, range: NSRange(location: 0, length: headingStr.length))
-                result.append(headingStr)
-                result.append(NSAttributedString(string: "\n"))
-
-            case let .paragraph(text):
-                let paraStr = inlineAttributedString(text, baseFont: bodyFont, color: textColor)
-                paraStr.addAttribute(.paragraphStyle, value: bodyParagraphStyle, range: NSRange(location: 0, length: paraStr.length))
-                result.append(paraStr)
-                result.append(NSAttributedString(string: "\n"))
-
-            case let .unorderedList(items):
-                let listStyle = NSMutableParagraphStyle()
-                listStyle.lineSpacing = 3
-                listStyle.paragraphSpacing = 5
-                listStyle.headIndent = 20
-                listStyle.firstLineHeadIndent = 4
-                listStyle.tabStops = [NSTextTab(textAlignment: .natural, location: 20)]
-
-                for (i, item) in items.enumerated() {
-                    let bullet = NSMutableAttributedString(string: "\u{2022}\t", attributes: [
-                        .font: bodyFont,
-                        .foregroundColor: tertiaryColor,
-                        .paragraphStyle: listStyle
-                    ])
-                    let itemStr = inlineAttributedString(item, baseFont: bodyFont, color: textColor)
-                    itemStr.addAttribute(.paragraphStyle, value: listStyle, range: NSRange(location: 0, length: itemStr.length))
-                    bullet.append(itemStr)
-                    result.append(bullet)
-                    if i < items.count - 1 || index < blocks.count - 1 {
-                        result.append(NSAttributedString(string: "\n"))
-                    }
-                }
-                if index < blocks.count - 1 {
-                    let spacer = NSMutableAttributedString(string: "\n")
-                    let spacerStyle = NSMutableParagraphStyle()
-                    spacerStyle.paragraphSpacing = 4
-                    spacer.addAttribute(.paragraphStyle, value: spacerStyle, range: NSRange(location: 0, length: 1))
-                    result.append(spacer)
-                }
-
-            case let .orderedList(items):
-                let listStyle = NSMutableParagraphStyle()
-                listStyle.lineSpacing = 3
-                listStyle.paragraphSpacing = 5
-                listStyle.headIndent = 28
-                listStyle.firstLineHeadIndent = 4
-                listStyle.tabStops = [NSTextTab(textAlignment: .natural, location: 28)]
-
-                for (i, item) in items.enumerated() {
-                    let marker = NSMutableAttributedString(string: "\(i + 1).\t", attributes: [
-                        .font: bodyFont,
-                        .foregroundColor: tertiaryColor,
-                        .paragraphStyle: listStyle
-                    ])
-                    let itemStr = inlineAttributedString(item, baseFont: bodyFont, color: textColor)
-                    itemStr.addAttribute(.paragraphStyle, value: listStyle, range: NSRange(location: 0, length: itemStr.length))
-                    marker.append(itemStr)
-                    result.append(marker)
-                    if i < items.count - 1 || index < blocks.count - 1 {
-                        result.append(NSAttributedString(string: "\n"))
-                    }
-                }
-                if index < blocks.count - 1 {
-                    let spacer = NSMutableAttributedString(string: "\n")
-                    let spacerStyle = NSMutableParagraphStyle()
-                    spacerStyle.paragraphSpacing = 4
-                    spacer.addAttribute(.paragraphStyle, value: spacerStyle, range: NSRange(location: 0, length: 1))
-                    result.append(spacer)
-                }
-
-            case let .codeBlock(_, code):
-                let codeFont = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
-                let codeStyle = NSMutableParagraphStyle()
-                codeStyle.lineSpacing = 2
-                codeStyle.paragraphSpacing = 10
-
-                // Apply the alpha inside a dynamic NSColor provider so the result
-                // re-resolves on light/dark flip. We resolve `surfaceElevated` under
-                // the supplied appearance, then attach the alpha — this keeps the
-                // single source of truth (`DesignSystem.Colors.surfaceElevated`)
-                // without snapping to the appearance that was current at first draw.
-                let codeBackground = NSColor(name: nil) { appearance in
-                    var resolved = NSColor.clear
-                    appearance.performAsCurrentDrawingAppearance {
-                        resolved = NSColor(DesignSystem.Colors.surfaceElevated)
-                    }
-                    return resolved.withAlphaComponent(0.7)
-                }
-                let codeStr = NSMutableAttributedString(string: code, attributes: [
-                    .font: codeFont,
-                    .foregroundColor: textColor,
-                    .paragraphStyle: codeStyle,
-                    .backgroundColor: codeBackground
-                ])
-                result.append(codeStr)
-                result.append(NSAttributedString(string: "\n"))
-
-            case let .blockquote(text):
-                let quoteStyle = NSMutableParagraphStyle()
-                quoteStyle.lineSpacing = 3
-                quoteStyle.paragraphSpacing = 10
-                quoteStyle.headIndent = 16
-                quoteStyle.firstLineHeadIndent = 16
-
-                let bar = NSMutableAttributedString(string: "\u{2503} ", attributes: [
-                    .font: bodyFont,
-                    .foregroundColor: accentColor.withAlphaComponent(0.4),
-                    .paragraphStyle: quoteStyle
-                ])
-                let quoteStr = inlineAttributedString(text, baseFont: bodyFont, color: secondaryColor)
-                quoteStr.addAttribute(.paragraphStyle, value: quoteStyle, range: NSRange(location: 0, length: quoteStr.length))
-                bar.append(quoteStr)
-                result.append(bar)
-                result.append(NSAttributedString(string: "\n"))
-
-            case .thematicBreak:
-                let hrStyle = NSMutableParagraphStyle()
-                hrStyle.paragraphSpacing = 10
-                hrStyle.paragraphSpacingBefore = 10
-                let hr = NSMutableAttributedString(string: "\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\u{2500}\n", attributes: [
-                    .font: NSFont.systemFont(ofSize: 8),
-                    .foregroundColor: tertiaryColor.withAlphaComponent(0.4),
-                    .paragraphStyle: hrStyle
-                ])
-                result.append(hr)
-            }
-        }
-
-        // Trim trailing newline
-        if result.length > 0, result.string.hasSuffix("\n") {
-            result.deleteCharacters(in: NSRange(location: result.length - 1, length: 1))
-        }
-
-        return result
-    }
-
-    private func inlineAttributedString(_ source: String, baseFont: NSFont, color: NSColor) -> NSMutableAttributedString {
-        if let swiftAttr = try? AttributedString(
-            markdown: source,
-            options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
-        ) {
-            let nsAttr = NSMutableAttributedString(swiftAttr)
-            let fullRange = NSRange(location: 0, length: nsAttr.length)
-            nsAttr.enumerateAttributes(in: fullRange) { attrs, range, _ in
-                nsAttr.addAttribute(.foregroundColor, value: color, range: range)
-
-                if let existingFont = attrs[.font] as? NSFont {
-                    let traits = existingFont.fontDescriptor.symbolicTraits
-                    var newFont = baseFont
-                    if traits.contains(.bold) && traits.contains(.italic) {
-                        newFont = NSFontManager.shared.convert(baseFont, toHaveTrait: [.boldFontMask, .italicFontMask])
-                    } else if traits.contains(.bold) {
-                        newFont = NSFont.systemFont(ofSize: baseFont.pointSize, weight: .semibold)
-                    } else if traits.contains(.italic) {
-                        newFont = NSFontManager.shared.convert(baseFont, toHaveTrait: .italicFontMask)
-                    }
-                    if existingFont.fontDescriptor.symbolicTraits.contains(.monoSpace) {
-                        newFont = NSFont.monospacedSystemFont(ofSize: baseFont.pointSize - 1, weight: .regular)
-                    }
-                    nsAttr.addAttribute(.font, value: newFont, range: range)
-                } else {
-                    nsAttr.addAttribute(.font, value: baseFont, range: range)
-                }
-            }
-            return nsAttr
-        }
-
-        return NSMutableAttributedString(string: source, attributes: [
-            .font: baseFont,
-            .foregroundColor: color
-        ])
-    }
-
-    // MARK: - Block Parser
-
-    private static func parse(_ content: String) -> [MarkdownBlock] {
-        var blocks: [MarkdownBlock] = []
-        let lines = content.replacingOccurrences(of: "\r\n", with: "\n")
-            .split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
-        var index = 0
-
-        while index < lines.count {
-            let line = lines[index]
-            let trimmed = line.trimmingCharacters(in: .whitespaces)
-
-            if trimmed.isEmpty {
-                index += 1
-                continue
-            }
-
-            if trimmed.hasPrefix("```") {
-                let lang = String(trimmed.dropFirst(3)).trimmingCharacters(in: .whitespaces)
-                var codeLines: [String] = []
-                index += 1
-                while index < lines.count {
-                    if lines[index].trimmingCharacters(in: .whitespaces).hasPrefix("```") {
-                        index += 1
-                        break
-                    }
-                    codeLines.append(lines[index])
-                    index += 1
-                }
-                blocks.append(.codeBlock(
-                    language: lang.isEmpty ? nil : lang,
-                    code: codeLines.joined(separator: "\n")
-                ))
-                continue
-            }
-
-            if isThematicBreak(trimmed) {
-                blocks.append(.thematicBreak)
-                index += 1
-                continue
-            }
-
-            if let heading = parseHeading(trimmed) {
-                blocks.append(heading)
-                index += 1
-                continue
-            }
-
-            if isUnorderedListItem(trimmed) {
-                var items: [String] = []
-                while index < lines.count {
-                    let l = lines[index].trimmingCharacters(in: .whitespaces)
-                    if isUnorderedListItem(l) {
-                        items.append(String(l.dropFirst(2)))
-                        index += 1
-                    } else if l.isEmpty {
-                        break
-                    } else {
-                        if !items.isEmpty {
-                            items[items.count - 1] += " " + l
-                        }
-                        index += 1
-                    }
-                }
-                blocks.append(.unorderedList(items: items))
-                continue
-            }
-
-            if isOrderedListItem(trimmed) {
-                var items: [String] = []
-                while index < lines.count {
-                    let l = lines[index].trimmingCharacters(in: .whitespaces)
-                    if isOrderedListItem(l) {
-                        items.append(stripOrderedMarker(l))
-                        index += 1
-                    } else if l.isEmpty {
-                        break
-                    } else {
-                        if !items.isEmpty {
-                            items[items.count - 1] += " " + l
-                        }
-                        index += 1
-                    }
-                }
-                blocks.append(.orderedList(items: items))
-                continue
-            }
-
-            if trimmed.hasPrefix(">") {
-                var quoteLines: [String] = []
-                while index < lines.count {
-                    let l = lines[index].trimmingCharacters(in: .whitespaces)
-                    guard l.hasPrefix(">") else { break }
-                    let dropCount = l.hasPrefix("> ") ? 2 : 1
-                    quoteLines.append(String(l.dropFirst(dropCount)))
-                    index += 1
-                }
-                blocks.append(.blockquote(content: quoteLines.joined(separator: "\n")))
-                continue
-            }
-
-            var paraLines: [String] = []
-            while index < lines.count {
-                let t = lines[index].trimmingCharacters(in: .whitespaces)
-                if t.isEmpty || t.hasPrefix("```") || isThematicBreak(t) ||
-                   parseHeading(t) != nil || isUnorderedListItem(t) ||
-                   isOrderedListItem(t) || t.hasPrefix(">") {
-                    break
-                }
-                paraLines.append(t)
-                index += 1
-            }
-            if !paraLines.isEmpty {
-                blocks.append(.paragraph(content: paraLines.joined(separator: " ")))
-            }
-        }
-
-        return blocks
-    }
-
-    private static func parseHeading(_ line: String) -> MarkdownBlock? {
-        var level = 0
-        for char in line {
-            if char == "#" { level += 1 }
-            else { break }
-        }
-        guard level >= 1, level <= 6,
-              line.count > level,
-              line[line.index(line.startIndex, offsetBy: level)] == " " else {
-            return nil
-        }
-        return .heading(level: level, content: String(line.dropFirst(level + 1)))
-    }
-
-    private static func isThematicBreak(_ line: String) -> Bool {
-        let stripped = line.replacingOccurrences(of: " ", with: "")
-        return stripped.count >= 3 && (
-            stripped.allSatisfy { $0 == "-" } ||
-            stripped.allSatisfy { $0 == "*" } ||
-            stripped.allSatisfy { $0 == "_" }
+        self.baseFontSize = font == DesignSystem.Typography.bodyLarge ? 15 : 14
+        self.isStreaming = isStreaming
+        self._streamingSource = StateObject(
+            wrappedValue: MarkdownSnapshotSource(initialContent: content)
         )
     }
 
-    private static func isUnorderedListItem(_ line: String) -> Bool {
-        line.hasPrefix("- ") || line.hasPrefix("* ") || line.hasPrefix("+ ")
-    }
-
-    private static func isOrderedListItem(_ line: String) -> Bool {
-        guard let dotIndex = line.firstIndex(of: ".") else { return false }
-        let prefix = line[line.startIndex..<dotIndex]
-        guard !prefix.isEmpty, prefix.allSatisfy(\.isWholeNumber) else { return false }
-        let afterDot = line.index(after: dotIndex)
-        return afterDot < line.endIndex && line[afterDot] == " "
-    }
-
-    private static func stripOrderedMarker(_ line: String) -> String {
-        guard let dotIndex = line.firstIndex(of: "."),
-              line.index(after: dotIndex) < line.endIndex else { return line }
-        return String(line[line.index(dotIndex, offsetBy: 2)...])
-    }
-}
-
-// MARK: - Self-Sizing NSTextView Container
-
-/// An NSView that wraps an NSTextView and reports its intrinsic content size
-/// based on the text layout, so SwiftUI can size it correctly.
-final class SelfSizingTextView: NSView {
-    let textView: NSTextView = {
-        let tv = NSTextView()
-        tv.autoresizingMask = [.width]
-        tv.translatesAutoresizingMaskIntoConstraints = false
-        return tv
-    }()
-
-    override init(frame frameRect: NSRect) {
-        super.init(frame: frameRect)
-        addSubview(textView)
-        NSLayoutConstraint.activate([
-            textView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            textView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            textView.topAnchor.constraint(equalTo: topAnchor),
-            textView.bottomAnchor.constraint(equalTo: bottomAnchor),
-        ])
-    }
-
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    override var intrinsicContentSize: NSSize {
-        guard let layoutManager = textView.layoutManager,
-              let textContainer = textView.textContainer else {
-            return super.intrinsicContentSize
+    @ViewBuilder
+    var body: some View {
+        Group {
+            if isStreaming {
+                StreamedMarkdownView(
+                    source: streamingSource,
+                    config: renderConfiguration,
+                    listener: MarkdownContentInteractionListener.shared
+                )
+                .onAppear {
+                    // AsyncStream does not replay consumed values when this
+                    // view returns to streaming after a completed render.
+                    streamingSource.send(content)
+                }
+                .onChange(of: content) { _, newContent in
+                    streamingSource.send(newContent)
+                }
+            } else {
+                MarkdownView(
+                    text: content,
+                    config: renderConfiguration,
+                    listener: MarkdownContentInteractionListener.shared
+                )
+            }
         }
-        layoutManager.ensureLayout(for: textContainer)
-        let usedRect = layoutManager.usedRect(for: textContainer)
-        return NSSize(width: NSView.noIntrinsicMetric, height: usedRect.height)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .textSelection(.enabled)
+        .environment(
+            \.openURL,
+            OpenURLAction { url in
+                MarkdownContentPolicy.isAllowedLink(url)
+                    ? .systemAction(url)
+                    : .discarded
+            })
     }
 
-    override func layout() {
-        super.layout()
-        // When our width changes, the text reflows — recalculate height
-        textView.textContainer?.containerSize = NSSize(width: bounds.width, height: .greatestFiniteMagnitude)
-        invalidateIntrinsicContentSize()
+    private var renderConfiguration: MarkdownRenderConfig {
+        MarkdownContentConfiguration.make(
+            baseFontSize: baseFontSize,
+            isStreaming: isStreaming
+        )
     }
 }
+
+final class MarkdownSnapshotSource: ObservableObject, StreamedMarkdownSource {
+    let text: AsyncStream<String>
+    private let continuation: AsyncStream<String>.Continuation
+
+    init(initialContent: String) {
+        var capturedContinuation: AsyncStream<String>.Continuation?
+        self.text = AsyncStream(bufferingPolicy: .bufferingNewest(1)) {
+            capturedContinuation = $0
+        }
+        guard let capturedContinuation else {
+            fatalError("AsyncStream must synchronously provide its continuation")
+        }
+        self.continuation = capturedContinuation
+        self.continuation.yield(initialContent)
+    }
+
+    func send(_ content: String) {
+        continuation.yield(content)
+    }
+
+    deinit {
+        continuation.finish()
+    }
+}
+
+enum MarkdownContentPolicy {
+    static func isAllowedLink(_ url: URL) -> Bool {
+        guard let scheme = url.scheme?.lowercased() else { return false }
+        return scheme == "http" || scheme == "https"
+    }
+}
+
+enum MarkdownContentConfiguration {
+    static func make(baseFontSize: CGFloat, isStreaming: Bool) -> MarkdownRenderConfig {
+        let bodyFonts = fonts(size: baseFontSize, lineHeight: baseFontSize + 6)
+        let smallFonts = fonts(size: max(12, baseFontSize - 1), lineHeight: baseFontSize + 4)
+        let codeFonts = TextFonts(
+            normal: .monospacedSystemFont(ofSize: max(12, baseFontSize - 1), weight: .regular),
+            italic: nil,
+            bold: .monospacedSystemFont(ofSize: max(12, baseFontSize - 1), weight: .semibold),
+            boldItalic: nil,
+            preferredLetterSpacing: 0,
+            preferredLineHeight: baseFontSize + 5
+        )
+
+        return MarkdownRenderConfig(
+            shouldAnimateText: isStreaming,
+            blockQuoteStyle: .init(
+                textFonts: bodyFonts,
+                textColor: DesignSystem.Colors.textSecondary
+            ),
+            headingStyle: .init(
+                h1Font: fonts(size: 22, weight: .semibold, lineHeight: 28),
+                h2Font: fonts(size: 17, weight: .semibold, lineHeight: 23),
+                h3Font: fonts(size: 15, weight: .semibold, lineHeight: 21),
+                h4Font: fonts(size: 14, weight: .semibold, lineHeight: 20),
+                h5Font: fonts(size: 14, weight: .semibold, lineHeight: 20),
+                h6Font: fonts(size: 14, weight: .semibold, lineHeight: 20),
+                textColor: DesignSystem.Colors.textPrimary
+            ),
+            orderedListStyle: .init(
+                textFonts: bodyFonts,
+                textColor: DesignSystem.Colors.textPrimary
+            ),
+            paragraphStyle: .init(
+                textFonts: bodyFonts,
+                textColor: DesignSystem.Colors.textPrimary
+            ),
+            tableStyle: .init(
+                textFonts: smallFonts,
+                headerTextColor: DesignSystem.Colors.textPrimary,
+                regularTextColor: DesignSystem.Colors.textPrimary,
+                headerBackgroundColor: DesignSystem.Colors.surfaceElevated,
+                borderColor: DesignSystem.Colors.border,
+                actionButtonColor: DesignSystem.Colors.accent
+            ),
+            inlineStyle: .init(
+                boldTextColor: DesignSystem.Colors.textPrimary,
+                linkTextFont: bodyFonts.normal,
+                linkTextColor: DesignSystem.Colors.accentDark,
+                linkUnderlineStyle: .single,
+                codeTextFont: codeFonts.normal,
+                codeTextColor: DesignSystem.Colors.textPrimary,
+                codeBackgroundColor: DesignSystem.Colors.surfaceElevated,
+                codeUnderlineColor: DesignSystem.Colors.border
+            ),
+            citationConfig: .init(
+                isEnabled: false,
+                font: smallFonts.normal,
+                textColor: DesignSystem.Colors.textSecondary,
+                backgroundColor: DesignSystem.Colors.surfaceElevated
+            ),
+            codeBlockConfig: .init(
+                theme: .xcode,
+                backgroundColor: DesignSystem.Colors.surfaceElevated,
+                foregroundColor: DesignSystem.Colors.textSecondary,
+                codeTextFonts: codeFonts,
+                chromeTextFonts: smallFonts
+            ),
+            blockSpacing: 10,
+            textSelectionConfig: .default,
+            thematicBreakColor: DesignSystem.Colors.divider,
+            imageConfig: .disabled
+        )
+    }
+
+    private static func fonts(
+        size: CGFloat,
+        weight: NSFont.Weight = .regular,
+        lineHeight: CGFloat
+    ) -> TextFonts {
+        let regular = NSFont.systemFont(ofSize: size, weight: weight)
+        let bold = NSFont.systemFont(ofSize: size, weight: .semibold)
+        return TextFonts(
+            normal: regular,
+            italic: NSFontManager.shared.convert(regular, toHaveTrait: .italicFontMask),
+            bold: bold,
+            boldItalic: NSFontManager.shared.convert(bold, toHaveTrait: .italicFontMask),
+            preferredLetterSpacing: 0,
+            preferredLineHeight: lineHeight
+        )
+    }
+}
+
+private final class MarkdownContentInteractionListener: MarkdownListener {
+    static let shared = MarkdownContentInteractionListener()
+
+    func onRender(markdown _: RenderableDocument) async {}
+
+    func onTableCopyTap(content: String) async {
+        await MainActor.run {
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(content, forType: .string)
+        }
+    }
+
+    func onTableDownloadTap(content: String) async {
+        await MainActor.run {
+            let panel = NSSavePanel()
+            panel.title = "Export Markdown table"
+            panel.nameFieldStringValue = "table.md"
+            panel.allowedContentTypes = [.plainText]
+            guard panel.runModal() == .OK, let url = panel.url else { return }
+            try? content.write(to: url, atomically: true, encoding: .utf8)
+        }
+    }
+
+    func onContextMenuAppear(id _: String, selectedContent _: String) async {}
+    func onContextMenuTap(id _: String, selectedContent _: String) async {}
+    func onImageTap(image _: MarkdownImage) async {}
+}
+#else
+/// Plain-text compile-time fallback used only by the first-party Swift 6 gate
+/// while SwiftStreamingMarkdown's dependency graph remains Swift 5-only.
+struct MarkdownContentView: View {
+    let content: String
+    let font: Font
+
+    init(
+        _ content: String,
+        font: Font = DesignSystem.Typography.body,
+        isStreaming _: Bool = false
+    ) {
+        self.content = content
+        self.font = font
+    }
+
+    var body: some View {
+        Text(content)
+            .font(font)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .textSelection(.enabled)
+    }
+}
+#endif

--- a/Sources/MacParakeet/Views/Components/MarkdownContentView.swift
+++ b/Sources/MacParakeet/Views/Components/MarkdownContentView.swift
@@ -39,8 +39,8 @@ struct MarkdownContentView: View {
                     listener: MarkdownContentInteractionListener.shared
                 )
                 .onAppear {
-                    // AsyncStream does not replay consumed values when this
-                    // view returns to streaming after a completed render.
+                    // Refresh the retained source after hidden/static content
+                    // changes; every renderer subscription replays its latest value.
                     streamingSource.send(content)
                 }
                 .onChange(of: content) { _, newContent in
@@ -73,28 +73,53 @@ struct MarkdownContentView: View {
     }
 }
 
-final class MarkdownSnapshotSource: ObservableObject, StreamedMarkdownSource {
-    let text: AsyncStream<String>
-    private let continuation: AsyncStream<String>.Continuation
+/// A retained snapshot store, with a separate stream for each renderer task.
+/// Cancelling a consumer terminates its AsyncStream permanently, so the source
+/// must create a fresh subscription when the same SwiftUI view reappears.
+final class MarkdownSnapshotSource: ObservableObject, StreamedMarkdownSource, @unchecked Sendable {
+    // The renderer subscribes/cancels from tasks while SwiftUI sends snapshots.
+    // All mutable state, including replay ordering, is protected by this lock.
+    private let lock = NSLock()
+    private var latestContent: String
+    private var subscribers: [UUID: AsyncStream<String>.Continuation] = [:]
 
     init(initialContent: String) {
-        var capturedContinuation: AsyncStream<String>.Continuation?
-        self.text = AsyncStream(bufferingPolicy: .bufferingNewest(1)) {
-            capturedContinuation = $0
+        self.latestContent = initialContent
+    }
+
+    var text: AsyncStream<String> {
+        let subscriptionID = UUID()
+        return AsyncStream(bufferingPolicy: .bufferingNewest(1)) { continuation in
+            lock.withLock {
+                subscribers[subscriptionID] = continuation
+                continuation.yield(latestContent)
+            }
+            continuation.onTermination = { [weak self] _ in
+                self?.removeSubscriber(subscriptionID)
+            }
         }
-        guard let capturedContinuation else {
-            fatalError("AsyncStream must synchronously provide its continuation")
-        }
-        self.continuation = capturedContinuation
-        self.continuation.yield(initialContent)
     }
 
     func send(_ content: String) {
-        continuation.yield(content)
+        lock.withLock {
+            latestContent = content
+            for continuation in subscribers.values {
+                continuation.yield(content)
+            }
+        }
+    }
+
+    private func removeSubscriber(_ id: UUID) {
+        lock.withLock {
+            _ = subscribers.removeValue(forKey: id)
+        }
     }
 
     deinit {
-        continuation.finish()
+        // No strong reference to the source survives into termination handlers.
+        for continuation in subscribers.values {
+            continuation.finish()
+        }
     }
 }
 

--- a/Sources/MacParakeet/Views/MeetingRecording/LiveAskPaneView.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/LiveAskPaneView.swift
@@ -685,11 +685,9 @@ private struct AssistantTurnView: View {
                         .accessibilityElement()
                         .accessibilityLabel("Thinking")
                 } else {
-                    // Reuse the canonical NSTextView-based renderer used
-                    // elsewhere (post-meeting Chat tab, PromptResults).
-                    // Markdown, headings, code blocks, lists, and proper text
-                    // selection — for free.
-                    MarkdownContentView(content)
+                    // Reuse the canonical renderer used elsewhere
+                    // (post-meeting Chat tab and Prompt Results).
+                    MarkdownContentView(content, isStreaming: isStreaming)
                         .fixedSize(horizontal: false, vertical: true)
                         .transition(.opacity)
                 }

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
@@ -2558,7 +2558,7 @@ struct TranscriptResultView: View {
                         MarkdownContentView(
                             generation.content,
                             font: DesignSystem.Typography.bodyLarge,
-                            isStreaming: generation.state == .streaming
+                            isStreaming: true
                         )
                             .frame(maxWidth: .infinity, alignment: .leading)
                     }

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
@@ -2555,7 +2555,11 @@ struct TranscriptResultView: View {
                     } else if generation.content.isEmpty {
                         SummarySkeletonView()
                     } else {
-                        MarkdownContentView(generation.content, font: DesignSystem.Typography.bodyLarge)
+                        MarkdownContentView(
+                            generation.content,
+                            font: DesignSystem.Typography.bodyLarge,
+                            isStreaming: generation.state == .streaming
+                        )
                             .frame(maxWidth: .infinity, alignment: .leading)
                     }
                 }
@@ -3108,7 +3112,7 @@ struct TranscriptResultView: View {
                                 .foregroundStyle(DesignSystem.Colors.onAccent)
                                 .textSelection(.enabled)
                         } else {
-                            MarkdownContentView(message.content)
+                            MarkdownContentView(message.content, isStreaming: message.isStreaming)
                         }
                     }
                     .padding(.horizontal, 14)

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -2,6 +2,16 @@
 
 This project bundles or downloads third-party software components. The following attributions summarize the relevant source, license, and usage information for those components.
 
+The Markdown dependency graph below has verbatim copyright, license, and NOTICE
+material in [`MarkdownDependencies.txt`](Sources/MacParakeet/Resources/Legal/MarkdownDependencies.txt),
+also copied to `Contents/Resources/Legal/MarkdownDependencies.txt` in dev and
+distribution bundles. It includes Highlight.js and Latin Modern Math resource
+notices (GUST Font License and LPPL 1.3c), not just library names/links.
+The font notice also identifies the complete, unmodified Latin Modern Math 1.959
+distribution, since iosMath ships only a subset of that upstream package.
+Equatable and swift-syntax are build/macro support; including their licenses
+does not claim their compiler executables are redistributed in the app.
+
 ## FFmpeg
 
 - Version: 8.0.1
@@ -128,7 +138,7 @@ This project bundles or downloads third-party software components. The following
 ### swift-markdown
 
 - Version: 0.7.3
-- License: Apache License 2.0
+- License: Apache License 2.0 with Runtime Library Exception
 - Source: <https://github.com/swiftlang/swift-markdown>
 - Used for: Markdown parsing through SwiftStreamingMarkdown
 
@@ -163,16 +173,16 @@ This project bundles or downloads third-party software components. The following
 ### swift-cmark
 
 - Version: 0.8.0
-- License: BSD 2-Clause License
+- License: BSD 2-Clause, plus the component notices reproduced in upstream `COPYING`
 - Source: <https://github.com/swiftlang/swift-cmark>
 - Used for: Transitive CommonMark/GFM parsing through swift-markdown
 
 ### swift-syntax
 
 - Version: 603.0.2
-- License: Apache License 2.0
+- License: Apache License 2.0 with Runtime Library Exception
 - Source: <https://github.com/swiftlang/swift-syntax>
-- Used for: Transitive swift-markdown build support
+- Used for: Equatable macro build support, not runtime Markdown parsing
 
 ## Parakeet TDT Model
 

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -119,9 +119,10 @@ This project bundles or downloads third-party software components. The following
 
 ### SwiftStreamingMarkdown
 
-- Version: 0.7.0 (pinned release commit)
+- Version: 0.7.0 compatibility fork, pinned at `1f10d5286985349b63145e1193f4f6ad5f7fdfe1`
 - License: MIT License
 - Source: <https://github.com/microsoft/SwiftStreamingMarkdown>
+- Compatibility source: <https://github.com/alfred-sa/SwiftStreamingMarkdown>
 - Used for: Rich Markdown rendering in Prompt Results, Chat, and live Ask
 
 ### swift-markdown

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -117,6 +117,60 @@ This project bundles or downloads third-party software components. The following
 - License: MIT License
 - Source: <https://github.com/sparkle-project/Sparkle>
 
+### SwiftStreamingMarkdown
+
+- Version: 0.7.0 (pinned release commit)
+- License: MIT License
+- Source: <https://github.com/microsoft/SwiftStreamingMarkdown>
+- Used for: Rich Markdown rendering in Prompt Results, Chat, and live Ask
+
+### swift-markdown
+
+- Version: 0.7.3
+- License: Apache License 2.0
+- Source: <https://github.com/swiftlang/swift-markdown>
+- Used for: Markdown parsing through SwiftStreamingMarkdown
+
+### HighlightSwift
+
+- License: MIT License
+- Source: <https://github.com/appstefan/highlightswift>
+- Used for: Fenced-code syntax highlighting through SwiftStreamingMarkdown
+
+### iosMath
+
+- License: MIT License
+- Source: <https://github.com/junyan72/iosMath>
+- Used for: Transitive math-rendering support in SwiftStreamingMarkdown
+
+### Equatable
+
+- Version: 1.4.1
+- License: Apache License 2.0
+- Source: <https://github.com/ordo-one/equatable>
+- Used for: Transitive SwiftStreamingMarkdown support
+
+### SwiftUI-Shimmer
+
+- Version: 1.5.1
+- License: MIT License
+- Source: <https://github.com/markiv/SwiftUI-Shimmer>
+- Used for: Transitive SwiftStreamingMarkdown support
+
+### swift-cmark
+
+- Version: 0.8.0
+- License: BSD 2-Clause License
+- Source: <https://github.com/swiftlang/swift-cmark>
+- Used for: Transitive CommonMark/GFM parsing through swift-markdown
+
+### swift-syntax
+
+- Version: 603.0.2
+- License: Apache License 2.0
+- Source: <https://github.com/swiftlang/swift-syntax>
+- Used for: Transitive swift-markdown build support
+
 ## Parakeet TDT Model
 
 - License: CC-BY-4.0

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -134,12 +134,14 @@ This project bundles or downloads third-party software components. The following
 
 ### HighlightSwift
 
+- Revision: `99c431b38a1444a5fd6a4978307fbbefe3a7af53`
 - License: MIT License
 - Source: <https://github.com/appstefan/highlightswift>
 - Used for: Fenced-code syntax highlighting through SwiftStreamingMarkdown
 
 ### iosMath
 
+- Revision: `ba9ab7729b151329c54fd895a7c1859981d9484c`
 - License: MIT License
 - Source: <https://github.com/junyan72/iosMath>
 - Used for: Transitive math-rendering support in SwiftStreamingMarkdown

--- a/Tests/MacParakeetTests/Views/MarkdownContentViewTests.swift
+++ b/Tests/MacParakeetTests/Views/MarkdownContentViewTests.swift
@@ -27,7 +27,7 @@ final class MarkdownContentViewTests: XCTestCase {
         }
         await fulfillment(of: [subscribed], timeout: 2)
 
-        // Match StreamedMarkdownController.end() when the pane disappears.
+        // Match SwiftStreamingMarkdown's StreamedMarkdownController.end() on disappearance.
         firstRenderer.cancel()
         let cancelledValue = await firstRenderer.value
         XCTAssertNil(cancelledValue)
@@ -62,6 +62,36 @@ final class MarkdownContentViewTests: XCTestCase {
         source.send("Replacement remains live")
         let next = await replacement.next()
         XCTAssertEqual(next, "Replacement remains live")
+    }
+
+    func testTableExportPreservesMarkdownSource() async throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let destination = directory.appendingPathComponent("table.md")
+        let content = "| Owner | Action |\n| --- | --- |\n| Élodie | Review **today** |\n"
+
+        try await MarkdownTableExporter.write(content, to: destination)
+
+        XCTAssertEqual(try String(contentsOf: destination, encoding: .utf8), content)
+    }
+
+    func testTableExportPropagatesDestinationWriteFailure() async throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        // A regular file cannot contain an exported table, regardless of the
+        // current user's filesystem permissions or whether tests run as root.
+        let parentFile = directory.appendingPathComponent("not-a-directory")
+        try "Keep this existing file".write(to: parentFile, atomically: true, encoding: .utf8)
+
+        do {
+            try await MarkdownTableExporter.write("| Table |", to: parentFile.appendingPathComponent("table.md"))
+            XCTFail("The UI must receive the write error to present Export Failed")
+        } catch {
+            XCTAssertEqual((error as NSError).domain, NSCocoaErrorDomain)
+        }
+        XCTAssertEqual(try String(contentsOf: parentFile, encoding: .utf8), "Keep this existing file")
     }
 
     func testKitchenSinkAndIncompleteSnapshotsProduceRenderableContent() async {

--- a/Tests/MacParakeetTests/Views/MarkdownContentViewTests.swift
+++ b/Tests/MacParakeetTests/Views/MarkdownContentViewTests.swift
@@ -15,6 +15,55 @@ final class MarkdownContentViewTests: XCTestCase {
         XCTAssertEqual(updated, "# Summary\n\n- [ ] Review")
     }
 
+    func testStreamingSourceReplaysLatestSnapshotAfterConsumerCancellation() async {
+        let source = MarkdownSnapshotSource(initialContent: "# First visit")
+        let subscribed = expectation(description: "First renderer consumed its snapshot")
+        let firstRenderer = Task {
+            var iterator = source.text.makeAsyncIterator()
+            let initial = await iterator.next()
+            XCTAssertEqual(initial, "# First visit")
+            subscribed.fulfill()
+            return await iterator.next()
+        }
+        await fulfillment(of: [subscribed], timeout: 2)
+
+        // Match StreamedMarkdownController.end() when the pane disappears.
+        firstRenderer.cancel()
+        let cancelledValue = await firstRenderer.value
+        XCTAssertNil(cancelledValue)
+        source.send("# Changed while hidden")
+
+        // SwiftUI keeps the StateObject when the pane returns. A fresh renderer
+        // must see both the latest hidden update and subsequent live snapshots.
+        var returnedRenderer = source.text.makeAsyncIterator()
+        let replayed = await returnedRenderer.next()
+        XCTAssertEqual(replayed, "# Changed while hidden")
+        source.send("# Continued after returning")
+        let continued = await returnedRenderer.next()
+        XCTAssertEqual(continued, "# Continued after returning")
+    }
+
+    func testCancellingOldRendererDoesNotTerminateReplacementSubscription() async {
+        let source = MarkdownSnapshotSource(initialContent: "Initial")
+        let subscribed = expectation(description: "Old renderer subscribed")
+        let oldRenderer = Task {
+            var iterator = source.text.makeAsyncIterator()
+            _ = await iterator.next()
+            subscribed.fulfill()
+            return await iterator.next()
+        }
+        await fulfillment(of: [subscribed], timeout: 2)
+        var replacement = source.text.makeAsyncIterator()
+        oldRenderer.cancel()
+        _ = await oldRenderer.value
+        let initial = await replacement.next()
+        XCTAssertEqual(initial, "Initial")
+
+        source.send("Replacement remains live")
+        let next = await replacement.next()
+        XCTAssertEqual(next, "Replacement remains live")
+    }
+
     func testKitchenSinkAndIncompleteSnapshotsProduceRenderableContent() async {
         let parser = MarkdownParserImpl()
         let config = MarkdownContentConfiguration.make(baseFontSize: 14, isStreaming: false)

--- a/Tests/MacParakeetTests/Views/MarkdownContentViewTests.swift
+++ b/Tests/MacParakeetTests/Views/MarkdownContentViewTests.swift
@@ -27,7 +27,7 @@ final class MarkdownContentViewTests: XCTestCase {
         }
         await fulfillment(of: [subscribed], timeout: 2)
 
-        // Match SwiftStreamingMarkdown's StreamedMarkdownController.end() on disappearance.
+        // Match SwiftUI cancelling the structured consumer on disappearance.
         firstRenderer.cancel()
         let cancelledValue = await firstRenderer.value
         XCTAssertNil(cancelledValue)
@@ -64,7 +64,96 @@ final class MarkdownContentViewTests: XCTestCase {
         XCTAssertEqual(next, "Replacement remains live")
     }
 
-    func testTableExportPreservesMarkdownSource() async throws {
+    @MainActor
+    func testCancelledParseCannotOverwriteReplacementRenderer() async {
+        let source = MarkdownSnapshotSource(initialContent: "Old result")
+        let config = MarkdownContentConfiguration.make(baseFontSize: 14, isStreaming: false)
+        let oldDocument = RenderableDocument(plainText: "Old result", config: config)
+        let newDocument = RenderableDocument(plainText: "New result", config: config)
+        let oldParseStarted = expectation(description: "Old parse suspended")
+        let replacementPublished = expectation(description: "Replacement published")
+        var finishOldParse: CheckedContinuation<RenderableDocument, Never>?
+        var published: [RenderableDocument] = []
+
+        let oldRenderer = Task {
+            await MarkdownSnapshotRenderer.render(
+                source: source, config: config,
+                parse: { _, _ in
+                    await withCheckedContinuation { continuation in
+                        finishOldParse = continuation
+                        oldParseStarted.fulfill()
+                    }
+                }, publish: { published.append($0) })
+        }
+        await fulfillment(of: [oldParseStarted], timeout: 2)
+        oldRenderer.cancel()
+        source.send("New result")
+
+        let replacement = Task {
+            await MarkdownSnapshotRenderer.render(
+                source: source, config: config,
+                parse: { text, _ in
+                    XCTAssertEqual(text, "New result")
+                    return newDocument
+                },
+                publish: {
+                    published.append($0)
+                    replacementPublished.fulfill()
+                })
+        }
+        await fulfillment(of: [replacementPublished], timeout: 2)
+
+        // The dependency parser need not observe cancellation. Its late result
+        // must still be discarded after a replacement consumer has published.
+        finishOldParse?.resume(returning: oldDocument)
+        await oldRenderer.value
+        replacement.cancel()
+        await replacement.value
+        XCTAssertEqual(published, [newDocument])
+    }
+
+    @MainActor
+    func testRendererCoalescesSnapshotsWhileParsing() async {
+        let source = MarkdownSnapshotSource(initialContent: "Initial")
+        let config = MarkdownContentConfiguration.make(baseFontSize: 14, isStreaming: true)
+        let initialParseStarted = expectation(description: "Initial parse suspended")
+        let latestPublished = expectation(description: "Latest snapshot published")
+        var finishInitialParse: CheckedContinuation<RenderableDocument, Never>?
+        var parsed: [String] = []
+        var publishedCount = 0
+
+        let renderer = Task {
+            await MarkdownSnapshotRenderer.render(
+                source: source, config: config,
+                parse: { text, config in
+                    parsed.append(text)
+                    if text == "Initial" {
+                        return await withCheckedContinuation { continuation in
+                            finishInitialParse = continuation
+                            initialParseStarted.fulfill()
+                        }
+                    }
+                    return RenderableDocument(plainText: text, config: config)
+                },
+                publish: { _ in
+                    publishedCount += 1
+                    if publishedCount == 2 {
+                        latestPublished.fulfill()
+                    }
+                })
+        }
+        await fulfillment(of: [initialParseStarted], timeout: 2)
+        source.send("Intermediate")
+        source.send("Latest")
+        XCTAssertEqual(parsed, ["Initial"], "Parsing remains serial")
+        finishInitialParse?.resume(returning: RenderableDocument(plainText: "Initial", config: config))
+        await fulfillment(of: [latestPublished], timeout: 2)
+        renderer.cancel()
+        await renderer.value
+        XCTAssertEqual(parsed, ["Initial", "Latest"])
+    }
+
+    func testTableExportPreservesProvidedTableMarkdown() async throws {
         let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: directory) }

--- a/Tests/MacParakeetTests/Views/MarkdownContentViewTests.swift
+++ b/Tests/MacParakeetTests/Views/MarkdownContentViewTests.swift
@@ -1,0 +1,88 @@
+import Foundation
+@testable import MacParakeet
+import SwiftStreamingMarkdown
+import XCTest
+
+final class MarkdownContentViewTests: XCTestCase {
+    func testStreamingSourcePublishesAccumulatedSnapshots() async {
+        let source = MarkdownSnapshotSource(initialContent: "# Sum")
+        var iterator = source.text.makeAsyncIterator()
+
+        let initial = await iterator.next()
+        XCTAssertEqual(initial, "# Sum")
+        source.send("# Summary\n\n- [ ] Review")
+        let updated = await iterator.next()
+        XCTAssertEqual(updated, "# Summary\n\n- [ ] Review")
+    }
+
+    func testKitchenSinkAndIncompleteSnapshotsProduceRenderableContent() async {
+        let parser = MarkdownParserImpl()
+        let config = MarkdownContentConfiguration.make(baseFontSize: 14, isStreaming: false)
+        let fixtures = [
+            """
+            # Summary
+
+            **Bold**, *italic*, ~~removed~~, `inline code`, and [web](https://example.com).
+
+            - Parent
+              - Nested
+            - [x] Done
+            - [ ] Next
+
+            3. Third
+            4. Fourth
+
+            | Item | Owner | Status |
+            |:-----|:-----:|-------:|
+            | API | **Sam** | Done |
+
+            > Quoted context
+
+            ```swift
+            let value = 42
+            ```
+
+            ---
+            """,
+            "**unfinished emphasis",
+            "```swift\nlet value = 42",
+            "| Item | Owner |\n|:--|--:|\n| Work",
+        ]
+
+        for fixture in fixtures {
+            let rendered = await parser.parse(text: fixture, config: config)
+            XCTAssertNotEqual(rendered, .empty, "Fixture should stay readable: \(fixture)")
+        }
+    }
+
+    func testLinkPolicyAllowsOnlyWebLinks() {
+        XCTAssertTrue(MarkdownContentPolicy.isAllowedLink(URL(string: "https://example.com/path")!))
+        XCTAssertTrue(MarkdownContentPolicy.isAllowedLink(URL(string: "HTTP://example.com")!))
+
+        XCTAssertFalse(MarkdownContentPolicy.isAllowedLink(URL(string: "file:///tmp/private.txt")!))
+        XCTAssertFalse(MarkdownContentPolicy.isAllowedLink(URL(string: "data:text/plain,secret")!))
+        XCTAssertFalse(MarkdownContentPolicy.isAllowedLink(URL(string: "javascript:alert(1)")!))
+        XCTAssertFalse(MarkdownContentPolicy.isAllowedLink(URL(string: "mailto:test@example.com")!))
+        XCTAssertFalse(MarkdownContentPolicy.isAllowedLink(URL(string: "/relative/path")!))
+    }
+
+    func testRenderConfigurationKeepsImagesDisabledAndSelectionEnabled() {
+        let config = MarkdownContentConfiguration.make(baseFontSize: 15, isStreaming: false)
+
+        XCTAssertFalse(config.imageConfig.enabled)
+        XCTAssertTrue(config.imageConfig.allowedImageTypes.isEmpty)
+        XCTAssertTrue(config.textSelectionConfig.isEnabled)
+        XCTAssertFalse(config.shouldAnimateText)
+    }
+
+    func testStreamingConfigurationOnlyEnablesTextAnimation() {
+        let staticConfig = MarkdownContentConfiguration.make(baseFontSize: 14, isStreaming: false)
+        let streamingConfig = MarkdownContentConfiguration.make(baseFontSize: 14, isStreaming: true)
+
+        XCTAssertFalse(staticConfig.shouldAnimateText)
+        XCTAssertTrue(streamingConfig.shouldAnimateText)
+        XCTAssertEqual(staticConfig.imageConfig, streamingConfig.imageConfig)
+        XCTAssertEqual(staticConfig.paragraphStyle, streamingConfig.paragraphStyle)
+        XCTAssertEqual(staticConfig.tableStyle, streamingConfig.tableStyle)
+    }
+}

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -2,7 +2,11 @@
 
 > Status: **ACTIVE** - Build, sign, notarize, and auto-update workflow
 
-This repo is SwiftPM-based, so we assemble a `.app` bundle manually for Developer ID distribution.
+This repo uses Swift packages. App distribution builds those packages through
+Xcode and assembles a `.app` bundle for Developer ID distribution. Xcode compiles
+asset catalogs and generates resource lookups that work after installation on
+another Mac. `BUILD_SYSTEM=swiftpm` is rejected for app distribution; ordinary
+`swift build`, `swift test`, and SwiftPM CLI builds remain supported.
 
 ## 1) Build the app bundle
 

--- a/docs/human-qa-guide.md
+++ b/docs/human-qa-guide.md
@@ -59,7 +59,9 @@ The script also stops every existing MacParakeet process **before** rebuilding
 or re-signing the Dev bundle. Never reorder that shutdown after bundle wrapping:
 modifying a signed executable while macOS is running it can terminate the app
 later with `SIGKILL (Code Signature Invalid)`, often when the next menu or sheet
-loads code from the changed page.
+loads code from the changed page. Shutdown waits up to ten seconds for the
+matched processes to exit. If process inspection fails or an app stays alive,
+the build aborts before modifying the bundle; it does not force-kill the app.
 
 **Or** QA the Sparkle release candidate DMG — closest to what users receive. Use this
 for release-gating checks (signing, notarization, first-run onboarding, auto-update).
@@ -81,14 +83,17 @@ for release-gating checks (signing, notarization, first-run onboarding, auto-upd
   “Copy table” and “Download table” and can activate both. The automated native
   selection regression passes, but the XCTest host does not expose the SwiftUI
   accessibility tree, so the VoiceOver check must run in the app.
-- While a result or chat response is streaming, leave its pane and return. The
-  latest text must appear and later chunks must continue to render. Repeat after
+- While a result, saved chat response, or live Ask response is streaming, leave
+  its pane and return. Existing text must remain visible and later chunks must
+  continue to render. Repeat after
   a completed result starts streaming again.
 - In a rendered table, select text in a header and a body cell, then copy it.
   Selection must remain usable without a table-wide click action consuming it.
 - Navigate the table actions with VoiceOver. Both **Copy table** and **Download
   table** must be named and reachable before clicking the table; downloading must
-  open the existing save dialog and export the original Markdown source.
+  open the existing save dialog and export the original Markdown source. Cancel
+  the dialog to confirm no file is written. If the destination becomes
+  unwritable, the app must show **Export Failed** instead of silently closing.
 
 ## Writing a QA checklist (for PR authors / agents)
 

--- a/docs/human-qa-guide.md
+++ b/docs/human-qa-guide.md
@@ -55,7 +55,7 @@ with `Macro “EquatableMacros” ... must be enabled before it can be used`, do
 not install or substitute a renderer: rerun `scripts/dev/run_app.sh`, or keep
 that flag in the equivalent Xcode invocation.
 
-The script also stops every existing MacParakeet process **before** rebuilding
+The script also requests ordinary quit for this worktree’s replaced dev executables **before** rebuilding
 or re-signing the Dev bundle. Never reorder that shutdown after bundle wrapping:
 modifying a signed executable while macOS is running it can terminate the app
 later with `SIGKILL (Code Signature Invalid)`, often when the next menu or sheet
@@ -91,12 +91,13 @@ for release-gating checks (signing, notarization, first-run onboarding, auto-upd
 - While a result, saved chat response, or live Ask response is streaming, leave
   its pane and return. Existing text must remain visible and later chunks must
   continue to render. Repeat after
-  a completed result starts streaming again.
+  a completed result starts streaming again. Also switch quickly between saved
+  results of different lengths; the selected result must not revert to stale text.
 - In a rendered table, select text in a header and a body cell, then copy it.
   Selection must remain usable without a table-wide click action consuming it.
 - Navigate the table actions with VoiceOver. Both **Copy table** and **Download
   table** must be named and reachable before clicking the table; downloading must
-  open the existing save dialog and export the original Markdown source. Cancel
+  open the save dialog and export normalized Markdown for that table. Cancel
   the dialog to confirm no file is written. If the destination becomes
   unwritable, the app must show **Export Failed** instead of silently closing.
 

--- a/docs/human-qa-guide.md
+++ b/docs/human-qa-guide.md
@@ -59,9 +59,14 @@ The script also stops every existing MacParakeet process **before** rebuilding
 or re-signing the Dev bundle. Never reorder that shutdown after bundle wrapping:
 modifying a signed executable while macOS is running it can terminate the app
 later with `SIGKILL (Code Signature Invalid)`, often when the next menu or sheet
-loads code from the changed page. Shutdown waits up to ten seconds for the
-matched processes to exit. If process inspection fails or an app stays alive,
-the build aborts before modifying the bundle; it does not force-kill the app.
+loads code from the changed page. Shutdown requests a normal macOS app quit,
+including the existing meeting confirmation and pending-note save flow, and
+waits up to ten seconds for exit. Cancelled quit, ongoing finalization, failed
+process inspection, or a raw executable without a normal app-quit interface
+abort the build before modifying the bundle. Quit the app normally and rerun
+the script when ready; it never sends a termination signal or force-kills it.
+Process matching uses actual executable paths, so checkout punctuation and
+unrelated command-line arguments cannot select the wrong process.
 
 **Or** QA the Sparkle release candidate DMG — closest to what users receive. Use this
 for release-gating checks (signing, notarization, first-run onboarding, auto-update).

--- a/docs/human-qa-guide.md
+++ b/docs/human-qa-guide.md
@@ -48,6 +48,19 @@ To QA a specific PR branch, run that script from inside **that branch's checkout
 worktree** — SwiftPM pins build paths per worktree, so build from where the branch
 actually lives.
 
+The script intentionally passes `-skipMacroValidation` to `xcodebuild` because
+the canonical `SwiftStreamingMarkdown` renderer includes the approved
+`EquatableMacros` plugin transitively. If a hand-written Xcode command fails
+with `Macro “EquatableMacros” ... must be enabled before it can be used`, do
+not install or substitute a renderer: rerun `scripts/dev/run_app.sh`, or keep
+that flag in the equivalent Xcode invocation.
+
+The script also stops every existing MacParakeet process **before** rebuilding
+or re-signing the Dev bundle. Never reorder that shutdown after bundle wrapping:
+modifying a signed executable while macOS is running it can terminate the app
+later with `SIGKILL (Code Signature Invalid)`, often when the next menu or sheet
+loads code from the changed page.
+
 **Or** QA the Sparkle release candidate DMG — closest to what users receive. Use this
 for release-gating checks (signing, notarization, first-run onboarding, auto-update).
 

--- a/docs/human-qa-guide.md
+++ b/docs/human-qa-guide.md
@@ -73,6 +73,17 @@ for release-gating checks (signing, notarization, first-run onboarding, auto-upd
   `tccutil reset All com.macparakeet.dev`.
 - Its history and settings are independent — a clean slate is expected, not a bug.
 
+## Markdown regression checks
+
+- While a result or chat response is streaming, leave its pane and return. The
+  latest text must appear and later chunks must continue to render. Repeat after
+  a completed result starts streaming again.
+- In a rendered table, select text in a header and a body cell, then copy it.
+  Selection must remain usable without a table-wide click action consuming it.
+- Navigate the table actions with VoiceOver. Both **Copy table** and **Download
+  table** must be named and reachable before clicking the table; downloading must
+  open the existing save dialog and export the original Markdown source.
+
 ## Writing a QA checklist (for PR authors / agents)
 
 Put this in the PR description so the human can self-serve. Keep items concrete and

--- a/docs/human-qa-guide.md
+++ b/docs/human-qa-guide.md
@@ -75,6 +75,12 @@ for release-gating checks (signing, notarization, first-run onboarding, auto-upd
 
 ## Markdown regression checks
 
+- Select text directly inside table headers and cells. The pinned compatibility
+  fork uses the same native selectable text view as ordinary paragraphs on macOS.
+  Table Copy and Download actions are always visible; verify VoiceOver announces
+  “Copy table” and “Download table” and can activate both. The automated native
+  selection regression passes, but the XCTest host does not expose the SwiftUI
+  accessibility tree, so the VoiceOver check must run in the app.
 - While a result or chat response is streaming, leave its pane and return. The
   latest text must appear and later chunks must continue to render. Repeat after
   a completed result starts streaming again.

--- a/scripts/dev/run_app.sh
+++ b/scripts/dev/run_app.sh
@@ -79,12 +79,21 @@ binary_has_rpath() {
   return 1
 }
 
-echo "[1/5] Building $CONFIG app bundle (xcodebuild, target signing disabled)…"
+echo "[1/5] Stopping existing MacParakeet processes before replacing the bundle…"
+pkill -f "/Applications/MacParakeet.app/Contents/MacOS/MacParakeet" || true
+pkill -f "$ROOT_DIR/dist/MacParakeet.app/Contents/MacOS/MacParakeet" || true
+pkill -f "MacParakeet-Dev.app/Contents/MacOS/MacParakeet" || true
+pkill -f "$PRODUCT_DIR/MacParakeet" || true
+pkill -f "$ROOT_DIR/.build/debug/MacParakeet" || true
+pkill -f "$ROOT_DIR/.build/arm64-apple-macosx/debug/MacParakeet" || true
+
+echo "[2/5] Building $CONFIG app bundle (xcodebuild, target signing disabled)…"
 if ! xcodebuild build \
   -scheme MacParakeet \
   -configuration "$CONFIG" \
   -destination "platform=OS X,arch=arm64" \
   -derivedDataPath "$DERIVED_DATA_DIR" \
+  -skipMacroValidation \
   CODE_SIGNING_ALLOWED=NO \
   CODE_SIGNING_REQUIRED=NO >"$BUILD_LOG_FILE" 2>&1; then
   echo "xcodebuild failed. Last 120 log lines from $BUILD_LOG_FILE:" >&2
@@ -106,7 +115,7 @@ if [[ -d "$PRODUCT_DIR/Sparkle.framework" && ! -e "$PKGFW_DIR/Sparkle.framework"
   ln -s "$PRODUCT_DIR/Sparkle.framework" "$PKGFW_DIR/Sparkle.framework"
 fi
 
-echo "[2/5] Wrapping in .app bundle for macOS permissions…"
+echo "[3/5] Wrapping in .app bundle for macOS permissions…"
 # Create a minimal .app bundle so macOS TCC (Accessibility, Microphone) can
 # identify and remember permissions for the dev build across rebuilds.
 MACOS_DIR="$APP_BUNDLE/Contents/MacOS"
@@ -120,6 +129,19 @@ if [[ -d "$RESOURCE_BUNDLE" ]]; then
   mkdir -p "$RESOURCES_DIR"
   rsync -a --delete "$RESOURCE_BUNDLE" "$RESOURCES_DIR/"
 fi
+
+# Dependency resource bundles must keep their bundle directory name because
+# Bundle.module resolves them under Contents/Resources at runtime. The
+# distribution builder already copies every SwiftPM bundle; mirror that here
+# for dependencies such as SwiftStreamingMarkdown and its syntax highlighter.
+RESOURCES_DIR="$APP_BUNDLE/Contents/Resources"
+mkdir -p "$RESOURCES_DIR"
+while IFS= read -r -d '' bundle; do
+  if [[ "$bundle" != "$RESOURCE_BUNDLE" ]]; then
+    bundle_name="${bundle##*/}"
+    rsync -a --delete "$bundle/" "$RESOURCES_DIR/$bundle_name/"
+  fi
+done < <(find "$PRODUCT_DIR" -maxdepth 1 -type d -name '*.bundle' -print0)
 
 # Copy frameworks into the bundle so dyld loads only bundle-local paths.
 BUNDLE_FW_DIR="$APP_BUNDLE/Contents/Frameworks"
@@ -194,15 +216,6 @@ if [[ "$CODESIGN_IDENTITY" == "-" ]]; then
 fi
 codesign --force --sign "$CODESIGN_IDENTITY" --options runtime \
   --entitlements "$SIGN_ENTITLEMENTS" --deep "$APP_BUNDLE"
-
-echo "[3/5] Stopping existing MacParakeet processes…"
-pkill -f "/Applications/MacParakeet.app/Contents/MacOS/MacParakeet" || true
-pkill -f "$ROOT_DIR/dist/MacParakeet.app/Contents/MacOS/MacParakeet" || true
-pkill -f "MacParakeet-Dev.app/Contents/MacOS/MacParakeet" || true
-pkill -f "$PRODUCT_DIR/MacParakeet" || true
-pkill -f "$ROOT_DIR/.build/debug/MacParakeet" || true
-pkill -f "$ROOT_DIR/.build/arm64-apple-macosx/debug/MacParakeet" || true
-sleep 1
 
 GIT_COMMIT="$(git -C "$ROOT_DIR" rev-parse --short=12 HEAD 2>/dev/null || echo unknown)"
 BUILD_DATE_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"

--- a/scripts/dev/run_app.sh
+++ b/scripts/dev/run_app.sh
@@ -84,7 +84,6 @@ source "$ROOT_DIR/scripts/dev/stop_app_processes.sh"
 stop_app_processes 10 \
   "/Applications/MacParakeet.app/Contents/MacOS/MacParakeet" \
   "$ROOT_DIR/dist/MacParakeet.app/Contents/MacOS/MacParakeet" \
-  "MacParakeet-Dev.app/Contents/MacOS/MacParakeet" \
   "$PRODUCT_DIR/MacParakeet" \
   "$ROOT_DIR/.build/debug/MacParakeet" \
   "$ROOT_DIR/.build/arm64-apple-macosx/debug/MacParakeet"

--- a/scripts/dev/run_app.sh
+++ b/scripts/dev/run_app.sh
@@ -80,12 +80,14 @@ binary_has_rpath() {
 }
 
 echo "[1/5] Stopping existing MacParakeet processes before replacing the bundle…"
-pkill -f "/Applications/MacParakeet.app/Contents/MacOS/MacParakeet" || true
-pkill -f "$ROOT_DIR/dist/MacParakeet.app/Contents/MacOS/MacParakeet" || true
-pkill -f "MacParakeet-Dev.app/Contents/MacOS/MacParakeet" || true
-pkill -f "$PRODUCT_DIR/MacParakeet" || true
-pkill -f "$ROOT_DIR/.build/debug/MacParakeet" || true
-pkill -f "$ROOT_DIR/.build/arm64-apple-macosx/debug/MacParakeet" || true
+source "$ROOT_DIR/scripts/dev/stop_app_processes.sh"
+stop_app_processes 10 \
+  "/Applications/MacParakeet.app/Contents/MacOS/MacParakeet" \
+  "$ROOT_DIR/dist/MacParakeet.app/Contents/MacOS/MacParakeet" \
+  "MacParakeet-Dev.app/Contents/MacOS/MacParakeet" \
+  "$PRODUCT_DIR/MacParakeet" \
+  "$ROOT_DIR/.build/debug/MacParakeet" \
+  "$ROOT_DIR/.build/arm64-apple-macosx/debug/MacParakeet"
 
 echo "[2/5] Building $CONFIG app bundle (xcodebuild, target signing disabled)…"
 if ! xcodebuild build \

--- a/scripts/dev/run_app.sh
+++ b/scripts/dev/run_app.sh
@@ -1,11 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
 # Build configuration: Debug by default. Set MACPARAKEET_CONFIG=Release for an
 # optimized build (e.g. to feel-test true STT latency — Debug Swift is ~10x
 # slower for the Cohere decoder's per-step work).
 CONFIG="${MACPARAKEET_CONFIG:-Debug}"
+case "$CONFIG" in
+  Debug|Release) ;;
+  *) echo "MACPARAKEET_CONFIG must be Debug or Release." >&2; exit 1 ;;
+esac
 DERIVED_DATA_DIR="$ROOT_DIR/.build/xcode-dev"
 PRODUCT_DIR="$DERIVED_DATA_DIR/Build/Products/$CONFIG"
 APP_BIN="$PRODUCT_DIR/MacParakeet"
@@ -79,14 +83,9 @@ binary_has_rpath() {
   return 1
 }
 
-echo "[1/5] Stopping existing MacParakeet processes before replacing the bundle…"
+echo "[1/5] Requesting ordinary quit for this worktree's dev build…"
 source "$ROOT_DIR/scripts/dev/stop_app_processes.sh"
-stop_app_processes 10 \
-  "/Applications/MacParakeet.app/Contents/MacOS/MacParakeet" \
-  "$ROOT_DIR/dist/MacParakeet.app/Contents/MacOS/MacParakeet" \
-  "$PRODUCT_DIR/MacParakeet" \
-  "$ROOT_DIR/.build/debug/MacParakeet" \
-  "$ROOT_DIR/.build/arm64-apple-macosx/debug/MacParakeet"
+stop_app_processes 10 "$ROOT_DIR" "$APP_BIN" "$APP_MACOS_BIN"
 
 echo "[2/5] Building $CONFIG app bundle (xcodebuild, target signing disabled)…"
 if ! xcodebuild build \
@@ -143,6 +142,9 @@ while IFS= read -r -d '' bundle; do
     rsync -a --delete "$bundle/" "$RESOURCES_DIR/$bundle_name/"
   fi
 done < <(find "$PRODUCT_DIR" -maxdepth 1 -type d -name '*.bundle' -print0)
+mkdir -p "$RESOURCES_DIR/Legal"
+cp "$ROOT_DIR/Sources/MacParakeet/Resources/Legal/MarkdownDependencies.txt" "$RESOURCES_DIR/Legal/MarkdownDependencies.txt"
+cp "$ROOT_DIR/THIRD_PARTY_LICENSES.md" "$RESOURCES_DIR/Legal/THIRD_PARTY_LICENSES.md"
 
 # Copy frameworks into the bundle so dyld loads only bundle-local paths.
 BUNDLE_FW_DIR="$APP_BUNDLE/Contents/Frameworks"
@@ -234,19 +236,11 @@ BUILD_DATE_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 BUILD_SOURCE="dev-run-xcodebuild-$(echo "$CONFIG" | tr '[:upper:]' '[:lower:]')"
 
 echo "[4/5] Launching ${CONFIG} app…"
-MACPARAKEET_GIT_COMMIT="$GIT_COMMIT" \
-MACPARAKEET_BUILD_DATE_UTC="$BUILD_DATE_UTC" \
-MACPARAKEET_BUILD_SOURCE="$BUILD_SOURCE" \
-nohup open "$APP_BUNDLE" --env MACPARAKEET_GIT_COMMIT="$GIT_COMMIT" \
+open -n "$APP_BUNDLE" --env MACPARAKEET_GIT_COMMIT="$GIT_COMMIT" \
   --env MACPARAKEET_BUILD_DATE_UTC="$BUILD_DATE_UTC" \
-  --env MACPARAKEET_BUILD_SOURCE="$BUILD_SOURCE" >"$LOG_FILE" 2>&1 &
+  --env MACPARAKEET_BUILD_SOURCE="$BUILD_SOURCE" >"$LOG_FILE" 2>&1
 
-sleep 2
-PID="$(pgrep -f "MacParakeet-Dev.app/Contents/MacOS/MacParakeet" | head -n 1 || true)"
-INSTALLED_PID="$(pgrep -f "/Applications/MacParakeet.app/Contents/MacOS/MacParakeet" | head -n 1 || true)"
-
-echo "[5/5] Running"
-echo "  pid: ${PID:-unknown}"
+echo "[5/5] Launch requested"
 echo "  bundle: $APP_BUNDLE"
 echo "  source: $BUILD_SOURCE"
 echo "  commit: $GIT_COMMIT"
@@ -254,6 +248,3 @@ echo "  built-at: $BUILD_DATE_UTC"
 echo "  codesign: $CODESIGN_IDENTITY"
 echo "  log: $LOG_FILE"
 echo "  build-log: $BUILD_LOG_FILE"
-if [[ -n "$INSTALLED_PID" ]]; then
-  echo "  warning: /Applications/MacParakeet.app is also running (pid $INSTALLED_PID)"
-fi

--- a/scripts/dev/stop_app_processes.sh
+++ b/scripts/dev/stop_app_processes.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-# Source this helper before replacing a running app's executable or resources.
+# Arguments: timeout, checkout ownership root, exact executable paths replaced.
+# Source this helper before replacing this worktree's executable or resources.
 # AppKit normal quit preserves recording confirmation and pending-note saves.
 stop_app_processes() {
   local helper_dir status=0

--- a/scripts/dev/stop_app_processes.sh
+++ b/scripts/dev/stop_app_processes.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+# Source this helper before replacing a running app's executable or resources.
+# Signal only the current user's matching PIDs, then require observed exit.
+# A timeout aborts the build; it never force-kills an app holding user data.
+stop_app_processes() {
+  local timeout_seconds="$1"
+  shift
+  local process_ids="" matches pattern process_id status
+  local current_uid
+  current_uid="$(id -u)" || return 1
+
+  for pattern in "$@"; do
+    if matches="$(pgrep -u "$current_uid" -f "$pattern")"; then
+      while IFS= read -r process_id; do
+        [[ "$process_id" =~ ^[0-9]+$ ]] || continue
+        [[ "$process_id" != "$$" ]] || continue
+        case " $process_ids " in
+          *" $process_id "*) ;;
+          *) process_ids="${process_ids:+$process_ids }$process_id" ;;
+        esac
+      done <<<"$matches"
+    else
+      status=$?
+      if [[ "$status" -ne 1 ]]; then
+        printf 'Cannot inspect running MacParakeet processes (pgrep exit %s). Build aborted.\n' "$status" >&2
+        return 1
+      fi
+    fi
+  done
+
+  # IDs are validated decimal values above, so word splitting is intentional.
+  for process_id in $process_ids; do
+    if ! kill -TERM "$process_id" 2>/dev/null; then
+      if kill -0 "$process_id" 2>/dev/null; then
+        printf 'Cannot stop MacParakeet process %s. Build aborted.\n' "$process_id" >&2
+        return 1
+      fi
+    fi
+  done
+
+  local deadline=$((SECONDS + timeout_seconds))
+  local remaining_ids
+  while :; do
+    remaining_ids=""
+    for process_id in $process_ids; do
+      if kill -0 "$process_id" 2>/dev/null; then
+        remaining_ids="${remaining_ids:+$remaining_ids }$process_id"
+      fi
+    done
+    [[ -n "$remaining_ids" ]] || return 0
+    if (( SECONDS >= deadline )); then
+      printf 'MacParakeet did not exit within %ss (PIDs: %s). Build aborted before modifying the bundle.\n' \
+        "$timeout_seconds" "$remaining_ids" >&2
+      return 1
+    fi
+    sleep 0.1
+  done
+}

--- a/scripts/dev/stop_app_processes.sh
+++ b/scripts/dev/stop_app_processes.sh
@@ -1,59 +1,21 @@
 #!/usr/bin/env bash
 
 # Source this helper before replacing a running app's executable or resources.
-# Signal only the current user's matching PIDs, then require observed exit.
-# A timeout aborts the build; it never force-kills an app holding user data.
+# AppKit normal quit preserves recording confirmation and pending-note saves.
 stop_app_processes() {
-  local timeout_seconds="$1"
-  shift
-  local process_ids="" matches pattern process_id status
-  local current_uid
-  current_uid="$(id -u)" || return 1
-
-  for pattern in "$@"; do
-    if matches="$(pgrep -u "$current_uid" -f "$pattern")"; then
-      while IFS= read -r process_id; do
-        [[ "$process_id" =~ ^[0-9]+$ ]] || continue
-        [[ "$process_id" != "$$" ]] || continue
-        case " $process_ids " in
-          *" $process_id "*) ;;
-          *) process_ids="${process_ids:+$process_ids }$process_id" ;;
-        esac
-      done <<<"$matches"
-    else
-      status=$?
-      if [[ "$status" -ne 1 ]]; then
-        printf 'Cannot inspect running MacParakeet processes (pgrep exit %s). Build aborted.\n' "$status" >&2
-        return 1
-      fi
-    fi
-  done
-
-  # IDs are validated decimal values above, so word splitting is intentional.
-  for process_id in $process_ids; do
-    if ! kill -TERM "$process_id" 2>/dev/null; then
-      if kill -0 "$process_id" 2>/dev/null; then
-        printf 'Cannot stop MacParakeet process %s. Build aborted.\n' "$process_id" >&2
-        return 1
-      fi
-    fi
-  done
-
-  local deadline=$((SECONDS + timeout_seconds))
-  local remaining_ids
-  while :; do
-    remaining_ids=""
-    for process_id in $process_ids; do
-      if kill -0 "$process_id" 2>/dev/null; then
-        remaining_ids="${remaining_ids:+$remaining_ids }$process_id"
-      fi
-    done
-    [[ -n "$remaining_ids" ]] || return 0
-    if (( SECONDS >= deadline )); then
-      printf 'MacParakeet did not exit within %ss (PIDs: %s). Build aborted before modifying the bundle.\n' \
-        "$timeout_seconds" "$remaining_ids" >&2
-      return 1
-    fi
-    sleep 0.1
-  done
+  local helper_dir status=0
+  helper_dir="$(mktemp -d "${TMPDIR:-/tmp}/macparakeet-quit.XXXXXX")" || return 1
+  local script_dir
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  # This standalone AppKit helper has no package dependencies. Build outside the
+  # app's products so inspecting/quitting never modifies the running app bundle.
+  if xcrun swiftc -parse-as-library -module-cache-path "${TMPDIR:-/tmp}/macparakeet-dev-helper-module-cache" \
+    "$script_dir/stop_app_processes.swift" -o "$helper_dir/stop-app"; then
+    "$helper_dir/stop-app" "$@" || status=$?
+  else
+    echo 'Could not prepare normal app shutdown. Build aborted.' >&2
+    status=1
+  fi
+  rm -rf "$helper_dir"
+  return "$status"
 }

--- a/scripts/dev/stop_app_processes.swift
+++ b/scripts/dev/stop_app_processes.swift
@@ -14,17 +14,28 @@ struct AppProcess {
 struct AppExecutableMatcher {
     let paths: Set<String>
 
-    init(paths: [String]) throws {
+    init(root: String, paths: [String]) throws {
         guard !paths.isEmpty else {
-            throw ShutdownError("At least one MacParakeet executable path is required.")
+            throw ShutdownError("At least one executable path is required.")
         }
-        guard paths.allSatisfy({ $0.hasPrefix("/") }) else {
-            throw ShutdownError("Executable paths must be absolute.")
+        guard root.hasPrefix("/"), paths.allSatisfy({ $0.hasPrefix("/") }) else {
+            throw ShutdownError("Ownership root and executable paths must be absolute.")
         }
-        guard paths.allSatisfy({ URL(fileURLWithPath: $0).lastPathComponent == "MacParakeet" }) else {
-            throw ShutdownError("Expected MacParakeet executable paths.")
-        }
-        self.paths = Set(paths.map(Self.canonicalPath))
+        let lexicalRoot = URL(fileURLWithPath: root).standardizedFileURL.path
+        let ownedRoot = Self.canonicalPath(root)
+        guard ownedRoot != "/" else { throw ShutdownError("Ownership root must not be the filesystem root.") }
+        self.paths = try Set(paths.map { path in
+            let lexical = URL(fileURLWithPath: path).standardizedFileURL.path
+            guard lexical.hasPrefix(lexicalRoot + "/") else {
+                throw ShutdownError("Executable is outside the ownership root: \(path).")
+            }
+            let relative = String(lexical.dropFirst(lexicalRoot.count + 1))
+            let expected = URL(fileURLWithPath: ownedRoot).appendingPathComponent(relative).path
+            guard Self.canonicalPath(path) == expected else {
+                throw ShutdownError("Executable ownership is redirected by a symlink: \(path).")
+            }
+            return expected
+        })
     }
 
     static func canonicalPath(_ path: String) -> String {
@@ -37,10 +48,7 @@ struct AppExecutableMatcher {
 
     func matches(_ executablePath: String) -> Bool {
         let path = Self.canonicalPath(executablePath)
-        // Other worktrees may also have a Dev bundle running. Match its literal
-        // executable path components, never a command-line argument or regex.
         return paths.contains(path)
-            || path.hasSuffix("/MacParakeet-Dev.app/Contents/MacOS/MacParakeet")
     }
 }
 
@@ -50,14 +58,14 @@ struct ShutdownRequest {
     let matcher: AppExecutableMatcher
 
     init(arguments: [String]) throws {
-        guard arguments.count >= 2 else {
-            throw ShutdownError("Expected a positive timeout and at least one absolute executable path.")
+        guard arguments.count >= 3 else {
+            throw ShutdownError("Expected a positive timeout, ownership root, and at least one absolute executable path.")
         }
         guard let timeout = TimeInterval(arguments[0]), timeout > 0, timeout.isFinite else {
             throw ShutdownError("Expected a positive timeout followed by absolute executable paths.")
         }
         self.timeout = timeout
-        matcher = try AppExecutableMatcher(paths: Array(arguments.dropFirst()))
+        matcher = try AppExecutableMatcher(root: arguments[1], paths: Array(arguments.dropFirst(2)))
     }
 }
 

--- a/scripts/dev/stop_app_processes.swift
+++ b/scripts/dev/stop_app_processes.swift
@@ -15,6 +15,9 @@ struct AppExecutableMatcher {
     let paths: Set<String>
 
     init(paths: [String]) throws {
+        guard !paths.isEmpty else {
+            throw ShutdownError("At least one MacParakeet executable path is required.")
+        }
         guard paths.allSatisfy({ $0.hasPrefix("/") }) else {
             throw ShutdownError("Executable paths must be absolute.")
         }
@@ -38,6 +41,23 @@ struct AppExecutableMatcher {
         // executable path components, never a command-line argument or regex.
         return paths.contains(path)
             || path.hasSuffix("/MacParakeet-Dev.app/Contents/MacOS/MacParakeet")
+    }
+}
+
+/// Validate the CLI contract before any process enumeration or quit request.
+struct ShutdownRequest {
+    let timeout: TimeInterval
+    let matcher: AppExecutableMatcher
+
+    init(arguments: [String]) throws {
+        guard arguments.count >= 2 else {
+            throw ShutdownError("Expected a positive timeout and at least one absolute executable path.")
+        }
+        guard let timeout = TimeInterval(arguments[0]), timeout > 0, timeout.isFinite else {
+            throw ShutdownError("Expected a positive timeout followed by absolute executable paths.")
+        }
+        self.timeout = timeout
+        matcher = try AppExecutableMatcher(paths: Array(arguments.dropFirst()))
     }
 }
 
@@ -130,13 +150,10 @@ func registeredApplication(_ process: AppProcess) -> QuitTarget? {
 struct StopMacParakeet {
     static func main() {
         do {
-            let args = Array(CommandLine.arguments.dropFirst())
-            guard let first = args.first, let timeout = TimeInterval(first), timeout > 0, timeout.isFinite else {
-                throw ShutdownError("Expected a positive timeout followed by absolute executable paths.")
-            }
-            let matcher = try AppExecutableMatcher(paths: Array(args.dropFirst()))
+            let request = try ShutdownRequest(arguments: Array(CommandLine.arguments.dropFirst()))
+            let matcher = request.matcher
             let targets = try prepareQuitTargets(processes: processSnapshot(executableNames: matcher.executableNames), matcher: matcher, application: registeredApplication)
-            try quitNormally(targets: targets, timeout: timeout)
+            try quitNormally(targets: targets, timeout: request.timeout)
             // A new app may have launched during the quit dialog or finalization.
             // Refuse to build rather than silently miss it or interrupt it again.
             guard try !processSnapshot(executableNames: matcher.executableNames).contains(where: { matcher.matches($0.executablePath) }) else {

--- a/scripts/dev/stop_app_processes.swift
+++ b/scripts/dev/stop_app_processes.swift
@@ -1,0 +1,151 @@
+import AppKit
+import Darwin
+
+struct ShutdownError: Error, CustomStringConvertible {
+    let description: String
+    init(_ description: String) { self.description = description }
+}
+
+struct AppProcess {
+    let pid: pid_t
+    let executablePath: String
+}
+
+struct AppExecutableMatcher {
+    let paths: Set<String>
+
+    init(paths: [String]) throws {
+        guard paths.allSatisfy({ $0.hasPrefix("/") }) else {
+            throw ShutdownError("Executable paths must be absolute.")
+        }
+        guard paths.allSatisfy({ URL(fileURLWithPath: $0).lastPathComponent == "MacParakeet" }) else {
+            throw ShutdownError("Expected MacParakeet executable paths.")
+        }
+        self.paths = Set(paths.map(Self.canonicalPath))
+    }
+
+    static func canonicalPath(_ path: String) -> String {
+        URL(fileURLWithPath: path).standardizedFileURL.resolvingSymlinksInPath().path
+    }
+
+    var executableNames: Set<String> {
+        Set(paths.map { URL(fileURLWithPath: $0).lastPathComponent }).union(["MacParakeet"])
+    }
+
+    func matches(_ executablePath: String) -> Bool {
+        let path = Self.canonicalPath(executablePath)
+        // Other worktrees may also have a Dev bundle running. Match its literal
+        // executable path components, never a command-line argument or regex.
+        return paths.contains(path)
+            || path.hasSuffix("/MacParakeet-Dev.app/Contents/MacOS/MacParakeet")
+    }
+}
+
+struct QuitTarget {
+    let pid: pid_t
+    let requestQuit: () -> Bool
+    let hasExited: () -> Bool
+}
+
+func quitNormally(
+    targets: [QuitTarget], timeout: TimeInterval,
+    now: () -> TimeInterval = { ProcessInfo.processInfo.systemUptime },
+    pause: () -> Void = { RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.1)) }
+) throws {
+    let deadline = now() + timeout
+    for target in targets where !target.hasExited() {
+        guard target.requestQuit() || target.hasExited() else {
+            throw ShutdownError("Normal quit request failed for PID \(target.pid). Quit MacParakeet manually, then retry.")
+        }
+    }
+    while targets.contains(where: { !$0.hasExited() }) {
+        guard now() < deadline else {
+            throw ShutdownError("MacParakeet is still open after \(timeout)s. Complete or cancel its quit dialog, then retry. No process was force-terminated.")
+        }
+        pause()
+    }
+}
+
+func processSnapshot(executableNames: Set<String> = ["MacParakeet"]) throws -> [AppProcess] {
+    // libproc returns executable paths independently of argv, including raw
+    // unbundled processes that NSWorkspace.runningApplications can omit.
+    for _ in 0..<3 {
+        let size = proc_listpids(UInt32(PROC_UID_ONLY), getuid(), nil, 0)
+        guard size > 0 else { throw ShutdownError("Cannot inspect current-user processes.") }
+        var pids = [pid_t](repeating: 0, count: Int(size) / MemoryLayout<pid_t>.stride + 128)
+        let capacity = Int32(pids.count * MemoryLayout<pid_t>.stride)
+        let bytes = proc_listpids(UInt32(PROC_UID_ONLY), getuid(), &pids, capacity)
+        guard bytes > 0 else { throw ShutdownError("Cannot inspect current-user processes.") }
+        if bytes >= capacity { continue }
+        return try pids.prefix(Int(bytes) / MemoryLayout<pid_t>.stride).filter { $0 > 0 }.compactMap { pid in
+            var buffer = [CChar](repeating: 0, count: 4 * Int(MAXPATHLEN))
+            if proc_pidpath(pid, &buffer, UInt32(buffer.count)) > 0 {
+                return AppProcess(pid: pid, executablePath: String(cString: buffer))
+            }
+            // A process can exit between enumeration and inspection. Any other
+            // failure must prevent rebuilding a potentially running executable.
+            let pathError = errno
+            if pathError == ESRCH || (kill(pid, 0) == -1 && errno == ESRCH) { return nil }
+            // macOS can hide paths for unrelated protected processes. Check
+            // the kernel executable name before treating that as a blocker;
+            // include canonical executable names in case a supplied path is a symlink.
+            var info = proc_bsdinfo()
+            if proc_pidinfo(pid, PROC_PIDTBSDINFO, 0, &info, Int32(MemoryLayout<proc_bsdinfo>.size))
+                == Int32(MemoryLayout<proc_bsdinfo>.size) {
+                let name = withUnsafePointer(to: &info.pbi_comm) {
+                    String(cString: UnsafeRawPointer($0).assumingMemoryBound(to: CChar.self))
+                }
+                if info.pbi_status == UInt32(SZOMB) || !executableNames.contains(name) { return nil }
+            }
+            throw ShutdownError("Cannot inspect executable for PID \(pid) (errno \(pathError)).")
+        }
+    }
+    throw ShutdownError("Process list kept changing during inspection; retry the build.")
+}
+
+func prepareQuitTargets(
+    processes: [AppProcess], matcher: AppExecutableMatcher,
+    application: (AppProcess) -> QuitTarget?
+) throws -> [QuitTarget] {
+    try processes.filter { matcher.matches($0.executablePath) }.map { process in
+        guard let target = application(process) else {
+            throw ShutdownError("MacParakeet PID \(process.pid) has no normal app-quit interface (\(process.executablePath)). Quit it manually before rebuilding.")
+        }
+        return target
+    }
+}
+
+func registeredApplication(_ process: AppProcess) -> QuitTarget? {
+    guard let app = NSRunningApplication(processIdentifier: process.pid),
+          app.bundleURL != nil,
+          let executableURL = app.executableURL,
+          AppExecutableMatcher.canonicalPath(executableURL.path)
+            == AppExecutableMatcher.canonicalPath(process.executablePath)
+    else { return nil }
+    return QuitTarget(pid: process.pid, requestQuit: { app.terminate() }, hasExited: { app.isTerminated })
+}
+
+#if !LAUNCHER_TESTS
+@main
+struct StopMacParakeet {
+    static func main() {
+        do {
+            let args = Array(CommandLine.arguments.dropFirst())
+            guard let first = args.first, let timeout = TimeInterval(first), timeout > 0, timeout.isFinite else {
+                throw ShutdownError("Expected a positive timeout followed by absolute executable paths.")
+            }
+            let matcher = try AppExecutableMatcher(paths: Array(args.dropFirst()))
+            let targets = try prepareQuitTargets(processes: processSnapshot(executableNames: matcher.executableNames), matcher: matcher, application: registeredApplication)
+            try quitNormally(targets: targets, timeout: timeout)
+            // A new app may have launched during the quit dialog or finalization.
+            // Refuse to build rather than silently miss it or interrupt it again.
+            guard try !processSnapshot(executableNames: matcher.executableNames).contains(where: { matcher.matches($0.executablePath) }) else {
+                throw ShutdownError("A MacParakeet executable is still running or restarted; quit it and retry.")
+            }
+        } catch {
+            FileHandle.standardError.write(Data("\(error) Build aborted before modifying the bundle.\n".utf8))
+            exit(1)
+        }
+    }
+}
+#endif

--- a/scripts/dev/test_stop_app_processes.sh
+++ b/scripts/dev/test_stop_app_processes.sh
@@ -13,7 +13,7 @@ xcrun swiftc -parse-as-library -D LAUNCHER_TESTS \
 # A compiler failure must stop the wrapper before it can inspect or quit apps.
 source "$SCRIPT_DIR/stop_app_processes.sh"
 xcrun() { return 1; }
-if stop_app_processes 1 /synthetic/MacParakeet 2>"$TEST_DIR/compiler-error"; then
+if stop_app_processes 1 /synthetic /synthetic/MacParakeet 2>"$TEST_DIR/compiler-error"; then
   echo 'FAIL: helper compilation failure did not abort' >&2
   exit 1
 fi
@@ -59,11 +59,11 @@ TEST_EXECUTABLE_TWO='/synthetic/literal$characters+/MacParakeet'
 for expected_status in 0 37; do
   export MACPARAKEET_WRAPPER_TEST_EXIT="$expected_status"
   wrapper_status=0
-  stop_app_processes 2.5 "$TEST_EXECUTABLE_ONE" "$TEST_EXECUTABLE_TWO" || wrapper_status=$?
+  stop_app_processes 2.5 /synthetic "$TEST_EXECUTABLE_ONE" "$TEST_EXECUTABLE_TWO" || wrapper_status=$?
   [[ "$wrapper_status" == "$expected_status" ]] || { echo 'Wrapper lost helper exit status' >&2; exit 1; }
   [[ -f "$MACPARAKEET_WRAPPER_TEST_RECEIPT" ]] || { echo 'Compiled fixture did not execute' >&2; exit 1; }
   helper_binary="$(head -n 1 "$MACPARAKEET_WRAPPER_TEST_RECEIPT")"
-  expected_arguments="$(printf '%s\n' 2.5 "$TEST_EXECUTABLE_ONE" "$TEST_EXECUTABLE_TWO")"
+  expected_arguments="$(printf '%s\n' 2.5 /synthetic "$TEST_EXECUTABLE_ONE" "$TEST_EXECUTABLE_TWO")"
   actual_arguments="$(tail -n +2 "$MACPARAKEET_WRAPPER_TEST_RECEIPT")"
   [[ "$actual_arguments" == "$expected_arguments" ]] || { echo 'Wrapper changed argument boundaries' >&2; exit 1; }
   [[ ! -e "$helper_binary" && ! -d "${helper_binary%/*}" ]] || { echo 'Wrapper left temporary helper files' >&2; exit 1; }

--- a/scripts/dev/test_stop_app_processes.sh
+++ b/scripts/dev/test_stop_app_processes.sh
@@ -2,65 +2,21 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEST_DIR="$(mktemp -d "${TMPDIR:-/tmp}/macparakeet-quit-tests.XXXXXX")"
+trap 'rm -rf "$TEST_DIR"' EXIT
+xcrun swiftc -parse-as-library -D LAUNCHER_TESTS \
+  -module-cache-path "${TMPDIR:-/tmp}/macparakeet-dev-helper-module-cache" \
+  "$SCRIPT_DIR/stop_app_processes.swift" "$SCRIPT_DIR/test_stop_app_processes.swift" \
+  -o "$TEST_DIR/quit-tests"
+"$TEST_DIR/quit-tests"
+
+# A compiler failure must stop the wrapper before it can inspect or quit apps.
 source "$SCRIPT_DIR/stop_app_processes.sh"
-TEST_DIR="$(mktemp -d "${TMPDIR:-/tmp}/macparakeet-stop-test.XXXXXX")"
-CHILD_PID=""
-cleanup() {
-  if [[ -n "$CHILD_PID" ]]; then
-    kill -KILL "$CHILD_PID" 2>/dev/null || true
-    wait "$CHILD_PID" 2>/dev/null || true
-  fi
-  rm -rf "$TEST_DIR"
-}
-trap cleanup EXIT
-
-wait_until_ready() {
-  local attempts=0
-  while [[ ! -e "$TEST_DIR/ready" ]]; do
-    attempts=$((attempts + 1))
-    [[ "$attempts" -lt 100 ]] || { echo 'Synthetic child did not start' >&2; return 1; }
-    sleep 0.02
-  done
-}
-
-# The random token exists only in this test's child command line. No app names
-# or user process patterns are passed to the helper by this test.
-TOKEN="macparakeet-synthetic-stop-$$-${TEST_DIR##*/}"
-bash -c 'trap '\''sleep 0.4; touch "$1/completed"; exit 0'\'' TERM; touch "$1/ready"; while :; do sleep 0.05; done' \
-  "$TOKEN" "$TEST_DIR" &
-CHILD_PID=$!
-wait_until_ready
-stop_app_processes 3 "$TOKEN"
-[[ -e "$TEST_DIR/completed" ]] || { echo 'Returned before termination completed' >&2; exit 1; }
-! kill -0 "$CHILD_PID" 2>/dev/null || { echo 'Child still alive after success' >&2; exit 1; }
-wait "$CHILD_PID"
-CHILD_PID=""
-printf 'PASS: waits for delayed termination\n'
-
-rm "$TEST_DIR/ready"
-bash -c 'trap "" TERM; touch "$1/ready"; while :; do sleep 0.05; done' \
-  "$TOKEN" "$TEST_DIR" &
-CHILD_PID=$!
-wait_until_ready
-if stop_app_processes 1 "$TOKEN" 2>"$TEST_DIR/timeout-error"; then
-  echo 'Unexpected success while child ignores TERM' >&2
+xcrun() { return 1; }
+if stop_app_processes 1 /synthetic/MacParakeet 2>"$TEST_DIR/compiler-error"; then
+  echo 'FAIL: helper compilation failure did not abort' >&2
   exit 1
 fi
-kill -0 "$CHILD_PID"
-[[ "$(cat "$TEST_DIR/timeout-error")" == *'Build aborted before modifying the bundle.'* ]]
-kill -KILL "$CHILD_PID"
-wait "$CHILD_PID" 2>/dev/null || true
-CHILD_PID=""
-printf 'PASS: timeout fails without force-killing the process\n'
-
-stop_app_processes 1 "$TOKEN"
-printf 'PASS: no matching process succeeds\n'
-
-pgrep() { return 3; }
-if stop_app_processes 1 "$TOKEN" 2>"$TEST_DIR/inspection-error"; then
-  echo 'Unexpected success after process inspection failure' >&2
-  exit 1
-fi
-unset -f pgrep
-[[ "$(cat "$TEST_DIR/inspection-error")" == *'Cannot inspect running MacParakeet processes'* ]]
-printf 'PASS: process inspection errors abort safely\n'
+unset -f xcrun
+[[ "$(cat "$TEST_DIR/compiler-error")" == *'Build aborted'* ]]
+printf 'PASS: helper preparation failure aborts safely\n'

--- a/scripts/dev/test_stop_app_processes.sh
+++ b/scripts/dev/test_stop_app_processes.sh
@@ -20,3 +20,55 @@ fi
 unset -f xcrun
 [[ "$(cat "$TEST_DIR/compiler-error")" == *'Build aborted'* ]]
 printf 'PASS: helper preparation failure aborts safely\n'
+
+# Exercise the real wrapper's compile/execute/cleanup path with an inert Swift
+# fixture. Even a regression must never call the production helper: its Dev
+# bundle suffix also matches user apps when the supplied path is synthetic.
+cat > "$TEST_DIR/inert-helper.swift" <<'SWIFT'
+import Foundation
+import Darwin
+@main
+struct InertWrapperFixture {
+    static func main() throws {
+        let environment = ProcessInfo.processInfo.environment
+        let receipt = environment["MACPARAKEET_WRAPPER_TEST_RECEIPT"]!
+        try CommandLine.arguments.joined(separator: "\n").write(
+            toFile: receipt, atomically: true, encoding: .utf8
+        )
+        exit(Int32(environment["MACPARAKEET_WRAPPER_TEST_EXIT"]!)!)
+    }
+}
+SWIFT
+xcrun() {
+  local original replaced=0
+  local compiler_args=()
+  for original in "$@"; do
+    if [[ "$original" == "$SCRIPT_DIR/stop_app_processes.swift" ]]; then
+      compiler_args+=("$TEST_DIR/inert-helper.swift")
+      replaced=$((replaced + 1))
+    else
+      compiler_args+=("$original")
+    fi
+  done
+  [[ "$replaced" == 1 ]] || { echo 'Unsafe test compiler invocation rejected' >&2; return 1; }
+  command xcrun "${compiler_args[@]}"
+}
+export MACPARAKEET_WRAPPER_TEST_RECEIPT="$TEST_DIR/wrapper-receipt"
+TEST_EXECUTABLE_ONE='/synthetic/space and (parentheses)[brackets]/MacParakeet'
+TEST_EXECUTABLE_TWO='/synthetic/literal$characters+/MacParakeet'
+for expected_status in 0 37; do
+  export MACPARAKEET_WRAPPER_TEST_EXIT="$expected_status"
+  wrapper_status=0
+  stop_app_processes 2.5 "$TEST_EXECUTABLE_ONE" "$TEST_EXECUTABLE_TWO" || wrapper_status=$?
+  [[ "$wrapper_status" == "$expected_status" ]] || { echo 'Wrapper lost helper exit status' >&2; exit 1; }
+  [[ -f "$MACPARAKEET_WRAPPER_TEST_RECEIPT" ]] || { echo 'Compiled fixture did not execute' >&2; exit 1; }
+  helper_binary="$(head -n 1 "$MACPARAKEET_WRAPPER_TEST_RECEIPT")"
+  expected_arguments="$(printf '%s\n' 2.5 "$TEST_EXECUTABLE_ONE" "$TEST_EXECUTABLE_TWO")"
+  actual_arguments="$(tail -n +2 "$MACPARAKEET_WRAPPER_TEST_RECEIPT")"
+  [[ "$actual_arguments" == "$expected_arguments" ]] || { echo 'Wrapper changed argument boundaries' >&2; exit 1; }
+  [[ ! -e "$helper_binary" && ! -d "${helper_binary%/*}" ]] || { echo 'Wrapper left temporary helper files' >&2; exit 1; }
+  rm "$MACPARAKEET_WRAPPER_TEST_RECEIPT"
+done
+unset -f xcrun
+unset MACPARAKEET_WRAPPER_TEST_RECEIPT MACPARAKEET_WRAPPER_TEST_EXIT
+printf 'PASS: real wrapper compiles/executes inert fixture, preserves arguments/status and cleans success/failure\n'

--- a/scripts/dev/test_stop_app_processes.sh
+++ b/scripts/dev/test_stop_app_processes.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/stop_app_processes.sh"
+TEST_DIR="$(mktemp -d "${TMPDIR:-/tmp}/macparakeet-stop-test.XXXXXX")"
+CHILD_PID=""
+cleanup() {
+  if [[ -n "$CHILD_PID" ]]; then
+    kill -KILL "$CHILD_PID" 2>/dev/null || true
+    wait "$CHILD_PID" 2>/dev/null || true
+  fi
+  rm -rf "$TEST_DIR"
+}
+trap cleanup EXIT
+
+wait_until_ready() {
+  local attempts=0
+  while [[ ! -e "$TEST_DIR/ready" ]]; do
+    attempts=$((attempts + 1))
+    [[ "$attempts" -lt 100 ]] || { echo 'Synthetic child did not start' >&2; return 1; }
+    sleep 0.02
+  done
+}
+
+# The random token exists only in this test's child command line. No app names
+# or user process patterns are passed to the helper by this test.
+TOKEN="macparakeet-synthetic-stop-$$-${TEST_DIR##*/}"
+bash -c 'trap '\''sleep 0.4; touch "$1/completed"; exit 0'\'' TERM; touch "$1/ready"; while :; do sleep 0.05; done' \
+  "$TOKEN" "$TEST_DIR" &
+CHILD_PID=$!
+wait_until_ready
+stop_app_processes 3 "$TOKEN"
+[[ -e "$TEST_DIR/completed" ]] || { echo 'Returned before termination completed' >&2; exit 1; }
+! kill -0 "$CHILD_PID" 2>/dev/null || { echo 'Child still alive after success' >&2; exit 1; }
+wait "$CHILD_PID"
+CHILD_PID=""
+printf 'PASS: waits for delayed termination\n'
+
+rm "$TEST_DIR/ready"
+bash -c 'trap "" TERM; touch "$1/ready"; while :; do sleep 0.05; done' \
+  "$TOKEN" "$TEST_DIR" &
+CHILD_PID=$!
+wait_until_ready
+if stop_app_processes 1 "$TOKEN" 2>"$TEST_DIR/timeout-error"; then
+  echo 'Unexpected success while child ignores TERM' >&2
+  exit 1
+fi
+kill -0 "$CHILD_PID"
+[[ "$(cat "$TEST_DIR/timeout-error")" == *'Build aborted before modifying the bundle.'* ]]
+kill -KILL "$CHILD_PID"
+wait "$CHILD_PID" 2>/dev/null || true
+CHILD_PID=""
+printf 'PASS: timeout fails without force-killing the process\n'
+
+stop_app_processes 1 "$TOKEN"
+printf 'PASS: no matching process succeeds\n'
+
+pgrep() { return 3; }
+if stop_app_processes 1 "$TOKEN" 2>"$TEST_DIR/inspection-error"; then
+  echo 'Unexpected success after process inspection failure' >&2
+  exit 1
+fi
+unset -f pgrep
+[[ "$(cat "$TEST_DIR/inspection-error")" == *'Cannot inspect running MacParakeet processes'* ]]
+printf 'PASS: process inspection errors abort safely\n'

--- a/scripts/dev/test_stop_app_processes.swift
+++ b/scripts/dev/test_stop_app_processes.swift
@@ -36,6 +36,17 @@ struct ShutdownTests {
         try expectFailure("absolute") { _ = try AppExecutableMatcher(paths: ["relative/MacParakeet"]) }
         print("PASS: literal executable paths and Dev bundle scope")
 
+        try expectFailure("At least one") { _ = try AppExecutableMatcher(paths: []) }
+        for arguments in [[], ["10"]] {
+            try expectFailure("at least one") { _ = try ShutdownRequest(arguments: arguments) }
+        }
+        for timeout in ["0", "-1", "nan", "inf", "invalid"] {
+            try expectFailure("positive timeout") { _ = try ShutdownRequest(arguments: [timeout, literal]) }
+        }
+        let request = try ShutdownRequest(arguments: ["0.5", literal])
+        try expect(request.timeout == 0.5 && request.matcher.matches(literal), "Valid CLI arguments must retain timeout and path")
+        print("PASS: empty matcher and missing/invalid CLI arguments rejected before inspection")
+
         var clock: TimeInterval = 0
         var requested = 0
         let delayed = QuitTarget(pid: 101, requestQuit: { requested += 1; return true }, hasExited: { clock >= 0.4 })

--- a/scripts/dev/test_stop_app_processes.swift
+++ b/scripts/dev/test_stop_app_processes.swift
@@ -1,0 +1,94 @@
+import AppKit
+import Darwin
+
+@main
+struct ShutdownTests {
+    static func expect(_ condition: @autoclosure () -> Bool, _ message: String) throws {
+        if !condition() { throw ShutdownError("FAIL: \(message)") }
+    }
+
+    static func expectFailure(_ fragment: String, _ operation: () throws -> Void) throws {
+        do {
+            try operation()
+        } catch {
+            try expect(String(describing: error).contains(fragment), "Unexpected failure: \(error)")
+            return
+        }
+        throw ShutdownError("FAIL: Expected failure containing \(fragment)")
+    }
+
+    static func main() {
+        do { try run() }
+        catch {
+            FileHandle.standardError.write(Data("\(error)\n".utf8))
+            exit(1)
+        }
+    }
+
+    static func run() throws {
+        let literal = "/private/tmp/work(qa)[draft]+/.build/debug/MacParakeet"
+        let matcher = try AppExecutableMatcher(paths: [literal])
+        try expect(matcher.matches(literal), "Literal regex punctuation must match")
+        try expect(!matcher.matches("/private/tmp/workqa/.build/debug/MacParakeet"), "Regex-shaped lookalike must not match")
+        try expect(!matcher.matches("/bin/sh"), "An unrelated executable must not match its arguments")
+        try expect(matcher.matches("/another/worktree/MacParakeet-Dev.app/Contents/MacOS/MacParakeet"), "Dev bundles in other worktrees remain covered")
+        try expect(!matcher.matches("/another/worktree/MacParakeet-Dev.app/Contents/MacOS/MacParakeet-helper"), "Executable suffix must not match")
+        try expectFailure("absolute") { _ = try AppExecutableMatcher(paths: ["relative/MacParakeet"]) }
+        print("PASS: literal executable paths and Dev bundle scope")
+
+        var clock: TimeInterval = 0
+        var requested = 0
+        let delayed = QuitTarget(pid: 101, requestQuit: { requested += 1; return true }, hasExited: { clock >= 0.4 })
+        try quitNormally(targets: [delayed], timeout: 1, now: { clock }, pause: { clock += 0.1 })
+        try expect(requested == 1 && clock >= 0.4, "Must await actual delayed exit")
+        print("PASS: normal quit waits for observed exit")
+
+        let refused = QuitTarget(pid: 102, requestQuit: { false }, hasExited: { false })
+        try expectFailure("Normal quit request failed") {
+            try quitNormally(targets: [refused], timeout: 1, now: { clock }, pause: { clock += 0.1 })
+        }
+        let cancelled = QuitTarget(pid: 103, requestQuit: { true }, hasExited: { false })
+        try expectFailure("still open") {
+            try quitNormally(targets: [cancelled], timeout: 1, now: { clock }, pause: { clock += 0.1 })
+        }
+        print("PASS: refused and cancelled quit abort without a signal fallback")
+
+        var rawWasRequested = false
+        try expectFailure("no normal app-quit interface") {
+            _ = try prepareQuitTargets(
+                processes: [AppProcess(pid: 104, executablePath: literal)], matcher: matcher,
+                application: { _ in rawWasRequested = true; return nil }
+            )
+        }
+        try expect(rawWasRequested, "Raw process must be classified before any quit request")
+        try quitNormally(targets: [], timeout: 1, now: { clock }, pause: { clock += 0.1 })
+        print("PASS: raw executable refusal and empty target list")
+
+        // Only these two test-owned children are ever terminated by the tests.
+        // Real app handles are never requested: libproc inspection is read-only.
+        let folder = FileManager.default.temporaryDirectory.appendingPathComponent("macparakeet-quit-test-\(UUID().uuidString)(qa)[literal]")
+        try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: folder) }
+        let rawURL = folder.appendingPathComponent("MacParakeet")
+        try FileManager.default.copyItem(at: URL(fileURLWithPath: "/bin/sleep"), to: rawURL)
+        let raw = Process()
+        raw.executableURL = rawURL
+        raw.arguments = ["20"]
+        try raw.run()
+        defer { if raw.isRunning { raw.terminate() }; raw.waitUntilExit() }
+        let decoy = Process()
+        decoy.executableURL = URL(fileURLWithPath: "/bin/sh")
+        decoy.arguments = ["-c", "while :; do :; done", rawURL.path]
+        try decoy.run()
+        defer { if decoy.isRunning { decoy.terminate() }; decoy.waitUntilExit() }
+        let children = try processSnapshot().filter { $0.pid == raw.processIdentifier || $0.pid == decoy.processIdentifier }
+        let rawMatcher = try AppExecutableMatcher(paths: [rawURL.path])
+        try expect(children.contains { $0.pid == raw.processIdentifier && rawMatcher.matches($0.executablePath) }, "libproc must see raw literal executable")
+        try expect(children.contains { $0.pid == decoy.processIdentifier && !rawMatcher.matches($0.executablePath) }, "libproc must ignore target path in unrelated arguments")
+        try expectFailure("no normal app-quit interface") {
+            _ = try prepareQuitTargets(processes: children, matcher: rawMatcher, application: registeredApplication)
+        }
+        try expect(raw.isRunning && decoy.isRunning, "Inspection/refusal must leave both children alive")
+        print("PASS: real synthetic raw executable refused; argv decoy untouched")
+    }
+}

--- a/scripts/dev/test_stop_app_processes.swift
+++ b/scripts/dev/test_stop_app_processes.swift
@@ -26,24 +26,24 @@ struct ShutdownTests {
     }
 
     static func run() throws {
-        let literal = "/private/tmp/work(qa)[draft]+/.build/debug/MacParakeet"
-        let matcher = try AppExecutableMatcher(paths: [literal])
+        let literal = "/synthetic/work(qa)[draft]+/.build/debug/MacParakeet"
+        let matcher = try AppExecutableMatcher(root: "/synthetic", paths: [literal])
         try expect(matcher.matches(literal), "Literal regex punctuation must match")
-        try expect(!matcher.matches("/private/tmp/workqa/.build/debug/MacParakeet"), "Regex-shaped lookalike must not match")
+        try expect(!matcher.matches("/synthetic/workqa/.build/debug/MacParakeet"), "Regex-shaped lookalike must not match")
         try expect(!matcher.matches("/bin/sh"), "An unrelated executable must not match its arguments")
-        try expect(matcher.matches("/another/worktree/MacParakeet-Dev.app/Contents/MacOS/MacParakeet"), "Dev bundles in other worktrees remain covered")
+        try expect(!matcher.matches("/another/worktree/MacParakeet-Dev.app/Contents/MacOS/MacParakeet"), "Dev bundles in other worktrees are untouched")
         try expect(!matcher.matches("/another/worktree/MacParakeet-Dev.app/Contents/MacOS/MacParakeet-helper"), "Executable suffix must not match")
-        try expectFailure("absolute") { _ = try AppExecutableMatcher(paths: ["relative/MacParakeet"]) }
+        try expectFailure("absolute") { _ = try AppExecutableMatcher(root: "/synthetic", paths: ["relative/MacParakeet"]) }
         print("PASS: literal executable paths and Dev bundle scope")
 
-        try expectFailure("At least one") { _ = try AppExecutableMatcher(paths: []) }
-        for arguments in [[], ["10"]] {
+        try expectFailure("At least one") { _ = try AppExecutableMatcher(root: "/synthetic", paths: []) }
+        for arguments in [[], ["10"], ["10", "/synthetic"]] {
             try expectFailure("at least one") { _ = try ShutdownRequest(arguments: arguments) }
         }
         for timeout in ["0", "-1", "nan", "inf", "invalid"] {
-            try expectFailure("positive timeout") { _ = try ShutdownRequest(arguments: [timeout, literal]) }
+            try expectFailure("positive timeout") { _ = try ShutdownRequest(arguments: [timeout, "/synthetic", literal]) }
         }
-        let request = try ShutdownRequest(arguments: ["0.5", literal])
+        let request = try ShutdownRequest(arguments: ["0.5", "/synthetic", literal])
         try expect(request.timeout == 0.5 && request.matcher.matches(literal), "Valid CLI arguments must retain timeout and path")
         print("PASS: empty matcher and missing/invalid CLI arguments rejected before inspection")
 
@@ -93,7 +93,7 @@ struct ShutdownTests {
         try decoy.run()
         defer { if decoy.isRunning { decoy.terminate() }; decoy.waitUntilExit() }
         let children = try processSnapshot().filter { $0.pid == raw.processIdentifier || $0.pid == decoy.processIdentifier }
-        let rawMatcher = try AppExecutableMatcher(paths: [rawURL.path])
+        let rawMatcher = try AppExecutableMatcher(root: folder.path, paths: [rawURL.path])
         try expect(children.contains { $0.pid == raw.processIdentifier && rawMatcher.matches($0.executablePath) }, "libproc must see raw literal executable")
         try expect(children.contains { $0.pid == decoy.processIdentifier && !rawMatcher.matches($0.executablePath) }, "libproc must ignore target path in unrelated arguments")
         try expectFailure("no normal app-quit interface") {

--- a/scripts/dev/test_stop_app_processes_appkit.sh
+++ b/scripts/dev/test_stop_app_processes_appkit.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run only in a logged-in macOS GUI session. Every application is a synthetic
+# fixture in this test's temporary directory; no real MacParakeet is addressed.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/stop_app_processes.sh"
+TEST_DIR="$(mktemp -d "${TMPDIR:-/tmp}/macparakeet-quit-test.XXXXXX")"
+CHILD_PIDS=""
+cleanup() {
+  for state in "$TEST_DIR"/state-*; do
+    [[ -d "$state" ]] && touch "$state/exit"
+  done
+  for pid in $CHILD_PIDS; do wait "$pid" 2>/dev/null || true; done
+  rm -rf "$TEST_DIR"
+}
+trap cleanup EXIT
+
+cat > "$TEST_DIR/Fixture.swift" <<'SWIFT'
+import AppKit
+
+let mode = CommandLine.arguments[1]
+let state = URL(fileURLWithPath: CommandLine.arguments[2])
+func mark(_ name: String) {
+    FileManager.default.createFile(atPath: state.appendingPathComponent(name).path, contents: Data())
+}
+if mode == "raw" {
+    mark("ready")
+    let deadline = ProcessInfo.processInfo.systemUptime + 60
+    while !FileManager.default.fileExists(atPath: state.appendingPathComponent("exit").path) {
+        if ProcessInfo.processInfo.systemUptime >= deadline { exit(2) }
+        Thread.sleep(forTimeInterval: 0.05)
+    }
+    exit(0)
+}
+final class Delegate: NSObject, NSApplicationDelegate {
+    func applicationDidFinishLaunching(_ notification: Notification) { mark("ready") }
+    func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        mark("quit-requested")
+        if mode == "cancel" { return .terminateCancel }
+        if mode == "unfinished" { return .terminateLater }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
+            mark("finalized")
+            sender.reply(toApplicationShouldTerminate: true)
+        }
+        return .terminateLater
+    }
+}
+let app = NSApplication.shared
+let delegate = Delegate()
+app.delegate = delegate
+app.setActivationPolicy(.accessory)
+// Fixture-only cleanup, independent of the quit behavior under test. Never
+// signal a real app, even when the test fails. The lifetime is bounded as well.
+let timer = Timer.scheduledTimer(withTimeInterval: 0.05, repeats: true) { _ in
+    if FileManager.default.fileExists(atPath: state.appendingPathComponent("exit").path) { exit(0) }
+}
+DispatchQueue.main.asyncAfter(deadline: .now() + 60) { exit(2) }
+app.run()
+SWIFT
+/usr/bin/swiftc "$TEST_DIR/Fixture.swift" -o "$TEST_DIR/Fixture"
+
+start_fixture() {
+  local name="$1" mode="$2" mentioned_path="${3:-}"
+  local bundle="$TEST_DIR/$name/Fixture.app"
+  local state="$TEST_DIR/state-$name"
+  mkdir -p "$bundle/Contents/MacOS" "$state"
+  cp "$TEST_DIR/Fixture" "$bundle/Contents/MacOS/Fixture"
+  cat > "$bundle/Contents/Info.plist" <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+<key>CFBundleIdentifier</key><string>com.macparakeet.synthetic-quit-test</string>
+<key>CFBundleExecutable</key><string>Fixture</string>
+<key>CFBundlePackageType</key><string>APPL</string>
+</dict></plist>
+PLIST
+  "$bundle/Contents/MacOS/Fixture" "$mode" "$state" "$mentioned_path" &
+  CHILD_PIDS="${CHILD_PIDS:+$CHILD_PIDS }$!"
+  local attempts=0
+  until [[ -e "$state/ready" ]]; do
+    attempts=$((attempts + 1))
+    (( attempts < 200 )) || { echo "Fixture $name failed to become ready" >&2; return 1; }
+    sleep 0.05
+  done
+}
+
+TARGET="$TEST_DIR/owned (dev)[1]/Fixture.app/Contents/MacOS/Fixture"
+start_fixture 'owned (dev)[1]' allow
+start_fixture production cancel "$TARGET"
+start_fixture other-worktree cancel
+stop_app_processes 3 "$TEST_DIR" "$TARGET"
+[[ -e "$TEST_DIR/state-owned (dev)[1]/finalized" ]]
+[[ ! -e "$TEST_DIR/state-production/quit-requested" ]]
+[[ ! -e "$TEST_DIR/state-other-worktree/quit-requested" ]]
+printf 'PASS: ordinary quit awaits finalization and ignores other executable paths/argument-only matches\n'
+
+ln -s "$TEST_DIR/production/Fixture.app" "$TEST_DIR/linked.app"
+if stop_app_processes 0.5 "$TEST_DIR" "$TEST_DIR/linked.app/Contents/MacOS/Fixture"; then
+  echo 'Unexpected success with redirected executable ownership' >&2; exit 1
+fi
+mkdir "$TEST_DIR/owned-root"
+if stop_app_processes 0.5 "$TEST_DIR/owned-root" "$TEST_DIR/production/Fixture.app/Contents/MacOS/Fixture"; then
+  echo 'Unexpected success with executable outside ownership root' >&2; exit 1
+fi
+[[ ! -e "$TEST_DIR/state-production/quit-requested" ]]
+printf 'PASS: linked and outside-root executables are rejected without requesting quit\n'
+
+start_fixture cancelled cancel
+CANCELLED_PID=$!
+if stop_app_processes 0.5 "$TEST_DIR" "$TEST_DIR/cancelled/Fixture.app/Contents/MacOS/Fixture"; then
+  echo 'Unexpected success after Cancel Quit' >&2; exit 1
+fi
+[[ -e "$TEST_DIR/state-cancelled/quit-requested" ]]
+[[ ! -e "$TEST_DIR/state-cancelled/finalized" ]]
+kill -0 "$CANCELLED_PID"
+printf 'PASS: Cancel Quit refuses the build\n'
+
+start_fixture unfinished unfinished
+UNFINISHED_PID=$!
+if stop_app_processes 0.5 "$TEST_DIR" "$TEST_DIR/unfinished/Fixture.app/Contents/MacOS/Fixture"; then
+  echo 'Unexpected success with unfinished finalization' >&2; exit 1
+fi
+[[ -e "$TEST_DIR/state-unfinished/quit-requested" ]]
+kill -0 "$UNFINISHED_PID"
+printf 'PASS: unfinished finalization refuses the build\n'
+
+stop_app_processes 1 "$TEST_DIR" "$TARGET"
+printf 'PASS: an exited exact executable does not block the build\n'
+
+# A raw executable must prevent all quit requests, including other owned apps.
+# This child also honors the fixture cleanup marker; no signal is sent.
+RAW="$TEST_DIR/raw-executable"
+mkdir "$TEST_DIR/state-raw"
+cp "$TEST_DIR/Fixture" "$RAW"
+"$RAW" raw "$TEST_DIR/state-raw" &
+RAW_PID=$!
+CHILD_PIDS="${CHILD_PIDS:+$CHILD_PIDS }$RAW_PID"
+attempts=0
+until [[ -e "$TEST_DIR/state-raw/ready" ]]; do
+  attempts=$((attempts + 1))
+  (( attempts < 200 )) || { echo 'Raw fixture failed to become ready' >&2; exit 1; }
+  sleep 0.05
+done
+if stop_app_processes 0.5 "$TEST_DIR" "$TEST_DIR/production/Fixture.app/Contents/MacOS/Fixture" "$RAW"; then
+  echo 'Unexpected success with a raw executable lacking an app-quit interface' >&2; exit 1
+fi
+kill -0 "$RAW_PID"
+[[ ! -e "$TEST_DIR/state-production/quit-requested" ]]
+printf 'PASS: raw executable refuses the build before any app receives quit\n'

--- a/scripts/dist/build_app_bundle.sh
+++ b/scripts/dist/build_app_bundle.sh
@@ -126,21 +126,22 @@ prepare_xcode_git_submodule_support() {
 build_xcodebuild() {
   # Xcode compiles assets and generates resource accessors for a relocatable app bundle.
   if [[ "$SKIP_BUILD" == "1" ]]; then
-    echo "[1/4] Skipping build (SKIP_BUILD=1)…"
-    return 0
+    echo "[1/4] Reusing existing Xcode Release products (SKIP_BUILD=1)…"
+  else
+    prepare_xcode_git_submodule_support
   fi
 
-  prepare_xcode_git_submodule_support
-
   if [[ "$UNIVERSAL" == "1" ]]; then
-    echo "[1/4] Building via xcodebuild (universal Release)…"
     local dd_arm="$XCODE_DERIVED_DATA-arm64"
     local dd_x86="$XCODE_DERIVED_DATA-x86_64"
 
-    xcodebuild build -scheme MacParakeet -configuration Release -destination "platform=OS X,arch=arm64" \
-      -derivedDataPath "$dd_arm" -skipMacroValidation CODE_SIGNING_ALLOWED=NO >/dev/null
-    xcodebuild build -scheme MacParakeet -configuration Release -destination "platform=OS X,arch=x86_64" \
-      -derivedDataPath "$dd_x86" -skipMacroValidation CODE_SIGNING_ALLOWED=NO >/dev/null
+    if [[ "$SKIP_BUILD" != "1" ]]; then
+      echo "[1/4] Building via xcodebuild (universal Release)…"
+      xcodebuild build -scheme MacParakeet -configuration Release -destination "platform=OS X,arch=arm64" \
+        -derivedDataPath "$dd_arm" -skipMacroValidation CODE_SIGNING_ALLOWED=NO >/dev/null
+      xcodebuild build -scheme MacParakeet -configuration Release -destination "platform=OS X,arch=x86_64" \
+        -derivedDataPath "$dd_x86" -skipMacroValidation CODE_SIGNING_ALLOWED=NO >/dev/null
+    fi
 
     local bin_arm="$dd_arm/Build/Products/Release/MacParakeet"
     local bin_x86="$dd_x86/Build/Products/Release/MacParakeet"
@@ -156,11 +157,13 @@ build_xcodebuild() {
     local product_dir="$dd_arm/Build/Products/Release"
     copy_resource_bundles "$product_dir"
   else
-    echo "[1/4] Building via xcodebuild (Release)…"
     local dd="$XCODE_DERIVED_DATA"
-    # Apple Silicon is the supported shipping target; lock to arm64 to avoid ambiguous destinations.
-    xcodebuild build -scheme MacParakeet -configuration Release -destination "platform=OS X,arch=arm64" \
-      -derivedDataPath "$dd" -skipMacroValidation CODE_SIGNING_ALLOWED=NO >/dev/null
+    if [[ "$SKIP_BUILD" != "1" ]]; then
+      echo "[1/4] Building via xcodebuild (Release)…"
+      # Apple Silicon is the supported shipping target; lock to arm64 to avoid ambiguous destinations.
+      xcodebuild build -scheme MacParakeet -configuration Release -destination "platform=OS X,arch=arm64" \
+        -derivedDataPath "$dd" -skipMacroValidation CODE_SIGNING_ALLOWED=NO >/dev/null
+    fi
 
     local product_dir="$dd/Build/Products/Release"
     local bin="$product_dir/MacParakeet"

--- a/scripts/dist/build_app_bundle.sh
+++ b/scripts/dist/build_app_bundle.sh
@@ -22,7 +22,7 @@ set -euo pipefail
 #   MIN_MACOS_VERSION   (default: 14.2)
 #   UNIVERSAL           (default: 0) build universal (arm64+x86_64) if 1
 #   SKIP_BUILD          (default: 0) reuse existing Release binary if 1
-#   BUILD_SYSTEM        (default: xcodebuild) 'xcodebuild' or 'swiftpm'
+#   BUILD_SYSTEM        (default: xcodebuild) app distribution requires xcodebuild
 #   XCODE_DERIVED_DATA  (default: .build/xcode-dist) derived data path for xcodebuild
 #   FFMPEG_PATH         (default: auto-download static build) source ffmpeg binary to bundle
 #   FFMPEG_VERSION      (default: release) 'release' or 'snapshot' from ffmpeg.martin-riedl.de
@@ -57,6 +57,10 @@ MIN_MACOS_VERSION="${MIN_MACOS_VERSION:-14.2}"
 UNIVERSAL="${UNIVERSAL:-0}"
 SKIP_BUILD="${SKIP_BUILD:-0}"
 BUILD_SYSTEM="${BUILD_SYSTEM:-xcodebuild}"
+if [[ "$BUILD_SYSTEM" != "xcodebuild" ]]; then
+  echo "App distribution requires BUILD_SYSTEM=xcodebuild for compiled assets and portable resource-bundle lookup. Unset BUILD_SYSTEM or set it to xcodebuild; swift build/test and SwiftPM CLI builds remain supported." >&2
+  exit 1
+fi
 BUILD_SOURCE="${BUILD_SOURCE:-dist-${BUILD_SYSTEM}-release}"
 XCODE_DERIVED_DATA="${XCODE_DERIVED_DATA:-$ROOT_DIR/.build/xcode-dist}"
 
@@ -76,29 +80,6 @@ if [[ "$VERSION" == "0.0.0" ]]; then
   echo "Warning: VERSION not set; building a local/dev bundle with CFBundleShortVersionString=0.0.0." >&2
   echo "Set VERSION=X.Y.Z for release builds so Sparkle and release metadata are correct." >&2
 fi
-
-build_swiftpm() {
-  if [[ "$SKIP_BUILD" == "1" ]]; then
-    echo "[1/4] Skipping build (SKIP_BUILD=1)…"
-    return 0
-  fi
-
-  if [[ "$UNIVERSAL" == "1" ]]; then
-    echo "[1/4] Building SwiftPM product (universal Release)…"
-  else
-    echo "[1/4] Building SwiftPM product (Release)…"
-  fi
-
-  pushd "$ROOT_DIR" >/dev/null
-  if [[ "$UNIVERSAL" == "1" ]]; then
-    swift build -c release --arch arm64 --arch x86_64 --product MacParakeet
-    swift build -c release --arch arm64 --arch x86_64 --product macparakeet-cli
-  else
-    swift build -c release --product MacParakeet
-    swift build -c release --product macparakeet-cli
-  fi
-  popd >/dev/null
-}
 
 build_cli_swiftpm() {
   if [[ "$SKIP_BUILD" == "1" ]]; then
@@ -143,7 +124,7 @@ prepare_xcode_git_submodule_support() {
 }
 
 build_xcodebuild() {
-  # Prefer xcodebuild so SwiftPM resource bundles are produced (notably mlx-swift_Cmlx.bundle with default.metallib).
+  # Xcode compiles assets and generates resource accessors for a relocatable app bundle.
   if [[ "$SKIP_BUILD" == "1" ]]; then
     echo "[1/4] Skipping build (SKIP_BUILD=1)…"
     return 0
@@ -157,9 +138,9 @@ build_xcodebuild() {
     local dd_x86="$XCODE_DERIVED_DATA-x86_64"
 
     xcodebuild build -scheme MacParakeet -configuration Release -destination "platform=OS X,arch=arm64" \
-      -derivedDataPath "$dd_arm" CODE_SIGNING_ALLOWED=NO >/dev/null
+      -derivedDataPath "$dd_arm" -skipMacroValidation CODE_SIGNING_ALLOWED=NO >/dev/null
     xcodebuild build -scheme MacParakeet -configuration Release -destination "platform=OS X,arch=x86_64" \
-      -derivedDataPath "$dd_x86" CODE_SIGNING_ALLOWED=NO >/dev/null
+      -derivedDataPath "$dd_x86" -skipMacroValidation CODE_SIGNING_ALLOWED=NO >/dev/null
 
     local bin_arm="$dd_arm/Build/Products/Release/MacParakeet"
     local bin_x86="$dd_x86/Build/Products/Release/MacParakeet"
@@ -179,7 +160,7 @@ build_xcodebuild() {
     local dd="$XCODE_DERIVED_DATA"
     # Apple Silicon is the supported shipping target; lock to arm64 to avoid ambiguous destinations.
     xcodebuild build -scheme MacParakeet -configuration Release -destination "platform=OS X,arch=arm64" \
-      -derivedDataPath "$dd" CODE_SIGNING_ALLOWED=NO >/dev/null
+      -derivedDataPath "$dd" -skipMacroValidation CODE_SIGNING_ALLOWED=NO >/dev/null
 
     local product_dir="$dd/Build/Products/Release"
     local bin="$product_dir/MacParakeet"
@@ -234,23 +215,8 @@ copy_cli_binary() {
   echo "Bundled CLI: $MACOS_DIR/macparakeet-cli"
 }
 
-if [[ "$BUILD_SYSTEM" == "swiftpm" ]]; then
-  build_swiftpm
-  # Locate the release binary produced by SwiftPM.
-  BIN_DIR="$(swiftpm_release_bin_dir MacParakeet)"
-  BIN_PATH="$BIN_DIR/MacParakeet"
-  if [[ ! -f "$BIN_PATH" ]]; then
-    echo "Failed to locate Release binary at: $BIN_PATH" >&2
-    exit 1
-  fi
-
-  echo "[2/4] Assembling app bundle…"
-  cp "$BIN_PATH" "$MACOS_DIR/$APP_NAME"
-  chmod +x "$MACOS_DIR/$APP_NAME"
-else
-  build_xcodebuild
-  echo "[2/4] Assembling app bundle…"
-fi
+build_xcodebuild
+echo "[2/4] Assembling app bundle…"
 
 copy_cli_binary
 
@@ -571,21 +537,15 @@ bundle_meeting_echo_assets
 # Embed Sparkle.framework for auto-updates.
 #
 # Sparkle is linked via @rpath and must live in Contents/Frameworks/.
-# For xcodebuild, the framework is produced in the derived-data product dir.
-# For SwiftPM, it's in .build/<triple>/release/.
+# Xcode produces the framework in its derived-data product directory.
 echo "Embedding Sparkle.framework…"
-SPARKLE_FW=""
-if [[ "$BUILD_SYSTEM" == "xcodebuild" ]]; then
-  SPARKLE_FW="$XCODE_DERIVED_DATA/Build/Products/Release/PackageFrameworks/Sparkle.framework"
-  # Fallback: xcodebuild may place it differently
-  if [[ ! -d "$SPARKLE_FW" ]]; then
-    SPARKLE_FW="$(find "$XCODE_DERIVED_DATA" -type d -name "Sparkle.framework" -path "*/Release/*" 2>/dev/null | head -n 1)"
-  fi
-else
-  SPARKLE_FW="$(find "$ROOT_DIR/.build" -type d -name "Sparkle.framework" -path "*/release/*" -not -path "*/artifacts/*" 2>/dev/null | head -n 1)"
-  if [[ ! -d "$SPARKLE_FW" ]]; then
-    SPARKLE_FW="$(find "$ROOT_DIR/.build" -type d -name "Sparkle.framework" -not -path "*/artifacts/*" 2>/dev/null | head -n 1)"
-  fi
+SPARKLE_PRODUCTS="$XCODE_DERIVED_DATA"
+if [[ "$UNIVERSAL" == "1" ]]; then
+  SPARKLE_PRODUCTS="$XCODE_DERIVED_DATA-arm64"
+fi
+SPARKLE_FW="$SPARKLE_PRODUCTS/Build/Products/Release/PackageFrameworks/Sparkle.framework"
+if [[ ! -d "$SPARKLE_FW" ]]; then
+  SPARKLE_FW="$(find "$SPARKLE_PRODUCTS" -type d -name "Sparkle.framework" -path "*/Release/*" 2>/dev/null | head -n 1)"
 fi
 
 if [[ -z "$SPARKLE_FW" || ! -d "$SPARKLE_FW" ]]; then
@@ -633,6 +593,7 @@ fi
 if [[ -f "$ROOT_DIR/THIRD_PARTY_LICENSES.md" ]]; then
   cp "$ROOT_DIR/THIRD_PARTY_LICENSES.md" "$LEGAL_DIR/THIRD_PARTY_LICENSES.md"
 fi
+cp "$ROOT_DIR/Sources/MacParakeet/Resources/Legal/MarkdownDependencies.txt" "$LEGAL_DIR/MarkdownDependencies.txt"
 echo "Bundled legal notices: $LEGAL_DIR"
 
 echo "[3/4] Writing Info.plist…"
@@ -772,14 +733,10 @@ echo "Sparkle trust anchor OK: SUPublicEDKey present and matches, feed is HTTPS.
 # Usage:  atos -o dist/MacParakeet.dSYM -arch arm64 -l <slide> <address>
 echo "Archiving dSYM for crash symbolication…"
 DSYM_ARCHIVED=0
-if [[ "$BUILD_SYSTEM" == "xcodebuild" ]]; then
-  if [[ "$UNIVERSAL" == "1" ]]; then
-    DSYM_SRC="$XCODE_DERIVED_DATA-arm64/Build/Products/Release/MacParakeet.dSYM"
-  else
-    DSYM_SRC="$XCODE_DERIVED_DATA/Build/Products/Release/MacParakeet.dSYM"
-  fi
+if [[ "$UNIVERSAL" == "1" ]]; then
+  DSYM_SRC="$XCODE_DERIVED_DATA-arm64/Build/Products/Release/MacParakeet.dSYM"
 else
-  DSYM_SRC="$BIN_DIR/MacParakeet.dSYM"
+  DSYM_SRC="$XCODE_DERIVED_DATA/Build/Products/Release/MacParakeet.dSYM"
 fi
 
 if [[ -d "$DSYM_SRC" ]]; then

--- a/spec/04-ui-patterns.md
+++ b/spec/04-ui-patterns.md
@@ -1201,6 +1201,10 @@ checked/unchecked task items, fenced code, and horizontally scrollable tables.
 The surrounding pane owns vertical scrolling; wide Markdown blocks must not
 expand the transcript detail or live-meeting panel.
 
+Each streaming renderer subscribes to a fresh snapshot stream and immediately
+receives the latest content. Closing or hiding a pane cancels only that
+subscription; returning to it must continue rendering new snapshots.
+
 Generated Markdown remains read-only and selectable. Task boxes communicate
 their checked state but are not controls. Headings and table cells preserve the
 renderer accessibility structure. Fonts and colors map to `DesignSystem` and

--- a/spec/04-ui-patterns.md
+++ b/spec/04-ui-patterns.md
@@ -1245,9 +1245,11 @@ checked/unchecked task items, fenced code, and horizontally scrollable tables.
 The surrounding pane owns vertical scrolling; wide Markdown blocks must not
 expand the transcript detail or live-meeting panel.
 
-Each streaming renderer subscribes to a fresh snapshot stream and immediately
-receives the latest content. Closing or hiding a pane cancels only that
-subscription; returning to it must continue rendering new snapshots.
+Static and streaming content share a serial snapshot renderer. Each appearance
+subscribes afresh and receives the latest content; only the newest pending
+snapshot is retained while parsing. Closing or hiding a pane cancels its
+consumer, and a cancelled parse cannot publish over a replacement renderer.
+Returning to the pane must continue rendering new snapshots.
 
 Generated Markdown remains read-only and selectable. Task boxes communicate
 their checked state but are not controls. Headings and table cells preserve the
@@ -1262,7 +1264,9 @@ Treat rendered model output as untrusted presentation data:
 - activation of `file:`, `javascript:`, custom schemes, and relative
   destinations is discarded;
 - raw HTML does not create a web view or executable embedded content;
-- Copy Result and exports continue using the original Markdown source.
+- Copy Result and full-result exports continue using the original Markdown
+  source. Table-only Copy and Download use the renderer's normalized Markdown
+  for that table.
 
 ---
 

--- a/spec/04-ui-patterns.md
+++ b/spec/04-ui-patterns.md
@@ -1192,6 +1192,32 @@ App launch → DiscoverViewModel.loadCached() → DiscoverService reads disk cac
 
 ---
 
+## LLM Markdown Content
+
+`MarkdownContentView` is the single presentation boundary for generated
+assistant content in Prompt Results, saved Chat, and live Ask. It renders the
+same CommonMark/GFM subset on every surface, including nested lists, static
+checked/unchecked task items, fenced code, and horizontally scrollable tables.
+The surrounding pane owns vertical scrolling; wide Markdown blocks must not
+expand the transcript detail or live-meeting panel.
+
+Generated Markdown remains read-only and selectable. Task boxes communicate
+their checked state but are not controls. Headings and table cells preserve the
+renderer accessibility structure. Fonts and colors map to `DesignSystem` and
+must remain appearance-aware.
+
+Treat rendered model output as untrusted presentation data:
+
+- image loading is disabled, including remote, local-file, bundled, and data URL
+  sources;
+- only `http` and `https` links may be handed to the system browser;
+- activation of `file:`, `javascript:`, custom schemes, and relative
+  destinations is discarded;
+- raw HTML does not create a web view or executable embedded content;
+- Copy Result and exports continue using the original Markdown source.
+
+---
+
 ## Design System
 
 All design tokens are centralized in `DesignSystem.swift` (`Views/Components/DesignSystem.swift`). A debug-only `DesignSystemGalleryView` (`#if DEBUG`) renders every token in one preview canvas — open it from Xcode when auditing for drift.

--- a/spec/12-processing-layer.md
+++ b/spec/12-processing-layer.md
@@ -276,11 +276,28 @@ When a generation completes:
 
 #### Completed Summary Tabs
 
-- completed summaries render as markdown
+- completed summaries render through the shared rich Markdown surface
 - generate appends a new completed summary tab every time
 - regenerate replaces only the specific summary the user chose, and only after the new result is durably saved
 - copy is available from both the pane and tab context menu
 - delete requires confirmation
+
+#### Rich Markdown Result Rendering
+
+Prompt Results, saved assistant Chat messages, and live Ask responses share
+`MarkdownContentView`. The stored `PromptResult.content` and chat content remain
+the unchanged Markdown source; rendering is presentation-only and never rewrites
+saved results or export payloads.
+
+The supported result dialect covers headings, paragraphs, emphasis,
+strikethrough, links, inline and fenced code, block quotes, thematic breaks,
+ordered/unordered/nested lists, display-only task lists, and GFM pipe tables.
+Wide tables and code blocks manage their own horizontal overflow. Streaming
+surfaces re-render the latest complete text snapshot and may animate appended
+text; completed and partial results use the same parser and styling.
+
+The renderer is isolated to the GUI target. Core processing and the CLI remain
+independent of the UI dependency.
 
 ### Management Sheet
 


### PR DESCRIPTION
## Summary

Render tables, fenced code, nested lists, task items and inline formatting consistently in Prompt Results, saved Chat and live Ask, including responses still streaming. Saved Markdown remains the source artifact.

This integrates alfred-sa's contribution with current main and repairs rendering lifecycle and bundle preparation. The compatibility fork stays pinned to `1f10d5286985349b63145e1193f4f6ad5f7fdfe1`.

## Design

One app-owned, structured task consumes accumulated Markdown snapshots serially and renders the dependency's public `DocumentView`. The snapshot store replays the latest content on return and buffers only the newest waiting update. Cancellation checks prevent an old parse from publishing over a replacement view. Static and streaming content share this path; streaming enables text animation.

Images are disabled and links permit only HTTP/HTTPS. Native table cells support selection and named Copy/Download actions. Table exports contain normalized table Markdown, while saved result source is unchanged. File writes run off the UI actor and report failures.

Development shutdown targets only this worktree's replaced executables, requests ordinary quit, and waits for observed exit. Cancellation, unresolved ownership or timeout aborts preparation. Dependency resources and complete third-party/font notices are included in dev and distribution bundles; App distribution consistently uses Xcode for compiled catalogs, bundle metadata and relocatable resource accessors. The unsupported SwiftPM app-bundling mode now fails before touching an existing app; SwiftPM builds/tests and CLI compilation remain available. CI exercises the Xcode bundle path.

## Risk and limits

- Rich rendering adds a pinned Swift 5 dependency graph. The existing first-party Swift 6/no-Whisper compatibility gate excludes that graph; ordinary release and test builds compile it.
- Selection within blocks is native; selection across blocks uses the dependency's “Select more text” sheet. Ordered-list start values and table alignment retain the documented dependency limitations.
- Automated lifecycle tests cover cancellation and replay. Full live Ask navigation, VoiceOver, keyboard link activation and manual table-selection interactions remain release QA items. The disposable test host could not expose its accessibility tree to Orca.
- This PR changes presentation and bundle preparation; notes persistence, speaker corrections and prompt management are separate PRs.

## Verification

- 11 focused Markdown tests pass, including suspended-parser cancellation, replacement subscriptions, newest-snapshot coalescing and export failures.
- Eight launcher helper/wrapper checks and six disposable AppKit scenarios pass, including unrelated-app preservation, quit cancellation, pending finalization and redirected-path rejection. No user app was closed by those tests.
- Independent correctness and maintainability reviews found no remaining actionable issue.
- First-party diff whitespace, shell syntax and README-reference checks pass. Renderer/test formatting is clean. Vendored license texts preserve upstream whitespace.
- A disposable native window rendered incomplete streaming Markdown, tables, code, lists and task items. Compiling the asset catalogs and supplying Xcode-style bundle metadata restored all missing markers and action icons; this exposed the packaging defects above.
- Full local suite: 5,438 XCTest tests (20 skipped), plus 29 Swift Testing tests; zero failures. The temporary visual harness was removed before this one full-suite run.
- The packaged-resource probe fails with missing bundle metadata and passes with compiled catalogs plus metadata; CI probes colors and both table action icons directly.
- Local first-party Swift 6 compatibility build passes (81.8 seconds); its documented dependency exclusions apply.
- Reviewed head: `b619a45804d678218c00adb6f6f5c80ba65961b9`. [CI run 34158297003](https://github.com/moona3k/macparakeet/actions/runs/34158297003) passed release compilation, CLI contract smoke, Xcode app assembly and asset lookup, concurrency safety, Swift 6 language mode and the hosted suite.
- CodeRabbit completed; its animation-reparse suggestion was declined with evidence from the pinned implementation. All 16 review threads are resolved. Cubic skipped its latest run; independent reviews provide the additional correctness/maintainability evidence.
- Current main `fc0d2ed8` adds separate Custom Words behavior. A merge-tree check combines it cleanly with this PR; the shared UI spec changes are in separate sections.

Local no-mistakes and Greptile CLIs are unavailable; direct verification, independent reviews and hosted checks provide the review gate. This description is the current reviewer walkthrough; earlier integrated-series validation is not claimed for this head.
