### PR TITLE
Polish Library labels and status cues

### DIFF
--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingAudioStateChip.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingAudioStateChip.swift
@@ -3,11 +3,38 @@ import SwiftUI
 
 struct MeetingAudioStateChip: View {
     let state: MeetingAudioFile.State
+    @State private var showingUnavailableAudioExplanation = false
 
     @ViewBuilder
     var body: some View {
-        if state != .notMeeting {
-            Label(title, systemImage: systemImage)
+        switch state {
+        case .saved, .notMeeting:
+            EmptyView()
+        case .removed:
+            Button {
+                showingUnavailableAudioExplanation.toggle()
+            } label: {
+                Image(systemName: "waveform.slash")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(DesignSystem.Colors.textSecondary)
+                    .frame(width: 20, height: 20)
+                    .contentShape(Circle())
+            }
+            .buttonStyle(.plain)
+            .help("Audio unavailable. Transcript is still available.")
+            .accessibilityLabel("Audio unavailable")
+            .accessibilityHint("Shows why playback and retranscription are unavailable")
+            .popover(isPresented: $showingUnavailableAudioExplanation, arrowEdge: .bottom) {
+                Text(
+                    "Audio unavailable. The transcript is still available, but playback and retranscription need retained meeting audio."
+                )
+                .font(DesignSystem.Typography.caption)
+                .foregroundStyle(DesignSystem.Colors.textPrimary)
+                .frame(width: 250, alignment: .leading)
+                .padding(DesignSystem.Spacing.md)
+            }
+        case .missing:
+            Label("Audio missing", systemImage: "exclamationmark.triangle")
                 .font(.system(size: 11, weight: .medium))
                 .foregroundStyle(foreground)
                 .lineLimit(1)
@@ -22,67 +49,29 @@ struct MeetingAudioStateChip: View {
         }
     }
 
-    private var title: String {
-        switch state {
-        case .saved:
-            return "Audio saved"
-        case .removed:
-            return "Audio removed"
-        case .missing:
-            return "Audio missing"
-        case .notMeeting:
-            return ""
-        }
-    }
-
-    private var systemImage: String {
-        switch state {
-        case .saved:
-            return "waveform"
-        case .removed:
-            return "waveform.slash"
-        case .missing:
-            return "exclamationmark.triangle"
-        case .notMeeting:
-            return ""
-        }
-    }
-
     private var foreground: Color {
         switch state {
-        case .saved:
-            return DesignSystem.Colors.textTertiary
-        case .removed:
-            return DesignSystem.Colors.textSecondary
         case .missing:
             return DesignSystem.Colors.warningAmber
-        case .notMeeting:
+        case .saved, .removed, .notMeeting:
             return DesignSystem.Colors.textTertiary
         }
     }
 
     private var background: Color {
         switch state {
-        case .saved:
-            return DesignSystem.Colors.surfaceElevated.opacity(0.65)
-        case .removed:
-            return DesignSystem.Colors.surfaceElevated.opacity(0.9)
         case .missing:
             return DesignSystem.Colors.warningAmber.opacity(0.12)
-        case .notMeeting:
+        case .saved, .removed, .notMeeting:
             return .clear
         }
     }
 
     private var accessibilityLabel: String {
         switch state {
-        case .saved:
-            return "Meeting audio is saved"
-        case .removed:
-            return "Meeting audio has been removed"
         case .missing:
             return "Meeting audio file is missing"
-        case .notMeeting:
+        case .saved, .removed, .notMeeting:
             return ""
         }
     }

--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingClassificationControls.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingClassificationControls.swift
@@ -9,12 +9,11 @@ struct MeetingClassificationBadges: View {
     var body: some View {
         if let classification, !classification.labels.isEmpty {
             HStack(spacing: 5) {
-                ForEach(Array(classification.labels.prefix(maximumLabels).enumerated()), id: \.element.id) {
-                    index, label in
+                ForEach(classification.labels.prefix(maximumLabels)) { label in
                     badge(
                         label.name,
                         icon: nil,
-                        tint: MeetingClassificationTint.color(for: label.colorToken, fallback: index + 1),
+                        tint: MeetingLabelTint.color(for: label),
                         isPrimary: false
                     )
                 }
@@ -86,13 +85,16 @@ struct MeetingClassificationFilterBar: View {
         .buttonStyle(.plain)
         .fixedSize()
         .popover(isPresented: $showingLabelFilters, arrowEdge: .bottom) {
-            MeetingLabelFilterPopover(libraryViewModel: libraryViewModel)
+            MeetingLabelFilterPopover(
+                libraryViewModel: libraryViewModel,
+                onDismiss: { showingLabelFilters = false }
+            )
         }
     }
 
     private var labelFilterTitle: String {
         let count = libraryViewModel.selectedMeetingLabelIDs.count
-        return count == 0 ? "All labels" : "Labels · \(count)"
+        return count == 0 ? "Labels" : "Labels · \(count)"
     }
 
     private func filterButtonLabel(title: String, icon: String) -> some View {
@@ -112,56 +114,76 @@ struct MeetingClassificationFilterBar: View {
 
 private struct MeetingLabelFilterPopover: View {
     @Bindable var libraryViewModel: TranscriptionLibraryViewModel
+    let onDismiss: () -> Void
     @State private var query = ""
+    @State private var showingSelectedOnly = false
+    @State private var optionsContentHeight: CGFloat = 1
+    @FocusState private var searchFocused: Bool
 
     private var labels: [MeetingLabel] {
         let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
         let allLabels = libraryViewModel.meetingClassificationViewModel.meetingLabels
-        guard !trimmed.isEmpty else { return allLabels }
-        return allLabels.filter { $0.name.localizedCaseInsensitiveContains(trimmed) }
+        return allLabels.filter { label in
+            (!showingSelectedOnly || libraryViewModel.selectedMeetingLabelIDs.contains(label.id))
+                && (trimmed.isEmpty || label.name.localizedCaseInsensitiveContains(trimmed))
+        }
     }
 
     var body: some View {
-        filterPopoverContainer(searchText: $query, prompt: "Search labels") {
-            if labels.isEmpty {
-                Text("No matching labels")
-                    .font(DesignSystem.Typography.caption)
-                    .foregroundStyle(DesignSystem.Colors.textTertiary)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.vertical, DesignSystem.Spacing.sm)
-            } else {
-                FlowLayout(spacing: 7) {
-                    ForEach(Array(labels.enumerated()), id: \.element.id) { index, label in
-                        filterChip(
-                            name: label.name,
-                            icon: "tag.fill",
-                            tint: MeetingClassificationTint.color(
-                                for: label.colorToken,
-                                fallback: index + 1
-                            ),
-                            selected: libraryViewModel.selectedMeetingLabelIDs.contains(label.id)
-                        ) {
-                            libraryViewModel.toggleMeetingLabelFilter(label.id)
-                        }
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+            searchField
+
+            Text("Match any selected label")
+                .font(DesignSystem.Typography.micro)
+                .foregroundStyle(DesignSystem.Colors.textTertiary)
+
+            Toggle("Show selected", isOn: $showingSelectedOnly)
+                .font(DesignSystem.Typography.caption)
+
+            Divider()
+
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 2) {
+                    filterRows
+                }
+                .background {
+                    GeometryReader { proxy in
+                        Color.clear.preference(
+                            key: LabelPopoverContentHeightKey.self,
+                            value: proxy.size.height
+                        )
                     }
                 }
             }
-        }
-    }
-}
+            .frame(height: min(optionsContentHeight, 260))
 
-@MainActor
-private func filterPopoverContainer<Content: View>(
-    searchText: Binding<String>,
-    prompt: String,
-    @ViewBuilder content: () -> Content
-) -> some View {
-    VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
+            if libraryViewModel.hasMeetingClassificationFilter {
+                Divider()
+                Button("Clear filters") {
+                    libraryViewModel.clearMeetingClassificationFilters()
+                }
+                .buttonStyle(.plain)
+                .font(DesignSystem.Typography.caption.weight(.medium))
+                .foregroundStyle(DesignSystem.Colors.textSecondary)
+            }
+        }
+        .padding(DesignSystem.Spacing.md)
+        .frame(width: 320)
+        .background(DesignSystem.Colors.contentBackground)
+        .onAppear {
+            Task { @MainActor in searchFocused = true }
+        }
+        .onPreferenceChange(LabelPopoverContentHeightKey.self) { optionsContentHeight = $0 }
+        .onExitCommand(perform: onDismiss)
+    }
+
+    private var searchField: some View {
         HStack(spacing: 7) {
             Image(systemName: "magnifyingglass")
                 .foregroundStyle(DesignSystem.Colors.textTertiary)
-            TextField(prompt, text: searchText)
+            TextField("Search labels", text: $query)
                 .textFieldStyle(.plain)
+                .focused($searchFocused)
         }
         .padding(.horizontal, 10)
         .frame(height: 32)
@@ -173,56 +195,55 @@ private func filterPopoverContainer<Content: View>(
             RoundedRectangle(cornerRadius: 8)
                 .strokeBorder(DesignSystem.Colors.border, lineWidth: 0.6)
         )
-
-        content()
     }
-    .padding(DesignSystem.Spacing.md)
-    .frame(width: 330)
-    .background(DesignSystem.Colors.contentBackground)
-}
 
-@MainActor
-private func filterChip(
-    name: String,
-    icon: String?,
-    tint: Color,
-    selected: Bool,
-    action: @escaping () -> Void
-) -> some View {
-    Button(action: action) {
-        HStack(spacing: 5) {
-            if selected {
-                Image(systemName: "checkmark")
-                    .font(.system(size: 9, weight: .bold))
-            } else if let icon {
-                Image(systemName: icon)
-                    .font(.system(size: 9, weight: .semibold))
+    @ViewBuilder
+    private var filterRows: some View {
+        if labels.isEmpty {
+            Text(query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "No labels yet." : "No matching labels")
+                .font(DesignSystem.Typography.caption)
+                .foregroundStyle(DesignSystem.Colors.textTertiary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.vertical, DesignSystem.Spacing.sm)
+        } else {
+            ForEach(labels) { label in
+                let selected = libraryViewModel.selectedMeetingLabelIDs.contains(label.id)
+                Button {
+                    libraryViewModel.toggleMeetingLabelFilter(label.id)
+                } label: {
+                    HStack(spacing: 8) {
+                        Circle()
+                            .fill(MeetingLabelTint.color(for: label))
+                            .frame(width: 8, height: 8)
+                        Text(label.name)
+                            .lineLimit(1)
+                            .help(label.name)
+                        Spacer(minLength: 0)
+                        Image(systemName: selected ? "checkmark" : "circle")
+                            .font(.system(size: 10, weight: .semibold))
+                            .foregroundStyle(selected ? MeetingLabelTint.color(for: label) : DesignSystem.Colors.textTertiary)
+                    }
+                    .font(DesignSystem.Typography.caption.weight(.medium))
+                    .foregroundStyle(DesignSystem.Colors.textPrimary)
+                    .padding(.horizontal, 7)
+                    .padding(.vertical, 6)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(label.name)
+                .accessibilityValue(selected ? "Selected" : "Not selected")
             }
-            Text(name)
-                .lineLimit(1)
         }
-        .font(DesignSystem.Typography.caption.weight(.medium))
-        .foregroundStyle(selected ? tint : DesignSystem.Colors.textSecondary)
-        .padding(.horizontal, 9)
-        .padding(.vertical, 6)
-        .background(
-            Capsule().fill(selected ? tint.opacity(0.16) : tint.opacity(0.07))
-        )
-        .overlay(
-            Capsule().strokeBorder(
-                selected ? tint.opacity(0.55) : tint.opacity(0.24),
-                lineWidth: selected ? 1 : 0.6
-            )
-        )
     }
-    .buttonStyle(.plain)
-    .accessibilityValue(selected ? "Selected" : "Not selected")
 }
 
 struct MeetingClassificationEditor: View {
     let transcription: Transcription
     @Bindable var viewModel: MeetingClassificationViewModel
+    let onDismiss: () -> Void
     @State private var newLabelName = ""
+    @State private var optionsContentHeight: CGFloat = 1
+    @FocusState private var searchFocused: Bool
 
     private var classification: MeetingClassification {
         viewModel.classification(for: transcription.id)
@@ -230,119 +251,107 @@ struct MeetingClassificationEditor: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+            Text("Labels")
+                .font(DesignSystem.Typography.bodySmall.weight(.semibold))
+
+            searchField
+
             ScrollView {
-                VStack(alignment: .leading, spacing: DesignSystem.Spacing.lg) {
-                    VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
-                        Text("Labels")
-                            .font(DesignSystem.Typography.bodySmall.weight(.semibold))
-
-                        HStack(spacing: 6) {
-                            if !classification.labels.isEmpty {
-                                ScrollView(.horizontal) {
-                                    HStack(spacing: 5) {
-                                        ForEach(Array(classification.labels.enumerated()), id: \.element.id) {
-                                            index, label in
-                                            selectedLabelToken(label, index: index)
-                                        }
-                                    }
-                                }
-                                .scrollIndicators(.hidden)
-                                .frame(maxWidth: .infinity)
+                VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+                    if !classification.labels.isEmpty {
+                        FlowLayout(spacing: 5) {
+                            ForEach(classification.labels) { label in
+                                selectedLabelToken(label)
                             }
-
-                            TextField("Search or create a label", text: $newLabelName)
-                                .textFieldStyle(.plain)
-                                .frame(minWidth: 125, idealWidth: 155)
-                                .onSubmit(createLabel)
-                                .help("Choose an existing suggestion or press Return to create a label")
                         }
-                        .padding(.horizontal, 8)
-                        .frame(height: 34)
-                        .background(
-                            RoundedRectangle(cornerRadius: 7)
-                                .fill(DesignSystem.Colors.surfaceElevated)
-                        )
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 7)
-                                .strokeBorder(DesignSystem.Colors.border, lineWidth: 0.6)
-                        )
-
-                        if !trimmedLabelQuery.isEmpty {
-                            VStack(alignment: .leading, spacing: 2) {
-                                ForEach(suggestedLabels) { label in
-                                    Button {
-                                        assignSuggestedLabel(label)
-                                    } label: {
-                                        HStack(spacing: 7) {
-                                            Image(
-                                                systemName: classification.labels.contains(where: { $0.id == label.id })
-                                                    ? "checkmark"
-                                                    : "tag"
-                                            )
-                                            .font(.system(size: 9, weight: .semibold))
-                                            .frame(width: 10)
-                                            Text(label.name)
-                                                .lineLimit(1)
-                                            Spacer(minLength: 0)
-                                        }
-                                        .foregroundStyle(DesignSystem.Colors.textPrimary)
-                                        .padding(.horizontal, 7)
-                                        .padding(.vertical, 5)
-                                        .contentShape(Rectangle())
-                                    }
-                                    .buttonStyle(.plain)
-                                }
-
-                                if exactLabelMatch == nil {
-                                    Button(action: createLabel) {
-                                        Label("Create “\(trimmedLabelQuery)”", systemImage: "plus")
-                                            .lineLimit(1)
-                                            .frame(maxWidth: .infinity, alignment: .leading)
-                                            .padding(.horizontal, 7)
-                                            .padding(.vertical, 5)
-                                    }
-                                    .buttonStyle(.plain)
-                                    .foregroundStyle(DesignSystem.Colors.accent)
-                                }
-                            }
-                            .padding(5)
-                            .background(
-                                RoundedRectangle(cornerRadius: 8)
-                                    .fill(DesignSystem.Colors.surfaceElevated)
-                            )
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 8)
-                                    .strokeBorder(DesignSystem.Colors.border, lineWidth: 0.5)
-                            )
-                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
                     }
 
-                    if viewModel.updatingTranscriptionIDs.contains(transcription.id) {
-                        HStack(spacing: 7) {
-                            ParakeetSpinner(.inline)
-                            Text("Saving classification…")
-                                .font(DesignSystem.Typography.caption)
-                                .foregroundStyle(DesignSystem.Colors.textTertiary)
-                        }
+                    if (!classification.labels.isEmpty && !suggestedLabels.isEmpty) || canCreateLabel {
+                        Divider()
                     }
 
-                    if let errorMessage = viewModel.errorMessage {
-                        Text(errorMessage)
+                    if canCreateLabel {
+                        Button(action: createLabel) {
+                            Label("Create “\(trimmedLabelQuery)”", systemImage: "plus")
+                                .lineLimit(1)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .padding(.horizontal, 7)
+                                .padding(.vertical, 5)
+                        }
+                        .buttonStyle(.plain)
+                        .foregroundStyle(DesignSystem.Colors.accent)
+                    }
+
+                    if suggestedLabels.isEmpty {
+                        Text(trimmedLabelQuery.isEmpty ? "No labels yet. Type a name to create one." : "No matching labels")
                             .font(DesignSystem.Typography.caption)
-                            .foregroundStyle(DesignSystem.Colors.errorRed)
+                            .foregroundStyle(DesignSystem.Colors.textTertiary)
+                            .padding(.vertical, DesignSystem.Spacing.xs)
+                    } else {
+                        ForEach(suggestedLabels) { label in
+                            availableLabelRow(label)
+                        }
                     }
-
-                    Spacer(minLength: 0)
                 }
-                .padding(DesignSystem.Spacing.lg)
+                .background {
+                    GeometryReader { proxy in
+                        Color.clear.preference(
+                            key: LabelPopoverContentHeightKey.self,
+                            value: proxy.size.height
+                        )
+                    }
+                }
+            }
+            .frame(height: min(optionsContentHeight, 260))
+
+            if viewModel.updatingTranscriptionIDs.contains(transcription.id) {
+                HStack(spacing: 7) {
+                    ParakeetSpinner(.inline)
+                    Text("Saving classification…")
+                        .font(DesignSystem.Typography.caption)
+                        .foregroundStyle(DesignSystem.Colors.textTertiary)
+                }
+            }
+
+            if let errorMessage = viewModel.errorMessage {
+                Text(errorMessage)
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundStyle(DesignSystem.Colors.errorRed)
             }
         }
+        .padding(DesignSystem.Spacing.md)
         .background(DesignSystem.Colors.contentBackground)
         .onAppear {
             viewModel.loadOptions()
             viewModel.loadClassification(for: transcription.id)
+            Task { @MainActor in searchFocused = true }
         }
+        .onPreferenceChange(LabelPopoverContentHeightKey.self) { optionsContentHeight = $0 }
+        .onExitCommand(perform: onDismiss)
+    }
+
+    private var searchField: some View {
+        HStack(spacing: 7) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(DesignSystem.Colors.textTertiary)
+            TextField("Search or create a label", text: $newLabelName)
+                .textFieldStyle(.plain)
+                .focused($searchFocused)
+                .onSubmit(createLabel)
+                .help("Choose an existing label or press Return to create a label")
+        }
+        .padding(.horizontal, 10)
+        .frame(height: 32)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(DesignSystem.Colors.surfaceElevated)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .strokeBorder(DesignSystem.Colors.border, lineWidth: 0.6)
+        )
     }
 
     private var displayedLabels: [MeetingLabel] {
@@ -356,10 +365,9 @@ struct MeetingClassificationEditor: View {
     }
 
     private var suggestedLabels: [MeetingLabel] {
-        Array(
-            displayedLabels.filter {
-                $0.name.localizedCaseInsensitiveContains(trimmedLabelQuery)
-            }.prefix(4))
+        displayedLabels.filter {
+            trimmedLabelQuery.isEmpty || $0.name.localizedCaseInsensitiveContains(trimmedLabelQuery)
+        }
     }
 
     private var exactLabelMatch: MeetingLabel? {
@@ -368,14 +376,21 @@ struct MeetingClassificationEditor: View {
         }
     }
 
-    private func selectedLabelToken(_ label: MeetingLabel, index: Int) -> some View {
-        let tint = MeetingClassificationTint.color(for: label.colorToken, fallback: index + 1)
+    private var canCreateLabel: Bool {
+        !trimmedLabelQuery.isEmpty && exactLabelMatch == nil
+    }
+
+    private func selectedLabelToken(_ label: MeetingLabel) -> some View {
+        let tint = MeetingLabelTint.color(for: label)
         return Button {
             viewModel.toggleLabel(label.id, for: transcription.id)
         } label: {
             HStack(spacing: 5) {
                 Text(label.name)
                     .lineLimit(1)
+                    .truncationMode(.tail)
+                    .frame(maxWidth: 180)
+                    .help(label.name)
                 Image(systemName: "xmark")
                     .font(.system(size: 8, weight: .bold))
             }
@@ -390,7 +405,37 @@ struct MeetingClassificationEditor: View {
         .accessibilityLabel(label.name)
         .accessibilityValue("Assigned")
         .accessibilityHint("Removes this label")
-        .fixedSize()
+    }
+
+    private func availableLabelRow(_ label: MeetingLabel) -> some View {
+        let isAssigned = classification.labels.contains(where: { $0.id == label.id })
+        let tint = MeetingLabelTint.color(for: label)
+        return Button {
+            assignSuggestedLabel(label)
+        } label: {
+            HStack(spacing: 8) {
+                Circle()
+                    .fill(tint)
+                    .frame(width: 8, height: 8)
+                Text(label.name)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                    .help(label.name)
+                Spacer(minLength: 0)
+                Image(systemName: isAssigned ? "checkmark" : "plus")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(isAssigned ? tint : DesignSystem.Colors.textTertiary)
+            }
+            .font(DesignSystem.Typography.caption.weight(.medium))
+            .foregroundStyle(DesignSystem.Colors.textPrimary)
+            .padding(.horizontal, 7)
+            .padding(.vertical, 6)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(label.name)
+        .accessibilityValue(isAssigned ? "Assigned" : "Available")
+        .accessibilityHint(isAssigned ? "Already assigned" : "Adds this label")
     }
 
     private func createLabel() {
@@ -408,6 +453,14 @@ struct MeetingClassificationEditor: View {
             viewModel.toggleLabel(label.id, for: transcription.id)
         }
         newLabelName = ""
+    }
+}
+
+private struct LabelPopoverContentHeightKey: PreferenceKey {
+    static var defaultValue: CGFloat = 1
+
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = nextValue()
     }
 }
 
@@ -444,7 +497,7 @@ struct MeetingTypesManagementCard: View {
                         HStack(spacing: DesignSystem.Spacing.sm) {
                             Circle()
                                 .fill(
-                                    MeetingClassificationTint.color(
+                                    MeetingTypeTint.color(
                                         for: meetingType.colorToken,
                                         fallback: index
                                     )
@@ -662,9 +715,10 @@ private struct MeetingClassificationPopoverModifier: ViewModifier {
             if let viewModel {
                 MeetingClassificationEditor(
                     transcription: transcription,
-                    viewModel: viewModel
+                    viewModel: viewModel,
+                    onDismiss: { item.wrappedValue = nil }
                 )
-                .frame(width: 340, height: 210)
+                .frame(width: 340)
             }
         }
     }
@@ -857,7 +911,62 @@ struct MeetingPromptPolicyEditor: View {
     }
 }
 
-enum MeetingClassificationTint {
+enum MeetingLabelTint {
+    enum ColorKey: Equatable {
+        case coral
+        case green
+        case amber
+        case red
+        case purple
+        case blue
+        case automatic(Int)
+    }
+
+    static func color(for label: MeetingLabel) -> Color {
+        color(for: colorKey(for: label))
+    }
+
+    static func colorKey(for label: MeetingLabel) -> ColorKey {
+        explicitColorKey(for: label.colorToken) ?? .automatic(automaticPaletteSlot(for: label.id))
+    }
+
+    static func automaticPaletteSlot(for id: UUID) -> Int {
+        var hash: UInt64 = 1_469_598_103_934_665_603
+        withUnsafeBytes(of: id.uuid) { bytes in
+            for byte in bytes {
+                hash ^= UInt64(byte)
+                hash &*= 1_099_511_628_211
+            }
+        }
+        return Int(hash % UInt64(DesignSystem.Colors.speakerColors.count))
+    }
+
+    private static func explicitColorKey(for token: String?) -> ColorKey? {
+        switch token?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "coral", "orange": return .coral
+        case "green": return .green
+        case "amber", "yellow": return .amber
+        case "red": return .red
+        case "purple": return .purple
+        case "blue": return .blue
+        default: return nil
+        }
+    }
+
+    private static func color(for key: ColorKey) -> Color {
+        switch key {
+        case .coral: return DesignSystem.Colors.accent
+        case .green: return DesignSystem.Colors.successGreen
+        case .amber: return DesignSystem.Colors.warningAmber
+        case .red: return DesignSystem.Colors.errorRed
+        case .purple: return DesignSystem.Colors.podcastPurple
+        case .blue: return DesignSystem.Colors.speakerColor(for: 0)
+        case .automatic(let slot): return DesignSystem.Colors.speakerColor(for: slot)
+        }
+    }
+}
+
+enum MeetingTypeTint {
     static func color(for token: String?, fallback: Int) -> Color {
         switch token?.lowercased() {
         case "coral", "orange": return DesignSystem.Colors.accent

--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingClassificationControls.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingClassificationControls.swift
@@ -477,7 +477,7 @@ struct MeetingClassificationEditor: View {
 }
 
 private struct LabelPopoverContentHeightKey: PreferenceKey {
-    static var defaultValue: CGFloat = 1
+    static let defaultValue: CGFloat = 1
 
     static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
         value = nextValue()

--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingClassificationControls.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingClassificationControls.swift
@@ -200,7 +200,7 @@ private struct MeetingLabelFilterPopover: View {
     @ViewBuilder
     private var filterRows: some View {
         if labels.isEmpty {
-            Text(query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "No labels yet." : "No matching labels")
+            Text(filterEmptyMessage)
                 .font(DesignSystem.Typography.caption)
                 .foregroundStyle(DesignSystem.Colors.textTertiary)
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -221,7 +221,9 @@ private struct MeetingLabelFilterPopover: View {
                         Spacer(minLength: 0)
                         Image(systemName: selected ? "checkmark" : "circle")
                             .font(.system(size: 10, weight: .semibold))
-                            .foregroundStyle(selected ? MeetingLabelTint.color(for: label) : DesignSystem.Colors.textTertiary)
+                            .foregroundStyle(
+                                selected ? MeetingLabelTint.color(for: label) : DesignSystem.Colors.textTertiary
+                            )
                     }
                     .font(DesignSystem.Typography.caption.weight(.medium))
                     .foregroundStyle(DesignSystem.Colors.textPrimary)
@@ -234,6 +236,16 @@ private struct MeetingLabelFilterPopover: View {
                 .accessibilityValue(selected ? "Selected" : "Not selected")
             }
         }
+    }
+
+    private var filterEmptyMessage: String {
+        if showingSelectedOnly && libraryViewModel.selectedMeetingLabelIDs.isEmpty {
+            return "No selected labels"
+        }
+        if query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return "No labels yet."
+        }
+        return "No matching labels"
     }
 }
 
@@ -285,7 +297,7 @@ struct MeetingClassificationEditor: View {
                     }
 
                     if suggestedLabels.isEmpty {
-                        Text(trimmedLabelQuery.isEmpty ? "No labels yet. Type a name to create one." : "No matching labels")
+                        Text(suggestedLabelsEmptyMessage)
                             .font(DesignSystem.Typography.caption)
                             .foregroundStyle(DesignSystem.Colors.textTertiary)
                             .padding(.vertical, DesignSystem.Spacing.xs)
@@ -370,6 +382,13 @@ struct MeetingClassificationEditor: View {
         }
     }
 
+    private var suggestedLabelsEmptyMessage: String {
+        if trimmedLabelQuery.isEmpty {
+            return "No labels yet. Type a name to create one."
+        }
+        return "No matching labels"
+    }
+
     private var exactLabelMatch: MeetingLabel? {
         displayedLabels.first {
             $0.name.compare(trimmedLabelQuery, options: [.caseInsensitive, .diacriticInsensitive]) == .orderedSame
@@ -436,6 +455,7 @@ struct MeetingClassificationEditor: View {
         .accessibilityLabel(label.name)
         .accessibilityValue(isAssigned ? "Assigned" : "Available")
         .accessibilityHint(isAssigned ? "Already assigned" : "Adds this label")
+        .disabled(isAssigned)
     }
 
     private func createLabel() {
@@ -716,7 +736,7 @@ private struct MeetingClassificationPopoverModifier: ViewModifier {
                 MeetingClassificationEditor(
                     transcription: transcription,
                     viewModel: viewModel,
-                    onDismiss: { item.wrappedValue = nil }
+                    onDismiss: { item = nil }
                 )
                 .frame(width: 340)
             }

--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingDeletionCopy.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingDeletionCopy.swift
@@ -113,7 +113,7 @@ enum MeetingDeletionCopy {
                 "audioUnavailableHelp called for .saved state; callers should show positive help text instead.")
             return "Meeting audio is available"
         case .removed:
-            return "Saved meeting audio has been removed"
+            return "Meeting audio is unavailable"
         case .missing:
             return "Meeting audio file is missing"
         case .notMeeting:

--- a/Sources/MacParakeet/Views/MeetingRecording/MeetingRowCard.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/MeetingRowCard.swift
@@ -25,6 +25,11 @@ struct MeetingRowCard<MenuContent: View>: View {
             HStack(alignment: .top, spacing: DesignSystem.Spacing.md) {
                 rowActivationButton
 
+                if audioState == .removed {
+                    MeetingAudioStateChip(state: audioState)
+                        .padding(.top, 2)
+                }
+
                 if showsRetryButton {
                     retryButton
                         .padding(.top, 4)
@@ -151,6 +156,11 @@ struct MeetingRowCard<MenuContent: View>: View {
                 .contentTransition(.opacity)
                 .layoutPriority(1)
 
+            if transcription.isFavorite {
+                FavoriteStatusMarker()
+                    .fixedSize()
+            }
+
             if sourceLabelStyle != .hidden {
                 sourceInline
             }
@@ -186,7 +196,7 @@ struct MeetingRowCard<MenuContent: View>: View {
 
     @ViewBuilder
     private var audioInline: some View {
-        if showsAudioInline {
+        if audioState == .missing {
             MeetingAudioStateChip(state: audioState)
         }
     }
@@ -366,7 +376,7 @@ struct MeetingRowCard<MenuContent: View>: View {
         case .saved:
             return "Transcription failed — audio is saved"
         case .removed:
-            return "Transcription failed — audio removed"
+            return "Transcription failed — audio unavailable"
         case .missing:
             return "Transcription failed — audio missing"
         case .notMeeting:
@@ -398,14 +408,8 @@ struct MeetingRowCard<MenuContent: View>: View {
             : "Saved meeting audio is required before retrying transcription"
     }
 
-    private var showsAudioInline: Bool {
-        guard audioState != .notMeeting else { return false }
-        return transcription.status != .error && transcription.status != .cancelled
-    }
-
     private func statusLine(_ prefix: String) -> String {
-        guard let suffix = audioStateSuffix else { return prefix }
-        return "\(prefix) · \(suffix)"
+        prefix
     }
 
     private var audioStateSuffix: String? {
@@ -413,7 +417,7 @@ struct MeetingRowCard<MenuContent: View>: View {
         case .saved:
             return "audio saved"
         case .removed:
-            return "audio removed"
+            return "audio unavailable"
         case .missing:
             return "audio missing"
         case .notMeeting:

--- a/Sources/MacParakeet/Views/Transcription/FavoriteStatusMarker.swift
+++ b/Sources/MacParakeet/Views/Transcription/FavoriteStatusMarker.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+struct FavoriteStatusMarker: View {
+    var body: some View {
+        Image(systemName: "star.fill")
+            .font(.system(size: 11, weight: .semibold))
+            .foregroundStyle(DesignSystem.Colors.warningAmber)
+            .help("Favorite")
+            .accessibilityLabel("Favorite")
+    }
+}

--- a/Sources/MacParakeet/Views/Transcription/PromptLibraryView.swift
+++ b/Sources/MacParakeet/Views/Transcription/PromptLibraryView.swift
@@ -578,21 +578,14 @@ struct PromptLibraryView: View {
                     if viewModel.hasCustomTargetingRules(for: prompt) {
                         Label("Custom availability", systemImage: "slider.horizontal.3")
                     } else if !targetLabels.isEmpty {
-                        ForEach(Array(targetLabels.prefix(3).enumerated()), id: \.element.id) { index, label in
+                        ForEach(targetLabels.prefix(3)) { label in
+                            let tint = MeetingLabelTint.color(for: label)
                             Label(label.name, systemImage: "tag.fill")
-                                .foregroundStyle(
-                                    MeetingClassificationTint.color(
-                                        for: label.colorToken,
-                                        fallback: index + 1
-                                    )
-                                )
+                                .foregroundStyle(tint)
                                 .padding(.horizontal, 7)
                                 .padding(.vertical, 3)
                                 .background(
-                                    MeetingClassificationTint.color(
-                                        for: label.colorToken,
-                                        fallback: index + 1
-                                    ).opacity(0.1)
+                                    tint.opacity(0.1)
                                 )
                                 .clipShape(Capsule())
                         }
@@ -1051,10 +1044,9 @@ struct PromptLibraryView: View {
                 }
                 .buttonStyle(.plain)
 
-                ForEach(Array(promptTargetingLabels(selection: selection).enumerated()), id: \.element.id) {
-                    index, label in
+                ForEach(promptTargetingLabels(selection: selection)) { label in
                     let selected = !hasCustomRules && selection.wrappedValue.contains(label.id)
-                    let tint = MeetingClassificationTint.color(for: label.colorToken, fallback: index + 1)
+                    let tint = MeetingLabelTint.color(for: label)
                     Button {
                         if selected {
                             selection.wrappedValue.remove(label.id)

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
@@ -1695,6 +1695,11 @@ struct TranscriptResultView: View {
                     .foregroundStyle(DesignSystem.Colors.textPrimary)
                     .lineLimit(headerExpanded ? 3 : 1)
 
+                if transcription.isFavorite {
+                    FavoriteStatusMarker()
+                        .fixedSize()
+                }
+
                 if canRenameTitle {
                     Button(action: beginTitleRename) {
                         Image(systemName: "pencil")

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionLibraryView.swift
@@ -915,16 +915,12 @@ struct TranscriptionLibraryView: View {
                 .font(.system(size: 40, weight: .light))
                 .foregroundStyle(DesignSystem.Colors.textTertiary)
             Text(
-                viewModel.searchText.isEmpty
-                    ? emptyStateTitle
-                    : "No matching transcriptions"
+                emptyStateTitle
             )
             .font(DesignSystem.Typography.body)
             .foregroundStyle(DesignSystem.Colors.textSecondary)
             Text(
-                viewModel.searchText.isEmpty
-                    ? emptyStateMessage
-                    : "Try different words or clear your search."
+                emptyStateMessage
             )
             .font(DesignSystem.Typography.bodySmall)
             .foregroundStyle(DesignSystem.Colors.textTertiary)
@@ -1070,18 +1066,38 @@ struct TranscriptionLibraryView: View {
     }
 
     private var emptyStateIcon: String {
+        if hasLabelFilter { return "tag" }
         if !viewModel.searchText.isEmpty { return "magnifyingglass" }
         return isMeetingContext ? "waveform.badge.mic" : "square.grid.2x2"
     }
 
     private var emptyStateTitle: String {
-        isMeetingContext ? "No meetings recorded yet" : emptyTitle
+        if hasLabelFilter {
+            if !viewModel.searchText.isEmpty {
+                return isMeetingContext
+                    ? "No meetings match this search and these labels"
+                    : "No transcriptions match this search and these labels"
+            }
+            return isMeetingContext ? "No meetings match these labels" : "No transcriptions match these labels"
+        }
+        if !viewModel.searchText.isEmpty { return "No matching transcriptions" }
+        return isMeetingContext ? "No meetings recorded yet" : emptyTitle
     }
 
     private var emptyStateMessage: String {
-        isMeetingContext
+        if hasLabelFilter {
+            return viewModel.searchText.isEmpty
+                ? "Clear filters to show every transcription."
+                : "Clear filters or search to broaden the results."
+        }
+        if !viewModel.searchText.isEmpty { return "Try different words or clear your search." }
+        return isMeetingContext
             ? "Press Record Meeting on the Transcribe tab to capture system audio and transcribe locally."
             : emptyMessage
+    }
+
+    private var hasLabelFilter: Bool {
+        !viewModel.selectedMeetingLabelIDs.isEmpty
     }
 }
 

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionThumbnailCard.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionThumbnailCard.swift
@@ -18,6 +18,30 @@ struct TranscriptionThumbnailCard<MenuContent: View>: View {
     @State private var hovered = false
 
     var body: some View {
+        ZStack(alignment: .bottomTrailing) {
+            cardButton
+
+            if showsUnavailableAudioIndicator {
+                MeetingAudioStateChip(state: .removed)
+                    .padding(8)
+            }
+        }
+        .accessibilityElement(children: .contain)
+        .onHover { hovered = $0 }
+        .animation(DesignSystem.Animation.hoverTransition, value: hovered)
+        .onAppear {
+            // If not locally cached, trigger background download so it's cached for next render
+            if sharedThumbnailCache.cachedThumbnail(for: transcription.id) == nil,
+               let urlString = transcription.thumbnailURL {
+                let id = transcription.id
+                Task.detached(priority: .utility) {
+                    _ = try? await ThumbnailCacheService.shared.downloadThumbnail(from: urlString, for: id)
+                }
+            }
+        }
+    }
+
+    private var cardButton: some View {
         Button(action: onTap) {
             VStack(alignment: .leading, spacing: 0) {
                 thumbnailArea
@@ -55,24 +79,6 @@ struct TranscriptionThumbnailCard<MenuContent: View>: View {
             moreButton
                 .opacity(hovered ? 1 : 0)
                 .allowsHitTesting(hovered)
-        }
-        .overlay(alignment: .bottomTrailing) {
-            if showsUnavailableAudioIndicator {
-                MeetingAudioStateChip(state: .removed)
-                    .padding(8)
-            }
-        }
-        .onHover { hovered = $0 }
-        .animation(DesignSystem.Animation.hoverTransition, value: hovered)
-        .onAppear {
-            // If not locally cached, trigger background download so it's cached for next render
-            if sharedThumbnailCache.cachedThumbnail(for: transcription.id) == nil,
-               let urlString = transcription.thumbnailURL {
-                let id = transcription.id
-                Task.detached(priority: .utility) {
-                    _ = try? await ThumbnailCacheService.shared.downloadThumbnail(from: urlString, for: id)
-                }
-            }
         }
         .accessibilityValue(showsSelectionControls ? (isSelected ? "Selected" : "Not selected") : "")
         .accessibilityHint(showsSelectionControls ? "Toggles selection" : "Opens transcription")

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionThumbnailCard.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionThumbnailCard.swift
@@ -56,6 +56,12 @@ struct TranscriptionThumbnailCard<MenuContent: View>: View {
                 .opacity(hovered ? 1 : 0)
                 .allowsHitTesting(hovered)
         }
+        .overlay(alignment: .bottomTrailing) {
+            if showsUnavailableAudioIndicator {
+                MeetingAudioStateChip(state: .removed)
+                    .padding(8)
+            }
+        }
         .onHover { hovered = $0 }
         .animation(DesignSystem.Animation.hoverTransition, value: hovered)
         .onAppear {
@@ -228,11 +234,19 @@ struct TranscriptionThumbnailCard<MenuContent: View>: View {
 
     private var infoArea: some View {
         VStack(alignment: .leading, spacing: 4) {
-            highlightedText(displayTitle)
-                .font(DesignSystem.Typography.bodySmall.weight(.medium))
-                .foregroundStyle(DesignSystem.Colors.textPrimary)
-                .lineLimit(2)
-                .truncationMode(.tail)
+            HStack(alignment: .firstTextBaseline, spacing: 5) {
+                highlightedText(displayTitle)
+                    .font(DesignSystem.Typography.bodySmall.weight(.medium))
+                    .foregroundStyle(DesignSystem.Colors.textPrimary)
+                    .lineLimit(2)
+                    .truncationMode(.tail)
+                    .layoutPriority(1)
+
+                if transcription.isFavorite {
+                    FavoriteStatusMarker()
+                        .fixedSize()
+                }
+            }
 
             if let channelName = transcription.channelName {
                 highlightedText(channelName)
@@ -256,7 +270,9 @@ struct TranscriptionThumbnailCard<MenuContent: View>: View {
 
             transcriptionStatus
 
-            if transcription.sourceType == .meeting {
+            if transcription.sourceType == .meeting,
+                MeetingAudioFile.state(for: transcription) == .missing
+            {
                 MeetingAudioStateChip(state: MeetingAudioFile.state(for: transcription))
             }
 
@@ -286,8 +302,13 @@ struct TranscriptionThumbnailCard<MenuContent: View>: View {
             MeetingClassificationBadges(classification: classification)
         }
         .padding(DesignSystem.Spacing.sm)
+        .padding(.trailing, showsUnavailableAudioIndicator ? 36 : 0)
         .frame(maxWidth: .infinity, alignment: .leading)
         .frame(minHeight: 100, alignment: .top)
+    }
+
+    private var showsUnavailableAudioIndicator: Bool {
+        transcription.sourceType == .meeting && MeetingAudioFile.state(for: transcription) == .removed
     }
 
     @ViewBuilder

--- a/Tests/MacParakeetTests/ViewModels/TranscriptionLibraryViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/TranscriptionLibraryViewModelTests.swift
@@ -237,6 +237,35 @@ final class TranscriptionLibraryViewModelTests: XCTestCase {
         XCTAssertEqual(Set(viewModel.filteredTranscriptions.map(\.fileName)), ["First", "Second"])
     }
 
+    func testClearingLabelFiltersPreservesAssignments() async throws {
+        let manager = try DatabaseManager()
+        let transcriptionRepo = TranscriptionRepository(dbQueue: manager.dbQueue)
+        let labelRepo = MeetingLabelRepository(dbQueue: manager.dbQueue)
+        let assignmentRepo = TranscriptionMeetingLabelRepository(dbQueue: manager.dbQueue)
+        let customer = MeetingLabel(name: "Customer")
+        try labelRepo.save(customer)
+
+        let labeled = Transcription(fileName: "Labeled", status: .completed, sourceType: .meeting)
+        let other = Transcription(fileName: "Other", status: .completed, sourceType: .meeting)
+        try transcriptionRepo.save(labeled)
+        try transcriptionRepo.save(other)
+        try assignmentRepo.add(labelId: customer.id, to: labeled.id)
+
+        let viewModel = TranscriptionLibraryViewModel(scope: .meetings)
+        viewModel.configure(transcriptionRepo: transcriptionRepo)
+        viewModel.toggleMeetingLabelFilter(customer.id)
+        await load(viewModel)
+        XCTAssertEqual(viewModel.filteredTranscriptions.map(\.fileName), ["Labeled"])
+
+        viewModel.clearMeetingClassificationFilters()
+        await load(viewModel)
+        XCTAssertEqual(Set(viewModel.filteredTranscriptions.map(\.fileName)), ["Labeled", "Other"])
+
+        viewModel.toggleMeetingLabelFilter(customer.id)
+        await load(viewModel)
+        XCTAssertEqual(viewModel.filteredTranscriptions.map(\.fileName), ["Labeled"])
+    }
+
     func testLabelFilterAppliesInsidePodcastSourceTab() async throws {
         let manager = try DatabaseManager()
         let transcriptionRepo = TranscriptionRepository(dbQueue: manager.dbQueue)

--- a/Tests/MacParakeetTests/Views/MeetingLabelTintTests.swift
+++ b/Tests/MacParakeetTests/Views/MeetingLabelTintTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+import MacParakeetCore
+@testable import MacParakeet
+
+final class MeetingLabelTintTests: XCTestCase {
+    func testAutomaticColorUsesLabelIdentityAcrossRenameAndReordering() throws {
+        let id = try XCTUnwrap(UUID(uuidString: "10000000-0000-0000-0000-000000000001"))
+        let planning = MeetingLabel(id: id, name: "Planning")
+        let renamed = MeetingLabel(id: id, name: "Customer planning")
+
+        XCTAssertEqual(
+            MeetingLabelTint.colorKey(for: planning),
+            MeetingLabelTint.colorKey(for: renamed)
+        )
+
+        let other = MeetingLabel(
+            id: try XCTUnwrap(UUID(uuidString: "20000000-0000-0000-0000-000000000002")),
+            name: "Research"
+        )
+        let reordered = [other, planning].map(MeetingLabelTint.colorKey(for:))
+
+        XCTAssertEqual(reordered[1], MeetingLabelTint.colorKey(for: planning))
+    }
+
+    func testExplicitTokensTakePrecedenceIncludingBlue() throws {
+        let id = try XCTUnwrap(UUID(uuidString: "30000000-0000-0000-0000-000000000003"))
+
+        XCTAssertEqual(
+            MeetingLabelTint.colorKey(for: MeetingLabel(id: id, name: "Blue", colorToken: "blue")),
+            .blue
+        )
+        XCTAssertEqual(
+            MeetingLabelTint.colorKey(for: MeetingLabel(id: id, name: "Coral", colorToken: "orange")),
+            .coral
+        )
+    }
+
+    func testUnknownTokenKeepsTheIdentityFallbackWithoutChangingStoredValue() throws {
+        let id = try XCTUnwrap(UUID(uuidString: "40000000-0000-0000-0000-000000000004"))
+        let missingToken = MeetingLabel(id: id, name: "Research")
+        let unsupportedToken = MeetingLabel(id: id, name: "Research", colorToken: "magenta")
+
+        XCTAssertEqual(
+            MeetingLabelTint.colorKey(for: missingToken),
+            MeetingLabelTint.colorKey(for: unsupportedToken)
+        )
+        XCTAssertEqual(unsupportedToken.colorToken, "magenta")
+    }
+}

--- a/docs/plans/2026-09-08-library-ui-polish.md
+++ b/docs/plans/2026-09-08-library-ui-polish.md
@@ -1,0 +1,29 @@
+# Library UI polish — implementation plan
+
+Status: approved for implementation and PR/merge on September 8, 2026.
+Base: origin/main edfaa4889b8beac34b28712829d3850f88bd8fd3.
+
+## Goal
+Make Library classification and status legible, compact, and consistent while preserving current card structure, persistence, filtering semantics, and actions.
+
+## Settled behavior
+- Label assignment popover: full-width search at top; selected chips in separate wrapping area; compact content-sized container with bounded scrollable results. Display available labels even with empty query. All matches reachable (remove prefix(4)); create row near search for valid new label. Preserve create/assign/remove/error behavior. Keyboard search/Return selection, Escape dismissal, focus, and VoiceOver names must work.
+- Labels use one shared identity-based color resolver across cards, list, detail, filter, selected editor chips, suggestions, prompt targeting. Honor supported explicit stored tokens including blue. Missing/unknown tokens map deterministically from UUID bytes, never index, name, hashValue. No migration, stored value rewriting, or color picker.
+- Filter: searchable vertical rows with color dot, label name, selection check; compact Labels/count trigger and Clear action. Show selected option. Explain Match any selected label. Preserve repository OR semantics, selected filters through search, and distinguish clearing query/filter from removing an assignment. No new Any/All mode or persistent row of every filter pill.
+- Routine audio state: remove repeated Audio saved/removed text pills from grid/list. Use a small accessible status icon in existing metadata layout, with tooltip and focusable/activatable explanation for unavailability. Existing item audio actions remain; do not add playback button plumbing just for this pass. Missing audio and partial capture retain explicit amber warnings. No retention/files/database changes. Removed means no retained path, not proof of user deletion.
+- Favorite: small persistent filled amber star near title for favorited items in grid/list/detail, tooltip and accessibility Favorite. Passive marker plus existing context menu; no empty stars on all other items. Preserve toggling/filter persistence. Applies to recordings, imports, URLs.
+- Preserve current card dimensions/thumbnails. Compact-card redesign and generated covers belong elsewhere.
+
+## Source map
+MeetingClassificationControls.swift: editor232–364, fixed340x210 popover655–669, tint860–870. Positional fallback also used in badges/filter/prompt views. MeetingAudioStateChip.swift; TranscriptionThumbnailCard.swift; MeetingRowCard.swift; TranscriptResultView.swift; PromptLibraryView.swift.
+
+## Invariants and verification
+UI presentation only: no public CLI signature or schema changes, no core capture processing edits, no personal data or private screenshot fixtures. Use existing parakeetAction style. Cover empty/many/long labels and explicit/unknown stable colors. Check filter selection and audio warning semantics with meaningful focused tests, build Swift6 clean, inspect native synthetic-data presentation if practical. User will perform live visual QA after merge.
+
+## Ordered execution and ownership
+Worker owns this isolated worktree, implementation, relevant focused tests, and spec/04-ui-patterns.md updates. Other worktrees are active: never modify or revert them. Read current governing specs before edits; add final behavior there, not new REQ IDs. No full swift test locally: root owns the single final combined full-suite run after integration. Do not launch/restart user's app; root coordinates final rebuild. Limit Swift build concurrency to avoid process exhaustion (e.g. --jobs 4).
+
+Commit reviewed-ready work with rich intent, push branch and open PR against main, but do not merge; root reviews/checks exact head and owns merge. Use explicit file staging. Record focused commands/counts, compile result, changes/deviations, and remaining native QA. Checkpoint a durable commit after focused checks; do not invoke a gate that silently runs another full suite.
+
+## Review and landing
+Independent review of UI state, accessibility and failure paths; fix findings then relevant focused checks. Hosted CI on current head; merge this PR before recording-cover PR. Root will use direct focused checks plus independent review because two automatic baseline full-suite gates would duplicate the single combined local suite budget. No website deployment or release publication.

--- a/spec/04-ui-patterns.md
+++ b/spec/04-ui-patterns.md
@@ -122,7 +122,7 @@ The tile body is informational. Only the visible Start and Stop capsules are rea
 
 ### Library Layouts and Meeting States
 
-When list mode is selected, the view renders a date-grouped list (`Today` / `Yesterday` / `Previous 7 Days` / `Previous 30 Days` / `{Month Year}`) using `MeetingDateGroupHeader` + `MeetingRowCard`. Meeting rows surface saved-audio state directly (`Audio saved`, `Audio removed`, or `Audio missing`) so playback/retranscription expectations are visible before the user opens a menu.
+When list mode is selected, the view renders a date-grouped list (`Today` / `Yesterday` / `Previous 7 Days` / `Previous 30 Days` / `{Month Year}`) using `MeetingDateGroupHeader` + `MeetingRowCard`. Routine retained-audio state does not add repeated text pills: retained audio has no marker, while no retained path uses a quiet crossed-waveform icon with a tooltip and keyboard-accessible explanation that the transcript remains available. A no-retained-path state is not proof that a user deleted the audio. Unexpected missing audio remains an explicit amber warning so recovery expectations stay visible before the user opens a menu.
 
 A finalized meeting whose `meetingCaptureReport.quality` is `partial` shows the
 existing **Partial audio** badge in both its Library row and thumbnail card, and
@@ -160,14 +160,21 @@ contextual actions, pagination, export, and bulk selection behave identically in
 either layout.
 
 Thumbnail cards show transcription failure, stopped transcription, and pending
-background transcription independently of saved-audio state. Queued and running
+background transcription independently of routine retained-audio state. Queued and running
 finalization both use the persisted `processing` status and the existing
 **Transcribing** presentation, never a completed claim. A stale or partial snippet
-must not hide a card's non-completed status. Card metadata grows to fit lifecycle,
-saved-audio, recovery, and partial-capture labels rather than clipping them to a
-fixed height.
+must not hide a card's non-completed status. Missing audio, recovery, and
+partial-capture warnings remain explicit rather than being compressed into a
+routine state icon.
 List rows retain their existing snippet-first preview behavior, including while
 a meeting with saved transcript text is being retranscribed.
+
+Favorited Library items show a small filled amber star beside their title in
+grid, list, and transcript detail. It is a passive status marker with a
+**Favorite** tooltip and accessibility label; the existing item menu keeps the
+Add/Remove Favorite action. Unfavorited items show no empty star. The marker
+applies consistently to meetings, imports, and URLs without changing favorite
+persistence or filtering.
 
 Opening an empty processing meeting row must preserve that same lifecycle
 truth. The transcript pane shows an indeterminate "Transcribing meeting"
@@ -190,8 +197,9 @@ Label editing uses a compact popover anchored to the action that opened it from
 Library, the Meetings workspace, or any saved-transcription detail. Labels are
 shared by meetings, podcasts, videos, and local files. The popover floats above
 the current context without masking or resizing it and is never presented as a
-blocking sheet. It does not repeat the transcription title or add its own
-heading; clicking outside or pressing Escape dismisses it.
+blocking sheet. It has a **Labels** heading, a focused full-width **Search or
+create a label** field, and a content-sized results region capped to the space
+available for the popover. Clicking outside or pressing Escape dismisses it.
 
 The source tabs — Meetings, Podcasts, Video, and Local — are the transcription
 types. The product does not add a second, user-defined "meeting type" taxonomy.
@@ -205,16 +213,28 @@ podcasts, videos, and local files. The same availability gate applies before
 automatic generation; the prompt's existing per-source Auto-Run setting remains
 the source of truth for whether matching content runs automatically.
 
-Library's label filter opens a compact popover with an integrated search field.
-Its options use colored, wrapping chips instead of vertical menu rows, allowing
-multi-selection at a glance in every source tab.
+The label editor keeps assigned labels in a separate wrapping token area below
+search. Available labels appear even with an empty query; every match is
+reachable by scrolling, and a valid unmatched query puts **Create “name”** next
+to the available-label results. Selected and available rows use a color dot,
+name, and state icon; tokens retain a reachable remove action. Pressing Return
+reuses an exact match or creates and immediately assigns a new value. Long
+labels truncate visually only after preserving their full tooltip and
+accessibility name.
 
-Labels use the same search-or-create semantics with live suggestions from
-existing labels. Assigned labels render as removable
-tokens on the same row as the input; the token area scrolls horizontally so the
-control stays one line tall. Pressing Return reuses an exact match or
-creates and immediately assigns a new value; there is no separate **Add**
-button.
+Every rendering of a label resolves its color from the same stored label ID:
+supported persisted tokens (`coral`/`orange`, `green`, `amber`/`yellow`, `red`,
+`purple`, and `blue`) take precedence; missing or unsupported tokens map
+deterministically from UUID bytes. Reordering, renaming, filtering, or restart
+does not change the color. This is display-only: no migration, stored-token
+rewrite, or color picker is implied.
+
+Library's compact **Labels** / **Labels · N** filter trigger opens a searchable
+vertical option list with color dots, names, and selected checks. It states
+**Match any selected label**, retains the existing OR query semantics, offers
+**Show selected**, and provides a scoped Clear action. Search or Show selected
+only changes visible options; neither removes a label assignment. No Any/All
+mode or persistent toolbar row of filter pills is added.
 
 ### Saved Meeting Notes
 


### PR DESCRIPTION
Polishes Library label assignment and filtering, keeps label colors stable by identity, and clarifies unavailable-audio and favorite status.

Design and review:

- [Approved implementation plan](https://github.com/moona3k/macparakeet/blob/dd6ece55d3c21a767fcb0c6a5589773d1b1f830f/docs/plans/2026-09-08-library-ui-polish.md); final behavior is recorded in `spec/04-ui-patterns.md`.
- Preserves label-filter OR semantics, storage, retention, and existing card layout. Recording artwork remains separate.
- The thumbnail's unavailable-audio control is a ZStack sibling of the card button: the card retains its accessibility label, value, and hint; the audio explanation is separately focusable. The 36-point metadata reserve remains in place.
- Independent Sol review is clear on exact head `dd6ece55d3c21a767fcb0c6a5589773d1b1f830f`. The only hosted Swift 6 diagnostic is resolved by making the label-popover PreferenceKey default immutable.

Validation:

- `swift test --jobs 4 --filter '(MeetingLabelTintTests|TranscriptionLibraryViewModelTests)'` — 61 passed
- `swift build --jobs 4` — passed
- `xcrun swiftc -swift-version 6 -typecheck /tmp/macparakeet-label-popover-height-key-swift6-20260908.swift` — passed
- `git diff --check` — passed
- Scoped Swift-format lint is clean for the label, audio, favorite, and empty-state files. Existing `TranscriptionThumbnailCard` lint debt remains outside the changed hunks.
- Hosted Swift 6 rerun is the full-target gate for `dd6ece55d3c21a767fcb0c6a5589773d1b1f830f`; no new local SwiftPM cache was created with 6.5 GiB free.

Native interaction smoke remains for the integrated QA pass; the app was not launched in this worktree.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Redesigned label filtering and editing with search, selected-only views, scrolling, clearer controls, and easier label creation.
  - Added consistent, deterministic colors for labels.
  - Added favorite star indicators throughout meeting and transcription views.
  - Added clearer audio availability indicators, warnings, and explanations for unavailable playback or retranscription.
  - Added label-aware empty states in the transcription library.

- **Bug Fixes**
  - Improved clearing and reapplying meeting label filters while preserving label assignments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Gate ownership: focused local tests and independent review precede hosted CI; the orchestrator owns one combined local full-suite run with the subsequent artwork change. Native interaction QA remains explicitly separate.
