### PR TITLE
Exempt CGNAT http endpoints from ATS for opted-in local providers

### DIFF
--- a/scripts/dev/run_app.sh
+++ b/scripts/dev/run_app.sh
@@ -159,6 +159,17 @@ cat > "$APP_BUNDLE/Contents/Info.plist" << 'PLIST'
     <dict>
         <key>NSAllowsLocalNetworking</key>
         <true/>
+        <!-- Keep in sync with scripts/dist/build_app_bundle.sh: ATS blocks
+             cleartext http to CGNAT 100.64.0.0/10 (Tailscale) even with
+             NSAllowsLocalNetworking, while the Settings validator allows it. -->
+        <key>NSExceptionDomains</key>
+        <dict>
+            <key>100.64.0.0/10</key>
+            <dict>
+                <key>NSExceptionAllowsInsecureHTTPLoads</key>
+                <true/>
+            </dict>
+        </dict>
     </dict>
     <key>NSMicrophoneUsageDescription</key>
     <string>MacParakeet needs microphone access for voice dictation.</string>

--- a/scripts/dist/build_app_bundle.sh
+++ b/scripts/dist/build_app_bundle.sh
@@ -702,6 +702,20 @@ cat >"$INFO_PLIST" <<EOF
   <dict>
     <key>NSAllowsLocalNetworking</key>
     <true/>
+    <!-- Settings lets an opted-in user point an OpenAI-compatible provider at
+         plain http on private IPv4/IPv6, link-local, .local, and CGNAT
+         100.64.0.0/10 (Tailscale) hosts. ATS already exempts the first four
+         but blocks cleartext to 100.64.0.0/10, and NSAllowsLocalNetworking
+         does not lift that. This exception matches the validator's allowlist
+         exactly; public hosts and addresses stay blocked. Issue #922. -->
+    <key>NSExceptionDomains</key>
+    <dict>
+      <key>100.64.0.0/10</key>
+      <dict>
+        <key>NSExceptionAllowsInsecureHTTPLoads</key>
+        <true/>
+      </dict>
+    </dict>
   </dict>
   <key>NSMicrophoneUsageDescription</key>
   <string>MacParakeet needs microphone access for dictation.</string>

--- a/scripts/dist/test_verify_app_privacy_surface.sh
+++ b/scripts/dist/test_verify_app_privacy_surface.sh
@@ -37,38 +37,38 @@ fi
 SCRIPT
 chmod +x "$FAKE_BIN/codesign"
 
