### PR TITLE
Restore global shortcuts after Accessibility is granted

### DIFF
--- a/Sources/MacParakeet/AppDelegate.swift
+++ b/Sources/MacParakeet/AppDelegate.swift
@@ -490,6 +490,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationDidBecomeActive(_ notification: Notification) {
+        settingsViewModel.refreshPermissions()
         onboardingCoordinator.handleApplicationDidBecomeActive(environment: appEnvironment)
         if let appEnvironment {
             meetingAudioRetentionSweepCoordinator.scheduleForegroundSweepIfDue(environment: appEnvironment)
@@ -516,6 +517,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func setupEnvironment(_ env: AppEnvironment) {
         appEnvironment = env
+        settingsViewModel.onAccessibilityGranted = { [weak self] in
+            self?.handleAccessibilityGrant()
+        }
 
         let runtime = environmentConfigurer.configure(
             environment: env,
@@ -722,6 +726,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     // MARK: - Event Handlers
+
+    private func handleAccessibilityGrant() {
+        // Startup may have discarded every event tap before access was granted.
+        // Reuse the normal refresh path, which preserves recorder suspension.
+        hotkeyCoordinator?.refreshAllHotkeys()
+        if !isHotkeyRecorderActive {
+            transformsCoordinator?.resumeHotkeys()
+        }
+    }
 
     private func handleHotkeyTriggerChange() {
         hotkeyCoordinator?.refreshAllHotkeys()

--- a/Sources/MacParakeet/Views/Settings/SettingsView.swift
+++ b/Sources/MacParakeet/Views/Settings/SettingsView.swift
@@ -190,7 +190,6 @@ struct SettingsView: View {
             viewModel.stopPermissionPolling()
         }
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
-            viewModel.refreshPermissions()
             viewModel.engine.refreshSpeechEngineSwitchAvailability()
             Task { await viewModel.refreshCalendarNotificationAuthorization() }
         }

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -764,6 +764,7 @@ public final class SettingsViewModel {
     // These handles are only mutated on the main actor during the view
     // model lifetime; unsafe access lets deinit cancel/unregister.
     @ObservationIgnored nonisolated(unsafe) private var permissionPollingTask: Task<Void, Never>?
+    @ObservationIgnored nonisolated(unsafe) private var accessibilityGrantWatchTask: Task<Void, Never>?
     @ObservationIgnored nonisolated(unsafe) private var microphoneTestTask: Task<Void, Never>?
     @ObservationIgnored nonisolated(unsafe) private var storageStatsTask: Task<Void, Never>?
     @ObservationIgnored nonisolated(unsafe) private var calendarSettingsObserver: NSObjectProtocol?
@@ -941,6 +942,7 @@ public final class SettingsViewModel {
 
     deinit {
         permissionPollingTask?.cancel()
+        accessibilityGrantWatchTask?.cancel()
         microphoneTestTask?.cancel()
         storageStatsTask?.cancel()
         if let calendarSettingsObserver {
@@ -1275,16 +1277,47 @@ public final class SettingsViewModel {
                 let micStatus = await service.checkMicrophonePermission()
                 let accStatus = service.checkAccessibilityPermission()
                 let screenRecordingStatus = service.checkScreenRecordingPermission()
-                let accessibilityBecameGranted = accStatus && !accessibilityGranted
                 microphoneGranted = micStatus == .granted
-                accessibilityGranted = accStatus
                 screenRecordingGranted = screenRecordingStatus
-                if accessibilityBecameGranted {
-                    onAccessibilityGranted?()
-                }
+                applyAccessibilityStatus(accStatus)
             }
             refreshCalendarPermission()
         }
+    }
+
+    private func applyAccessibilityStatus(_ granted: Bool) {
+        let becameGranted = granted && !accessibilityGranted
+        accessibilityGranted = granted
+        if granted {
+            stopAccessibilityGrantWatch()
+        } else {
+            startAccessibilityGrantWatch()
+        }
+        if becameGranted {
+            onAccessibilityGranted?()
+        }
+    }
+
+    /// Only Accessibility is re-checked here, so a grant made while the app
+    /// stays in the background with Settings closed still restores shortcuts.
+    private func startAccessibilityGrantWatch() {
+        guard accessibilityGrantWatchTask == nil else { return }
+        accessibilityGrantWatchTask = Task { [weak self] in
+            guard let self else { return }
+            while !Task.isCancelled {
+                try? await Task.sleep(for: self.permissionPollingInterval)
+                guard !Task.isCancelled, let service = self.permissionService else { break }
+                if service.checkAccessibilityPermission() {
+                    self.applyAccessibilityStatus(true)
+                    break
+                }
+            }
+        }
+    }
+
+    private func stopAccessibilityGrantWatch() {
+        accessibilityGrantWatchTask?.cancel()
+        accessibilityGrantWatchTask = nil
     }
 
     public func refreshMicrophoneDevices() {

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -705,6 +705,8 @@ public final class SettingsViewModel {
     public var microphoneGranted = false
     public var accessibilityGranted = false
     public var screenRecordingGranted = false
+    /// Reinstall shortcuts after macOS grants access to a running app.
+    public var onAccessibilityGranted: (() -> Void)?
 
     // Stats
     public var dictationCount = 0
@@ -1273,9 +1275,13 @@ public final class SettingsViewModel {
                 let micStatus = await service.checkMicrophonePermission()
                 let accStatus = service.checkAccessibilityPermission()
                 let screenRecordingStatus = service.checkScreenRecordingPermission()
+                let accessibilityBecameGranted = accStatus && !accessibilityGranted
                 microphoneGranted = micStatus == .granted
                 accessibilityGranted = accStatus
                 screenRecordingGranted = screenRecordingStatus
+                if accessibilityBecameGranted {
+                    onAccessibilityGranted?()
+                }
             }
             refreshCalendarPermission()
         }

--- a/Sources/MacParakeetViewModels/SettingsViewModel.swift
+++ b/Sources/MacParakeetViewModels/SettingsViewModel.swift
@@ -1302,11 +1302,13 @@ public final class SettingsViewModel {
     /// stays in the background with Settings closed still restores shortcuts.
     private func startAccessibilityGrantWatch() {
         guard accessibilityGrantWatchTask == nil else { return }
+        // Only a weak reference survives each sleep so releasing the view
+        // model's owner still runs `deinit`, which cancels this watch.
+        let interval = permissionPollingInterval
         accessibilityGrantWatchTask = Task { [weak self] in
-            guard let self else { return }
             while !Task.isCancelled {
-                try? await Task.sleep(for: self.permissionPollingInterval)
-                guard !Task.isCancelled, let service = self.permissionService else { break }
+                try? await Task.sleep(for: interval)
+                guard !Task.isCancelled, let self, let service = self.permissionService else { break }
                 if service.checkAccessibilityPermission() {
                     self.applyAccessibilityStatus(true)
                     break

--- a/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
@@ -1367,6 +1367,52 @@ final class SettingsViewModelTests: XCTestCase {
 
     // MARK: - Permissions
 
+    func testAccessibilityGrantRetriesShortcutsOnlyOnGrantTransitions() async throws {
+        mockPermissions.accessibilityPermission = false
+        var recoveryStates: [Bool] = []
+        viewModel.onAccessibilityGranted = { [weak viewModel] in
+            recoveryStates.append(viewModel?.accessibilityGranted == true)
+        }
+        viewModel.configure(
+            permissionService: mockPermissions,
+            dictationRepo: mockRepo,
+            entitlementsService: entitlements,
+            checkoutURL: nil
+        )
+        try await waitUntil { self.mockPermissions.checkScreenRecordingPermissionCallCount == 1 }
+        XCTAssertTrue(recoveryStates.isEmpty, "Denied startup must not attempt permission recovery")
+
+        for (granted, expectedRecoveries) in [(false, 0), (true, 1), (true, 1), (false, 1), (true, 2)] {
+            let previousChecks = mockPermissions.checkScreenRecordingPermissionCallCount
+            mockPermissions.accessibilityPermission = granted
+            viewModel.refreshPermissions()
+            try await waitUntil { self.mockPermissions.checkScreenRecordingPermissionCallCount > previousChecks }
+
+            XCTAssertEqual(viewModel.accessibilityGranted, granted)
+            XCTAssertEqual(recoveryStates, Array(repeating: true, count: expectedRecoveries))
+        }
+        viewModel.onAccessibilityGranted = nil
+    }
+
+    func testFirstGrantedPermissionRefreshRecoversFailedStartupShortcuts() async throws {
+        // Permission can be granted while environment setup is finishing,
+        // before the first asynchronous permission refresh publishes its state.
+        mockPermissions.accessibilityPermission = true
+        var recoveryCount = 0
+        viewModel.onAccessibilityGranted = { recoveryCount += 1 }
+        viewModel.configure(
+            permissionService: mockPermissions,
+            dictationRepo: mockRepo,
+            entitlementsService: entitlements,
+            checkoutURL: nil
+        )
+        try await waitUntil { self.mockPermissions.checkScreenRecordingPermissionCallCount == 1 }
+
+        XCTAssertTrue(viewModel.accessibilityGranted)
+        XCTAssertEqual(recoveryCount, 1)
+        viewModel.onAccessibilityGranted = nil
+    }
+
     func testRefreshPermissionsUpdatesGrantedState() async throws {
         mockPermissions.microphonePermission = .granted
         mockPermissions.accessibilityPermission = true

--- a/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
@@ -1439,6 +1439,24 @@ final class SettingsViewModelTests: XCTestCase {
         vm.onAccessibilityGranted = nil
     }
 
+    func testAccessibilityWatchDoesNotKeepDeniedViewModelAlive() async throws {
+        mockPermissions.accessibilityPermission = false
+        weak var weakViewModel: SettingsViewModel?
+        do {
+            let vm = makeBackgroundGrantViewModel()
+            weakViewModel = vm
+            try await waitUntil { self.mockPermissions.checkAccessibilityPermissionCallCount >= 2 }
+            XCTAssertFalse(vm.accessibilityGranted)
+        }
+        try await waitUntil { weakViewModel == nil }
+        XCTAssertNil(weakViewModel, "Denied-permission watch must not retain the view model")
+
+        let checksAfterRelease = mockPermissions.checkAccessibilityPermissionCallCount
+        try await Task.sleep(for: .milliseconds(120))
+        XCTAssertEqual(mockPermissions.checkAccessibilityPermissionCallCount, checksAfterRelease,
+                       "Watch must stop polling once the view model is released")
+    }
+
     func testAccessibilityWatchStopsWhenSharedRefreshObservesGrant() async throws {
         mockPermissions.accessibilityPermission = false
         var recoveryCount = 0

--- a/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/SettingsViewModelTests.swift
@@ -1394,6 +1394,91 @@ final class SettingsViewModelTests: XCTestCase {
         viewModel.onAccessibilityGranted = nil
     }
 
+    private func makeBackgroundGrantViewModel() -> SettingsViewModel {
+        let vm = SettingsViewModel(
+            defaults: testDefaults,
+            youtubeDownloadsDirPath: { [youtubeDownloadsTestDir] in
+                youtubeDownloadsTestDir?.path ?? AppPaths.youtubeDownloadsDir
+            },
+            meetingRecordingsDirPath: { [meetingRecordingsTestDir] in
+                meetingRecordingsTestDir?.path ?? AppPaths.meetingRecordingsDir
+            },
+            permissionPollingInterval: .milliseconds(20)
+        )
+        vm.configure(
+            permissionService: mockPermissions,
+            dictationRepo: mockRepo,
+            entitlementsService: entitlements,
+            checkoutURL: nil
+        )
+        return vm
+    }
+
+    func testBackgroundAccessibilityGrantRecoversShortcutsWithoutSettingsOrActivation() async throws {
+        mockPermissions.accessibilityPermission = false
+        var recoveryCount = 0
+        let vm = makeBackgroundGrantViewModel()
+        vm.onAccessibilityGranted = { recoveryCount += 1 }
+        try await waitUntil { self.mockPermissions.checkAccessibilityPermissionCallCount >= 3 }
+        XCTAssertFalse(vm.accessibilityGranted)
+        XCTAssertEqual(recoveryCount, 0)
+        XCTAssertEqual(mockPermissions.checkScreenRecordingPermissionCallCount, 1,
+                       "Accessibility watch must not poll the other permissions")
+
+        mockPermissions.accessibilityPermission = true
+        try await waitUntil { recoveryCount == 1 }
+        XCTAssertTrue(vm.accessibilityGranted)
+
+        try await waitUntil { self.mockPermissions.checkAccessibilityPermissionCallCount >= 1 }
+        let checksAfterGrant = mockPermissions.checkAccessibilityPermissionCallCount
+        try await Task.sleep(for: .milliseconds(120))
+        XCTAssertEqual(recoveryCount, 1, "Recovery must fire once per grant")
+        XCTAssertEqual(mockPermissions.checkAccessibilityPermissionCallCount, checksAfterGrant,
+                       "Watch must stop once access is granted")
+        XCTAssertEqual(mockPermissions.checkScreenRecordingPermissionCallCount, 1)
+        vm.onAccessibilityGranted = nil
+    }
+
+    func testAccessibilityWatchStopsWhenSharedRefreshObservesGrant() async throws {
+        mockPermissions.accessibilityPermission = false
+        var recoveryCount = 0
+        let vm = makeBackgroundGrantViewModel()
+        vm.onAccessibilityGranted = { recoveryCount += 1 }
+        try await waitUntil { self.mockPermissions.checkAccessibilityPermissionCallCount >= 2 }
+
+        mockPermissions.accessibilityPermission = true
+        vm.refreshPermissions()
+        try await waitUntil { recoveryCount == 1 }
+        try await waitUntil { self.mockPermissions.checkScreenRecordingPermissionCallCount == 2 }
+
+        let checksAfterGrant = mockPermissions.checkAccessibilityPermissionCallCount
+        try await Task.sleep(for: .milliseconds(120))
+        XCTAssertEqual(recoveryCount, 1)
+        XCTAssertEqual(mockPermissions.checkAccessibilityPermissionCallCount, checksAfterGrant,
+                       "Shared refresh observing the grant must cancel the watch")
+        vm.onAccessibilityGranted = nil
+    }
+
+    func testAccessibilityWatchRestartsAfterAccessIsRevoked() async throws {
+        mockPermissions.accessibilityPermission = true
+        var recoveryCount = 0
+        let vm = makeBackgroundGrantViewModel()
+        vm.onAccessibilityGranted = { recoveryCount += 1 }
+        try await waitUntil { recoveryCount == 1 }
+        let checksWhileGranted = mockPermissions.checkAccessibilityPermissionCallCount
+        try await Task.sleep(for: .milliseconds(100))
+        XCTAssertEqual(mockPermissions.checkAccessibilityPermissionCallCount, checksWhileGranted,
+                       "No Accessibility watch runs while access is granted")
+
+        mockPermissions.accessibilityPermission = false
+        vm.refreshPermissions()
+        try await waitUntil { !vm.accessibilityGranted }
+        mockPermissions.accessibilityPermission = true
+        try await waitUntil { recoveryCount == 2 }
+        XCTAssertTrue(vm.accessibilityGranted)
+        vm.onAccessibilityGranted = nil
+    }
+
     func testFirstGrantedPermissionRefreshRecoversFailedStartupShortcuts() async throws {
         // Permission can be granted while environment setup is finishing,
         // before the first asynchronous permission refresh publishes its state.

--- a/Tests/MacParakeetTests/ViewModels/ViewModelMocks.swift
+++ b/Tests/MacParakeetTests/ViewModels/ViewModelMocks.swift
@@ -1359,6 +1359,7 @@ final class MockPermissionService: PermissionServiceProtocol, @unchecked Sendabl
     var requestAccessibilityResult: Bool = true
     var requestMicrophonePermissionCallCount = 0
     var checkScreenRecordingPermissionCallCount = 0
+    var checkAccessibilityPermissionCallCount = 0
     var openMicrophoneSettingsCallCount = 0
     var screenRecordingPermissionSequence: [Bool] = []
 
@@ -1393,7 +1394,8 @@ final class MockPermissionService: PermissionServiceProtocol, @unchecked Sendabl
     func openScreenRecordingSettings() {}
 
     func checkAccessibilityPermission() -> Bool {
-        accessibilityPermission
+        checkAccessibilityPermissionCallCount += 1
+        return accessibilityPermission
     }
 
     func requestAccessibilityPermission(prompt: Bool) -> Bool {

--- a/spec/adr/009-custom-hotkey.md
+++ b/spec/adr/009-custom-hotkey.md
@@ -89,4 +89,7 @@ The app retries configured dictation, auxiliary and Transform shortcuts through
 their existing lifecycle methods. Repeated granted checks do not restart taps,
 and shortcut recording keeps production listeners suspended until it finishes.
 Permission status refreshes on application activation as well as the existing
-Settings polling, so returning from System Settings does not require a restart.
+Settings polling. While Accessibility is denied, the app additionally re-checks
+only that permission on the Settings polling interval, so granting access while
+MacParakeet stays in the background with Settings closed still restores the
+shortcuts. The watch stops once access is granted and restarts if it is revoked.

--- a/spec/adr/009-custom-hotkey.md
+++ b/spec/adr/009-custom-hotkey.md
@@ -79,3 +79,14 @@ Community issue #234 requested hotkeys such as Right Command+Right Option. The e
 ### Original decision preserved
 
 Existing `.modifier`, `.keyCode`, and `.chord` persisted values decode unchanged. Modifier-only chords are additive and use the existing key-agnostic gesture controller for the configured role semantics.
+
+## Amendment: Accessibility grant recovery (2026-09-07)
+
+A running app can fail to install its global event taps before Accessibility is
+granted. The shared permission refresh must notify the app when access changes
+from unavailable to granted, including the first successful check after startup.
+The app retries configured dictation, auxiliary and Transform shortcuts through
+their existing lifecycle methods. Repeated granted checks do not restart taps,
+and shortcut recording keeps production listeners suspended until it finishes.
+Permission status refreshes on application activation as well as the existing
+Settings polling, so returning from System Settings does not require a restart.


### PR DESCRIPTION
## What changes

After granting Accessibility in macOS, MacParakeet can record from its pill while Fn and other global shortcuts remain inactive until the app restarts. Permission status now has a single denied-to-granted transition that restores the existing shortcut registrations. A lightweight watch detects the grant while the app is in the background with Settings closed; it stops once permission is granted.

Transform shortcuts resume through their existing registration path, preserving the shortcut recorder's active state. Existing gesture behavior, bindings, and audio processing are unchanged. ADR-009 documents the recovery behavior.

## Validation

- Regression tests reproduced the missing grant callback before implementation.
- Review found two gaps and both were repaired: recovery with Settings closed, and a watch task retaining its view model while access remained denied. The lifetime regression reproduced three failing assertions before the repair.
- Final head `5a082c267896da11f880ac0a1b00876a907b1819`: 477 focused tests pass across settings, hotkey coordination, gesture handling, onboarding preview, and Transform registration. Release compilation passes.
- Both final CI runs passed: [PR merge CI](https://github.com/moona3k/macparakeet/actions/runs/34183464065) and [branch CI](https://github.com/moona3k/macparakeet/actions/runs/34183461334). PR CI tested this head merged with latest main `f4eee2f8`, including speaker attribution: 5,662 parallel XCTest entries and 29 Swift Testing passes.
- Independent correctness and maintainability reviews passed. CodeRabbit reported no further actionable findings; Greptile explicitly rechecked the repaired head and confirmed its blocker was fixed. Both review threads are resolved. The local Greptile CLI was unavailable.
- Formatting is informational in this repository. Production files introduce no lint diagnostics; the new tests add ten multiline-assertion layout notices.

## Native evidence and limits

The affected local app had zero owned keyboard event taps; an ordinary restart restored three taps, and the user confirmed physical Fn recording worked. This establishes the original recovery symptom and workaround.

A separately signed QA app with an isolated database and F18 bindings is prepared for the same-process background permission-grant check. It remains denied with its window closed; completing the normal macOS grant currently requires the user's Touch ID. Automated tests establish the code path, but native grant recovery is not yet claimed as verified.

The release QA report will retain source hashes, test evidence, and this hardware/permission distinction. No release is published by this PR.
