### PR TITLE
Make built-in Fn dictation passive and reject mixed gestures

### DIFF
--- a/Sources/MacParakeet/Hotkey/HotkeyManager.swift
+++ b/Sources/MacParakeet/Hotkey/HotkeyManager.swift
@@ -50,7 +50,13 @@ public final class HotkeyManager {
     private var modifierChordBlockedUntilRelease = false
     private var activeRecordingMode: FnKeyStateMachine.RecordingMode?
 
-    /// Bare-tap filtering: true until a non-Escape key is pressed while modifier is held.
+    /// Passive ledger for ordinary virtual key codes. The canonical macOS
+    /// keyboard range is 0...127; Fn's synthetic 179 is deliberately excluded.
+    private static let ordinaryKeyCodeRange: ClosedRange<UInt16> = 0...127
+    private var pressedNonFnKeyCodes: Set<UInt16> = []
+    private var physicalKeyStateProvider: (UInt16) -> Bool
+
+    /// Bare-tap filtering: true until another physical key or modifier transition is observed.
     private var bareTap = true
 
     /// Mask of the 4 relevant modifier bits (⌃⌥⇧⌘) for chord matching.
@@ -77,6 +83,9 @@ public final class HotkeyManager {
         self.tapThresholdMs = self.gestureController.tapThresholdMs
         self.targetMask = trigger.kind == .modifier ? ModifierKeyMatcher.mask(for: trigger.modifierName) : nil
         self.requiredChordFlags = trigger.chordEventFlags
+        self.physicalKeyStateProvider = { keyCode in
+            CGEventSource.keyState(.combinedSessionState, key: CGKeyCode(keyCode))
+        }
     }
 
     /// The built-in bare-Fn gesture is observational only. A listen-only tap
@@ -185,6 +194,7 @@ public final class HotkeyManager {
         modifierChordGestureIsActive = false
         modifierChordBlockedUntilRelease = false
         activeRecordingMode = nil
+        pressedNonFnKeyCodes.removeAll(keepingCapacity: true)
         bareTap = true
         gestureController.reset()
     }
@@ -339,6 +349,14 @@ public final class HotkeyManager {
                 targetModifierGestureIsActive = true
                 // Modifier down — start bare-tap tracking
                 bareTap = true
+                if trigger == .fn {
+                    reconcilePassiveFnKeyState()
+                    if passiveFnInputIsContaminated(flags: flags) {
+                        targetModifierGestureIsActive = false
+                        bareTap = false
+                        return []
+                    }
+                }
                 if gestureMode == .singleTapToggle {
                     return []
                 }
@@ -390,9 +408,19 @@ public final class HotkeyManager {
         keyCode: Int64,
         timestampMs: UInt64
     ) -> [HotkeyGestureController.Output] {
+        let physicalKeyCode = UInt16(keyCode)
+        if trigger == .fn, Self.isTrackableNonFnKeyCode(physicalKeyCode) {
+            guard pressedNonFnKeyCodes.insert(physicalKeyCode).inserted else {
+                return []
+            }
+            if targetModifierGestureIsActive {
+                bareTap = false
+            }
+        }
+
         if keyCode == 53 { // Escape
             return gestureController.escapePressed()
-        } else if !HotkeyTrigger.isFnKeyCode(UInt16(keyCode)) {
+        } else if !HotkeyTrigger.isFnKeyCode(physicalKeyCode) {
             // Skip Fn/Globe key (63/179) — macOS generates a synthetic keyDown
             // with keyCode 179 when Fn is released (for "Change Input Source" or
             // "Show Emoji & Symbols"). Without this guard, that keyDown resets the
@@ -416,11 +444,13 @@ public final class HotkeyManager {
         keyCode: Int64,
         timestampMs _: UInt64
     ) -> [HotkeyGestureController.Output] {
+        let physicalKeyCode = UInt16(keyCode)
         guard trigger == .fn,
-              targetModifierGestureIsActive,
-              !HotkeyTrigger.isFnKeyCode(UInt16(keyCode)) else {
+              Self.isTrackableNonFnKeyCode(physicalKeyCode) else {
             return []
         }
+        pressedNonFnKeyCodes.remove(physicalKeyCode)
+        guard targetModifierGestureIsActive else { return [] }
 
         bareTap = false
         return gestureMode == .singleTapToggle ? [] : gestureController.interrupted()
@@ -459,6 +489,13 @@ public final class HotkeyManager {
         let outputs = modifierKeyUpOutputs(keyCode: keyCode, timestampMs: timestampMs)
         rememberRecordingState(for: outputs)
         return outputs
+    }
+
+    func setPhysicalKeyStateProviderForTesting(
+        _ provider: @escaping (UInt16) -> Bool
+    ) {
+        physicalKeyStateProvider = provider
+        reconcilePassiveFnKeyState()
     }
 
     func startupDebounceElapsedForTesting() -> [HotkeyGestureController.Output] {
@@ -860,6 +897,25 @@ public final class HotkeyManager {
             triggerKeyPressed: triggerKeyPressed
         )
 
+        if trigger == .fn {
+            let currentFlags = flags ?? CGEventSource.flagsState(.combinedSessionState)
+            reconcilePassiveFnKeyState()
+            if triggerPressed, passiveFnInputIsContaminated(flags: currentFlags) {
+                cancelStartupTimer()
+                cancelHoldTimer()
+                syncRecoveredTriggerState(
+                    flags: flags,
+                    triggerKeyPressed: triggerKeyPressed,
+                    triggerPressed: triggerPressed
+                )
+                let outputs = gestureController.interrupted()
+                targetModifierGestureIsActive = false
+                bareTap = false
+                handleOutputs(outputs)
+                return outputs
+            }
+        }
+
         switch activeRecordingMode {
         case .holdToTalk:
             cancelStartupTimer()
@@ -921,6 +977,7 @@ public final class HotkeyManager {
         activeRecordingMode = nil
         bareTap = true
         gestureController.reset()
+        reconcilePassiveFnKeyState()
         syncModifierPressedState(flags: flags)
         syncModifierChordPressedState(flags: flags)
     }
@@ -1008,6 +1065,11 @@ public final class HotkeyManager {
             if !activeTrackedModifiers.subtracting(mask).isEmpty {
                 return true
             }
+            if trigger == .fn {
+                if currentFlags.contains(.maskAlphaShift) || !pressedNonFnKeyCodes.isEmpty {
+                    return true
+                }
+            }
             if let targetKeyCode = trigger.modifierKeyCode {
                 return ModifierKeyMatcher.oppositeSideModifierIsPressed(
                     flags: currentFlags,
@@ -1020,6 +1082,27 @@ public final class HotkeyManager {
         default:
             return false
         }
+    }
+
+    private static func isTrackableNonFnKeyCode(_ keyCode: UInt16) -> Bool {
+        ordinaryKeyCodeRange.contains(keyCode) && !HotkeyTrigger.isFnKeyCode(keyCode)
+    }
+
+    private func reconcilePassiveFnKeyState() {
+        guard trigger == .fn else { return }
+        pressedNonFnKeyCodes = Set(
+            Self.ordinaryKeyCodeRange.filter { keyCode in
+                !HotkeyTrigger.isFnKeyCode(keyCode) && physicalKeyStateProvider(keyCode)
+            }
+        )
+    }
+
+    private func passiveFnInputIsContaminated(flags: CGEventFlags) -> Bool {
+        guard let fnMask = targetMask else { return true }
+        let activeTrackedModifiers = flags.intersection(ModifierKeyMatcher.trackedModifierMasks)
+        return !activeTrackedModifiers.subtracting(fnMask).isEmpty
+            || flags.contains(.maskAlphaShift)
+            || !pressedNonFnKeyCodes.isEmpty
     }
 
     private func chordTriggerKeyUpOutputs(

--- a/Sources/MacParakeet/Hotkey/HotkeyManager.swift
+++ b/Sources/MacParakeet/Hotkey/HotkeyManager.swift
@@ -902,8 +902,16 @@ public final class HotkeyManager {
 
         if trigger == .fn {
             let currentFlags = flags ?? CGEventSource.flagsState(.combinedSessionState)
+            let capsLockChangedWhileTapWasDisabled =
+                previousModifierFlags.contains(.maskAlphaShift)
+                != currentFlags.contains(.maskAlphaShift)
+            let capsLockContaminatesCurrentGesture =
+                capsLockChangedWhileTapWasDisabled
+                && (targetModifierGestureIsActive || gestureController.hasPendingTriggerPress)
             reconcilePassiveFnKeyState()
-            if triggerPressed, passiveFnInputIsContaminated(flags: currentFlags) {
+            if triggerPressed,
+               passiveFnInputIsContaminated(flags: currentFlags)
+               || capsLockContaminatesCurrentGesture {
                 cancelStartupTimer()
                 cancelHoldTimer()
                 syncRecoveredTriggerState(

--- a/Sources/MacParakeet/Hotkey/HotkeyManager.swift
+++ b/Sources/MacParakeet/Hotkey/HotkeyManager.swift
@@ -453,7 +453,9 @@ public final class HotkeyManager {
             return []
         }
         pressedNonFnKeyCodes.remove(physicalKeyCode)
-        guard targetModifierGestureIsActive else { return [] }
+        guard targetModifierGestureIsActive else {
+            return interruptPendingPassiveFnWindow()
+        }
 
         bareTap = false
         return gestureMode == .singleTapToggle ? [] : gestureController.interrupted()

--- a/Sources/MacParakeet/Hotkey/HotkeyManager.swift
+++ b/Sources/MacParakeet/Hotkey/HotkeyManager.swift
@@ -79,6 +79,23 @@ public final class HotkeyManager {
         self.requiredChordFlags = trigger.chordEventFlags
     }
 
+    /// The built-in bare-Fn gesture is observational only. A listen-only tap
+    /// cannot consume or rewrite the physical Fn event (or any cancellation
+    /// event observed while Fn is held). Configurable non-Fn triggers retain
+    /// their established active-tap behavior.
+    static func eventTapOptions(for trigger: HotkeyTrigger) -> CGEventTapOptions {
+        trigger == .fn ? .listenOnly : .defaultTap
+    }
+
+    static func eventMask(for trigger: HotkeyTrigger) -> CGEventMask {
+        var mask: CGEventMask = (1 << CGEventType.flagsChanged.rawValue)
+            | (1 << CGEventType.keyDown.rawValue)
+        if trigger == .fn || trigger.kind == .keyCode || trigger.kind == .chord {
+            mask |= (1 << CGEventType.keyUp.rawValue)
+        }
+        return mask
+    }
+
     deinit {
         // Inline cleanup — deinit is nonisolated, can't call @MainActor stop().
         // Safe because deinit guarantees exclusive access to self.
@@ -99,16 +116,12 @@ public final class HotkeyManager {
         // Guard against double-start: stop existing tap to prevent leaking it
         if eventTap != nil { stop() }
 
-        var eventMask: CGEventMask = (1 << CGEventType.flagsChanged.rawValue)
-            | (1 << CGEventType.keyDown.rawValue)
-        if trigger.kind == .keyCode || trigger.kind == .chord {
-            eventMask |= (1 << CGEventType.keyUp.rawValue)
-        }
+        let eventMask = Self.eventMask(for: trigger)
 
         guard let tap = CGEvent.tapCreate(
             tap: .cgSessionEventTap,
             place: .headInsertEventTap,
-            options: .defaultTap,
+            options: Self.eventTapOptions(for: trigger),
             eventsOfInterest: eventMask,
             callback: { _, type, event, refcon -> Unmanaged<CGEvent>? in
                 guard let refcon else { return Unmanaged.passUnretained(event) }
@@ -221,6 +234,14 @@ public final class HotkeyManager {
             let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
             handleOutputs(
                 modifierKeyDownOutputs(
+                    keyCode: keyCode,
+                    timestampMs: timestampMs
+                )
+            )
+        } else if type == .keyUp {
+            let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
+            handleOutputs(
+                modifierKeyUpOutputs(
                     keyCode: keyCode,
                     timestampMs: timestampMs
                 )
@@ -339,8 +360,24 @@ public final class HotkeyManager {
         }
 
         // Additional modifier changes while the trigger is still held invalidate the
-        // "bare modifier" assumption just like a regular keyDown would.
+        // "bare modifier" assumption just like a regular keyDown would. For the
+        // passive built-in Fn gesture, key off the physical transition rather than
+        // the currently-active flags so a modifier release also cancels the gesture.
         guard targetModifierGestureIsActive else { return [] }
+        if trigger == .fn {
+            let changedModifiers = Self.changedTrackedModifierKeyCodes(
+                from: previousModifierFlags,
+                to: flags,
+                changedKeyCode: changedKeyCode
+            ).subtracting([HotkeyTrigger.canonicalFnKeyCode])
+            let capsLockChanged = changedKeyCode == 57
+                && previousModifierFlags.contains(.maskAlphaShift) != flags.contains(.maskAlphaShift)
+            guard !changedModifiers.isEmpty || capsLockChanged else { return [] }
+
+            bareTap = false
+            return gestureMode == .singleTapToggle ? [] : gestureController.interrupted()
+        }
+
         let activeTrackedModifiers = flags.intersection(ModifierKeyMatcher.trackedModifierMasks)
         let nonTargetTrackedModifiers = activeTrackedModifiers.subtracting(mask)
         guard !nonTargetTrackedModifiers.isEmpty else { return [] }
@@ -375,6 +412,20 @@ public final class HotkeyManager {
         return []
     }
 
+    private func modifierKeyUpOutputs(
+        keyCode: Int64,
+        timestampMs _: UInt64
+    ) -> [HotkeyGestureController.Output] {
+        guard trigger == .fn,
+              targetModifierGestureIsActive,
+              !HotkeyTrigger.isFnKeyCode(UInt16(keyCode)) else {
+            return []
+        }
+
+        bareTap = false
+        return gestureMode == .singleTapToggle ? [] : gestureController.interrupted()
+    }
+
     // Test seam: lets unit tests exercise the real modifier-path state logic
     // without constructing CGEvents or arming timers.
     func modifierFlagsChangedOutputsForTesting(
@@ -397,6 +448,15 @@ public final class HotkeyManager {
         timestampMs: UInt64
     ) -> [HotkeyGestureController.Output] {
         let outputs = modifierKeyDownOutputs(keyCode: keyCode, timestampMs: timestampMs)
+        rememberRecordingState(for: outputs)
+        return outputs
+    }
+
+    func modifierKeyUpOutputsForTesting(
+        keyCode: Int64,
+        timestampMs: UInt64
+    ) -> [HotkeyGestureController.Output] {
+        let outputs = modifierKeyUpOutputs(keyCode: keyCode, timestampMs: timestampMs)
         rememberRecordingState(for: outputs)
         return outputs
     }

--- a/Sources/MacParakeet/Hotkey/HotkeyManager.swift
+++ b/Sources/MacParakeet/Hotkey/HotkeyManager.swift
@@ -97,7 +97,8 @@ public final class HotkeyManager {
     }
 
     static func eventMask(for trigger: HotkeyTrigger) -> CGEventMask {
-        var mask: CGEventMask = (1 << CGEventType.flagsChanged.rawValue)
+        var mask: CGEventMask =
+            (1 << CGEventType.flagsChanged.rawValue)
             | (1 << CGEventType.keyDown.rawValue)
         if trigger == .fn || trigger.kind == .keyCode || trigger.kind == .chord {
             mask |= (1 << CGEventType.keyUp.rawValue)
@@ -387,7 +388,8 @@ public final class HotkeyManager {
                 to: flags,
                 changedKeyCode: changedKeyCode
             ).subtracting([HotkeyTrigger.canonicalFnKeyCode])
-            let capsLockChanged = changedKeyCode == 57
+            let capsLockChanged =
+                changedKeyCode == 57
                 && previousModifierFlags.contains(.maskAlphaShift) != flags.contains(.maskAlphaShift)
             guard !changedModifiers.isEmpty || capsLockChanged else { return [] }
 
@@ -449,7 +451,8 @@ public final class HotkeyManager {
     ) -> [HotkeyGestureController.Output] {
         let physicalKeyCode = UInt16(keyCode)
         guard trigger == .fn,
-              Self.isTrackableNonFnKeyCode(physicalKeyCode) else {
+            Self.isTrackableNonFnKeyCode(physicalKeyCode)
+        else {
             return []
         }
         pressedNonFnKeyCodes.remove(physicalKeyCode)
@@ -912,8 +915,9 @@ public final class HotkeyManager {
                 && (targetModifierGestureIsActive || gestureController.hasPendingTriggerPress)
             reconcilePassiveFnKeyState()
             if triggerPressed,
-               passiveFnInputIsContaminated(flags: currentFlags)
-               || capsLockContaminatesCurrentGesture {
+                passiveFnInputIsContaminated(flags: currentFlags)
+                    || capsLockContaminatesCurrentGesture
+            {
                 cancelStartupTimer()
                 cancelHoldTimer()
                 syncRecoveredTriggerState(

--- a/Sources/MacParakeet/Hotkey/HotkeyManager.swift
+++ b/Sources/MacParakeet/Hotkey/HotkeyManager.swift
@@ -354,7 +354,7 @@ public final class HotkeyManager {
                     if passiveFnInputIsContaminated(flags: flags) {
                         targetModifierGestureIsActive = false
                         bareTap = false
-                        return []
+                        return interruptPendingPassiveFnWindow()
                     }
                 }
                 if gestureMode == .singleTapToggle {
@@ -377,11 +377,10 @@ public final class HotkeyManager {
             return outputs
         }
 
-        // Additional modifier changes while the trigger is still held invalidate the
-        // "bare modifier" assumption just like a regular keyDown would. For the
-        // passive built-in Fn gesture, key off the physical transition rather than
-        // the currently-active flags so a modifier release also cancels the gesture.
-        guard targetModifierGestureIsActive else { return [] }
+        // Additional modifier changes invalidate the "bare modifier" assumption
+        // just like a regular keyDown would. For passive built-in Fn, key off the
+        // physical transition rather than current flags so both press and release
+        // cancel an active gesture or an outstanding second-tap window.
         if trigger == .fn {
             let changedModifiers = Self.changedTrackedModifierKeyCodes(
                 from: previousModifierFlags,
@@ -392,10 +391,14 @@ public final class HotkeyManager {
                 && previousModifierFlags.contains(.maskAlphaShift) != flags.contains(.maskAlphaShift)
             guard !changedModifiers.isEmpty || capsLockChanged else { return [] }
 
-            bareTap = false
-            return gestureMode == .singleTapToggle ? [] : gestureController.interrupted()
+            if targetModifierGestureIsActive {
+                bareTap = false
+                return gestureMode == .singleTapToggle ? [] : gestureController.interrupted()
+            }
+            return interruptPendingPassiveFnWindow()
         }
 
+        guard targetModifierGestureIsActive else { return [] }
         let activeTrackedModifiers = flags.intersection(ModifierKeyMatcher.trackedModifierMasks)
         let nonTargetTrackedModifiers = activeTrackedModifiers.subtracting(mask)
         guard !nonTargetTrackedModifiers.isEmpty else { return [] }
@@ -1066,7 +1069,7 @@ public final class HotkeyManager {
                 return true
             }
             if trigger == .fn {
-                if currentFlags.contains(.maskAlphaShift) || !pressedNonFnKeyCodes.isEmpty {
+                if !pressedNonFnKeyCodes.isEmpty {
                     return true
                 }
             }
@@ -1100,9 +1103,18 @@ public final class HotkeyManager {
     private func passiveFnInputIsContaminated(flags: CGEventFlags) -> Bool {
         guard let fnMask = targetMask else { return true }
         let activeTrackedModifiers = flags.intersection(ModifierKeyMatcher.trackedModifierMasks)
+        // Alpha Shift is a latched state, not proof that Caps Lock is held.
+        // A physical Caps key is covered by the key ledger; transitions are
+        // handled from changedKeyCode in modifierFlagsChangedOutputs.
         return !activeTrackedModifiers.subtracting(fnMask).isEmpty
-            || flags.contains(.maskAlphaShift)
             || !pressedNonFnKeyCodes.isEmpty
+    }
+
+    private func interruptPendingPassiveFnWindow() -> [HotkeyGestureController.Output] {
+        guard activeRecordingMode == nil, gestureController.hasPendingTriggerPress else {
+            return []
+        }
+        return gestureController.interrupted()
     }
 
     private func chordTriggerKeyUpOutputs(

--- a/Tests/MacParakeetTests/Hotkey/HotkeyManagerTests.swift
+++ b/Tests/MacParakeetTests/Hotkey/HotkeyManagerTests.swift
@@ -806,11 +806,13 @@ final class HotkeyManagerTests: XCTestCase {
             changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
         )
         XCTAssertEqual(manager.startupDebounceElapsedForTesting(), [.startRecording(mode: .holdToTalk)])
-        XCTAssertEqual(manager.modifierKeyDownOutputsForTesting(keyCode: 0, timestampMs: 1_150), [
-            .cancelStartupDebounce,
-            .cancelHoldWindow,
-            .cancelRecording,
-        ])
+        XCTAssertEqual(
+            manager.modifierKeyDownOutputsForTesting(keyCode: 0, timestampMs: 1_150),
+            [
+                .cancelStartupDebounce,
+                .cancelHoldWindow,
+                .cancelRecording,
+            ])
         XCTAssertEqual(
             manager.modifierKeyUpOutputsForTesting(keyCode: 0, timestampMs: 1_200),
             [.cancelStartupDebounce, .cancelHoldWindow]

--- a/Tests/MacParakeetTests/Hotkey/HotkeyManagerTests.swift
+++ b/Tests/MacParakeetTests/Hotkey/HotkeyManagerTests.swift
@@ -15,6 +15,202 @@ final class HotkeyManagerTests: XCTestCase {
         CGEventFlags(rawValue: masks.reduce(0, |))
     }
 
+    func testBareFnUsesListenOnlyTapWithoutChangingOtherHotkeyTapBehavior() {
+        let keyUpMask: CGEventMask = 1 << CGEventType.keyUp.rawValue
+
+        XCTAssertEqual(HotkeyManager.eventTapOptions(for: .fn), .listenOnly)
+        XCTAssertEqual(HotkeyManager.eventTapOptions(for: .control), .defaultTap)
+        XCTAssertEqual(HotkeyManager.eventTapOptions(for: .fnSpace), .defaultTap)
+        XCTAssertEqual(
+            HotkeyManager.eventTapOptions(for: .fromKeyCode(119)),
+            .defaultTap
+        )
+        XCTAssertEqual(HotkeyManager.eventMask(for: .fn) & keyUpMask, keyUpMask)
+        XCTAssertEqual(HotkeyManager.eventMask(for: .control) & keyUpMask, 0)
+    }
+
+    func testPassiveFnCleanHoldReleaseStartsAndStopsExactlyOnceDespiteNoise() {
+        let manager = HotkeyManager(trigger: .fn, gestureMode: .holdOnly)
+
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskSecondaryFn],
+                timestampMs: 1_000,
+                changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+            ),
+            [.scheduleStartupDebounce(milliseconds: FnKeyStateMachine.defaultStartupDebounceMs)]
+        )
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskSecondaryFn],
+                timestampMs: 1_010,
+                changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+            ),
+            []
+        )
+        XCTAssertEqual(manager.startupDebounceElapsedForTesting(), [.startRecording(mode: .holdToTalk)])
+        XCTAssertEqual(manager.startupDebounceElapsedForTesting(), [])
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [],
+                timestampMs: 1_250,
+                changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+            ),
+            [.cancelStartupDebounce, .cancelHoldWindow, .stopRecording]
+        )
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [],
+                timestampMs: 1_260,
+                changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+            ),
+            []
+        )
+    }
+
+    func testPassiveFnOtherKeyCancellationCannotStopOrRestartOnRelease() {
+        let manager = HotkeyManager(trigger: .fn, gestureMode: .holdOnly)
+
+        _ = manager.modifierFlagsChangedOutputsForTesting(
+            flags: [.maskSecondaryFn],
+            timestampMs: 1_000,
+            changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+        )
+        XCTAssertEqual(manager.startupDebounceElapsedForTesting(), [.startRecording(mode: .holdToTalk)])
+        XCTAssertEqual(
+            manager.modifierKeyDownOutputsForTesting(keyCode: 0, timestampMs: 1_200),
+            [.cancelStartupDebounce, .cancelHoldWindow, .cancelRecording]
+        )
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [],
+                timestampMs: 1_250,
+                changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+            ),
+            [.cancelStartupDebounce, .cancelHoldWindow]
+        )
+        XCTAssertEqual(manager.startupDebounceElapsedForTesting(), [])
+        XCTAssertEqual(manager.holdWindowElapsedForTesting(), [])
+    }
+
+    func testPassiveFnReleaseOfAlreadyHeldOtherKeyCancelsGesture() {
+        let manager = HotkeyManager(trigger: .fn, gestureMode: .holdOnly)
+
+        _ = manager.modifierFlagsChangedOutputsForTesting(
+            flags: [.maskSecondaryFn],
+            timestampMs: 1_000,
+            changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+        )
+        XCTAssertEqual(manager.startupDebounceElapsedForTesting(), [.startRecording(mode: .holdToTalk)])
+        XCTAssertEqual(
+            manager.modifierKeyUpOutputsForTesting(keyCode: 0, timestampMs: 1_200),
+            [.cancelStartupDebounce, .cancelHoldWindow, .cancelRecording]
+        )
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [],
+                timestampMs: 1_250,
+                changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+            ),
+            [.cancelStartupDebounce, .cancelHoldWindow]
+        )
+    }
+
+    func testPassiveFnOtherModifierTransitionCancelsWithoutPostCancelStop() {
+        let manager = HotkeyManager(trigger: .fn, gestureMode: .holdOnly)
+
+        _ = manager.modifierFlagsChangedOutputsForTesting(
+            flags: [.maskSecondaryFn],
+            timestampMs: 1_000,
+            changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+        )
+        XCTAssertEqual(manager.startupDebounceElapsedForTesting(), [.startRecording(mode: .holdToTalk)])
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskSecondaryFn, .maskControl],
+                timestampMs: 1_200,
+                changedKeyCode: 59
+            ),
+            [.cancelStartupDebounce, .cancelHoldWindow, .cancelRecording]
+        )
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskSecondaryFn],
+                timestampMs: 1_220,
+                changedKeyCode: 59
+            ),
+            [.cancelStartupDebounce, .cancelHoldWindow]
+        )
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [],
+                timestampMs: 1_250,
+                changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+            ),
+            [.cancelStartupDebounce, .cancelHoldWindow]
+        )
+    }
+
+    func testPassiveFnCapsLockTransitionCancelsPendingGesture() {
+        let manager = HotkeyManager(trigger: .fn)
+
+        _ = manager.modifierFlagsChangedOutputsForTesting(
+            flags: [.maskSecondaryFn],
+            timestampMs: 1_000,
+            changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+        )
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskSecondaryFn, .maskAlphaShift],
+                timestampMs: 1_050,
+                changedKeyCode: 57
+            ),
+            [.cancelStartupDebounce, .cancelHoldWindow]
+        )
+        XCTAssertEqual(manager.startupDebounceElapsedForTesting(), [])
+        XCTAssertEqual(manager.holdWindowElapsedForTesting(), [])
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskAlphaShift],
+                timestampMs: 1_100,
+                changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+            ),
+            [.cancelStartupDebounce, .cancelHoldWindow]
+        )
+    }
+
+    func testPassiveFnTapRecoveryAndResetCannotDuplicateActions() {
+        let manager = HotkeyManager(trigger: .fn, gestureMode: .holdOnly)
+
+        _ = manager.modifierFlagsChangedOutputsForTesting(
+            flags: [.maskSecondaryFn],
+            timestampMs: 1_000,
+            changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+        )
+        XCTAssertEqual(
+            manager.recoverFromDisabledTapForTesting(
+                flags: [.maskSecondaryFn],
+                triggerKeyPressed: true,
+                timestampMs: 1_050
+            ),
+            []
+        )
+        XCTAssertEqual(manager.startupDebounceElapsedForTesting(), [.startRecording(mode: .holdToTalk)])
+        XCTAssertEqual(manager.startupDebounceElapsedForTesting(), [])
+
+        manager.suppressUntilReset()
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [],
+                timestampMs: 1_200,
+                changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+            ),
+            []
+        )
+        XCTAssertEqual(manager.startupDebounceElapsedForTesting(), [])
+        XCTAssertEqual(manager.holdWindowElapsedForTesting(), [])
+    }
+
     func testDoubleTapOnlyGestureModeDoesNotStartHoldRecording() {
         let manager = HotkeyManager(trigger: .fn, gestureMode: .doubleTapOnly)
 

--- a/Tests/MacParakeetTests/Hotkey/HotkeyManagerTests.swift
+++ b/Tests/MacParakeetTests/Hotkey/HotkeyManagerTests.swift
@@ -255,6 +255,338 @@ final class HotkeyManagerTests: XCTestCase {
         )
     }
 
+    func testPassiveFnContaminatedAdmissionInvalidatesPendingDoubleTapWindow() {
+        let manager = HotkeyManager(trigger: .fn, gestureMode: .doubleTapOnly)
+        manager.setPhysicalKeyStateProviderForTesting { _ in false }
+
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskSecondaryFn],
+                timestampMs: 1_000,
+                changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+            ),
+            []
+        )
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [],
+                timestampMs: 1_050,
+                changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+            ),
+            [.cancelStartupDebounce, .cancelHoldWindow, .showReadyForSecondTap]
+        )
+
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskSecondaryFn, .maskControl],
+                timestampMs: 1_100,
+                changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+            ),
+            [.cancelStartupDebounce, .cancelHoldWindow]
+        )
+        XCTAssertEqual(manager.startupDebounceElapsedForTesting(), [])
+        XCTAssertEqual(manager.holdWindowElapsedForTesting(), [])
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskControl],
+                timestampMs: 1_150,
+                changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+            ),
+            []
+        )
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [],
+                timestampMs: 1_175,
+                changedKeyCode: 59
+            ),
+            []
+        )
+
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskSecondaryFn],
+                timestampMs: 1_200,
+                changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+            ),
+            []
+        )
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [],
+                timestampMs: 1_250,
+                changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+            ),
+            [.cancelStartupDebounce, .cancelHoldWindow, .showReadyForSecondTap]
+        )
+    }
+
+    func testPassiveFnModifierTransitionBetweenTapsInvalidatesPendingWindow() {
+        let manager = HotkeyManager(trigger: .fn, gestureMode: .doubleTapOnly)
+        manager.setPhysicalKeyStateProviderForTesting { _ in false }
+
+        _ = manager.modifierFlagsChangedOutputsForTesting(
+            flags: [.maskSecondaryFn],
+            timestampMs: 1_000,
+            changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+        )
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [],
+                timestampMs: 1_050,
+                changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+            ),
+            [.cancelStartupDebounce, .cancelHoldWindow, .showReadyForSecondTap]
+        )
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskAlternate],
+                timestampMs: 1_100,
+                changedKeyCode: 58
+            ),
+            [.cancelStartupDebounce, .cancelHoldWindow]
+        )
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [],
+                timestampMs: 1_125,
+                changedKeyCode: 58
+            ),
+            []
+        )
+        XCTAssertEqual(manager.startupDebounceElapsedForTesting(), [])
+        XCTAssertEqual(manager.holdWindowElapsedForTesting(), [])
+
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskSecondaryFn],
+                timestampMs: 1_150,
+                changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+            ),
+            []
+        )
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [],
+                timestampMs: 1_200,
+                changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+            ),
+            [.cancelStartupDebounce, .cancelHoldWindow, .showReadyForSecondTap]
+        )
+    }
+
+    func testPassiveFnContaminatedAdmissionPreservesActivePersistentOwnership() {
+        let manager = HotkeyManager(trigger: .fn, gestureMode: .doubleTapOnly)
+        manager.setPhysicalKeyStateProviderForTesting { _ in false }
+
+        _ = manager.modifierFlagsChangedOutputsForTesting(
+            flags: [.maskSecondaryFn],
+            timestampMs: 1_000,
+            changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+        )
+        _ = manager.modifierFlagsChangedOutputsForTesting(
+            flags: [],
+            timestampMs: 1_050,
+            changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+        )
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskSecondaryFn],
+                timestampMs: 1_100,
+                changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+            ),
+            [.startRecording(mode: .persistent)]
+        )
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [],
+                timestampMs: 1_125,
+                changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+            ),
+            [.cancelStartupDebounce, .cancelHoldWindow]
+        )
+
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskSecondaryFn, .maskControl],
+                timestampMs: 1_150,
+                changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+            ),
+            []
+        )
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskControl],
+                timestampMs: 1_175,
+                changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+            ),
+            []
+        )
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [],
+                timestampMs: 1_190,
+                changedKeyCode: 59
+            ),
+            []
+        )
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskSecondaryFn],
+                timestampMs: 1_200,
+                changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+            ),
+            [.stopRecording]
+        )
+    }
+
+    func testPassiveFnPreLatchedCapsLockAllowsHoldAndDoubleTap() {
+        let holdManager = HotkeyManager(trigger: .fn, gestureMode: .holdOnly)
+        holdManager.setPhysicalKeyStateProviderForTesting { _ in false }
+
+        XCTAssertEqual(
+            holdManager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskSecondaryFn, .maskAlphaShift],
+                timestampMs: 1_000,
+                changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+            ),
+            [.scheduleStartupDebounce(milliseconds: FnKeyStateMachine.defaultStartupDebounceMs)]
+        )
+        XCTAssertEqual(
+            holdManager.startupDebounceElapsedForTesting(),
+            [.startRecording(mode: .holdToTalk)]
+        )
+        XCTAssertEqual(
+            holdManager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskAlphaShift],
+                timestampMs: 1_100,
+                changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+            ),
+            [.cancelStartupDebounce, .cancelHoldWindow, .stopRecording]
+        )
+
+        let tapManager = HotkeyManager(trigger: .fn, gestureMode: .doubleTapOnly)
+        tapManager.setPhysicalKeyStateProviderForTesting { _ in false }
+        XCTAssertEqual(
+            tapManager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskSecondaryFn, .maskAlphaShift],
+                timestampMs: 2_000,
+                changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+            ),
+            []
+        )
+        XCTAssertEqual(
+            tapManager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskAlphaShift],
+                timestampMs: 2_050,
+                changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+            ),
+            [.cancelStartupDebounce, .cancelHoldWindow, .showReadyForSecondTap]
+        )
+        XCTAssertEqual(
+            tapManager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskSecondaryFn, .maskAlphaShift],
+                timestampMs: 2_100,
+                changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+            ),
+            [.startRecording(mode: .persistent)]
+        )
+    }
+
+    func testPassiveFnCapsLockTransitionBetweenTapsAndDuringHoldCancels() {
+        let tapManager = HotkeyManager(trigger: .fn, gestureMode: .doubleTapOnly)
+        tapManager.setPhysicalKeyStateProviderForTesting { _ in false }
+
+        _ = tapManager.modifierFlagsChangedOutputsForTesting(
+            flags: [.maskSecondaryFn],
+            timestampMs: 1_000,
+            changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+        )
+        _ = tapManager.modifierFlagsChangedOutputsForTesting(
+            flags: [],
+            timestampMs: 1_050,
+            changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+        )
+        XCTAssertEqual(
+            tapManager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskAlphaShift],
+                timestampMs: 1_100,
+                changedKeyCode: 57
+            ),
+            [.cancelStartupDebounce, .cancelHoldWindow]
+        )
+        XCTAssertEqual(
+            tapManager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskSecondaryFn, .maskAlphaShift],
+                timestampMs: 1_150,
+                changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+            ),
+            []
+        )
+
+        let holdManager = HotkeyManager(trigger: .fn, gestureMode: .holdOnly)
+        holdManager.setPhysicalKeyStateProviderForTesting { _ in false }
+        _ = holdManager.modifierFlagsChangedOutputsForTesting(
+            flags: [.maskSecondaryFn],
+            timestampMs: 2_000,
+            changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+        )
+        XCTAssertEqual(
+            holdManager.startupDebounceElapsedForTesting(),
+            [.startRecording(mode: .holdToTalk)]
+        )
+        XCTAssertEqual(
+            holdManager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskSecondaryFn, .maskAlphaShift],
+                timestampMs: 2_100,
+                changedKeyCode: 57
+            ),
+            [.cancelStartupDebounce, .cancelHoldWindow, .cancelRecording]
+        )
+        XCTAssertEqual(
+            holdManager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskAlphaShift],
+                timestampMs: 2_150,
+                changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+            ),
+            [.cancelStartupDebounce, .cancelHoldWindow]
+        )
+    }
+
+    func testPassiveFnRecoveryAllowsPreLatchedCapsLock() {
+        let manager = HotkeyManager(trigger: .fn, gestureMode: .holdOnly)
+        manager.setPhysicalKeyStateProviderForTesting { _ in false }
+
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskSecondaryFn, .maskAlphaShift],
+                timestampMs: 1_000,
+                changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+            ),
+            [.scheduleStartupDebounce(milliseconds: FnKeyStateMachine.defaultStartupDebounceMs)]
+        )
+        XCTAssertEqual(
+            manager.recoverFromDisabledTapForTesting(
+                flags: [.maskSecondaryFn, .maskAlphaShift],
+                triggerKeyPressed: true,
+                timestampMs: 1_050
+            ),
+            []
+        )
+        XCTAssertEqual(
+            manager.startupDebounceElapsedForTesting(),
+            [.startRecording(mode: .holdToTalk)]
+        )
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskAlphaShift],
+                timestampMs: 1_100,
+                changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+            ),
+            [.cancelStartupDebounce, .cancelHoldWindow, .stopRecording]
+        )
+    }
+
     func testPassiveFnReleaseOfObservedOtherKeyCancelsGesture() {
         let manager = HotkeyManager(trigger: .fn, gestureMode: .holdOnly)
         manager.setPhysicalKeyStateProviderForTesting { _ in false }
@@ -1035,18 +1367,14 @@ final class HotkeyManagerTests: XCTestCase {
                 flags: [.maskSecondaryFn, .maskControl],
                 timestampMs: 1_200
             ),
-            []
+            [.cancelStartupDebounce, .cancelHoldWindow, .cancelRecording]
         )
         XCTAssertEqual(
             manager.modifierFlagsChangedOutputsForTesting(
                 flags: [.maskControl],
                 timestampMs: 1_300
             ),
-            [
-                .cancelStartupDebounce,
-                .cancelHoldWindow,
-                .cancelRecording,
-            ]
+            []
         )
     }
 