+# make_app builds a fixture .app whose Info.plist carries the fixed privacy
+# strings plus the given NSAppTransportSecurity fragment (a JSON object), or
+# no NSAppTransportSecurity key at all when ats_json is empty. Building the
+# whole ATS dict as JSON — rather than issuing PlistBuddy `Add` commands per
+# key — lets each fixture describe an arbitrary shape (extra domains, extra
+# attributes) in one line.
 make_app() {
   local name="$1"
-  local local_networking="$2"
-  local cgnat_exception="${3:-true}"
+  local ats_json="$2"
   local app_path="$TMP_DIR/${name}.app"
   local plist_path="$app_path/Contents/Info.plist"
+  local json_path="$TMP_DIR/${name}.json"
 
   mkdir -p "$app_path/Contents"
-  /usr/libexec/PlistBuddy -c 'Clear dict' "$plist_path" >/dev/null 2>&1 || true
-  /usr/libexec/PlistBuddy -c 'Add :CFBundleIdentifier string com.macparakeet.fixture' "$plist_path"
-  /usr/libexec/PlistBuddy -c 'Add :NSMicrophoneUsageDescription string Microphone' "$plist_path"
-  /usr/libexec/PlistBuddy -c 'Add :NSAudioCaptureUsageDescription string System audio' "$plist_path"
-  /usr/libexec/PlistBuddy -c 'Add :NSCalendarsFullAccessUsageDescription string Calendar' "$plist_path"
-  if [[ "$local_networking" != "missing" ]]; then
-    /usr/libexec/PlistBuddy -c 'Add :NSAppTransportSecurity dict' "$plist_path"
-    /usr/libexec/PlistBuddy \
-      -c "Add :NSAppTransportSecurity:NSAllowsLocalNetworking bool $local_networking" \
-      "$plist_path"
-  fi
-  if [[ "$cgnat_exception" == "arbitrary" ]]; then
-    /usr/libexec/PlistBuddy -c 'Add :NSAppTransportSecurity dict' "$plist_path" >/dev/null 2>&1 || true
-    /usr/libexec/PlistBuddy -c 'Add :NSAppTransportSecurity:NSAllowsArbitraryLoads bool true' "$plist_path"
-    cgnat_exception="true"
-  fi
-  if [[ "$cgnat_exception" != "missing" ]]; then
-    /usr/libexec/PlistBuddy -c 'Add :NSAppTransportSecurity dict' "$plist_path" >/dev/null 2>&1 || true
-    /usr/libexec/PlistBuddy -c 'Add :NSAppTransportSecurity:NSExceptionDomains dict' "$plist_path"
-    /usr/libexec/PlistBuddy -c 'Add :NSAppTransportSecurity:NSExceptionDomains:100.64.0.0/10 dict' "$plist_path"
-    /usr/libexec/PlistBuddy \
-      -c "Add :NSAppTransportSecurity:NSExceptionDomains:100.64.0.0/10:NSExceptionAllowsInsecureHTTPLoads bool $cgnat_exception" \
-      "$plist_path"
-  fi
+
+  python3 - "$json_path" "$ats_json" <<'PY'
+import json
+import sys
+
+json_path, ats_json = sys.argv[1], sys.argv[2]
+doc = {
+    "CFBundleIdentifier": "com.macparakeet.fixture",
+    "NSMicrophoneUsageDescription": "Microphone",
+    "NSAudioCaptureUsageDescription": "System audio",
+    "NSCalendarsFullAccessUsageDescription": "Calendar",
+}
+if ats_json:
+    doc["NSAppTransportSecurity"] = json.loads(ats_json)
+with open(json_path, "w") as f:
+    json.dump(doc, f)
+PY
+  plutil -convert xml1 -o "$plist_path" "$json_path"
 
   printf '%s\n' "$app_path"
 }
@@ -112,26 +112,66 @@ assert_fail_contains() {
   fi
 }
 
