### PR TITLE
feat(library): add deterministic Branching Field covers

### DIFF
--- a/Sources/MacParakeet/Views/Components/BranchingRecordingCoverView.swift
+++ b/Sources/MacParakeet/Views/Components/BranchingRecordingCoverView.swift
@@ -1,0 +1,191 @@
+import SwiftUI
+import MacParakeetCore
+
+/// Static, UUID-seeded artwork for a recording with no available image.
+///
+/// `BranchingRecordingCoverRecipe` is intentionally computed before `Canvas`
+/// draws. The canvas closure only maps its bounded, normalized geometry to the
+/// card's current size; it does not inspect recording content or schedule work.
+struct BranchingRecordingCoverView: View {
+    @State private var recipe: BranchingRecordingCoverRecipe
+
+    init(recordingID: UUID) {
+        _recipe = State(initialValue: BranchingRecordingCoverRecipe(recordingID: recordingID))
+    }
+
+    var body: some View {
+        Canvas { context, size in
+            let colors = recipe.palette.colors
+            let background = Color(colors.background)
+            let field = Color(colors.field)
+            let branch = Color(colors.branch)
+            let accent = Color(colors.accent)
+            let line = Color(colors.line)
+            let bounds = CGRect(origin: .zero, size: size)
+
+            context.fill(Path(bounds), with: .color(background))
+            context.fill(
+                Path(bounds),
+                with: .linearGradient(
+                    Gradient(colors: [field.opacity(0.58), background.opacity(0.15), branch.opacity(0.18)]),
+                    startPoint: CGPoint(x: 0, y: size.height),
+                    endPoint: CGPoint(x: size.width, y: 0)
+                )
+            )
+
+            for limb in recipe.limbs {
+                let pigment = color(for: limb.pigment, field: field, branch: branch, accent: accent)
+                let bodyPath = taperedPath(for: limb, in: size)
+                let start = point(limb.start, in: size)
+                let end = point(limb.end, in: size)
+                let centerline = curvedPath(for: limb, in: size)
+
+                context.fill(
+                    bodyPath,
+                    with: .linearGradient(
+                        Gradient(colors: [
+                            pigment.opacity(limb.opacity * 0.22),
+                            pigment.opacity(limb.opacity * 0.72),
+                        ]),
+                        startPoint: start,
+                        endPoint: end
+                    )
+                )
+                context.stroke(
+                    centerline,
+                    with: .color(line.opacity(0.20 + limb.opacity * 0.24)),
+                    lineWidth: max(0.45, min(size.width, size.height) * CGFloat(limb.endWidth) * 0.18)
+                )
+            }
+
+            let focalPoint = point(recipe.focalPoint, in: size)
+            let focalRadius = max(2, min(size.width, size.height) * 0.055)
+            let aura = Path(
+                ellipseIn: CGRect(
+                    x: focalPoint.x - focalRadius * 2.5,
+                    y: focalPoint.y - focalRadius * 2.5,
+                    width: focalRadius * 5,
+                    height: focalRadius * 5
+                ))
+            context.fill(
+                aura,
+                with: .radialGradient(
+                    Gradient(colors: [accent.opacity(0.42), accent.opacity(0.06), .clear]),
+                    center: focalPoint,
+                    startRadius: 0,
+                    endRadius: focalRadius * 2.5
+                )
+            )
+            context.fill(
+                Path(
+                    ellipseIn: CGRect(
+                        x: focalPoint.x - focalRadius * 0.28,
+                        y: focalPoint.y - focalRadius * 0.28,
+                        width: focalRadius * 0.56,
+                        height: focalRadius * 0.56
+                    )),
+                with: .color(accent.opacity(0.92))
+            )
+        }
+        .accessibilityHidden(true)
+    }
+
+    private func color(
+        for pigment: BranchingRecordingCoverPigment,
+        field: Color,
+        branch: Color,
+        accent: Color
+    ) -> Color {
+        switch pigment {
+        case .field: field
+        case .branch: branch
+        case .accent: accent
+        }
+    }
+
+    private func taperedPath(for limb: BranchingRecordingCoverLimb, in size: CGSize) -> Path {
+        let start = point(limb.start, in: size)
+        let control = point(limb.control, in: size)
+        let end = point(limb.end, in: size)
+        let minimumSize = min(size.width, size.height)
+        let startOffset = normal(from: start, to: control).scaled(by: minimumSize * CGFloat(limb.startWidth) * 0.5)
+        let endOffset = normal(from: control, to: end).scaled(by: minimumSize * CGFloat(limb.endWidth) * 0.5)
+        let controlOffset = (startOffset + endOffset).scaled(by: 0.5)
+        let outerControls = cubicControls(
+            from: start + startOffset,
+            through: control + controlOffset,
+            to: end + endOffset
+        )
+        let innerControls = cubicControls(
+            from: end - endOffset,
+            through: control - controlOffset,
+            to: start - startOffset
+        )
+
+        var path = Path()
+        path.move(to: start + startOffset)
+        path.addCurve(
+            to: end + endOffset,
+            control1: outerControls.0,
+            control2: outerControls.1
+        )
+        path.addLine(to: end - endOffset)
+        path.addCurve(
+            to: start - startOffset,
+            control1: innerControls.0,
+            control2: innerControls.1
+        )
+        path.closeSubpath()
+        return path
+    }
+
+    private func curvedPath(for limb: BranchingRecordingCoverLimb, in size: CGSize) -> Path {
+        let start = point(limb.start, in: size)
+        let end = point(limb.end, in: size)
+        let controls = cubicControls(from: start, through: point(limb.control, in: size), to: end)
+        var path = Path()
+        path.move(to: start)
+        path.addCurve(to: end, control1: controls.0, control2: controls.1)
+        return path
+    }
+
+    /// Converts the shared quadratic shape model into equivalent cubic controls
+    /// so filled tapered limbs and their center strokes bend together.
+    private func cubicControls(from start: CGPoint, through control: CGPoint, to end: CGPoint) -> (CGPoint, CGPoint) {
+        (
+            start + (control - start).scaled(by: 2.0 / 3.0),
+            end + (control - end).scaled(by: 2.0 / 3.0)
+        )
+    }
+
+    private func point(_ point: BranchingRecordingCoverPoint, in size: CGSize) -> CGPoint {
+        CGPoint(x: point.x * size.width, y: point.y * size.height)
+    }
+
+    private func normal(from start: CGPoint, to end: CGPoint) -> CGPoint {
+        let dx = end.x - start.x
+        let dy = end.y - start.y
+        let length = max(0.0001, hypot(dx, dy))
+        return CGPoint(x: -dy / length, y: dx / length)
+    }
+}
+
+private extension Color {
+    init(_ color: BranchingRecordingCoverColor) {
+        self.init(.sRGB, red: color.red, green: color.green, blue: color.blue, opacity: 1)
+    }
+}
+
+private extension CGPoint {
+    static func + (lhs: CGPoint, rhs: CGPoint) -> CGPoint {
+        CGPoint(x: lhs.x + rhs.x, y: lhs.y + rhs.y)
+    }
+
+    static func - (lhs: CGPoint, rhs: CGPoint) -> CGPoint {
+        CGPoint(x: lhs.x - rhs.x, y: lhs.y - rhs.y)
+    }
+
+    func scaled(by factor: CGFloat) -> CGPoint {
+        CGPoint(x: x * factor, y: y * factor)
+    }
+}

