### PR TITLE
fix(llm): apply GPT-5 request policy on OpenAI-compatible gateways

### DIFF
--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -89,6 +89,14 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
 
 ## [Unreleased]
 
+### Fixed
+
+- OpenAI-compatible gateways (including Vercel AI Gateway model IDs such as
+  `openai/gpt-5.6-luna` and `openai/gpt-5.6-sol`) now use the same GPT-5.x
+  request policy as native OpenAI: omit unsupported sampling, send
+  `max_completion_tokens`, and surface parameter-compatibility 400s as provider
+  errors instead of a false context-limit failure.
+
 ## [4.0.0] — 2026-09-07
 
 ### Added

--- a/Sources/MacParakeetCore/Models/PromptInferenceSettings.swift
+++ b/Sources/MacParakeetCore/Models/PromptInferenceSettings.swift
@@ -209,8 +209,21 @@ public enum PromptInferenceCapabilityResolver {
         case .ollama:
             return [.temperature, .topP, .topK, .maxTokens, .thinkingMode]
         case .openaiCompatible:
+            if OpenAIModelPolicy.requiresMaxCompletionTokens(model: config.modelName) {
+                var fields: Set<PromptInferenceSettings.Field> = [.maxTokens]
+                if !OpenAIModelPolicy.shouldOmitSampling(model: config.modelName) {
+                    fields.formUnion([.temperature, .topP])
+                }
+                return fields
+            }
             return [.temperature, .topP, .topK, .maxTokens, .thinkingMode, .reasoningEffort]
-        case .gemini, .openrouter, .lmstudio:
+        case .openrouter:
+            var fields: Set<PromptInferenceSettings.Field> = [.maxTokens]
+            if !OpenAIModelPolicy.shouldOmitSampling(model: config.modelName) {
+                fields.insert(.temperature)
+            }
+            return fields
+        case .gemini, .lmstudio:
             return [.temperature, .maxTokens]
         case .localCLI:
             return []
@@ -307,22 +320,48 @@ private extension ChatCompletionOptions {
 }
 
 enum OpenAIModelPolicy {
-    static func shouldOmitSampling(model: String) -> Bool {
+    /// Last path component of a provider-prefixed ID (`openai/gpt-5.6-luna` →
+    /// `gpt-5.6-luna`). Gateways such as Vercel AI Gateway and OpenRouter use
+    /// this form; native OpenAI IDs are returned unchanged.
+    static func canonicalModelID(_ model: String) -> String {
         let lowered = model.lowercased()
-        if isReasoningModel(lowered) { return true }
-        if lowered.contains("chat") { return false }
-        guard lowered.hasPrefix("gpt-") else { return false }
-        let digits = lowered.dropFirst(4).prefix(while: { $0.isNumber })
-        return (Int(digits) ?? 0) >= 5
+        guard let slash = lowered.lastIndex(of: "/") else { return lowered }
+        return String(lowered[lowered.index(after: slash)...])
     }
 
-    private static func isReasoningModel(_ model: String) -> Bool {
-        guard model.hasPrefix("o") else { return false }
-        let suffix = model.dropFirst()
+    static func shouldOmitSampling(model: String) -> Bool {
+        let id = canonicalModelID(model)
+        if isReasoningModel(id) { return true }
+        if id.contains("chat") { return false }
+        return gptMajorVersion(id).map { $0 >= 5 } ?? false
+    }
+
+    static func requiresMaxCompletionTokens(model: String) -> Bool {
+        let id = canonicalModelID(model)
+        if isReasoningModel(id) { return true }
+        return gptMajorVersion(id).map { $0 >= 5 } ?? false
+    }
+
+    static func isReasoningModelID(_ model: String) -> Bool {
+        isReasoningModel(canonicalModelID(model))
+    }
+
+    /// Major version of a "gpt-<n>..." model ID ("gpt-5.5" → 5, "gpt-10" → 10),
+    /// or nil for IDs without a gpt- numeric prefix.
+    static func gptMajorVersion(_ model: String) -> Int? {
+        let id = canonicalModelID(model)
+        guard id.hasPrefix("gpt-") else { return nil }
+        let digits = id.dropFirst(4).prefix(while: { $0.isNumber })
+        return Int(digits)
+    }
+
+    private static func isReasoningModel(_ id: String) -> Bool {
+        guard id.hasPrefix("o") else { return false }
+        let suffix = id.dropFirst()
         guard let generation = suffix.first, generation.isNumber else { return false }
         let prefix = "o\(generation)"
-        let boundary = model.dropFirst(prefix.count).first
-        return model.hasPrefix(prefix) && (boundary == nil || boundary == "-")
+        let boundary = id.dropFirst(prefix.count).first
+        return id.hasPrefix(prefix) && (boundary == nil || boundary == "-")
     }
 }
 

--- a/Sources/MacParakeetCore/Services/LLM/LLMHTTPTransport.swift
+++ b/Sources/MacParakeetCore/Services/LLM/LLMHTTPTransport.swift
@@ -141,7 +141,7 @@ enum LLMHTTPErrorMapper {
             }
             return .providerError(message)
         case 400:
-            if message.lowercased().contains("context") || message.lowercased().contains("token") {
+            if isContextOverflowMessage(message) {
                 return .contextTooLong
             }
             return .providerError(message)
@@ -154,11 +154,7 @@ enum LLMHTTPErrorMapper {
         let message = scrubAPIKeyArtifacts(from: rawMessage)
         let lowered = message.lowercased()
 
-        if lowered.contains("context")
-            || lowered.contains("tokens to keep")
-            || lowered.contains("too many tokens")
-            || lowered.contains("maximum number of tokens")
-        {
+        if isContextOverflowMessage(message) {
             return .contextTooLong
         }
         if lowered.contains("rate limit") || lowered.contains("rate_limit") {
@@ -176,6 +172,29 @@ enum LLMHTTPErrorMapper {
             return .modelNotFound(message)
         }
         return .streamingError(message)
+    }
+
+    /// True context-window failures, not parameter-compatibility errors that
+    /// happen to mention `max_tokens`.
+    static func isContextOverflowMessage(_ message: String) -> Bool {
+        let lowered = message.lowercased()
+        if isUnsupportedTokenParameterMessage(lowered) {
+            return false
+        }
+        return lowered.contains("context")
+            || lowered.contains("too many tokens")
+            || lowered.contains("tokens to keep")
+            || lowered.contains("maximum number of tokens")
+    }
+
+    private static func isUnsupportedTokenParameterMessage(_ lowered: String) -> Bool {
+        let mentionsTokenParameter =
+            lowered.contains("max_tokens") || lowered.contains("max_completion_tokens")
+        let mentionsUnsupported =
+            lowered.contains("unsupported")
+            || lowered.contains("not supported")
+            || lowered.contains("unknown parameter")
+        return mentionsTokenParameter && mentionsUnsupported
     }
 
     /// Strips obvious API-key artifacts from a provider error message before

--- a/Sources/MacParakeetCore/Services/LLM/LLMHTTPTransport.swift
+++ b/Sources/MacParakeetCore/Services/LLM/LLMHTTPTransport.swift
@@ -181,10 +181,14 @@ enum LLMHTTPErrorMapper {
         if isUnsupportedTokenParameterMessage(lowered) {
             return false
         }
-        return lowered.contains("context")
+        return lowered.contains("context length")
+            || lowered.contains("context window")
+            || lowered.contains("context limit")
+            || lowered.contains("maximum context")
             || lowered.contains("too many tokens")
             || lowered.contains("tokens to keep")
             || lowered.contains("maximum number of tokens")
+            || lowered.contains("prompt is too long")
     }
 
     private static func isUnsupportedTokenParameterMessage(_ lowered: String) -> Bool {

--- a/Sources/MacParakeetCore/Services/LLM/OpenAICompatibleLLMHTTPAdapter.swift
+++ b/Sources/MacParakeetCore/Services/LLM/OpenAICompatibleLLMHTTPAdapter.swift
@@ -221,7 +221,7 @@ struct OpenAICompatibleLLMHTTPAdapter: LLMHTTPAdapter {
         // Models that use reasoning tokens (o1/o3/o4, gpt-5.x) need more budget since
         // max_completion_tokens covers both reasoning and visible output.
         // 128 is enough for a minimal response. Older models can use 1 to minimize cost.
-        let needsMoreTokens = config.id == .openai && Self.openAIRequiresMaxCompletionTokens(config.modelName)
+        let needsMoreTokens = Self.openAIRequiresMaxCompletionTokens(config.modelName)
         let options = ChatCompletionOptions(maxTokens: needsMoreTokens ? 128 : 1)
         _ = try await chatCompletion(messages: messages, config: config, options: options)
     }
@@ -306,23 +306,25 @@ struct OpenAICompatibleLLMHTTPAdapter: LLMHTTPAdapter {
 
         // OpenAI reasoning models reject max_tokens. Explicit temperature
         // support varies by model and reasoning effort, so omit it for the
-        // GPT-5.x reasoning tier (gpt-5.5, gpt-5.4-mini, ...); its "-chat"
-        // variants still accept explicit values. Newer models also require
-        // max_completion_tokens instead of max_tokens.
-        let shouldOmitSampling = config.id == .openai && Self.openAIShouldOmitTemperature(config.modelName)
-        let needsNewTokenParam = config.id == .openai && Self.openAIRequiresMaxCompletionTokens(config.modelName)
+        // GPT-5.x reasoning tier (gpt-5.5, gpt-5.4-mini, gpt-5.6-luna, ...);
+        // "-chat" variants still accept explicit values. Apply this from the
+        // model ID, including gateway prefixes such as `openai/gpt-5.6-sol`,
+        // rather than only the native OpenAI provider. Newer models also
+        // require max_completion_tokens instead of max_tokens.
+        let shouldOmitSampling = Self.openAIShouldOmitTemperature(config.modelName)
+        let needsNewTokenParam = Self.openAIRequiresMaxCompletionTokens(config.modelName)
         let temperature = shouldOmitSampling ? nil : options.temperature
         let topP: Double?
         switch config.id {
-        case .openai:
+        case .openai, .openaiCompatible:
             topP = shouldOmitSampling ? nil : options.topP
-        case .openaiCompatible:
-            topP = options.topP
         case .anthropic, .gemini, .openrouter, .ollama, .lmstudio, .localCLI, .inProcessLocal:
             topP = nil
         }
         let supportsCustomOpenAICompatibleOptions =
-            config.id == .openaiCompatible && options.usesPromptInferenceSettings
+            config.id == .openaiCompatible
+            && options.usesPromptInferenceSettings
+            && !needsNewTokenParam
         let maxTokens = needsNewTokenParam ? nil : options.maxTokens
         let maxCompletionTokens = needsNewTokenParam ? options.maxTokens : nil
 
@@ -361,48 +363,34 @@ struct OpenAICompatibleLLMHTTPAdapter: LLMHTTPAdapter {
 
     /// OpenAI reasoning models that reject temperature and max_tokens parameters.
     static func isOpenAIReasoningModel(_ model: String) -> Bool {
-        isOpenAIReasoningModelID(model.lowercased())
+        OpenAIModelPolicy.isReasoningModelID(model)
     }
 
     /// OpenAI models for which MacParakeet omits explicit `temperature`: the
     /// o-series and GPT-5.x+ reasoning tier. Chat-tier variants
     /// (gpt-5.3-chat-latest) and pre-5.x models keep the caller's value.
+    /// Provider prefixes (`openai/gpt-5.6-luna`) are stripped first.
     static func openAIShouldOmitTemperature(_ model: String) -> Bool {
         OpenAIModelPolicy.shouldOmitSampling(model: model)
     }
 
     /// Major version of a "gpt-<n>..." model ID ("gpt-5.5" → 5, "gpt-10" → 10),
     /// or nil for IDs without a gpt- numeric prefix. Reads all leading digits so
-    /// future multi-digit major versions compare correctly.
+    /// future multi-digit major versions compare correctly. Accepts gateway
+    /// prefixes such as `openai/gpt-5.6-sol`.
     static func gptMajorVersion(_ loweredModel: String) -> Int? {
-        guard loweredModel.hasPrefix("gpt-") else { return nil }
-        let digits = loweredModel.dropFirst(4).prefix(while: { $0.isNumber })
-        return Int(digits)
+        OpenAIModelPolicy.gptMajorVersion(loweredModel)
     }
 
     /// OpenAI models that require max_completion_tokens instead of max_tokens.
-    /// Includes reasoning models and newer GPT models (5.x+).
+    /// Includes reasoning models and newer GPT models (5.x+), including
+    /// gateway IDs such as `openai/gpt-5.6-luna`.
     static func openAIRequiresMaxCompletionTokens(_ model: String) -> Bool {
-        let lowered = model.lowercased()
-        if isOpenAIReasoningModel(lowered) { return true }
-        // GPT-5.x and beyond reject max_tokens
-        if let version = gptMajorVersion(lowered), version >= 5 {
-            return true
-        }
-        return false
+        OpenAIModelPolicy.requiresMaxCompletionTokens(model: model)
     }
 
     static func isOpenAIReasoningModelID(_ model: String) -> Bool {
-        guard model.hasPrefix("o") else { return false }
-        let suffix = model.dropFirst()
-        guard let generation = suffix.first, generation.isNumber else { return false }
-        return hasOpenAIModelPrefix(model, prefix: "o\(generation)")
-    }
-
-    static func hasOpenAIModelPrefix(_ model: String, prefix: String) -> Bool {
-        guard model.hasPrefix(prefix) else { return false }
-        let boundary = model.dropFirst(prefix.count).first
-        return boundary == nil || boundary == "-"
+        OpenAIModelPolicy.isReasoningModelID(model)
     }
 
     static func responseFormat(from format: ChatResponseFormat?) -> OpenAIResponseFormat? {

--- a/Sources/MacParakeetCore/Services/LLM/OpenAICompatibleLLMHTTPAdapter.swift
+++ b/Sources/MacParakeetCore/Services/LLM/OpenAICompatibleLLMHTTPAdapter.swift
@@ -221,7 +221,8 @@ struct OpenAICompatibleLLMHTTPAdapter: LLMHTTPAdapter {
         // Models that use reasoning tokens (o1/o3/o4, gpt-5.x) need more budget since
         // max_completion_tokens covers both reasoning and visible output.
         // 128 is enough for a minimal response. Older models can use 1 to minimize cost.
-        let needsMoreTokens = Self.openAIRequiresMaxCompletionTokens(config.modelName)
+        let needsMoreTokens =
+            config.id != .lmstudio && Self.openAIRequiresMaxCompletionTokens(config.modelName)
         let options = ChatCompletionOptions(maxTokens: needsMoreTokens ? 128 : 1)
         _ = try await chatCompletion(messages: messages, config: config, options: options)
     }
@@ -310,9 +311,14 @@ struct OpenAICompatibleLLMHTTPAdapter: LLMHTTPAdapter {
         // "-chat" variants still accept explicit values. Apply this from the
         // model ID, including gateway prefixes such as `openai/gpt-5.6-sol`,
         // rather than only the native OpenAI provider. Newer models also
-        // require max_completion_tokens instead of max_tokens.
-        let shouldOmitSampling = Self.openAIShouldOmitTemperature(config.modelName)
-        let needsNewTokenParam = Self.openAIRequiresMaxCompletionTokens(config.modelName)
+        // require max_completion_tokens instead of max_tokens. LM Studio's
+        // documented chat-completions contract still uses max_tokens and
+        // temperature even when a loaded model ID happens to look like GPT-5.
+        let appliesOpenAIFamilyWirePolicy = config.id != .lmstudio
+        let shouldOmitSampling =
+            appliesOpenAIFamilyWirePolicy && Self.openAIShouldOmitTemperature(config.modelName)
+        let needsNewTokenParam =
+            appliesOpenAIFamilyWirePolicy && Self.openAIRequiresMaxCompletionTokens(config.modelName)
         let temperature = shouldOmitSampling ? nil : options.temperature
         let topP: Double?
         switch config.id {

--- a/Tests/MacParakeetTests/Models/PromptInferenceSettingsTests.swift
+++ b/Tests/MacParakeetTests/Models/PromptInferenceSettingsTests.swift
@@ -175,6 +175,14 @@ final class PromptInferenceSettingsTests: XCTestCase {
             config: .openai(apiKey: "key", model: "gpt-5.5"),
             requested: nil)
         XCTAssertNil(openAIReasoning.effectiveSettings)
+
+        let gatewayLuna = try PromptInferenceCapabilityResolver.resolve(
+            config: .openaiCompatible(
+                model: "openai/gpt-5.6-luna",
+                baseURL: URL(string: "https://ai-gateway.vercel.sh/v1")!
+            ),
+            requested: nil)
+        XCTAssertNil(gatewayLuna.effectiveSettings)
     }
 
     func testAnthropicTopPReplacesInheritedTemperatureAndRegeneratesUnchanged() throws {

--- a/Tests/MacParakeetTests/Services/LLM/LLMClientTests.swift
+++ b/Tests/MacParakeetTests/Services/LLM/LLMClientTests.swift
@@ -1058,7 +1058,7 @@ final class LLMClientTests: XCTestCase {
         XCTAssertEqual(capturedBody?["temperature"] as? Double, 0.7)
     }
 
-    func testOpenAICompatibleProviderDoesNotApplyOpenAISpecificTokenParameters() async throws {
+    func testOpenAICompatibleGPT5AppliesNativeTokenParameters() async throws {
         var capturedBody: [String: Any]?
 
         MockURLProtocol.handler = { request in
@@ -1071,6 +1071,32 @@ final class LLMClientTests: XCTestCase {
         let config = LLMProviderConfig.openaiCompatible(
             apiKey: "sk-test",
             model: "gpt-5.2",
+            baseURL: URL(string: "https://api.example.com/v1")!
+        )
+        _ = try await llmClient.chatCompletion(
+            messages: [ChatMessage(role: .user, content: "Hi")],
+            config: config,
+            options: ChatCompletionOptions(temperature: 0.7, maxTokens: 500)
+        )
+
+        XCTAssertNil(capturedBody?["max_tokens"])
+        XCTAssertEqual(capturedBody?["max_completion_tokens"] as? Int, 500)
+        XCTAssertNil(capturedBody?["temperature"])
+    }
+
+    func testOpenAICompatibleGenericModelKeepsMaxTokensAndTemperature() async throws {
+        var capturedBody: [String: Any]?
+
+        MockURLProtocol.handler = { request in
+            if let body = self.extractBody(from: request) {
+                capturedBody = body
+            }
+            return (self.okResponse(for: request), self.validResponseData())
+        }
+
+        let config = LLMProviderConfig.openaiCompatible(
+            apiKey: "sk-test",
+            model: "llama-3.1-8b-instruct",
             baseURL: URL(string: "https://api.example.com/v1")!
         )
         _ = try await llmClient.chatCompletion(

--- a/Tests/MacParakeetTests/Services/LLM/LLMClientTests.swift
+++ b/Tests/MacParakeetTests/Services/LLM/LLMClientTests.swift
@@ -587,6 +587,18 @@ final class LLMClientTests: XCTestCase {
         }
     }
 
+    func testGenericContextWordIsNotMappedToContextLimit() {
+        let error = LLMHTTPErrorMapper.mapError(
+            statusCode: 400,
+            data: Data("{\"error\":{\"message\":\"Please provide more context for this request\"}}".utf8)
+        )
+        if case .providerError(let message) = error {
+            XCTAssertTrue(message.contains("more context"), message)
+        } else {
+            XCTFail("Expected providerError, got \(error)")
+        }
+    }
+
     func testServerErrorReturnsProviderError() async {
         MockURLProtocol.handler = { request in
             let response = HTTPURLResponse(

--- a/Tests/MacParakeetTests/Services/LLM/LLMClientTests.swift
+++ b/Tests/MacParakeetTests/Services/LLM/LLMClientTests.swift
@@ -524,6 +524,44 @@ final class LLMClientTests: XCTestCase {
         }
     }
 
+    func testUnsupportedMaxTokensParameterIsNotMappedToContextLimit() async {
+        MockURLProtocol.handler = { request in
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: 400, httpVersion: nil, headerFields: nil
+            )!
+            return (
+                response,
+                Data(
+                    """
+                    {"error":{"message":"Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead."}}
+                    """.utf8
+                )
+            )
+        }
+
+        let config = LLMProviderConfig.openaiCompatible(
+            apiKey: "vck-test",
+            model: "openai/gpt-5.6-sol",
+            baseURL: URL(string: "https://ai-gateway.vercel.sh/v1")!
+        )
+        do {
+            _ = try await llmClient.chatCompletion(
+                messages: [ChatMessage(role: .user, content: "Hi")],
+                config: config,
+                options: .default
+            )
+            XCTFail("Expected LLMError.providerError")
+        } catch let error as LLMError {
+            if case .providerError(let message) = error {
+                XCTAssertTrue(message.contains("max_completion_tokens"), message)
+            } else {
+                XCTFail("Expected providerError, got \(error)")
+            }
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
     func testContextLengthErrorMappedCorrectly() async {
         MockURLProtocol.handler = { request in
             let response = HTTPURLResponse(
@@ -592,6 +630,28 @@ final class LLMClientTests: XCTestCase {
         try await llmClient.testConnection(config: config)
 
         XCTAssertEqual(capturedBody?["max_tokens"] as? Int, 1)
+    }
+
+    func testGatewayGPT56ConnectionTestUsesMaxCompletionTokens() async throws {
+        var capturedBody: [String: Any]?
+
+        MockURLProtocol.handler = { request in
+            if let body = self.extractBody(from: request) {
+                capturedBody = body
+            }
+            return (self.okResponse(for: request), self.validResponseData())
+        }
+
+        let config = LLMProviderConfig.openaiCompatible(
+            apiKey: "vck-test",
+            model: "openai/gpt-5.6-sol",
+            baseURL: URL(string: "https://ai-gateway.vercel.sh/v1")!
+        )
+        try await llmClient.testConnection(config: config)
+
+        XCTAssertNil(capturedBody?["max_tokens"])
+        XCTAssertEqual(capturedBody?["max_completion_tokens"] as? Int, 128)
+        XCTAssertNil(capturedBody?["temperature"])
     }
 
     // MARK: - SSE Parsing

--- a/Tests/MacParakeetTests/Services/LLM/LLMHTTPAdapterTests.swift
+++ b/Tests/MacParakeetTests/Services/LLM/LLMHTTPAdapterTests.swift
@@ -525,7 +525,7 @@ final class LLMHTTPAdapterTests: XCTestCase {
         }
         let accepting = [
             "gpt-5.3-chat-latest", "openai/gpt-5.3-chat-latest", "gpt-4.1", "gpt-4.1-mini",
-            "gpt-4o", "chatgpt-4o-latest", "local-model",
+            "gpt-4o", "chatgpt-4o-latest", "local-model", "gpt-oss-120b",
         ]
         for model in accepting {
             XCTAssertFalse(
@@ -577,6 +577,39 @@ final class LLMHTTPAdapterTests: XCTestCase {
             resolution.unsupportedSettings,
             [.temperature, .topP, .topK, .thinkingMode, .reasoningEffort]
         )
+    }
+
+    func testOpenRouterGatewayGPT56UsesNativeOpenAIParameterPolicy() async throws {
+        var capturedRequest: URLRequest?
+
+        AdapterRequestURLProtocol.handler = { request in
+            capturedRequest = request
+            return (self.okResponse(for: request), self.validOpenAIResponseData())
+        }
+
+        let providerConfig = LLMProviderConfig.openrouter(
+            apiKey: "sk-or-test",
+            model: "openai/gpt-5.6-sol"
+        )
+        let resolution = try PromptInferenceCapabilityResolver.resolve(
+            config: providerConfig,
+            requested: PromptInferenceSettings(temperature: 0.2, maxTokens: 2048)
+        )
+
+        _ = try await openAIAdapter.chatCompletion(
+            messages: goldenMessages,
+            config: providerConfig,
+            options: resolution.options
+        )
+
+        try assertJSONBody(
+            try XCTUnwrap(capturedRequest),
+            equals: """
+                {"max_completion_tokens":2048,"messages":[{"content":"System","role":"system"},{"content":"Hello","role":"user"}],"model":"openai/gpt-5.6-sol","stream":false}
+                """
+        )
+        XCTAssertEqual(resolution.effectiveSettings, PromptInferenceSettings(maxTokens: 2048))
+        XCTAssertEqual(resolution.unsupportedSettings, [.temperature])
     }
 
     func testOpenAICompatibleAdapterEncodesNullableKnowledgeCardOwnerSchema() async throws {

--- a/Tests/MacParakeetTests/Services/LLM/LLMHTTPAdapterTests.swift
+++ b/Tests/MacParakeetTests/Services/LLM/LLMHTTPAdapterTests.swift
@@ -513,20 +513,70 @@ final class LLMHTTPAdapterTests: XCTestCase {
     }
 
     func testOpenAIShouldOmitTemperatureModelMatrix() {
-        let rejecting = ["o3", "o4-mini", "gpt-5.5", "gpt-5.4", "gpt-5.4-nano", "GPT-5.4-Mini", "gpt-10"]
+        let rejecting = [
+            "o3", "o4-mini", "gpt-5.5", "gpt-5.4", "gpt-5.4-nano", "GPT-5.4-Mini", "gpt-10",
+            "gpt-5.6-sol", "gpt-5.6-luna", "openai/gpt-5.6-sol", "openai/gpt-5.6-luna",
+        ]
         for model in rejecting {
             XCTAssertTrue(
                 OpenAICompatibleLLMHTTPAdapter.openAIShouldOmitTemperature(model),
                 "\(model) should omit temperature"
             )
         }
-        let accepting = ["gpt-5.3-chat-latest", "gpt-4.1", "gpt-4.1-mini", "gpt-4o", "chatgpt-4o-latest"]
+        let accepting = [
+            "gpt-5.3-chat-latest", "openai/gpt-5.3-chat-latest", "gpt-4.1", "gpt-4.1-mini",
+            "gpt-4o", "chatgpt-4o-latest", "local-model",
+        ]
         for model in accepting {
             XCTAssertFalse(
                 OpenAICompatibleLLMHTTPAdapter.openAIShouldOmitTemperature(model),
                 "\(model) should keep temperature"
             )
         }
+    }
+
+    func testOpenAICompatibleGatewayGPT56UsesNativeOpenAIParameterPolicy() async throws {
+        var capturedRequest: URLRequest?
+
+        AdapterRequestURLProtocol.handler = { request in
+            capturedRequest = request
+            return (self.okResponse(for: request), self.validOpenAIResponseData())
+        }
+
+        let providerConfig = LLMProviderConfig.openaiCompatible(
+            apiKey: "vck-test",
+            model: "openai/gpt-5.6-luna",
+            baseURL: URL(string: "https://ai-gateway.vercel.sh/v1")!
+        )
+        let resolution = try PromptInferenceCapabilityResolver.resolve(
+            config: providerConfig,
+            requested: PromptInferenceSettings(
+                temperature: 0.2,
+                topP: 0.9,
+                topK: 20,
+                maxTokens: 4096,
+                thinkingMode: .enabled,
+                reasoningEffort: .medium
+            )
+        )
+
+        _ = try await openAIAdapter.chatCompletion(
+            messages: goldenMessages,
+            config: providerConfig,
+            options: resolution.options
+        )
+
+        try assertJSONBody(
+            try XCTUnwrap(capturedRequest),
+            equals: """
+                {"max_completion_tokens":4096,"messages":[{"content":"System","role":"system"},{"content":"Hello","role":"user"}],"model":"openai/gpt-5.6-luna","stream":false}
+                """
+        )
+        XCTAssertEqual(resolution.effectiveSettings, PromptInferenceSettings(maxTokens: 4096))
+        XCTAssertEqual(
+            resolution.unsupportedSettings,
+            [.temperature, .topP, .topK, .thinkingMode, .reasoningEffort]
+        )
     }
 
     func testOpenAICompatibleAdapterEncodesNullableKnowledgeCardOwnerSchema() async throws {

--- a/Tests/MacParakeetTests/Services/LLM/LLMHTTPAdapterTests.swift
+++ b/Tests/MacParakeetTests/Services/LLM/LLMHTTPAdapterTests.swift
@@ -612,6 +612,28 @@ final class LLMHTTPAdapterTests: XCTestCase {
         XCTAssertEqual(resolution.unsupportedSettings, [.temperature])
     }
 
+    func testLMStudioKeepsMaxTokensEvenWhenModelIDLooksLikeGPT5() async throws {
+        var capturedRequest: URLRequest?
+
+        AdapterRequestURLProtocol.handler = { request in
+            capturedRequest = request
+            return (self.okResponse(for: request), self.validOpenAIResponseData())
+        }
+
+        _ = try await openAIAdapter.chatCompletion(
+            messages: goldenMessages,
+            config: .lmstudio(model: "gpt-5.5"),
+            options: ChatCompletionOptions(temperature: 0.2, maxTokens: 256)
+        )
+
+        try assertJSONBody(
+            try XCTUnwrap(capturedRequest),
+            equals: """
+                {"max_tokens":256,"messages":[{"content":"System","role":"system"},{"content":"Hello","role":"user"}],"model":"gpt-5.5","stream":false,"temperature":0.2}
+                """
+        )
+    }
+
     func testOpenAICompatibleAdapterEncodesNullableKnowledgeCardOwnerSchema() async throws {
         var capturedRequest: URLRequest?
 

--- a/spec/11-llm-integration.md
+++ b/spec/11-llm-integration.md
@@ -78,6 +78,13 @@ The service boundary stays stable even though the transport is mixed.
 | Local CLI | CLI | N/A (subprocess) | N/A (tool manages its own auth) |
 | Local MLX | In-process local, developer-gated | `inprocess://local` | N/A |
 
+**OpenAI-Compatible** is the path for aggregators such as Vercel AI Gateway.
+OpenAI-family model IDs (`gpt-5.x`, `o3`, and prefixed forms such as
+`openai/gpt-5.6-luna`) use the native OpenAI chat-completions parameter policy
+on that path: omit sampling the model rejects, send `max_completion_tokens`,
+and do not attach llama.cpp `chat_template_kwargs`. Generic local model IDs
+keep the broader compatible mapping.
+
 **Local CLI:** Users with Claude Code or Codex subscriptions can use their CLI tools directly. The app runs the configured command as a subprocess via `posix_spawn`, delivering prompts via stdin and `MACPARAKEET_*` environment variables. No API key needed — the CLI tool manages its own authentication. Built-in presets for Claude Code (`claude -p --model haiku`) and Codex (`codex exec --model gpt-5.4-mini`), or any custom command. See PR #47.
 
 ### OpenCode Go (custom endpoint)

--- a/spec/11-llm-integration.md
+++ b/spec/11-llm-integration.md
@@ -83,7 +83,8 @@ OpenAI-family model IDs (`gpt-5.x`, `o3`, and prefixed forms such as
 `openai/gpt-5.6-luna`) use the native OpenAI chat-completions parameter policy
 on that path: omit sampling the model rejects, send `max_completion_tokens`,
 and do not attach llama.cpp `chat_template_kwargs`. Generic local model IDs
-keep the broader compatible mapping.
+keep the broader compatible mapping. OpenRouter shares this adapter, so the
+same model-ID policy applies there.
 
 **Local CLI:** Users with Claude Code or Codex subscriptions can use their CLI tools directly. The app runs the configured command as a subprocess via `posix_spawn`, delivering prompts via stdin and `MACPARAKEET_*` environment variables. No API key needed — the CLI tool manages its own authentication. Built-in presets for Claude Code (`claude -p --model haiku`) and Codex (`codex exec --model gpt-5.4-mini`), or any custom command. See PR #47.
 
@@ -266,8 +267,9 @@ capability contract is:
 | Native OpenAI | `temperature` and `topP` when model policy permits them; `maxTokens` through the existing token-key policy |
 | Native Anthropic | `temperature` in `0...1` or `topP` in `0...1` when model-compatible (Top P wins); `maxTokens` |
 | Native Ollama | Temperature, top-p, top-k, output tokens, and thinking; numeric values use Ollama `options`, thinking uses top-level `think`; reasoning effort is unsupported |
-| Custom OpenAI-compatible | All six settings; thinking uses `chat_template_kwargs.enable_thinking`, and optional effort uses `chat_template_kwargs.reasoning_effort` only while thinking is enabled |
-| Gemini, OpenRouter, LM Studio | `temperature` and `maxTokens` initially |
+| Custom OpenAI-compatible | All six settings for generic local IDs; thinking uses `chat_template_kwargs.enable_thinking`, and optional effort uses `chat_template_kwargs.reasoning_effort` only while thinking is enabled. OpenAI-family IDs follow the native OpenAI token-key and sampling policy instead of the llama.cpp mapping |
+| OpenRouter | `maxTokens` through the existing token-key policy; `temperature` when model policy permits it |
+| Gemini, LM Studio | `temperature` and `maxTokens` initially |
 | In-process local | `temperature` and `maxTokens` |
 | Local CLI | None in the initial contract |
 

--- a/spec/14-per-prompt-inference-settings.md
+++ b/spec/14-per-prompt-inference-settings.md
@@ -216,7 +216,8 @@ configured value when a model rejects it.
 | Native Ollama | `temperature`, `top_p`, `top_k`, `num_predict` inside `options`; thinking maps to top-level `think`; reasoning effort is initially unsupported |
 | Native OpenAI | `temperature` and `top_p` when model-compatible; output budget uses the adapter's existing `max_tokens` / `max_completion_tokens` policy; omit `top_k` and thinking |
 | Native Anthropic | `temperature` in `0...1` or `top_p` in `0...1`, and `max_tokens` when model-compatible; Top P takes precedence over explicit or inherited temperature; omit `top_k` and thinking |
-| Gemini / OpenRouter / LM Studio | Map fields explicitly supported by the existing endpoint contract; omit the rest |
+| OpenRouter | Output budget uses the adapter's `max_tokens` / `max_completion_tokens` policy; `temperature` when the model accepts sampling; omit `top_p`, `top_k`, and thinking. Prefixed OpenAI-family IDs such as `openai/gpt-5.6-sol` follow the same GPT-5 / o-series sampling omit as native OpenAI. |
+| Gemini / LM Studio | Map fields explicitly supported by the existing endpoint contract; omit the rest |
 | In-process MLX / local CLI | Apply only fields supported by the runtime/CLI contract; report the rest as unsupported |
 
 For a model served through an OpenAI-compatible llama.cpp endpoint:

--- a/spec/14-per-prompt-inference-settings.md
+++ b/spec/14-per-prompt-inference-settings.md
@@ -212,7 +212,7 @@ configured value when a model rejects it.
 
 | Provider path | Mapping |
 | --- | --- |
-| Custom OpenAI-compatible, including llama.cpp | `temperature`, `top_p`, `top_k`, `max_tokens`; thinking and optional effort map to `chat_template_kwargs.enable_thinking` and `chat_template_kwargs.reasoning_effort` |
+| Custom OpenAI-compatible, including llama.cpp | `temperature`, `top_p`, `top_k`, `max_tokens`; thinking and optional effort map to `chat_template_kwargs.enable_thinking` and `chat_template_kwargs.reasoning_effort`. OpenAI-family IDs on the same path (`gpt-5.x`, `gpt-5.6-luna`/`sol`, and gateway prefixes such as `openai/gpt-5.6-luna`) follow the native OpenAI mapping instead: omit llama.cpp kwargs, omit sampling when the model rejects it, and send `max_completion_tokens`. |
 | Native Ollama | `temperature`, `top_p`, `top_k`, `num_predict` inside `options`; thinking maps to top-level `think`; reasoning effort is initially unsupported |
 | Native OpenAI | `temperature` and `top_p` when model-compatible; output budget uses the adapter's existing `max_tokens` / `max_completion_tokens` policy; omit `top_k` and thinking |
 | Native Anthropic | `temperature` in `0...1` or `top_p` in `0...1`, and `max_tokens` when model-compatible; Top P takes precedence over explicit or inherited temperature; omit `top_k` and thinking |


### PR DESCRIPTION
## Summary

Fixes [#927](https://github.com/moona3k/macparakeet/issues/927). OpenAI GPT-5.6 Luna/Sol through Vercel AI Gateway (and the same IDs on OpenRouter) failed with *“Text exceeds the model's context limit.”* That copy is wrong: these models have a **1.05M-token** window, and MacParakeet’s cloud input budget is ~140k tokens.

The real failure is a GPT-5 request-shape 400 (`temperature` / `max_tokens`), then an error mapper that treated any 400 mentioning tokens or “context” as overflow. The adapter now keys GPT-5 / o-series wire policy off the **model ID**, including gateway prefixes such as `openai/gpt-5.6-luna`. Connection tests and prompt generation send `max_completion_tokens`, omit sampling those models reject, and leave llama.cpp-style compatible endpoints unchanged. Unsupported-parameter 400s surface as provider errors.

## Design

Native OpenAI already had this policy (#831 / `OpenAIModelPolicy`): omit temperature for o-series and non-chat GPT-5.x, and send `max_completion_tokens`. Vercel, OpenRouter, and user-supplied compatible URLs all go through `OpenAICompatibleLLMHTTPAdapter`, but the policy was gated on `config.id == .openai`. Gateway catalogs use `openai/gpt-5.6-luna`, which also failed the `gpt-` prefix check.

Settled in this PR, not in a prior brief:

- Canonicalize by last path component (`openai/gpt-5.6-luna` → `gpt-5.6-luna`) rather than a hardcoded vendor list.
- Treat “looks like hosted OpenAI GPT-5+ / o-series” as the switch off llama.cpp `chat_template_kwargs` on the compatible path. Generic IDs such as `local-model`, `llama-3.1-8b-instruct`, and `gpt-oss-120b` stay on the broad compatible mapping.
- Do **not** add per-model context budgets. The reported error was not an overflow.
- Gemini and LM Studio field allow-lists stay as they were. LM Studio keeps `max_tokens` even when a loaded model ID looks like GPT-5, matching its documented chat-completions contract. OpenRouter shares this adapter, so the hosted model-ID policy applies there.

Specs updated: [spec/11-llm-integration.md](spec/11-llm-integration.md), [spec/14-per-prompt-inference-settings.md](spec/14-per-prompt-inference-settings.md).

## How it works

```mermaid
flowchart TD
  A["User selects OpenAI-Compatible<br/>model openai/gpt-5.6-luna"] --> B["OpenAIModelPolicy.canonicalModelID"]
  B --> C{"GPT-5+ / o-series?"}
  C -->|yes| D["Omit temperature/top_p<br/>Send max_completion_tokens<br/>No chat_template_kwargs"]
  C -->|no| E["Existing compatible mapping<br/>temperature, max_tokens, kwargs"]
  D --> F["Provider 400?"]
  E --> F
  F -->|"unsupported max_tokens"| G["LLMError.providerError<br/>actual message"]
  F -->|"maximum context length"| H["LLMError.contextTooLong"]
```

| Before | After |
| --- | --- |
| Policy only if `config.id == .openai` | Policy if the model ID is GPT-5+ / o-series (except LM Studio) |
| `openai/gpt-5.6-luna` treated like llama.cpp | Same wire shape as native `gpt-5.5` |
| Connection test sends `max_tokens: 1` | Connection test sends `max_completion_tokens: 128` |
| Any 400 containing `"token"` or `"context"` → context limit | Overflow phrases only; unsupported-parameter 400s stay provider errors |

## Risk surface

Review hardest:

- `OpenAICompatibleLLMHTTPAdapter.buildRequest` and `testConnection` — a **hosted** compatible model ID that looks like `gpt-5*` now follows OpenAI-family mapping. LM Studio is excluded. `gpt-oss-120b` does not match.
- `PromptInferenceCapabilityResolver.supportedFields` — receipts must not claim temperature was sent when the adapter omitted it.
- `LLMHTTPErrorMapper` — real context-length 400s must still map to `.contextTooLong`.

Deliberately out of scope: live Vercel authentication, shrinking the 500k-character cloud budget, Responses API, and native OpenAI model-catalog prefix filtering.

## Test evidence

Focused gate (replayable):

```sh
swift test --filter 'PromptInferenceSettingsTests|LLMHTTPAdapterTests|LLMClientTests.testTestConnection|LLMClientTests.testContextLength|LLMClientTests.testUnsupported|LLMClientTests.testGateway|LLMClientTests.testReasoning|LLMClientTests.testGPT5|LLMClientTests.testResolvedGPT5|LLMClientTests.testGenericContext|LLMClientTests.testOpenAICompatibleGPT5|LLMClientTests.testOpenAICompatibleGeneric'
```

**76 focused tests passed locally**, plus the CI-caught case below after rewrite:

- Gateway golden request for `openai/gpt-5.6-luna` (no sampling, `max_completion_tokens`, no kwargs)
- OpenRouter golden request for `openai/gpt-5.6-sol`
- Connection probe for `openai/gpt-5.6-sol` uses `max_completion_tokens: 128`
- Hosted compatible `gpt-5.2` uses `max_completion_tokens` (this inverted a stale test that encoded the bug)
- Generic compatible `llama-3.1-8b-instruct` still sends `max_tokens` + temperature
- LM Studio `gpt-5.5` still sends `max_tokens` + temperature
- `max_tokens` unsupported 400 → `.providerError`, not `.contextTooLong`
- Existing context-length 400 still → `.contextTooLong`
- A 400 that merely says “provide more context” stays `.providerError`
- Native GPT-5.5 / chat-tier / o-series golden requests unchanged

Not covered: a live Vercel AI Gateway call with a real key.

## Test plan

- [x] Focused LLM adapter / client / inference-settings tests above
- [ ] Hosted CI on this head (`swift-test` previously failed on the stale `gpt-5.2` compatible assertion)
- [ ] Optional: Settings → OpenAI-Compatible → `https://ai-gateway.vercel.sh/v1` + `openai/gpt-5.6-luna` → Test Connection
- [ ] Optional: generate a short meeting summary on Luna/Sol; confirm a true oversize prompt still shows the context-limit copy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved GPT-5.x compatibility across OpenAI-compatible gateways and OpenRouter.
  - Requests now use the appropriate completion-token setting and omit unsupported sampling options.
  - Parameter-compatibility errors are reported accurately instead of being classified as context-limit failures.
  - Improved recognition of provider-prefixed and multi-digit GPT model IDs.

- **Documentation**
  - Updated provider capability and per-prompt settings documentation.
  - Added an unreleased changelog entry describing these compatibility updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->