-assert_pass "local networking explicitly allowed" "$(make_app allowed true)"
+ATS_MISMATCH="does not match the approved allowlist"
+
+# The one intended shape: local networking on, exactly one CGNAT exception
+# domain carrying exactly one attribute.
+ATS_OK='{"NSAllowsLocalNetworking": true, "NSExceptionDomains": {"100.64.0.0/10": {"NSExceptionAllowsInsecureHTTPLoads": true}}}'
+
+# Arbitrary-loads keys are allowed only when explicitly false (equivalent to absent).
+ATS_ARBITRARY_EXPLICITLY_FALSE='{"NSAllowsLocalNetworking": true, "NSExceptionDomains": {"100.64.0.0/10": {"NSExceptionAllowsInsecureHTTPLoads": true}}, "NSAllowsArbitraryLoads": false, "NSAllowsArbitraryLoadsInWebContent": false, "NSAllowsArbitraryLoadsForMedia": false}'
+
+ATS_LOCAL_NETWORKING_FALSE='{"NSAllowsLocalNetworking": false, "NSExceptionDomains": {"100.64.0.0/10": {"NSExceptionAllowsInsecureHTTPLoads": true}}}'
+ATS_CGNAT_MISSING='{"NSAllowsLocalNetworking": true}'
+ATS_CGNAT_FALSE='{"NSAllowsLocalNetworking": true, "NSExceptionDomains": {"100.64.0.0/10": {"NSExceptionAllowsInsecureHTTPLoads": false}}}'
+ATS_ARBITRARY_LOADS='{"NSAllowsLocalNetworking": true, "NSExceptionDomains": {"100.64.0.0/10": {"NSExceptionAllowsInsecureHTTPLoads": true}}, "NSAllowsArbitraryLoads": true}'
+ATS_ARBITRARY_LOADS_WEB='{"NSAllowsLocalNetworking": true, "NSExceptionDomains": {"100.64.0.0/10": {"NSExceptionAllowsInsecureHTTPLoads": true}}, "NSAllowsArbitraryLoadsInWebContent": true}'
+ATS_ARBITRARY_LOADS_MEDIA='{"NSAllowsLocalNetworking": true, "NSExceptionDomains": {"100.64.0.0/10": {"NSExceptionAllowsInsecureHTTPLoads": true}}, "NSAllowsArbitraryLoadsForMedia": true}'
+ATS_EXTRA_EXCEPTION_DOMAIN='{"NSAllowsLocalNetworking": true, "NSExceptionDomains": {"100.64.0.0/10": {"NSExceptionAllowsInsecureHTTPLoads": true}, "example.com": {"NSExceptionAllowsInsecureHTTPLoads": true}}}'
+ATS_OVERPERMISSIVE_DOMAIN_ENTRY='{"NSAllowsLocalNetworking": true, "NSExceptionDomains": {"100.64.0.0/10": {"NSExceptionAllowsInsecureHTTPLoads": true, "NSExceptionAllowsInsecureHTTPSLoads": true}}}'
+
+assert_pass "exact approved ATS surface" "$(make_app allowed "$ATS_OK")"
+assert_pass "arbitrary-loads keys explicitly false" "$(make_app allowed_false_explicit "$ATS_ARBITRARY_EXPLICITLY_FALSE")"
+
 assert_fail_contains \
-  "local networking key missing" \
-  "$(make_app missing missing)" \
-  "NSAppTransportSecurity:NSAllowsLocalNetworking"
+  "NSAppTransportSecurity key missing entirely" \
+  "$(make_app missing "")" \
+  "$ATS_MISMATCH"
 assert_fail_contains \
   "local networking explicitly denied" \
-  "$(make_app denied false)" \
-  "NSAppTransportSecurity:NSAllowsLocalNetworking"
+  "$(make_app denied "$ATS_LOCAL_NETWORKING_FALSE")" \
+  "$ATS_MISMATCH"
 assert_fail_contains \
   "CGNAT http exception missing" \
-  "$(make_app no_cgnat true missing)" \
-  "NSAppTransportSecurity:NSExceptionDomains:100.64.0.0/10:NSExceptionAllowsInsecureHTTPLoads"
+  "$(make_app no_cgnat "$ATS_CGNAT_MISSING")" \
+  "$ATS_MISMATCH"
 assert_fail_contains \
   "CGNAT http exception explicitly denied" \
-  "$(make_app cgnat_denied true false)" \
-  "NSAppTransportSecurity:NSExceptionDomains:100.64.0.0/10:NSExceptionAllowsInsecureHTTPLoads"
+  "$(make_app cgnat_denied "$ATS_CGNAT_FALSE")" \
+  "$ATS_MISMATCH"
 assert_fail_contains \
   "arbitrary loads must stay disabled" \
