### PR TITLE
fix: preserve telemetry consent and audio diagnostic evidence

### DIFF
--- a/Sources/CLI/Commands/CLITelemetry.swift
+++ b/Sources/CLI/Commands/CLITelemetry.swift
@@ -254,6 +254,9 @@ extension Result where Success == Void, Failure == Error {
         case .success:
             return nil
         case .failure(let error):
+            // ArgumentParser uses successful thrown exits for help and other
+            // early completions. They must not carry a runtime error bucket.
+            guard !CLI.normalizedExitCode(for: error).isSuccess else { return nil }
             if let jsonExit = error as? CLIJSONEnvelopeExit {
                 return CLIErrorType.key(for: jsonExit.originalError)
             }

--- a/Sources/MacParakeetCore/Audio/AudioCaptureDiagnostics.swift
+++ b/Sources/MacParakeetCore/Audio/AudioCaptureDiagnostics.swift
@@ -20,6 +20,15 @@ public enum AudioCaptureDiagnostics {
     private static let retainedLogBytes = Int(maxLogBytes / 2)
     private static let maxMessageCharacters = 16_384
 
+    private enum MainThreadAppendResult {
+        case completed
+        case deferred(reason: String)
+    }
+
+    private enum LogWriteError: Error {
+        case rotationRequiresBackground
+    }
+
     public static var diagnosticLogFileURL: URL {
         diagnosticLogURL()
     }
@@ -98,21 +107,23 @@ public enum AudioCaptureDiagnostics {
 
     static func appendEncodedLogLine(_ data: Data, to logURL: URL) {
         if Thread.isMainThread {
-            let completed = lock.withLockIfAvailable {
+            let result = lock.withLockIfAvailable {
                 do {
-                    try writeLogLine(data, to: logURL, waitForLock: false)
-                    return true
+                    try writeLogLine(data, to: logURL, waitForLock: false, allowRotation: false)
+                    return MainThreadAppendResult.completed
+                } catch LogWriteError.rotationRequiresBackground {
+                    return .deferred(reason: "rotation")
                 } catch {
                     let code = (error as NSError).code
                     if (error as NSError).domain == NSPOSIXErrorDomain, code == Int(EWOULDBLOCK) {
-                        return false
+                        return .deferred(reason: "lock_contended")
                     }
                     logger.error("audio_diagnostic_write_failed error_type=\(errorType(error), privacy: .public)")
-                    return true
+                    return .completed
                 }
-            } ?? false
-            if !completed {
-                logger.info("audio_diagnostic_write_deferred reason=lock_contended")
+            } ?? .deferred(reason: "lock_contended")
+            if case .deferred(let reason) = result {
+                logger.info("audio_diagnostic_write_deferred reason=\(reason, privacy: .public)")
                 // Keep the exact record and its occurrence clocks. Only its
                 // visibility is deferred; a busy writer must not block the UI.
                 appendQueue.async { appendEncodedLogLine(data, to: logURL) }
@@ -162,7 +173,9 @@ public enum AudioCaptureDiagnostics {
     /// Serialize the complete create/append/rotate operation across cooperating
     /// app and CLI processes. Keeping the boundary throwable also lets tests
     /// exercise failures against isolated files instead of user logs.
-    static func writeLogLine(_ data: Data, to logURL: URL, waitForLock: Bool = true) throws {
+    static func writeLogLine(
+        _ data: Data, to logURL: URL, waitForLock: Bool = true, allowRotation: Bool = true
+    ) throws {
         let fm = FileManager.default
         try fm.createDirectory(
             at: logURL.deletingLastPathComponent(),
@@ -177,6 +190,7 @@ public enum AudioCaptureDiagnostics {
                 defer { try? handle.close() }
                 let size = try handle.seekToEnd()
                 if size + UInt64(data.count) > maxLogBytes {
+                    guard allowRotation else { throw LogWriteError.rotationRequiresBackground }
                     let existingData = try Data(contentsOf: logURL)
                     var rotatedData = retainedLogSuffix(existingData, maxBytes: retainedLogBytes)
                     rotatedData.append(data)

--- a/Sources/MacParakeetCore/Audio/AudioCaptureDiagnostics.swift
+++ b/Sources/MacParakeetCore/Audio/AudioCaptureDiagnostics.swift
@@ -1,9 +1,12 @@
 import CoreAudio
+import Darwin
 import Foundation
 import os
 
 public enum AudioCaptureDiagnostics {
     private static let lock = OSAllocatedUnfairLock(initialState: ())
+    private static let logger = Logger(subsystem: "com.macparakeet.core", category: "AudioCaptureDiagnostics")
+    private static let processSession = UUID().uuidString.lowercased()
     private static let appendQueue = DispatchQueue(
         label: "com.macparakeet.audio-capture-diagnostics.append",
         qos: .utility
@@ -60,11 +63,13 @@ public enum AudioCaptureDiagnostics {
     }
 
     static func errorFields(_ error: Error) -> String {
-        let detail = sanitizedLogValue(error.localizedDescription)
-        guard !detail.isEmpty else {
-            return "error_type=\(errorType(error))"
-        }
-        return "error_type=\(errorType(error)) error_detail=\"\(detail)\""
+        // This file can be attached to public feedback. Arbitrary error text
+        // can contain speech, filenames or credentials that regex redaction
+        // cannot reliably recognize. Keep classified type and the NSError
+        // bridge code here. For Swift wrappers that code can be an enum ordinal,
+        // not the underlying OSStatus retained in the classified type. Existing
+        // OSLog calls carry separate, privacy-marked localized descriptions.
+        "error_type=\(errorType(error)) bridged_error_code=\((error as NSError).code)"
     }
 
     static func sanitizedMessage(_ message: String) -> String {
@@ -83,66 +88,107 @@ public enum AudioCaptureDiagnostics {
     }
 
     public static func append(_ message: @autoclosure () -> String) {
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        let sanitized = String(sanitizedMessage(message()).prefix(maxMessageCharacters))
-        let line = "\(formatter.string(from: Date())) \(sanitized)\n"
+        append(message(), timestamp: Date(), uptimeNanoseconds: DispatchTime.now().uptimeNanoseconds)
+    }
 
-        guard let data = line.data(using: .utf8) else { return }
+    private static func append(_ message: String, timestamp: Date, uptimeNanoseconds: UInt64) {
+        let data = encodedLogLine(message, timestamp: timestamp, uptimeNanoseconds: uptimeNanoseconds)
 
         lock.withLock {
-            let fm = FileManager.default
-            let logURL = diagnosticLogURL()
-
             do {
-                try fm.createDirectory(
-                    at: logURL.deletingLastPathComponent(),
-                    withIntermediateDirectories: true
-                )
-
-                if let attributes = try? fm.attributesOfItem(atPath: logURL.path),
-                    let size = attributes[.size] as? UInt64,
-                    size + UInt64(data.count) > maxLogBytes
-                {
-                    let existingData = try Data(contentsOf: logURL)
-                    var rotatedData = retainedLogSuffix(
-                        existingData,
-                        maxBytes: retainedLogBytes
-                    )
-                    rotatedData.append(data)
-                    try rotatedData.write(to: logURL, options: .atomic)
-                    return
-                }
-
-                if fm.fileExists(atPath: logURL.path),
-                    let handle = try? FileHandle(forWritingTo: logURL)
-                {
-                    try handle.seekToEnd()
-                    try handle.write(contentsOf: data)
-                    try handle.close()
-                } else {
-                    try data.write(to: logURL, options: .atomic)
-                }
+                try writeLogLine(data, to: diagnosticLogURL())
             } catch {
-                // Diagnostics must never affect audio capture.
+                // Keep capture independent of the file sink, but make a failed
+                // diagnostic write visible through the independent system log.
+                logger.error("audio_diagnostic_write_failed error_type=\(errorType(error), privacy: .public)")
             }
         }
     }
 
+    /// Capture the clocks before dispatching: a busy utility queue must not
+    /// make a first-buffer event appear to have happened after Stop. The random
+    /// process session distinguishes app/CLI runs without a persistent ID.
     public static func appendAsync(_ message: String) {
+        let timestamp = Date()
+        let uptimeNanoseconds = DispatchTime.now().uptimeNanoseconds
         appendQueue.async {
-            append(message)
+            append(message, timestamp: timestamp, uptimeNanoseconds: uptimeNanoseconds)
         }
     }
 
-    /// Keeps only complete newest log lines. Starting after the first newline
-    /// also discards any UTF-8 code point split by the byte boundary.
+    static func encodedLogLine(_ message: String, timestamp: Date, uptimeNanoseconds: UInt64) -> Data {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let sanitized = String(sanitizedMessage(message).prefix(maxMessageCharacters))
+        let line =
+            "\(formatter.string(from: timestamp)) \(sanitized)"
+            + " process_id=\(ProcessInfo.processInfo.processIdentifier)"
+            + " process_session=\(processSession) uptime_ns=\(uptimeNanoseconds)\n"
+        return Data(line.utf8)
+    }
+
+    /// Serialize the complete create/append/rotate operation across cooperating
+    /// app and CLI processes. Keeping the boundary throwable also lets tests
+    /// exercise failures against isolated files instead of user logs.
+    static func writeLogLine(_ data: Data, to logURL: URL) throws {
+        let fm = FileManager.default
+        try fm.createDirectory(
+            at: logURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+
+        try withLogFileLock(at: logURL) {
+            if fm.fileExists(atPath: logURL.path) {
+                // An open failure is not an absent file: replacing it would erase
+                // the existing history (e.g. a read-only log in a writable folder).
+                let handle = try FileHandle(forWritingTo: logURL)
+                defer { try? handle.close() }
+                let size = try handle.seekToEnd()
+                if size + UInt64(data.count) > maxLogBytes {
+                    let existingData = try Data(contentsOf: logURL)
+                    var rotatedData = retainedLogSuffix(existingData, maxBytes: retainedLogBytes)
+                    rotatedData.append(data)
+                    try rotatedData.write(to: logURL, options: .atomic)
+                    return
+                }
+                try handle.write(contentsOf: data)
+            } else {
+                try data.write(to: logURL, options: .atomic)
+            }
+        }
+    }
+
+    /// The sibling inode is stable across atomic log replacement. Never unlink
+    /// this file: another process may already hold or be waiting on its lock.
+    /// This advisory lock only coordinates participating local writers; readers
+    /// remain independent. Closing releases it on success, failure, or exit.
+    static func withLogFileLock(at logURL: URL, _ operation: () throws -> Void) throws {
+        let lockURL = logURL.appendingPathExtension("lock")
+        let descriptor = Darwin.open(lockURL.path, O_WRONLY | O_CREAT | O_CLOEXEC, S_IRUSR | S_IWUSR)
+        guard descriptor >= 0 else {
+            throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
+        }
+        defer { _ = Darwin.close(descriptor) }
+        while flock(descriptor, LOCK_EX) != 0 {
+            let code = errno
+            guard code == EINTR else {
+                throw NSError(domain: NSPOSIXErrorDomain, code: Int(code))
+            }
+        }
+        try operation()
+    }
+
+    /// Keeps only complete newest log lines. If the byte boundary splits a
+    /// line, starting after its newline also discards any split UTF-8 scalar.
     static func retainedLogSuffix(_ data: Data, maxBytes: Int) -> Data {
         guard maxBytes > 0, data.count > maxBytes else {
             return maxBytes > 0 ? data : Data()
         }
 
         let suffix = data.suffix(maxBytes)
+        if data[data.index(before: suffix.startIndex)] == 0x0A {
+            return Data(suffix)
+        }
         guard let firstNewline = suffix.firstIndex(of: 0x0A) else {
             return Data()
         }

--- a/Sources/MacParakeetCore/Audio/AudioCaptureDiagnostics.swift
+++ b/Sources/MacParakeetCore/Audio/AudioCaptureDiagnostics.swift
@@ -93,15 +93,47 @@ public enum AudioCaptureDiagnostics {
 
     private static func append(_ message: String, timestamp: Date, uptimeNanoseconds: UInt64) {
         let data = encodedLogLine(message, timestamp: timestamp, uptimeNanoseconds: uptimeNanoseconds)
+        appendEncodedLogLine(data, to: diagnosticLogURL())
+    }
+
+    static func appendEncodedLogLine(_ data: Data, to logURL: URL) {
+        if Thread.isMainThread {
+            let completed = lock.withLockIfAvailable {
+                do {
+                    try writeLogLine(data, to: logURL, waitForLock: false)
+                    return true
+                } catch {
+                    let code = (error as NSError).code
+                    if (error as NSError).domain == NSPOSIXErrorDomain, code == Int(EWOULDBLOCK) {
+                        return false
+                    }
+                    logger.error("audio_diagnostic_write_failed error_type=\(errorType(error), privacy: .public)")
+                    return true
+                }
+            } ?? false
+            if !completed {
+                logger.info("audio_diagnostic_write_deferred reason=lock_contended")
+                // Keep the exact record and its occurrence clocks. Only its
+                // visibility is deferred; a busy writer must not block the UI.
+                appendQueue.async { appendEncodedLogLine(data, to: logURL) }
+            }
+            return
+        }
 
         lock.withLock {
             do {
-                try writeLogLine(data, to: diagnosticLogURL())
+                try writeLogLine(data, to: logURL)
             } catch {
                 // Keep capture independent of the file sink, but make a failed
                 // diagnostic write visible through the independent system log.
                 logger.error("audio_diagnostic_write_failed error_type=\(errorType(error), privacy: .public)")
             }
+        }
+    }
+
+    static func flushPendingAppends() async {
+        await withCheckedContinuation { continuation in
+            appendQueue.async { continuation.resume() }
         }
     }
 
@@ -130,14 +162,14 @@ public enum AudioCaptureDiagnostics {
     /// Serialize the complete create/append/rotate operation across cooperating
     /// app and CLI processes. Keeping the boundary throwable also lets tests
     /// exercise failures against isolated files instead of user logs.
-    static func writeLogLine(_ data: Data, to logURL: URL) throws {
+    static func writeLogLine(_ data: Data, to logURL: URL, waitForLock: Bool = true) throws {
         let fm = FileManager.default
         try fm.createDirectory(
             at: logURL.deletingLastPathComponent(),
             withIntermediateDirectories: true
         )
 
-        try withLogFileLock(at: logURL) {
+        try withLogFileLock(at: logURL, waitForLock: waitForLock) {
             if fm.fileExists(atPath: logURL.path) {
                 // An open failure is not an absent file: replacing it would erase
                 // the existing history (e.g. a read-only log in a writable folder).
@@ -162,14 +194,14 @@ public enum AudioCaptureDiagnostics {
     /// this file: another process may already hold or be waiting on its lock.
     /// This advisory lock only coordinates participating local writers; readers
     /// remain independent. Closing releases it on success, failure, or exit.
-    static func withLogFileLock(at logURL: URL, _ operation: () throws -> Void) throws {
+    static func withLogFileLock(at logURL: URL, waitForLock: Bool = true, _ operation: () throws -> Void) throws {
         let lockURL = logURL.appendingPathExtension("lock")
         let descriptor = Darwin.open(lockURL.path, O_WRONLY | O_CREAT | O_CLOEXEC, S_IRUSR | S_IWUSR)
         guard descriptor >= 0 else {
             throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
         }
         defer { _ = Darwin.close(descriptor) }
-        while flock(descriptor, LOCK_EX) != 0 {
+        while flock(descriptor, waitForLock ? LOCK_EX : LOCK_EX | LOCK_NB) != 0 {
             let code = errno
             guard code == EINTR else {
                 throw NSError(domain: NSPOSIXErrorDomain, code: Int(code))

--- a/Sources/MacParakeetCore/Audio/AudioRecorder.swift
+++ b/Sources/MacParakeetCore/Audio/AudioRecorder.swift
@@ -518,11 +518,9 @@ public actor AudioRecorder {
                     let interleaved = bufferFormat.isInterleaved
                     let frameLength = monoBuffer.frameLength
                     let hasFloatData = monoBuffer.floatChannelData != nil
-                    Task {
-                        AudioCaptureDiagnostics.append(
-                            "dictation_capture_first_buffer sr=\(sr) ch=\(ch) original_ch=\(originalChannelCount) common_format=\(commonFormat) interleaved=\(interleaved) frames=\(frameLength) has_float_data=\(hasFloatData)"
-                        )
-                    }
+                    AudioCaptureDiagnostics.appendAsync(
+                        "dictation_capture_first_buffer sr=\(sr) ch=\(ch) original_ch=\(originalChannelCount) common_format=\(commonFormat) interleaved=\(interleaved) frames=\(frameLength) has_float_data=\(hasFloatData)"
+                    )
                 }
 
                 guard bufferFormat.sampleRate > 0, bufferFormat.channelCount > 0 else {

--- a/Sources/MacParakeetCore/Audio/DiagnosticLogScope.swift
+++ b/Sources/MacParakeetCore/Audio/DiagnosticLogScope.swift
@@ -122,28 +122,14 @@ extension AudioCaptureDiagnostics {
         var result = kept.joined(separator: "\n")
         result.append("\n")
 
-        // Hard byte-ceiling guarantee. `tail` admits its newest line
-        // unconditionally, so only a single pathologically long line can push
-        // past `maxBytes`. Real entries are short and newline-terminated, so
-        // this trim never fires in practice — it just keeps the contract
-        // ("recent uploads stay within the cap") true for any input. Cut on a
-        // UTF-8 scalar boundary so we never emit replacement characters or
-        // overshoot the cap when a multi-byte sequence straddles the boundary.
-        if result.utf8.count > maxBytes {
-            let utf8 = result.utf8
-            var start = utf8.index(utf8.endIndex, offsetBy: -maxBytes)
-            while start < utf8.endIndex, utf8[start] & 0xC0 == 0x80 {
-                start = utf8.index(after: start)
-            }
-            result = String(decoding: utf8[start...], as: UTF8.self)
-        }
         return result
     }
 
     /// Walks `lines` newest-first, keeping lines until a hard cap halts it, and
     /// returns them in chronological order. Lines for which `skip` returns true
-    /// are passed over without stopping the walk. The newest kept line is
-    /// always admitted (so the byte cap can be exceeded only by a single line).
+    /// are passed over without stopping the walk. A line larger than the entire
+    /// byte budget is also skipped: slicing its tail would remove its timestamp
+    /// and event name, making an otherwise structured record misleading.
     private static func tail(
         of lines: [Substring],
         maxBytes: Int,
@@ -156,7 +142,8 @@ extension AudioCaptureDiagnostics {
             if kept.count >= maxLines { break }
             if skip(line) { continue }
             let lineBytes = line.utf8.count + 1 // +1 for the rejoined newline
-            if !kept.isEmpty, byteCount + lineBytes > maxBytes { break }
+            if lineBytes > maxBytes { continue }
+            if byteCount + lineBytes > maxBytes { break }
             kept.append(line)
             byteCount += lineBytes
         }

--- a/Sources/MacParakeetCore/Audio/README.md
+++ b/Sources/MacParakeetCore/Audio/README.md
@@ -108,12 +108,25 @@ owned by `AppEnvironment`.
   `media_resume_*` outcomes here so uploaded logs show the
   press→pause window next to the capture timeline; issue #474).
   Capture-callback first-buffer records use `appendAsync` so log compaction
-  cannot block buffer delivery.
+  cannot block buffer delivery. Both paths stamp the event at submission time,
+  with a process ID, per-launch random `process_session`, and monotonic
+  `uptime_ns` for correlating app/CLI runs and ordering delayed writes across
+  wall-clock corrections. The shared file's `errorFields` includes classified
+  error type and numeric code, never arbitrary localized error descriptions;
+  raw details belong only to separately privacy-marked OSLog fields. File sink
+  failures surface through OSLog without failing capture or replacing history
+  when an existing log cannot be opened for append.
 - `DiagnosticLogScope.swift` — `AudioCaptureDiagnostics.scopedLogForUpload`
   trims the log to a recent window (`.recent`, the feedback default:
   last 7 days, 2 MB / 20k-line safety ceilings, min-tail fallback) or
   the whole file (`.full`, advanced opt-in) before a feedback upload.
-  Scopes whole lines by recency; never edits line contents.
+  Scopes whole lines by recency; never edits line contents. An individual line
+  larger than the entire upload byte budget is omitted whole so retained
+  records keep their timestamp and event name.
+- `scripts/dev/query_audio_diagnostics.py` provides a bounded, read-only JSON
+  query for local agents, including event/time/process filters and explicit
+  missing/partial evidence counters. See the
+  [local diagnostic query runbook](../../../docs/local-audio-diagnostics-query.md).
 - `AudioChunker.swift` — actor that buffers resampled audio for
   incremental STT (live meeting transcription).
 - `MeetingLiveAudioChunking.swift`,

--- a/Sources/MacParakeetCore/Audio/README.md
+++ b/Sources/MacParakeetCore/Audio/README.md
@@ -116,6 +116,11 @@ owned by `AppEnvironment`.
   raw details belong only to separately privacy-marked OSLog fields. File sink
   failures surface through OSLog without failing capture or replacing history
   when an existing log cannot be opened for append.
+  Main-thread writes try both writer locks without waiting. On contention, the
+  existing utility queue retains and writes the same encoded record, preserving
+  its occurrence clocks; OSLog reports `audio_diagnostic_write_deferred`.
+  Such records become visible after the contending writer finishes, and remain
+  best effort if the process exits before the queue drains.
 - `DiagnosticLogScope.swift` — `AudioCaptureDiagnostics.scopedLogForUpload`
   trims the log to a recent window (`.recent`, the feedback default:
   last 7 days, 2 MB / 20k-line safety ceilings, min-tail fallback) or

--- a/Sources/MacParakeetCore/Audio/README.md
+++ b/Sources/MacParakeetCore/Audio/README.md
@@ -116,10 +116,12 @@ owned by `AppEnvironment`.
   raw details belong only to separately privacy-marked OSLog fields. File sink
   failures surface through OSLog without failing capture or replacing history
   when an existing log cannot be opened for append.
-  Main-thread writes try both writer locks without waiting. On contention, the
+  Main-thread writes try both writer locks without waiting and defer rotation
+  before reading or rewriting the log history. On contention or rotation, the
   existing utility queue retains and writes the same encoded record, preserving
-  its occurrence clocks; OSLog reports `audio_diagnostic_write_deferred`.
-  Such records become visible after the contending writer finishes, and remain
+  its occurrence clocks; OSLog reports `audio_diagnostic_write_deferred` with
+  `reason=lock_contended` or `reason=rotation`.
+  Such records become visible after the queued write finishes, and remain
   best effort if the process exits before the queue drains.
 - `DiagnosticLogScope.swift` — `AudioCaptureDiagnostics.scopedLogForUpload`
   trims the log to a recent window (`.recent`, the feedback default:

--- a/Sources/MacParakeetCore/Audio/SpeechBoundaryMeetingLiveAudioChunker.swift
+++ b/Sources/MacParakeetCore/Audio/SpeechBoundaryMeetingLiveAudioChunker.swift
@@ -208,7 +208,7 @@ actor SpeechBoundaryMeetingLiveAudioChunker: MeetingLiveAudioChunking {
             diag.vadErrors += 1
             consecutiveVADErrors += 1
             logger.error(
-                "meeting_vad_stream_error consecutive=\(self.consecutiveVADErrors) error=\(error.localizedDescription, privacy: .public)"
+                "meeting_vad_stream_error consecutive=\(self.consecutiveVADErrors) error_type=\(AudioCaptureDiagnostics.errorType(error), privacy: .public) error_detail=\(error.localizedDescription, privacy: .private)"
             )
             if consecutiveVADErrors >= Self.maxConsecutiveVADErrors {
                 fellBackToFixed = true

--- a/Sources/MacParakeetCore/Services/Dictation/DictationService.swift
+++ b/Sources/MacParakeetCore/Services/Dictation/DictationService.swift
@@ -132,6 +132,7 @@ public actor DictationService: DictationServiceProtocol {
     private var currentTelemetryContext = DictationTelemetryContext()
     private var recordingStartedAt: Date?
     private var currentOperationID: String?
+    private var currentOperationTerminalEmitted = false
     private var currentOperationTelemetryContext = DictationTelemetryContext()
     private var currentOperationSpeechEngineAttribution: SpeechEngineTelemetryAttribution?
     private var currentObservabilityOperationContext: ObservabilityOperationContext?
@@ -279,7 +280,7 @@ public actor DictationService: DictationServiceProtocol {
                     operationContext: operationContext,
                     telemetryContext: context,
                     speechEngineAttribution: speechEngineAttribution,
-                    outcome: .unavailable,
+                    outcome: error is CancellationError ? .cancelled : .unavailable,
                     errorType: Self.errorType(for: error),
                     device: device
                 )
@@ -327,6 +328,7 @@ public actor DictationService: DictationServiceProtocol {
         currentAIFormatterFinishContext = nil
         clearLiveTranscript()
         currentOperationID = operationContext.operationID
+        currentOperationTerminalEmitted = false
         currentOperationTelemetryContext = context
         currentOperationSpeechEngineAttribution = nil
         currentObservabilityOperationContext = operationContext
@@ -378,7 +380,7 @@ public actor DictationService: DictationServiceProtocol {
                 await cancelLiveDictationTranscription(sessionID: requestedSessionID)
                 await cancelDisplayPreview(sessionID: requestedSessionID, clearText: true)
                 logger.notice(
-                    "startRecording stale failure ignored session=\(requestedSessionID) active=\(activeAtFailure) error=\(error.localizedDescription, privacy: .public)"
+                    "startRecording stale failure ignored session=\(requestedSessionID) active=\(activeAtFailure) error_type=\(Self.errorType(for: error), privacy: .public) error_detail=\(error.localizedDescription, privacy: .private)"
                 )
                 throw error
             }
@@ -401,7 +403,7 @@ public actor DictationService: DictationServiceProtocol {
             let device = await audioProcessor.recordingDeviceInfo
             guard activeSessionID == requestedSessionID else {
                 logger.notice(
-                    "startRecording stale failure ignored session=\(requestedSessionID) active=\(self.activeSessionID) error=\(error.localizedDescription, privacy: .public)"
+                    "startRecording stale failure ignored session=\(requestedSessionID) active=\(self.activeSessionID) error_type=\(Self.errorType(for: error), privacy: .public) error_detail=\(error.localizedDescription, privacy: .private)"
                 )
                 throw error
             }
@@ -416,17 +418,19 @@ public actor DictationService: DictationServiceProtocol {
                 operationContext: observabilityOperationContext,
                 telemetryContext: telemetryContext,
                 speechEngineAttribution: speechEngineAttribution,
-                outcome: .failure,
+                outcome: error is CancellationError ? .cancelled : .failure,
                 errorType: Self.errorType(for: error),
                 device: device
             )
             clearCurrentOperation()
-            Telemetry.send(
-                .dictationFailed(
-                    errorType: Self.errorType(for: error), errorDetail: TelemetryErrorClassifier.errorDetail(error),
-                    device: device))
+            if !(error is CancellationError) {
+                Telemetry.send(
+                    .dictationFailed(
+                        errorType: Self.errorType(for: error), errorDetail: TelemetryErrorClassifier.errorDetail(error),
+                        device: device))
+            }
             logger.error(
-                "startRecording failed session=\(requestedSessionID) error=\(error.localizedDescription, privacy: .public)"
+                "startRecording failed session=\(requestedSessionID) error_type=\(Self.errorType(for: error), privacy: .public) error_detail=\(error.localizedDescription, privacy: .private)"
             )
             throw error
         }
@@ -528,7 +532,14 @@ public actor DictationService: DictationServiceProtocol {
                 throw error
             }
             _state = .idle
-            if Self.isNoSpeechError(error) {
+            if error is CancellationError {
+                sendDictationOperation(
+                    outcome: .cancelled,
+                    durationSeconds: resolvedDurationSeconds(capturedMs: capturedDurationMs),
+                    errorType: Self.errorType(for: error),
+                    device: device
+                )
+            } else if Self.isNoSpeechError(error) {
                 sendDictationOperation(
                     outcome: .empty,
                     durationSeconds: resolvedDurationSeconds(capturedMs: capturedDurationMs),
@@ -555,7 +566,7 @@ public actor DictationService: DictationServiceProtocol {
             recordingStartedAt = nil
             clearCurrentOperation()
             logger.error(
-                "stopRecording failed session=\(currentSession) error=\(error.localizedDescription, privacy: .public)"
+                "stopRecording failed session=\(currentSession) error_type=\(Self.errorType(for: error), privacy: .public) error_detail=\(error.localizedDescription, privacy: .private)"
             )
             throw error
         }
@@ -747,7 +758,14 @@ public actor DictationService: DictationServiceProtocol {
                 throw error
             }
             _state = .idle
-            if Self.isNoSpeechError(error) {
+            if error is CancellationError {
+                sendDictationOperation(
+                    outcome: .cancelled,
+                    durationSeconds: resolvedDurationSeconds(capturedMs: capturedDurationMs),
+                    errorType: Self.errorType(for: error),
+                    device: device
+                )
+            } else if Self.isNoSpeechError(error) {
                 sendDictationOperation(
                     outcome: .empty,
                     durationSeconds: resolvedDurationSeconds(capturedMs: capturedDurationMs),
@@ -1533,6 +1551,7 @@ public actor DictationService: DictationServiceProtocol {
 
     private func clearCurrentOperation() {
         currentOperationID = nil
+        currentOperationTerminalEmitted = false
         currentOperationTelemetryContext = DictationTelemetryContext()
         currentOperationSpeechEngineAttribution = nil
         currentObservabilityOperationContext = nil
@@ -1558,6 +1577,14 @@ public actor DictationService: DictationServiceProtocol {
         device: RecordingDeviceInfo? = nil
     ) {
         guard let id = operationID ?? currentOperationID else { return }
+        if id == currentOperationID {
+            // Success stays visible briefly before the service resets. A late
+            // confirmation in that window must not turn the same operation
+            // into both success and cancellation. Independent entitlement
+            // attempts carry their own ID and do not consume this session's gate.
+            guard !currentOperationTerminalEmitted else { return }
+            currentOperationTerminalEmitted = true
+        }
         let context = telemetryContext ?? currentOperationTelemetryContext
         let attribution = speechEngineAttribution ?? currentOperationSpeechEngineAttribution
         let observabilityContext = operationContext ?? currentObservabilityOperationContext

--- a/Sources/MacParakeetCore/Services/Dictation/DictationService.swift
+++ b/Sources/MacParakeetCore/Services/Dictation/DictationService.swift
@@ -160,6 +160,14 @@ public actor DictationService: DictationServiceProtocol {
         liveTranscriptText
     }
 
+    private var successDisplayWaiter: @Sendable () async -> Void = {
+        try? await Task.sleep(for: .milliseconds(500))
+    }
+
+    func setSuccessDisplayWaiterForTesting(_ waiter: @escaping @Sendable () async -> Void) {
+        successDisplayWaiter = waiter
+    }
+
     public init(
         audioProcessor: AudioProcessorProtocol,
         sttTranscriber: STTTranscribing,
@@ -426,7 +434,7 @@ public actor DictationService: DictationServiceProtocol {
             if !(error is CancellationError) {
                 Telemetry.send(
                     .dictationFailed(
-                        errorType: Self.errorType(for: error), errorDetail: TelemetryErrorClassifier.errorDetail(error),
+                        errorType: Self.errorType(for: error),
                         device: device))
             }
             logger.error(
@@ -513,7 +521,7 @@ public actor DictationService: DictationServiceProtocol {
             logger.debug(
                 "stopRecording success session=\(currentSession) rawChars=\(result.dictation.rawTranscript.count) cleanChars=\(result.dictation.cleanTranscript?.count ?? 0)"
             )
-            try? await Task.sleep(for: .milliseconds(500))
+            await successDisplayWaiter()
             guard activeSessionID == currentSession else { return result }
             _state = .idle
             recordingStartedAt = nil
@@ -560,7 +568,7 @@ public actor DictationService: DictationServiceProtocol {
                 )
                 Telemetry.send(
                     .dictationFailed(
-                        errorType: Self.errorType(for: error), errorDetail: TelemetryErrorClassifier.errorDetail(error),
+                        errorType: Self.errorType(for: error),
                         device: device))
             }
             recordingStartedAt = nil
@@ -743,7 +751,7 @@ public actor DictationService: DictationServiceProtocol {
                     appCategory: currentTelemetryContext.appCategory,
                     device: device
                 ))
-            try? await Task.sleep(for: .milliseconds(500))
+            await successDisplayWaiter()
             guard activeSessionID == currentSession else { return result }
             _state = .idle
             recordingStartedAt = nil
@@ -786,7 +794,7 @@ public actor DictationService: DictationServiceProtocol {
                 )
                 Telemetry.send(
                     .dictationFailed(
-                        errorType: Self.errorType(for: error), errorDetail: TelemetryErrorClassifier.errorDetail(error),
+                        errorType: Self.errorType(for: error),
                         device: device))
             }
             recordingStartedAt = nil

--- a/Sources/MacParakeetCore/Services/Telemetry/TelemetryErrorClassifier.swift
+++ b/Sources/MacParakeetCore/Services/Telemetry/TelemetryErrorClassifier.swift
@@ -4,11 +4,41 @@ import Foundation
 ///
 /// Produces strings like "URLError.notConnectedToInternet", "DictationServiceError",
 /// "CancellationError" — more useful for grouping than raw `type(of:)` class names.
+/// NSError domains are retained only for known platform errors; custom domains
+/// become `NSError.<code>` even when their text resembles a technical identifier.
 public enum TelemetryErrorClassifier {
+    // Keep this finite platform-domain set aligned with the website's numeric
+    // categories in functions/lib/public-error-category.mjs. Identifier-shaped
+    // custom domains can still be user content and must not cross the boundary.
+    private static let knownNSErrorDomains: Set<String> = [
+        NSCocoaErrorDomain,
+        NSPOSIXErrorDomain,
+        NSOSStatusErrorDomain,
+        NSURLErrorDomain,
+        "AVFoundationErrorDomain",
+        "com.apple.coreaudio.avfaudio",
+    ]
+
     public static func classify(_ error: Error) -> String {
         // URLError: include the code name for network diagnosis
         if let urlError = error as? URLError {
             return "URLError.\(urlErrorCodeName(urlError.code))"
+        }
+
+        if let audioError = error as? AudioProcessorError,
+            case .recordingFailed("interrupted during subscribe") = audioError
+        {
+            return "AudioProcessorError.recordingFailed.interrupted_subscribe"
+        }
+
+        // SharedMicrophoneStream currently crosses its queue boundary with the
+        // localized NSError description. Preserve known CoreAudio domain/code
+        // pairs without transmitting any of that message's free-form content.
+        if let subscribeError = error as? SharedMicrophoneStream.SubscribeError,
+            case .engineStartFailed(let reason) = subscribeError,
+            let coreAudioCode = coreAudioClassification(in: reason)
+        {
+            return "SubscribeError.engineStartFailed.\(coreAudioCode)"
         }
 
         // Swift-native error types (enums, structs, classes) — include case name for enums
@@ -16,55 +46,104 @@ public enum TelemetryErrorClassifier {
         if typeName != "_SwiftNativeNSError" && typeName != "NSError" {
             // For enum errors, extract the case name (e.g., "AudioProcessorError.insufficientSamples")
             let mirror = Mirror(reflecting: error)
+            guard mirror.displayStyle == .enum else { return typeName }
             if let caseName = mirror.children.first?.label {
                 return "\(typeName).\(caseName)"
             }
-            // Non-enum errors or cases without associated values (Mirror has no children
-            // for simple enum cases) — use String(describing:) which prints the case name
+            // A custom description can contain user content, even when it looks
+            // like a single identifier. Only the compiler's enum description is safe.
+            guard !(error is any CustomStringConvertible),
+                !(error is any CustomDebugStringConvertible)
+            else { return typeName }
             let described = String(describing: error)
-            if described != typeName && !described.contains("(") {
+            if described != typeName,
+                described.range(of: #"^[A-Za-z_][A-Za-z0-9_]*$"#, options: .regularExpression) != nil
+            {
                 return "\(typeName).\(described)"
             }
             return typeName
         }
 
-        // Bridged NSError with a specific domain — include domain + code
+        // Retain only known platform domains. Custom NSError domains are
+        // arbitrary strings, so even single-word values must be discarded.
         let nsError = error as NSError
-        return "\(nsError.domain).\(nsError.code)"
+        let safeDomain = knownNSErrorDomains.contains(nsError.domain) ? nsError.domain : "NSError"
+        return "\(safeDomain).\(nsError.code)"
     }
 
-    /// Returns a privacy-safe error detail string: paths and URLs stripped, truncated to 512 chars.
+    /// Redacts recognizable paths, URLs, emails and credentials, then truncates to 512 chars.
+    /// Arbitrary user content cannot be made safe by pattern matching; callers must
+    /// omit details from errors that can contain transcripts or provider responses.
     public static func errorDetail(_ error: Error) -> String {
         return String(sanitize(error.localizedDescription).prefix(512))
     }
 
-    /// Strips file paths and URLs from an arbitrary string. Idempotent — running
-    /// twice produces the same result. Used both by `errorDetail(_:)` for Error
-    /// values and by `TelemetryEvent.errorOccurred` for raw description strings,
-    /// so any caller route into telemetry is automatically privacy-clean even
-    /// if the caller forgot to invoke `errorDetail` themselves. No truncation
-    /// here — callers truncate to whatever budget they're enforcing.
+    /// Strips recognizable private values from a diagnostic string. Idempotent — running
+    /// twice produces the same result. Used by `errorDetail(_:)` for defensive
+    /// diagnostic scrubbing; network events omit free-form descriptions entirely.
+    /// No truncation here — callers enforce their own diagnostic length budget.
     public static func sanitize(_ string: String) -> String {
         var sanitized = string
-        // Strip file:// URLs (must run before path stripping to catch file:///Users/...)
+        // Paths can contain spaces, quotes, or punctuation. Redact through the
+        // end of the line: guessing where the path ends leaked meeting names in
+        // ffmpeg errors from iCloud Drive and external volumes.
         sanitized = sanitized.replacingOccurrences(
-            of: #"file://[^\s\"',)\]]+"#,
+            of: #"(?i)file:(?://)?[^\r\n]+"#,
             with: "<path>",
             options: .regularExpression
         )
-        // Strip absolute paths: /Users/..., /var/folders/..., /private/..., /tmp/...
+        // Strip URLs before paths so their slashes are not treated as file paths.
         sanitized = sanitized.replacingOccurrences(
-            of: #"(?:/Volumes/[^\s/]+)?/(?:Users/[^\s/]+|private/var/folders|var/folders|tmp)[^\s\"',)\]]*"#,
-            with: "<path>",
-            options: .regularExpression
-        )
-        // Strip http(s) URLs that may contain video IDs, tokens, or query params
-        sanitized = sanitized.replacingOccurrences(
-            of: #"https?://[^\s\"',)\]]+"#,
+            of: #"(?i)\b[a-z][a-z0-9+.-]*://[^\s\"',)\]]+"#,
             with: "<url>",
             options: .regularExpression
         )
+        sanitized = sanitized.replacingOccurrences(
+            of: #"(?<![A-Za-z0-9/])(?:~?/)[^\s/][^\r\n]*"#,
+            with: "<path>",
+            options: .regularExpression
+        )
+        sanitized = sanitized.replacingOccurrences(
+            of: #"(?i)\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b"#,
+            with: "<email>",
+            options: .regularExpression
+        )
+        sanitized = sanitized.replacingOccurrences(
+            of: #"(?i)\bBearer\s+[^\s\"',;<>]+"#,
+            with: "Bearer <redacted>",
+            options: .regularExpression
+        )
+        sanitized = sanitized.replacingOccurrences(
+            of: #"(?i)\b(?:api[_-]?key|access[_-]?token|token|authorization)\s*[:=]\s*[^\s\"',;<>]+"#,
+            with: "credential=<redacted>",
+            options: .regularExpression
+        )
+        sanitized = sanitized.replacingOccurrences(
+            of: #"\b(?:sk-[A-Za-z0-9_-]{12,}|AIza[A-Za-z0-9_-]{20,})\b"#,
+            with: "<redacted>",
+            options: .regularExpression
+        )
         return sanitized
+    }
+
+    private static func coreAudioClassification(in reason: String) -> String? {
+        let patterns = [
+            #"\((com\.apple\.coreaudio\.avfaudio|NSOSStatusErrorDomain|OSStatus) error (-?[0-9]{1,10})\.\)"#,
+            #"Error Domain=(com\.apple\.coreaudio\.avfaudio|NSOSStatusErrorDomain) Code=(-?[0-9]{1,10})(?:\s|$)"#,
+        ]
+        for pattern in patterns {
+            guard let regex = try? NSRegularExpression(pattern: pattern),
+                let match = regex.firstMatch(in: reason, range: NSRange(reason.startIndex..., in: reason)),
+                let domainRange = Range(match.range(at: 1), in: reason),
+                let codeRange = Range(match.range(at: 2), in: reason),
+                let code = Int32(reason[codeRange])
+            else { continue }
+            // Foundation renders NSOSStatusErrorDomain as "OSStatus" in its
+            // localized description; retain the canonical domain for grouping.
+            let domain = reason[domainRange] == "OSStatus" ? "NSOSStatusErrorDomain" : String(reason[domainRange])
+            return "\(domain).\(code)"
+        }
+        return nil
     }
 
     private static func urlErrorCodeName(_ code: URLError.Code) -> String {

--- a/Sources/MacParakeetCore/Services/Telemetry/TelemetryErrorClassifier.swift
+++ b/Sources/MacParakeetCore/Services/Telemetry/TelemetryErrorClassifier.swift
@@ -88,7 +88,7 @@ public enum TelemetryErrorClassifier {
         // end of the line: guessing where the path ends leaked meeting names in
         // ffmpeg errors from iCloud Drive and external volumes.
         sanitized = sanitized.replacingOccurrences(
-            of: #"(?i)file:(?://)?[^\r\n]+"#,
+            of: #"(?i)\bfile:/[^\r\n]+"#,
             with: "<path>",
             options: .regularExpression
         )
@@ -114,7 +114,7 @@ public enum TelemetryErrorClassifier {
             options: .regularExpression
         )
         sanitized = sanitized.replacingOccurrences(
-            of: #"(?i)\b(?:api[_-]?key|access[_-]?token|token|authorization)\s*[:=]\s*[^\s\"',;<>]+"#,
+            of: #"(?i)\b(?:api[_-]?key|access[_-]?token|token|authorization)\s*[:=]\s*(?:\"(?:\\[^\r\n]|[^\"\\\r\n])*\\?(?:\"|(?=[\r\n]|$))|'(?:\\[^\r\n]|[^'\\\r\n])*\\?(?:'|(?=[\r\n]|$))|[^\s\"',;<>]+)"#,
             with: "credential=<redacted>",
             options: .regularExpression
         )

--- a/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
+++ b/Sources/MacParakeetCore/Services/Telemetry/TelemetryEvent.swift
@@ -581,6 +581,9 @@ public enum TelemetrySettingName: String, Sendable, Equatable {
     case calendarIncludedCalendars = "calendar_included_calendars"
 }
 
+/// Free-form error details, descriptions and crash reasons are accepted for
+/// source compatibility but omitted from network properties. Pattern-based
+/// redaction cannot guarantee that provider/subprocess output is content-free.
 public enum TelemetryEventSpec: Sendable {
     static let maxCrashStackTraceCharacters = 1024
 
@@ -1152,9 +1155,8 @@ extension TelemetryEventSpec {
                 Self.compactProps(
                     ("duration_seconds", durationSeconds.map(Self.format))
                 ), device)
-        case .dictationFailed(let errorType, let errorDetail, let device):
-            var props = ["error_type": errorType]
-            if let errorDetail = Self.sanitizedErrorDetail(errorDetail) { props["error_detail"] = errorDetail }
+        case .dictationFailed(let errorType, _, let device):
+            let props = ["error_type": errorType]
             return Self.mergeDevice(props, device)
         case .dictationOperation(
             let operationID,
@@ -1231,13 +1233,12 @@ extension TelemetryEventSpec {
                 ("audio_duration_seconds", audioDurationSeconds.map(Self.format)),
                 ("stage", stage.rawValue)
             )
-        case .transcriptionFailed(let source, let stage, let errorType, let errorDetail):
-            var props = [
+        case .transcriptionFailed(let source, let stage, let errorType, _):
+            let props = [
                 "source": source.rawValue,
                 "stage": stage.rawValue,
                 "error_type": errorType,
             ]
-            if let errorDetail = Self.sanitizedErrorDetail(errorDetail) { props["error_detail"] = errorDetail }
             return props
         case .transcriptionOperation(
             let operationID,
@@ -1292,33 +1293,28 @@ extension TelemetryEventSpec {
                 "speaker_count": "\(speakerCount)",
                 "duration_seconds": Self.format(durationSeconds),
             ]
-        case .diarizationFailed(let source, let errorType, let errorDetail):
-            var props = ["source": source.rawValue, "error_type": errorType]
-            if let errorDetail = Self.sanitizedErrorDetail(errorDetail) { props["error_detail"] = errorDetail }
+        case .diarizationFailed(let source, let errorType, _):
+            let props = ["source": source.rawValue, "error_type": errorType]
             return props
         case .exportUsed(let format):
             return ["format": format]
-        case .exportFailed(let format, let errorType, let errorDetail):
-            var props = ["format": format, "error_type": errorType]
-            if let errorDetail = Self.sanitizedErrorDetail(errorDetail) { props["error_detail"] = errorDetail }
+        case .exportFailed(let format, let errorType, _):
+            let props = ["format": format, "error_type": errorType]
             return props
         case .llmPromptResultUsed(let provider):
             return ["provider": provider]
-        case .llmPromptResultFailed(let provider, let errorType, let errorDetail):
-            var props = ["provider": provider, "error_type": errorType]
-            if let errorDetail = Self.sanitizedErrorDetail(errorDetail) { props["error_detail"] = errorDetail }
+        case .llmPromptResultFailed(let provider, let errorType, _):
+            let props = ["provider": provider, "error_type": errorType]
             return props
         case .llmChatUsed(let provider, let source, let messageCount):
             return ["provider": provider, "source": source.rawValue, "message_count": "\(messageCount)"]
-        case .llmChatFailed(let provider, let source, let errorType, let errorDetail):
-            var props = ["provider": provider, "source": source.rawValue, "error_type": errorType]
-            if let errorDetail = Self.sanitizedErrorDetail(errorDetail) { props["error_detail"] = errorDetail }
+        case .llmChatFailed(let provider, let source, let errorType, _):
+            let props = ["provider": provider, "source": source.rawValue, "error_type": errorType]
             return props
         case .llmTransformUsed(let provider):
             return ["provider": provider]
-        case .llmTransformFailed(let provider, let errorType, let errorDetail):
-            var props = ["provider": provider, "error_type": errorType]
-            if let errorDetail = Self.sanitizedErrorDetail(errorDetail) { props["error_detail"] = errorDetail }
+        case .llmTransformFailed(let provider, let errorType, _):
+            let props = ["provider": provider, "error_type": errorType]
             return props
         case .transformExecuted(let name, let capture, let replace, let llmMs, let totalMs, let appCategory):
             return Self.compactProps(
@@ -1474,13 +1470,12 @@ extension TelemetryEventSpec {
                 ("total_steps", totalSteps.map(String.init)),
                 ("engine_state", engineState)
             )
-        case .licenseActivationFailed(let errorType, let errorDetail):
-            var props = ["error_type": errorType]
-            if let errorDetail = Self.sanitizedErrorDetail(errorDetail) { props["error_detail"] = errorDetail }
+        case .licenseActivationFailed(let errorType, _):
+            let props = ["error_type": errorType]
             return props
-        case .restoreFailed(let errorType, let errorDetail):
+        case .restoreFailed(let errorType, _):
             return Self.compactProps(
-                ("error_type", errorType), ("error_detail", Self.sanitizedErrorDetail(errorDetail)))
+                ("error_type", errorType))
         case .permissionPrompted(let permission):
             return ["permission": permission.rawValue]
         case .permissionGranted(let permission):
@@ -1507,15 +1502,14 @@ extension TelemetryEventSpec {
                 ("speech_engine", speechEngine?.rawValue),
                 ("engine_variant", Self.safeEngineVariant(engineVariant))
             )
-        case .modelDownloadFailed(let errorType, let errorDetail, let modelKind, let speechEngine, let engineVariant):
-            var props =
+        case .modelDownloadFailed(let errorType, _, let modelKind, let speechEngine, let engineVariant):
+            let props =
                 Self.compactProps(
                     ("error_type", errorType),
                     ("model_kind", modelKind?.rawValue),
                     ("speech_engine", speechEngine?.rawValue),
                     ("engine_variant", Self.safeEngineVariant(engineVariant))
                 ) ?? [:]
-            if let errorDetail = Self.sanitizedErrorDetail(errorDetail) { props["error_detail"] = errorDetail }
             return props
         case .modelOperation(
             let operationID,
@@ -1604,9 +1598,8 @@ extension TelemetryEventSpec {
             ]
         case .meetingRecordingCancelled(let durationSeconds):
             return ["duration_seconds": Self.format(durationSeconds)]
-        case .meetingRecordingFailed(let errorType, let errorDetail):
-            var props = ["error_type": errorType]
-            if let errorDetail = Self.sanitizedErrorDetail(errorDetail) { props["error_detail"] = errorDetail }
+        case .meetingRecordingFailed(let errorType, _):
+            let props = ["error_type": errorType]
             return props
         case .meetingOperation(
             let operationID,
@@ -1664,14 +1657,13 @@ extension TelemetryEventSpec {
                 "source": source.rawValue,
                 "phases": TelemetryMeetingRecoveryPhases.aggregate(lockStates: phases),
             ]
-        case .meetingRecoveryFailed(let count, let source, let phases, let errorType, let errorDetail):
-            var props = [
+        case .meetingRecoveryFailed(let count, let source, let phases, let errorType, _):
+            let props = [
                 "count": "\(count)",
                 "source": source.rawValue,
                 "phases": TelemetryMeetingRecoveryPhases.aggregate(lockStates: phases),
                 "error_type": errorType,
             ]
-            if let errorDetail = Self.sanitizedErrorDetail(errorDetail) { props["error_detail"] = errorDetail }
             return props
         case .meetingAutoStopProposed(let reason),
             .meetingAutoStopConfirmed(let reason),
@@ -1703,21 +1695,14 @@ extension TelemetryEventSpec {
             return ["reason": reason]
         case .sttRuntimeUnhealthy(let reason):
             return ["reason": reason]
-        case .errorOccurred(let domain, let code, let description):
-            // Defense in depth: sanitize() at the boundary so any caller route
-            // (including future call sites that forget to run
-            // `TelemetryErrorClassifier.errorDetail` first) cannot leak file
-            // paths or URLs into telemetry. `sanitize` is idempotent, so
-            // double-sanitizing existing well-behaved callers costs nothing.
-            return [
-                "domain": domain,
-                "code": code,
-                "description": String(TelemetryErrorClassifier.sanitize(description).prefix(512)),
-            ]
+        case .errorOccurred(let domain, let code, _):
+            // Descriptions and provider/subprocess errors can contain arbitrary
+            // user content. Keep only structured dimensions in network telemetry.
+            return ["domain": domain, "code": code]
         case .crashOccurred(
             let crashType, let signal, let name, let crashTimestamp,
             let crashAppVer, let crashOsVer, let uuid, let slide,
-            let reason, let stackTrace):
+            _, let stackTrace):
             return Self.compactProps(
                 ("crash_type", crashType),
                 ("signal", signal),
@@ -1727,7 +1712,6 @@ extension TelemetryEventSpec {
                 ("crash_os_ver", crashOsVer),
                 ("uuid", uuid),
                 ("slide", slide),
-                ("reason", reason.map { String($0.prefix(512)) }),
                 ("stack_trace", String(stackTrace.prefix(Self.maxCrashStackTraceCharacters)))
             )
         case .cliOperation(
@@ -1788,11 +1772,6 @@ extension TelemetryEventSpec {
 
     private static func boolString(_ value: Bool) -> String {
         value ? "true" : "false"
-    }
-
-    private static func sanitizedErrorDetail(_ detail: String?) -> String? {
-        guard let detail, !detail.isEmpty else { return nil }
-        return String(TelemetryErrorClassifier.sanitize(detail).prefix(512))
     }
 
     private static func safeEngineVariant(_ variant: String?) -> String? {
@@ -1950,7 +1929,7 @@ public enum TelemetryImplementedContract {
         .calendarAutoStartCancelled: ["reason"],
         .calendarAutoStartFailed: ["reason"],
         .sttRuntimeUnhealthy: ["reason"],
-        .errorOccurred: ["domain", "code", "description"],
+        .errorOccurred: ["domain", "code"],
         .crashOccurred: ["crash_type", "signal", "name", "crash_ts", "crash_app_ver"],
         .cliOperation: ["operation_id", "command", "outcome", "duration_seconds"],
         .autoSaveOperation: ["operation_id", "scope", "format", "outcome", "duration_seconds"],

--- a/Sources/MacParakeetCore/Services/Telemetry/TelemetryService.swift
+++ b/Sources/MacParakeetCore/Services/Telemetry/TelemetryService.swift
@@ -46,6 +46,9 @@ public final class TelemetryService: TelemetryServiceProtocol, @unchecked Sendab
     private let lock = NSLock()
     private let flushGate = TelemetryFlushGate()
     private var queue: [TelemetryEvent] = []
+    // Clearing consent invalidates snapshots already removed from the queue,
+    // including retries and batches that have not been admitted for dispatch.
+    private var queueGeneration: UInt64 = 0
     private var flushTimer: Timer?
     private var lifecycleObserver: NSObjectProtocol?
 
@@ -139,12 +142,18 @@ public final class TelemetryService: TelemetryServiceProtocol, @unchecked Sendab
     }
 
     public func send(_ event: TelemetryEventSpec) {
-        guard isEnabled() || event.name == .telemetryOptedOut else { return }
+        guard let generation = queueGeneration(ifAllowed: event.name) else { return }
 
         let telemetryEvent = makeTelemetryEvent(from: event)
 
         let shouldFlush: Bool
         lock.lock()
+        guard generation == queueGeneration,
+            isEnabled() || event.name == .telemetryOptedOut
+        else {
+            lock.unlock()
+            return
+        }
         queue.append(telemetryEvent)
         if queue.count > Self.maxQueueSize {
             queue.removeFirst(queue.count - Self.maxQueueSize)
@@ -159,12 +168,15 @@ public final class TelemetryService: TelemetryServiceProtocol, @unchecked Sendab
 
     @discardableResult
     public func sendAndFlush(_ event: TelemetryEventSpec) async -> Bool {
-        guard isEnabled() || event.name == .telemetryOptedOut else { return true }
+        guard let generation = queueGeneration(ifAllowed: event.name) else { return true }
 
         let telemetryEvent = makeTelemetryEvent(from: event)
 
         await flushGate.enter()
-        enqueue(telemetryEvent)
+        guard enqueue(telemetryEvent, generation: generation) else {
+            await flushGate.leave()
+            return true  // Intentionally discarded by an opt-out while waiting.
+        }
         let failedEventIds = await flushQueuedEvents()
         await flushGate.leave()
 
@@ -179,16 +191,19 @@ public final class TelemetryService: TelemetryServiceProtocol, @unchecked Sendab
 
     public func clearQueue() {
         lock.lock()
+        queueGeneration &+= 1
         queue.removeAll()
         lock.unlock()
     }
 
     private func flushQueuedEvents() async -> Set<String> {
-        let events = takeQueuedEvents()
+        let (events, generation) = takeQueuedEvents()
         guard !events.isEmpty else { return [] }
-        let failedEvents = await sendBatches(events, using: session, timeoutInterval: requestTimeoutInterval)
-        requeueFailedEvents(failedEvents)
-        return Set(failedEvents.map(\.eventId))
+        let failedEvents = await sendBatches(
+            events, generation: generation, using: session, timeoutInterval: requestTimeoutInterval
+        )
+        let retainedFailures = requeueFailedEvents(failedEvents, generation: generation)
+        return Set(retainedFailures.map(\.eventId))
     }
 
     // MARK: - Internal (for testing)
@@ -201,31 +216,57 @@ public final class TelemetryService: TelemetryServiceProtocol, @unchecked Sendab
 
     // MARK: - Private
 
-    private func enqueue(_ event: TelemetryEvent) {
+    private func queueGeneration(ifAllowed event: TelemetryEventName) -> UInt64? {
         lock.lock()
+        defer { lock.unlock() }
+        guard isEnabled() || event == .telemetryOptedOut else { return nil }
+        return queueGeneration
+    }
+
+    private func enqueue(_ event: TelemetryEvent, generation: UInt64) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard generation == queueGeneration,
+            isEnabled() || event.event == TelemetryEventName.telemetryOptedOut.rawValue
+        else { return false }
         queue.append(event)
         if queue.count > Self.maxQueueSize {
             queue.removeFirst(queue.count - Self.maxQueueSize)
         }
-        lock.unlock()
+        return true
     }
 
-    private func takeQueuedEvents() -> [TelemetryEvent] {
+    private func takeQueuedEvents() -> ([TelemetryEvent], UInt64) {
         lock.lock()
+        defer { lock.unlock() }
         let events = queue
         queue.removeAll()
-        lock.unlock()
-        return events
+        return (events, queueGeneration)
     }
 
-    private func requeueFailedEvents(_ events: [TelemetryEvent]) {
-        guard !events.isEmpty else { return }
+    private func requeueFailedEvents(_ events: [TelemetryEvent], generation: UInt64) -> [TelemetryEvent] {
+        guard !events.isEmpty else { return [] }
         lock.lock()
-        queue.insert(contentsOf: events, at: 0)
+        defer { lock.unlock() }
+        guard generation == queueGeneration else { return [] }
+        let retained = eventsAllowedByConsent(events)
+        queue.insert(contentsOf: retained, at: 0)
         if queue.count > Self.maxQueueSize {
             queue.removeLast(queue.count - Self.maxQueueSize)
         }
-        lock.unlock()
+        return retained
+    }
+
+    /// Called under `lock`; only the final opt-out event may be sent while disabled.
+    private func eventsAllowedByConsent(_ events: [TelemetryEvent]) -> [TelemetryEvent] {
+        isEnabled() ? events : events.filter { $0.event == TelemetryEventName.telemetryOptedOut.rawValue }
+    }
+
+    private func eventsAllowedForDispatch(_ events: [TelemetryEvent], generation: UInt64) -> [TelemetryEvent] {
+        lock.lock()
+        defer { lock.unlock() }
+        guard generation == queueGeneration else { return [] }
+        return eventsAllowedByConsent(events)
     }
 
     private func makeTelemetryEvent(from event: TelemetryEventSpec) -> TelemetryEvent {
@@ -270,6 +311,7 @@ public final class TelemetryService: TelemetryServiceProtocol, @unchecked Sendab
             ))
         }
         let events = queue
+        let generation = queueGeneration
         queue.removeAll()
         lock.unlock()
 
@@ -281,7 +323,9 @@ public final class TelemetryService: TelemetryServiceProtocol, @unchecked Sendab
                 completion.signal()
                 return
             }
-            _ = await self.sendBatches(events, using: session, timeoutInterval: Self.terminationRequestTimeout)
+            _ = await self.sendBatches(
+                events, generation: generation, using: session, timeoutInterval: Self.terminationRequestTimeout
+            )
             completion.signal()
         }
         _ = completion.wait(timeout: .now() + Self.terminationFlushMaxWait)
@@ -289,6 +333,7 @@ public final class TelemetryService: TelemetryServiceProtocol, @unchecked Sendab
 
     private func sendBatches(
         _ events: [TelemetryEvent],
+        generation: UInt64,
         using session: URLSession,
         timeoutInterval: TimeInterval
     ) async -> [TelemetryEvent] {
@@ -299,7 +344,8 @@ public final class TelemetryService: TelemetryServiceProtocol, @unchecked Sendab
 
         for batchStart in stride(from: 0, to: events.count, by: Self.maxBatchSize) {
             let batchEnd = min(batchStart + Self.maxBatchSize, events.count)
-            let batchEvents = Array(events[batchStart..<batchEnd])
+            let batchEvents = eventsAllowedForDispatch(Array(events[batchStart..<batchEnd]), generation: generation)
+            guard !batchEvents.isEmpty else { continue }
             let payload = TelemetryPayload(events: batchEvents)
 
             guard let body = try? encoder.encode(payload) else {

--- a/Sources/MacParakeetCore/Services/Telemetry/TelemetryService.swift
+++ b/Sources/MacParakeetCore/Services/Telemetry/TelemetryService.swift
@@ -39,6 +39,29 @@ private actor TelemetryFlushGate {
     }
 }
 
+/// Bridges structured task cancellation to the synchronously admitted URL task.
+private final class TelemetryRequestCancellation: @unchecked Sendable {
+    private let lock = NSLock()
+    private var task: URLSessionDataTask?
+    private var cancelled = false
+
+    func install(_ task: URLSessionDataTask) {
+        let shouldCancel = lock.withLock {
+            self.task = task
+            return cancelled
+        }
+        if shouldCancel { task.cancel() }
+    }
+
+    func cancel() {
+        let task = lock.withLock {
+            cancelled = true
+            return self.task
+        }
+        task?.cancel()
+    }
+}
+
 // MARK: - Implementation
 
 public final class TelemetryService: TelemetryServiceProtocol, @unchecked Sendable {
@@ -214,6 +237,9 @@ public final class TelemetryService: TelemetryServiceProtocol, @unchecked Sendab
         return queue.count
     }
 
+    // Set before starting a flush in tests to exercise the encoding/admission gap.
+    var beforeRequestAdmission: (@Sendable () -> Void)?
+
     // MARK: - Private
 
     private func queueGeneration(ifAllowed event: TelemetryEventName) -> UInt64? {
@@ -360,7 +386,8 @@ public final class TelemetryService: TelemetryServiceProtocol, @unchecked Sendab
             request.httpBody = body
             request.timeoutInterval = timeoutInterval
 
-            let sent = await sendAsync(request, using: session)
+            beforeRequestAdmission?()
+            let sent = await sendAsync(request, events: batchEvents, generation: generation, using: session)
             if !sent {
                 failedEvents.append(contentsOf: batchEvents)
             }
@@ -369,17 +396,38 @@ public final class TelemetryService: TelemetryServiceProtocol, @unchecked Sendab
         return failedEvents
     }
 
-    private func sendAsync(_ request: URLRequest, using session: URLSession) async -> Bool {
-        do {
-            let (_, response) = try await session.data(for: request)
-            if let http = response as? HTTPURLResponse, !(200...299).contains(http.statusCode) {
-                logger.warning("Telemetry server returned \(http.statusCode)")
-                return false
+    private func sendAsync(
+        _ request: URLRequest, events: [TelemetryEvent], generation: UInt64, using session: URLSession
+    ) async -> Bool {
+        let cancellation = TelemetryRequestCancellation()
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                // Encoding can race with opt-out. Admit and resume under the
+                // same lock as clearQueue, so no stale request starts afterward.
+                lock.withLock {
+                    guard generation == queueGeneration,
+                        isEnabled() || events.allSatisfy({ $0.event == TelemetryEventName.telemetryOptedOut.rawValue })
+                    else {
+                        continuation.resume(returning: true)
+                        return
+                    }
+                    let task = session.dataTask(with: request) { [logger] _, response, error in
+                        if let error {
+                            logger.debug("Telemetry flush failed: \(error.localizedDescription)")
+                            continuation.resume(returning: false)
+                        } else if let http = response as? HTTPURLResponse, !(200...299).contains(http.statusCode) {
+                            logger.warning("Telemetry server returned \(http.statusCode)")
+                            continuation.resume(returning: false)
+                        } else {
+                            continuation.resume(returning: true)
+                        }
+                    }
+                    cancellation.install(task)
+                    task.resume()
+                }
             }
-            return true
-        } catch {
-            logger.debug("Telemetry flush failed: \(error.localizedDescription)")
-            return false
+        } onCancel: {
+            cancellation.cancel()
         }
     }
 

--- a/Tests/CLITests/CLITelemetryTests.swift
+++ b/Tests/CLITests/CLITelemetryTests.swift
@@ -5,6 +5,20 @@ import XCTest
 
 final class CLITelemetryTests: XCTestCase {
 
+    func testSuccessfulThrownExitHasNoTelemetryError() {
+        let result: Result<Void, Error> = .failure(ExitCode.success)
+        XCTAssertEqual(result.cliTelemetryOutcome, .success)
+        XCTAssertEqual(result.cliTelemetryExitCode, 0)
+        XCTAssertNil(result.cliTelemetryErrorType)
+    }
+
+    func testRuntimeFailureStillHasTelemetryError() {
+        let result: Result<Void, Error> = .failure(ExitCode.failure)
+        XCTAssertEqual(result.cliTelemetryOutcome, .failure)
+        XCTAssertEqual(result.cliTelemetryExitCode, 1)
+        XCTAssertNotNil(result.cliTelemetryErrorType)
+    }
+
     // MARK: - decideOverride: explicit MACPARAKEET_TELEMETRY
 
     func testDecideOverrideExplicitForceOffAccepts0FalseNoOff() {

--- a/Tests/MacParakeetTests/Audio/AudioCaptureDiagnosticsTests.swift
+++ b/Tests/MacParakeetTests/Audio/AudioCaptureDiagnosticsTests.swift
@@ -1,4 +1,5 @@
 import CoreAudio
+import Darwin
 import XCTest
 @testable import MacParakeetCore
 
@@ -23,7 +24,7 @@ final class AudioCaptureDiagnosticsTests: XCTestCase {
     }
 
     func testDiagnosticMessageSanitizerStripsPathsAndURLs() {
-        let message = #"failed path=/Users/alex/Secret/file.wav url=https://example.com/watch?v=abc"#
+        let message = "failed path=/Users/alex/Secret/file.wav\nurl=https://example.com/watch?v=abc"
 
         let sanitized = AudioCaptureDiagnostics.sanitizedMessage(message)
 
@@ -43,6 +44,33 @@ final class AudioCaptureDiagnosticsTests: XCTestCase {
         XCTAssertEqual(sanitized, "first line second line third line")
     }
 
+    func testErrorFieldsRetainBridgedCodeWithoutArbitraryContent() {
+        let error = NSError(
+            domain: NSOSStatusErrorDomain,
+            code: -10875,
+            userInfo: [NSLocalizedDescriptionKey: "private spoken words api_key=do-not-share"]
+        )
+
+        let fields = AudioCaptureDiagnostics.errorFields(error)
+
+        XCTAssertTrue(fields.contains("error_type=NSOSStatusErrorDomain.-10875"))
+        XCTAssertTrue(fields.contains("bridged_error_code=-10875"))
+        XCTAssertFalse(fields.contains("private spoken words"))
+        XCTAssertFalse(fields.contains("api_key"))
+        XCTAssertFalse(fields.contains("error_detail"))
+    }
+
+    func testWrappedCoreAudioErrorKeepsStatusDistinctFromItsBridgeCode() {
+        let underlying = NSError(domain: NSOSStatusErrorDomain, code: -10868)
+        let wrapped = SharedMicrophoneStream.SubscribeError.engineStartFailed(underlying.localizedDescription)
+
+        let fields = AudioCaptureDiagnostics.errorFields(wrapped).split(separator: " ")
+
+        XCTAssertTrue(fields.contains("error_type=SubscribeError.engineStartFailed.NSOSStatusErrorDomain.-10868"))
+        XCTAssertTrue(fields.contains("bridged_error_code=0"))
+        XCTAssertFalse(fields.contains { $0.hasPrefix("error_code=") })
+    }
+
     func testRetainedLogSuffixKeepsNewestCompleteLines() throws {
         let original = try XCTUnwrap(
             "first line\nmiddle line\nlatest one\nlatest two\n".data(using: .utf8)
@@ -59,5 +87,158 @@ final class AudioCaptureDiagnosticsTests: XCTestCase {
         let retained = AudioCaptureDiagnostics.retainedLogSuffix(original, maxBytes: 17)
 
         XCTAssertTrue(retained.isEmpty)
+    }
+
+    func testRetainedLogSuffixPreservesLineExactlyAtByteBoundary() {
+        let original = Data("old\nnewest\n".utf8)
+
+        let retained = AudioCaptureDiagnostics.retainedLogSuffix(original, maxBytes: 7)
+
+        XCTAssertEqual(String(decoding: retained, as: UTF8.self), "newest\n")
+    }
+
+    func testRetainedLogSuffixDoesNotSplitMultibyteText() {
+        let original = Data("old\nééé\nlatest\n".utf8)
+
+        let retained = AudioCaptureDiagnostics.retainedLogSuffix(original, maxBytes: 10)
+
+        XCTAssertEqual(String(decoding: retained, as: UTF8.self), "latest\n")
+    }
+
+    func testEncodedLinePreservesEventTimeAndAddsProcessCorrelation() throws {
+        let timestamp = Date(timeIntervalSince1970: 1_780_000_000)
+        let data = AudioCaptureDiagnostics.encodedLogLine(
+            "dictation_capture_first_buffer frames=480",
+            timestamp: timestamp,
+            uptimeNanoseconds: 123_456_789
+        )
+        let line = String(decoding: data, as: UTF8.self)
+        let fields = line.split(whereSeparator: \.isWhitespace)
+
+        XCTAssertEqual(fields[0], "2026-05-28T20:26:40.000Z")
+        XCTAssertEqual(fields[1], "dictation_capture_first_buffer")
+        XCTAssertTrue(fields.contains("frames=480"))
+        XCTAssertTrue(fields.contains("process_id=\(ProcessInfo.processInfo.processIdentifier)"))
+        XCTAssertTrue(fields.contains("uptime_ns=123456789"))
+        let sessionField = try XCTUnwrap(fields.first { $0.hasPrefix("process_session=") })
+        let sessionID = String(sessionField.dropFirst("process_session=".count))
+        XCTAssertNotNil(UUID(uuidString: sessionID))
+
+        let second = String(
+            decoding: AudioCaptureDiagnostics.encodedLogLine(
+                "dictation_capture_stop",
+                timestamp: timestamp,
+                uptimeNanoseconds: 987_654_321
+            ),
+            as: UTF8.self
+        )
+        XCTAssertTrue(second.contains(String(sessionField)), "One process must retain the same correlation ID")
+        XCTAssertTrue(line.hasSuffix("\n"))
+    }
+
+    func testWritePreservesExistingHistoryWhenLogCannotBeOpenedForAppend() throws {
+        let logURL = try temporaryLogURL()
+        let original = Data("existing diagnostic history\n".utf8)
+        try original.write(to: logURL)
+        try FileManager.default.setAttributes([.posixPermissions: 0o400], ofItemAtPath: logURL.path)
+        defer {
+            try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: logURL.path)
+        }
+        // Running as root bypasses mode bits, so this failure cannot be induced.
+        guard !FileManager.default.isWritableFile(atPath: logURL.path) else {
+            throw XCTSkip("The process can write read-only files")
+        }
+
+        XCTAssertThrowsError(try AudioCaptureDiagnostics.writeLogLine(Data("new event\n".utf8), to: logURL))
+
+        XCTAssertEqual(try Data(contentsOf: logURL), original)
+    }
+
+    func testWriteCreatesAndAppendsWithoutLosingHistory() throws {
+        let logURL = try temporaryLogURL()
+
+        try AudioCaptureDiagnostics.writeLogLine(Data("first\n".utf8), to: logURL)
+        try AudioCaptureDiagnostics.writeLogLine(Data("second\n".utf8), to: logURL)
+
+        XCTAssertEqual(try String(contentsOf: logURL, encoding: .utf8), "first\nsecond\n")
+    }
+
+    func testWriteCompactsHistoryAtDiskCapAndKeepsNewestEntry() throws {
+        let logURL = try temporaryLogURL()
+        try AudioCaptureDiagnostics.writeLogLine(Data("initial event\n".utf8), to: logURL)
+        let lockURL = logURL.appendingPathExtension("lock")
+        let originalLockInode =
+            try FileManager.default.attributesOfItem(atPath: lockURL.path)[.systemFileNumber] as? NSNumber
+        let original = Data(String(repeating: "older event\n", count: 450_000).utf8)
+        try original.write(to: logURL)
+        let newest = Data("newest event\n".utf8)
+
+        try AudioCaptureDiagnostics.writeLogLine(newest, to: logURL)
+
+        let result = try Data(contentsOf: logURL)
+        XCTAssertLessThanOrEqual(result.count, Int(AudioCaptureDiagnostics.diagnosticLogMaxBytes))
+        XCTAssertTrue(result.starts(with: Data("older event\n".utf8)))
+        XCTAssertTrue(result.suffix(newest.count).elementsEqual(newest))
+        XCTAssertLessThan(result.count, original.count)
+        let lockInode = try FileManager.default.attributesOfItem(atPath: lockURL.path)[.systemFileNumber] as? NSNumber
+        XCTAssertNotNil(originalLockInode)
+        XCTAssertEqual(lockInode, originalLockInode, "Rotation must preserve the shared lock inode")
+    }
+
+    func testSiblingLockExcludesAnotherHandleAndReleasesAfterFailure() throws {
+        let logURL = try temporaryLogURL()
+        let lockURL = logURL.appendingPathExtension("lock")
+        let competingDescriptor = Darwin.open(lockURL.path, O_WRONLY | O_CREAT | O_CLOEXEC, S_IRUSR | S_IWUSR)
+        XCTAssertGreaterThanOrEqual(competingDescriptor, 0)
+        guard competingDescriptor >= 0 else { return }
+        defer { _ = Darwin.close(competingDescriptor) }
+        enum TestFailure: Error { case expected }
+
+        XCTAssertThrowsError(
+            try AudioCaptureDiagnostics.withLogFileLock(at: logURL) {
+                let attempt = flock(competingDescriptor, LOCK_EX | LOCK_NB)
+                let code = errno
+                XCTAssertEqual(attempt, -1)
+                XCTAssertEqual(code, EWOULDBLOCK)
+                throw TestFailure.expected
+            })
+
+        XCTAssertEqual(flock(competingDescriptor, LOCK_EX | LOCK_NB), 0, "Throwing must release the lock")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: lockURL.path), "The stable lock file must remain")
+    }
+
+    func testConcurrentWriterHandlesPreserveEntriesAcrossRotation() async throws {
+        let logURL = try temporaryLogURL()
+        let oldData = Data(String(repeating: "older event\n", count: 450_000).utf8)
+        try oldData.write(to: logURL)
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            for writer in 0..<2 {
+                group.addTask {
+                    for sequence in 0..<100 {
+                        let data = Data("writer=\(writer) sequence=\(sequence)\n".utf8)
+                        try AudioCaptureDiagnostics.writeLogLine(data, to: logURL)
+                    }
+                }
+            }
+            try await group.waitForAll()
+        }
+
+        let result = try String(contentsOf: logURL, encoding: .utf8)
+        let actual = result.split(separator: "\n").filter { $0.hasPrefix("writer=") }.map(String.init)
+        let expected = (0..<2).flatMap { writer in
+            (0..<100).map { "writer=\(writer) sequence=\($0)" }
+        }
+        XCTAssertEqual(actual.count, expected.count)
+        XCTAssertEqual(Set(actual), Set(expected))
+        XCTAssertLessThanOrEqual(result.utf8.count, Int(AudioCaptureDiagnostics.diagnosticLogMaxBytes))
+    }
+
+    private func temporaryLogURL() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("AudioCaptureDiagnosticsTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        addTeardownBlock { try FileManager.default.removeItem(at: directory) }
+        return directory.appendingPathComponent("dictation-audio.log")
     }
 }

--- a/Tests/MacParakeetTests/Audio/AudioCaptureDiagnosticsTests.swift
+++ b/Tests/MacParakeetTests/Audio/AudioCaptureDiagnosticsTests.swift
@@ -4,11 +4,12 @@ import XCTest
 @testable import MacParakeetCore
 
 final class AudioCaptureDiagnosticsTests: XCTestCase {
-    func testAppendUsesTemporaryLogUnderXCTest() throws {
+    func testAppendUsesTemporaryLogUnderXCTest() async throws {
         let logURL = AudioCaptureDiagnostics.diagnosticLogURL()
         let marker = "unit_test_diagnostic_marker_\(UUID().uuidString)"
 
         AudioCaptureDiagnostics.append(marker)
+        await AudioCaptureDiagnostics.flushPendingAppends()
 
         let contents = try String(contentsOf: logURL, encoding: .utf8)
         XCTAssertTrue(logURL.path.contains("MacParakeetTests/Logs"))
@@ -232,6 +233,30 @@ final class AudioCaptureDiagnosticsTests: XCTestCase {
         XCTAssertEqual(actual.count, expected.count)
         XCTAssertEqual(Set(actual), Set(expected))
         XCTAssertLessThanOrEqual(result.utf8.count, Int(AudioCaptureDiagnostics.diagnosticLogMaxBytes))
+    }
+
+    func testMainThreadContentionDefersTheOriginalRecordUntilLockRelease() async throws {
+        let logURL = try temporaryLogURL()
+        let lockURL = logURL.appendingPathExtension("lock")
+        let descriptor = Darwin.open(lockURL.path, O_WRONLY | O_CREAT | O_CLOEXEC, S_IRUSR | S_IWUSR)
+        guard descriptor >= 0 else { return XCTFail("Cannot open test lock") }
+        defer { _ = Darwin.close(descriptor) }
+        XCTAssertEqual(flock(descriptor, LOCK_EX), 0)
+        defer { _ = flock(descriptor, LOCK_UN) }
+        let original = AudioCaptureDiagnostics.encodedLogLine(
+            "capture_stop frames=480", timestamp: Date(timeIntervalSince1970: 1_780_000_000),
+            uptimeNanoseconds: 123_456_789
+        )
+
+        // This call must return while the other descriptor still owns the lock.
+        await MainActor.run {
+            AudioCaptureDiagnostics.appendEncodedLogLine(original, to: logURL)
+        }
+        XCTAssertFalse(FileManager.default.fileExists(atPath: logURL.path))
+        XCTAssertEqual(flock(descriptor, LOCK_UN), 0)
+        await AudioCaptureDiagnostics.flushPendingAppends()
+
+        XCTAssertEqual(try Data(contentsOf: logURL), original)
     }
 
     private func temporaryLogURL() throws -> URL {

--- a/Tests/MacParakeetTests/Audio/AudioCaptureDiagnosticsTests.swift
+++ b/Tests/MacParakeetTests/Audio/AudioCaptureDiagnosticsTests.swift
@@ -259,6 +259,31 @@ final class AudioCaptureDiagnosticsTests: XCTestCase {
         XCTAssertEqual(try Data(contentsOf: logURL), original)
     }
 
+    func testMainThreadRotationDefersTheOriginalRecordWithoutRewritingHistoryInline() async throws {
+        let logURL = try temporaryLogURL()
+        let history = Data(String(repeating: "older event\n", count: 450_000).utf8)
+        try history.write(to: logURL)
+        let original = AudioCaptureDiagnostics.encodedLogLine(
+            "capture_stop frames=480", timestamp: Date(timeIntervalSince1970: 1_780_000_000),
+            uptimeNanoseconds: 123_456_789
+        )
+
+        XCTAssertThrowsError(try AudioCaptureDiagnostics.writeLogLine(
+            original, to: logURL, waitForLock: false, allowRotation: false
+        ))
+        XCTAssertEqual(try Data(contentsOf: logURL), history)
+
+        await MainActor.run {
+            AudioCaptureDiagnostics.appendEncodedLogLine(original, to: logURL)
+        }
+        await AudioCaptureDiagnostics.flushPendingAppends()
+
+        let persisted = try Data(contentsOf: logURL)
+        XCTAssertLessThanOrEqual(persisted.count, Int(AudioCaptureDiagnostics.diagnosticLogMaxBytes))
+        XCTAssertTrue(persisted.starts(with: Data("older event\n".utf8)))
+        XCTAssertTrue(persisted.suffix(original.count).elementsEqual(original))
+    }
+
     private func temporaryLogURL() throws -> URL {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("AudioCaptureDiagnosticsTests-\(UUID().uuidString)", isDirectory: true)

--- a/Tests/MacParakeetTests/Audio/DiagnosticLogScopeTests.swift
+++ b/Tests/MacParakeetTests/Audio/DiagnosticLogScopeTests.swift
@@ -159,18 +159,17 @@ final class DiagnosticLogScopeTests: XCTestCase {
     }
 
     func testByteCeilingHoldsForSinglePathologicallyLongLine() {
-        // One line, no newline, larger than the cap: still bounded.
+        // One line larger than the cap cannot be included as a complete record.
         let raw = String(repeating: "a", count: AudioCaptureDiagnostics.recentUploadMaxBytes * 2)
 
         let scoped = AudioCaptureDiagnostics.scopedLogForUpload(raw, scope: .recent, now: now)
 
-        XCTAssertLessThanOrEqual(scoped.utf8.count, AudioCaptureDiagnostics.recentUploadMaxBytes)
+        XCTAssertEqual(scoped, "")
     }
 
     func testByteCeilingHoldsForMultiByteSingleLine() {
-        // A single line of 3-byte characters whose byte length exceeds the cap:
-        // the boundary trim must stay within the cap AND not emit replacement
-        // characters from a mid-sequence cut.
+        // Oversized multibyte records are dropped whole, never split into
+        // invalid UTF-8 or detached from their timestamp/event name.
         let euros = String(
             repeating: "€",
             count: AudioCaptureDiagnostics.recentUploadMaxBytes / 3 + 100
@@ -178,8 +177,21 @@ final class DiagnosticLogScopeTests: XCTestCase {
 
         let scoped = AudioCaptureDiagnostics.scopedLogForUpload(euros, scope: .recent, now: now)
 
-        XCTAssertLessThanOrEqual(scoped.utf8.count, AudioCaptureDiagnostics.recentUploadMaxBytes)
-        XCTAssertFalse(scoped.contains("\u{FFFD}"), "trim must cut on a UTF-8 boundary")
+        XCTAssertEqual(scoped, "")
+    }
+
+    func testOversizedLineDoesNotHideCompleteNeighboringEvents() {
+        let older = line(hoursAgo: 2, "capture_started")
+        let newest = line(hoursAgo: 1, "capture_failed")
+        let oversized = line(
+            hoursAgo: 1,
+            String(repeating: "x", count: AudioCaptureDiagnostics.recentUploadMaxBytes)
+        )
+        let raw = joined([older, oversized, newest, oversized])
+
+        let scoped = AudioCaptureDiagnostics.scopedLogForUpload(raw, scope: .recent, now: now)
+
+        XCTAssertEqual(scoped, joined([older, newest]))
     }
 
     // MARK: - No parseable timestamps

--- a/Tests/MacParakeetTests/Services/Dictation/DictationServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/Dictation/DictationServiceTests.swift
@@ -4,11 +4,17 @@ import XCTest
 private final class DictationTelemetrySpy: TelemetryServiceProtocol, @unchecked Sendable {
     private let lock = NSLock()
     private var events: [TelemetryEventSpec] = []
+    private let observer: (@Sendable (TelemetryEventSpec) -> Void)?
+
+    init(observer: (@Sendable (TelemetryEventSpec) -> Void)? = nil) {
+        self.observer = observer
+    }
 
     func send(_ event: TelemetryEventSpec) {
         lock.lock()
         events.append(event)
         lock.unlock()
+        observer?(event)
     }
 
     func sendAndFlush(_ event: TelemetryEventSpec) async -> Bool {
@@ -229,6 +235,144 @@ final class DictationServiceTests: XCTestCase {
         XCTAssertEqual(operation["outcome"], "failure")
         XCTAssertEqual(operation["trigger"], "hotkey")
         XCTAssertEqual(operation["mode"], "hold")
+    }
+
+    func testStartCaptureCancellationEmitsOneCancelledOperationWithoutFailureBreadcrumb() async throws {
+        let telemetry = DictationTelemetrySpy()
+        Telemetry.configure(telemetry)
+        await mockAudio.configureCaptureError(CancellationError())
+
+        do {
+            try await service.startRecording(context: DictationTelemetryContext(trigger: .hotkey, mode: .hold))
+            XCTFail("Expected capture cancellation")
+        } catch is CancellationError {
+        }
+        await service.confirmCancel()
+
+        let events = telemetry.snapshot()
+        let operations = dictationOperationProps(in: events)
+        XCTAssertEqual(operations.count, 1)
+        XCTAssertEqual(operations.first?["outcome"], "cancelled")
+        XCTAssertEqual(operations.first?["error_type"], "CancellationError")
+        XCTAssertEqual(operations.first?["trigger"], "hotkey")
+        XCTAssertEqual(operations.first?["mode"], "hold")
+        XCTAssertFalse(
+            events.contains { event in
+                if case .dictationFailed = event { return true }
+                return false
+            })
+    }
+
+    func testStopCaptureCancellationEmitsOneCancelledOperationWithoutFailureBreadcrumb() async throws {
+        let telemetry = DictationTelemetrySpy()
+        Telemetry.configure(telemetry)
+        try await service.startRecording(context: DictationTelemetryContext(trigger: .hotkey, mode: .hold))
+        await mockAudio.configureCaptureError(CancellationError())
+
+        do {
+            _ = try await service.stopRecording()
+            XCTFail("Expected capture cancellation")
+        } catch is CancellationError {
+        }
+        await service.confirmCancel()
+
+        let events = telemetry.snapshot()
+        let operations = dictationOperationProps(in: events)
+        XCTAssertEqual(operations.count, 1)
+        XCTAssertEqual(operations.first?["outcome"], "cancelled")
+        XCTAssertEqual(operations.first?["error_type"], "CancellationError")
+        XCTAssertFalse(
+            events.contains { event in
+                if case .dictationFailed = event { return true }
+                return false
+            })
+    }
+
+    func testUndoTranscriptionCancellationEmitsOneCancelledOperationWithoutFailureBreadcrumb() async throws {
+        let telemetry = DictationTelemetrySpy()
+        Telemetry.configure(telemetry)
+        let audioURL = try makeTemporaryAudioURL()
+        await mockAudio.configure(captureResult: audioURL)
+        await mockSTT.configure(error: CancellationError())
+        try await service.startRecording(context: DictationTelemetryContext(trigger: .hotkey, mode: .hold))
+        await service.cancelRecording(reason: .hotkey)
+
+        do {
+            _ = try await service.undoCancel()
+            XCTFail("Expected transcription cancellation")
+        } catch is CancellationError {
+        }
+        await service.confirmCancel()
+
+        let events = telemetry.snapshot()
+        let operations = dictationOperationProps(in: events)
+        XCTAssertEqual(operations.count, 1)
+        XCTAssertEqual(operations.first?["outcome"], "cancelled")
+        XCTAssertEqual(operations.first?["error_type"], "CancellationError")
+        XCTAssertFalse(
+            events.contains { event in
+                if case .dictationFailed = event { return true }
+                return false
+            })
+    }
+
+    func testConfirmCancelAfterSuccessDoesNotEmitAnotherTerminalOutcome() async throws {
+        let success = expectation(description: "Success emitted before the service's existing display dwell")
+        let telemetry = DictationTelemetrySpy { event in
+            if event.name == .dictationOperation, event.props?["outcome"] == "success" {
+                success.fulfill()
+            }
+        }
+        Telemetry.configure(telemetry)
+        let audioURL = try makeTemporaryAudioURL()
+        await mockAudio.configure(captureResult: audioURL)
+        await mockSTT.configure(result: STTResult(text: "first result"))
+        let service = try XCTUnwrap(self.service)
+        try await service.startRecording(sessionID: 1)
+        let stopTask = Task { try await service.stopRecording(sessionID: 1) }
+
+        await fulfillment(of: [success], timeout: 2)
+        guard case .success = await service.state else {
+            _ = try await stopTask.value
+            return XCTFail("The test must confirm cancellation while Stop is still displaying success")
+        }
+        await service.confirmCancel(sessionID: 1)
+        _ = try await stopTask.value
+
+        let operations = dictationOperationProps(in: telemetry.snapshot())
+        XCTAssertEqual(operations.count, 1)
+        XCTAssertEqual(operations.first?["outcome"], "success")
+    }
+
+    func testNewOperationAfterSuccessRetainsItsTerminalOutcomeAndIgnoresStaleCancel() async throws {
+        let success = expectation(description: "First operation succeeded")
+        let telemetry = DictationTelemetrySpy { event in
+            if event.name == .dictationOperation, event.props?["outcome"] == "success" {
+                success.fulfill()
+            }
+        }
+        Telemetry.configure(telemetry)
+        let audioURL = try makeTemporaryAudioURL()
+        await mockAudio.configure(captureResult: audioURL)
+        await mockSTT.configure(result: STTResult(text: "first result"))
+        let service = try XCTUnwrap(self.service)
+        try await service.startRecording(sessionID: 1)
+        let stopTask = Task { try await service.stopRecording(sessionID: 1) }
+
+        await fulfillment(of: [success], timeout: 2)
+        guard case .success = await service.state else {
+            _ = try await stopTask.value
+            return XCTFail("The new operation must replace the first operation during its success dwell")
+        }
+        try await service.startRecording(sessionID: 2)
+        await service.confirmCancel(sessionID: 1)
+        await service.confirmCancel(sessionID: 2)
+        _ = try await stopTask.value
+
+        let operations = dictationOperationProps(in: telemetry.snapshot())
+        XCTAssertEqual(operations.count, 2)
+        XCTAssertEqual(operations.map { $0["outcome"] }, ["success", "cancelled"])
+        XCTAssertEqual(Set(operations.compactMap { $0["operation_id"] }).count, 2)
     }
 
     func testCancelDuringStartCaptureStillEmitsCancelledOperation() async throws {

--- a/Tests/MacParakeetTests/Services/Dictation/DictationServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/Dictation/DictationServiceTests.swift
@@ -1,6 +1,22 @@
 import XCTest
 @testable import MacParakeetCore
 
+private actor DictationSuccessDisplayGate {
+    private var continuation: CheckedContinuation<Void, Never>?
+    private var released = false
+
+    func wait() async {
+        guard !released else { return }
+        await withCheckedContinuation { continuation = $0 }
+    }
+
+    func release() {
+        released = true
+        continuation?.resume()
+        continuation = nil
+    }
+}
+
 private final class DictationTelemetrySpy: TelemetryServiceProtocol, @unchecked Sendable {
     private let lock = NSLock()
     private var events: [TelemetryEventSpec] = []
@@ -317,6 +333,9 @@ final class DictationServiceTests: XCTestCase {
     }
 
     func testConfirmCancelAfterSuccessDoesNotEmitAnotherTerminalOutcome() async throws {
+        let displayGate = DictationSuccessDisplayGate()
+        await service.setSuccessDisplayWaiterForTesting { await displayGate.wait() }
+        defer { Task { await displayGate.release() } }
         let success = expectation(description: "Success emitted before the service's existing display dwell")
         let telemetry = DictationTelemetrySpy { event in
             if event.name == .dictationOperation, event.props?["outcome"] == "success" {
@@ -333,10 +352,12 @@ final class DictationServiceTests: XCTestCase {
 
         await fulfillment(of: [success], timeout: 2)
         guard case .success = await service.state else {
+            await displayGate.release()
             _ = try await stopTask.value
             return XCTFail("The test must confirm cancellation while Stop is still displaying success")
         }
         await service.confirmCancel(sessionID: 1)
+        await displayGate.release()
         _ = try await stopTask.value
 
         let operations = dictationOperationProps(in: telemetry.snapshot())
@@ -345,6 +366,9 @@ final class DictationServiceTests: XCTestCase {
     }
 
     func testNewOperationAfterSuccessRetainsItsTerminalOutcomeAndIgnoresStaleCancel() async throws {
+        let displayGate = DictationSuccessDisplayGate()
+        await service.setSuccessDisplayWaiterForTesting { await displayGate.wait() }
+        defer { Task { await displayGate.release() } }
         let success = expectation(description: "First operation succeeded")
         let telemetry = DictationTelemetrySpy { event in
             if event.name == .dictationOperation, event.props?["outcome"] == "success" {
@@ -361,12 +385,14 @@ final class DictationServiceTests: XCTestCase {
 
         await fulfillment(of: [success], timeout: 2)
         guard case .success = await service.state else {
+            await displayGate.release()
             _ = try await stopTask.value
             return XCTFail("The new operation must replace the first operation during its success dwell")
         }
         try await service.startRecording(sessionID: 2)
         await service.confirmCancel(sessionID: 1)
         await service.confirmCancel(sessionID: 2)
+        await displayGate.release()
         _ = try await stopTask.value
 
         let operations = dictationOperationProps(in: telemetry.snapshot())

--- a/Tests/MacParakeetTests/Services/Telemetry/TelemetryErrorClassifierTests.swift
+++ b/Tests/MacParakeetTests/Services/Telemetry/TelemetryErrorClassifierTests.swift
@@ -259,4 +259,29 @@ struct TelemetryErrorClassifierTests {
         let message = "AUHAL -10868; input=48000Hz/2ch; conversionFailed; NSOSStatusErrorDomain.-10868"
         #expect(TelemetryErrorClassifier.sanitize(message) == message)
     }
+
+    @Test("file URI redaction preserves words ending in file")
+    func fileURIBoundaries() {
+        let diagnostic = "profile: microphone; file: unavailable; sample_rate=48000"
+        #expect(TelemetryErrorClassifier.sanitize(diagnostic) == diagnostic)
+        #expect(TelemetryErrorClassifier.sanitize("open file:/private/audio.wav") == "open <path>")
+    }
+
+    @Test("redacts quoted credential values without leaking their suffix")
+    func quotedCredentials() {
+        for message in [
+            "api_key: \"private-key-value\"",
+            "Authorization: 'Basic private credential value'",
+            "access_token=\"private-token-value\"; status=401",
+            #"token="abc\"private-suffix""#,
+            #"api_key='abc\'private-suffix'"#,
+            "token=\"unterminated private suffix\nstatus=401",
+            "token=\"private suffix\\",
+        ] {
+            let sanitized = TelemetryErrorClassifier.sanitize(message)
+            #expect(!sanitized.contains("private"))
+            #expect(!sanitized.contains("credential value"))
+            #expect(TelemetryErrorClassifier.sanitize(sanitized) == sanitized)
+        }
+    }
 }

--- a/Tests/MacParakeetTests/Services/Telemetry/TelemetryErrorClassifierTests.swift
+++ b/Tests/MacParakeetTests/Services/Telemetry/TelemetryErrorClassifierTests.swift
@@ -49,11 +49,92 @@ struct TelemetryErrorClassifierTests {
             == "CancellationError")
     }
 
-    @Test("classifies NSError with domain and code")
+    @Test("classifies NSError with a known platform domain and code")
     func nsError() {
-        let error = NSError(domain: "TestDomain", code: 42)
+        let error = NSError(domain: NSPOSIXErrorDomain, code: 42)
         #expect(TelemetryErrorClassifier.classify(error)
-            == "TestDomain.42")
+            == "NSPOSIXErrorDomain.42")
+    }
+
+    @Test("omits identifier-shaped private NSError domains")
+    func identifierShapedNSErrorDomainIsPrivate() {
+        let error = NSError(domain: "private_customer_amy", code: 7)
+        #expect(TelemetryErrorClassifier.classify(error) == "NSError.7")
+    }
+
+    @Test("preserves the allowlisted Foundation and CoreAudio domain codes")
+    func knownPlatformNSErrorDomains() {
+        for domain in [
+            NSCocoaErrorDomain, NSPOSIXErrorDomain, NSOSStatusErrorDomain,
+            "AVFoundationErrorDomain", "com.apple.coreaudio.avfaudio",
+        ] {
+            let error = NSError(domain: domain, code: -10868)
+            #expect(TelemetryErrorClassifier.classify(error) == "\(domain).-10868")
+        }
+        let urlError = NSError(domain: NSURLErrorDomain, code: URLError.notConnectedToInternet.rawValue)
+        #expect(TelemetryErrorClassifier.classify(urlError) == "URLError.notConnectedToInternet")
+    }
+
+    @Test("does not classify arbitrary custom descriptions as error types")
+    func customDescriptionsAreNotTelemetryDimensions() {
+        enum DescribedError: Error, CustomStringConvertible {
+            case failed
+            var description: String { "private_transcript_text" }
+        }
+        struct DescribedStructError: Error, CustomStringConvertible {
+            var description: String { "private transcript text" }
+        }
+        #expect(TelemetryErrorClassifier.classify(DescribedError.failed) == "DescribedError")
+        #expect(TelemetryErrorClassifier.classify(DescribedStructError()) == "DescribedStructError")
+    }
+
+    @Test("rejects NSError domains containing paths or user content")
+    func unsafeNSErrorDomain() {
+        let error = NSError(domain: "/Users/alice/private meeting.wav", code: -10868)
+        #expect(TelemetryErrorClassifier.classify(error) == "NSError.-10868")
+    }
+
+    @Test("preserves CoreAudio status in the microphone engine start wrapper")
+    func microphoneStartCoreAudioStatus() {
+        for domain in ["com.apple.coreaudio.avfaudio", "NSOSStatusErrorDomain"] {
+            let underlying = NSError(domain: domain, code: -10868)
+            let error = SharedMicrophoneStream.SubscribeError.engineStartFailed(underlying.localizedDescription)
+            #expect(TelemetryErrorClassifier.classify(error) == "SubscribeError.engineStartFailed.\(domain).-10868")
+        }
+        for domain in ["com.apple.coreaudio.avfaudio", "NSOSStatusErrorDomain"] {
+            let error = SharedMicrophoneStream.SubscribeError.engineStartFailed(
+                "Error Domain=\(domain) Code=-10868 UserInfo={private spoken content}"
+            )
+            #expect(TelemetryErrorClassifier.classify(error) == "SubscribeError.engineStartFailed.\(domain).-10868")
+        }
+        let localizedAlias = SharedMicrophoneStream.SubscribeError.engineStartFailed(
+            "The operation couldn’t be completed. (OSStatus error -10868.)"
+        )
+        #expect(TelemetryErrorClassifier.classify(localizedAlias)
+            == "SubscribeError.engineStartFailed.NSOSStatusErrorDomain.-10868")
+    }
+
+    @Test("does not scrape arbitrary numeric data from microphone errors")
+    func microphoneStartUnrecognizedDetails() {
+        let messages = [
+            "private spoken content -10868",
+            "(private.customer.domain error -10868.)",
+            "(com.apple.coreaudio.avfaudio error 999999999999999999999.)",
+        ]
+        for message in messages {
+            let error = SharedMicrophoneStream.SubscribeError.engineStartFailed(message)
+            #expect(TelemetryErrorClassifier.classify(error) == "SubscribeError.engineStartFailed")
+        }
+    }
+
+    @Test("preserves the fixed interrupted-subscribe diagnostic without free-form text")
+    func interruptedSubscribeCode() {
+        #expect(TelemetryErrorClassifier.classify(
+            AudioProcessorError.recordingFailed("interrupted during subscribe")
+        ) == "AudioProcessorError.recordingFailed.interrupted_subscribe")
+        #expect(TelemetryErrorClassifier.classify(
+            AudioProcessorError.recordingFailed("interrupted during subscribe: private spoken content")
+        ) == "AudioProcessorError.recordingFailed")
     }
 
     // MARK: - errorDetail
@@ -143,5 +224,39 @@ struct TelemetryErrorClassifierTests {
         ])
         let detail = TelemetryErrorClassifier.errorDetail(error)
         #expect(detail.count == 512)
+    }
+
+    @Test("redacts complete paths containing spaces and punctuation")
+    func pathsWithSpaces() {
+        let paths = [
+            "/Users/alice/Library/Mobile Documents/com~apple~CloudDocs/private meeting.wav",
+            "/Volumes/External Disk/Alice's Private Meeting (final).wav",
+            "~/Documents/private meeting.wav",
+            "/custom location/private meeting.wav",
+            "file:///Users/alice/Library/Application Support/private meeting.wav",
+        ]
+        for path in paths {
+            let message = "Audio conversion failed: \(path)\nCoreAudio status -10868"
+            let sanitized = TelemetryErrorClassifier.sanitize(message)
+            #expect(sanitized == "Audio conversion failed: <path>\nCoreAudio status -10868")
+            #expect(TelemetryErrorClassifier.sanitize(sanitized) == sanitized)
+        }
+    }
+
+    @Test("redacts email addresses and recognizable credentials")
+    func emailsAndCredentials() {
+        let message = "user=alice@example.com\nAuthorization: Bearer private-token-value\napi_key=private-key-value\nsk-proj-12345678901234567890"
+        let sanitized = TelemetryErrorClassifier.sanitize(message)
+        #expect(!sanitized.contains("alice@example.com"))
+        #expect(!sanitized.contains("private-token-value"))
+        #expect(!sanitized.contains("private-key-value"))
+        #expect(!sanitized.contains("sk-proj-"))
+        #expect(TelemetryErrorClassifier.sanitize(sanitized) == sanitized)
+    }
+
+    @Test("preserves useful technical dimensions")
+    func technicalContextIsPreserved() {
+        let message = "AUHAL -10868; input=48000Hz/2ch; conversionFailed; NSOSStatusErrorDomain.-10868"
+        #expect(TelemetryErrorClassifier.sanitize(message) == message)
     }
 }

--- a/Tests/MacParakeetTests/TelemetryServiceTests.swift
+++ b/Tests/MacParakeetTests/TelemetryServiceTests.swift
@@ -12,10 +12,57 @@ private struct RecordedTelemetryEvent: Decodable {
     let session: String
 }
 
+private final class TelemetryConsent: @unchecked Sendable {
+    private let lock = NSLock()
+    private var enabled = true
+    private var readObserver: (() -> Void)?
+
+    func isEnabled() -> Bool {
+        lock.lock()
+        let value = enabled
+        let observer = readObserver
+        lock.unlock()
+        observer?()
+        return value
+    }
+
+    func setEnabled(_ value: Bool) {
+        lock.lock()
+        enabled = value
+        lock.unlock()
+    }
+
+    func observeReads(_ observer: (() -> Void)?) {
+        lock.lock()
+        readObserver = observer
+        lock.unlock()
+    }
+}
+
+private final class HeldTelemetryRequest: @unchecked Sendable {
+    private let lock = NSLock()
+    private var request: TelemetryMockURLProtocol?
+
+    func hold(_ request: TelemetryMockURLProtocol) {
+        lock.lock()
+        self.request = request
+        lock.unlock()
+    }
+
+    func respond() {
+        lock.lock()
+        let request = self.request
+        self.request = nil
+        lock.unlock()
+        request?.respond(statusCode: 200)
+    }
+}
+
 private final class TelemetryMockURLProtocol: URLProtocol {
     static let lock = NSLock()
     static var statusCode = 200
     static var payloads: [RecordedTelemetryPayload] = []
+    static var requestHandler: ((TelemetryMockURLProtocol) -> Void)?
 
     override class func canInit(with request: URLRequest) -> Bool {
         true
@@ -26,8 +73,6 @@ private final class TelemetryMockURLProtocol: URLProtocol {
     }
 
     override func startLoading() {
-        defer { client?.urlProtocolDidFinishLoading(self) }
-
         let body: Data?
         if let httpBody = request.httpBody {
             body = httpBody
@@ -58,16 +103,15 @@ private final class TelemetryMockURLProtocol: URLProtocol {
             let payload = try JSONDecoder().decode(RecordedTelemetryPayload.self, from: body)
             Self.lock.lock()
             Self.payloads.append(payload)
+            let handler = Self.requestHandler
+            let statusCode = Self.statusCode
             Self.lock.unlock()
 
-            let response = HTTPURLResponse(
-                url: request.url!,
-                statusCode: Self.statusCode,
-                httpVersion: nil,
-                headerFields: nil
-            )!
-            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-            client?.urlProtocol(self, didLoad: Data())
+            if let handler {
+                handler(self)
+            } else {
+                respond(statusCode: statusCode)
+            }
         } catch {
             client?.urlProtocol(self, didFailWithError: error)
         }
@@ -75,10 +119,26 @@ private final class TelemetryMockURLProtocol: URLProtocol {
 
     override func stopLoading() {}
 
+    func respond(statusCode: Int) {
+        let response = HTTPURLResponse(
+            url: request.url!, statusCode: statusCode, httpVersion: nil, headerFields: nil
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data())
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    static func setRequestHandler(_ handler: ((TelemetryMockURLProtocol) -> Void)?) {
+        lock.lock()
+        requestHandler = handler
+        lock.unlock()
+    }
+
     static func reset() {
         lock.lock()
         payloads = []
         statusCode = 200
+        requestHandler = nil
         lock.unlock()
     }
 
@@ -109,6 +169,11 @@ final class TelemetryServiceTests: XCTestCase {
 
     override func setUp() {
         TelemetryMockURLProtocol.reset()
+        Telemetry.configure(NoOpTelemetryService())
+    }
+
+    override func tearDown() {
+        TelemetryMockURLProtocol.setRequestHandler(nil)
         Telemetry.configure(NoOpTelemetryService())
     }
 
@@ -157,6 +222,120 @@ final class TelemetryServiceTests: XCTestCase {
         XCTAssertEqual(service.pendingEventCount, 0)
         let events = try await eventuallyRecordedEvents()
         XCTAssertEqual(events.map(\.event), [TelemetryEventName.telemetryOptedOut.rawValue])
+    }
+
+    func testDisabledConsentDropsEventsQueuedBeforeFlush() async {
+        let consent = TelemetryConsent()
+        let service = makeService(isEnabled: consent.isEnabled)
+        service.send(.appLaunched)
+        consent.setEnabled(false)
+
+        await service.flush()
+
+        XCTAssertEqual(service.pendingEventCount, 0)
+        XCTAssertTrue(TelemetryMockURLProtocol.recordedPayloads().isEmpty)
+    }
+
+    func testClearQueueDuringFailedRequestDoesNotResurrectEventsAfterReenable() async {
+        let consent = TelemetryConsent()
+        let service = makeService(isEnabled: consent.isEnabled)
+        TelemetryMockURLProtocol.setRequestHandler { request in
+            consent.setEnabled(false)
+            service.clearQueue()
+            consent.setEnabled(true)
+            request.respond(statusCode: 500)
+        }
+
+        let handled = await service.sendAndFlush(.appLaunched)
+
+        XCTAssertTrue(handled, "An event discarded by opt-out is intentionally handled")
+        XCTAssertEqual(service.pendingEventCount, 0)
+        await service.flush()
+        XCTAssertEqual(TelemetryMockURLProtocol.recordedPayloads().count, 1)
+    }
+
+    func testOptOutDuringFailedRequestAllowsOnlyFinalOptOutEvent() async {
+        let consent = TelemetryConsent()
+        let service = makeService(isEnabled: consent.isEnabled)
+        TelemetryMockURLProtocol.setRequestHandler { request in
+            consent.setEnabled(false)
+            service.clearQueue()
+            TelemetryMockURLProtocol.setRequestHandler(nil)
+            service.send(.telemetryOptedOut)
+            request.respond(statusCode: 500)
+        }
+
+        _ = await service.sendAndFlush(.appLaunched)
+        await service.flush()
+
+        XCTAssertEqual(service.pendingEventCount, 0)
+        XCTAssertEqual(
+            TelemetryMockURLProtocol.recordedPayloads().flatMap(\.events).map(\.event),
+            [TelemetryEventName.appLaunched.rawValue, TelemetryEventName.telemetryOptedOut.rawValue]
+        )
+    }
+
+    func testClearQueueInvalidatesSendAndFlushWaitingForAnotherRequest() async {
+        let consent = TelemetryConsent()
+        let service = makeService(isEnabled: consent.isEnabled)
+        let heldRequest = HeldTelemetryRequest()
+        let started = expectation(description: "First request is in flight")
+        TelemetryMockURLProtocol.setRequestHandler { request in
+            heldRequest.hold(request)
+            started.fulfill()
+        }
+        service.send(.appLaunched)
+        let firstFlush = Task { await service.flush() }
+        await fulfillment(of: [started], timeout: 2)
+
+        let waiting = expectation(description: "Second event checked consent before waiting")
+        consent.observeReads { waiting.fulfill() }
+        let secondFlush = Task { await service.sendAndFlush(.dictationStarted(trigger: .hotkey, mode: .hold)) }
+        await fulfillment(of: [waiting], timeout: 2)
+        consent.observeReads(nil)
+        consent.setEnabled(false)
+        service.clearQueue()
+        consent.setEnabled(true)
+        TelemetryMockURLProtocol.setRequestHandler(nil)
+        heldRequest.respond()
+
+        await firstFlush.value
+        let handled = await secondFlush.value
+        XCTAssertTrue(handled)
+        XCTAssertEqual(service.pendingEventCount, 0)
+        XCTAssertEqual(TelemetryMockURLProtocol.recordedPayloads().flatMap(\.events).map(\.event), ["app_launched"])
+    }
+
+    func testClearQueueDuringBatchSkipsRequestsThatHaveNotStarted() async {
+        let consent = TelemetryConsent()
+        let service = makeService(isEnabled: consent.isEnabled)
+        let heldRequest = HeldTelemetryRequest()
+        let started = expectation(description: "First request is in flight")
+        TelemetryMockURLProtocol.setRequestHandler { request in
+            heldRequest.hold(request)
+            started.fulfill()
+        }
+        service.send(.appLaunched)
+        let firstFlush = Task { await service.flush() }
+        await fulfillment(of: [started], timeout: 2)
+
+        // Holding the first request keeps auto-flushes behind the flush gate,
+        // so the next snapshot deterministically contains two batches.
+        for _ in 0..<150 {
+            service.send(.dictationStarted(trigger: .hotkey, mode: .hold))
+        }
+        TelemetryMockURLProtocol.setRequestHandler { request in
+            consent.setEnabled(false)
+            service.clearQueue()
+            consent.setEnabled(true)
+            request.respond(statusCode: 200)
+        }
+        heldRequest.respond()
+        await firstFlush.value
+        await service.flush()
+
+        XCTAssertEqual(TelemetryMockURLProtocol.recordedPayloads().map { $0.events.count }, [1, 100])
+        XCTAssertEqual(service.pendingEventCount, 0)
     }
 
     // MARK: - Queue Limits
@@ -353,12 +532,12 @@ final class TelemetryServiceTests: XCTestCase {
         XCTAssertTrue(json["props"] is NSNull || json["props"] == nil)
     }
 
-    func testErrorOccurredDescriptionIsSanitizedAndTruncated() throws {
+    func testErrorOccurredOmitsFreeFormDescription() throws {
         let event = TelemetryEvent(
             spec: .errorOccurred(
                 domain: "Test",
                 code: "42",
-                description: "Failed /Users/alice/secret.wav via https://example.com/token?\(String(repeating: "x", count: 600))"
+                description: "Failed /Users/alice/secret.wav\nvia https://example.com/token?\(String(repeating: "x", count: 600))"
             ),
             appVer: "0.4.2",
             osVer: "15.3",
@@ -372,19 +551,13 @@ final class TelemetryServiceTests: XCTestCase {
         let data = try encoder.encode(event)
         let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
         let props = try XCTUnwrap(json["props"] as? [String: String])
-        let description = try XCTUnwrap(props["description"])
-
         XCTAssertEqual(props["domain"], "Test")
         XCTAssertEqual(props["code"], "42")
-        XCTAssertFalse(description.contains("/Users/alice"))
-        XCTAssertFalse(description.contains("example.com"))
-        XCTAssertTrue(description.contains("<path>"))
-        XCTAssertTrue(description.contains("<url>"))
-        XCTAssertLessThanOrEqual(description.count, 512)
+        XCTAssertNil(props["description"])
     }
 
-    func testErrorDetailPropsAreSanitizedAtSerializationBoundary() throws {
-        let rawDetail = "Failed /Users/alice/private-meeting-playback.m4a via https://example.com/token?secret=abc"
+    func testErrorDetailPropsAreOmittedAtSerializationBoundary() throws {
+        let rawDetail = "private spoken content without a path, provider credential, or other recognizable pattern"
         let specs: [TelemetryEventSpec] = [
             .dictationFailed(errorType: "runtime", errorDetail: rawDetail),
             .transcriptionFailed(source: .file, stage: .stt, errorType: "runtime", errorDetail: rawDetail),
@@ -422,15 +595,30 @@ final class TelemetryServiceTests: XCTestCase {
             let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
             let props = try XCTUnwrap(json["props"] as? [String: String])
             let eventName = spec.name.rawValue
-            let detail = try XCTUnwrap(props["error_detail"], "Missing error_detail for \(eventName)")
-
-            XCTAssertFalse(detail.contains("/Users/alice"), eventName)
-            XCTAssertFalse(detail.contains("private-meeting"), eventName)
-            XCTAssertFalse(detail.contains("example.com"), eventName)
-            XCTAssertTrue(detail.contains("<path>"), eventName)
-            XCTAssertTrue(detail.contains("<url>"), eventName)
-            XCTAssertLessThanOrEqual(detail.count, 512, eventName)
+            XCTAssertNil(props["error_detail"], eventName)
+            XCTAssertNotNil(props["error_type"], eventName)
+            XCTAssertFalse(String(decoding: data, as: UTF8.self).contains(rawDetail), eventName)
         }
+    }
+
+    func testCrashOmitsFreeFormReasonButKeepsSymbolicationFields() throws {
+        let event = TelemetryEvent(
+            spec: .crashOccurred(
+                crashType: "exception", signal: "exception", name: "NSInternalInconsistencyException",
+                crashTimestamp: "1711900000", crashAppVer: "0.7.3", crashOsVer: "15.3",
+                uuid: "IMAGE-UUID", slide: "0x100000", reason: "private spoken content",
+                stackTrace: "0x1234\n0x5678"
+            ),
+            appVer: "0.7.3", osVer: "15.3", locale: nil, chip: "Apple M1", session: "test"
+        )
+        let data = try JSONEncoder().encode(event)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let props = try XCTUnwrap(json["props"] as? [String: String])
+        XCTAssertNil(props["reason"])
+        XCTAssertEqual(props["name"], "NSInternalInconsistencyException")
+        XCTAssertEqual(props["uuid"], "IMAGE-UUID")
+        XCTAssertEqual(props["slide"], "0x100000")
+        XCTAssertEqual(props["stack_trace"], "0x1234\n0x5678")
     }
 
     func testTranscriptionCompletedSerializesDiarizationContext() throws {

--- a/Tests/MacParakeetTests/TelemetryServiceTests.swift
+++ b/Tests/MacParakeetTests/TelemetryServiceTests.swift
@@ -236,6 +236,47 @@ final class TelemetryServiceTests: XCTestCase {
         XCTAssertTrue(TelemetryMockURLProtocol.recordedPayloads().isEmpty)
     }
 
+    func testClearQueueAfterEncodingPreventsRequestAdmission() async {
+        let consent = TelemetryConsent()
+        let service = makeService(isEnabled: consent.isEnabled)
+        service.beforeRequestAdmission = { [weak service] in
+            consent.setEnabled(false)
+            service?.clearQueue()
+            consent.setEnabled(true)
+        }
+
+        let handled = await service.sendAndFlush(.appLaunched)
+
+        XCTAssertTrue(handled)
+        XCTAssertEqual(service.pendingEventCount, 0)
+        XCTAssertTrue(TelemetryMockURLProtocol.recordedPayloads().isEmpty)
+    }
+
+    func testDisabledConsentAfterEncodingPreventsRequestAdmission() async {
+        let consent = TelemetryConsent()
+        let service = makeService(isEnabled: consent.isEnabled)
+        service.beforeRequestAdmission = { consent.setEnabled(false) }
+
+        let handled = await service.sendAndFlush(.appLaunched)
+
+        XCTAssertTrue(handled)
+        XCTAssertTrue(TelemetryMockURLProtocol.recordedPayloads().isEmpty)
+    }
+
+    func testCancellationCompletesAnAdmittedRequest() async {
+        let service = makeService()
+        let started = expectation(description: "Request admitted before cancellation")
+        TelemetryMockURLProtocol.setRequestHandler { _ in started.fulfill() }
+        let flush = Task { await service.sendAndFlush(.appLaunched) }
+        await fulfillment(of: [started], timeout: 2)
+
+        flush.cancel()
+        let handled = await flush.value
+
+        XCTAssertFalse(handled)
+        XCTAssertEqual(service.pendingEventCount, 1)
+    }
+
     func testClearQueueDuringFailedRequestDoesNotResurrectEventsAfterReenable() async {
         let consent = TelemetryConsent()
         let service = makeService(isEnabled: consent.isEnabled)

--- a/docs/audits/2026-09-06-observability-review.md
+++ b/docs/audits/2026-09-06-observability-review.md
@@ -1,0 +1,123 @@
+# Telemetry and local audio observability review
+
+Reviewed [Logging Sucks](https://loggingsucks.com/), the live
+[stats page](https://macparakeet.com/stats/) and its JSON endpoint, the Swift
+telemetry producer and outcome call sites, local audio diagnostics, and the
+website ingestion, aggregation, rollup and deterministic agent-review code.
+
+App baseline: `1159dfca8ae53a15ffcc1562b1efb9220f95cd88`.
+Website baseline: `80be9eb` in the separate `macparakeet-website` repository.
+Both changes use isolated worktrees; existing working-copy edits were preserved.
+
+## Assessment
+
+The operation-wide-event model already fits MacParakeet. An operation outcome,
+safe dimensions and short-lived correlation let agents answer useful questions
+without collecting speech content. The article's recommendation to enrich
+outcomes is useful; its user-identifying examples do not fit this product's
+privacy contract. More generic log volume or a new observability vendor would
+not solve the defects found here.
+
+| Observed defect | Change |
+| --- | --- |
+| Live API returned a snapshot generated at `2026-09-06T02:50:10.416Z` when fetched at `07:26:36Z`, with `X-Stats-Cache: stale`, despite live/five-minute page copy | Explicit JSON and visible freshness, expiry-bounded caching, uncached stale/error responses; distinguish 15-minute snapshots from five-minute polling |
+| Public failure details contained a residual filename/path after whitespace stopped the sanitizer | Omit free-form network errors; drop them at ingestion for old clients; filter cached public snapshots and coarsen unknown public error categories |
+| Failed in-flight telemetry could restore a queue cleared during opt-out; queued batches could send later | Consent generation invalidates retries and waiting batches; already-dispatched requests may complete |
+| Cancellation inflated dictation failures; successful CLI thrown exits carried runtime error categories | Preserve cancellation as a separate terminal outcome and remove errors from successful CLI exits |
+| A late confirmation through the public dictation service could emit cancellation after success for the same operation | Admit at most one terminal outcome for the current operation; reset the guard for a new operation without changing capture/UI timing |
+| Private reviewer used stage-specific or missing denominators, and missed runtime/VAD/export diagnostics | Whole-operation denominators with action/command separation, explicit unknown evidence and separate diagnostic-signal counts |
+| Overall and meeting durations weighted incomplete averages by all operation/success counts | Expose and use measured duration sample counts; older snapshots produce unknown aggregate duration |
+| Activity panels divided unrelated time-window starts/completions; dual capture was inferred from separate track totals | Show breadcrumb counts without cohort claims; count both tracks on the same successful meeting outcome, using known track statuses as the denominator and showing measurement coverage |
+| Local async log timestamps represented write time; append failures could overwrite history; retention could discard complete lines; app/CLI writers could race during rotation | Capture occurrence clocks before enqueue, add local process correlation, preserve history on failure and retain whole lines; coordinate participating writers through a stable advisory lock |
+| Agents had no bounded structured query path for the audio log | Offline JSON query utility with filters and explicit missing, incomplete, changed-during-read and unparseable evidence |
+| Malformed ingestion objects/types could reach D1 binding or throw before the error handler | Validate record shapes, bounded envelope strings and UTC timestamps before binding |
+
+The website also emits a structured stats-request outcome with duration,
+cache state, historical source and available aggregate query metadata, and no
+longer scans events for the retired formatter panel.
+
+## Essential signals and how to query them
+
+| Question | Evidence and limits |
+| --- | --- |
+| Did an operation succeed, fail, cancel, return empty or become unavailable? | Canonical `*_operation` outcomes; delivered terminal events are the denominator, not a census of all attempts |
+| Which engine/version/stage is implicated? | Release/surface, engine/variant, operation stage and classified error type; preserve recognized CoreAudio numeric status and the fixed interrupted-subscribe category |
+| Did capture receive or retain audio? | Local first-buffer, timeout, frame/sample/signal, stop-summary and meeting source-health events; these do not establish semantic transcription quality |
+| Did recovery happen? | Local configuration-change recovery attempt/outcome and microphone/system-stream diagnostics; detections alone are not terminal operation failures |
+| Is the dashboard current? | Read `freshness` and expiry; a successful read does not prove ingestion health |
+| Is there enough evidence for an agent verdict? | Review input age/population, denominators and diagnostic query scan metadata; missing data means unknown |
+
+See the [telemetry contract](../../spec/contracts/telemetry-v1.md),
+[offline query guide](../local-audio-diagnostics-query.md), and the separate
+website repository's `docs/telemetry-api.md` and `docs/telemetry-reviewer.md`.
+
+Read-only local verification scanned the existing 1,992,759-byte audio log:
+13,847 complete lines, 13,840 parsed records, seven unparseable lines, no byte
+truncation and no observed modification during the read. The latest timestamp
+was `2026-09-05T06:52:14.460Z`. Only aggregate counts and timestamps were
+reported; no audio or transcripts were opened. This is historical diagnostic
+evidence, not a new microphone/hardware exercise.
+
+## Boundaries and follow-ups
+
+- This app change does not deploy the companion website or release a new app
+  version. The website fixes need their own reviewed deployment. No production
+  telemetry write canary or historical row deletion was performed.
+- The live refresh failure's underlying D1/Worker cause remains unconfirmed:
+  the original D1 request returned authentication error `10000`, but subsequent
+  device authorization succeeded. Authenticated database metadata and schema
+  queries now pass; the database is approximately 2.2 GB and the event, snapshot
+  and rollup tables exist. This does not establish snapshot-refresh health or
+  the reason for the earlier stale result.
+- Every current Swift event name was accepted by the checked-in Worker name
+  allowlist. A persistent cross-repository name/schema gate and complete
+  per-event property/value schemas remain follow-ups; generic length/shape
+  validation is not a complete privacy boundary for arbitrary future clients.
+- Telemetry remains best effort. Queue caps, opt-out, offline sessions and process
+  death limit completeness. No all-attempt availability claim or user-level
+  cohort inference is justified from these counts.
+- Per-process local correlation is available on newly written records; a capture
+  operation ID is not yet present on every low-level audio event. Legacy records
+  remain readable and must be interpreted with their weaker correlation.
+
+## Verification
+
+- Final combined Swift focused checks passed: 224 XCTest cases and 21 Swift
+  Testing cases. These cover telemetry consent/retry behavior, event privacy,
+  error classification, CLI outcomes, dictation terminal outcomes, diagnostic
+  writing/rotation and scope, plus all 35 `AudioRecorderFormatChangeTests`.
+- The single full `swift test --disable-automatic-resolution -j 1` run executed
+  5,243 XCTest cases with 20 skips and two failure reports from one case:
+  `AudioRecorderFormatChangeTests.testDiscardPreRollMakesMediaOnlyCaptureInsufficient`.
+  Its mock-engine readiness poll reached its two-second deadline, then the test
+  cancelled capture. All 25 Swift Testing cases passed. The entire failing test
+  family passed in the subsequent focused run; the failure's cause remains
+  unconfirmed. This is not a clean full-suite result. The terminal guard and
+  bridged-code naming received their focused verification after that full run.
+- Offline diagnostic-query tests passed: 11 synthetic-file tests. The read-only
+  historical log inspection is described above.
+- Independent agent reviews covered client privacy/consent/outcomes, local
+  writer concurrency/data preservation/query semantics, and website evidence
+  calculations. Valid findings were addressed; production publication gates
+  and external review bots were not invoked.
+- Website checks passed: 52 tests with zero skips, including real TypeScript
+  route handlers and all 53 stats statements against synthetic in-memory SQLite
+  data. The fixtures cover incomplete duration/track measurements, disjoint
+  audio tracks, stale/error caching, malformed ingestion and cached privacy.
+  `pnpm build` produced 86 pages successfully.
+- `git diff --check` passed in both worktrees. Informational Swift formatting
+  checks addressed new diagnostics; inherited repository warnings remain.
+- The final classifier-only check passed all 23 tests after restricting native
+  NSError domain transmission to six recognized system domains. Identifier-like
+  custom/private domains now fall back to `NSError.<code>`.
+- After Cloudflare authentication, the updated reviewer completed against live
+  D1 with `--no-write`. Latest stable v0.7.4 had no thresholded alerts among
+  observed events. All-version watch signals concerned v0.7.3 GUI engine-busy
+  switches (three), microphone-stall detections (28), and unhealthy-runtime
+  detections (17). This is operational evidence, not complete event-delivery
+  coverage or deployed website verification.
+
+No physical microphone, browser visual comparison or deployed Worker behavior
+was exercised. The machine also showed substantial process pressure during
+setup, including process-start failures; this does not establish the cause of
+the Swift test timeout.

--- a/docs/audits/2026-09-06-observability-review.md
+++ b/docs/audits/2026-09-06-observability-review.md
@@ -82,8 +82,9 @@ evidence, not a new microphone/hardware exercise.
 
 ## Verification
 
-- Final combined Swift focused checks passed: 224 XCTest cases and 21 Swift
-  Testing cases. These cover telemetry consent/retry behavior, event privacy,
+- Final combined Swift focused checks passed: 224 XCTest cases and a focused
+  subset of 21 Swift Testing cases (the full suite below ran 25). These cover
+  telemetry consent/retry behavior, event privacy,
   error classification, CLI outcomes, dictation terminal outcomes, diagnostic
   writing/rotation and scope, plus all 35 `AudioRecorderFormatChangeTests`.
 - The single full `swift test --disable-automatic-resolution -j 1` run executed
@@ -96,6 +97,12 @@ evidence, not a new microphone/hardware exercise.
   bridged-code naming received their focused verification after that full run.
 - Offline diagnostic-query tests passed: 11 synthetic-file tests. The read-only
   historical log inspection is described above.
+- PR #962 feedback verification: 149 focused XCTest cases passed across
+  telemetry, dictation, and audio diagnostics; the final classifier-only run
+  passed all 25 Swift Testing cases. The query suite passed 14 synthetic-file
+  tests, including first-byte alignment, atomic replacement, and disappearance.
+  These follow-up runs cover atomic request admission, cancellation, deferred
+  writes with original clocks, deterministic success dwell, and quoted secrets.
 - Independent agent reviews covered client privacy/consent/outcomes, local
   writer concurrency/data preservation/query semantics, and website evidence
   calculations. Valid findings were addressed; production publication gates

--- a/docs/local-audio-diagnostics-query.md
+++ b/docs/local-audio-diagnostics-query.md
@@ -21,8 +21,9 @@ Quoted values such as `reason="no usable buffers"` remain one field. Historical
 lines without process fields remain valid. Raw lines and unstructured text are
 omitted; this is a local inspection tool, not a privacy scrubber for attachments.
 
-The scan reads at most 5,000,000 bytes from the newest part of the file. When a
-file is larger, one byte in that budget establishes the first record's boundary.
+The scan reads at most 5,000,000 tail bytes, plus one look-behind byte when the
+file is larger. `scan.bytes_read` counts tail bytes and
+`scan.boundary_probe_bytes` counts the separate boundary probe (zero or one).
 Partial first/last lines and malformed UTF-8 or quoted fields are counted in
 `scan` and omitted. `scan.changed_during_read` reports a detected concurrent
 file change; retry the query if a stable copy is needed. Rotation can already
@@ -74,6 +75,10 @@ App and CLI writers coordinate file creation, append and rotation through the
 stable sibling `dictation-audio.log.lock`; preserve this file. The advisory lock
 coordinates participating writers, including separate processes. It does not
 lock readers or coordinate with older app versions that do not acquire it.
+Contended main-thread writes are deferred to the existing utility queue with
+their original timestamps and fields; OSLog reports
+`audio_diagnostic_write_deferred`. A query before that queue drains can miss
+those pending records, and process exit can prevent their best-effort write.
 
 Run the deterministic synthetic-file tests with:
 

--- a/docs/local-audio-diagnostics-query.md
+++ b/docs/local-audio-diagnostics-query.md
@@ -75,8 +75,8 @@ App and CLI writers coordinate file creation, append and rotation through the
 stable sibling `dictation-audio.log.lock`; preserve this file. The advisory lock
 coordinates participating writers, including separate processes. It does not
 lock readers or coordinate with older app versions that do not acquire it.
-Contended main-thread writes are deferred to the existing utility queue with
-their original timestamps and fields; OSLog reports
+Main-thread writes that encounter contention or require log rotation are
+deferred to the existing utility queue with their original timestamps and fields; OSLog reports
 `audio_diagnostic_write_deferred`. A query before that queue drains can miss
 those pending records, and process exit can prevent their best-effort write.
 

--- a/docs/local-audio-diagnostics-query.md
+++ b/docs/local-audio-diagnostics-query.md
@@ -1,0 +1,82 @@
+# Query local audio diagnostics
+
+Run the offline maintenance utility from the MacParakeet checkout:
+
+```sh
+python3 scripts/dev/query_audio_diagnostics.py --since 2026-09-06T00:00:00Z --limit 100
+python3 scripts/dev/query_audio_diagnostics.py --event dictation_capture_stop --event dictation_capture_unavailable
+python3 scripts/dev/query_audio_diagnostics.py --path /tmp/copied-audio.log --process-session PROCESS_SESSION_FROM_A_RECORD
+```
+
+It reads `~/Library/Logs/MacParakeet/dictation-audio.log`, performs no network
+requests, and never modifies the source. `--path` overrides
+`MACPARAKEET_AUDIO_DIAGNOSTICS_LOG_PATH`, which overrides the usual location.
+When `MACPARAKEET_DEBUG_APP_STATE_DIR` is set for a debug app, the default is
+`<debug-root>/logs/dictation-audio.log`. Explicit paths are useful for copied
+support attachments. The utility does not open audio, transcripts, or databases.
+
+JSON output has `schema_version: 1`. `records` contains timestamp, event, and
+parsed `fields`; field values stay strings, including booleans and numbers.
+Quoted values such as `reason="no usable buffers"` remain one field. Historical
+lines without process fields remain valid. Raw lines and unstructured text are
+omitted; this is a local inspection tool, not a privacy scrubber for attachments.
+
+The scan reads at most 5,000,000 bytes from the newest part of the file. When a
+file is larger, one byte in that budget establishes the first record's boundary.
+Partial first/last lines and malformed UTF-8 or quoted fields are counted in
+`scan` and omitted. `scan.changed_during_read` reports a detected concurrent
+file change; retry the query if a stable copy is needed. Rotation can already
+have removed older evidence, even when `scan.truncated` is false.
+
+`--since` is inclusive and requires an explicit timezone. Repeated `--event`
+values are alternatives, combined with the other filters. `records` returns
+the newest timestamps first, with physical file order breaking timestamp ties;
+the return limit is 1–1,000. The scan checks every complete line because async
+appends and clock changes can make timestamps differ from file order.
+`event_counts` and `matched_records` cover **all matching records in the scanned
+tail**, before the return limit; they are not lifetime totals.
+
+Always inspect `status` and the scan counters before drawing conclusions:
+
+- `available`: matching records were read; this says nothing about capture health.
+- `missing`, `empty`, or `unparseable`: no usable evidence was available.
+- `no_matches`: parsed records exist, but the requested filters matched none.
+- `unreadable`: the source could not be opened as a regular file; `scan.error_code`
+  is the OS error number. The command exits 1 for this status and 0 for the other
+  completed queries; invalid arguments exit 2.
+
+New records carry `process_id`, a random per-launch `process_session`, and
+monotonic `uptime_ns`. Filter by `process_session` to separate app/CLI launches.
+Use `uptime_ns` within a process to reason about wall-clock corrections or
+delayed writes. This local ID is distinct from the network telemetry session
+UUID. It is not a user ID or a capture-operation ID.
+
+For a dictation incident, inspect `dictation_capture_start`,
+`dictation_capture_first_buffer`, `dictation_capture_stop`, and terminal
+`dictation_capture_unavailable` / `dictation_capture_insufficient` events.
+The stop record carries input/output buffer counts, input frames, effective
+sample count, audio/wall durations, max RMS/level, non-silent buffers, invalid
+formats, and the first-buffer timeout bit. Shared-mic recovery events explain
+callback stalls, exact-zero input, route-change retries, and terminal recovery
+exhaustion. Meeting mic and system-audio first-buffer/stall events distinguish
+the two sources. Combine these observations; a missing stop record is unknown,
+and low signal alone is not proof that an engine stopped.
+
+The log retains only about 5 MB and best-effort writes can fail. New file sink
+failures are reported through OSLog's `AudioCaptureDiagnostics` category as
+`audio_diagnostic_write_failed`. Shareable file error fields contain classified
+type and `bridged_error_code`; separately privacy-marked OSLog details may provide more
+context locally. Legacy file contents retain their original privacy limitations.
+The bridged code can be a Swift enum ordinal, not the underlying audio status.
+For recognized CoreAudio wrappers, `error_type` retains the native domain/status.
+
+App and CLI writers coordinate file creation, append and rotation through the
+stable sibling `dictation-audio.log.lock`; preserve this file. The advisory lock
+coordinates participating writers, including separate processes. It does not
+lock readers or coordinate with older app versions that do not acquire it.
+
+Run the deterministic synthetic-file tests with:
+
+```sh
+PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s scripts/dev/tests -p 'test_query_audio_diagnostics.py'
+```

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -308,7 +308,7 @@ events remain useful for diarization-specific timing and failure analysis.
 |---|---|---|
 | `diarization_started` | — | How often is diarization used? |
 | `diarization_completed` | `duration_seconds`, `speaker_count` | How long does it take? How many speakers? |
-| `diarization_failed` | `error_type`, `error_detail` | What breaks in diarization? |
+| `diarization_failed` | `error_type` | What breaks in diarization? |
 
 ### 4. Feature Adoption — "What features matter?"
 
@@ -364,7 +364,7 @@ prompt-customization trend.
 | `meeting_recovery_started` | `count`, `source`, `phases` | How often users choose to recover, by interrupted lock phase |
 | `meeting_recovery_completed` | `count`, `duration_seconds`, `source`, `phases` | Recovery success rate and latency by interrupted lock phase |
 | `meeting_recovery_discarded` | `count`, `source`, `phases` | How often users intentionally discard interrupted recordings, by interrupted lock phase |
-| `meeting_recovery_failed` | `count`, `source`, `phases`, `error_type`, `error_detail` | What blocks recovery in the field, by interrupted lock phase |
+| `meeting_recovery_failed` | `count`, `source`, `phases`, `error_type` | What blocks recovery in the field, by interrupted lock phase |
 
 ### 4c. Meeting Recording — "Is meeting capture healthy?"
 
@@ -482,8 +482,8 @@ Accessibility note: macOS does not provide a direct denial callback for Accessib
 
 | Event | Props | Question It Answers |
 |---|---|---|
-| `error_occurred` | `domain`, `code`, `description` | What errors are users hitting? |
-| `crash_occurred` | `crash_type`, `signal`, `reason`, `stack_trace`, `crash_app_ver`, `crash_os_ver` | What crashes are happening? |
+| `error_occurred` | `domain`, `code` | What errors are users hitting? |
+| `crash_occurred` | `crash_type`, `signal`, `stack_trace`, `crash_app_ver`, `crash_os_ver` | What crashes are happening? |
 
 ### 10. CLI — "Are agents and scripts succeeding?"
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -30,6 +30,12 @@
 
 ## Philosophy
 
+The September 2026 observability changes and verification boundaries are recorded
+in [the audit](audits/2026-09-06-observability-review.md). The
+[telemetry contract](../spec/contracts/telemetry-v1.md) governs privacy and outcome
+semantics; the [local diagnostic query guide](local-audio-diagnostics-query.md)
+provides an offline JSON inspection path for agents.
+
 **Goal:** Understand how the app is used so we can make it better. Not to track users.
 
 **Principles:**
@@ -135,12 +141,14 @@ deriving it from the event name when older clients do not send the field.
 - Raw provider error bodies or free-form user content in error fields
 - Any data that could identify the user
 
-Error details that are sent are sanitized at the Swift event-serialization
-boundary: local file paths, `file://` URLs, and `http(s)` URLs are replaced and
-values are truncated. LLM call sites intentionally omit error detail because
-provider errors can echo transcript or prompt content. The ingestion Worker
-validates event names, top-level fields, batch size, and prop length; it should
-not be treated as the primary privacy scrubber for app-originated strings.
+The typed Swift serialization boundary omits free-form `error_detail`,
+`error_occurred.description`, and crash `reason` entirely. Exceptions and
+subprocess errors can echo transcript text or filenames, so regex redaction is
+insufficient. Error categories, safe domain/numeric codes and crash symbolication
+fields remain. The paired website change drops the same text fields from older
+clients before D1 insertion and removes historical error details from public
+snapshots. These changes require an app release and website deployment to affect
+production; historical private D1 rows are not rewritten by this change.
 
 ---
 
@@ -514,12 +522,10 @@ They should not be mixed into GUI app sessions, app version adoption,
 crash-free rates, or GUI operation failure lists because each CLI invocation is
 a one-shot process with a fresh session ID.
 
-> **Important:** `error_occurred` includes a bounded `description` field, but
-> callers should treat it as an allowlisted diagnostic string, not a place for
-> arbitrary provider or user-content error bodies. `TelemetryEventSpec.props`
-> sanitizes paths and URLs at serialization time and truncates descriptions to
-> 512 chars. The Worker is an ingestion validator, not the primary redaction
-> boundary.
+`error_occurred` serializes `domain` and `code`. Source-compatible factory
+arguments for descriptions remain available to callers but are not transmitted.
+The same omission applies to legacy `error_detail` factory arguments across the
+catalog below; no raw exception or provider description is a telemetry field.
 
 ---
 
@@ -795,7 +801,7 @@ External AI review of the telemetry design. Each point was evaluated and accepte
 
 | # | Feedback | Action Taken |
 |---|---|---|
-| 1 | `error_occurred.description` is a privacy leak — free-form text could contain file paths, user content | **Partially accepted.** Kept a bounded `description`, but the current implemented guardrail is Swift-side serialization sanitization for paths/URLs plus truncation. Worker-side PII redaction remains a defense-in-depth follow-up. |
+| 1 | `error_occurred.description` is a privacy leak — free-form text could contain file paths, user content | **Accepted.** The September 2026 change omits descriptions and free-form error details at both the typed client boundary and the paired Worker ingestion boundary. Historical public snapshots are scrubbed before response. |
 | 2 | No dedupe/idempotency key — retries cause double-counting | Added `event_id TEXT NOT NULL UNIQUE` (client-generated UUID) to schema. |
 | 3 | "Anonymous by architecture" is too strong — session + chip + locale + country + timestamps could theoretically single out users | Reworded to "non-identifying, session-scoped telemetry" throughout. |
 | 4 | Missing `permission_prompted` / `permission_granted` — can't compute denial rate without denominator | Added both events to new "Permissions" category. |
@@ -832,10 +838,10 @@ External AI review of the telemetry design. Each point was evaluated and accepte
 
 ## Future Considerations
 
-- **Server-side defense-in-depth redaction** — Add Worker-side scrubbing for
-  paths, URLs, API-key-looking strings, and emails before D1 insert. The app
-  already sanitizes current emitted details, but the Worker should not rely on
-  every future client doing the right thing.
+- **Per-event server property schemas** — The paired Worker now drops known
+  free-form error fields and validates envelope types/lengths. A complete
+  per-event property/value allowlist remains a separate boundary improvement;
+  do not assume generic string-length validation proves privacy.
 - **Expanded local diagnostic export** — The in-app feedback form can now
   attach `~/Library/Logs/MacParakeet/dictation-audio.log` by explicit opt-in.
   A fuller user-triggered bundle should add recent `os.Logger` entries for

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -694,7 +694,9 @@ OpenClaw, Hermes, or another local agent framework.
   `BUILDKITE`, `CIRCLECI`, `TRAVIS`, `JENKINS_URL`, `TF_BUILD`,
   `TEAMCITY_VERSION` — any one set to a truthy value). Override CI auto-
   disable with `MACPARAKEET_TELEMETRY=1`. See `docs/telemetry.md` for the
-  full event catalog and the Worker-side PII redaction policy.
+  full event catalog and the structured-error privacy contract. For read-only
+  local audio-log JSON queries from a source checkout, see
+  [the diagnostic query guide](../docs/local-audio-diagnostics-query.md).
 - **Concurrency:** the STT scheduler reserves one slot for dictation and shares
   a second slot for meeting/batch work **within a process** (ADR-016).
   Multi-file batches are sequential. Separate CLI processes do not share that

--- a/scripts/dev/query_audio_diagnostics.py
+++ b/scripts/dev/query_audio_diagnostics.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Read a bounded local audio diagnostic tail as JSON. Never uploads data."""
+
+import argparse
+from collections import Counter
+from datetime import datetime, timezone
+import errno
+import heapq
+import json
+import os
+from pathlib import Path
+import re
+import shlex
+import stat
+
+
+MAX_SCAN_BYTES = 5_000_000
+MAX_RETURNED_RECORDS = 1_000
+IDENTIFIER = re.compile(r"^[A-Za-z_][A-Za-z0-9_.-]*$")
+
+
+def default_log_path():
+    override = os.environ.get("MACPARAKEET_AUDIO_DIAGNOSTICS_LOG_PATH", "")
+    if override.strip():
+        return Path(override).expanduser()
+    debug_root = os.environ.get("MACPARAKEET_DEBUG_APP_STATE_DIR", "")
+    if debug_root.strip():
+        return Path(debug_root).expanduser() / "logs" / "dictation-audio.log"
+    return Path.home() / "Library" / "Logs" / "MacParakeet" / "dictation-audio.log"
+
+
+def parse_timestamp(value):
+    """Require a timezone; normalize explicit offsets to UTC."""
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        raise ValueError("timestamp must include Z or an explicit UTC offset")
+    return parsed.astimezone(timezone.utc)
+
+
+def parse_line(line):
+    tokens = shlex.split(line, comments=False, posix=True)
+    if len(tokens) < 2 or not IDENTIFIER.fullmatch(tokens[1]):
+        raise ValueError("missing timestamp or event")
+    timestamp = parse_timestamp(tokens[0])
+    fields = {}
+    unparsed_tokens = 0
+    duplicate_fields = 0
+    for token in tokens[2:]:
+        key, separator, value = token.partition("=")
+        if not separator or not IDENTIFIER.fullmatch(key):
+            unparsed_tokens += 1
+            continue
+        if key in fields:
+            duplicate_fields += 1
+        fields[key] = value
+    return timestamp, {
+        "timestamp": timestamp.isoformat(timespec="milliseconds").replace("+00:00", "Z"),
+        "event": tokens[1],
+        "fields": fields,
+    }, unparsed_tokens, duplicate_fields
+
+
+def query_log(path, *, since=None, events=(), process_session=None, limit=100,
+              max_scan_bytes=MAX_SCAN_BYTES):
+    if not 1 <= limit <= MAX_RETURNED_RECORDS:
+        raise ValueError(f"limit must be between 1 and {MAX_RETURNED_RECORDS}")
+    if not 2 <= max_scan_bytes <= MAX_SCAN_BYTES:
+        raise ValueError(f"scan budget must be between 2 and {MAX_SCAN_BYTES}")
+    if since is not None and since.tzinfo is None:
+        raise ValueError("since must include a timezone")
+
+    scan = {
+        "max_bytes": max_scan_bytes,
+        "file_size_bytes": None,
+        "bytes_read": 0,
+        "truncated": False,
+        "changed_during_read": False,
+        "discarded_partial_start_bytes": 0,
+        "discarded_partial_end_bytes": 0,
+        "incomplete_lines": 0,
+        "complete_lines": 0,
+        "parsed_records": 0,
+        "unparsed_lines": 0,
+        "unparsed_field_tokens": 0,
+        "duplicate_fields": 0,
+    }
+    result = {
+        "schema_version": 1,
+        "status": "available",
+        "scan": scan,
+        "matched_records": 0,
+        "returned_records": 0,
+        "limit": limit,
+        "event_counts": {},
+        "records": [],
+    }
+
+    try:
+        # O_NONBLOCK prevents an accidental FIFO path from hanging an agent.
+        # It has no effect on normal files. Inspect the open handle so a rename
+        # during log compaction cannot mix bytes from different files.
+        descriptor = os.open(path, os.O_RDONLY | os.O_NONBLOCK)
+        with os.fdopen(descriptor, "rb") as handle:
+            before = os.fstat(handle.fileno())
+            if not stat.S_ISREG(before.st_mode):
+                raise OSError(errno.EINVAL, "diagnostic input must be a regular file")
+            scan["file_size_bytes"] = before.st_size
+            # Reserve one byte inside the budget to determine whether the tail
+            # starts exactly at a line boundary. No read exceeds max_scan_bytes.
+            start = max(0, before.st_size - max_scan_bytes)
+            handle.seek(start)
+            data = handle.read(max_scan_bytes)
+            scan["bytes_read"] = len(data)
+            scan["truncated"] = start > 0
+            if start > 0 and data:
+                previous, data = data[:1], data[1:]
+                if previous != b"\n":
+                    first_newline = data.find(b"\n")
+                    discarded = len(data) if first_newline < 0 else first_newline + 1
+                    scan["discarded_partial_start_bytes"] = discarded + 1
+                    scan["incomplete_lines"] += 1
+                    data = data[discarded:]
+                else:
+                    scan["discarded_partial_start_bytes"] = 1
+            after = os.fstat(handle.fileno())
+            scan["changed_during_read"] = (
+                before.st_size != after.st_size or before.st_mtime_ns != after.st_mtime_ns
+                or scan["bytes_read"] != min(before.st_size, max_scan_bytes)
+            )
+    except FileNotFoundError:
+        result["status"] = "missing"
+        return result
+    except OSError as error:
+        result["status"] = "unreadable"
+        scan["error_code"] = error.errno
+        return result
+
+    if not scan["file_size_bytes"]:
+        result["status"] = "empty"
+        return result
+
+    if data and not data.endswith(b"\n"):
+        end = data.rfind(b"\n") + 1
+        scan["discarded_partial_end_bytes"] = len(data) - end
+        scan["incomplete_lines"] += 1
+        data = data[:end]
+
+    allowed_events = set(events)
+    counts = Counter()
+    newest = []
+    # Do not stop on an old timestamp: async appends and clock changes can put
+    # older events physically after newer events. Rank by timestamp, with file
+    # order breaking ties; uptime_ns remains available for clock-change analysis.
+    for position, encoded in enumerate(data.split(b"\n")[:-1]):
+        scan["complete_lines"] += 1
+        try:
+            timestamp, record, unparsed_tokens, duplicates = parse_line(encoded.decode("utf-8"))
+        except (UnicodeError, ValueError):
+            scan["unparsed_lines"] += 1
+            continue
+        scan["parsed_records"] += 1
+        scan["unparsed_field_tokens"] += unparsed_tokens
+        scan["duplicate_fields"] += duplicates
+        if since is not None and timestamp < since:
+            continue
+        if allowed_events and record["event"] not in allowed_events:
+            continue
+        if process_session is not None and record["fields"].get("process_session") != process_session:
+            continue
+        result["matched_records"] += 1
+        counts[record["event"]] += 1
+        candidate = (timestamp, position, record)
+        if len(newest) < limit:
+            heapq.heappush(newest, candidate)
+        else:
+            heapq.heappushpop(newest, candidate)
+
+    result["records"] = [item[2] for item in sorted(newest, reverse=True)]
+    result["returned_records"] = len(newest)
+    result["event_counts"] = dict(sorted(counts.items()))
+    if scan["parsed_records"] == 0:
+        result["status"] = "unparseable"
+    elif not result["matched_records"]:
+        result["status"] = "no_matches"
+    return result
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--path", type=Path, default=None, help="Diagnostic log path (defaults to the app log)")
+    parser.add_argument("--since", help="Inclusive ISO-8601 timestamp with timezone, e.g. 2026-09-06T00:00:00Z")
+    parser.add_argument("--event", action="append", default=[], help="Exact event name; repeat to include several")
+    parser.add_argument("--process-session", help="Exact per-launch process_session field")
+    parser.add_argument("--limit", type=int, default=100, help=f"Newest records to return, 1–{MAX_RETURNED_RECORDS}")
+    args = parser.parse_args(argv)
+    try:
+        since = parse_timestamp(args.since) if args.since else None
+        result = query_log(
+            args.path.expanduser() if args.path is not None else default_log_path(),
+            since=since, events=args.event, process_session=args.process_session, limit=args.limit,
+        )
+    except ValueError as error:
+        parser.error(str(error))
+    print(json.dumps(result, ensure_ascii=True, indent=2))
+    return 1 if result["status"] == "unreadable" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dev/query_audio_diagnostics.py
+++ b/scripts/dev/query_audio_diagnostics.py
@@ -73,6 +73,7 @@ def query_log(path, *, since=None, events=(), process_session=None, limit=100,
         "max_bytes": max_scan_bytes,
         "file_size_bytes": None,
         "bytes_read": 0,
+        "boundary_probe_bytes": 0,
         "truncated": False,
         "changed_during_read": False,
         "discarded_partial_start_bytes": 0,
@@ -105,28 +106,40 @@ def query_log(path, *, since=None, events=(), process_session=None, limit=100,
             if not stat.S_ISREG(before.st_mode):
                 raise OSError(errno.EINVAL, "diagnostic input must be a regular file")
             scan["file_size_bytes"] = before.st_size
-            # Reserve one byte inside the budget to determine whether the tail
-            # starts exactly at a line boundary. No read exceeds max_scan_bytes.
+            # The retained tail has its own byte budget. A separate one-byte
+            # look-behind preserves a full record aligned with its first byte.
             start = max(0, before.st_size - max_scan_bytes)
+            previous = b"\n"
+            if start > 0:
+                handle.seek(start - 1)
+                previous = handle.read(1)
+                scan["boundary_probe_bytes"] = len(previous)
             handle.seek(start)
             data = handle.read(max_scan_bytes)
             scan["bytes_read"] = len(data)
             scan["truncated"] = start > 0
             if start > 0 and data:
-                previous, data = data[:1], data[1:]
                 if previous != b"\n":
                     first_newline = data.find(b"\n")
                     discarded = len(data) if first_newline < 0 else first_newline + 1
-                    scan["discarded_partial_start_bytes"] = discarded + 1
-                    scan["incomplete_lines"] += 1
+                    scan["discarded_partial_start_bytes"] = discarded
+                    scan["incomplete_lines"] += int(not data.startswith(b"\n"))
                     data = data[discarded:]
-                else:
-                    scan["discarded_partial_start_bytes"] = 1
             after = os.fstat(handle.fileno())
             scan["changed_during_read"] = (
                 before.st_size != after.st_size or before.st_mtime_ns != after.st_mtime_ns
                 or scan["bytes_read"] != min(before.st_size, max_scan_bytes)
             )
+            try:
+                current = os.stat(path)
+                scan["changed_during_read"] |= (
+                    (current.st_dev, current.st_ino, current.st_size, current.st_mtime_ns)
+                    != (after.st_dev, after.st_ino, after.st_size, after.st_mtime_ns)
+                )
+            except OSError:
+                # An opened tail remains useful when its path disappears or
+                # becomes inaccessible, but cannot be presented as stable.
+                scan["changed_during_read"] = True
     except FileNotFoundError:
         result["status"] = "missing"
         return result

--- a/scripts/dev/tests/test_query_audio_diagnostics.py
+++ b/scripts/dev/tests/test_query_audio_diagnostics.py
@@ -1,0 +1,150 @@
+import importlib.util
+from contextlib import redirect_stdout
+import io
+import json
+import os
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+
+SPEC = importlib.util.spec_from_file_location(
+    "query_audio_diagnostics", Path(__file__).parents[1] / "query_audio_diagnostics.py"
+)
+diagnostics = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(diagnostics)
+
+
+class QueryAudioDiagnosticsTests(unittest.TestCase):
+    def setUp(self):
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        self.path = Path(temporary.name) / "dictation-audio.log"
+
+    def write(self, content):
+        self.path.write_bytes(content.encode("utf-8") if isinstance(content, str) else content)
+
+    def test_quoted_values_and_legacy_lines_remain_structured_strings(self):
+        self.write('2026-09-06T01:00:00.123Z capture_failed reason="no usable buffers" frames=001 enabled=false\n')
+
+        result = diagnostics.query_log(self.path)
+
+        self.assertEqual(result["status"], "available")
+        self.assertEqual(result["records"][0]["fields"], {
+            "reason": "no usable buffers", "frames": "001", "enabled": "false",
+        })
+        self.assertNotIn("raw", result["records"][0])
+
+    def test_timestamp_order_filters_entire_tail_and_counts_before_limit(self):
+        self.write(
+            "2026-09-06T03:00:00Z capture_stop frames=3\n"
+            "2026-09-06T01:00:00Z capture_stop frames=1\n"
+            "2026-09-06T02:00:00Z capture_stop frames=2\n"
+        )
+
+        result = diagnostics.query_log(
+            self.path, since=diagnostics.parse_timestamp("2026-09-06T02:00:00Z"), limit=1
+        )
+
+        self.assertEqual(result["matched_records"], 2)
+        self.assertEqual(result["returned_records"], 1)
+        self.assertEqual(result["event_counts"], {"capture_stop": 2})
+        self.assertEqual(result["records"][0]["fields"]["frames"], "3")
+
+    def test_event_and_process_filters_are_conjunctive(self):
+        self.write(
+            "2026-09-06T00:00:00Z capture_start process_session=run-a\n"
+            "2026-09-06T00:00:01Z capture_stop process_session=run-a\n"
+            "2026-09-06T00:00:02Z capture_stop process_session=run-b\n"
+            "2026-09-06T00:00:03Z capture_stop\n"
+        )
+
+        result = diagnostics.query_log(self.path, events=["capture_stop", "capture_failed"], process_session="run-a")
+
+        self.assertEqual(result["event_counts"], {"capture_stop": 1})
+        self.assertEqual(result["scan"]["parsed_records"], 4)
+
+    def test_bounded_tail_discards_partial_utf8_and_unfinished_newest_line(self):
+        complete = "2026-09-06T00:00:01Z capture_stop frames=480\n"
+        unfinished = "2026-09-06T00:00:02Z capture_star"
+        self.write("old " + "é" * 100 + "\n" + complete + unfinished)
+        budget = len((complete + unfinished).encode()) + 4
+
+        result = diagnostics.query_log(self.path, max_scan_bytes=budget)
+
+        self.assertTrue(result["scan"]["truncated"])
+        self.assertLessEqual(result["scan"]["bytes_read"], budget)
+        self.assertEqual(result["scan"]["incomplete_lines"], 2)
+        self.assertEqual(result["scan"]["discarded_partial_end_bytes"], len(unfinished))
+        self.assertEqual(result["event_counts"], {"capture_stop": 1})
+        self.assertEqual(result["scan"]["unparsed_lines"], 0)
+
+    def test_exact_tail_boundary_keeps_complete_newest_line(self):
+        complete = "2026-09-06T00:00:01Z capture_stop\n"
+        self.write("old event\n" + complete)
+
+        result = diagnostics.query_log(self.path, max_scan_bytes=len(complete) + 1)
+
+        self.assertEqual(result["event_counts"], {"capture_stop": 1})
+        self.assertEqual(result["scan"]["incomplete_lines"], 0)
+
+    def test_malformed_records_and_fields_are_counted_without_raw_output(self):
+        self.write(
+            b"unstructured private text\n"
+            b'2026-09-06T00:00:00Z capture_failed reason="unclosed\n'
+            b"2026-09-06T00:00:01Z capture_stop frames=1 stray frames=2\n"
+            b"\xff\n"
+        )
+
+        result = diagnostics.query_log(self.path)
+
+        self.assertEqual(result["scan"]["unparsed_lines"], 3)
+        self.assertEqual(result["scan"]["unparsed_field_tokens"], 1)
+        self.assertEqual(result["scan"]["duplicate_fields"], 1)
+        self.assertNotIn("unstructured private text", str(result))
+        self.assertEqual(result["records"][0]["fields"]["frames"], "2")
+
+    def test_missing_empty_unparseable_and_no_matches_are_explicit(self):
+        self.assertEqual(diagnostics.query_log(self.path)["status"], "missing")
+        self.write("")
+        self.assertEqual(diagnostics.query_log(self.path)["status"], "empty")
+        self.write("invalid\n")
+        self.assertEqual(diagnostics.query_log(self.path)["status"], "unparseable")
+        self.write("2026-09-06T00:00:00Z capture_start\n")
+        self.assertEqual(diagnostics.query_log(self.path, events=["other"])["status"], "no_matches")
+
+    def test_nonregular_input_is_rejected_without_blocking(self):
+        os.mkfifo(self.path)
+        self.assertEqual(diagnostics.query_log(self.path)["status"], "unreadable")
+
+    def test_default_path_honors_explicit_and_debug_environment(self):
+        with patch.dict(os.environ, {"MACPARAKEET_DEBUG_APP_STATE_DIR": "/tmp/debug"}, clear=True):
+            self.assertEqual(diagnostics.default_log_path(), Path("/tmp/debug/logs/dictation-audio.log"))
+            with patch.dict(os.environ, {"MACPARAKEET_AUDIO_DIAGNOSTICS_LOG_PATH": "/tmp/chosen.log"}):
+                self.assertEqual(diagnostics.default_log_path(), Path("/tmp/chosen.log"))
+
+    def test_naive_timestamps_and_unbounded_limits_are_rejected(self):
+        with self.assertRaises(ValueError):
+            diagnostics.parse_timestamp("2026-09-06T00:00:00")
+        for limit in [0, 1001]:
+            with self.assertRaises(ValueError):
+                diagnostics.query_log(self.path, limit=limit)
+
+    def test_command_outputs_json_and_preserves_the_source(self):
+        content = "2026-09-06T00:00:00Z capture_stop frames=480\n"
+        self.write(content)
+        modified = self.path.stat().st_mtime_ns
+        output = io.StringIO()
+
+        with redirect_stdout(output):
+            exit_code = diagnostics.main(["--path", str(self.path), "--event", "capture_stop", "--limit", "1"])
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(json.loads(output.getvalue())["event_counts"], {"capture_stop": 1})
+        self.assertEqual(self.path.read_text(), content)
+        self.assertEqual(self.path.stat().st_mtime_ns, modified)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/dev/tests/test_query_audio_diagnostics.py
+++ b/scripts/dev/tests/test_query_audio_diagnostics.py
@@ -89,6 +89,55 @@ class QueryAudioDiagnosticsTests(unittest.TestCase):
         self.assertEqual(result["event_counts"], {"capture_stop": 1})
         self.assertEqual(result["scan"]["incomplete_lines"], 0)
 
+    def test_tail_starting_at_record_first_byte_keeps_that_record(self):
+        complete = "2026-09-06T00:00:01Z capture_stop\n"
+        self.write("old event\n" + complete)
+
+        result = diagnostics.query_log(self.path, max_scan_bytes=len(complete))
+
+        self.assertEqual(result["event_counts"], {"capture_stop": 1})
+        self.assertEqual(result["scan"]["incomplete_lines"], 0)
+        self.assertEqual(result["scan"]["discarded_partial_start_bytes"], 0)
+
+    def test_atomic_replacement_during_read_is_reported(self):
+        self.write("2026-09-06T00:00:01Z capture_stop\n")
+        replacement = self.path.with_suffix(".replacement")
+        replacement.write_text("2026-09-06T00:00:02Z capture_start\n")
+        original_fstat = os.fstat
+        checks = 0
+
+        def replace_before_final_check(descriptor):
+            nonlocal checks
+            checks += 1
+            if checks == 2:
+                replacement.replace(self.path)
+            return original_fstat(descriptor)
+
+        with patch.object(diagnostics.os, "fstat", side_effect=replace_before_final_check):
+            result = diagnostics.query_log(self.path)
+
+        self.assertTrue(result["scan"]["changed_during_read"])
+        self.assertEqual(result["event_counts"], {"capture_stop": 1})
+
+    def test_path_disappearance_during_read_preserves_evidence_and_reports_change(self):
+        self.write("2026-09-06T00:00:01Z capture_stop\n")
+        original_fstat = os.fstat
+        checks = 0
+
+        def remove_before_final_check(descriptor):
+            nonlocal checks
+            checks += 1
+            if checks == 2:
+                self.path.unlink()
+            return original_fstat(descriptor)
+
+        with patch.object(diagnostics.os, "fstat", side_effect=remove_before_final_check):
+            result = diagnostics.query_log(self.path)
+
+        self.assertEqual(result["status"], "available")
+        self.assertTrue(result["scan"]["changed_during_read"])
+        self.assertEqual(result["event_counts"], {"capture_stop": 1})
+
     def test_malformed_records_and_fields_are_counted_without_raw_output(self):
         self.write(
             b"unstructured private text\n"

--- a/spec/adr/012-telemetry-system.md
+++ b/spec/adr/012-telemetry-system.md
@@ -46,8 +46,8 @@ The system is designed as **non-identifying, session-scoped telemetry**:
 - **Country only** — Derived from Cloudflare's `CF-IPCountry` header, not from IP geolocation we perform
 - **No content** — Transcription text, custom words, file names, URLs, LLM prompts are never sent
 - **Idempotent** — Client-generated event UUIDs prevent double-counting
-- **Error messages redacted** — Server-side regex strips file paths, URLs, API keys, and emails before storage. Descriptions truncated to 512 chars.
-- **Opt-out** — Users can disable in Settings; `send()` becomes a no-op
+- **Structured errors** — The typed client omits free-form `error_detail`, `error_occurred.description`, and crash `reason`. Keep error categories, safe domain/numeric codes, and crash symbolication fields. The paired website ingestion change discards these text fields from older clients too; public stats scrub historical snapshots before serving them. Regex cannot establish that arbitrary error text is content-free. See [the telemetry contract](../contracts/telemetry-v1.md).
+- **Opt-out** — Discard queued events and invalidate retries and waiting batches. A request already in flight may finish; only the explicit final opt-out event can bypass the disabled preference.
 
 This is not "anonymous" in the strict GDPR sense (session + chip + locale + country + timestamps could theoretically single out users). It is non-identifying: we have no mechanism to map any event to any person, and we don't try.
 

--- a/spec/contracts/telemetry-v1.md
+++ b/spec/contracts/telemetry-v1.md
@@ -1,0 +1,73 @@
+# Telemetry and diagnostic evidence
+
+This contract governs the existing typed telemetry surface. The event catalog
+and envelope are in [docs/telemetry.md](../../docs/telemetry.md); this document
+records the September 2026 tightening of privacy and outcome semantics.
+
+## Network event boundary
+
+- Preserve random per-launch sessions, event UUID idempotency, and optional
+  telemetry. Audio, transcripts, prompts, filenames, device identities and
+  persistent user identifiers are excluded.
+- Omit `error_detail`, `error_occurred.description`, and crash `reason` from
+  serialized events. Retaining factory parameters does not permit transmission.
+  The paired website ingestion change drops these fields for older clients.
+- Retain bounded error categories and safe numeric codes. CoreAudio domain/code
+  information may be recovered from the recognized Foundation wrapper format;
+  arbitrary numbers, domains and descriptions are not error categories.
+- Opt-out clears the queue and invalidates retries and batches waiting behind
+  another flush. In-flight network requests can complete. An explicit final
+  `telemetry_opted_out` event is the only disabled-preference exception.
+- A thrown cancellation is `cancelled`, not `failure`. Exactly one canonical
+  outcome should describe an operation. Breadcrumb counts are separate evidence.
+- A successful CLI early exit has `outcome=success`, `exit_code=0` and no
+  `error_type`, even when ArgumentParser implements it by throwing.
+
+## Aggregate evidence
+
+The website's `/api/stats` keeps its existing aggregate fields. Additive
+`freshness` metadata reports snapshot generation, expiry, serving time, age and
+`fresh`/`stale` status. A stale fallback is `200` with usable historical data,
+`reason=refresh_failed` and `Cache-Control: no-store`; it is not live health.
+Public failure rows retain `error_detail: null` for compatibility and merge
+historical detail groups into error-category counts. No free-form error text
+should be added back to the public response.
+
+Snapshots last 15 minutes; the page polls every five minutes. Time-window counts
+are not matched start/completion cohorts. Terminal failure rates require the
+corresponding operation denominator, with lifecycle actions separated. Missing
+denominators, missing durations, absent local reports and missing telemetry are
+unknown evidence. They must not be presented as zero failures or proven health.
+`meeting.by_trigger[].both_tracks_present` counts successful meeting outcomes
+whose same event reports both tracks. Separate microphone and system-audio
+totals cannot establish that intersection. `track_samples` counts successful
+outcomes with both track statuses known and supplies the rate's denominator;
+show its coverage against successful outcomes. `duration_samples` counts the
+successful outcomes with a measured duration. Older snapshots without these
+fields have unknown aggregate duration and dual-capture coverage.
+
+Telemetry is best effort: opt-outs, offline events, queue limits, process death
+and crashes without a later launch prevent complete population accounting. A
+fresh stats snapshot proves a successful read/aggregation, not ingestion health.
+
+## Local diagnostic evidence
+
+The bounded local audio log records event occurrence time, process ID, a random
+per-process session, monotonic uptime and audio lifecycle fields. These process
+correlation fields are not transmitted as telemetry; an explicit diagnostic
+export includes the log. Legacy lines without them remain readable.
+The shareable log records structured error type and explicitly named
+`bridged_error_code` rather than raw exception text. A bridged Swift enum code
+is not an underlying CoreAudio status; recognized native status is retained in
+the classified type. File-write failures use the independent system logger.
+
+The [offline query utility](../../docs/local-audio-diagnostics-query.md) returns
+bounded JSON evidence with explicit missing, truncated and unparseable states.
+It reads the log only. It does not record audio, change app settings, upload
+diagnostics or claim that the absence of logged failures means successful audio.
+
+## Rollout
+
+App changes require a new app/CLI build. Website changes are in the separate
+`macparakeet-website` repository and require deployment. Existing stored private
+rows and previously cached public responses are not deleted by source changes.

--- a/spec/contracts/telemetry-v1.md
+++ b/spec/contracts/telemetry-v1.md
@@ -16,7 +16,8 @@ records the September 2026 tightening of privacy and outcome semantics.
   information may be recovered from the recognized Foundation wrapper format;
   arbitrary numbers, domains and descriptions are not error categories.
 - Opt-out clears the queue and invalidates retries and batches waiting behind
-  another flush. In-flight network requests can complete. An explicit final
+  another flush, including batches encoded but not started. Request admission
+  and URL task resume share the queue-clear lock. In-flight requests can complete. An explicit final
   `telemetry_opted_out` event is the only disabled-preference exception.
 - A thrown cancellation is `cancelled`, not `failure`. Exactly one canonical
   outcome should describe an operation. Breadcrumb counts are separate evidence.


### PR DESCRIPTION
## Summary

Telemetry and local audio diagnostics now give users and agents useful failure evidence while respecting consent and keeping speech content on-device. Opt-out prevents pending uploads from starting, operation outcomes remain truthful, and local queries expose missing or incomplete evidence.

This is the app contribution to the observability audit. The companion website change sanitizes public snapshots from current and legacy clients and corrects freshness and measurement coverage. These app changes reach users in the next app release; the website can ship independently.

## Design

- Consent generations invalidate queued batches and retries. Final admission and request start share the consent lock; requests already dispatched may complete.
- Network events omit arbitrary error descriptions, crash reasons, and unrecognized NSError domains. Recognized platform codes remain available for diagnosis.
- Dictation records one terminal outcome per operation and distinguishes cancellation from failure. Successful CLI exits have no runtime error classification.
- Local records retain occurrence time, process identity, and monotonic time. Participating app and CLI writers share a stable advisory lock; failed writes preserve history and retention preserves complete records.
- Main-thread writes defer on contention or rotation, retaining the exact encoded record and its clocks. Small uncontended appends remain synchronous; deferred records become visible after the utility writer completes.
- The bounded offline JSON query reports missing, truncated, malformed, and concurrently changed evidence, including path replacement during rotation. A separate one-byte boundary probe preserves aligned records.

The telemetry contract and ADR-012 govern the privacy boundary. Telemetry remains best effort. Older logs retain their original correlation and privacy limits.

| Scenario | Corrected behavior |
| --- | --- |
| Opt-out occurs while an upload is being prepared | Reject the stale generation before request start |
| Cancellation arrives after successful dictation | Keep the original terminal result |
| App and CLI rotate the same log | Coordinate through the stable lock file |
| A main-thread append encounters contention or rotation | Queue the original record without waiting for the lock or rewriting history inline |

Related: moona3k/macparakeet-website#34

## Test evidence

- Initial focused gate: 224 XCTest and 21 Swift Testing cases passed, including all 35 `AudioRecorderFormatChangeTests`.
- Review corrections: 149 XCTest cases passed across audio diagnostics, dictation, and telemetry; 25 classifier Swift Testing cases and all 14 Python query tests passed.
- Final rotation correction: all 18 `AudioCaptureDiagnosticsTests` passed on `3bee9d4b`; diff checks and independent reviews found no remaining code blocker.
- [Initial-candidate CI](https://github.com/moona3k/macparakeet/actions/runs/34026123986) passed on `443c4efe`. That is historical evidence. [Final-candidate CI](https://github.com/moona3k/macparakeet/actions/runs/34028683184) passed on `3bee9d4b`, including release build, CLI and bundle smoke, concurrency checks, Swift 6 language mode, and tests.

Replay the focused areas with `swift test --filter 'AudioCaptureDiagnosticsTests|DictationServiceTests|TelemetryServiceTests|TelemetryErrorClassifierTests'` and `python3 -m unittest discover -s scripts/dev/tests -p 'test_query_audio_diagnostics.py'`.

The single local full-suite run executed 5,243 XCTest cases with 20 skips and two failure reports from one case: `AudioRecorderFormatChangeTests.testDiscardPreRollMakesMediaOnlyCaptureInsufficient`. Its mock readiness poll hit a two-second deadline; the entire 35-case family passed afterward. All 25 Swift Testing cases passed. The cause is unconfirmed, and this is **not a clean local full-suite result**. Later corrections received focused coverage; the full local suite was not repeated.

No physical microphone exercise or stable app release was performed. Detailed findings and limits are in `docs/audits/2026-09-06-observability-review.md`; the public boundaries are in `spec/contracts/telemetry-v1.md` and `docs/local-audio-diagnostics-query.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves telemetry consent and makes audio failures diagnosable. Previously, failed uploads could restore events after opt-out and free-form error text crossed the network; now opt-out blocks queued and pending requests before they start, and only safe platform codes are transmitted. Local diagnostics gain richer correlation, credential redaction, and an offline query tool, with changes reaching app users in the next release; the companion website sanitizes legacy snapshots independently.

**Telemetry**
- Final admission and request start are atomic with opt-out; in-flight requests may complete.
- Network events omit free-form error descriptions and crash reasons; known platform codes remain.
- Dictation emits one terminal outcome per operation, with cancellation distinct from failure.
- CLI help and other successful thrown exits no longer produce an error type.

**Local audio diagnostics**
- Logs capture occurrence time before enqueueing, plus process session and monotonic time; main-thread writes reject rotation and queue the original record to the background writer, keeping small appends synchronous.
- Writers coordinate via a stable advisory lock; failed writes preserve history, quoted credentials are redacted, and oversized records are dropped whole.
- The offline JSON query (`scripts/dev/query_audio_diagnostics.py`) reports missing, truncated, malformed, and changed-during-read evidence, plus log replacement or disappearance.

<sup>Written for commit 3bee9d4bf14f7b6c2b37e45acd491437242a1766. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/962?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Privacy**
  * Telemetry now excludes free-form error details and crash reasons from network data, retaining only safe categories and codes.
  * Clearing telemetry consent now prevents queued events and retries from being sent.

* **Bug Fixes**
  * Cancellations are reported accurately and no longer appear as failures.
  * Successful CLI exits are no longer classified as errors.
  * Diagnostic logs preserve complete neighboring events when oversized lines are encountered.
  * Concurrent and delayed diagnostic writes are handled more reliably.

* **New Features**
  * Added a read-only JSON utility for filtering and inspecting local audio diagnostics.

* **Documentation**
  * Updated telemetry privacy, diagnostic logging, and observability guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