--- a/Tests/MacParakeetTests/Hotkey/HotkeyManagerTests.swift
+++ b/Tests/MacParakeetTests/Hotkey/HotkeyManagerTests.swift
@@ -31,6 +31,7 @@ final class HotkeyManagerTests: XCTestCase {
 
     func testPassiveFnCleanHoldReleaseStartsAndStopsExactlyOnceDespiteNoise() {
         let manager = HotkeyManager(trigger: .fn, gestureMode: .holdOnly)
+        manager.setPhysicalKeyStateProviderForTesting { _ in false }
 
         XCTAssertEqual(
             manager.modifierFlagsChangedOutputsForTesting(
@@ -70,6 +71,7 @@ final class HotkeyManagerTests: XCTestCase {
 
     func testPassiveFnOtherKeyCancellationCannotStopOrRestartOnRelease() {
         let manager = HotkeyManager(trigger: .fn, gestureMode: .holdOnly)
+        manager.setPhysicalKeyStateProviderForTesting { _ in false }
 
         _ = manager.modifierFlagsChangedOutputsForTesting(
             flags: [.maskSecondaryFn],
@@ -93,8 +95,169 @@ final class HotkeyManagerTests: XCTestCase {
         XCTAssertEqual(manager.holdWindowElapsedForTesting(), [])
     }
 
-    func testPassiveFnReleaseOfAlreadyHeldOtherKeyCancelsGesture() {
+    func testPassiveFnPreHeldModifierBlocksEntireGesture() {
         let manager = HotkeyManager(trigger: .fn, gestureMode: .holdOnly)
+        manager.setPhysicalKeyStateProviderForTesting { _ in false }
+
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskSecondaryFn, .maskControl],
+                timestampMs: 1_000,
+                changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+            ),
+            []
+        )
+        XCTAssertEqual(manager.startupDebounceElapsedForTesting(), [])
+        XCTAssertEqual(manager.holdWindowElapsedForTesting(), [])
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskControl],
+                timestampMs: 1_250,
+                changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+            ),
+            []
+        )
+    }
+
+    func testPassiveFnPreHeldOrdinaryKeyRemainingHeldBlocksEntireGesture() {
+        let manager = HotkeyManager(trigger: .fn, gestureMode: .holdOnly)
+        manager.setPhysicalKeyStateProviderForTesting { $0 == 0 }
+
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskSecondaryFn],
+                timestampMs: 1_000,
+                changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+            ),
+            []
+        )
+        XCTAssertEqual(manager.startupDebounceElapsedForTesting(), [])
+        XCTAssertEqual(manager.holdWindowElapsedForTesting(), [])
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [],
+                timestampMs: 1_250,
+                changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+            ),
+            []
+        )
+        XCTAssertEqual(manager.modifierKeyUpOutputsForTesting(keyCode: 0, timestampMs: 1_300), [])
+    }
+
+    func testPassiveFnPreHeldOrdinaryKeyReleasedDuringFnRemainsCancelled() {
+        var pressedKeyCodes: Set<UInt16> = [0]
+        let manager = HotkeyManager(trigger: .fn, gestureMode: .holdOnly)
+        manager.setPhysicalKeyStateProviderForTesting { pressedKeyCodes.contains($0) }
+
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskSecondaryFn],
+                timestampMs: 1_000,
+                changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+            ),
+            []
+        )
+        pressedKeyCodes.remove(0)
+        XCTAssertEqual(manager.modifierKeyUpOutputsForTesting(keyCode: 0, timestampMs: 1_150), [])
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [],
+                timestampMs: 1_250,
+                changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+            ),
+            []
+        )
+        XCTAssertEqual(manager.startupDebounceElapsedForTesting(), [])
+        XCTAssertEqual(manager.holdWindowElapsedForTesting(), [])
+    }
+
+    func testPassiveFnSingleTapEscapeHeldThroughReleaseCannotStartRecording() {
+        let manager = HotkeyManager(trigger: .fn, gestureMode: .singleTapToggle)
+        manager.setPhysicalKeyStateProviderForTesting { _ in false }
+
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskSecondaryFn],
+                timestampMs: 1_000,
+                changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+            ),
+            []
+        )
+        XCTAssertEqual(
+            manager.modifierKeyDownOutputsForTesting(keyCode: 53, timestampMs: 1_050),
+            [.escapeWhileIdle]
+        )
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [],
+                timestampMs: 1_100,
+                changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+            ),
+            []
+        )
+        XCTAssertEqual(manager.modifierKeyUpOutputsForTesting(keyCode: 53, timestampMs: 1_150), [])
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [],
+                timestampMs: 1_200,
+                changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+            ),
+            []
+        )
+    }
+
+    func testPassiveFnTapRecoveryReconcilesPreHeldKeyAndFailsClosed() {
+        var pressedKeyCodes: Set<UInt16> = []
+        let manager = HotkeyManager(trigger: .fn, gestureMode: .holdOnly)
+        manager.setPhysicalKeyStateProviderForTesting { pressedKeyCodes.contains($0) }
+
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskSecondaryFn],
+                timestampMs: 1_000,
+                changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+            ),
+            [.scheduleStartupDebounce(milliseconds: FnKeyStateMachine.defaultStartupDebounceMs)]
+        )
+        pressedKeyCodes.insert(0)
+        XCTAssertEqual(
+            manager.recoverFromDisabledTapForTesting(
+                flags: [.maskSecondaryFn],
+                triggerKeyPressed: true,
+                timestampMs: 1_050
+            ),
+            [.cancelStartupDebounce, .cancelHoldWindow]
+        )
+        XCTAssertEqual(manager.startupDebounceElapsedForTesting(), [])
+        XCTAssertEqual(manager.holdWindowElapsedForTesting(), [])
+
+        pressedKeyCodes.remove(0)
+        XCTAssertEqual(manager.modifierKeyUpOutputsForTesting(keyCode: 0, timestampMs: 1_100), [])
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [],
+                timestampMs: 1_150,
+                changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+            ),
+            []
+        )
+        XCTAssertEqual(manager.startupDebounceElapsedForTesting(), [])
+
+        pressedKeyCodes.insert(0)
+        manager.resetToIdle(flags: [])
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskSecondaryFn],
+                timestampMs: 1_200,
+                changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+            ),
+            []
+        )
+    }
+
+    func testPassiveFnReleaseOfObservedOtherKeyCancelsGesture() {
+        let manager = HotkeyManager(trigger: .fn, gestureMode: .holdOnly)
+        manager.setPhysicalKeyStateProviderForTesting { _ in false }
 
         _ = manager.modifierFlagsChangedOutputsForTesting(
             flags: [.maskSecondaryFn],
@@ -102,9 +265,14 @@ final class HotkeyManagerTests: XCTestCase {
             changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
         )
         XCTAssertEqual(manager.startupDebounceElapsedForTesting(), [.startRecording(mode: .holdToTalk)])
+        XCTAssertEqual(manager.modifierKeyDownOutputsForTesting(keyCode: 0, timestampMs: 1_150), [
+            .cancelStartupDebounce,
+            .cancelHoldWindow,
+            .cancelRecording,
+        ])
         XCTAssertEqual(
             manager.modifierKeyUpOutputsForTesting(keyCode: 0, timestampMs: 1_200),
-            [.cancelStartupDebounce, .cancelHoldWindow, .cancelRecording]
+            [.cancelStartupDebounce, .cancelHoldWindow]
         )
         XCTAssertEqual(
             manager.modifierFlagsChangedOutputsForTesting(

--- a/Tests/MacParakeetTests/Hotkey/HotkeyManagerTests.swift
+++ b/Tests/MacParakeetTests/Hotkey/HotkeyManagerTests.swift
@@ -1915,7 +1915,8 @@ final class HotkeyManagerTests: XCTestCase {
         XCTAssertEqual(
             manager.modifierFlagsChangedOutputsForTesting(
                 flags: [.maskSecondaryFn, .maskControl],
-                timestampMs: 1_050
+                timestampMs: 1_050,
+                changedKeyCode: 59
             ),
             [
                 .cancelStartupDebounce,
@@ -2008,7 +2009,8 @@ final class HotkeyManagerTests: XCTestCase {
         XCTAssertEqual(
             manager.modifierFlagsChangedOutputsForTesting(
                 flags: [.maskSecondaryFn, .maskControl],
-                timestampMs: 1_175
+                timestampMs: 1_175,
+                changedKeyCode: 59
             ),
             [
                 .cancelStartupDebounce,

--- a/Tests/MacParakeetTests/Hotkey/HotkeyManagerTests.swift
+++ b/Tests/MacParakeetTests/Hotkey/HotkeyManagerTests.swift
@@ -587,6 +587,119 @@ final class HotkeyManagerTests: XCTestCase {
         )
     }
 
+    func testPassiveFnRecoveryCancelsPendingGestureWhenCapsLockTurnsOn() {
+        let manager = HotkeyManager(trigger: .fn, gestureMode: .holdOnly)
+        manager.setPhysicalKeyStateProviderForTesting { _ in false }
+
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskSecondaryFn],
+                timestampMs: 1_000,
+                changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+            ),
+            [.scheduleStartupDebounce(milliseconds: FnKeyStateMachine.defaultStartupDebounceMs)]
+        )
+        XCTAssertEqual(
+            manager.recoverFromDisabledTapForTesting(
+                flags: [.maskSecondaryFn, .maskAlphaShift],
+                triggerKeyPressed: true,
+                timestampMs: 1_050
+            ),
+            [.cancelStartupDebounce, .cancelHoldWindow]
+        )
+        XCTAssertEqual(manager.startupDebounceElapsedForTesting(), [])
+        XCTAssertEqual(manager.holdWindowElapsedForTesting(), [])
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskAlphaShift],
+                timestampMs: 1_100,
+                changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+            ),
+            []
+        )
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [],
+                timestampMs: 1_150,
+                changedKeyCode: 57
+            ),
+            []
+        )
+    }
+
+    func testPassiveFnRecoveryCancelsPendingGestureWhenCapsLockTurnsOff() {
+        let manager = HotkeyManager(trigger: .fn, gestureMode: .holdOnly)
+        manager.setPhysicalKeyStateProviderForTesting { _ in false }
+
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskSecondaryFn, .maskAlphaShift],
+                timestampMs: 1_000,
+                changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+            ),
+            [.scheduleStartupDebounce(milliseconds: FnKeyStateMachine.defaultStartupDebounceMs)]
+        )
+        XCTAssertEqual(
+            manager.recoverFromDisabledTapForTesting(
+                flags: [.maskSecondaryFn],
+                triggerKeyPressed: true,
+                timestampMs: 1_050
+            ),
+            [.cancelStartupDebounce, .cancelHoldWindow]
+        )
+        XCTAssertEqual(manager.startupDebounceElapsedForTesting(), [])
+        XCTAssertEqual(manager.holdWindowElapsedForTesting(), [])
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [],
+                timestampMs: 1_100,
+                changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+            ),
+            []
+        )
+    }
+
+    func testPassiveFnRecoveryCapsLockDeltaCancelsActiveHoldExactlyOnce() {
+        let manager = HotkeyManager(trigger: .fn, gestureMode: .holdOnly)
+        manager.setPhysicalKeyStateProviderForTesting { _ in false }
+
+        _ = manager.modifierFlagsChangedOutputsForTesting(
+            flags: [.maskSecondaryFn],
+            timestampMs: 1_000,
+            changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+        )
+        XCTAssertEqual(
+            manager.startupDebounceElapsedForTesting(),
+            [.startRecording(mode: .holdToTalk)]
+        )
+        XCTAssertEqual(
+            manager.recoverFromDisabledTapForTesting(
+                flags: [.maskSecondaryFn, .maskAlphaShift],
+                triggerKeyPressed: true,
+                timestampMs: 1_100
+            ),
+            [.cancelStartupDebounce, .cancelHoldWindow, .cancelRecording]
+        )
+        XCTAssertEqual(
+            manager.recoverFromDisabledTapForTesting(
+                flags: [.maskSecondaryFn, .maskAlphaShift],
+                triggerKeyPressed: true,
+                timestampMs: 1_150
+            ),
+            []
+        )
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskAlphaShift],
+                timestampMs: 1_200,
+                changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+            ),
+            []
+        )
+        XCTAssertEqual(manager.startupDebounceElapsedForTesting(), [])
+        XCTAssertEqual(manager.holdWindowElapsedForTesting(), [])
+    }
+
     func testPassiveFnReleaseOfObservedOtherKeyCancelsGesture() {
         let manager = HotkeyManager(trigger: .fn, gestureMode: .holdOnly)
         manager.setPhysicalKeyStateProviderForTesting { _ in false }

--- a/Tests/MacParakeetTests/Hotkey/HotkeyManagerTests.swift
+++ b/Tests/MacParakeetTests/Hotkey/HotkeyManagerTests.swift
@@ -375,6 +375,102 @@ final class HotkeyManagerTests: XCTestCase {
         )
     }
 