-  "$(make_app arbitrary true arbitrary)" \
-  "NSAppTransportSecurity:NSAllowsArbitraryLoads"
+  "$(make_app arbitrary "$ATS_ARBITRARY_LOADS")" \
+  "$ATS_MISMATCH"
+# Regression for the Greptile P1 (thread PRRT_kwDORMx8l86fvfg1): a presence
+# check on the CGNAT exception and the base NSAllowsArbitraryLoads key let an
+# extra insecure exception domain, or the web/media arbitrary-loads keys,
+# through undetected. The allowlist comparison must reject each of them.
+assert_fail_contains \
+  "extra exception domain rejected" \
+  "$(make_app extra_domain "$ATS_EXTRA_EXCEPTION_DOMAIN")" \
+  "$ATS_MISMATCH"
+assert_fail_contains \
+  "NSAllowsArbitraryLoadsInWebContent rejected" \
+  "$(make_app arbitrary_web "$ATS_ARBITRARY_LOADS_WEB")" \
+  "$ATS_MISMATCH"
+assert_fail_contains \
+  "NSAllowsArbitraryLoadsForMedia rejected" \
+  "$(make_app arbitrary_media "$ATS_ARBITRARY_LOADS_MEDIA")" \
+  "$ATS_MISMATCH"
+assert_fail_contains \
+  "over-permissive attribute inside the approved domain entry rejected" \
+  "$(make_app overpermissive_domain "$ATS_OVERPERMISSIVE_DOMAIN_ENTRY")" \
+  "$ATS_MISMATCH"
 
 echo "verify_app_privacy_surface fixture tests passed"

