### PR TITLE
Respect telemetry suppression and pace failed uploads

### DIFF
--- a/Sources/CLI/Commands/CLITelemetry.swift
+++ b/Sources/CLI/Commands/CLITelemetry.swift
@@ -32,18 +32,7 @@ enum CLITelemetry {
         }
     }
 
-    /// Outcome of evaluating env-var overrides for CLI telemetry. Resolved before
-    /// the user's persisted UserDefaults preference is consulted.
-    enum EnvOverride: Equatable {
-        /// `MACPARAKEET_TELEMETRY=1/true/yes/on` — explicit force-on, defeats CI auto-disable.
-        case forceOn
-        /// `MACPARAKEET_TELEMETRY=0/false/no/off` or `DO_NOT_TRACK=1` — explicit force-off.
-        case forceOff
-        /// Headless CI context (`CI=true`, `GITHUB_ACTIONS=true`, etc.) with no explicit override.
-        case ciAutoDisable
-        /// No override; honor the persisted UserDefaults `telemetryEnabled` preference.
-        case none
-    }
+    typealias EnvOverride = TelemetryPolicy.EnvOverride
 
     static func configureIfNeeded(env: [String: String] = ProcessInfo.processInfo.environment) {
         switch decideOverride(env: env) {
@@ -68,58 +57,12 @@ enum CLITelemetry {
         }
     }
 
-    /// Pure decision function — testable without ProcessInfo or UserDefaults state.
-    /// `MACPARAKEET_TELEMETRY` wins outright. Then `DO_NOT_TRACK=1` (industry-standard,
-    /// honored by Homebrew, GitLab, VS Code, etc.). Then CI auto-disable so a 1000-job
-    /// agent run in GitHub Actions doesn't silently flood the endpoint with `cli_operation`
-    /// events.
     static func decideOverride(env: [String: String]) -> EnvOverride {
-        if let raw = env["MACPARAKEET_TELEMETRY"]?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
-           !raw.isEmpty {
-            if ["0", "false", "no", "off"].contains(raw) { return .forceOff }
-            if ["1", "true", "yes", "on"].contains(raw) { return .forceOn }
-        }
-
-        if let dnt = env["DO_NOT_TRACK"]?.trimmingCharacters(in: .whitespacesAndNewlines), dnt == "1" {
-            return .forceOff
-        }
-
-        if isCIEnvironment(env: env) {
-            return .ciAutoDisable
-        }
-
-        return .none
+        TelemetryPolicy.decideOverride(env: env)
     }
 
-    /// Variables that conventionally mark a CI/automation context.
-    /// Hoisted out of `isCIEnvironment` so it isn't reallocated per call.
-    private static let ciEnvVars: [String] = [
-        "CI",
-        "GITHUB_ACTIONS",
-        "GITLAB_CI",
-        "BUILDKITE",
-        "CIRCLECI",
-        "TRAVIS",
-        "JENKINS_URL",
-        "TF_BUILD",
-        "TEAMCITY_VERSION"
-    ]
-
-    /// Detects common CI/automation contexts. Conservative: only treats a variable as
-    /// CI-positive when it's set to a truthy value, so `CI=false` (yes, some setups
-    /// pass that) does not trigger auto-disable.
     static func isCIEnvironment(env: [String: String]) -> Bool {
-        for name in ciEnvVars {
-            guard let raw = env[name]?.trimmingCharacters(in: .whitespacesAndNewlines), !raw.isEmpty else {
-                continue
-            }
-            let lower = raw.lowercased()
-            if lower == "false" || lower == "0" || lower == "no" || lower == "off" {
-                continue
-            }
-            return true
-        }
-        return false
+        TelemetryPolicy.isCIEnvironment(env: env)
     }
 
     static func runInstrumented(_ command: inout ParsableCommand) async throws {

--- a/Sources/MacParakeetCore/Services/Telemetry/TelemetryPolicy.swift
+++ b/Sources/MacParakeetCore/Services/Telemetry/TelemetryPolicy.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+/// Shared environment policy. Explicit enablement overrides development/CI defaults;
+/// GUI consent is evaluated separately and remains authoritative.
+public enum TelemetryPolicy {
+    public enum EnvOverride: Equatable, Sendable {
+        case forceOn, forceOff, ciAutoDisable, none
+    }
+
+    public static func decideOverride(env: [String: String]) -> EnvOverride {
+        if let raw = env["MACPARAKEET_TELEMETRY"]?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+            if ["0", "false", "no", "off"].contains(raw) { return .forceOff }
+            if ["1", "true", "yes", "on"].contains(raw) { return .forceOn }
+        }
+        if env["DO_NOT_TRACK"]?.trimmingCharacters(in: .whitespacesAndNewlines) == "1" { return .forceOff }
+        return isCIEnvironment(env: env) ? .ciAutoDisable : .none
+    }
+
+    public static func isCIEnvironment(env: [String: String]) -> Bool {
+        ["CI", "GITHUB_ACTIONS", "GITLAB_CI", "BUILDKITE", "CIRCLECI", "TRAVIS",
+         "JENKINS_URL", "TF_BUILD", "TEAMCITY_VERSION"].contains { key in
+            guard let value = env[key]?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
+                !value.isEmpty else { return false }
+            return !["false", "0", "no", "off"].contains(value)
+        }
+    }
+
+    public static func guiEnabled(
+        preferenceEnabled: Bool, env: [String: String], isDebug: Bool, buildSource: String, version: String
+    ) -> Bool {
+        preferenceEnabled && guiTransportEligible(
+            env: env, isDebug: isDebug, buildSource: buildSource, version: version
+        )
+    }
+
+    public static func guiTransportEligible(
+        env: [String: String], isDebug: Bool, buildSource: String, version: String
+    ) -> Bool {
+        switch decideOverride(env: env) {
+        case .forceOn: return true
+        case .forceOff, .ciAutoDisable: return false
+        case .none:
+            return !isDebug && !buildSource.hasPrefix("dev-")
+                && !buildSource.hasPrefix("swiftpm-") && version != "0.0.0" && version != "dev"
+        }
+    }
+
+    public static func currentGUIEnabled() -> Bool {
+        AppPreferences.isTelemetryEnabled(defaults: .standard) && currentGUITransportEligible()
+    }
+
+    public static func currentGUITransportEligible() -> Bool {
+        #if DEBUG
+        let isDebug = true
+        #else
+        let isDebug = false
+        #endif
+        let identity = BuildIdentity.current
+        return guiTransportEligible(
+            env: ProcessInfo.processInfo.environment, isDebug: isDebug,
+            buildSource: identity.buildSource, version: identity.version
+        )
+    }
+}

--- a/Sources/MacParakeetCore/Services/Telemetry/TelemetryService.swift
+++ b/Sources/MacParakeetCore/Services/Telemetry/TelemetryService.swift
@@ -392,7 +392,8 @@ public final class TelemetryService: TelemetryServiceProtocol, @unchecked Sendab
         }
         let events: [TelemetryEvent]
         if let nextRetryAt, now() < nextRetryAt {
-            events = queue.filter { $0.event == TelemetryEventName.telemetryOptedOut.rawValue }
+            // Consent permits the final event, but does not bypass server backoff.
+            events = []
         } else {
             events = queue
         }

