### PR TITLE
Add persistent grid and list layouts to the Library

### DIFF
--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingRowCard.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingRowCard.swift
@@ -9,6 +9,7 @@ struct MeetingRowCard<MenuContent: View>: View {
     var searchText: String = ""
     var isSelected: Bool = false
     var showsSelectionControls: Bool = false
+    var showsSource = false
     var isRetrying: Bool = false
     var onTap: () -> Void
     var onRetry: (() -> Void)? = nil
@@ -144,6 +145,10 @@ struct MeetingRowCard<MenuContent: View>: View {
                 .contentTransition(.opacity)
                 .layoutPriority(1)
 
+            if showsSource {
+                sourceInline
+            }
+
             speakerInline
                 .layoutPriority(0)
 
@@ -152,6 +157,15 @@ struct MeetingRowCard<MenuContent: View>: View {
 
             Spacer(minLength: 0)
         }
+    }
+
+    private var sourceInline: some View {
+        let source = TranscriptionSourceDisplay.resolve(for: transcription)
+        return Label(source.collapsedText, systemImage: source.systemImage)
+            .font(DesignSystem.Typography.micro.weight(.medium))
+            .foregroundStyle(source.tint)
+            .lineLimit(1)
+            .fixedSize()
     }
 
     @ViewBuilder

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
@@ -3,6 +3,11 @@ import SwiftUI
 import MacParakeetCore
 import MacParakeetViewModels
 
+private enum LibraryLayoutMode: String {
+    case grid
+    case list
+}
+
 struct TranscriptionLibraryView: View {
     @Bindable var viewModel: TranscriptionLibraryViewModel
     var title: String = "Library"
@@ -27,6 +32,8 @@ struct TranscriptionLibraryView: View {
     private var bulkExportIncludeSpeakerLabels = true
     @AppStorage("com.macparakeet.libraryBulkExportIncludeMetadata")
     private var bulkExportIncludeMetadata = true
+    @AppStorage("com.macparakeet.libraryLayoutMode")
+    private var libraryLayoutMode = LibraryLayoutMode.grid
     @State private var bulkExportInProgress = false
     @State private var bulkExportResult: BulkTranscriptExportResult?
     @State private var bulkExportErrorMessage: String?
@@ -53,6 +60,20 @@ struct TranscriptionLibraryView: View {
                     .foregroundStyle(DesignSystem.Colors.textPrimary)
 
                 Spacer()
+
+                Picker("Library layout", selection: $libraryLayoutMode) {
+                    Image(systemName: "square.grid.2x2")
+                        .accessibilityLabel("Grid")
+                        .tag(LibraryLayoutMode.grid)
+                    Image(systemName: "list.bullet")
+                        .accessibilityLabel("List")
+                        .tag(LibraryLayoutMode.list)
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+                .accessibilityLabel("Library layout")
+                .frame(width: 76)
+                .help(libraryLayoutMode == .grid ? "Switch to list view" : "Switch to grid view")
 
                 if showsSelectManyButton {
                     LibrarySelectManyButton {
@@ -100,8 +121,8 @@ struct TranscriptionLibraryView: View {
                 loadingState
             } else if viewModel.filteredTranscriptions.isEmpty {
                 emptyState
-            } else if isMeetingListMode {
-                meetingsList
+            } else if usesListLayout {
+                transcriptionList
             } else {
                 thumbnailGrid
             }
@@ -300,7 +321,7 @@ struct TranscriptionLibraryView: View {
         }
     }
 
-    private var meetingsList: some View {
+    private var transcriptionList: some View {
         ScrollView {
             LazyVStack(alignment: .leading, spacing: 0) {
                 ForEach(viewModel.groupedTranscriptions, id: \.group) { section in
@@ -311,6 +332,7 @@ struct TranscriptionLibraryView: View {
                             searchText: viewModel.searchText,
                             isSelected: viewModel.isTranscriptionSelected(transcription),
                             showsSelectionControls: viewModel.isBulkSelectionModeEnabled,
+                            showsSource: !isMeetingContext,
                             isRetrying: viewModel.isRetryingMeetingTranscription(transcription),
                             onTap: {
                                 if viewModel.isBulkOperationInProgress || bulkExportInProgress {
@@ -470,7 +492,7 @@ struct TranscriptionLibraryView: View {
         BulkTranscriptionSelectionBar(
             selectedCount: selectedBulkExportTargets.count,
             selectedMeetingAudioCount: viewModel.selectedMeetingAudioCount,
-            isMeetingContext: isMeetingListMode,
+            isMeetingContext: isMeetingContext,
             areAllVisibleSelected: viewModel.areAllLoadedVisibleTranscriptionsSelected,
             isPerformingOperation: viewModel.isBulkOperationInProgress || bulkExportInProgress,
             operationLabel: bulkExportInProgress ? "Exporting..." : "Deleting...",
@@ -903,8 +925,12 @@ struct TranscriptionLibraryView: View {
         }
     }
 
-    private var isMeetingListMode: Bool {
+    private var isMeetingContext: Bool {
         viewModel.scope == .meetings || viewModel.filter == .meeting
+    }
+
+    private var usesListLayout: Bool {
+        libraryLayoutMode == .list
     }
 
     private var bulkOperationTitle: String {
@@ -995,15 +1021,15 @@ struct TranscriptionLibraryView: View {
 
     private var emptyStateIcon: String {
         if !viewModel.searchText.isEmpty { return "magnifyingglass" }
-        return isMeetingListMode ? "waveform.badge.mic" : "square.grid.2x2"
+        return isMeetingContext ? "waveform.badge.mic" : "square.grid.2x2"
     }
 
     private var emptyStateTitle: String {
-        isMeetingListMode ? "No meetings recorded yet" : emptyTitle
+        isMeetingContext ? "No meetings recorded yet" : emptyTitle
     }
 
     private var emptyStateMessage: String {
-        isMeetingListMode
+        isMeetingContext
             ? "Press Record Meeting on the Transcribe tab to capture system audio and transcribe locally."
             : emptyMessage
     }

--- a/spec/04-ui-patterns.md
+++ b/spec/04-ui-patterns.md
@@ -51,7 +51,7 @@ Design philosophy: **Simple, native, stays out of the way.** No chrome, no clutt
 │  🎤 Transcribe   │  [Depends on sidebar selection]           │
 │  🗂 Library      │                                           │
 │  🕒 Dictations   │  - Transcribe: 3-mode capture hub        │
-│  📖 Vocabulary   │  - Library: Grid (or list for Meetings)  │
+│  📖 Vocabulary   │  - Library: Grid or list                 │
 │  ✦ Transforms    │  - Dictations: History list               │
 │  💬 Feedback     │  - Vocabulary: Processing mode + manage   │
 │  ⚙ Settings      │  - Transforms: Rewrite selected text      │
@@ -68,7 +68,7 @@ Minimum window width: 800pt.
 The sidebar uses NavigationSplitView with flat items (icon + label):
 
 - **Transcribe** (`waveform`) -- Capture hub: YouTube card + file drop card + Meeting Recording tile
-- **Library** (`square.grid.2x2`) -- All transcriptions; filter chips switch between thumbnail grid (All/YouTube/Local/Favorites) and date-grouped list (Meetings)
+- **Library** (`square.grid.2x2`) -- All transcriptions; every filter offers the same persistent Grid/List switch
 - **Dictations** (`clock.arrow.circlepath`) -- Flat history list with bottom bar player
 - **Meetings** (`person.2.wave.2`) -- Workflow space for upcoming, live, and saved meeting work; visible when `AppFeatures.meetingRecordingEnabled` is true
 - **Vocabulary** (`book.fill`) -- Processing mode, pipeline guide, custom words & snippets management
@@ -121,7 +121,7 @@ The tile body is informational. Only the visible Start and Stop capsules are rea
 
 ### Library Meetings Filter
 
-When `Library.filter == .meeting`, the view renders a date-grouped list (`Today` / `Yesterday` / `Previous 7 Days` / `Previous 30 Days` / `{Month Year}`) using `MeetingDateGroupHeader` + `MeetingRowCard` instead of the thumbnail grid the other filters use. Meeting rows surface saved-audio state directly (`Audio saved`, `Audio removed`, or `Audio missing`) so playback/retranscription expectations are visible before the user opens a menu.
+When list mode is selected, the view renders a date-grouped list (`Today` / `Yesterday` / `Previous 7 Days` / `Previous 30 Days` / `{Month Year}`) using `MeetingDateGroupHeader` + `MeetingRowCard`. Meeting rows surface saved-audio state directly (`Audio saved`, `Audio removed`, or `Audio missing`) so playback/retranscription expectations are visible before the user opens a menu.
 
 A finalized meeting whose `meetingCaptureReport.quality` is `partial` shows the
 existing **Partial audio** badge in its Library meeting row and the existing
@@ -131,6 +131,12 @@ system source status is `silent`, its message is: “System audio contained no
 audible signal. Microphone audio remains saved.” This state is durable and
 appears after finalization; it does not add a live alert or automatically
 restart ScreenCaptureKit during a meeting.
+
+Every Library filter, including Meetings, exposes a compact Grid/List segmented
+control in the header. The preference persists across launches. List mode reuses the
+date-grouped row presentation and adds the transcription source beside the
+title; search, filters, contextual actions, pagination, and bulk selection
+behave identically in either layout.
 
 Opening an empty processing meeting row must preserve that same lifecycle
 truth. The transcript pane shows an indeterminate "Transcribing meeting"

--- a/spec/04-ui-patterns.md
+++ b/spec/04-ui-patterns.md
@@ -119,7 +119,7 @@ States, all bound to the long-lived `MeetingRecordingPillViewModel` shared with 
 
 The tile body is informational. Only the visible Start and Stop capsules are real SwiftUI `Button`s, and both call the same `toggleRecording` path the menu bar uses. Completing, transcribing, completed, and error states render as inert status surfaces and must not expose button traits or no-op accessibility actions. The floating pill stays visible by default during recording so users who hide the main window keep an active control surface; users can hide it in Settings and continue controlling the live recording from the status menu, hotkey, or Meetings surfaces.
 
-### Library Meetings Filter
+### Library Layouts and Meeting States
 
 When list mode is selected, the view renders a date-grouped list (`Today` / `Yesterday` / `Previous 7 Days` / `Previous 30 Days` / `{Month Year}`) using `MeetingDateGroupHeader` + `MeetingRowCard`. Meeting rows surface saved-audio state directly (`Audio saved`, `Audio removed`, or `Audio missing`) so playback/retranscription expectations are visible before the user opens a menu.
 


### PR DESCRIPTION
## Why this is useful

Library users can now choose between a thumbnail grid and a compact, date-grouped list, including when filtering to meetings. The choice persists across launches. List rows reuse the existing meeting-row interactions and show the source for non-meeting items, making mixed libraries easier to scan.

The compact segmented picker has explicit Grid/List accessibility labels. Search, pagination, context menus, bulk selection and export continue through the existing Library paths.

## Screenshots

Captured from the corrected integrated app with fictional demonstration data. Navigation may differ from the independent feature branches.

![Browse the Library in the thumbnail grid.](https://raw.githubusercontent.com/alfred-sa/macparakeet/ed1828c790a3ff5296157ed80a2945ea22d74c98/screenshots/958-library-grid.png)

*Browse the Library in the thumbnail grid.*

![Switch the Library to the compact list layout.](https://raw.githubusercontent.com/alfred-sa/macparakeet/ed1828c790a3ff5296157ed80a2945ea22d74c98/screenshots/958-library-list.png)

*Switch the Library to the compact list layout.*

## Scope

This small, independent extraction starts at upstream `1159dfca8ae53a15ffcc1562b1efb9220f95cd88`: two Swift view files and the UI specification. Classification badges, label filters, prompt management and speaker projections are deliberately left in their feature PRs. The default layout is grid; a previous meeting-only list is therefore now a user-selectable layout.

## Validation and review focus

- This extracted branch built successfully and passed all nine `MainWindowStateTests`. Both changed Swift files pass syntax parsing; whitespace/conflict-marker checks pass.
- The corrected integrated series passed its focused selection: 1,579 tests, one skipped, zero failures. Independent review found no remaining actionable issue in the eight corrections across the series. This does not establish manual GUI behavior for this extracted branch.
- Before merge: verify both layouts across Library filters, persistence across launches, pagination, context actions, bulk selection/export, and the Meetings entry point. No dedicated test was added just to mirror this reversible view preference.

Upstream CI currently requires maintainer action (`action_required`), and CodeRabbit skipped review while the PR was a draft. Neither is a green check.

Local `no-mistakes` and Greptile CLIs are unavailable. The contributor-guide walkthrough website repository is inaccessible (404); this body contains the standalone explanation.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a persistent Grid/List layout switch to the Transcription Library, available across all filters.
  * Added source labels to meeting recording rows when displayed in meeting context.
  * Preserved the selected library layout between sessions.
* **Documentation**
  * Updated UI guidance to describe the layout switch, persisted preference, and list-mode presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
Cubic review follow-up: renamed the shared Library layout section so its heading also covers non-meeting filters. Documentation only.
