### PR TITLE
Add Library layouts without changing contextual defaults

### DIFF
--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingRowCard.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingRowCard.swift
@@ -9,6 +9,7 @@ struct MeetingRowCard<MenuContent: View>: View {
     var searchText: String = ""
     var isSelected: Bool = false
     var showsSelectionControls: Bool = false
+    var showsSource = false
     var isRetrying: Bool = false
     var onTap: () -> Void
     var onRetry: (() -> Void)? = nil
@@ -144,6 +145,10 @@ struct MeetingRowCard<MenuContent: View>: View {
                 .contentTransition(.opacity)
                 .layoutPriority(1)
 
+            if showsSource {
+                sourceInline
+            }
+
             speakerInline
                 .layoutPriority(0)
 
@@ -152,6 +157,15 @@ struct MeetingRowCard<MenuContent: View>: View {
 
             Spacer(minLength: 0)
         }
+    }
+
+    private var sourceInline: some View {
+        let source = TranscriptionSourceDisplay.resolve(for: transcription)
+        return Label(source.collapsedText, systemImage: source.systemImage)
+            .font(DesignSystem.Typography.micro.weight(.medium))
+            .foregroundStyle(source.tint)
+            .lineLimit(1)
+            .fixedSize()
     }
 
     @ViewBuilder
@@ -174,13 +188,7 @@ struct MeetingRowCard<MenuContent: View>: View {
 
     @ViewBuilder
     private var snippetRow: some View {
-        if let snippet = displayedSnippet {
-            highlightedText(snippet)
-                .font(DesignSystem.Typography.bodySmall)
-                .foregroundStyle(DesignSystem.Colors.textSecondary)
-                .lineLimit(1)
-                .truncationMode(.tail)
-        } else if transcription.status == .processing {
+        if transcription.status == .processing {
             HStack(spacing: 5) {
                 ParakeetSpinner(.inline)
                     .scaleEffect(0.85)
@@ -199,6 +207,12 @@ struct MeetingRowCard<MenuContent: View>: View {
                 .font(DesignSystem.Typography.bodySmall)
                 .foregroundStyle(DesignSystem.Colors.textTertiary)
                 .lineLimit(1)
+        } else if let snippet = displayedSnippet {
+            highlightedText(snippet)
+                .font(DesignSystem.Typography.bodySmall)
+                .foregroundStyle(DesignSystem.Colors.textSecondary)
+                .lineLimit(1)
+                .truncationMode(.tail)
         }
     }
 

--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingRowCard.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingRowCard.swift
@@ -9,6 +9,7 @@ struct MeetingRowCard<MenuContent: View>: View {
     var searchText: String = ""
     var isSelected: Bool = false
     var showsSelectionControls: Bool = false
+    var showsSource = false
     var isRetrying: Bool = false
     var onTap: () -> Void
     var onRetry: (() -> Void)? = nil
@@ -144,6 +145,10 @@ struct MeetingRowCard<MenuContent: View>: View {
                 .contentTransition(.opacity)
                 .layoutPriority(1)
 
+            if showsSource {
+                sourceInline
+            }
+
             speakerInline
                 .layoutPriority(0)
 
@@ -152,6 +157,15 @@ struct MeetingRowCard<MenuContent: View>: View {
 
             Spacer(minLength: 0)
         }
+    }
+
+    private var sourceInline: some View {
+        let source = TranscriptionSourceDisplay.resolve(for: transcription)
+        return Label(source.collapsedText, systemImage: source.systemImage)
+            .font(DesignSystem.Typography.micro.weight(.medium))
+            .foregroundStyle(source.tint)
+            .lineLimit(1)
+            .fixedSize()
     }
 
     @ViewBuilder

--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingRowCard.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingRowCard.swift
@@ -188,7 +188,13 @@ struct MeetingRowCard<MenuContent: View>: View {
 
     @ViewBuilder
     private var snippetRow: some View {
-        if transcription.status == .processing {
+        if let snippet = displayedSnippet {
+            highlightedText(snippet)
+                .font(DesignSystem.Typography.bodySmall)
+                .foregroundStyle(DesignSystem.Colors.textSecondary)
+                .lineLimit(1)
+                .truncationMode(.tail)
+        } else if transcription.status == .processing {
             HStack(spacing: 5) {
                 ParakeetSpinner(.inline)
                     .scaleEffect(0.85)
@@ -207,12 +213,6 @@ struct MeetingRowCard<MenuContent: View>: View {
                 .font(DesignSystem.Typography.bodySmall)
                 .foregroundStyle(DesignSystem.Colors.textTertiary)
                 .lineLimit(1)
-        } else if let snippet = displayedSnippet {
-            highlightedText(snippet)
-                .font(DesignSystem.Typography.bodySmall)
-                .foregroundStyle(DesignSystem.Colors.textSecondary)
-                .lineLimit(1)
-                .truncationMode(.tail)
         }
     }
 

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
@@ -3,6 +3,11 @@ import SwiftUI
 import MacParakeetCore
 import MacParakeetViewModels
 
+private enum LibraryLayoutMode: String {
+    case grid
+    case list
+}
+
 struct TranscriptionLibraryView: View {
     @Bindable var viewModel: TranscriptionLibraryViewModel
     var title: String = "Library"
@@ -27,6 +32,8 @@ struct TranscriptionLibraryView: View {
     private var bulkExportIncludeSpeakerLabels = true
     @AppStorage("com.macparakeet.libraryBulkExportIncludeMetadata")
     private var bulkExportIncludeMetadata = true
+    @AppStorage("com.macparakeet.libraryLayoutMode")
+    private var storedLibraryLayoutMode: String?
     @State private var bulkExportInProgress = false
     @State private var bulkExportResult: BulkTranscriptExportResult?
     @State private var bulkExportErrorMessage: String?
@@ -53,6 +60,26 @@ struct TranscriptionLibraryView: View {
                     .foregroundStyle(DesignSystem.Colors.textPrimary)
 
                 Spacer()
+
+                Picker(
+                    "Library layout",
+                    selection: Binding(
+                        get: { libraryLayoutMode },
+                        set: { storedLibraryLayoutMode = $0.rawValue }
+                    )
+                ) {
+                    Image(systemName: "square.grid.2x2")
+                        .accessibilityLabel("Grid")
+                        .tag(LibraryLayoutMode.grid)
+                    Image(systemName: "list.bullet")
+                        .accessibilityLabel("List")
+                        .tag(LibraryLayoutMode.list)
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+                .accessibilityLabel("Library layout")
+                .frame(width: 76)
+                .help(libraryLayoutMode == .grid ? "Switch to list view" : "Switch to grid view")
 
                 if showsSelectManyButton {
                     LibrarySelectManyButton {
@@ -100,8 +127,8 @@ struct TranscriptionLibraryView: View {
                 loadingState
             } else if viewModel.filteredTranscriptions.isEmpty {
                 emptyState
-            } else if isMeetingListMode {
-                meetingsList
+            } else if usesListLayout {
+                transcriptionList
             } else {
                 thumbnailGrid
             }
@@ -300,7 +327,7 @@ struct TranscriptionLibraryView: View {
         }
     }
 
-    private var meetingsList: some View {
+    private var transcriptionList: some View {
         ScrollView {
             LazyVStack(alignment: .leading, spacing: 0) {
                 ForEach(viewModel.groupedTranscriptions, id: \.group) { section in
@@ -311,6 +338,7 @@ struct TranscriptionLibraryView: View {
                             searchText: viewModel.searchText,
                             isSelected: viewModel.isTranscriptionSelected(transcription),
                             showsSelectionControls: viewModel.isBulkSelectionModeEnabled,
+                            showsSource: !isMeetingContext,
                             isRetrying: viewModel.isRetryingMeetingTranscription(transcription),
                             onTap: {
                                 if viewModel.isBulkOperationInProgress || bulkExportInProgress {
@@ -470,7 +498,7 @@ struct TranscriptionLibraryView: View {
         BulkTranscriptionSelectionBar(
             selectedCount: selectedBulkExportTargets.count,
             selectedMeetingAudioCount: viewModel.selectedMeetingAudioCount,
-            isMeetingContext: isMeetingListMode,
+            isMeetingContext: isMeetingContext,
             areAllVisibleSelected: viewModel.areAllLoadedVisibleTranscriptionsSelected,
             isPerformingOperation: viewModel.isBulkOperationInProgress || bulkExportInProgress,
             operationLabel: bulkExportInProgress ? "Exporting..." : "Deleting...",
@@ -903,8 +931,18 @@ struct TranscriptionLibraryView: View {
         }
     }
 
-    private var isMeetingListMode: Bool {
+    private var isMeetingContext: Bool {
         viewModel.scope == .meetings || viewModel.filter == .meeting
+    }
+
+    private var libraryLayoutMode: LibraryLayoutMode {
+        // Browsing must not persist a default: only the picker writes a global choice.
+        storedLibraryLayoutMode.flatMap(LibraryLayoutMode.init(rawValue:))
+            ?? (isMeetingContext ? .list : .grid)
+    }
+
+    private var usesListLayout: Bool {
+        libraryLayoutMode == .list
     }
 
     private var bulkOperationTitle: String {
@@ -995,15 +1033,15 @@ struct TranscriptionLibraryView: View {
 
     private var emptyStateIcon: String {
         if !viewModel.searchText.isEmpty { return "magnifyingglass" }
-        return isMeetingListMode ? "waveform.badge.mic" : "square.grid.2x2"
+        return isMeetingContext ? "waveform.badge.mic" : "square.grid.2x2"
     }
 
     private var emptyStateTitle: String {
-        isMeetingListMode ? "No meetings recorded yet" : emptyTitle
+        isMeetingContext ? "No meetings recorded yet" : emptyTitle
     }
 
     private var emptyStateMessage: String {
-        isMeetingListMode
+        isMeetingContext
             ? "Press Record Meeting on the Transcribe tab to capture system audio and transcribe locally."
             : emptyMessage
     }

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
@@ -3,6 +3,11 @@ import SwiftUI
 import MacParakeetCore
 import MacParakeetViewModels
 
+private enum LibraryLayoutMode: String {
+    case grid
+    case list
+}
+
 struct TranscriptionLibraryView: View {
     @Bindable var viewModel: TranscriptionLibraryViewModel
     var title: String = "Library"
@@ -27,6 +32,8 @@ struct TranscriptionLibraryView: View {
     private var bulkExportIncludeSpeakerLabels = true
     @AppStorage("com.macparakeet.libraryBulkExportIncludeMetadata")
     private var bulkExportIncludeMetadata = true
+    @AppStorage("com.macparakeet.libraryLayoutMode")
+    private var libraryLayoutMode = LibraryLayoutMode.grid
     @State private var bulkExportInProgress = false
     @State private var bulkExportResult: BulkTranscriptExportResult?
     @State private var bulkExportErrorMessage: String?
@@ -53,6 +60,20 @@ struct TranscriptionLibraryView: View {
                     .foregroundStyle(DesignSystem.Colors.textPrimary)
 
                 Spacer()
+
+                Picker("Library layout", selection: $libraryLayoutMode) {
+                    Image(systemName: "square.grid.2x2")
+                        .accessibilityLabel("Grid")
+                        .tag(LibraryLayoutMode.grid)
+                    Image(systemName: "list.bullet")
+                        .accessibilityLabel("List")
+                        .tag(LibraryLayoutMode.list)
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+                .accessibilityLabel("Library layout")
+                .frame(width: 76)
+                .help(libraryLayoutMode == .grid ? "Switch to list view" : "Switch to grid view")
 
                 if showsSelectManyButton {
                     LibrarySelectManyButton {
@@ -100,8 +121,8 @@ struct TranscriptionLibraryView: View {
                 loadingState
             } else if viewModel.filteredTranscriptions.isEmpty {
                 emptyState
-            } else if isMeetingListMode {
-                meetingsList
+            } else if usesListLayout {
+                transcriptionList
             } else {
                 thumbnailGrid
             }
@@ -300,7 +321,7 @@ struct TranscriptionLibraryView: View {
         }
     }
 
-    private var meetingsList: some View {
+    private var transcriptionList: some View {
         ScrollView {
             LazyVStack(alignment: .leading, spacing: 0) {
                 ForEach(viewModel.groupedTranscriptions, id: \.group) { section in
@@ -311,6 +332,7 @@ struct TranscriptionLibraryView: View {
                             searchText: viewModel.searchText,
                             isSelected: viewModel.isTranscriptionSelected(transcription),
                             showsSelectionControls: viewModel.isBulkSelectionModeEnabled,
+                            showsSource: !isMeetingContext,
                             isRetrying: viewModel.isRetryingMeetingTranscription(transcription),
                             onTap: {
                                 if viewModel.isBulkOperationInProgress || bulkExportInProgress {
@@ -470,7 +492,7 @@ struct TranscriptionLibraryView: View {
         BulkTranscriptionSelectionBar(
             selectedCount: selectedBulkExportTargets.count,
             selectedMeetingAudioCount: viewModel.selectedMeetingAudioCount,
-            isMeetingContext: isMeetingListMode,
+            isMeetingContext: isMeetingContext,
             areAllVisibleSelected: viewModel.areAllLoadedVisibleTranscriptionsSelected,
             isPerformingOperation: viewModel.isBulkOperationInProgress || bulkExportInProgress,
             operationLabel: bulkExportInProgress ? "Exporting..." : "Deleting...",
@@ -903,8 +925,12 @@ struct TranscriptionLibraryView: View {
         }
     }
 
-    private var isMeetingListMode: Bool {
+    private var isMeetingContext: Bool {
         viewModel.scope == .meetings || viewModel.filter == .meeting
+    }
+
+    private var usesListLayout: Bool {
+        libraryLayoutMode == .list
     }
 
     private var bulkOperationTitle: String {
@@ -995,15 +1021,15 @@ struct TranscriptionLibraryView: View {
 
     private var emptyStateIcon: String {
         if !viewModel.searchText.isEmpty { return "magnifyingglass" }
-        return isMeetingListMode ? "waveform.badge.mic" : "square.grid.2x2"
+        return isMeetingContext ? "waveform.badge.mic" : "square.grid.2x2"
     }
 
     private var emptyStateTitle: String {
-        isMeetingListMode ? "No meetings recorded yet" : emptyTitle
+        isMeetingContext ? "No meetings recorded yet" : emptyTitle
     }
 
     private var emptyStateMessage: String {
-        isMeetingListMode
+        isMeetingContext
             ? "Press Record Meeting on the Transcribe tab to capture system audio and transcribe locally."
             : emptyMessage
     }

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionThumbnailCard.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionThumbnailCard.swift
@@ -147,15 +147,6 @@ struct TranscriptionThumbnailCard<MenuContent: View>: View {
                         .padding(8)
                 }
             }
-            .overlay(alignment: .bottomLeading) {
-                if transcription.sourceType == .meeting {
-                    let state = MeetingAudioFile.state(for: transcription)
-                    if state != .notMeeting {
-                        MeetingAudioStateChip(state: state)
-                            .padding(8)
-                    }
-                }
-            }
             .clipShape(Rectangle())
     }
 
@@ -218,7 +209,7 @@ struct TranscriptionThumbnailCard<MenuContent: View>: View {
     }
 
     private var sourceIcon: String {
-        if transcription.sourceURL != nil {
+        if transcription.sourceType != .file {
             return sourceDisplay.systemImage
         }
         let ext = transcription.filePath.map { URL(fileURLWithPath: $0).pathExtension.lowercased() } ?? ""
@@ -245,15 +236,39 @@ struct TranscriptionThumbnailCard<MenuContent: View>: View {
                     .font(DesignSystem.Typography.caption)
                     .foregroundStyle(DesignSystem.Colors.textTertiary)
                     .lineLimit(1)
+            }
+
+            HStack(spacing: 6) {
+                Label(sourceDisplay.collapsedText, systemImage: sourceDisplay.systemImage)
+                    .foregroundStyle(sourceDisplay.tint)
+                    .fixedSize()
 
                 Text(transcription.createdAt.relativeFormatted)
-                    .font(DesignSystem.Typography.caption)
-                    .foregroundStyle(DesignSystem.Colors.textTertiary)
-            } else {
-                Text(transcription.createdAt.relativeFormatted)
-                    .font(DesignSystem.Typography.caption)
                     .foregroundStyle(DesignSystem.Colors.textTertiary)
                     .lineLimit(1)
+            }
+            .font(DesignSystem.Typography.caption)
+
+            transcriptionStatus
+
+            if transcription.sourceType == .meeting {
+                MeetingAudioStateChip(state: MeetingAudioFile.state(for: transcription))
+            }
+
+            if let partialCapture = MeetingPartialCapturePresentation.make(for: transcription) {
+                Text(partialCapture.badgeText)
+                    .font(DesignSystem.Typography.micro.weight(.semibold))
+                    .foregroundStyle(DesignSystem.Colors.warningAmber)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(
+                        Capsule()
+                            .fill(DesignSystem.Colors.warningAmber.opacity(0.10))
+                    )
+                    .fixedSize()
+                    .help(partialCapture.message)
+                    .accessibilityLabel(partialCapture.badgeText)
+                    .accessibilityHint(partialCapture.message)
             }
 
             if transcription.recoveredFromCrash {
@@ -265,7 +280,39 @@ struct TranscriptionThumbnailCard<MenuContent: View>: View {
         }
         .padding(DesignSystem.Spacing.sm)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .frame(height: 80, alignment: .top)
+        .frame(minHeight: 80, alignment: .top)
+    }
+
+    @ViewBuilder
+    private var transcriptionStatus: some View {
+        switch transcription.status {
+        case .processing:
+            HStack(spacing: 5) {
+                ParakeetSpinner(.inline)
+                    .scaleEffect(0.85)
+                    .frame(width: 12, height: 12)
+                Text("Transcribing")
+                    .font(DesignSystem.Typography.bodySmall)
+                    .foregroundStyle(DesignSystem.Colors.textTertiary)
+            }
+        case .error:
+            HStack(spacing: 5) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(DesignSystem.Colors.warningAmber)
+                Text("Transcription failed")
+                    .font(DesignSystem.Typography.bodySmall)
+                    .foregroundStyle(DesignSystem.Colors.textSecondary)
+            }
+            .help(transcription.errorMessage ?? "Transcription failed")
+            .accessibilityHint(transcription.errorMessage ?? "Transcription failed")
+        case .cancelled:
+            Text("Transcription stopped")
+                .font(DesignSystem.Typography.bodySmall)
+                .foregroundStyle(DesignSystem.Colors.textTertiary)
+        case .completed:
+            EmptyView()
+        }
     }
 
     // MARK: - Search Highlighting

--- a/spec/04-ui-patterns.md
+++ b/spec/04-ui-patterns.md
@@ -51,7 +51,7 @@ Design philosophy: **Simple, native, stays out of the way.** No chrome, no clutt
 │  🎤 Transcribe   │  [Depends on sidebar selection]           │
 │  🗂 Library      │                                           │
 │  🕒 Dictations   │  - Transcribe: 3-mode capture hub        │
-│  📖 Vocabulary   │  - Library: Grid (or list for Meetings)  │
+│  📖 Vocabulary   │  - Library: Grid or list                 │
 │  ✦ Transforms    │  - Dictations: History list               │
 │  💬 Feedback     │  - Vocabulary: Processing mode + manage   │
 │  ⚙ Settings      │  - Transforms: Rewrite selected text      │
@@ -68,7 +68,7 @@ Minimum window width: 800pt.
 The sidebar uses NavigationSplitView with flat items (icon + label):
 
 - **Transcribe** (`waveform`) -- Capture hub: YouTube card + file drop card + Meeting Recording tile
-- **Library** (`square.grid.2x2`) -- All transcriptions; filter chips switch between thumbnail grid (All/YouTube/Local/Favorites) and date-grouped list (Meetings)
+- **Library** (`square.grid.2x2`) -- All transcriptions; every filter offers the same persistent Grid/List switch
 - **Dictations** (`clock.arrow.circlepath`) -- Flat history list with bottom bar player
 - **Meetings** (`person.2.wave.2`) -- Workflow space for upcoming, live, and saved meeting work; visible when `AppFeatures.meetingRecordingEnabled` is true
 - **Vocabulary** (`book.fill`) -- Processing mode, pipeline guide, custom words & snippets management
@@ -119,18 +119,37 @@ States, all bound to the long-lived `MeetingRecordingPillViewModel` shared with 
 
 The tile body is informational. Only the visible Start and Stop capsules are real SwiftUI `Button`s, and both call the same `toggleRecording` path the menu bar uses. Completing, transcribing, completed, and error states render as inert status surfaces and must not expose button traits or no-op accessibility actions. The floating pill stays visible by default during recording so users who hide the main window keep an active control surface; users can hide it in Settings and continue controlling the live recording from the status menu, hotkey, or Meetings surfaces.
 
-### Library Meetings Filter
+### Library Layouts and Meeting States
 
-When `Library.filter == .meeting`, the view renders a date-grouped list (`Today` / `Yesterday` / `Previous 7 Days` / `Previous 30 Days` / `{Month Year}`) using `MeetingDateGroupHeader` + `MeetingRowCard` instead of the thumbnail grid the other filters use. Meeting rows surface saved-audio state directly (`Audio saved`, `Audio removed`, or `Audio missing`) so playback/retranscription expectations are visible before the user opens a menu.
+When list mode is selected, the view renders a date-grouped list (`Today` / `Yesterday` / `Previous 7 Days` / `Previous 30 Days` / `{Month Year}`) using `MeetingDateGroupHeader` + `MeetingRowCard`. Meeting rows surface saved-audio state directly (`Audio saved`, `Audio removed`, or `Audio missing`) so playback/retranscription expectations are visible before the user opens a menu.
 
 A finalized meeting whose `meetingCaptureReport.quality` is `partial` shows the
-existing **Partial audio** badge in its Library meeting row and the existing
-**Partial meeting audio** banner in transcript detail. The shared presentation
-explains elapsed versus captured duration and each degraded source. When the
-system source status is `silent`, its message is: “System audio contained no
-audible signal. Microphone audio remains saved.” This state is durable and
-appears after finalization; it does not add a live alert or automatically
-restart ScreenCaptureKit during a meeting.
+existing **Partial audio** badge in both its Library row and thumbnail card, and
+the existing **Partial meeting audio** banner in transcript detail. The shared
+presentation explains elapsed versus captured duration and each degraded source.
+Healthy silent system audio adds no warning; silence also adds no extra message
+when another source has a genuine capture failure. Missing, interrupted, failed,
+or short capture and playback fallback remain visible. This state is durable and
+appears after finalization; it does not add a live alert or automatically restart
+ScreenCaptureKit during a meeting.
+
+Every Library filter, including Meetings, exposes a compact Grid/List segmented
+control in the header. With no stored choice, Meetings uses the date-grouped list
+and other Library contexts use the grid. Browsing and switching filters do not
+save a preference. An explicit Grid or List choice is global across Library
+contexts and persists across launches; the separate Meetings workspace is unchanged.
+List mode reuses the date-grouped row presentation and adds the transcription
+source beside the title; thumbnail cards also show the source. Search, filters,
+contextual actions, pagination, export, and bulk selection behave identically in
+either layout.
+
+Rows and cards show transcription failure, stopped transcription, and pending
+background transcription independently of saved-audio state. Queued and running
+finalization both use the persisted `processing` status and the existing
+**Transcribing** presentation, never a completed claim. A stale or partial snippet
+must not hide a non-completed status. Card metadata grows to fit lifecycle,
+saved-audio, recovery, and partial-capture labels rather than clipping them to a
+fixed height.
 
 Opening an empty processing meeting row must preserve that same lifecycle
 truth. The transcript pane shows an indeterminate "Transcribing meeting"

--- a/spec/04-ui-patterns.md
+++ b/spec/04-ui-patterns.md
@@ -51,7 +51,7 @@ Design philosophy: **Simple, native, stays out of the way.** No chrome, no clutt
 │  🎤 Transcribe   │  [Depends on sidebar selection]           │
 │  🗂 Library      │                                           │
 │  🕒 Dictations   │  - Transcribe: 3-mode capture hub        │
-│  📖 Vocabulary   │  - Library: Grid (or list for Meetings)  │
+│  📖 Vocabulary   │  - Library: Grid or list                 │
 │  ✦ Transforms    │  - Dictations: History list               │
 │  💬 Feedback     │  - Vocabulary: Processing mode + manage   │
 │  ⚙ Settings      │  - Transforms: Rewrite selected text      │
@@ -68,7 +68,7 @@ Minimum window width: 800pt.
 The sidebar uses NavigationSplitView with flat items (icon + label):
 
 - **Transcribe** (`waveform`) -- Capture hub: YouTube card + file drop card + Meeting Recording tile
-- **Library** (`square.grid.2x2`) -- All transcriptions; filter chips switch between thumbnail grid (All/YouTube/Local/Favorites) and date-grouped list (Meetings)
+- **Library** (`square.grid.2x2`) -- All transcriptions; every filter offers the same persistent Grid/List switch
 - **Dictations** (`clock.arrow.circlepath`) -- Flat history list with bottom bar player
 - **Meetings** (`person.2.wave.2`) -- Workflow space for upcoming, live, and saved meeting work; visible when `AppFeatures.meetingRecordingEnabled` is true
 - **Vocabulary** (`book.fill`) -- Processing mode, pipeline guide, custom words & snippets management
@@ -121,7 +121,7 @@ The tile body is informational. Only the visible Start and Stop capsules are rea
 
 ### Library Meetings Filter
 
-When `Library.filter == .meeting`, the view renders a date-grouped list (`Today` / `Yesterday` / `Previous 7 Days` / `Previous 30 Days` / `{Month Year}`) using `MeetingDateGroupHeader` + `MeetingRowCard` instead of the thumbnail grid the other filters use. Meeting rows surface saved-audio state directly (`Audio saved`, `Audio removed`, or `Audio missing`) so playback/retranscription expectations are visible before the user opens a menu.
+When list mode is selected, the view renders a date-grouped list (`Today` / `Yesterday` / `Previous 7 Days` / `Previous 30 Days` / `{Month Year}`) using `MeetingDateGroupHeader` + `MeetingRowCard`. Meeting rows surface saved-audio state directly (`Audio saved`, `Audio removed`, or `Audio missing`) so playback/retranscription expectations are visible before the user opens a menu.
 
 A finalized meeting whose `meetingCaptureReport.quality` is `partial` shows the
 existing **Partial audio** badge in its Library meeting row and the existing
@@ -131,6 +131,12 @@ system source status is `silent`, its message is: “System audio contained no
 audible signal. Microphone audio remains saved.” This state is durable and
 appears after finalization; it does not add a live alert or automatically
 restart ScreenCaptureKit during a meeting.
+
+Every Library filter, including Meetings, exposes a compact Grid/List segmented
+control in the header. The preference persists across launches. List mode reuses the
+date-grouped row presentation and adds the transcription source beside the
+title; search, filters, contextual actions, pagination, and bulk selection
+behave identically in either layout.
 
 Opening an empty processing meeting row must preserve that same lifecycle
 truth. The transcript pane shows an indeterminate "Transcribing meeting"

--- a/spec/04-ui-patterns.md
+++ b/spec/04-ui-patterns.md
@@ -119,7 +119,7 @@ States, all bound to the long-lived `MeetingRecordingPillViewModel` shared with 
 
 The tile body is informational. Only the visible Start and Stop capsules are real SwiftUI `Button`s, and both call the same `toggleRecording` path the menu bar uses. Completing, transcribing, completed, and error states render as inert status surfaces and must not expose button traits or no-op accessibility actions. The floating pill stays visible by default during recording so users who hide the main window keep an active control surface; users can hide it in Settings and continue controlling the live recording from the status menu, hotkey, or Meetings surfaces.
 
-### Library Meetings Filter
+### Library Layouts and Meeting States
 
 When list mode is selected, the view renders a date-grouped list (`Today` / `Yesterday` / `Previous 7 Days` / `Previous 30 Days` / `{Month Year}`) using `MeetingDateGroupHeader` + `MeetingRowCard`. Meeting rows surface saved-audio state directly (`Audio saved`, `Audio removed`, or `Audio missing`) so playback/retranscription expectations are visible before the user opens a menu.
 

--- a/spec/04-ui-patterns.md
+++ b/spec/04-ui-patterns.md
@@ -143,13 +143,15 @@ source beside the title; thumbnail cards also show the source. Search, filters,
 contextual actions, pagination, export, and bulk selection behave identically in
 either layout.
 
-Rows and cards show transcription failure, stopped transcription, and pending
+Thumbnail cards show transcription failure, stopped transcription, and pending
 background transcription independently of saved-audio state. Queued and running
 finalization both use the persisted `processing` status and the existing
 **Transcribing** presentation, never a completed claim. A stale or partial snippet
-must not hide a non-completed status. Card metadata grows to fit lifecycle,
+must not hide a card's non-completed status. Card metadata grows to fit lifecycle,
 saved-audio, recovery, and partial-capture labels rather than clipping them to a
 fixed height.
+List rows retain their existing snippet-first preview behavior, including while
+a meeting with saved transcript text is being retranscribed.
 
 Opening an empty processing meeting row must preserve that same lifecycle
 truth. The transcript pane shows an indeterminate "Transcribing meeting"


### PR DESCRIPTION
## Summary

Adopts #958's persistent Library Grid/List choice while preserving the existing contextual defaults: Meetings starts as a list, other Library filters as a grid. Browsing never saves a default; an explicit layout choice persists globally across filters.

## Reviewed corrections

- Keep both layouts on existing Library selection, pagination, context-menu and export paths.
- Reuse meeting rows in mixed lists with a source label.
- Expose meeting processing, failed, cancelled and partial-capture state in grid cards instead of hiding it behind stale snippets or audio status. Preserve audio status separately and allow metadata height to grow.
- Retain non-hit-testing selection badges so clicking them reaches the card selection action.
- Dedicated Meetings workspace stays unchanged.

This is a current-main maintainer adaptation of #958, preserving the prepared review decision not to change Meetings' default to grid. The contributor branch remains intact; merge this candidate rather than the original alternative defaults.

## Verification

`swift test --filter 'TranscriptionLibraryViewModelTests|TranscriptionDateGroupingTests|MeetingsWorkspaceViewModelTests|ResumedLibraryNativeSmokeTests'`: **80 passed, zero failures** (79 existing focused cases plus one disposable native smoke).

The native smoke hosted the actual Library with synthetic records in an in-memory database and isolated AppStorage. It rendered grid/list/selected-grid and default Meetings list; switching layouts retained selection, explicit preference persisted, and browsing Meetings without a preference did not write one. Screenshots visually inspected. Repeated the native smoke after adding the normal hosting background for faithful screenshots; passed. Disposable smoke source/preferences removed afterward.

Final review caught an unintended shared-row change: a retranscribing meeting with saved text lost its existing preview. Restored snippet-first behavior for list rows, leaving the stronger grid-card lifecycle presentation intact. A second disposable native smoke rendered that real processing meeting row; visually confirmed the saved transcript preview remains visible. Smoke passed and was removed.

## Limits and merge gate

Existing focused tests cover model filters, search, pagination, selected-loaded-only export and shared workspace behavior. Native smoke does not claim pointer/VoiceOver, full app relaunch, a save-panel interaction, or end-to-end media export. No user recordings/database accessed. Current-candidate CI remains the full-suite merge gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Choose between grid and list layouts in the transcription library; your preference is saved.
  * View transcription sources directly on meeting rows and cards.
  * See clearer processing, error, cancelled, completed, meeting-state, and partial-capture indicators.
  * Library layouts and empty states now adapt to meeting contexts.

* **UI Improvements**
  * Card metadata displays more status and recovery information without clipping.
  * List rows retain snippet previews during meeting retranscription.

* **Documentation**
  * Updated UI guidance for transcription cards, list rows, and status presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->