--- a/Sources/MacParakeetCore/Services/Telemetry/TelemetryService.swift
+++ b/Sources/MacParakeetCore/Services/Telemetry/TelemetryService.swift
@@ -72,6 +72,24 @@ public final class TelemetryService: TelemetryServiceProtocol, @unchecked Sendab
     // Clearing consent invalidates snapshots already removed from the queue,
     // including retries and batches that have not been admitted for dispatch.
     private var queueGeneration: UInt64 = 0
+    private var automaticFlushPending = false
+    private var nextRetryAt: Date?
+    private var consecutiveFailures = 0
+    // Configured before use in deterministic transport tests.
+    var now: @Sendable () -> Date = { Date() }
+    var retryJitter: @Sendable () -> Double = { Double.random(in: 0.8...1.2) }
+
+    private struct BatchResult {
+        var retryEvents: [TelemetryEvent] = []
+        var rejectedIDs: Set<String> = []
+    }
+
+    private enum DeliveryResult {
+        case delivered
+        case discarded
+        case rejected(status: Int)
+        case retry(status: Int, after: TimeInterval?)
+    }
     private var flushTimer: Timer?
     private var lifecycleObserver: NSObjectProtocol?
 
@@ -85,6 +103,7 @@ public final class TelemetryService: TelemetryServiceProtocol, @unchecked Sendab
     private let chip: String
     private let surface: String
     private let isEnabled: () -> Bool
+    private let isTransportEligible: () -> Bool
     private let requestTimeoutInterval: TimeInterval
 
     static let maxQueueSize = 200
@@ -124,9 +143,8 @@ public final class TelemetryService: TelemetryServiceProtocol, @unchecked Sendab
         requestTimeoutInterval: TimeInterval = 10,
         surface: String = "gui",
         appVersionOverride: String? = nil,