--- a/scripts/dist/test_verify_app_privacy_surface.sh
+++ b/scripts/dist/test_verify_app_privacy_surface.sh
@@ -40,6 +40,7 @@ chmod +x "$FAKE_BIN/codesign"
 make_app() {
   local name="$1"
   local local_networking="$2"
+  local cgnat_exception="${3:-true}"
   local app_path="$TMP_DIR/${name}.app"
   local plist_path="$app_path/Contents/Info.plist"
 
@@ -53,6 +54,19 @@ make_app() {
     /usr/libexec/PlistBuddy -c 'Add :NSAppTransportSecurity dict' "$plist_path"
     /usr/libexec/PlistBuddy \
       -c "Add :NSAppTransportSecurity:NSAllowsLocalNetworking bool $local_networking" \
+      "$plist_path"
+  fi
+  if [[ "$cgnat_exception" == "arbitrary" ]]; then
+    /usr/libexec/PlistBuddy -c 'Add :NSAppTransportSecurity dict' "$plist_path" >/dev/null 2>&1 || true
+    /usr/libexec/PlistBuddy -c 'Add :NSAppTransportSecurity:NSAllowsArbitraryLoads bool true' "$plist_path"
+    cgnat_exception="true"
+  fi
+  if [[ "$cgnat_exception" != "missing" ]]; then
+    /usr/libexec/PlistBuddy -c 'Add :NSAppTransportSecurity dict' "$plist_path" >/dev/null 2>&1 || true
+    /usr/libexec/PlistBuddy -c 'Add :NSAppTransportSecurity:NSExceptionDomains dict' "$plist_path"
+    /usr/libexec/PlistBuddy -c 'Add :NSAppTransportSecurity:NSExceptionDomains:100.64.0.0/10 dict' "$plist_path"
+    /usr/libexec/PlistBuddy \
+      -c "Add :NSAppTransportSecurity:NSExceptionDomains:100.64.0.0/10:NSExceptionAllowsInsecureHTTPLoads bool $cgnat_exception" \
       "$plist_path"
   fi
 
@@ -107,5 +121,17 @@ assert_fail_contains \
   "local networking explicitly denied" \
   "$(make_app denied false)" \
   "NSAppTransportSecurity:NSAllowsLocalNetworking"
+assert_fail_contains \
+  "CGNAT http exception missing" \
+  "$(make_app no_cgnat true missing)" \
+  "NSAppTransportSecurity:NSExceptionDomains:100.64.0.0/10:NSExceptionAllowsInsecureHTTPLoads"
+assert_fail_contains \
+  "CGNAT http exception explicitly denied" \
+  "$(make_app cgnat_denied true false)" \
+  "NSAppTransportSecurity:NSExceptionDomains:100.64.0.0/10:NSExceptionAllowsInsecureHTTPLoads"
+assert_fail_contains \
+  "arbitrary loads must stay disabled" \
+  "$(make_app arbitrary true arbitrary)" \
+  "NSAppTransportSecurity:NSAllowsArbitraryLoads"
 
 echo "verify_app_privacy_surface fixture tests passed"

--- a/scripts/dist/verify_app_privacy_surface.sh
+++ b/scripts/dist/verify_app_privacy_surface.sh
@@ -67,12 +67,54 @@ require_entitlement_true() {
   fi
 }
 
+require_exact_ats_surface() {
+  # Allowlist, not a presence check: the intended ATS policy is
+  # NSAllowsLocalNetworking plus exactly one CGNAT exception domain
+  # carrying exactly one attribute. Anything else — an extra exception
+  # domain, an over-permissive attribute inside the approved domain (e.g.
+  # NSExceptionAllowsInsecureHTTPSLoads, NSIncludesSubdomains, a lowered
+  # TLS minimum), or NSAllowsArbitraryLoads/…InWebContent/…ForMedia set to
+  # true — must fail the gate rather than pass silently.
+  local surface
+  surface="$(plutil -extract NSAppTransportSecurity json -o - "$INFO_PLIST" 2>/dev/null || echo '{}')"
+  python3 - "$surface" <<'PY' || fail "NSAppTransportSecurity does not match the approved allowlist"
+import json
+import sys
+
+surface = json.loads(sys.argv[1])
+
+# These three may be present as an explicit false, but never true or absent-with-truthy-intent elsewhere.
+for key in (
+    "NSAllowsArbitraryLoads",
+    "NSAllowsArbitraryLoadsInWebContent",
+    "NSAllowsArbitraryLoadsForMedia",
+):
+    if surface.get(key) is False:
+        del surface[key]
+
+expected = {
+    "NSAllowsLocalNetworking": True,
+    "NSExceptionDomains": {
+        "100.64.0.0/10": {
+            "NSExceptionAllowsInsecureHTTPLoads": True,
+        },
+    },
+}
+
+if surface != expected:
+    print(
+        "got {} expected {}".format(
+            json.dumps(surface, sort_keys=True),
+            json.dumps(expected, sort_keys=True),
+        ),
+        file=sys.stderr,
+    )
+    sys.exit(1)
+PY
+}
+
 require_info_value "CFBundleIdentifier" "$EXPECTED_BUNDLE_ID"
-require_info_value "NSAppTransportSecurity:NSAllowsLocalNetworking" "true"
-require_info_value \
-  "NSAppTransportSecurity:NSExceptionDomains:100.64.0.0/10:NSExceptionAllowsInsecureHTTPLoads" \
-  "true"
-require_info_value "NSAppTransportSecurity:NSAllowsArbitraryLoads" ""
+require_exact_ats_surface
 
 require_info_string "NSMicrophoneUsageDescription"
 require_info_string "NSAudioCaptureUsageDescription"

--- a/scripts/dist/verify_app_privacy_surface.sh
+++ b/scripts/dist/verify_app_privacy_surface.sh
@@ -69,6 +69,10 @@ require_entitlement_true() {
 
 require_info_value "CFBundleIdentifier" "$EXPECTED_BUNDLE_ID"
 require_info_value "NSAppTransportSecurity:NSAllowsLocalNetworking" "true"
+require_info_value \
+  "NSAppTransportSecurity:NSExceptionDomains:100.64.0.0/10:NSExceptionAllowsInsecureHTTPLoads" \
+  "true"
+require_info_value "NSAppTransportSecurity:NSAllowsArbitraryLoads" ""
 
 require_info_string "NSMicrophoneUsageDescription"
 require_info_string "NSAudioCaptureUsageDescription"


### PR DESCRIPTION
## Summary

Fixes the "Allow HTTP" toggle appearing to do nothing for OpenAI-compatible providers on Tailscale (#922). The toggle and validator work as designed; the app bundle's App Transport Security (ATS) policy blocked the resulting cleartext requests. This PR adds a scoped ATS exception for the one address range the validator allows but ATS does not.

## Root cause

ATS, not the validator. The issue screenshot shows `http://100.113.12.48/v1`, a Tailscale (CGNAT `100.64.0.0/10`) address. `LLMSettingsDraft` accepts it as local-network HTTP (the "sent to your local AI endpoint over HTTP" banner is visible in the screenshot), so the config saves. Every request then fails with `NSURLErrorAppTransportSecurityRequiresSecureConnection`.

Probe `.app` bundles on macOS 26.6.2, plain `http://` to each host:

| Info.plist ATS config | 10.x / 192.168.x / fe80 / fd12 / .local | `100.113.12.48` | `8.8.8.8`, `example.com` |
|---|---|---|---|
| none | allowed | blocked | blocked |
| `NSAllowsLocalNetworking` (2853e296) | allowed | blocked | blocked |
| `NSExceptionDomains` `100.64.0.0/10` (this PR) | allowed | allowed | blocked |
| `NSAllowsArbitraryLoads` | allowed | allowed | allowed |

Every other range the validator allows is already exempt from ATS by default. `100.64.0.0/10` is the only mismatch. The `NSAllowsLocalNetworking` key added in 2853e296 does not cover the Tailscale range, so that commit alone does not close #922. The CLI binary has no Info.plist and is not subject to ATS.

## Fix

- `scripts/dist/build_app_bundle.sh`, `scripts/dev/run_app.sh`: add `NSExceptionDomains` -> `100.64.0.0/10` -> `NSExceptionAllowsInsecureHTTPLoads = true`. Public hosts and addresses stay blocked. `NSAllowsArbitraryLoads` is not used.
- `scripts/dist/verify_app_privacy_surface.sh`: require the CIDR exception and assert `NSAllowsArbitraryLoads` is unset.
- `scripts/dist/test_verify_app_privacy_surface.sh`: fixtures for present, missing, false, and arbitrary-loads cases.

No Swift, spec, or copy change. Widening `LLMSettingsDraft` would not have helped; the reporter's URL already passes validation.

## Scope: this closes the OpenAI-compatible path, not every provider

The exception matches the validator's allowlist for the **OpenAI-compatible**
provider, which is the path #922 reports. It is deliberately narrower than the
validator for local providers.

`LLMSettingsDraft.validationIssue` returns `nil` for any `http` host when
`providerID.isLocal` (Ollama, LM Studio), with no opt-in required. So an Ollama
user pointing at an `http` host outside the ATS-exempt ranges still saves the
config and still hits the same opaque
`NSURLErrorAppTransportSecurityRequiresSecureConnection` at request time.

That gap is left open on purpose. Closing it by widening ATS would mean allowing
cleartext to arbitrary public hosts, which is the wrong trade for prompt bodies
and transcripts. Closing it by narrowing the validator would break existing
working local-provider setups. If it turns out to bite real users, the better
fix is surfacing the ATS failure as an actionable message rather than changing
either boundary.

## Verification

- `bash scripts/dist/test_verify_app_privacy_surface.sh`: passed (6 assertions, 3 new).
- Rendered both real plists (dist heredoc via bash eval with fixture values, dev heredoc) and ran `plutil -lint`: OK for both.
- Probe with those exact rendered plists: `http://100.113.12.48` passes ATS (reaches connection attempt), `http://8.8.8.8` and `http://example.com` remain ATS-blocked, `https://example.com` unaffected.
- `git diff --check` clean. Scripts-only change, so no `swift build` or `swift test` needed.

Not verified: the signed release bundle has not been run against a live
Tailscale endpoint. Evidence is probe bundles carrying the exact rendered
plists, not an end-to-end request from the shipping app.

Closes #922

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Development Improvements**
  - Development builds can now connect to services hosted on the Tailscale CGNAT range using HTTP.
  - This improves local testing and development workflows for apps that communicate with Tailscale-hosted services without HTTPS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->