### PR TITLE
fix: show transient meeting notes save feedback

### DIFF
--- a/Sources/MacParakeet/Views/Transcription/SavedMeetingNotesSaveStatusPresentation.swift
+++ b/Sources/MacParakeet/Views/Transcription/SavedMeetingNotesSaveStatusPresentation.swift
@@ -1,0 +1,116 @@
+import Foundation
+import Observation
+import MacParakeetViewModels
+
+/// Transient feedback for the saved-meeting Notes footer.
+///
+/// The editor's save state is durable enough to follow a meeting between detail
+/// views. This presentation state intentionally is not: a check only confirms
+/// a save that completes while this Notes pane is visible.
+@MainActor
+@Observable
+final class SavedMeetingNotesSaveStatusPresentation {
+    static let confirmationDuration: Duration = .seconds(2)
+
+    private(set) var showsSaveConfirmation = false
+
+    @ObservationIgnored private var confirmationTask: Task<Void, Never>?
+    private var confirmationToken: UUID?
+    private var observedMeetingID: UUID?
+    private var observedSaveState: SavedMeetingNotesViewModel.SaveState?
+    private let duration: Duration
+    private let waitForConfirmation: (Duration) async throws -> Void
+
+    init() {
+        duration = Self.confirmationDuration
+        waitForConfirmation = { duration in
+            try await ContinuousClock().sleep(for: duration)
+        }
+    }
+
+    init(
+        duration: Duration,
+        waitForConfirmation: @escaping (Duration) async throws -> Void
+    ) {
+        self.duration = duration
+        self.waitForConfirmation = waitForConfirmation
+    }
+
+    /// Starts a new visible Notes-pane session. A cached editor's current state
+    /// is only a baseline; it never earns a new saved confirmation on entry.
+    func beginPresentation(
+        meetingID: UUID?,
+        displayedMeetingID: UUID,
+        saveState: SavedMeetingNotesViewModel.SaveState
+    ) {
+        clearConfirmation()
+        guard meetingID == displayedMeetingID else {
+            observedMeetingID = nil
+            observedSaveState = nil
+            return
+        }
+        observedMeetingID = meetingID
+        observedSaveState = saveState
+    }
+
+    /// Records an editor state transition only when it belongs to the pane that
+    /// established this presentation session. This avoids a replacement editor
+    /// turning an old `.saving` state into a visible checkmark.
+    func observeSaveStateChange(
+        from previousState: SavedMeetingNotesViewModel.SaveState,
+        to saveState: SavedMeetingNotesViewModel.SaveState,
+        meetingID: UUID?,
+        displayedMeetingID: UUID
+    ) {
+        guard
+            meetingID == displayedMeetingID,
+            observedMeetingID == meetingID,
+            observedSaveState == previousState
+        else {
+            beginPresentation(
+                meetingID: meetingID,
+                displayedMeetingID: displayedMeetingID,
+                saveState: saveState
+            )
+            return
+        }
+
+        observedSaveState = saveState
+        guard previousState == .saving, saveState == .saved else {
+            if saveState != .saved {
+                clearConfirmation()
+            }
+            return
+        }
+
+        showConfirmation()
+    }
+
+    func endPresentation() {
+        clearConfirmation()
+        observedMeetingID = nil
+        observedSaveState = nil
+    }
+
+    private func showConfirmation() {
+        let token = UUID()
+        confirmationToken = token
+        confirmationTask?.cancel()
+        showsSaveConfirmation = true
+        confirmationTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            try? await self.waitForConfirmation(self.duration)
+            guard !Task.isCancelled, self.confirmationToken == token else { return }
+            self.showsSaveConfirmation = false
+            self.confirmationTask = nil
+            self.confirmationToken = nil
+        }
+    }
+
+    private func clearConfirmation() {
+        confirmationTask?.cancel()
+        confirmationTask = nil
+        confirmationToken = nil
+        showsSaveConfirmation = false
+    }
+}

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
@@ -497,6 +497,7 @@ struct TranscriptResultView: View {
     @State private var notesCopied = false
     @State private var notesCopiedResetTask: Task<Void, Never>?
     @State private var savedMeetingNotesViewModel = SavedMeetingNotesViewModel()
+    @State private var savedMeetingNotesSaveStatus = SavedMeetingNotesSaveStatusPresentation()
     @State private var dismissTask: Task<Void, Never>?
     @State private var editingTitle = false
     @State private var titleDraft = ""
@@ -2661,7 +2662,10 @@ struct TranscriptResultView: View {
 
                 meetingNotesSaveStatus
 
-                Text("\(savedMeetingNotesViewModel.wordCount.formatted()) words")
+                Text(
+                    "\(savedMeetingNotesViewModel.wordCount.formatted()) "
+                        + (savedMeetingNotesViewModel.wordCount == 1 ? "word" : "words")
+                )
                     .font(DesignSystem.Typography.caption.monospacedDigit())
                     .foregroundStyle(DesignSystem.Colors.textTertiary)
             }
@@ -2692,36 +2696,84 @@ struct TranscriptResultView: View {
 
     @ViewBuilder
     private var meetingNotesSaveStatus: some View {
-        switch savedMeetingNotesViewModel.saveState {
-        case .deleted:
-            Label("Meeting deleted — notes were not saved", systemImage: "trash")
-                .foregroundStyle(DesignSystem.Colors.textSecondary)
-        case .saved:
-            Label("Saved", systemImage: "checkmark.circle.fill")
-                .foregroundStyle(DesignSystem.Colors.successGreen)
-        case .saving:
-            HStack(spacing: DesignSystem.Spacing.xs) {
+        if savedMeetingNotesViewModel.meetingID != displayedMeetingNotesID {
+            Color.clear
+                .frame(width: 16, height: 16)
+        } else {
+            switch savedMeetingNotesViewModel.saveState {
+            case .deleted:
+                Label("Meeting deleted — notes were not saved", systemImage: "trash")
+                    .foregroundStyle(DesignSystem.Colors.textSecondary)
+                    .help("Meeting deleted — notes were not saved")
+            case .saved where savedMeetingNotesSaveStatus.showsSaveConfirmation:
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(DesignSystem.Colors.successGreen.opacity(0.7))
+                    .help("Saved")
+                    .accessibilityLabel("Saved")
+                    .frame(width: 16, alignment: .leading)
+            case .saved:
+                Color.clear
+                    .frame(width: 16, height: 16)
+            case .saving:
                 ProgressView()
                     .controlSize(.small)
-                Text("Saving…")
-            }
-            .foregroundStyle(DesignSystem.Colors.textSecondary)
-        case .failed:
-            HStack(spacing: DesignSystem.Spacing.xs) {
-                Label("Couldn’t save", systemImage: "exclamationmark.triangle.fill")
-                    .foregroundStyle(DesignSystem.Colors.errorRed)
-                Button("Retry") {
-                    retrySavedMeetingNotes()
+                    .help("Saving")
+                    .accessibilityLabel("Saving")
+                    .frame(width: 16, alignment: .leading)
+            case .failed:
+                HStack(spacing: DesignSystem.Spacing.xs) {
+                    Label("Couldn’t save", systemImage: "exclamationmark.triangle.fill")
+                        .foregroundStyle(DesignSystem.Colors.errorRed)
+                    Button("Retry") {
+                        retrySavedMeetingNotes()
+                    }
+                    .parakeetAction(.secondary)
+                    .controlSize(.small)
                 }
-                .parakeetAction(.secondary)
-                .controlSize(.small)
             }
         }
+    }
+
+    private var displayedMeetingNotesID: UUID {
+        activeTranscription.id
+    }
+
+    private func beginMeetingNotesSaveStatusPresentation() {
+        savedMeetingNotesSaveStatus.beginPresentation(
+            meetingID: savedMeetingNotesViewModel.meetingID,
+            displayedMeetingID: displayedMeetingNotesID,
+            saveState: savedMeetingNotesViewModel.saveState
+        )
+    }
+
+    private func observeMeetingNotesSaveState(
+        from previousState: SavedMeetingNotesViewModel.SaveState,
+        to saveState: SavedMeetingNotesViewModel.SaveState
+    ) {
+        savedMeetingNotesSaveStatus.observeSaveStateChange(
+            from: previousState,
+            to: saveState,
+            meetingID: savedMeetingNotesViewModel.meetingID,
+            displayedMeetingID: displayedMeetingNotesID
+        )
+    }
+
+    private func resetMeetingNotesSaveStatusPresentation() {
+        savedMeetingNotesSaveStatus.endPresentation()
     }
 
     private var meetingNotesPane: some View {
         meetingNotesSection
             .padding(DesignSystem.Spacing.lg)
+            .onAppear(perform: beginMeetingNotesSaveStatusPresentation)
+            .onChange(of: savedMeetingNotesViewModel.meetingID) {
+                beginMeetingNotesSaveStatusPresentation()
+            }
+            .onChange(of: savedMeetingNotesViewModel.saveState) { previousState, saveState in
+                observeMeetingNotesSaveState(from: previousState, to: saveState)
+            }
+            .onDisappear(perform: resetMeetingNotesSaveStatusPresentation)
     }
 
     // MARK: - Tab Bar
@@ -4482,6 +4534,7 @@ struct TranscriptResultView: View {
     private var cachedSpeakerStats: [String: SpeakerStatistics] { displayedSegmentCache?.payload.speakerStats ?? [:] }
 
     private func handleDisappear() {
+        resetMeetingNotesSaveStatusPresentation()
         navigationNotesActionGate.invalidate()
         promptNotesActionGate.invalidate()
         chatNotesActionGate.invalidate()
@@ -4676,6 +4729,7 @@ struct TranscriptResultView: View {
     }
 
     private func configureSavedMeetingNotes(for transcription: Transcription) {
+        resetMeetingNotesSaveStatusPresentation()
         let previousEditor = savedMeetingNotesViewModel
         if transcription.sourceType == .meeting {
             savedMeetingNotesViewModel = SavedMeetingNotesCoordinator.shared.editor(

--- a/Tests/MacParakeetTests/Views/SavedMeetingNotesSaveStatusPresentationTests.swift
+++ b/Tests/MacParakeetTests/Views/SavedMeetingNotesSaveStatusPresentationTests.swift
@@ -1,0 +1,124 @@
+import XCTest
+import MacParakeetViewModels
+@testable import MacParakeet
+
+@MainActor
+final class SavedMeetingNotesSaveStatusPresentationTests: XCTestCase {
+    private final class ManualTimer {
+        private let ticks: AsyncStream<Void>
+        private let tickContinuation: AsyncStream<Void>.Continuation
+        var onSleep: (() -> Void)?
+
+        init() {
+            var continuation: AsyncStream<Void>.Continuation?
+            ticks = AsyncStream { continuation = $0 }
+            tickContinuation = continuation!
+        }
+
+        func sleep(for _: Duration) async throws {
+            try Task.checkCancellation()
+            onSleep?()
+            var iterator = ticks.makeAsyncIterator()
+            guard await iterator.next() != nil else { throw CancellationError() }
+            try Task.checkCancellation()
+        }
+
+        func advance() {
+            tickContinuation.yield()
+        }
+    }
+
+    func testShowsOnlySuccessfulSaveDuringVisiblePaneAndThenExpires() async {
+        let timer = ManualTimer()
+        let confirmationStarted = expectation(description: "Confirmation timer started")
+        timer.onSleep = { confirmationStarted.fulfill() }
+        let presentation = SavedMeetingNotesSaveStatusPresentation(
+            duration: .seconds(1),
+            waitForConfirmation: timer.sleep
+        )
+        let meetingID = UUID()
+
+        presentation.beginPresentation(
+            meetingID: meetingID,
+            displayedMeetingID: meetingID,
+            saveState: .saved
+        )
+        XCTAssertFalse(presentation.showsSaveConfirmation)
+
+        presentation.observeSaveStateChange(
+            from: .saved,
+            to: .saving,
+            meetingID: meetingID,
+            displayedMeetingID: meetingID
+        )
+        XCTAssertFalse(presentation.showsSaveConfirmation)
+
+        presentation.observeSaveStateChange(
+            from: .saving,
+            to: .saved,
+            meetingID: meetingID,
+            displayedMeetingID: meetingID
+        )
+        XCTAssertTrue(presentation.showsSaveConfirmation)
+        await fulfillment(of: [confirmationStarted], timeout: 1)
+
+        timer.advance()
+        let deadline = ContinuousClock.now + .seconds(1)
+        while presentation.showsSaveConfirmation, ContinuousClock.now < deadline {
+            await Task.yield()
+        }
+        XCTAssertFalse(presentation.showsSaveConfirmation)
+    }
+
+    func testNewEditFailureOrReplacementEditorCannotLeaveStaleConfirmation() async {
+        let timer = ManualTimer()
+        let confirmationStarted = expectation(description: "Confirmation timer started")
+        timer.onSleep = { confirmationStarted.fulfill() }
+        let presentation = SavedMeetingNotesSaveStatusPresentation(
+            duration: .seconds(1),
+            waitForConfirmation: timer.sleep
+        )
+        let firstMeetingID = UUID()
+        let replacementMeetingID = UUID()
+
+        presentation.beginPresentation(
+            meetingID: firstMeetingID,
+            displayedMeetingID: firstMeetingID,
+            saveState: .saving
+        )
+        presentation.observeSaveStateChange(
+            from: .saving,
+            to: .saved,
+            meetingID: firstMeetingID,
+            displayedMeetingID: firstMeetingID
+        )
+        XCTAssertTrue(presentation.showsSaveConfirmation)
+        await fulfillment(of: [confirmationStarted], timeout: 1)
+
+        presentation.observeSaveStateChange(
+            from: .saved,
+            to: .saving,
+            meetingID: firstMeetingID,
+            displayedMeetingID: firstMeetingID
+        )
+        presentation.observeSaveStateChange(
+            from: .saving,
+            to: .failed,
+            meetingID: firstMeetingID,
+            displayedMeetingID: firstMeetingID
+        )
+        XCTAssertFalse(presentation.showsSaveConfirmation)
+
+        timer.advance()
+        await Task.yield()
+        XCTAssertFalse(presentation.showsSaveConfirmation)
+
+        presentation.observeSaveStateChange(
+            from: .saving,
+            to: .saved,
+            meetingID: replacementMeetingID,
+            displayedMeetingID: replacementMeetingID
+        )
+        XCTAssertFalse(presentation.showsSaveConfirmation)
+    }
+}

--- a/spec/04-ui-patterns.md
+++ b/spec/04-ui-patterns.md
@@ -226,8 +226,13 @@ factual transcript pane. The tab always shows an editable plaintext
 existing 7,500-word soft-cap warning. The separate 8,000-word cap bounds notes
 sent to prompt assembly; it does not truncate stored notes.
 
-Changes auto-save to SQLite after a 500 ms idle debounce. A quiet status reports Saving,
-Saved, or a retryable failure; the editor stays writable during persistence.
+Changes auto-save to SQLite after a 500 ms idle debounce. The status is hidden
+on entry, including for empty notes. Editing shows a small spinner; a successful
+save briefly shows a muted green check before the status disappears. These
+routine states use icons with tooltips and accessibility labels, in a fixed-size
+slot. Save failures retain visible text and Retry. The word count remains
+separate and uses singular wording for one word. The editor stays writable
+during persistence.
 Leaving the tab, leaving the detail page, or starting an LLM action flushes the
 latest draft and refreshes the derived meeting files once. Ordinary quit also
 flushes pending file refreshes, including drafts already saved to SQLite.


### PR DESCRIPTION
The Notes footer now starts quiet, shows a spinner during a save, and shows a confirmation icon for two seconds only when that save completes in the visible pane. Cached editor state and meeting switches cannot surface a stale success indicator; failures retain the Retry control, and persistence behavior is unchanged.

Validation:
- Saved meeting notes focused tests: 25 passed, 0 failed.
- Full suite: 5,843 XCTest tests passed, 20 skipped, 0 failed; 29 Swift Testing tests passed.
- Release build, strict signature, and restart checks passed.
- Manual UI verification was not repeated after the latest rebuild.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the meeting notes footer save status so it no longer shows a stale "Saved" state after switching meetings or reopening cached editor state.

- The footer now starts quiet and shows a small spinner during a save, with a muted checkmark for two seconds only when the save completes in the visible notes pane.
- Save failures still show the error text and Retry control; persistence behavior is unchanged.
- The word count now reads "word" for a single word instead of "words".

<sup>Written for commit 898fa0bc686fb5118d983de9d0f8dd5e39116170. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/986?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **UI Improvements**
  - Saved Meeting Notes now shows a compact spinner while saving and a brief checkmark confirmation after a successful save.
  - Save confirmations are cleared when editing fails or switching meetings, preventing outdated status messages.
  - Save errors remain visible with retry options, while the editor stays usable during saving.
  - Word counts now use correct singular and plural wording.

- **Documentation**
  - Updated the UI patterns documentation to describe the revised save-status behavior and accessibility guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->