### PR TITLE
Draw the Library source label at the level the filter leaves open

### DIFF
--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingRowCard.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingRowCard.swift
@@ -1,4 +1,5 @@
 import MacParakeetCore
+import MacParakeetViewModels
 import SwiftUI
 
 /// Single row in the Meetings list. Apple-minimal layout: title + snippet on
@@ -9,7 +10,7 @@ struct MeetingRowCard<MenuContent: View>: View {
     var searchText: String = ""
     var isSelected: Bool = false
     var showsSelectionControls: Bool = false
-    var showsSource = false
+    var sourceLabelStyle: LibrarySourceLabelStyle = .hidden
     var isRetrying: Bool = false
     var onTap: () -> Void
     var onRetry: (() -> Void)? = nil
@@ -145,7 +146,7 @@ struct MeetingRowCard<MenuContent: View>: View {
                 .contentTransition(.opacity)
                 .layoutPriority(1)
 
-            if showsSource {
+            if sourceLabelStyle != .hidden {
                 sourceInline
             }
 
@@ -160,12 +161,11 @@ struct MeetingRowCard<MenuContent: View>: View {
     }
 
     private var sourceInline: some View {
-        let source = TranscriptionSourceDisplay.resolve(for: transcription)
-        return Label(source.collapsedText, systemImage: source.systemImage)
-            .font(DesignSystem.Typography.micro.weight(.medium))
-            .foregroundStyle(source.tint)
-            .lineLimit(1)
-            .fixedSize()
+        TranscriptionSourceLabel(
+            source: TranscriptionSourceDisplay.resolve(for: transcription),
+            style: sourceLabelStyle,
+            font: DesignSystem.Typography.micro.weight(.medium)
+        )
     }
 
     @ViewBuilder

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
@@ -301,7 +301,8 @@ struct TranscriptionLibraryView: View {
                             transcription: transcription,
                             searchText: viewModel.searchText,
                             isSelected: viewModel.isTranscriptionSelected(transcription),
-                            showsSelectionControls: viewModel.isBulkSelectionModeEnabled
+                            showsSelectionControls: viewModel.isBulkSelectionModeEnabled,
+                            sourceLabelStyle: sourceLabelStyle
                         ) {
                             if viewModel.isBulkOperationInProgress || bulkExportInProgress {
                                 return
@@ -338,7 +339,7 @@ struct TranscriptionLibraryView: View {
                             searchText: viewModel.searchText,
                             isSelected: viewModel.isTranscriptionSelected(transcription),
                             showsSelectionControls: viewModel.isBulkSelectionModeEnabled,
-                            showsSource: !isMeetingContext,
+                            sourceLabelStyle: sourceLabelStyle,
                             isRetrying: viewModel.isRetryingMeetingTranscription(transcription),
                             onTap: {
                                 if viewModel.isBulkOperationInProgress || bulkExportInProgress {
@@ -933,6 +934,12 @@ struct TranscriptionLibraryView: View {
 
     private var isMeetingContext: Bool {
         viewModel.scope == .meetings || viewModel.filter == .meeting
+    }
+
+    /// Drawn from the same `(scope, filter)` pair the query uses, so the label
+    /// disappears exactly when the filter has already answered it.
+    private var sourceLabelStyle: LibrarySourceLabelStyle {
+        viewModel.scope.sourceLabelStyle(for: viewModel.filter)
     }
 
     private var libraryLayoutMode: LibraryLayoutMode {

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionSourceDisplay.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionSourceDisplay.swift
@@ -43,6 +43,21 @@ enum TranscriptionSourceDisplay: Equatable {
         }
     }
 
+    /// Whether the glyph alone identifies the source.
+    ///
+    /// The platform marks are logos people already read as the brand, so the
+    /// word beside them adds nothing. The rest are plain SF Symbols — a
+    /// waveform or a film frame names no source on its own — and must keep
+    /// their text wherever the surrounding context does not supply it.
+    var markIsSelfEvident: Bool {
+        switch self {
+        case .youtube, .x, .vimeo, .facebook, .tiktok, .instagram:
+            return true
+        case .meeting, .localFile, .podcast, .audioURL, .mediaURL:
+            return false
+        }
+    }
+
     var collapsedText: String {
         switch self {
         case .meeting: return "Meeting"

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionSourceDisplay.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionSourceDisplay.swift
@@ -43,6 +43,26 @@ enum TranscriptionSourceDisplay: Equatable {
         }
     }
 
+    /// The platform whose bundled brand mark identifies this source on sight.
+    ///
+    /// Only the six whose display maps to exactly one platform. `.podcast`
+    /// covers any feed, not just Apple Podcasts, and `.mediaURL` covers Twitch
+    /// *and* unrecognized hosts, so neither can claim a mark. `.audioURL` is
+    /// reached only from SoundCloud today, but the case is named for audio in
+    /// general and would mislabel a future generic audio source, so it is left
+    /// out too. Anything absent here keeps its SF Symbol and its text.
+    var brandedPlatform: MediaPlatform? {
+        switch self {
+        case .youtube: return .youtube
+        case .x: return .x
+        case .vimeo: return .vimeo
+        case .facebook: return .facebook
+        case .tiktok: return .tiktok
+        case .instagram: return .instagram
+        case .meeting, .localFile, .podcast, .audioURL, .mediaURL: return nil
+        }
+    }
+
     var collapsedText: String {
         switch self {
         case .meeting: return "Meeting"

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionSourceDisplay.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionSourceDisplay.swift
@@ -43,21 +43,6 @@ enum TranscriptionSourceDisplay: Equatable {
         }
     }
 
-    /// Whether the glyph alone identifies the source.
-    ///
-    /// The platform marks are logos people already read as the brand, so the
-    /// word beside them adds nothing. The rest are plain SF Symbols — a
-    /// waveform or a film frame names no source on its own — and must keep
-    /// their text wherever the surrounding context does not supply it.
-    var markIsSelfEvident: Bool {
-        switch self {
-        case .youtube, .x, .vimeo, .facebook, .tiktok, .instagram:
-            return true
-        case .meeting, .localFile, .podcast, .audioURL, .mediaURL:
-            return false
-        }
-    }
-
     var collapsedText: String {
         switch self {
         case .meeting: return "Meeting"

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionSourceLabel.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionSourceLabel.swift
@@ -1,17 +1,17 @@
 import SwiftUI
 import MacParakeetViewModels
 
-/// Source attribution for a Library row or card, drawn at the level the
-/// surrounding context actually leaves open.
+/// Source attribution for a Library row or card, drawn only where the
+/// surrounding context leaves the source open.
 ///
 /// Both the grid card and the list row render source the same way, so the
 /// decision lives here rather than being restated at each call site.
 ///
-/// `style` says how much the context leaves unanswered; the resolved source
-/// says whether its own glyph can carry the meaning alone. `.iconOnly`
-/// degrades to icon-and-text for a source whose mark is a plain SF Symbol —
-/// under Video, a SoundCloud upload is "Audio" and a Twitch VOD is "Video",
-/// and a bare waveform would drop that distinction rather than tighten it.
+/// The text is never dropped while the glyph stays. Seven of the sources
+/// reachable under the Video filter share `play.rectangle.fill` and differ
+/// only by tint, so an icon on its own would name no platform — and would
+/// name nothing at all to a reader who cannot separate those tints. Hiding
+/// the label entirely is honest; hiding only its text is not.
 struct TranscriptionSourceLabel: View {
     let source: TranscriptionSourceDisplay
     let style: LibrarySourceLabelStyle
@@ -21,29 +21,12 @@ struct TranscriptionSourceLabel: View {
         switch style {
         case .hidden:
             EmptyView()
-        case .full:
-            label(showsText: true)
-        case .iconOnly:
-            label(showsText: source.markIsSelfEvident == false)
+        case .visible:
+            Label(source.collapsedText, systemImage: source.systemImage)
+                .font(font)
+                .foregroundStyle(source.tint)
+                .lineLimit(1)
+                .fixedSize()
         }
-    }
-
-    private func label(showsText: Bool) -> some View {
-        Label {
-            if showsText {
-                Text(source.collapsedText)
-            }
-        } icon: {
-            Image(systemName: source.systemImage)
-        }
-        .labelStyle(.titleAndIcon)
-        .font(font)
-        .foregroundStyle(source.tint)
-        .lineLimit(1)
-        .fixedSize()
-        // The text is dropped only because the glyph already says it; a
-        // screen reader gets no glyph, so it always hears the full name.
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel(source.collapsedText)
     }
 }

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionSourceLabel.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionSourceLabel.swift
@@ -1,0 +1,49 @@
+import SwiftUI
+import MacParakeetViewModels
+
+/// Source attribution for a Library row or card, drawn at the level the
+/// surrounding context actually leaves open.
+///
+/// Both the grid card and the list row render source the same way, so the
+/// decision lives here rather than being restated at each call site.
+///
+/// `style` says how much the context leaves unanswered; the resolved source
+/// says whether its own glyph can carry the meaning alone. `.iconOnly`
+/// degrades to icon-and-text for a source whose mark is a plain SF Symbol —
+/// under Video, a SoundCloud upload is "Audio" and a Twitch VOD is "Video",
+/// and a bare waveform would drop that distinction rather than tighten it.
+struct TranscriptionSourceLabel: View {
+    let source: TranscriptionSourceDisplay
+    let style: LibrarySourceLabelStyle
+    var font: Font = DesignSystem.Typography.caption
+
+    var body: some View {
+        switch style {
+        case .hidden:
+            EmptyView()
+        case .full:
+            label(showsText: true)
+        case .iconOnly:
+            label(showsText: source.markIsSelfEvident == false)
+        }
+    }
+
+    private func label(showsText: Bool) -> some View {
+        Label {
+            if showsText {
+                Text(source.collapsedText)
+            }
+        } icon: {
+            Image(systemName: source.systemImage)
+        }
+        .labelStyle(.titleAndIcon)
+        .font(font)
+        .foregroundStyle(source.tint)
+        .lineLimit(1)
+        .fixedSize()
+        // The text is dropped only because the glyph already says it; a
+        // screen reader gets no glyph, so it always hears the full name.
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(source.collapsedText)
+    }
+}

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionSourceLabel.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionSourceLabel.swift
@@ -1,32 +1,53 @@
 import SwiftUI
+import MacParakeetCore
 import MacParakeetViewModels
 
-/// Source attribution for a Library row or card, drawn only where the
-/// surrounding context leaves the source open.
+/// Source attribution for a Library row or card, drawn at the level the
+/// surrounding context leaves open.
 ///
 /// Both the grid card and the list row render source the same way, so the
 /// decision lives here rather than being restated at each call site.
 ///
-/// The text is never dropped while the glyph stays. Seven of the sources
-/// reachable under the Video filter share `play.rectangle.fill` and differ
-/// only by tint, so an icon on its own would name no platform — and would
-/// name nothing at all to a reader who cannot separate those tints. Hiding
-/// the label entirely is honest; hiding only its text is not.
+/// The text is dropped only where a real brand mark replaces it. The SF Symbol
+/// fallback cannot carry a source on its own — seven of the sources reachable
+/// under the Video filter share `play.rectangle.fill` and differ only by tint,
+/// which names nothing to a reader who cannot separate those colors — so
+/// anything without a bundled mark keeps its word.
 struct TranscriptionSourceLabel: View {
     let source: TranscriptionSourceDisplay
     let style: LibrarySourceLabelStyle
     var font: Font = DesignSystem.Typography.caption
+    var markSize: CGFloat = 11
+
+    /// A brand mark stands in for the text only when we actually ship one for
+    /// this source *and* the context has already narrowed the family.
+    private var brandMark: MediaPlatform? {
+        guard style == .brandMarkOnly else { return nil }
+        guard let platform = source.brandedPlatform else { return nil }
+        guard BrandGlyphImage.image(for: platform) != nil else { return nil }
+        return platform
+    }
 
     var body: some View {
         switch style {
         case .hidden:
             EmptyView()
-        case .visible:
-            Label(source.collapsedText, systemImage: source.systemImage)
-                .font(font)
-                .foregroundStyle(source.tint)
-                .lineLimit(1)
-                .fixedSize()
+        case .visible, .brandMarkOnly:
+            if let platform = brandMark {
+                PlatformGlyph(platform: platform, color: source.tint)
+                    .frame(width: markSize, height: markSize)
+                    // PlatformGlyph hides itself from accessibility, so the
+                    // name a sighted reader gets from the logo is restored
+                    // here rather than lost with the text.
+                    .accessibilityElement()
+                    .accessibilityLabel(source.collapsedText)
+            } else {
+                Label(source.collapsedText, systemImage: source.systemImage)
+                    .font(font)
+                    .foregroundStyle(source.tint)
+                    .lineLimit(1)
+                    .fixedSize()
+            }
         }
     }
 }

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionSourceLabel.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionSourceLabel.swift
@@ -13,6 +13,14 @@ import MacParakeetViewModels
 /// under the Video filter share `play.rectangle.fill` and differ only by tint,
 /// which names nothing to a reader who cannot separate those colors — so
 /// anything without a bundled mark keeps its word.
+///
+/// Known gap, pre-existing and not closed here: `resolve` falls back to
+/// `.youtube` for a `.youtube` row with no stored `sourceURL`, so such a row
+/// draws the YouTube mark whatever its real origin. It already read "YouTube"
+/// before this change, and the only creation path always stores the URL, so
+/// this needs a legacy or corrupt row. Closing it means changing that fallback
+/// to `.mediaURL`, which also moves the transcript detail chip and is its own
+/// change.
 struct TranscriptionSourceLabel: View {
     let source: TranscriptionSourceDisplay
     let style: LibrarySourceLabelStyle
@@ -34,13 +42,20 @@ struct TranscriptionSourceLabel: View {
             EmptyView()
         case .visible, .brandMarkOnly:
             if let platform = brandMark {
-                PlatformGlyph(platform: platform, color: source.tint)
-                    .frame(width: markSize, height: markSize)
-                    // PlatformGlyph hides itself from accessibility, so the
-                    // name a sighted reader gets from the logo is restored
-                    // here rather than lost with the text.
-                    .accessibilityElement()
-                    .accessibilityLabel(source.collapsedText)
+                // `.iconOnly` keeps the title as the element's accessibility
+                // text while drawing only the mark, so the name a sighted
+                // reader takes from the logo is not lost with the word. The
+                // explicit label is belt and braces: PlatformGlyph hides
+                // itself, and this must not depend on that flag being
+                // overridden from outside.
+                Label {
+                    Text(source.collapsedText)
+                } icon: {
+                    PlatformGlyph(platform: platform, color: source.tint)
+                        .frame(width: markSize, height: markSize)
+                }
+                .labelStyle(.iconOnly)
+                .accessibilityLabel(source.collapsedText)
             } else {
                 Label(source.collapsedText, systemImage: source.systemImage)
                     .font(font)

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionThumbnailCard.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionThumbnailCard.swift
@@ -241,7 +241,11 @@ struct TranscriptionThumbnailCard<MenuContent: View>: View {
             }
 
             HStack(spacing: 6) {
-                TranscriptionSourceLabel(source: sourceDisplay, style: sourceLabelStyle)
+                // Guarded rather than relying on an EmptyView contributing no
+                // spacing, so a hidden label cannot shift the date 6pt right.
+                if sourceLabelStyle != .hidden {
+                    TranscriptionSourceLabel(source: sourceDisplay, style: sourceLabelStyle)
+                }
 
                 Text(transcription.createdAt.relativeFormatted)
                     .foregroundStyle(DesignSystem.Colors.textTertiary)

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionThumbnailCard.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionThumbnailCard.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import MacParakeetCore
+import MacParakeetViewModels
 
 private let sharedThumbnailCache = ThumbnailCacheService.shared
 
@@ -9,6 +10,7 @@ struct TranscriptionThumbnailCard<MenuContent: View>: View {
     var searchText: String = ""
     var isSelected: Bool = false
     var showsSelectionControls: Bool = false
+    var sourceLabelStyle: LibrarySourceLabelStyle = .full
     var onTap: () -> Void
     @ViewBuilder var menuContent: () -> MenuContent
 
@@ -239,9 +241,7 @@ struct TranscriptionThumbnailCard<MenuContent: View>: View {
             }
 
             HStack(spacing: 6) {
-                Label(sourceDisplay.collapsedText, systemImage: sourceDisplay.systemImage)
-                    .foregroundStyle(sourceDisplay.tint)
-                    .fixedSize()
+                TranscriptionSourceLabel(source: sourceDisplay, style: sourceLabelStyle)
 
                 Text(transcription.createdAt.relativeFormatted)
                     .foregroundStyle(DesignSystem.Colors.textTertiary)

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionThumbnailCard.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionThumbnailCard.swift
@@ -10,7 +10,7 @@ struct TranscriptionThumbnailCard<MenuContent: View>: View {
     var searchText: String = ""
     var isSelected: Bool = false
     var showsSelectionControls: Bool = false
-    var sourceLabelStyle: LibrarySourceLabelStyle = .full
+    var sourceLabelStyle: LibrarySourceLabelStyle = .visible
     var onTap: () -> Void
     @ViewBuilder var menuContent: () -> MenuContent
 

--- a/Sources/MacParakeetViewModels/TranscriptionLibraryViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionLibraryViewModel.swift
@@ -16,20 +16,16 @@ public enum TranscriptionLibraryScope: Sendable {
     case meetings
 }
 
-/// How much of a row/card's source attribution is worth drawing.
+/// Whether a row/card's source attribution is worth drawing.
 ///
 /// A source label that repeats the active filter is noise: browsing Podcasts
 /// and reading "Podcast" on every card answers a question the filter already
 /// answered. The label only earns its place when the current context leaves
 /// the source genuinely open.
 public enum LibrarySourceLabelStyle: String, Sendable, Equatable, CaseIterable {
-    /// Icon and text. The context admits several unrelated sources, so the
-    /// label is the only thing separating a meeting from a podcast episode.
-    case full
-    /// Icon alone. The context narrows the source to one family whose members
-    /// are told apart by a recognizable platform mark, so the word is
-    /// redundant with both the filter and the glyph.
-    case iconOnly
+    /// Icon and text. The context admits more than one source, so the label
+    /// carries information the filter does not.
+    case visible
     /// Nothing. The context admits exactly one source, so the label can only
     /// restate the filter.
     case hidden
@@ -42,8 +38,8 @@ extension TranscriptionLibraryScope {
     ///
     /// Kept in step with `makeQuery(offset:)`, which maps the same pairs onto
     /// a stored `SourceType`. A pair whose query pins one `SourceType` that
-    /// resolves to exactly one display is `.hidden`; the shared URL source
-    /// type resolves to nine different platforms, so it is `.iconOnly`.
+    /// resolves to exactly one display is `.hidden`; anything that can still
+    /// resolve to more than one display keeps its label.
     public func sourceLabelStyle(for filter: LibraryFilter) -> LibrarySourceLabelStyle {
         switch self {
         case .meetings:
@@ -51,9 +47,13 @@ extension TranscriptionLibraryScope {
         case .all:
             switch filter {
             case .all, .favorites:
-                return .full
+                return .visible
+            // Video narrows to one stored source type that still resolves to
+            // several platforms, and they share a single `play.rectangle.fill`
+            // glyph that differs only by tint. The text is the only thing
+            // telling an X post from a YouTube video here, so it stays.
             case .youtube:
-                return .iconOnly
+                return .visible
             case .podcast, .local, .meeting:
                 return .hidden
             }

--- a/Sources/MacParakeetViewModels/TranscriptionLibraryViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionLibraryViewModel.swift
@@ -26,6 +26,11 @@ public enum LibrarySourceLabelStyle: String, Sendable, Equatable, CaseIterable {
     /// Icon and text. The context admits more than one source, so the label
     /// carries information the filter does not.
     case visible
+    /// Icon alone where a source has a brand mark that identifies it on sight;
+    /// icon and text otherwise. The context has narrowed the source to one
+    /// family, so the word repeats the filter for anything already named by
+    /// its logo.
+    case brandMarkOnly
     /// Nothing. The context admits exactly one source, so the label can only
     /// restate the filter.
     case hidden
@@ -48,12 +53,8 @@ extension TranscriptionLibraryScope {
             switch filter {
             case .all, .favorites:
                 return .visible
-            // Video narrows to one stored source type that still resolves to
-            // several platforms, and they share a single `play.rectangle.fill`
-            // glyph that differs only by tint. The text is the only thing
-            // telling an X post from a YouTube video here, so it stays.
             case .youtube:
-                return .visible
+                return .brandMarkOnly
             case .podcast, .local, .meeting:
                 return .hidden
             }

--- a/Sources/MacParakeetViewModels/TranscriptionLibraryViewModel.swift
+++ b/Sources/MacParakeetViewModels/TranscriptionLibraryViewModel.swift
@@ -16,6 +16,51 @@ public enum TranscriptionLibraryScope: Sendable {
     case meetings
 }
 
+/// How much of a row/card's source attribution is worth drawing.
+///
+/// A source label that repeats the active filter is noise: browsing Podcasts
+/// and reading "Podcast" on every card answers a question the filter already
+/// answered. The label only earns its place when the current context leaves
+/// the source genuinely open.
+public enum LibrarySourceLabelStyle: String, Sendable, Equatable, CaseIterable {
+    /// Icon and text. The context admits several unrelated sources, so the
+    /// label is the only thing separating a meeting from a podcast episode.
+    case full
+    /// Icon alone. The context narrows the source to one family whose members
+    /// are told apart by a recognizable platform mark, so the word is
+    /// redundant with both the filter and the glyph.
+    case iconOnly
+    /// Nothing. The context admits exactly one source, so the label can only
+    /// restate the filter.
+    case hidden
+}
+
+extension TranscriptionLibraryScope {
+    /// Resolved against `(scope, filter)` rather than the filter alone: the
+    /// Meetings workspace shows only meetings whatever its filter says, so
+    /// even Favorites is fully determined there.
+    ///
+    /// Kept in step with `makeQuery(offset:)`, which maps the same pairs onto
+    /// a stored `SourceType`. A pair whose query pins one `SourceType` that
+    /// resolves to exactly one display is `.hidden`; the shared URL source
+    /// type resolves to nine different platforms, so it is `.iconOnly`.
+    public func sourceLabelStyle(for filter: LibraryFilter) -> LibrarySourceLabelStyle {
+        switch self {
+        case .meetings:
+            return .hidden
+        case .all:
+            switch filter {
+            case .all, .favorites:
+                return .full
+            case .youtube:
+                return .iconOnly
+            case .podcast, .local, .meeting:
+                return .hidden
+            }
+        }
+    }
+}
+
 public typealias LibrarySortOrder = TranscriptionLibrarySortOrder
 
 /// Date-based bucket used to group meeting/library rows under headers like

--- a/Tests/MacParakeetTests/ViewModels/LibrarySourceLabelStyleTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/LibrarySourceLabelStyleTests.swift
@@ -13,12 +13,12 @@ final class LibrarySourceLabelStyleTests: XCTestCase {
     func testMixedContextsShowTheFullLabel() {
         XCTAssertEqual(
             TranscriptionLibraryScope.all.sourceLabelStyle(for: .all),
-            .full,
+            .visible,
             "All admits every source, so the label is the only source attribution"
         )
         XCTAssertEqual(
             TranscriptionLibraryScope.all.sourceLabelStyle(for: .favorites),
-            .full,
+            .visible,
             "Favorites spans sources, so a starred meeting and a starred podcast must stay distinguishable"
         )
     }
@@ -45,13 +45,16 @@ final class LibrarySourceLabelStyleTests: XCTestCase {
         }
     }
 
-    // MARK: - The multi-platform filter keeps the glyph, drops the word
+    // MARK: - The multi-platform filter keeps its label
 
-    func testVideoFilterCollapsesToTheIcon() {
+    /// Video looks like the obvious place to drop the word, and it is not.
+    /// Its platforms share one `play.rectangle.fill` glyph separated only by
+    /// tint, so the text is the only thing naming the platform.
+    func testVideoFilterKeepsTheLabelBecauseItsPlatformsShareOneGlyph() {
         XCTAssertEqual(
             TranscriptionLibraryScope.all.sourceLabelStyle(for: .youtube),
-            .iconOnly,
-            "Video spans several platforms, so the mark still carries information but the word repeats the filter"
+            .visible,
+            "Video resolves to several platforms that are not distinguishable by glyph alone"
         )
     }
 

--- a/Tests/MacParakeetTests/ViewModels/LibrarySourceLabelStyleTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/LibrarySourceLabelStyleTests.swift
@@ -50,30 +50,47 @@ final class LibrarySourceLabelStyleTests: XCTestCase {
     /// Video looks like the obvious place to drop the word, and it is not.
     /// Its platforms share one `play.rectangle.fill` glyph separated only by
     /// tint, so the text is the only thing naming the platform.
-    func testVideoFilterKeepsTheLabelBecauseItsPlatformsShareOneGlyph() {
+    func testVideoFilterUsesBrandMarks() {
         XCTAssertEqual(
             TranscriptionLibraryScope.all.sourceLabelStyle(for: .youtube),
-            .visible,
-            "Video resolves to several platforms that are not distinguishable by glyph alone"
+            .brandMarkOnly,
+            "Video has narrowed the family, so a platform named by its own logo need not repeat the word"
         )
     }
 
     // MARK: - Drift guard
 
     /// The style is only correct because it mirrors how `makeQuery(offset:)`
-    /// narrows each pair. If a new filter is added without deciding its style,
-    /// this fails rather than defaulting to a label that may be noise.
-    func testEveryScopeAndFilterPairHasADecidedStyle() {
-        let scopes: [TranscriptionLibraryScope] = [.all, .meetings]
-        for scope in scopes {
-            for filter in LibraryFilter.allCases {
-                let style = scope.sourceLabelStyle(for: filter)
-                XCTAssertTrue(
-                    LibrarySourceLabelStyle.allCases.contains(style),
-                    "No decided source-label style for (\(scope), \(filter.rawValue))"
-                )
-            }
+    /// narrows each pair. Assert the mapping itself, so adding a filter or
+    /// re-pointing an existing one fails here rather than silently hiding a
+    /// label over a query that still admits several sources.
+    func testMappingMatchesEveryQueryNarrowing() {
+        let expected: [(TranscriptionLibraryScope, LibraryFilter, LibrarySourceLabelStyle)] = [
+            (.all, .all, .visible),
+            (.all, .favorites, .visible),
+            (.all, .youtube, .brandMarkOnly),
+            (.all, .podcast, .hidden),
+            (.all, .local, .hidden),
+            (.all, .meeting, .hidden),
+            (.meetings, .all, .hidden),
+            (.meetings, .favorites, .hidden),
+            (.meetings, .youtube, .hidden),
+            (.meetings, .podcast, .hidden),
+            (.meetings, .local, .hidden),
+            (.meetings, .meeting, .hidden),
+        ]
+
+        for (scope, filter, style) in expected {
+            XCTAssertEqual(
+                scope.sourceLabelStyle(for: filter),
+                style,
+                "(\(scope), \(filter.rawValue)) must stay in step with makeQuery's narrowing"
+            )
         }
-        XCTAssertEqual(LibraryFilter.allCases.count, 6, "A new Library filter needs its own source-label decision")
+        XCTAssertEqual(
+            expected.count,
+            2 * LibraryFilter.allCases.count,
+            "Every scope and filter pair needs a decided source-label style"
+        )
     }
 }

--- a/Tests/MacParakeetTests/ViewModels/LibrarySourceLabelStyleTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/LibrarySourceLabelStyleTests.swift
@@ -1,0 +1,76 @@
+import XCTest
+@testable import MacParakeetCore
+@testable import MacParakeetViewModels
+
+/// A source label that repeats the active filter is noise. These pin the rule
+/// that decides when it is drawn, and — more importantly — pin it to the same
+/// `(scope, filter)` pairs the library query itself switches on, so the two
+/// cannot drift apart silently.
+final class LibrarySourceLabelStyleTests: XCTestCase {
+
+    // MARK: - Mixed contexts keep the label
+
+    func testMixedContextsShowTheFullLabel() {
+        XCTAssertEqual(
+            TranscriptionLibraryScope.all.sourceLabelStyle(for: .all),
+            .full,
+            "All admits every source, so the label is the only source attribution"
+        )
+        XCTAssertEqual(
+            TranscriptionLibraryScope.all.sourceLabelStyle(for: .favorites),
+            .full,
+            "Favorites spans sources, so a starred meeting and a starred podcast must stay distinguishable"
+        )
+    }
+
+    // MARK: - Single-source filters drop it
+
+    func testFiltersPinnedToOneSourceHideTheLabel() {
+        for filter in [LibraryFilter.podcast, .local, .meeting] {
+            XCTAssertEqual(
+                TranscriptionLibraryScope.all.sourceLabelStyle(for: filter),
+                .hidden,
+                "\(filter.rawValue) admits exactly one source, so the label can only restate the filter"
+            )
+        }
+    }
+
+    func testMeetingsWorkspaceHidesTheLabelUnderEveryFilter() {
+        for filter in LibraryFilter.allCases {
+            XCTAssertEqual(
+                TranscriptionLibraryScope.meetings.sourceLabelStyle(for: filter),
+                .hidden,
+                "The Meetings workspace shows only meetings, so even Favorites is fully determined there"
+            )
+        }
+    }
+
+    // MARK: - The multi-platform filter keeps the glyph, drops the word
+
+    func testVideoFilterCollapsesToTheIcon() {
+        XCTAssertEqual(
+            TranscriptionLibraryScope.all.sourceLabelStyle(for: .youtube),
+            .iconOnly,
+            "Video spans several platforms, so the mark still carries information but the word repeats the filter"
+        )
+    }
+
+    // MARK: - Drift guard
+
+    /// The style is only correct because it mirrors how `makeQuery(offset:)`
+    /// narrows each pair. If a new filter is added without deciding its style,
+    /// this fails rather than defaulting to a label that may be noise.
+    func testEveryScopeAndFilterPairHasADecidedStyle() {
+        let scopes: [TranscriptionLibraryScope] = [.all, .meetings]
+        for scope in scopes {
+            for filter in LibraryFilter.allCases {
+                let style = scope.sourceLabelStyle(for: filter)
+                XCTAssertTrue(
+                    LibrarySourceLabelStyle.allCases.contains(style),
+                    "No decided source-label style for (\(scope), \(filter.rawValue))"
+                )
+            }
+        }
+        XCTAssertEqual(LibraryFilter.allCases.count, 6, "A new Library filter needs its own source-label decision")
+    }
+}

--- a/Tests/MacParakeetTests/Views/TranscriptionSourceDisplayTests.swift
+++ b/Tests/MacParakeetTests/Views/TranscriptionSourceDisplayTests.swift
@@ -86,4 +86,44 @@ final class TranscriptionSourceDisplayTests: XCTestCase {
         XCTAssertEqual(TranscriptionSourceDisplay.resolve(for: local).collapsedText, "Local")
         XCTAssertEqual(TranscriptionSourceDisplay.resolve(for: meeting).collapsedText, "Meeting")
     }
+
+    // MARK: - Which glyphs can stand alone
+
+    /// Under the Video filter the word is dropped and the mark carries the
+    /// source. That only works for real logos, so the split has to hold.
+    func testPlatformMarksStandAloneAndGenericGlyphsDoNot() {
+        for branded in [TranscriptionSourceDisplay.youtube, .x, .vimeo, .facebook, .tiktok, .instagram] {
+            XCTAssertTrue(
+                branded.markIsSelfEvident,
+                "\(branded.collapsedText) is a logo people already read as the brand"
+            )
+        }
+        for generic in [TranscriptionSourceDisplay.meeting, .localFile, .podcast, .audioURL, .mediaURL] {
+            XCTAssertFalse(
+                generic.markIsSelfEvident,
+                "\(generic.collapsedText) is a plain SF Symbol and names no source without its text"
+            )
+        }
+    }
+
+    /// A SoundCloud upload and a Twitch VOD both live under the Video filter
+    /// but resolve to generic glyphs, so collapsing them to an icon would drop
+    /// the audio-versus-video distinction rather than remove a repetition.
+    func testVideoFilterSourcesThatMustKeepTheirText() {
+        let soundcloud = Transcription(
+            fileName: "set.m4a",
+            sourceURL: "https://soundcloud.com/artist/track",
+            sourceType: .youtube
+        )
+        let twitch = Transcription(
+            fileName: "vod.m4a",
+            sourceURL: "https://www.twitch.tv/videos/123456789",
+            sourceType: .youtube
+        )
+
+        XCTAssertEqual(TranscriptionSourceDisplay.resolve(for: soundcloud), .audioURL)
+        XCTAssertEqual(TranscriptionSourceDisplay.resolve(for: twitch), .mediaURL)
+        XCTAssertFalse(TranscriptionSourceDisplay.resolve(for: soundcloud).markIsSelfEvident)
+        XCTAssertFalse(TranscriptionSourceDisplay.resolve(for: twitch).markIsSelfEvident)
+    }
 }

--- a/Tests/MacParakeetTests/Views/TranscriptionSourceDisplayTests.swift
+++ b/Tests/MacParakeetTests/Views/TranscriptionSourceDisplayTests.swift
@@ -87,43 +87,26 @@ final class TranscriptionSourceDisplayTests: XCTestCase {
         XCTAssertEqual(TranscriptionSourceDisplay.resolve(for: meeting).collapsedText, "Meeting")
     }
 
-    // MARK: - Which glyphs can stand alone
+    // MARK: - Why the Video filter keeps its text
 
-    /// Under the Video filter the word is dropped and the mark carries the
-    /// source. That only works for real logos, so the split has to hold.
-    func testPlatformMarksStandAloneAndGenericGlyphsDoNot() {
-        for branded in [TranscriptionSourceDisplay.youtube, .x, .vimeo, .facebook, .tiktok, .instagram] {
-            XCTAssertTrue(
-                branded.markIsSelfEvident,
-                "\(branded.collapsedText) is a logo people already read as the brand"
-            )
-        }
-        for generic in [TranscriptionSourceDisplay.meeting, .localFile, .podcast, .audioURL, .mediaURL] {
-            XCTAssertFalse(
-                generic.markIsSelfEvident,
-                "\(generic.collapsedText) is a plain SF Symbol and names no source without its text"
-            )
-        }
+    /// The reason the label survives under Video: every platform it can
+    /// resolve to draws the same symbol, so removing the word would leave
+    /// tint as the only difference between an X post and a YouTube video.
+    func testVideoFilterSourcesAreIndistinguishableByGlyph() {
+        let underVideoFilter: [TranscriptionSourceDisplay] =
+            [.youtube, .x, .vimeo, .facebook, .tiktok, .instagram, .mediaURL]
+        let glyphs = Set(underVideoFilter.map(\.systemImage))
+
+        XCTAssertEqual(
+            glyphs,
+            ["play.rectangle.fill"],
+            "These share one glyph, so an icon-only label would name no platform"
+        )
+        XCTAssertEqual(
+            Set(underVideoFilter.map(\.collapsedText)).count,
+            underVideoFilter.count,
+            "Their text is what distinguishes them and must not be dropped"
+        )
     }
 
-    /// A SoundCloud upload and a Twitch VOD both live under the Video filter
-    /// but resolve to generic glyphs, so collapsing them to an icon would drop
-    /// the audio-versus-video distinction rather than remove a repetition.
-    func testVideoFilterSourcesThatMustKeepTheirText() {
-        let soundcloud = Transcription(
-            fileName: "set.m4a",
-            sourceURL: "https://soundcloud.com/artist/track",
-            sourceType: .youtube
-        )
-        let twitch = Transcription(
-            fileName: "vod.m4a",
-            sourceURL: "https://www.twitch.tv/videos/123456789",
-            sourceType: .youtube
-        )
-
-        XCTAssertEqual(TranscriptionSourceDisplay.resolve(for: soundcloud), .audioURL)
-        XCTAssertEqual(TranscriptionSourceDisplay.resolve(for: twitch), .mediaURL)
-        XCTAssertFalse(TranscriptionSourceDisplay.resolve(for: soundcloud).markIsSelfEvident)
-        XCTAssertFalse(TranscriptionSourceDisplay.resolve(for: twitch).markIsSelfEvident)
-    }
 }

--- a/Tests/MacParakeetTests/Views/TranscriptionSourceDisplayTests.swift
+++ b/Tests/MacParakeetTests/Views/TranscriptionSourceDisplayTests.swift
@@ -87,26 +87,41 @@ final class TranscriptionSourceDisplayTests: XCTestCase {
         XCTAssertEqual(TranscriptionSourceDisplay.resolve(for: meeting).collapsedText, "Meeting")
     }
 
-    // MARK: - Why the Video filter keeps its text
+    // MARK: - Which sources can drop their text
 
-    /// The reason the label survives under Video: every platform it can
-    /// resolve to draws the same symbol, so removing the word would leave
-    /// tint as the only difference between an X post and a YouTube video.
-    func testVideoFilterSourcesAreIndistinguishableByGlyph() {
-        let underVideoFilter: [TranscriptionSourceDisplay] =
-            [.youtube, .x, .vimeo, .facebook, .tiktok, .instagram, .mediaURL]
-        let glyphs = Set(underVideoFilter.map(\.systemImage))
+    /// The text is dropped only where a bundled brand mark replaces it. If an
+    /// asset goes missing this fails here rather than shipping a blank label.
+    @MainActor
+    func testBrandedSourcesShipAMarkThatCanReplaceTheirText() throws {
+        for display in [TranscriptionSourceDisplay.youtube, .x, .vimeo, .facebook, .tiktok, .instagram] {
+            let platform = try XCTUnwrap(
+                display.brandedPlatform,
+                "\(display.collapsedText) must name the platform whose mark identifies it"
+            )
+            XCTAssertNotNil(
+                BrandGlyphImage.image(for: platform),
+                "\(display.collapsedText) claims a brand mark but no asset is bundled for it"
+            )
+        }
+    }
 
+    /// The SF Symbol fallback cannot stand alone: these all draw the same play
+    /// rectangle and are separated only by tint, so anything without a bundled
+    /// mark must keep its word.
+    func testUnbrandedSourcesKeepTheirTextBecauseTheGlyphIsShared() {
+        let shareOneGlyph: [TranscriptionSourceDisplay] = [.youtube, .x, .vimeo, .facebook, .tiktok, .instagram, .mediaURL]
         XCTAssertEqual(
-            glyphs,
+            Set(shareOneGlyph.map(\.systemImage)),
             ["play.rectangle.fill"],
-            "These share one glyph, so an icon-only label would name no platform"
+            "The SF Symbol path names no platform, which is why it never drops its text"
         )
-        XCTAssertEqual(
-            Set(underVideoFilter.map(\.collapsedText)).count,
-            underVideoFilter.count,
-            "Their text is what distinguishes them and must not be dropped"
-        )
+
+        for display in [TranscriptionSourceDisplay.meeting, .localFile, .podcast, .audioURL, .mediaURL] {
+            XCTAssertNil(
+                display.brandedPlatform,
+                "\(display.collapsedText) is ambiguous or unbranded and must keep its text"
+            )
+        }
     }
 
 }

--- a/spec/04-ui-patterns.md
+++ b/spec/04-ui-patterns.md
@@ -139,7 +139,17 @@ and other Library contexts use the grid. Browsing and switching filters do not
 save a preference. An explicit Grid or List choice is global across Library
 contexts and persists across launches; the separate Meetings workspace is unchanged.
 List mode reuses the date-grouped row presentation and adds the transcription
-source beside the title; thumbnail cards also show the source. Search, filters,
+source beside the title; thumbnail cards also show the source. Source
+attribution is drawn only at the level the active context leaves open, resolved
+from the same `(scope, filter)` pair as the library query: `All` and
+`Favorites` admit any source and show the icon with its text; `Video` narrows
+to one shared URL source type that still spans several platforms, so the mark
+is kept and the word dropped; `Podcasts`, `Local`, `Meetings`, and every filter
+inside the Meetings workspace admit exactly one source, so the label is omitted
+rather than repeating the filter. A `Video` item whose glyph is a generic
+symbol rather than a platform logo (SoundCloud audio, an unrecognized host)
+keeps its text, since collapsing it would drop the audio-versus-video
+distinction. Screen readers always receive the full source name. Search, filters,
 contextual actions, pagination, export, and bulk selection behave identically in
 either layout.
 

--- a/spec/04-ui-patterns.md
+++ b/spec/04-ui-patterns.md
@@ -141,18 +141,20 @@ contexts and persists across launches; the separate Meetings workspace is unchan
 List mode reuses the date-grouped row presentation and adds the transcription
 source beside the title; thumbnail cards also show the source. Source
 attribution is drawn only where the active context leaves the source open,
-resolved from the same `(scope, filter)` pair as the library query. `All`,
-`Favorites`, and `Video` can each show more than one source, so their rows and
-cards carry the icon with its text. `Podcasts`, `Local`, `Meetings`, and every
-filter inside the Meetings workspace admit exactly one source, so the label is
-omitted rather than repeating the filter.
+resolved from the same `(scope, filter)` pair as the library query. `All` and
+`Favorites` admit any source and show the icon with its text. `Podcasts`,
+`Local`, `Meetings`, and every filter inside the Meetings workspace admit
+exactly one source, so the label is omitted rather than repeating the filter.
 
-The label is shown whole or not at all; its text is never dropped while the
-glyph stays. Seven of the sources reachable under `Video` share the
-`play.rectangle.fill` symbol and are separated only by tint, so an icon alone
-names no platform, and names nothing at all to a reader who cannot separate
-those tints. Distinct per-platform marks would be a prerequisite for collapsing
-that label, not a consequence of it. Search, filters,
+`Video` has narrowed the source to one family but not to one platform, so it
+shows the platform's own brand mark from `Resources/BrandGlyphs` without the
+word. The word is dropped only where such a mark replaces it: a source that
+maps to more than one platform (`Podcast` covers any feed, `Video` covers
+Twitch and unrecognized hosts) or whose asset fails to load keeps its text,
+because the SF Symbol fallback is shared by seven sources and separated only
+by tint, which names nothing to a reader who cannot distinguish those colors.
+The brand mark is hidden from accessibility, so the label supplies the source
+name that the logo carries visually. Search, filters,
 contextual actions, pagination, export, and bulk selection behave identically in
 either layout.
 

--- a/spec/04-ui-patterns.md
+++ b/spec/04-ui-patterns.md
@@ -140,16 +140,19 @@ save a preference. An explicit Grid or List choice is global across Library
 contexts and persists across launches; the separate Meetings workspace is unchanged.
 List mode reuses the date-grouped row presentation and adds the transcription
 source beside the title; thumbnail cards also show the source. Source
-attribution is drawn only at the level the active context leaves open, resolved
-from the same `(scope, filter)` pair as the library query: `All` and
-`Favorites` admit any source and show the icon with its text; `Video` narrows
-to one shared URL source type that still spans several platforms, so the mark
-is kept and the word dropped; `Podcasts`, `Local`, `Meetings`, and every filter
-inside the Meetings workspace admit exactly one source, so the label is omitted
-rather than repeating the filter. A `Video` item whose glyph is a generic
-symbol rather than a platform logo (SoundCloud audio, an unrecognized host)
-keeps its text, since collapsing it would drop the audio-versus-video
-distinction. Screen readers always receive the full source name. Search, filters,
+attribution is drawn only where the active context leaves the source open,
+resolved from the same `(scope, filter)` pair as the library query. `All`,
+`Favorites`, and `Video` can each show more than one source, so their rows and
+cards carry the icon with its text. `Podcasts`, `Local`, `Meetings`, and every
+filter inside the Meetings workspace admit exactly one source, so the label is
+omitted rather than repeating the filter.
+
+The label is shown whole or not at all; its text is never dropped while the
+glyph stays. Seven of the sources reachable under `Video` share the
+`play.rectangle.fill` symbol and are separated only by tint, so an icon alone
+names no platform, and names nothing at all to a reader who cannot separate
+those tints. Distinct per-platform marks would be a prerequisite for collapsing
+that label, not a consequence of it. Search, filters,
 contextual actions, pagination, export, and bulk selection behave identically in
 either layout.
 


### PR DESCRIPTION
## Summary

The Library layouts change (#966) gave every card a source label. It is not always carrying information:

- Under **Podcasts**, **Local** and **Meetings** it can only repeat what the filter already said.
- Under **Video** it prints "YouTube" beside an icon on nearly every card.

This hides the label where the filter pins one source, and replaces the word with the platform's real brand mark where the filter has narrowed the family but not the platform.

## The rule

Resolved from the same `(scope, filter)` pair `makeQuery(offset:)` already switches on, so the label and the query cannot drift apart:

| Context | Sources it admits | Label |
|---|---|---|
| `All`, `Favorites` | any | icon **and** text |
| `Video` | several platforms | **brand mark**, no text |
| `Podcasts`, `Local`, `Meetings` | exactly one | **hidden** |
| Meetings workspace, every filter | only meetings | **hidden** |

## Two corrections during review, both worth recording

**The first attempt dropped the word under Video on the reasoning that the mark is a logo. It was not.** `TranscriptionSourceDisplay.systemImage` returns `play.rectangle.fill` for YouTube, X, Vimeo, Facebook, TikTok, Instagram *and* unrecognized hosts. Seven sources, one glyph, separated only by tint — indistinguishable at 11pt, and colour-only encoding besides. Caught by Greptile and independently by review.

**The fix is not to keep the word; it is to draw the mark the repo already ships.** `Resources/BrandGlyphs` holds CC0 single-path vector PDFs for all six platforms, `PlatformGlyph` renders them as tintable templates, and that directory's README states they are for "the Transcribe-URL hero **and Library source badges**". The Library badge simply never adopted them.

So the approved design is delivered, with a true premise behind it.

## Where the word is kept

The text is dropped only where a mark genuinely replaces it. `brandedPlatform` covers the six displays that map to exactly one platform. It deliberately excludes:

| Source | Why it keeps its text |
|---|---|
| `Podcast` | covers any feed, not only Apple Podcasts |
| `Video` (unknown host) | covers Twitch *and* unrecognized hosts |
| `Audio` | named for audio in general; reached from SoundCloud today, but the case is not SoundCloud |
| `Meeting`, `Local` | no platform, no mark |

A source whose bundled asset fails to load also falls back to icon-and-text — checked at the call site rather than assumed. A test loads every claimed asset from the bundle, so a missing file fails there rather than shipping a blank label.

`PlatformGlyph` marks itself `accessibilityHidden`, so the label restores the source name the logo carries visually. Nothing is lost to a screen reader.

## Also

- Both card types render source through one `TranscriptionSourceLabel` instead of each building its own `Label`.
- Replaces `MeetingRowCard.showsSource`, which encoded the same idea as a binary and could only say "meeting context or not". Its default is `.hidden`, matching the old `false`, so the `MeetingsView` workspace call site is unchanged.

## Review findings addressed

- **Drift guard was tautological.** It asserted `LibrarySourceLabelStyle.allCases.contains(style)`, which a total function returning a non-optional enum can never fail. It now asserts the mapping pair by pair, so re-pointing a filter fails the test.
- **Phantom spacing in the grid.** The `HStack(spacing: 6)` held the label unconditionally, relying on `EmptyView` contributing no spacing. It now guards `.hidden` explicitly, matching what the list row already did.
- **Accessibility of hidden labels** (Greptile finding 2) — declined, with reasoning in the thread. `.hidden` removes the label for everyone, so sighted and VoiceOver readers get the same thing and the filter is the shared context. Attaching an invisible label to every row would make 200 rows in the Podcasts filter each announce "Podcast".

## Verification

- `swift test --filter 'LibrarySourceLabelStyleTests|TranscriptionSourceDisplayTests'` — 13 tests, 0 failures.
- `swift test --filter 'TranscriptionLibraryViewModelTests|MeetingRowCard|LibrarySourceLabel|TranscriptionSourceDisplay|TranscriptionThumbnail'` — 66 tests, 0 failures.
- `swift build` clean; Swift 6 language mode gate clean.

**Not verified:** the rendered label has not been looked at. The bundled assets are confirmed to *load*; they are not confirmed to *read well* as 11pt marks in a metadata row. That is the one thing worth a native pass before merge.

### On the earlier CI failure

`DictationFlowCoordinatorLoadCaptionTests.testFirstInstallShowsPreparingThenClearsOnSuccess` failed on one runner of `90d046b4`. Unrelated to this diff, which touches no dictation, coordinator or telemetry code: the twin `swift-test` job on the same commit passed, and the suite passed 6/6 locally. The failing assertion is a `captionShown` telemetry event missing from a snapshot taken after `captionDuration` arrived — a transient-observation race of the kind already documented for this suite, on a different test than the two previously recorded.

## Not in this PR

A `LazyVGrid` row sizes to its tallest card, so one card carrying Transcribing plus Audio saved plus Partial audio leaves dead space under its neighbours. Untouched: the status rows were the point of #966 and clipping them would be worse.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Source labels now adapt to the library context: they may show text, be hidden when redundant, or display a recognizable platform brand mark.
  - Video-filter results can show branded icons for supported platforms while retaining readable source text when no unique mark is available.
  - Source labels remain accessible with descriptive source names, including when only a brand mark is visible.

- **Documentation**
  - Updated library layout guidance to clarify source attribution and branding behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->