--- a/Sources/MacParakeet/Views/Transcription/TranscriptionThumbnailCard.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptionThumbnailCard.swift
@@ -181,7 +181,11 @@ struct TranscriptionThumbnailCard<MenuContent: View>: View {
                     image
                         .resizable()
                         .aspectRatio(contentMode: .fill)
-                default:
+                case .empty:
+                    remoteLoadingView
+                case .failure:
+                    placeholderView
+                @unknown default:
                     placeholderView
                 }
             }
@@ -204,32 +208,21 @@ struct TranscriptionThumbnailCard<MenuContent: View>: View {
     }
 
     private var placeholderView: some View {
+        BranchingRecordingCoverView(recordingID: transcription.id)
+            .id(transcription.id)
+    }
+
+    private var remoteLoadingView: some View {
         ZStack {
             DesignSystem.Colors.surfaceElevated
-
-            if let symbolText = sourceDisplay.symbolText {
-                Text(symbolText)
-                    .font(.system(size: 28, weight: .semibold))
-                    .foregroundStyle(sourceDisplay.tint)
-            } else {
-                Image(systemName: sourceIcon)
-                    .font(.system(size: 28, weight: .light))
-                    .foregroundStyle(DesignSystem.Colors.textTertiary)
-            }
+            ProgressView()
+                .controlSize(.small)
+                .tint(DesignSystem.Colors.textTertiary)
         }
     }
 
     private var displayTitle: String {
         transcription.effectiveDisplayTitle
-    }
-
-    private var sourceIcon: String {
-        if transcription.sourceType != .file {
-            return sourceDisplay.systemImage
-        }
-        let ext = transcription.filePath.map { URL(fileURLWithPath: $0).pathExtension.lowercased() } ?? ""
-        let videoExts: Set = ["mp4", "mov", "mkv", "avi", "webm", "m4v", "flv", "wmv"]
-        return videoExts.contains(ext) ? "film" : "waveform"
     }
 
     private var sourceDisplay: TranscriptionSourceDisplay {

--- a/Sources/MacParakeetCore/Models/BranchingRecordingCoverRecipe.swift
+++ b/Sources/MacParakeetCore/Models/BranchingRecordingCoverRecipe.swift
@@ -1,0 +1,328 @@
+import Foundation
+
+/// The fixed v1, UUID-only recipe for a missing-recording cover.
+///
+/// The recipe deliberately holds normalized geometry and palette decisions rather
+/// than a raster. SwiftUI owns drawing it in the app target; callers can reuse
+/// this small value without reading audio, transcript, database, or cache state.
+public struct BranchingRecordingCoverRecipe: Sendable, Equatable {
+    static let version = 1
+    static let maximumLimbCount = 96
+    /// A bounded amount of off-canvas growth keeps the clipped composition
+    /// organic without making a Canvas redraw unbounded.
+    static let maximumNormalizedCoordinateMagnitude = 2.0
+
+    public let palette: BranchingRecordingCoverPalette
+    public let focalPoint: BranchingRecordingCoverPoint
+    public let limbs: [BranchingRecordingCoverLimb]
+
+    public init(recordingID: UUID) {
+        var paletteFamilyRandom = SplitMix64(
+            seed: Self.stableSeed(for: recordingID, domain: "palette-family")
+        )
+        var paletteVariantRandom = SplitMix64(
+            seed: Self.stableSeed(for: recordingID, domain: "palette-variant")
+        )
+        palette = BranchingRecordingCoverPalette(
+            family: BranchingRecordingCoverPalette.Family.allCases[
+                paletteFamilyRandom.nextInt(upperBound: BranchingRecordingCoverPalette.Family.allCases.count)
+            ],
+            variant: paletteVariantRandom.nextInt(upperBound: BranchingRecordingCoverPalette.variantCount)
+        )
+
+        var geometryRandom = SplitMix64(
+            seed: Self.stableSeed(for: recordingID, domain: "geometry")
+        )
+        focalPoint = BranchingRecordingCoverPoint(
+            x: 0.43 + geometryRandom.nextUnit() * 0.14,
+            y: 0.42 + geometryRandom.nextUnit() * 0.16
+        )
+
+        var generatedLimbs: [BranchingRecordingCoverLimb] = []
+        // Six roots remain safely below the 96-limb cap even when every
+        // descendant splits at each of the three bounded depths (6 × 15 = 90).
+        let primaryCount = 5 + geometryRandom.nextInt(upperBound: 2)
+        let phase = geometryRandom.nextUnit() * Double.pi * 2
+
+        for index in 0..<primaryCount {
+            let angle =
+                phase
+                + (Double(index) / Double(primaryCount)) * Double.pi * 2
+                + (geometryRandom.nextUnit() - 0.5) * 0.30
+            Self.appendLimb(
+                from: focalPoint,
+                angle: angle,
+                // Keep the first generation compact enough that its smaller
+                // descendants remain legible inside a thumbnail.
+                length: 0.14 + geometryRandom.nextUnit() * 0.065,
+                width: 0.060 + geometryRandom.nextUnit() * 0.025,
+                depth: 0,
+                random: &geometryRandom,
+                limbs: &generatedLimbs
+            )
+        }
+
+        // Canvas receives this back-to-front order directly; do not sort in its
+        // drawing closure while a library grid is scrolling.
+        limbs = generatedLimbs.sorted { $0.depth > $1.depth }
+    }
+
+    /// FNV-1a over the recipe domain followed by the UUID's RFC 4122 bytes,
+    /// ordered exactly as the canonical UUID string's hex pairs. Do not replace
+    /// this with `hashValue`, whose seed changes between process launches.
+    static func stableSeed(for recordingID: UUID, domain: String) -> UInt64 {
+        var value: UInt64 = 0xCBF2_9CE4_8422_2325
+        let input = Array("MacParakeet.recording-cover.v\(version).\(domain)".utf8) + uuidBytes(recordingID)
+        for byte in input {
+            value ^= UInt64(byte)
+            value &*= 0x0000_0100_0000_01B3
+        }
+        return value
+    }
+
+    /// RFC 4122 network byte order, exposed internally so tests can pin this
+    /// contract without depending on the platform representation of `uuid_t`.
+    static func uuidBytes(_ recordingID: UUID) -> [UInt8] {
+        let value = recordingID.uuid
+        return [
+            value.0, value.1, value.2, value.3,
+            value.4, value.5, value.6, value.7,
+            value.8, value.9, value.10, value.11,
+            value.12, value.13, value.14, value.15,
+        ]
+    }
+
+    private static func appendLimb(
+        from start: BranchingRecordingCoverPoint,
+        angle: Double,
+        length: Double,
+        width: Double,
+        depth: Int,
+        random: inout SplitMix64,
+        limbs: inout [BranchingRecordingCoverLimb]
+    ) {
+        guard limbs.count < maximumLimbCount, depth <= 3, length >= 0.035 else { return }
+
+        let bend = (random.nextUnit() - 0.5) * (0.36 + Double(depth) * 0.08)
+        let endAngle = angle + bend
+        let endpoint = start.translated(
+            x: cos(endAngle) * length,
+            y: sin(endAngle) * length * (16.0 / 9.0)
+        )
+        let controlAngle = angle + bend * 0.35
+        let control = start.translated(
+            x: cos(controlAngle) * length * 0.53,
+            y: sin(controlAngle) * length * 0.53 * (16.0 / 9.0)
+        )
+        let pigment: BranchingRecordingCoverPigment
+        switch (depth + random.nextInt(upperBound: 3)) % 3 {
+        case 0: pigment = .field
+        case 1: pigment = .branch
+        default: pigment = .accent
+        }
+
+        limbs.append(
+            BranchingRecordingCoverLimb(
+                start: start,
+                control: control,
+                end: endpoint,
+                startWidth: width,
+                endWidth: width * (0.30 + random.nextUnit() * 0.16),
+                depth: depth,
+                pigment: pigment,
+                opacity: 0.84 - Double(depth) * 0.14
+            )
+        )
+
+        guard depth < 3 else { return }
+        let childCount: Int
+        if depth == 0 {
+            childCount = 2
+        } else {
+            childCount = random.nextUnit() < 0.68 ? 2 : 1
+        }
+
+        for childIndex in 0..<childCount where limbs.count < maximumLimbCount {
+            let side = childCount == 1 ? (random.nextUnit() - 0.5) : (childIndex == 0 ? -1.0 : 1.0)
+            let spread = 0.32 + random.nextUnit() * 0.28
+            appendLimb(
+                from: endpoint,
+                angle: endAngle + side * spread,
+                length: length * (0.53 + random.nextUnit() * 0.10),
+                width: width * (0.56 + random.nextUnit() * 0.07),
+                depth: depth + 1,
+                random: &random,
+                limbs: &limbs
+            )
+        }
+    }
+}
+
+public struct BranchingRecordingCoverPoint: Sendable, Equatable {
+    public let x: Double
+    public let y: Double
+
+    init(x: Double, y: Double) {
+        self.x = x
+        self.y = y
+    }
+
+    func translated(x: Double, y: Double) -> Self {
+        Self(x: self.x + x, y: self.y + y)
+    }
+}
+
+public struct BranchingRecordingCoverLimb: Sendable, Equatable {
+    public let start: BranchingRecordingCoverPoint
+    public let control: BranchingRecordingCoverPoint
+    public let end: BranchingRecordingCoverPoint
+    public let startWidth: Double
+    public let endWidth: Double
+    public let depth: Int
+    public let pigment: BranchingRecordingCoverPigment
+    public let opacity: Double
+}
+
+public enum BranchingRecordingCoverPigment: Sendable, Equatable {
+    case field
+    case branch
+    case accent
+}
+
+public struct BranchingRecordingCoverColor: Sendable, Equatable {
+    public let red: Double
+    public let green: Double
+    public let blue: Double
+
+    init(red: Double, green: Double, blue: Double) {
+        self.red = red
+        self.green = green
+        self.blue = blue
+    }
+}
+
+public struct BranchingRecordingCoverPalette: Sendable, Equatable {
+    enum Family: String, CaseIterable, Sendable {
+        case tidalStone
+        case lichenDusk
+        case plumMineral
+    }
+
+    static let variantCount = 3
+
+    let family: Family
+    let variant: Int
+    public let colors: BranchingRecordingCoverPaletteColors
+
+    init(family: Family, variant: Int) {
+        self.family = family
+        self.variant = min(max(variant, 0), Self.variantCount - 1)
+        colors = Self.resolvedColors(family: family, variant: self.variant)
+    }
+
+    private static func resolvedColors(
+        family: Family,
+        variant: Int
+    ) -> BranchingRecordingCoverPaletteColors {
+        let variants: [BranchingRecordingCoverPaletteColors]
+        switch family {
+        case .tidalStone:
+            variants = [
+                .init(
+                    background: .init(red: 0.063, green: 0.125, blue: 0.145),
+                    field: .init(red: 0.094, green: 0.318, blue: 0.345),
+                    branch: .init(red: 0.263, green: 0.651, blue: 0.647),
+                    accent: .init(red: 0.894, green: 0.643, blue: 0.376),
+                    line: .init(red: 0.718, green: 0.847, blue: 0.804)),
+                .init(
+                    background: .init(red: 0.078, green: 0.125, blue: 0.153),
+                    field: .init(red: 0.192, green: 0.322, blue: 0.376),
+                    branch: .init(red: 0.373, green: 0.624, blue: 0.714),
+                    accent: .init(red: 0.843, green: 0.604, blue: 0.408),
+                    line: .init(red: 0.761, green: 0.808, blue: 0.816)),
+                .init(
+                    background: .init(red: 0.075, green: 0.129, blue: 0.129),
+                    field: .init(red: 0.176, green: 0.333, blue: 0.314),
+                    branch: .init(red: 0.400, green: 0.678, blue: 0.596),
+                    accent: .init(red: 0.851, green: 0.651, blue: 0.396),
+                    line: .init(red: 0.769, green: 0.824, blue: 0.714)),
+            ]
+        case .lichenDusk:
+            variants = [
+                .init(
+                    background: .init(red: 0.082, green: 0.133, blue: 0.114),
+                    field: .init(red: 0.192, green: 0.365, blue: 0.282),
+                    branch: .init(red: 0.475, green: 0.706, blue: 0.553),
+                    accent: .init(red: 0.859, green: 0.647, blue: 0.392),
+                    line: .init(red: 0.765, green: 0.835, blue: 0.635)),
+                .init(
+                    background: .init(red: 0.106, green: 0.129, blue: 0.106),
+                    field: .init(red: 0.290, green: 0.353, blue: 0.212),
+                    branch: .init(red: 0.612, green: 0.698, blue: 0.459),
+                    accent: .init(red: 0.788, green: 0.604, blue: 0.400),
+                    line: .init(red: 0.835, green: 0.812, blue: 0.631)),
+                .init(
+                    background: .init(red: 0.090, green: 0.129, blue: 0.118),
+                    field: .init(red: 0.192, green: 0.337, blue: 0.314),
+                    branch: .init(red: 0.416, green: 0.667, blue: 0.616),
+                    accent: .init(red: 0.867, green: 0.631, blue: 0.408),
+                    line: .init(red: 0.722, green: 0.816, blue: 0.694)),
+            ]
+        case .plumMineral:
+            variants = [
+                .init(
+                    background: .init(red: 0.129, green: 0.098, blue: 0.145),
+                    field: .init(red: 0.388, green: 0.243, blue: 0.376),
+                    branch: .init(red: 0.678, green: 0.459, blue: 0.635),
+                    accent: .init(red: 0.886, green: 0.631, blue: 0.443),
+                    line: .init(red: 0.839, green: 0.706, blue: 0.792)),
+                .init(
+                    background: .init(red: 0.129, green: 0.106, blue: 0.145),
+                    field: .init(red: 0.318, green: 0.235, blue: 0.408),
+                    branch: .init(red: 0.549, green: 0.467, blue: 0.714),
+                    accent: .init(red: 0.851, green: 0.616, blue: 0.459),
+                    line: .init(red: 0.780, green: 0.725, blue: 0.855)),
+                .init(
+                    background: .init(red: 0.145, green: 0.106, blue: 0.125),
+                    field: .init(red: 0.412, green: 0.275, blue: 0.314),
+                    branch: .init(red: 0.725, green: 0.478, blue: 0.518),
+                    accent: .init(red: 0.886, green: 0.627, blue: 0.427),
+                    line: .init(red: 0.851, green: 0.722, blue: 0.733)),
+            ]
+        }
+        return variants[variant]
+    }
+}
+
+public struct BranchingRecordingCoverPaletteColors: Sendable, Equatable {
+    public let background: BranchingRecordingCoverColor
+    public let field: BranchingRecordingCoverColor
+    public let branch: BranchingRecordingCoverColor
+    public let accent: BranchingRecordingCoverColor
+    public let line: BranchingRecordingCoverColor
+}
+
+private struct SplitMix64 {
+    private var state: UInt64
+
+    init(seed: UInt64) {
+        state = seed
+    }
+
+    mutating func nextUnit() -> Double {
+        Double(next() >> 11) * (1.0 / 9_007_199_254_740_992.0)
+    }
+
+    mutating func nextInt(upperBound: Int) -> Int {
+        precondition(upperBound > 0)
+        return Int(next() % UInt64(upperBound))
+    }
+
+    private mutating func next() -> UInt64 {
+        state &+= 0x9E37_79B9_7F4A_7C15
+        var value = state
+        value = (value ^ (value >> 30)) &* 0xBF58_476D_1CE4_E5B9
+        value = (value ^ (value >> 27)) &* 0x94D0_49BB_1331_11EB
+        return value ^ (value >> 31)
+    }
+}

--- a/Tests/MacParakeetTests/Models/BranchingRecordingCoverRecipeTests.swift
+++ b/Tests/MacParakeetTests/Models/BranchingRecordingCoverRecipeTests.swift
@@ -1,0 +1,145 @@
+import Foundation
+import XCTest
+@testable import MacParakeetCore
+
+final class BranchingRecordingCoverRecipeTests: XCTestCase {
+    func testStableUUIDBytesUseCanonicalRFC4122Order() throws {
+        let id = try XCTUnwrap(UUID(uuidString: "00112233-4455-6677-8899-AABBCCDDEEFF"))
+
+        XCTAssertEqual(
+            BranchingRecordingCoverRecipe.uuidBytes(id),
+            [0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF]
+        )
+        XCTAssertEqual(
+            BranchingRecordingCoverRecipe.stableSeed(for: id, domain: "geometry"),
+            0x65B5_0BE2_B5BB_4987
+        )
+    }
+
+    func testSameUUIDAlwaysProducesTheSameRecipe() throws {
+        let id = try XCTUnwrap(UUID(uuidString: "85B4897C-4F5D-4ED1-94EB-C0B5841B1EF5"))
+
+        XCTAssertEqual(
+            BranchingRecordingCoverRecipe(recordingID: id),
+            BranchingRecordingCoverRecipe(recordingID: id)
+        )
+    }
+
+    func testRepresentativeUUIDPinsV1PaletteFocalPointAndGeometry() throws {
+        let id = try XCTUnwrap(UUID(uuidString: "85B4897C-4F5D-4ED1-94EB-C0B5841B1EF5"))
+        let recipe = BranchingRecordingCoverRecipe(recordingID: id)
+
+        XCTAssertEqual(recipe.palette.family, .tidalStone)
+        XCTAssertEqual(recipe.palette.variant, 0)
+        XCTAssertEqual(quantized(recipe.focalPoint.x), 453_199)
+        XCTAssertEqual(quantized(recipe.focalPoint.y), 435_403)
+        XCTAssertEqual(recipeDigest(recipe), 0xE13C_E9C0_6B60_0272)
+    }
+
+    func testRepresentativeUUIDsProduceDistinctBoundedFiniteGeometry() throws {
+        let recipes = try [
+            "00112233-4455-6677-8899-AABBCCDDEEFF",
+            "11112233-4455-6677-8899-AABBCCDDEEFF",
+            "22212233-4455-6677-8899-AABBCCDDEEFF",
+            "33312233-4455-6677-8899-AABBCCDDEEFF",
+            "44412233-4455-6677-8899-AABBCCDDEEFF",
+            "55512233-4455-6677-8899-AABBCCDDEEFF",
+        ].map { value in
+            BranchingRecordingCoverRecipe(recordingID: try XCTUnwrap(UUID(uuidString: value)))
+        }
+
+        for recipe in recipes {
+            XCTAssertLessThanOrEqual(recipe.limbs.count, BranchingRecordingCoverRecipe.maximumLimbCount)
+            XCTAssertFalse(recipe.limbs.isEmpty)
+            XCTAssertTrue((5...6).contains(recipe.limbs.filter { $0.depth == 0 }.count))
+            XCTAssertTrue(recipe.focalPoint.x.isFinite)
+            XCTAssertTrue(recipe.focalPoint.y.isFinite)
+            XCTAssertTrue(
+                recipe.limbs.allSatisfy { limb in
+                    [
+                        limb.start.x, limb.start.y, limb.control.x, limb.control.y,
+                        limb.end.x, limb.end.y, limb.startWidth, limb.endWidth, limb.opacity,
+                    ].allSatisfy(\.isFinite)
+                })
+        }
+
+        for (left, right) in zip(recipes, recipes.dropFirst()) {
+            XCTAssertNotEqual(left, right)
+        }
+    }
+
+    func testUUIDPaletteSelectionCoversTheThreeCuratedFamiliesWithoutQuotas() throws {
+        let recipes = try (0..<96).map { value in
+            let id = try XCTUnwrap(UUID(uuidString: String(format: "00000000-0000-0000-0000-%012X", value)))
+            return BranchingRecordingCoverRecipe(recordingID: id)
+        }
+
+        XCTAssertEqual(Set(recipes.map(\.palette.family)), Set(BranchingRecordingCoverPalette.Family.allCases))
+        XCTAssertTrue(recipes.allSatisfy { 0..<BranchingRecordingCoverPalette.variantCount ~= $0.palette.variant })
+    }
+
+    func testSampledGeometryStaysWithinTheAcceptedClippedCoordinateBound() throws {
+        for value in 0..<512 {
+            let id = try XCTUnwrap(UUID(uuidString: String(format: "00000000-0000-0000-0000-%012X", value)))
+            let recipe = BranchingRecordingCoverRecipe(recordingID: id)
+            let coordinates = recipe.limbs.flatMap { limb in
+                [
+                    limb.start.x, limb.start.y,
+                    limb.control.x, limb.control.y,
+                    limb.end.x, limb.end.y,
+                ]
+            }
+
+            XCTAssertTrue(
+                coordinates.allSatisfy {
+                    abs($0) <= BranchingRecordingCoverRecipe.maximumNormalizedCoordinateMagnitude
+                },
+                "UUID \(id) exceeded the static Canvas composition bound"
+            )
+        }
+    }
+
+    private func recipeDigest(_ recipe: BranchingRecordingCoverRecipe) -> UInt64 {
+        var digest: UInt64 = 0xCBF2_9CE4_8422_2325
+
+        func append(_ value: UInt64) {
+            digest ^= value
+            digest &*= 0x0000_0100_0000_01B3
+        }
+
+        append(UInt64(BranchingRecordingCoverRecipe.version))
+        append(UInt64(BranchingRecordingCoverPalette.Family.allCases.firstIndex(of: recipe.palette.family)!))
+        append(UInt64(recipe.palette.variant))
+        append(UInt64(recipe.limbs.count))
+        append(UInt64(bitPattern: quantized(recipe.focalPoint.x)))
+        append(UInt64(bitPattern: quantized(recipe.focalPoint.y)))
+
+        for limb in recipe.limbs {
+            append(UInt64(bitPattern: quantized(limb.start.x)))
+            append(UInt64(bitPattern: quantized(limb.start.y)))
+            append(UInt64(bitPattern: quantized(limb.control.x)))
+            append(UInt64(bitPattern: quantized(limb.control.y)))
+            append(UInt64(bitPattern: quantized(limb.end.x)))
+            append(UInt64(bitPattern: quantized(limb.end.y)))
+            append(UInt64(bitPattern: quantized(limb.startWidth)))
+            append(UInt64(bitPattern: quantized(limb.endWidth)))
+            append(UInt64(limb.depth))
+            append(UInt64(pigmentIndex(limb.pigment)))
+            append(UInt64(bitPattern: quantized(limb.opacity)))
+        }
+
+        return digest
+    }
+
+    private func quantized(_ value: Double) -> Int64 {
+        Int64((value * 1_000_000).rounded())
+    }
+
+    private func pigmentIndex(_ pigment: BranchingRecordingCoverPigment) -> Int {
+        switch pigment {
+        case .field: 0
+        case .branch: 1
+        case .accent: 2
+        }
+    }
+}

--- a/Tests/MacParakeetTests/Views/BranchingRecordingCoverViewTests.swift
+++ b/Tests/MacParakeetTests/Views/BranchingRecordingCoverViewTests.swift
@@ -1,0 +1,116 @@
+import AppKit
+import Foundation
+import SwiftUI
+import XCTest
+@testable import MacParakeet
+
+@MainActor
+final class BranchingRecordingCoverViewTests: XCTestCase {
+    func testNativeCanvasProducesDistinctSyntheticCoverPNGs() throws {
+        let firstID = try XCTUnwrap(UUID(uuidString: "00112233-4455-6677-8899-AABBCCDDEEFF"))
+        let secondID = try XCTUnwrap(UUID(uuidString: "11112233-4455-6677-8899-AABBCCDDEEFF"))
+
+        let first = try rasterizedPNG(for: firstID)
+        let repeated = try rasterizedPNG(for: firstID)
+        let second = try rasterizedPNG(for: secondID)
+
+        XCTAssertGreaterThan(first.count, 300)
+        XCTAssertEqual(first, repeated)
+        XCTAssertNotEqual(first, second)
+    }
+
+    func testReportsNativeSyntheticGalleryRenderMeasurements() throws {
+        guard ProcessInfo.processInfo.environment["MACPARAKEET_RECORDING_COVER_MEASURE"] == "1" else {
+            throw XCTSkip("Set MACPARAKEET_RECORDING_COVER_MEASURE=1 to run the manual native rendering measurement.")
+        }
+        guard let outputDirectoryPath = ProcessInfo.processInfo.environment["MACPARAKEET_RECORDING_COVER_OUTPUT_DIR"]
+        else {
+            throw XCTSkip("Set MACPARAKEET_RECORDING_COVER_OUTPUT_DIR to save the manual native PNG gallery.")
+        }
+
+        let ids = try (0..<24).map { value in
+            try XCTUnwrap(UUID(uuidString: String(format: "00000000-0000-0000-0000-%012X", value)))
+        }
+
+        // This creates a fresh native renderer for every cover. It is a
+        // reproducible synthetic cost check, not a scrolling-frame profile or
+        // a cache decision by itself.
+        let cold = try ids.map { id in
+            try measure { _ = try rasterizedPNG(for: id) }
+        }
+        let warm = try ids.map { id in
+            try measure { _ = try rasterizedPNG(for: id) }
+        }
+        let flatPlaceholder = try ids.map { _ in
+            try measure { _ = try rasterizedPNG(content: FlatRecordingPlaceholderView()) }
+        }
+        let twelveCardGrid = try measure {
+            for id in ids.prefix(12) {
+                _ = try rasterizedPNG(for: id)
+            }
+        }
+        let flatTwelveCardGrid = try measure {
+            for _ in ids.prefix(12) {
+                _ = try rasterizedPNG(content: FlatRecordingPlaceholderView())
+            }
+        }
+
+        print(
+            "Branching cover native synthetic 320x180pt @2x (640x360px), combined SwiftUI ImageRenderer recipe + Canvas raster + PNG encoding: cold p50 \(format(percentile(cold, 0.50))) ms, "
+                + "p95 \(format(percentile(cold, 0.95))) ms; warm p50 \(format(percentile(warm, 0.50))) ms, "
+                + "p95 \(format(percentile(warm, 0.95))) ms; 12 sequential covers \(format(twelveCardGrid)) ms. "
+                + "Flat waveform placeholder in the same harness: p50 \(format(percentile(flatPlaceholder, 0.50))) ms, "
+                + "p95 \(format(percentile(flatPlaceholder, 0.95))) ms; 12 covers \(format(flatTwelveCardGrid)) ms."
+        )
+
+        let outputDirectory = URL(fileURLWithPath: outputDirectoryPath, isDirectory: true)
+        try FileManager.default.createDirectory(at: outputDirectory, withIntermediateDirectories: true)
+        for (index, id) in ids.prefix(12).enumerated() {
+            let data = try rasterizedPNG(for: id)
+            let output = outputDirectory.appendingPathComponent(
+                String(format: "%02d-%@.png", index + 1, id.uuidString.lowercased())
+            )
+            try data.write(to: output, options: .atomic)
+        }
+        print("Branching cover native synthetic PNG gallery: \(outputDirectory.path)")
+    }
+
+    private func rasterizedPNG(for id: UUID) throws -> Data {
+        try rasterizedPNG(content: BranchingRecordingCoverView(recordingID: id))
+    }
+
+    private func rasterizedPNG<Content: View>(content: Content) throws -> Data {
+        let size = NSSize(width: 320, height: 180)
+        let renderer = ImageRenderer(content: content.frame(width: size.width, height: size.height))
+        renderer.scale = 2
+        let representation = NSBitmapImageRep(cgImage: try XCTUnwrap(renderer.cgImage))
+        return try XCTUnwrap(representation.representation(using: .png, properties: [:]))
+    }
+
+    private func measure(_ work: () throws -> Void) rethrows -> TimeInterval {
+        let start = ProcessInfo.processInfo.systemUptime
+        try work()
+        return (ProcessInfo.processInfo.systemUptime - start) * 1_000
+    }
+
+    private func percentile(_ values: [TimeInterval], _ quantile: Double) -> TimeInterval {
+        let sorted = values.sorted()
+        let index = min(sorted.count - 1, Int((Double(sorted.count - 1) * quantile).rounded(.up)))
+        return sorted[index]
+    }
+
+    private func format(_ milliseconds: TimeInterval) -> String {
+        String(format: "%.2f", milliseconds)
+    }
+}
+
+private struct FlatRecordingPlaceholderView: View {
+    var body: some View {
+        ZStack {
+            Color(nsColor: .windowBackgroundColor)
+            Image(systemName: "waveform")
+                .font(.system(size: 28, weight: .light))
+                .foregroundStyle(.secondary)
+        }
+    }
+}

--- a/docs/plans/2026-09-08-recording-branching-covers.md
+++ b/docs/plans/2026-09-08-recording-branching-covers.md
@@ -1,0 +1,36 @@
+# Branching recording covers — implementation plan
+
+Status: approved for implementation and PR/merge on September 8, 2026.
+Base: origin/main edfaa4889b8beac34b28712829d3850f88bd8fd3; land after Library UI polish.
+
+## Goal
+Replace generic missing-artwork placeholders with a stable, beautiful Branching Field cover using bounded native drawing that does not interfere with Library scrolling or capture.
+
+## Settled design
+User selected Branching Field above harmonic and orbital alternatives. Reference: seed72841659, density6, disruption0.44, negative space0.28; three approved curated palettes Tidal stone, Lichen dusk, Plum mineral. Automatically select family and restrained variant from domain-separated deterministic UUID seed streams. No product palette picker. Approximate uniform distribution, not quotas; adding/sorting/deleting recordings cannot recolor others. Color is decorative, never label/status identity.
+
+Use the local study as visual reference: /Users/dmoon/code/macparakeet/docs/design/2026-09-08-recording-art/index.html (renderBranch, paletteForSeed and paletteMap). Do not copy p5 runtime/HTML into the app. Preserve organic branch silhouette, hierarchy, small warm center; make primary limbs legible at thumbnail size. No animation/timers/particles needing continuous updates. Keep title, duration and status in existing card chrome.
+
+## Stable inputs and architecture
+UUID only plus fixed version1 recipe, explicit reproducible PRNG and byte-order contract; not Swift hashValue, title, duration, text, timestamps, confidence, source path or audio data. No audio reads/FFT, network, inference, migration, sidecars or required post-processing job. Same item stays recognizable after rename/transcript edits/reprocess/restart/audio removal. V1 fixed globally; future selective v2 needs explicit version selection, do not promise preservation from cache alone.
+
+Start with bounded static Canvas and pure small geometry/palette model, ideally computed once per identity rather than every draw. Measure actual native render cost. Only add raster caching if measurements show meaningful redraw cost. If needed separate namespace from ThumbnailCacheService (<UUID>.jpg there is real-image cache with no provenance/version). Do not broaden scope into new cache framework without root discussion.
+
+Insertion point: TranscriptionThumbnailCard cached/remote image branch then placeholderView around163–205. Keep real artwork first. Preserve remote loading state; generated art for no artwork or failed load. No source schema/capture lifecycle changes. Existing completion refresh sufficient. SonicMandalaView has reusable curve ideas but text/confidence seed is wrong; leave it unchanged.
+
+## Verification
+Test deterministic bounded geometry and stable UUID palette selection, distinct representative IDs, finiteness at accepted sizes and branch limits. Demonstrate fallback/real artwork priority with focused meaningful tests where testable. Add a native synthetic gallery or renderer harness artifact for actual AppKit/CoreGraphics/Canvas output and measurements (cold/warm per-image p50/p95 and dense-grid implications); HTML timings are not native evidence. No private app/database/audio inputs. Inspect output at normal thumbnail scale and relevant appearances.
+
+Worker owns this isolated worktree: source, tests, narrow spec/04-ui-patterns.md behavior update and final plan evidence. Not alone: preserve other worktrees. UI worker also edits ThumbnailCard and spec in its own branch; root merges UI first and coordinates rebase/conflict resolution. Do not rebase automatically while root reviews.
+
+## Implementation evidence (September 8, 2026)
+The bounded v1 recipe now produces 5–6 roots, at most 96 limbs, and compact primary reach so that its smaller generations remain visible at card scale. A UUID pin fixes the selected palette, focal point and quantized limb-model digest; 512 synthetic UUIDs stayed within the documented ±2 normalized Canvas composition bound. Canvas clips that bounded overscan at the card edge without a separate clipping system.
+
+Focused checks used `swift test --jobs 4 --filter BranchingRecordingCoverRecipeTests` (6 passed) and an opt-in native renderer run for `BranchingRecordingCoverViewTests` (2 passed). The latter constructs a fresh 320×180 pt SwiftUI `ImageRenderer` at 2×, obtains its `CGImage`, encodes it through `NSBitmapImageRep`, and saves an explicit 12-image synthetic PNG gallery only when an output directory is supplied. The gallery was inspected at 640×360 px; it showed distinct teal, lichen, and plum branching compositions with visible secondary and tertiary tips. No recordings, audio, database, or network data entered the harness.
+
+On the final focused run, the complete Branching Field recipe plus renderer and PNG pipeline measured cold p50/p95 5.36/6.14 ms and warm p50/p95 5.38/6.49 ms across 24 UUIDs; twelve sequential covers took 62.45 ms. A flat waveform placeholder through the same pipeline measured p50/p95 1.41/3.19 ms and 18.89 ms for twelve. These are native synthetic export measurements, not a library scrolling profile; they do not establish a cache need or a no-lag claim. The implementation remains uncached and static pending combined UI QA.
+
+The combined-suite attempt on the stacked UI-plus-art head did not pass: `/tmp/macparakeet-library-art-combined-full-20260908.log` exited 1 after 5,855 XCTest tests with 21 skips and 46 assertion failures across 22 `HotkeyManagerTests`; Swift Testing reported 29 passed. At the same code head, `/tmp/macparakeet-hotkey-focused-20260908-rerun.log` ran the isolated `HotkeyManagerTests` 87/87 passed. Independent UI review found the Hotkey source and tests byte-identical to `origin/main`; all 22 failing cases use the live physical-keyboard default without injection, and the host state was not captured. This is evidence of a likely pre-existing test-isolation flake, not a full-suite pass. No source or test change was made for it; hosted exact-head CI remains required.
+
+## Execution and gates
+Read project instructions and governing specs. Swift6 clean build, focused checks only. Limit build concurrency (--jobs4) due previous process exhaustion. Root owns single final full swift test across combined changes after rebase; do not run full suite/gate baseline yourself. Do not launch/restart user's running app or publish a release. Commit with rich intent, push branch, open PR main, but do not merge. Root owns independent review and exact-head CI/merge. Report PR URL/head, files, native measurements and method, test counts, deviations and limitations honestly. Do not claim no lag without actual profiling.

--- a/spec/04-ui-patterns.md
+++ b/spec/04-ui-patterns.md
@@ -166,6 +166,15 @@ finalization both use the persisted `processing` status and the existing
 must not hide a card's non-completed status. Missing audio, recovery, and
 partial-capture warnings remain explicit rather than being compressed into a
 routine state icon.
+
+When a grid card has locally cached or successfully loaded remote artwork, that
+real artwork remains first. A remote image that is still loading keeps its loading
+surface. When no artwork exists or remote loading fails, the 16:9 area shows a
+static Branching Field cover derived only from the transcription UUID and fixed
+v1 recipe. The selected curated palette is decorative; it does not encode source,
+status, audio, transcript, confidence, title, duration, or time. The cover has no
+text or animation, so existing title, duration, source, and lifecycle chrome stay
+legible and authoritative outside the artwork.
 List rows retain their existing snippet-first preview behavior, including while
 a meeting with saved transcript text is being retranscribed.
 


### PR DESCRIPTION
## Summary

Adds a deterministic, UUID-only Branching Field cover for recordings without usable artwork. Cached artwork and successful remote images still win; remote images retain their loading surface; missing or failed artwork receives a static native Canvas composition. The recipe is bounded, versioned, palette-curated, and has no audio, transcript, network, cache, or background-job input.

## Design and validation

- [Implementation plan](https://github.com/moona3k/macparakeet/blob/846fdfcf56f79eb4cce4c8d78e155fadca7c7e31/docs/plans/2026-09-08-recording-branching-covers.md) records the stable UUID/FNV contract, fallback lifecycle, and native measurement method.
- Recipe tests pin the v1 palette, focal point, and quantized limb digest; cover finite bounded geometry, UUID distinction, palette coverage, and a 512-ID clipped-coordinate sample.
- Native SwiftUI `ImageRenderer` output asserts repeatable pixels for the same UUID and distinct pixels for different UUIDs. The opt-in benchmark exports synthetic 640×360 PNGs only to an explicitly supplied directory.
- The accepted benchmark run measured the combined recipe, Canvas, and PNG path at cold p50/p95 5.36/6.14 ms and warm 5.38/6.49 ms across 24 IDs; twelve sequential covers took 62.45 ms. The same flat placeholder pipeline measured 1.41/3.19 ms and 18.89 ms for twelve.
- After the first stacked UI review, `swift build --jobs 4` passed. `swift test --jobs 4 --filter BranchingRecordingCover` passed 7 tests with one opt-in measurement test skipped; the earlier benchmark-enabled run passed 8 tests.
- An independent review cleared the original art source, and the rebased diff received a separate root review. The current restack verification found no art-file delta.

## Full-suite evidence

The combined local full-suite attempt did not pass: 5,855 XCTest tests, 21 skips, and 46 assertion failures across 22 `HotkeyManagerTests`; Swift Testing reported 29 passed. At the same code head, isolated `HotkeyManagerTests` passed 87/87. The Hotkey source and tests matched `origin/main`; the failed cases use the live physical-keyboard default without injection, and host state was not captured. This is recorded as a likely existing test-isolation flake, not a full-suite pass. Hosted CI passed on exact head `846fdfcf56f79eb4cce4c8d78e155fadca7c7e31`, including release build, packaged-app smoke, concurrency checking, Swift 6 mode, and the full test suite. The final native Release build also passed on that head.

## Remaining QA

The art has native synthetic pixel and gallery coverage. Native interaction, accessibility, and dense-library scrolling remain for the integrated app QA pass.
