### PR TITLE
Avoid duplicate CI runs for feature branch updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,10 @@ name: CI
 
 on:
   push:
+    # PRs validate feature branches; avoid a second full run for the same update.
+    branches: [main]
+    # Keep tag validation when restricting branch pushes.
+    tags: ["**"]
     paths-ignore:
       - "docs/**"
       - "plans/**"

--- a/spec/09-testing.md
+++ b/spec/09-testing.md
@@ -186,6 +186,52 @@ swift test --filter WhisperLanguageCatalogTests
 The app requires the Xcode app-build path; optional runtime build gates and
 canonical commands are documented in [AGENTS.md](../AGENTS.md).
 
+## Continuous Integration
+
+The [CI workflow](../.github/workflows/ci.yml) validates PRs and the integrated
+`main` branch. Its trigger policy avoids running the entire pipeline twice for
+the same feature-branch update:
+
+| Event | CI behavior |
+|-------|-------------|
+| PR opened, updated, or reopened, including fork PRs | Run against the PR merge ref, subject to GitHub approval requirements |
+| Push to `main` | Run against the integrated commit |
+| Push to another branch | No automatic push run; use the PR or manual dispatch |
+| Tag push | Run; tag validation is retained explicitly |
+| Manual dispatch | Run against the selected ref |
+
+The existing `docs/**` and `plans/**` exclusions still apply to push and PR
+path filtering. GitHub does not apply path filters to tag pushes. PR updates
+cancel superseded runs for that PR; the `swift-test` check name and all build,
+bundle, concurrency, language-mode, and test gates are retained. See GitHub's
+[branch and tag filter semantics](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#onpushbranchestagsbranches-ignoretags-ignore).
+
+For a branch that needs hosted validation before a PR exists, select it under
+Actions → CI → Run workflow, or use:
+
+```bash
+gh workflow run ci.yml --ref <branch>
+```
+
+### Timing baseline and optimization priorities
+
+On 2026-09-08, six sampled successful jobs took approximately 40–52 minutes.
+For PR #984, the [PR job](https://github.com/moona3k/macparakeet/actions/runs/34195968512)
+took 40m 55s, and its redundant
+[branch-push job](https://github.com/moona3k/macparakeet/actions/runs/34195965402)
+took 46m 53s: nearly 88 runner-minutes combined. The PR job spent 9m 30s on
+the release build, 13m on the app bundle, 5m 15s on concurrency compilation,
+4m 17s on Swift 6 compilation, and 8m 9s on test compilation and execution.
+These are historical measurements, not performance guarantees.
+
+Removing the feature-branch push run saves duplicate runner work; it does not
+halve the duration of the remaining job. Measure subsequent runs before
+changing the pipeline further. Independent build jobs and compiled-output
+reuse are follow-up candidates, but must preserve the Xcode bundle/resource
+check and the separate Swift 6 compatibility gate. The current cache stores
+dependencies, not compiled outputs. Compare both elapsed time and total
+runner-minutes before adding parallel jobs or more caching.
+
 ## AI Agent Testing Loop
 
 Follow [AGENTS.md](../AGENTS.md#commands), not a second full-suite loop here:


### PR DESCRIPTION
## Summary

Feature-branch updates currently run the complete macOS CI pipeline twice: once for `push` and once for `pull_request`. Restrict automatic branch-push validation to `main`, retain tag pushes explicitly, and keep PR and manual runs.

PR #984 used nearly 88 runner-minutes across its two successful jobs. This change removes duplicate runner work; it does not claim to halve the duration of the remaining job.

## Design and scope

- Feature branches use PR validation, including fork PRs; manual dispatch remains available before opening a PR.
- `main` pushes retain automatic validation subject to the existing `docs/**` and `plans/**` path exclusions. Docs-only/plan-only pushes remain intentionally excluded. Tag pushes retain validation (GitHub does not apply path filtering to tags).
- All jobs, build/test commands, check names, path filters, and concurrency settings are unchanged.
- The testing specification documents the trigger policy, manual command, measured timing baseline, and follow-up measurement priorities.

## Verification

- `actionlint` 1.7.12 passed.
- Parsed YAML comparison confirms only the two push filters differ from the base; the entire job configuration is identical.
- Documentation local links and `git diff --check` passed.
- No local Swift suite was run for this trigger/documentation-only change. Hosted PR CI remains the final gate.
- After publication, check that this branch has one PR run and no redundant push run; after merge, verify the `main` push run is scheduled.

## Review disposition

Greptile flagged the retained docs/plans exclusions as a missing main-push gate. Declined: these exclusions predate the PR and preserving path filters is explicit scope, also documented in `spec/09-testing.md`. Running the full Swift pipeline for docs-only main updates is not a requirement of this change.


## Final gate disposition

Final exact-head CI [run 34200891502](https://github.com/moona3k/macparakeet/actions/runs/34200891502) passed. Independent review revalidated the exact head. The Greptile failure is stale and its sole inherited docs/plans finding is resolved; no correctness issue remains.