-        isEnabled: @escaping () -> Bool = {
-            UserDefaults.standard.object(forKey: "telemetryEnabled") as? Bool ?? true
-        }
+        isTransportEligible: (() -> Bool)? = nil,
+        isEnabled: (() -> Bool)? = nil
     ) {
         if let baseURL {
             self.baseURL = baseURL
@@ -137,7 +155,11 @@ public final class TelemetryService: TelemetryServiceProtocol, @unchecked Sendab
             self.baseURL = URL(string: "https://macparakeet.com/api")!
         }
         self.session = session
-        self.isEnabled = isEnabled
+        self.isEnabled = isEnabled ?? TelemetryPolicy.currentGUIEnabled
+        // Explicit consent injection is used by the CLI and isolated clients;
+        // those callers already select their policy rather than the GUI defaults.
+        self.isTransportEligible = isTransportEligible
+            ?? (isEnabled == nil ? TelemetryPolicy.currentGUITransportEligible : { true })
         self.requestTimeoutInterval = requestTimeoutInterval
         self.sessionId = UUID().uuidString
         self.sessionStartedAt = Date()
@@ -172,21 +194,21 @@ public final class TelemetryService: TelemetryServiceProtocol, @unchecked Sendab
         let shouldFlush: Bool
         lock.lock()
         guard generation == queueGeneration,
-            isEnabled() || event.name == .telemetryOptedOut
+            isTransportEligible(), isEnabled() || event.name == .telemetryOptedOut
         else {
             lock.unlock()
             return
         }
         queue.append(telemetryEvent)
         if queue.count > Self.maxQueueSize {
-            queue.removeFirst(queue.count - Self.maxQueueSize)
+            let dropped = queue.count - Self.maxQueueSize
+            queue.removeFirst(dropped)
+            logger.info("telemetry_transport outcome=queue_full dropped_count=\(dropped, privacy: .public)")
         }
         shouldFlush = queue.count >= Self.flushThreshold || Self.immediateEvents.contains(event.name)
         lock.unlock()
 
-        if shouldFlush {
-            Task { await flush() }
-        }
+        if shouldFlush { scheduleAutomaticFlush() }
     }
 
     @discardableResult
@@ -215,18 +237,45 @@ public final class TelemetryService: TelemetryServiceProtocol, @unchecked Sendab
     public func clearQueue() {
         lock.lock()
         queueGeneration &+= 1
+        nextRetryAt = nil
+        consecutiveFailures = 0
         queue.removeAll()
         lock.unlock()
     }
 
+    private func scheduleAutomaticFlush() {
+        let scheduled = lock.withLock {
+            guard !automaticFlushPending else { return false }
+            automaticFlushPending = true
+            return true
+        }
+        guard scheduled else { return }
+        Task {
+            await flush()
+            let needsAnotherFlush = lock.withLock {
+                automaticFlushPending = false
+                guard nextRetryAt.map({ now() >= $0 }) ?? true else { return false }
+                return queue.count >= Self.flushThreshold || queue.contains {
+                    Self.immediateEvents.contains(TelemetryEventName(rawValue: $0.event) ?? .appLaunched)
+                }
+            }
+            if needsAnotherFlush { scheduleAutomaticFlush() }
+        }
+    }
+
     private func flushQueuedEvents() async -> Set<String> {
+        let deferred = lock.withLock { () -> Set<String>? in
+            guard let nextRetryAt, now() < nextRetryAt else { return nil }
+            return Set(queue.map(\.eventId))
+        }
+        if let deferred { return deferred }
         let (events, generation) = takeQueuedEvents()
         guard !events.isEmpty else { return [] }
-        let failedEvents = await sendBatches(
+        let result = await sendBatches(
             events, generation: generation, using: session, timeoutInterval: requestTimeoutInterval
         )
-        let retainedFailures = requeueFailedEvents(failedEvents, generation: generation)
-        return Set(retainedFailures.map(\.eventId))
+        let retainedFailures = requeueFailedEvents(result.retryEvents, generation: generation)
+        return Set(retainedFailures.map(\.eventId)).union(result.rejectedIDs)
     }
 
     // MARK: - Internal (for testing)
@@ -245,7 +294,7 @@ public final class TelemetryService: TelemetryServiceProtocol, @unchecked Sendab
     private func queueGeneration(ifAllowed event: TelemetryEventName) -> UInt64? {
         lock.lock()
         defer { lock.unlock() }
-        guard isEnabled() || event == .telemetryOptedOut else { return nil }
+        guard isTransportEligible(), isEnabled() || event == .telemetryOptedOut else { return nil }
         return queueGeneration
     }
 
@@ -253,11 +302,13 @@ public final class TelemetryService: TelemetryServiceProtocol, @unchecked Sendab
         lock.lock()
         defer { lock.unlock() }
         guard generation == queueGeneration,
-            isEnabled() || event.event == TelemetryEventName.telemetryOptedOut.rawValue
+            isTransportEligible(), isEnabled() || event.event == TelemetryEventName.telemetryOptedOut.rawValue
         else { return false }
         queue.append(event)
         if queue.count > Self.maxQueueSize {
-            queue.removeFirst(queue.count - Self.maxQueueSize)
+            let dropped = queue.count - Self.maxQueueSize
+            queue.removeFirst(dropped)
+            logger.info("telemetry_transport outcome=queue_full dropped_count=\(dropped, privacy: .public)")
         }
         return true
     }