+    func testPassiveFnKeyUpOnlyBetweenTapsInvalidatesPendingWindowOnce() {
+        let manager = HotkeyManager(trigger: .fn, gestureMode: .doubleTapAndHold)
+        manager.setPhysicalKeyStateProviderForTesting { _ in false }
+
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskSecondaryFn],
+                timestampMs: 1_000,
+                changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+            ),
+            [
+                .scheduleStartupDebounce(milliseconds: FnKeyStateMachine.defaultStartupDebounceMs),
+                .scheduleHoldWindow(milliseconds: FnKeyStateMachine.defaultTapThresholdMs),
+            ]
+        )
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [],
+                timestampMs: 1_050,
+                changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+            ),
+            [.cancelStartupDebounce, .cancelHoldWindow, .showReadyForSecondTap]
+        )
+        XCTAssertEqual(
+            manager.modifierKeyUpOutputsForTesting(keyCode: 0, timestampMs: 1_100),
+            [.cancelStartupDebounce, .cancelHoldWindow]
+        )
+        XCTAssertEqual(manager.modifierKeyUpOutputsForTesting(keyCode: 0, timestampMs: 1_125), [])
+        XCTAssertEqual(manager.startupDebounceElapsedForTesting(), [])
+        XCTAssertEqual(manager.holdWindowElapsedForTesting(), [])
+
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskSecondaryFn],
+                timestampMs: 1_150,
+                changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+            ),
+            [
+                .scheduleStartupDebounce(milliseconds: FnKeyStateMachine.defaultStartupDebounceMs),
+                .scheduleHoldWindow(milliseconds: FnKeyStateMachine.defaultTapThresholdMs),
+            ]
+        )
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [],
+                timestampMs: 1_200,
+                changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+            ),
+            [.cancelStartupDebounce, .cancelHoldWindow, .showReadyForSecondTap]
+        )
+    }
+
+    func testPassiveFnKeyUpOnlyDoesNotCancelOwnedPersistentRecording() {
+        let manager = HotkeyManager(trigger: .fn, gestureMode: .doubleTapOnly)
+        manager.setPhysicalKeyStateProviderForTesting { _ in false }
+
+        _ = manager.modifierFlagsChangedOutputsForTesting(
+            flags: [.maskSecondaryFn],
+            timestampMs: 1_000,
+            changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+        )
+        _ = manager.modifierFlagsChangedOutputsForTesting(
+            flags: [],
+            timestampMs: 1_050,
+            changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+        )
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskSecondaryFn],
+                timestampMs: 1_100,
+                changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+            ),
+            [.startRecording(mode: .persistent)]
+        )
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [],
+                timestampMs: 1_125,
+                changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+            ),
+            [.cancelStartupDebounce, .cancelHoldWindow]
+        )
+
+        XCTAssertEqual(manager.modifierKeyUpOutputsForTesting(keyCode: 0, timestampMs: 1_150), [])
+        XCTAssertEqual(manager.startupDebounceElapsedForTesting(), [])
+        XCTAssertEqual(manager.holdWindowElapsedForTesting(), [])
+        XCTAssertEqual(
+            manager.modifierFlagsChangedOutputsForTesting(
+                flags: [.maskSecondaryFn],
+                timestampMs: 1_200,
+                changedKeyCode: HotkeyTrigger.canonicalFnKeyCode
+            ),
+            [.stopRecording]
+        )
+    }
+
     func testPassiveFnContaminatedAdmissionPreservesActivePersistentOwnership() {
         let manager = HotkeyManager(trigger: .fn, gestureMode: .doubleTapOnly)
         manager.setPhysicalKeyStateProviderForTesting { _ in false }

--- a/spec/02-features.md
+++ b/spec/02-features.md
@@ -152,7 +152,12 @@ Dictation defaults to a built-in shared `Fn` gesture preset: hold `Fn` for push-
 Legacy default installs using `Fn+Space` hands-free plus `Fn` push-to-talk migrate to the shared `Fn` gesture preset. Legacy single-hotkey installs are migrated to the shared default gesture when the stored trigger is `Fn`. Otherwise the old trigger becomes push-to-talk, while hands-free moves to the default `Fn` preset or disables itself if that would conflict.
 
 **Implementation:**
-- `CGEvent` tap for system-wide key event interception
+- The built-in bare-`Fn` gesture uses a listen-only `CGEvent` tap: Fn and every
+  observed cancellation event pass through unchanged. Other configurable
+  hotkeys retain their established active-tap behavior.
+- While built-in Fn is held, any other physical key-down/key-up or modifier
+  transition cancels the pending gesture. Its later Fn release cannot stop,
+  transcribe, paste, or submit that cancelled gesture.
 - `HotkeyTrigger` struct with `.modifier` / `.keyCode` / `.chord` / `.modifierChord` kind discriminator (see ADR-009)
 - Modifier triggers: `flagsChanged` events with `CGEventFlags` mask, bare-tap filtering
 - KeyCode triggers: `keyDown`/`keyUp` events with event swallowing, edge detection via `triggerKeyIsPressed` boolean

--- a/spec/02-features.md
+++ b/spec/02-features.md
@@ -155,9 +155,12 @@ Legacy default installs using `Fn+Space` hands-free plus `Fn` push-to-talk migra
 - The built-in bare-`Fn` gesture uses a listen-only `CGEvent` tap: Fn and every
   observed cancellation event pass through unchanged. Other configurable
   hotkeys retain their established active-tap behavior.
-- While built-in Fn is held, any other physical key-down/key-up or modifier
-  transition cancels the pending gesture. Its later Fn release cannot stop,
-  transcribe, paste, or submit that cancelled gesture.
+- Built-in Fn is admitted only when a combined-session snapshot shows no
+  pre-held non-Fn modifier or ordinary physical key. While Fn is held, every
+  non-Fn key-down/key-up (including Escape) or modifier transition cancels the
+  pending gesture. Tap-disable recovery reconciles that passive key-state
+  ledger and fails closed when input is contaminated. A cancelled gesture's
+  later Fn/key release cannot stop, transcribe, paste, or submit.
 - `HotkeyTrigger` struct with `.modifier` / `.keyCode` / `.chord` / `.modifierChord` kind discriminator (see ADR-009)
 - Modifier triggers: `flagsChanged` events with `CGEventFlags` mask, bare-tap filtering
 - KeyCode triggers: `keyDown`/`keyUp` events with event swallowing, edge detection via `triggerKeyIsPressed` boolean

--- a/spec/02-features.md
+++ b/spec/02-features.md
@@ -162,9 +162,11 @@ Legacy default installs using `Fn+Space` hands-free plus `Fn` push-to-talk migra
   non-Fn key-down/key-up (including Escape) or modifier transition cancels the
   gesture. Those transitions also invalidate an outstanding second-tap window,
   including a rejected contaminated Fn admission. Tap-disable recovery
-  reconciles the passive key-state ledger and fails closed on physical input
-  contamination, including a Caps Lock latch delta from the last delivered
-  modifier snapshot. A stable pre-latched Caps Lock state remains allowed. A
+  detects non-Fn keys and modifiers that remain held, plus a Caps Lock latch
+  delta from the last delivered modifier snapshot. A stable pre-latched Caps
+  Lock state remains allowed. A non-latching ordinary key pressed and released
+  wholly while the event tap is disabled leaves no current state or latch delta
+  and is inherently unobservable; this remains a runtime proof limit. A
   cancelled gesture's later Fn/key release cannot stop, transcribe, paste, or
   submit.
 - `HotkeyTrigger` struct with `.modifier` / `.keyCode` / `.chord` / `.modifierChord` kind discriminator (see ADR-009)

--- a/spec/02-features.md
+++ b/spec/02-features.md
@@ -156,11 +156,15 @@ Legacy default installs using `Fn+Space` hands-free plus `Fn` push-to-talk migra
   observed cancellation event pass through unchanged. Other configurable
   hotkeys retain their established active-tap behavior.
 - Built-in Fn is admitted only when a combined-session snapshot shows no
-  pre-held non-Fn modifier or ordinary physical key. While Fn is held, every
+  pre-held non-Fn modifier or ordinary physical key. A latched Caps Lock state
+  alone is allowed because it does not prove the physical key remains held;
+  an observed Caps Lock transition still cancels. While Fn is held, every
   non-Fn key-down/key-up (including Escape) or modifier transition cancels the
-  pending gesture. Tap-disable recovery reconciles that passive key-state
-  ledger and fails closed when input is contaminated. A cancelled gesture's
-  later Fn/key release cannot stop, transcribe, paste, or submit.
+  gesture. Those transitions also invalidate an outstanding second-tap window,
+  including a rejected contaminated Fn admission. Tap-disable recovery
+  reconciles the passive key-state ledger and fails closed on physical input
+  contamination. A cancelled gesture's later Fn/key release cannot stop,
+  transcribe, paste, or submit.
 - `HotkeyTrigger` struct with `.modifier` / `.keyCode` / `.chord` / `.modifierChord` kind discriminator (see ADR-009)
 - Modifier triggers: `flagsChanged` events with `CGEventFlags` mask, bare-tap filtering
 - KeyCode triggers: `keyDown`/`keyUp` events with event swallowing, edge detection via `triggerKeyIsPressed` boolean

--- a/spec/02-features.md
+++ b/spec/02-features.md
@@ -163,8 +163,10 @@ Legacy default installs using `Fn+Space` hands-free plus `Fn` push-to-talk migra
   gesture. Those transitions also invalidate an outstanding second-tap window,
   including a rejected contaminated Fn admission. Tap-disable recovery
   reconciles the passive key-state ledger and fails closed on physical input
-  contamination. A cancelled gesture's later Fn/key release cannot stop,
-  transcribe, paste, or submit.
+  contamination, including a Caps Lock latch delta from the last delivered
+  modifier snapshot. A stable pre-latched Caps Lock state remains allowed. A
+  cancelled gesture's later Fn/key release cannot stop, transcribe, paste, or
+  submit.
 - `HotkeyTrigger` struct with `.modifier` / `.keyCode` / `.chord` / `.modifierChord` kind discriminator (see ADR-009)
 - Modifier triggers: `flagsChanged` events with `CGEventFlags` mask, bare-tap filtering
 - KeyCode triggers: `keyDown`/`keyUp` events with event swallowing, edge detection via `triggerKeyIsPressed` boolean


### PR DESCRIPTION
## Summary

Bare Fn dictation should observe keyboard input without swallowing the user's keys or admitting a gesture mixed with another shortcut. Extract the six Fn-only commits from #870 into a standalone change on current main, preserving @ctut (Chris Tuttle)'s authorship and original commit references.

The built-in Fn trigger now uses a listen-only event tap. Other configurable triggers retain their existing event-tap behavior. Codex auto-submit is not included.

## Design

A physical-key snapshot rejects pre-held input; delivered ordinary-key and modifier transitions cancel a held gesture or pending double-tap window. Recovery checks held input and Caps Lock latch changes. Stable latched Caps Lock remains allowed, and synthetic Fn/Globe events remain inert.

| Input | Expected behavior |
|---|---|
| Clean Fn hold/release | Start and stop once |
| Another key/modifier during Fn | Cancel; trailing releases cannot submit |
| Another key between Fn taps | Invalidate pending double-tap window |
| Stable latched Caps Lock | Permit clean Fn |
| Input held across disabled-tap recovery | Reject contaminated gesture |
| Existing persistent recording | Preserve recording ownership on unrelated input |

## Risk surface

This changes built-in Fn handling for all users, independently of optional post-paste actions. Review cancellation, recovery, stale timer outputs, and non-Fn compatibility. A non-latching key pressed and released entirely while the tap is disabled is unobservable from the recovered state; the governing feature spec records this limit.

## Verification

- Cherry-picked `205eef18`, `2e3df02b`, `14d86f71`, `568130d4`, `93d1a3ff`, and `db20aa82` onto main `8f00a37f`.
- Only `HotkeyManager.swift`, its tests, and the governing Fn feature specification change.
- Final candidate `4476e57e`: **110 focused tests passed** with `MACPARAKEET_TELEMETRY=0 swift test --jobs 4 --filter 'HotkeyManagerTests|GestureControllerTests|ModifierKeyMatcherTests'`.
- Independent correctness review found no blocking findings, including a follow-up review of the final whitespace-only formatting commit.
- README references and whitespace checks passed. Base-relative formatting check found no additional warnings; existing warnings remain report-only.
- Local retries encountered disk exhaustion during signing/debug-symbol generation. Removed only this task worktree's generated caches/symbols, then the final focused build and tests passed.
- **Single local full suite passed:** `MACPARAKEET_TELEMETRY=0 swift test --jobs 4` completed 5,826 XCTest cases (20 skipped), plus 29 Swift Testing cases, with zero failures.
- **Both current-candidate hosted CI runs passed:** [PR run](https://github.com/moona3k/macparakeet/actions/runs/34195968512) and [branch run](https://github.com/moona3k/macparakeet/actions/runs/34195965402), including release build, CLI smoke, release-bundle validation, strict concurrency, Swift 6 language mode, and hosted tests.
- CodeRabbit and Greptile passed; no review threads remain. Cubic skipped its review. Direct checks and independent review own this task's validation.
- Physical keyboard and macOS permission behavior have not been revalidated on this candidate. July canaries from #870 are historical evidence, not current runtime proof.