@@ -278,14 +329,17 @@ public final class TelemetryService: TelemetryServiceProtocol, @unchecked Sendab
         let retained = eventsAllowedByConsent(events)
         queue.insert(contentsOf: retained, at: 0)
         if queue.count > Self.maxQueueSize {
-            queue.removeLast(queue.count - Self.maxQueueSize)
+            let dropped = queue.count - Self.maxQueueSize
+            queue.removeLast(dropped)
+            logger.info("telemetry_transport outcome=queue_full dropped_count=\(dropped, privacy: .public)")
         }
         return retained
     }
 
     /// Called under `lock`; only the final opt-out event may be sent while disabled.
     private func eventsAllowedByConsent(_ events: [TelemetryEvent]) -> [TelemetryEvent] {
-        isEnabled() ? events : events.filter { $0.event == TelemetryEventName.telemetryOptedOut.rawValue }
+        guard isTransportEligible() else { return [] }
+        return isEnabled() ? events : events.filter { $0.event == TelemetryEventName.telemetryOptedOut.rawValue }
     }
 
     private func eventsAllowedForDispatch(_ events: [TelemetryEvent], generation: UInt64) -> [TelemetryEvent] {
@@ -312,7 +366,7 @@ public final class TelemetryService: TelemetryServiceProtocol, @unchecked Sendab
             guard let self else { return }
             let timer = Timer(timeInterval: Self.flushInterval, repeats: true) { [weak self] _ in
                 guard let self else { return }
-                Task { await self.flush() }
+                self.scheduleAutomaticFlush()
             }
             RunLoop.main.add(timer, forMode: .common)
             self.flushTimer = timer
@@ -331,12 +385,17 @@ public final class TelemetryService: TelemetryServiceProtocol, @unchecked Sendab
 
     public func flushForTermination() {
         lock.lock()
-        if isEnabled() {
+        if isTransportEligible(), isEnabled() {
             queue.append(makeTelemetryEvent(
                 from: .appQuit(sessionDurationSeconds: Date().timeIntervalSince(sessionStartedAt))
             ))
         }
-        let events = queue
+        let events: [TelemetryEvent]
+        if let nextRetryAt, now() < nextRetryAt {
+            events = queue.filter { $0.event == TelemetryEventName.telemetryOptedOut.rawValue }
+        } else {
+            events = queue
+        }
         let generation = queueGeneration
         queue.removeAll()
         lock.unlock()
@@ -362,11 +421,11 @@ public final class TelemetryService: TelemetryServiceProtocol, @unchecked Sendab
         generation: UInt64,
         using session: URLSession,
         timeoutInterval: TimeInterval
-    ) async -> [TelemetryEvent] {
+    ) async -> BatchResult {
         let encoder = JSONEncoder()
         encoder.keyEncodingStrategy = .convertToSnakeCase
         let url = baseURL.appendingPathComponent("telemetry")
-        var failedEvents: [TelemetryEvent] = []
+        var result = BatchResult()
 
         for batchStart in stride(from: 0, to: events.count, by: Self.maxBatchSize) {
             let batchEnd = min(batchStart + Self.maxBatchSize, events.count)
@@ -376,7 +435,7 @@ public final class TelemetryService: TelemetryServiceProtocol, @unchecked Sendab
 
             guard let body = try? encoder.encode(payload) else {
                 logger.error("Failed to encode telemetry payload")
-                failedEvents.append(contentsOf: batchEvents)
+                result.rejectedIDs.formUnion(batchEvents.map(\.eventId))
                 continue
             }
 
@@ -387,18 +446,53 @@ public final class TelemetryService: TelemetryServiceProtocol, @unchecked Sendab
             request.timeoutInterval = timeoutInterval
 
             beforeRequestAdmission?()
-            let sent = await sendAsync(request, events: batchEvents, generation: generation, using: session)
-            if !sent {
-                failedEvents.append(contentsOf: batchEvents)
+            let delivery = await sendAsync(request, events: batchEvents, generation: generation, using: session)
+            switch delivery {
+            case .discarded:
+                logger.debug("telemetry_transport outcome=consent_discarded batch_count=\(batchEvents.count, privacy: .public)")
+            case .delivered:
+                lock.withLock {
+                    if generation == queueGeneration {
+                        nextRetryAt = nil
+                        consecutiveFailures = 0
+                    }
+                }
+                logger.debug("telemetry_transport outcome=delivered batch_count=\(batchEvents.count, privacy: .public)")
+            case .rejected(let status):
+                result.rejectedIDs.formUnion(batchEvents.map(\.eventId))
+                logger.warning("telemetry_transport outcome=rejected status=\(status, privacy: .public) dropped_count=\(batchEvents.count, privacy: .public)")
+            case .retry(let status, let after):
+                let delay = lock.withLock { () -> TimeInterval in
+                    guard generation == queueGeneration else { return 0 }
+                    consecutiveFailures = min(consecutiveFailures + 1, 10)
+                    let backoff = min(900, 5 * pow(2, Double(consecutiveFailures - 1)) * retryJitter())
+                    let delay = max(backoff, after ?? 0)
+                    nextRetryAt = now().addingTimeInterval(delay)
+                    return delay
+                }
+                result.retryEvents.append(contentsOf: batchEvents)
+                result.retryEvents.append(contentsOf: events.dropFirst(batchEnd))
+                logger.info("telemetry_transport outcome=retry status=\(status, privacy: .public) retry_seconds=\(delay, privacy: .public) pending_count=\(result.retryEvents.count, privacy: .public)")
+                return result
             }
         }
 
-        return failedEvents
+        return result
+    }
+
+    static func retryAfter(_ value: String?, now: Date) -> TimeInterval? {
+        guard let value else { return nil }
+        if let seconds = TimeInterval(value), seconds.isFinite, seconds >= 0 { return seconds }
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
+        return formatter.date(from: value).map { max(0, $0.timeIntervalSince(now)) }
     }
 
     private func sendAsync(
         _ request: URLRequest, events: [TelemetryEvent], generation: UInt64, using session: URLSession
-    ) async -> Bool {
+    ) async -> DeliveryResult {
         let cancellation = TelemetryRequestCancellation()
         return await withTaskCancellationHandler {
             await withCheckedContinuation { continuation in
@@ -406,20 +500,27 @@ public final class TelemetryService: TelemetryServiceProtocol, @unchecked Sendab
                 // same lock as clearQueue, so no stale request starts afterward.
                 lock.withLock {
                     guard generation == queueGeneration,
-                        isEnabled() || events.allSatisfy({ $0.event == TelemetryEventName.telemetryOptedOut.rawValue })
+                        isTransportEligible(), isEnabled() || events.allSatisfy({ $0.event == TelemetryEventName.telemetryOptedOut.rawValue })
                     else {
-                        continuation.resume(returning: true)
+                        continuation.resume(returning: DeliveryResult.discarded)
                         return
                     }
-                    let task = session.dataTask(with: request) { [logger] _, response, error in
-                        if let error {
-                            logger.debug("Telemetry flush failed: \(error.localizedDescription)")
-                            continuation.resume(returning: false)
-                        } else if let http = response as? HTTPURLResponse, !(200...299).contains(http.statusCode) {
-                            logger.warning("Telemetry server returned \(http.statusCode)")
-                            continuation.resume(returning: false)
+                    let task = session.dataTask(with: request) { [now] _, response, error in
+                        if error != nil {
+                            continuation.resume(returning: DeliveryResult.retry(status: 0, after: nil))
+                        } else if let http = response as? HTTPURLResponse {
+                            if (200...299).contains(http.statusCode) {
+                                continuation.resume(returning: DeliveryResult.delivered)
+                            } else if http.statusCode == 408 || http.statusCode == 429 || (500...599).contains(http.statusCode) {
+                                continuation.resume(returning: DeliveryResult.retry(
+                                    status: http.statusCode,
+                                    after: Self.retryAfter(http.value(forHTTPHeaderField: "Retry-After"), now: now())
+                                ))
+                            } else {
+                                continuation.resume(returning: DeliveryResult.rejected(status: http.statusCode))
+                            }
                         } else {
-                            continuation.resume(returning: true)
+                            continuation.resume(returning: DeliveryResult.retry(status: 0, after: nil))
                         }
                     }
                     cancellation.install(task)

--- a/Tests/MacParakeetTests/TelemetryServiceTests.swift
+++ b/Tests/MacParakeetTests/TelemetryServiceTests.swift
@@ -10,6 +10,12 @@ private struct RecordedTelemetryPayload: Decodable {
 private struct RecordedTelemetryEvent: Decodable {
     let event: String
     let session: String
+    let eventId: String
+
+    enum CodingKeys: String, CodingKey {
+        case event, session
+        case eventId = "event_id"
+    }
 }
 
 private final class TelemetryConsent: @unchecked Sendable {
@@ -119,9 +125,9 @@ private final class TelemetryMockURLProtocol: URLProtocol {
 
     override func stopLoading() {}
 
-    func respond(statusCode: Int) {
+    func respond(statusCode: Int, headers: [String: String]? = nil) {
         let response = HTTPURLResponse(
-            url: request.url!, statusCode: statusCode, httpVersion: nil, headerFields: nil
+            url: request.url!, statusCode: statusCode, httpVersion: nil, headerFields: headers
         )!
         client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
         client?.urlProtocol(self, didLoad: Data())
@@ -377,6 +383,120 @@ final class TelemetryServiceTests: XCTestCase {
 
         XCTAssertEqual(TelemetryMockURLProtocol.recordedPayloads().map { $0.events.count }, [1, 100])
         XCTAssertEqual(service.pendingEventCount, 0)
+    }
+
+    func testPermanentRejectionDropsBatchAndReportsUndelivered() async {
+        TelemetryMockURLProtocol.statusCode = 400
+        let service = makeService()
+        let delivered = await service.sendAndFlush(.appLaunched)
+        XCTAssertFalse(delivered)
+        XCTAssertEqual(service.pendingEventCount, 0)
+        await service.flush()
+        XCTAssertEqual(TelemetryMockURLProtocol.recordedPayloads().count, 1)
+    }
+
+    func testTransientRetryWaitsAndPreservesEventID() async {
+        let service = makeService()
+        service.now = { Date(timeIntervalSince1970: 100) }
+        service.retryJitter = { 1 }
+        TelemetryMockURLProtocol.setRequestHandler { request in
+            request.respond(statusCode: 429, headers: ["Retry-After": "120"])
+        }
+        let delivered = await service.sendAndFlush(.appLaunched)
+        XCTAssertFalse(delivered)
+        await service.flush()
+        XCTAssertEqual(TelemetryMockURLProtocol.recordedPayloads().count, 1)
+        service.now = { Date(timeIntervalSince1970: 219) }
+        await service.flush()
+        XCTAssertEqual(TelemetryMockURLProtocol.recordedPayloads().count, 1)
+        service.now = { Date(timeIntervalSince1970: 220) }
+        TelemetryMockURLProtocol.setRequestHandler(nil)
+        await service.flush()
+        let events = TelemetryMockURLProtocol.recordedPayloads().flatMap(\.events)
+        XCTAssertEqual(events.count, 2)
+        XCTAssertEqual(events.first?.eventId, events.last?.eventId)
+        XCTAssertEqual(service.pendingEventCount, 0)
+    }
+
+    func testBurstDuringOutageDoesNotRepeatedlySendRejectedRequests() async {
+        let service = makeService()
+        service.now = { Date(timeIntervalSince1970: 100) }
+        service.retryJitter = { 1 }
+        TelemetryMockURLProtocol.statusCode = 503
+        for _ in 0..<150 { service.send(.appLaunched) }
+        await service.flush()
+        await service.flush()
+        XCTAssertEqual(TelemetryMockURLProtocol.recordedPayloads().count, 1)
+        XCTAssertEqual(service.pendingEventCount, 150)
+        service.clearQueue()
+    }
+
+    func testRetryAfterHTTPDateAndMalformedValue() {
+        let date = Date(timeIntervalSince1970: 0)
+        XCTAssertEqual(TelemetryService.retryAfter("Thu, 01 Jan 1970 00:02:00 GMT", now: date), 120)
+        XCTAssertNil(TelemetryService.retryAfter("NaN", now: date))
+        XCTAssertNil(TelemetryService.retryAfter("-1", now: date))
+    }
+
+    func testTransportPolicySuppressesOptOutRequestsForEnvironmentAndDevelopment() async {
+        let cases: [(env: [String: String], debug: Bool, source: String)] = [
+            (["MACPARAKEET_TELEMETRY": "0"], false, "dist-xcodebuild-release"),
+            (["DO_NOT_TRACK": "1"], false, "dist-xcodebuild-release"),
+            (["CI": "true"], false, "dist-xcodebuild-release"),
+            ([:], true, "dist-xcodebuild-release"),
+            ([:], false, "dev-run-xcodebuild-release"),
+        ]
+        for policy in cases {
+            let service = TelemetryService(
+                baseURL: URL(string: "https://localhost:9999")!, session: makeSession(),
+                isTransportEligible: {
+                    TelemetryPolicy.guiTransportEligible(env: policy.env, isDebug: policy.debug,
+                        buildSource: policy.source, version: "0.8.0")
+                },
+                isEnabled: { false }
+            )
+            service.clearQueue()
+            service.send(.telemetryOptedOut)
+            _ = await service.sendAndFlush(.telemetryOptedOut)
+            await service.flush()
+            service.flushForTermination()
+            XCTAssertEqual(service.pendingEventCount, 0)
+        }
+        XCTAssertTrue(TelemetryMockURLProtocol.recordedPayloads().isEmpty)
+    }
+
+    func testEligibleProductionTransportStillSendsFinalConsentOptOut() async {
+        let service = TelemetryService(
+            baseURL: URL(string: "https://localhost:9999")!, session: makeSession(),
+            isTransportEligible: {
+                TelemetryPolicy.guiTransportEligible(env: [:], isDebug: false,
+                    buildSource: "dist-xcodebuild-release", version: "0.8.0")
+            },
+            isEnabled: { false }
+        )
+        service.send(.appLaunched)
+        let delivered = await service.sendAndFlush(.telemetryOptedOut)
+        XCTAssertTrue(delivered)
+        XCTAssertEqual(TelemetryMockURLProtocol.recordedPayloads().flatMap(\.events).map(\.event),
+                       [TelemetryEventName.telemetryOptedOut.rawValue])
+    }
+
+    func testGUIDevelopmentPolicyAndConsent() {
+        func enabled(_ env: [String: String] = [:], debug: Bool = false,
+                     source: String = "dist-xcodebuild-release", version: String = "0.8.0",
+                     consent: Bool = true) -> Bool {
+            TelemetryPolicy.guiEnabled(preferenceEnabled: consent, env: env, isDebug: debug,
+                                       buildSource: source, version: version)
+        }
+        XCTAssertTrue(enabled())
+        XCTAssertFalse(enabled(debug: true))
+        XCTAssertFalse(enabled(source: "dev-run-xcodebuild-release"))
+        XCTAssertFalse(enabled(version: "0.0.0"))
+        XCTAssertFalse(enabled(["CI": "true"]))
+        XCTAssertFalse(enabled(["DO_NOT_TRACK": "1"]))
+        XCTAssertFalse(enabled(["MACPARAKEET_TELEMETRY": "0"]))
+        XCTAssertTrue(enabled(["MACPARAKEET_TELEMETRY": "1", "CI": "true"], debug: true))
+        XCTAssertFalse(enabled(["MACPARAKEET_TELEMETRY": "1"], consent: false))
     }
 
     // MARK: - Queue Limits

--- a/Tests/MacParakeetTests/TelemetryServiceTests.swift
+++ b/Tests/MacParakeetTests/TelemetryServiceTests.swift
@@ -569,6 +569,26 @@ final class TelemetryServiceTests: XCTestCase {
         XCTAssertEqual(totalEvents, eventCount)
     }
 
+    func testTerminationDoesNotRetryRateLimitedOptOutBeforeRetryAfter() async {
+        let service = makeService(isEnabled: { false })
+        service.now = { Date(timeIntervalSince1970: 100) }
+        service.retryJitter = { 1 }
+        TelemetryMockURLProtocol.setRequestHandler { request in
+            request.respond(statusCode: 429, headers: ["Retry-After": "120"])
+        }
+
+        let delivered = await service.sendAndFlush(.telemetryOptedOut)
+        XCTAssertFalse(delivered)
+        XCTAssertEqual(service.pendingEventCount, 1)
+        XCTAssertEqual(TelemetryMockURLProtocol.recordedPayloads().count, 1)
+
+        service.flushForTermination()
+
+        XCTAssertEqual(TelemetryMockURLProtocol.recordedPayloads().count, 1,
+                       "Termination must honor the server retry floor even for the final opt-out event")
+        XCTAssertEqual(service.pendingEventCount, 0, "The best-effort termination queue is discarded")
+    }
+
     func testTerminationFlushDoesNotEmitAppQuitWhenTelemetryDisabled() async throws {
         let service = makeService(isEnabled: { false })
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -888,6 +888,9 @@ report its version; that does not prove the version was published.
 
 The delivery queue coalesces automatic flushes, retries transient HTTP/network
 failures with jittered exponential backoff and `Retry-After`, and drops permanent
-HTTP rejection batches. Drops and retry decisions are reported through bounded
+HTTP rejection batches. Retry delays are minimum intervals: the GUI's existing
+60-second timer attempts eligible retries, while short-lived CLI commands do
+not wait for a future retry before exiting. Termination respects the retry floor
+even for the final opt-out event; pending events are not persisted across exit. Drops and retry decisions are reported through bounded
 local `telemetry_transport` fields. See the [telemetry contract](../spec/contracts/telemetry-v1.md#client-delivery-policy)
 for exact policy, retry timing and compatibility limits.

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -876,3 +876,18 @@ External AI review of the telemetry design. Each point was evaluated and accepte
 - **Retained licensing telemetry** -- Keep unfired trial/purchase/restore event
   names unless the project owner explicitly decides to remove the future
   paid-distribution option and records that decision in an ADR/spec update
+
+## Development and transport policy
+
+GUI debug/dev builds default to telemetry off; explicit environment enablement
+can opt test runs in, while the GUI preference still controls consent. CLI and
+GUI share environment parsing. Environment/CI/development disabling suppresses
+even the final opt-out event; an eligible production session can still report
+that final consent change. A versioned release-candidate bundle may still
+report its version; that does not prove the version was published.
+
+The delivery queue coalesces automatic flushes, retries transient HTTP/network
+failures with jittered exponential backoff and `Retry-After`, and drops permanent
+HTTP rejection batches. Drops and retry decisions are reported through bounded
+local `telemetry_transport` fields. See the [telemetry contract](../spec/contracts/telemetry-v1.md#client-delivery-policy)
+for exact policy, retry timing and compatibility limits.

--- a/spec/contracts/telemetry-v1.md
+++ b/spec/contracts/telemetry-v1.md
@@ -24,6 +24,32 @@ records the September 2026 tightening of privacy and outcome semantics.
 - A successful CLI early exit has `outcome=success`, `exit_code=0` and no
   `error_type`, even when ArgumentParser implements it by throwing.
 
+## Client delivery policy
+
+GUI telemetry defaults off in debug builds, builds marked `dev-*` or `swiftpm-*`,
+and versions `dev` or `0.0.0`. `MACPARAKEET_TELEMETRY=1/true/yes/on` explicitly
+permits development/CI telemetry; `0/false/no/off` disables it. Without that
+explicit override, `DO_NOT_TRACK=1` and recognized CI environments disable it.
+The GUI's persisted opt-out remains authoritative even with explicit enablement.
+Transport eligibility is separate from consent: environment/CI/development
+disabling suppresses every request, including the final opt-out event. Eligible
+production sessions may still send their final consent opt-out event. Explicitly
+injected clients supply their own policy; omitted eligibility defaults to allowed
+when a consent closure is injected, preserving CLI and isolated-client behavior.
+The CLI retains its existing explicit-environment precedence. Versioned release
+candidate bundles are not evidence of publication; the wire envelope does not
+claim a release channel.
+
+Automatic flush requests are coalesced. Network failures, HTTP 408/429 and 5xx
+retain event UUIDs for retry with jittered exponential backoff (5 seconds initial,
+15 minutes maximum), respecting a longer `Retry-After` delay (seconds or HTTP
+date). The periodic timer attempts eligible retries; explicit flushes also honor
+the delay. Permanent HTTP rejections discard the rejected batch, including any
+valid events in that batch, and report delivery failure rather than repeatedly
+poisoning the queue. Consent changes invalidate retry timing and queued snapshots.
+Local structured `telemetry_transport` logs contain outcomes, numeric status,
+batch/drop counts and retry timing, never event props or response bodies.
+
 ## Aggregate evidence
 
 The website's `/api/stats` keeps its existing aggregate fields. Additive

--- a/spec/contracts/telemetry-v1.md
+++ b/spec/contracts/telemetry-v1.md
@@ -43,8 +43,11 @@ claim a release channel.
 Automatic flush requests are coalesced. Network failures, HTTP 408/429 and 5xx
 retain event UUIDs for retry with jittered exponential backoff (5 seconds initial,
 15 minutes maximum), respecting a longer `Retry-After` delay (seconds or HTTP
-date). The periodic timer attempts eligible retries; explicit flushes also honor
-the delay. Permanent HTTP rejections discard the rejected batch, including any
+date). These delays are minimum retry intervals, not exact delivery deadlines.
+The existing 60-second GUI timer attempts eligible retries; explicit and
+termination flushes also honor the delay, including for a final opt-out event.
+The CLI makes its best-effort flush before exit and does not remain alive for a
+later retry. Queued events are not persisted across process exit. Permanent HTTP rejections discard the rejected batch, including any
 valid events in that batch, and report delivery failure rather than repeatedly
 poisoning the queue. Consent changes invalidate retry timing and queued snapshots.
 Local structured `telemetry_transport` logs contain outcomes, numeric status,


### PR DESCRIPTION
GUI development/CI builds now default to no telemetry, and explicit transport suppression blocks even the final opt-out event. Eligible production sessions retain the consent opt-out notification. The CLI keeps its existing environment precedence through a shared parser.

Uploads now coalesce automatic flushes, preserve event IDs across paced transient retries, honor Retry-After, and drop permanently rejected batches with bounded local diagnostics. A permanent rejection drops the whole batch, including valid co-batched events; this avoids inventing a partial-ack protocol.

Validation: 107 focused telemetry/CLI tests passed on final head `38e66b1a`. The termination Retry-After regression was reproduced before its fix. On preceding head `13ac2d87`, the one-shot full suite passed (5,669 XCTest tests with 20 skipped, plus 29 Swift Testing tests). Independent review checked consent admission and retry lifecycle. The telemetry contract and catalog document the behavior. Existing worktrees and user data were preserved.

These source changes need a future app/CLI release; no signed application release is included.

Retry timing is deliberately a minimum eligibility delay, checked by the existing 60-second GUI timer and explicit/event-driven flushes. One-shot CLI commands do not wait for deferred telemetry retries; both the previous and new implementation lose any remaining in-memory batch at exit. Independent review evaluated the automated request for exact-deadline retry scheduling and retained this documented best-effort policy rather than adding CLI latency or durable telemetry storage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent telemetry controls for GUI and CLI environments, including explicit opt-in/opt-out and CI handling.
  * Added automatic retry handling for temporary delivery failures, including support for server-provided retry delays.
  * Added privacy-safe telemetry transport diagnostics.

* **Bug Fixes**
  * Prevented telemetry from bypassing retry limits during application shutdown.
  * Preserved event identifiers across delivery attempts.

* **Documentation**
  * Documented telemetry eligibility, consent behavior, retry timing, CLI behavior, and shutdown handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Final integration review

Independent correctness review of `38e66b1a` found no merge-blocking defect. Both current-head CI runs passed, and a trial merge with main including #961/#984 was conflict-free. The exact-deadline retry request is declined for the documented best-effort policy above and its thread is resolved.

Non-blocking follow-up: normal flushing and termination can overlap; a success response can clear backoff established by the other response. This remains a bounded shutdown-telemetry limitation, with no identified privacy or application-data consequence. A deterministic overlapping-response test would improve coverage in a later transport change. No live endpoint or packaged GUI validation was repeated during this integration review.
