### PR TITLE
Simplify Prompts into transcript and Live Ask management

### DIFF
--- a/Sources/MacParakeet/Views/MainWindowView.swift
+++ b/Sources/MacParakeet/Views/MainWindowView.swift
@@ -196,9 +196,9 @@ struct MainWindowView: View {
                     case .dictations:
                         DictationHistoryView(viewModel: historyViewModel)
                     case .prompts:
-                        PromptLibraryView(
-                            viewModel: promptsViewModel,
-                            showsDismissButton: false
+                        PromptsWorkspaceView(
+                            promptsViewModel: promptsViewModel,
+                            quickPromptsViewModel: meetingsWorkspaceViewModel.quickPromptsViewModel
                         )
                     case .transforms:
                         TransformsView(

--- a/Sources/MacParakeet/Views/MeetingRecording/AskPromptsSheet.swift
+++ b/Sources/MacParakeet/Views/MeetingRecording/AskPromptsSheet.swift
@@ -17,6 +17,9 @@ struct AskPromptsSheet: View {
     @Environment(\.dismiss) private var dismiss
     @Bindable var viewModel: QuickPromptsViewModel
 
+    /// Removes sheet-only chrome when this manager is rendered in the Prompts workspace.
+    var isEmbedded: Bool = false
+
     @State private var hoveredID: UUID?
     @State private var pendingDelete: QuickPrompt?
     @State private var showingResetConfirm = false
@@ -69,7 +72,10 @@ struct AskPromptsSheet: View {
             }
         }
         .background(.thickMaterial)
-        .frame(minWidth: 720, minHeight: 640)
+        .frame(
+            minWidth: isEmbedded ? nil : 720,
+            minHeight: isEmbedded ? nil : 640
+        )
         .alert(
             "Delete prompt?",
             isPresented: Binding(
@@ -137,10 +143,10 @@ struct AskPromptsSheet: View {
     private var header: some View {
         HStack(alignment: .bottom) {
             VStack(alignment: .leading, spacing: 4) {
-                Text("Ask Prompts")
+                Text("Live Ask")
                     .font(DesignSystem.Typography.heroTitle)
                     .foregroundStyle(DesignSystem.Colors.textPrimary)
-                Text("Reusable questions for live meetings. Pin the ones you reach for most to keep them front and center — the rest stay in your library, ready when you need them.")
+                Text("Reusable questions for a live meeting. Pin the ones you reach for most to keep them easy to reach in Ask.")
                     .font(DesignSystem.Typography.body)
                     .foregroundStyle(DesignSystem.Colors.textSecondary)
             }
@@ -161,18 +167,20 @@ struct AskPromptsSheet: View {
             .polishedTooltip("More options")
             .accessibilityLabel("More options")
 
-            Button {
-                dismiss()
-            } label: {
-                Text("Done")
-                    .font(DesignSystem.Typography.body.weight(.semibold))
-                    .padding(.horizontal, DesignSystem.Spacing.sm)
+            if !isEmbedded {
+                Button {
+                    dismiss()
+                } label: {
+                    Text("Done")
+                        .font(DesignSystem.Typography.body.weight(.semibold))
+                        .padding(.horizontal, DesignSystem.Spacing.sm)
+                }
+                .parakeetAction(.primaryProminent)
+                .controlSize(.large)
+                // Esc dismisses (Apple HIG default for sheets). `.cancelAction`
+                // is Esc + Cmd-. on macOS — both reach the close intent.
+                .keyboardShortcut(.cancelAction)
             }
-            .parakeetAction(.primaryProminent)
-            .controlSize(.large)
-            // Esc dismisses (Apple HIG default for sheets). `.cancelAction`
-            // is Esc + Cmd-. on macOS — both reach the close intent.
-            .keyboardShortcut(.cancelAction)
         }
         .padding(DesignSystem.Spacing.xl)
         .background(DesignSystem.Colors.surface)

--- a/Sources/MacParakeet/Views/Transcription/PromptLibraryView.swift
+++ b/Sources/MacParakeet/Views/Transcription/PromptLibraryView.swift
@@ -6,24 +6,26 @@ enum PromptLibraryPresentation {
     case library
     case meetingAutoNotes
 
-    var includesTransforms: Bool {
-        self == .library
-    }
-
     var title: String {
         switch self {
-        case .library: "Prompts"
-        case .meetingAutoNotes: "Meeting Prompts"
+        case .library: "Transcript prompts"
+        case .meetingAutoNotes: "Meeting prompts"
         }
     }
 
     var subtitle: String {
         switch self {
         case .library:
-            "Instructions for your transcripts and selected-text Transforms."
+            "Instructions that run on completed transcripts."
         case .meetingAutoNotes:
-            "Instructions that generate results from meeting transcripts."
+            "Instructions that generate notes from completed meetings."
         }
+    }
+
+    var creationCategory: Prompt.Category { .result }
+
+    func includes(category: Prompt.Category) -> Bool {
+        category == .result
     }
 }
 
@@ -31,12 +33,6 @@ struct PromptLibraryView: View {
     private enum ContentMode: String, CaseIterable {
         case edit = "Edit"
         case preview = "Preview"
-    }
-
-    private enum PromptKindFilter: String, CaseIterable {
-        case all = "All prompts"
-        case results = "Results"
-        case transforms = "Transforms"
     }
 
     private enum LibrarySheet: String, Identifiable {
@@ -58,7 +54,6 @@ struct PromptLibraryView: View {
     @State private var diffToVersionID: UUID?
     @State private var versionDiff = PromptVersionDiffViewModel()
     @State private var collectionFilterID: UUID?
-    @State private var promptKindFilter: PromptKindFilter = .all
     @State private var collectionDraftNames: [UUID: String] = [:]
     @State private var hoveredPromptId: UUID?
     @State private var expandedPromptIds: Set<UUID> = []
@@ -68,6 +63,13 @@ struct PromptLibraryView: View {
     /// gets the same icon brightening + AutoRunBadge reveal that a mouse
     /// user gets on hover.
     @FocusState private var focusedPromptId: UUID?
+
+    private var editingTranscriptPrompt: Prompt? {
+        guard let prompt = viewModel.editingPrompt, presentation.includes(category: prompt.category) else {
+            return nil
+        }
+        return prompt
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -102,15 +104,6 @@ struct PromptLibraryView: View {
                         .textFieldStyle(.roundedBorder)
                         .frame(minWidth: 160, maxWidth: .infinity)
                         .accessibilityLabel("Search prompts")
-                    if presentation.includesTransforms {
-                        Picker("Prompt kind", selection: $promptKindFilter) {
-                            ForEach(PromptKindFilter.allCases, id: \.self) { kind in
-                                Text(kind.rawValue).tag(kind)
-                            }
-                        }
-                        .labelsHidden()
-                        .frame(width: 140)
-                    }
                     if !viewModel.collections.isEmpty {
                         Picker("Collection", selection: $collectionFilterID) {
                             Text("All collections").tag(Optional<UUID>.none)
@@ -123,7 +116,7 @@ struct PromptLibraryView: View {
                     }
                     Menu {
                         Button("Manage collections…") { librarySheet = .collections }
-                        Button("Trash (\(viewModel.deletedPrompts.count))…") { librarySheet = .trash }
+                        Button("Trash (\(displayedDeletedPrompts.count))…") { librarySheet = .trash }
                     } label: {
                         Image(systemName: "ellipsis.circle")
                     }
@@ -140,7 +133,6 @@ struct PromptLibraryView: View {
 
             ScrollView {
                 let prompts = filteredPrompts
-                let showsTransformBadge = shouldShowTransformBadge(in: prompts)
 
                 VStack(spacing: DesignSystem.Spacing.lg) {
                     if let errorMessage = viewModel.errorMessage {
@@ -151,7 +143,7 @@ struct PromptLibraryView: View {
                     } else {
                         cardGroup {
                             ForEach(Array(prompts.enumerated()), id: \.element.id) { index, prompt in
-                                promptRow(prompt, showsTransformBadge: showsTransformBadge)
+                                promptRow(prompt)
                                 if index < prompts.count - 1 { Divider().padding(.leading, 16) }
                             }
                         }
@@ -205,7 +197,7 @@ struct PromptLibraryView: View {
         }
         .sheet(
             isPresented: Binding(
-                get: { viewModel.editingPrompt != nil },
+                get: { editingTranscriptPrompt != nil },
                 set: { if !$0 { viewModel.editingPrompt = nil } }
             ),
             onDismiss: {
@@ -215,7 +207,7 @@ struct PromptLibraryView: View {
                 viewModel.cancelEditing()
             }
         ) {
-            if let prompt = viewModel.editingPrompt {
+            if let prompt = editingTranscriptPrompt {
                 editSheet(prompt: prompt)
                     .alert("Discard changes?", isPresented: $showingDiscardConfirm) {
                         Button("Discard", role: .destructive) {
@@ -263,13 +255,11 @@ struct PromptLibraryView: View {
 
     private var hasActiveFilters: Bool {
         !searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-            || collectionFilterID != nil || promptKindFilter != .all
+            || collectionFilterID != nil
     }
 
     private func beginCreatingPrompt() {
-        if !presentation.includesTransforms {
-            viewModel.newPromptCategory = .result
-        }
+        viewModel.newPromptCategory = presentation.creationCategory
         librarySheet = .create
     }
 
@@ -324,31 +314,18 @@ struct PromptLibraryView: View {
     private var filteredPrompts: [Prompt] {
         let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
         return viewModel.managedPrompts.filter {
-            guard presentation.includesTransforms || $0.category == .result else { return false }
+            guard presentation.includes(category: $0.category) else { return false }
             let matchesCollection = collectionFilterID == nil || $0.collectionId == collectionFilterID
-            let matchesKind: Bool
-            switch promptKindFilter {
-            case .all: matchesKind = true
-            case .results: matchesKind = $0.category == .result
-            case .transforms: matchesKind = $0.category == .transform
-            }
             let matchesQuery =
                 query.isEmpty
                 || $0.name.localizedCaseInsensitiveContains(query)
                 || $0.content.localizedCaseInsensitiveContains(query)
-            return matchesCollection && matchesKind && matchesQuery
+            return matchesCollection && matchesQuery
         }
     }
 
-    private func shouldShowTransformBadge(in prompts: [Prompt]) -> Bool {
-        presentation.includesTransforms
-            && promptKindFilter == .all
-            && prompts.contains { $0.category == .result }
-            && prompts.contains { $0.category == .transform }
-    }
-
     private var displayedDeletedPrompts: [Prompt] {
-        viewModel.deletedPrompts.filter { presentation.includesTransforms || $0.category == .result }
+        viewModel.deletedPrompts.filter { presentation.includes(category: $0.category) }
     }
 
     private func errorBanner(_ message: String) -> some View {
@@ -367,9 +344,7 @@ struct PromptLibraryView: View {
     private var collectionManager: some View {
         sectionContainer(
             title: "Collections",
-            subtitle: presentation.includesTransforms
-                ? "Organize result prompts and Transforms without changing their version history."
-                : "Organize result prompts without changing their version history."
+            subtitle: "Organize your prompts into collections."
         ) {
             cardGroup {
                 VStack(spacing: 0) {
@@ -446,7 +421,7 @@ struct PromptLibraryView: View {
                         VStack(alignment: .leading, spacing: 3) {
                             Text(prompt.name)
                                 .font(DesignSystem.Typography.body.weight(.semibold))
-                            Text(prompt.category == .transform ? "Transform" : "Result prompt")
+                            Text("Transcript prompt")
                                 .font(DesignSystem.Typography.caption)
                                 .foregroundStyle(DesignSystem.Colors.textSecondary)
                         }
@@ -502,7 +477,7 @@ struct PromptLibraryView: View {
         .cardShadow(DesignSystem.Shadows.cardRest)
     }
 
-    private func promptRow(_ prompt: Prompt, showsTransformBadge: Bool) -> some View {
+    private func promptRow(_ prompt: Prompt) -> some View {
         // Treat keyboard focus the same as hover so a Tab-only user gets
         // identical icon brightening + AutoRunBadge reveal.
         let isActive = hoveredPromptId == prompt.id || focusedPromptId == prompt.id
@@ -540,16 +515,6 @@ struct PromptLibraryView: View {
                     if prompt.isBuiltIn {
                         Text("Built-in")
                             .font(DesignSystem.Typography.caption.weight(.semibold))
-                            .foregroundStyle(DesignSystem.Colors.textSecondary)
-                            .padding(.horizontal, 7)
-                            .padding(.vertical, 2)
-                            .background(DesignSystem.Colors.surfaceElevated)
-                            .clipShape(Capsule())
-                    }
-
-                    if showsTransformBadge && prompt.category == .transform {
-                        Text("Transform")
-                            .font(DesignSystem.Typography.caption)
                             .foregroundStyle(DesignSystem.Colors.textSecondary)
                             .padding(.horizontal, 7)
                             .padding(.vertical, 2)
@@ -796,7 +761,6 @@ struct PromptLibraryView: View {
                 Button("Clear filters") {
                     searchText = ""
                     collectionFilterID = nil
-                    promptKindFilter = .all
                 }
                 .parakeetAction(.secondary)
             }
@@ -815,21 +779,6 @@ struct PromptLibraryView: View {
     private var addPromptCard: some View {
         VStack(spacing: 0) {
             VStack(alignment: .leading, spacing: DesignSystem.Spacing.lg) {
-                if presentation.includesTransforms {
-                    VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
-                        Text("Type")
-                            .font(DesignSystem.Typography.caption.weight(.medium))
-                            .foregroundStyle(DesignSystem.Colors.textSecondary)
-                        Picker("Type", selection: $viewModel.newPromptCategory) {
-                            Text("Result prompt").tag(Prompt.Category.result)
-                            Text("Transform").tag(Prompt.Category.transform)
-                        }
-                        .labelsHidden()
-                        .pickerStyle(.segmented)
-                        .frame(width: 240)
-                    }
-                }
-
                 VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
                     Text("Name")
                         .font(DesignSystem.Typography.caption.weight(.medium))
@@ -855,9 +804,7 @@ struct PromptLibraryView: View {
 
                 collectionPicker(selection: $viewModel.newCollectionID)
 
-                if viewModel.newPromptCategory == .result {
-                    promptLabelTargeting(selection: $viewModel.newTargetLabelIDs)
-                }
+                promptLabelTargeting(selection: $viewModel.newTargetLabelIDs)
 
                 GenerationSettingsEditor(
                     draft: $viewModel.newInferenceSettings,
@@ -869,9 +816,7 @@ struct PromptLibraryView: View {
                     }
                 )
 
-                if viewModel.newPromptCategory == .result {
-                    meetingNotesContextToggle(isOn: $viewModel.newIncludeMeetingNotes)
-                }
+                meetingNotesContextToggle(isOn: $viewModel.newIncludeMeetingNotes)
             }
             .padding(DesignSystem.Spacing.lg)
 
@@ -884,7 +829,6 @@ struct PromptLibraryView: View {
                     if viewModel.newName.isEmpty && viewModel.newContent.isEmpty {
                         searchText = ""
                         collectionFilterID = nil
-                        promptKindFilter = .all
                         librarySheet = nil
                     }
                 } label: {
@@ -914,9 +858,7 @@ struct PromptLibraryView: View {
         )
         .cardShadow(DesignSystem.Shadows.cardRest)
         .onAppear {
-            if !presentation.includesTransforms {
-                viewModel.newPromptCategory = .result
-            }
+            viewModel.newPromptCategory = presentation.creationCategory
         }
     }
 
@@ -963,15 +905,13 @@ struct PromptLibraryView: View {
 
                     collectionPicker(selection: $viewModel.editingCollectionID)
 
-                    if prompt.category == .result {
-                        promptLabelTargeting(
-                            selection: Binding(
-                                get: { viewModel.editingTargetLabelIDs },
-                                set: { viewModel.setEditingTargetLabels($0) }
-                            ),
-                            hasCustomRules: viewModel.editingHasCustomTargetingRules
-                        )
-                    }
+                    promptLabelTargeting(
+                        selection: Binding(
+                            get: { viewModel.editingTargetLabelIDs },
+                            set: { viewModel.setEditingTargetLabels($0) }
+                        ),
+                        hasCustomRules: viewModel.editingHasCustomTargetingRules
+                    )
 
                     GenerationSettingsEditor(
                         draft: $viewModel.editingInferenceSettings,
@@ -983,9 +923,7 @@ struct PromptLibraryView: View {
                         }
                     )
 
-                    if prompt.category == .result {
-                        meetingNotesContextToggle(isOn: $viewModel.editingIncludeMeetingNotes)
-                    }
+                    meetingNotesContextToggle(isOn: $viewModel.editingIncludeMeetingNotes)
                     versionHistory(prompt: prompt)
                 }
                 .padding(DesignSystem.Spacing.xl)

--- a/Sources/MacParakeet/Views/Transcription/PromptsWorkspaceView.swift
+++ b/Sources/MacParakeet/Views/Transcription/PromptsWorkspaceView.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+import MacParakeetViewModels
+
+enum PromptsWorkspaceSection: String, CaseIterable, Identifiable {
+    case transcriptPrompts = "Transcript prompts"
+    case liveAsk = "Live Ask"
+
+    static let defaultSection = Self.transcriptPrompts
+
+    var id: Self { self }
+}
+
+/// The sidebar home for transcript output instructions and the questions used
+/// while a meeting is in progress. Each section keeps its established manager
+/// and repository-backed view model.
+struct PromptsWorkspaceView: View {
+    let promptsViewModel: PromptsViewModel
+    let quickPromptsViewModel: QuickPromptsViewModel
+
+    @State private var section = PromptsWorkspaceSection.defaultSection
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Picker("Prompt section", selection: $section) {
+                ForEach(PromptsWorkspaceSection.allCases) { section in
+                    Text(section.rawValue).tag(section)
+                }
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+            .accessibilityLabel("Prompt section")
+            .frame(width: 340)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(DesignSystem.Spacing.xl)
+            .background(DesignSystem.Colors.surface)
+
+            Divider()
+
+            switch section {
+            case .transcriptPrompts:
+                PromptLibraryView(
+                    viewModel: promptsViewModel,
+                    showsDismissButton: false
+                )
+            case .liveAsk:
+                AskPromptsSheet(
+                    viewModel: quickPromptsViewModel,
+                    isEmbedded: true
+                )
+                .onAppear {
+                    quickPromptsViewModel.refresh()
+                }
+                .onDisappear {
+                    quickPromptsViewModel.cancelCreating()
+                    quickPromptsViewModel.editingPrompt = nil
+                    quickPromptsViewModel.refresh()
+                }
+            }
+        }
+    }
+}

--- a/Tests/MacParakeetTests/Views/PromptManagementPresentationTests.swift
+++ b/Tests/MacParakeetTests/Views/PromptManagementPresentationTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+import MacParakeetCore
+@testable import MacParakeet
+
+final class PromptManagementPresentationTests: XCTestCase {
+    func testPromptLibraryOnlyIncludesTranscriptPromptsInEveryPresentation() {
+        for presentation in [
+            PromptLibraryPresentation.library,
+            PromptLibraryPresentation.meetingAutoNotes,
+        ] {
+            XCTAssertTrue(presentation.includes(category: .result))
+            XCTAssertFalse(presentation.includes(category: .transform))
+            XCTAssertEqual(presentation.creationCategory, .result)
+        }
+    }
+
+    func testPromptsWorkspaceDefaultsToTranscriptPrompts() {
+        XCTAssertEqual(PromptsWorkspaceSection.defaultSection, .transcriptPrompts)
+        XCTAssertEqual(
+            PromptsWorkspaceSection.allCases,
+            [.transcriptPrompts, .liveAsk]
+        )
+    }
+}

--- a/docs/plans/2026-09-08-prompt-management-navigation.md
+++ b/docs/plans/2026-09-08-prompt-management-navigation.md
@@ -1,0 +1,34 @@
+# Clarify prompt management navigation
+
+Status: implemented; PR verification pending. Base: 233b5f4d. This plan implements the user's approved separation without changing stored instructions or public CLI categories.
+
+## Product contract
+
+- Prompts is the management home for **Transcript prompts** and **Live Ask**, selected through two clearly named sections. Transcript prompts operate on completed transcriptions under the existing source and auto-run policies. Live Ask contains reusable questions used during meetings.
+- Meetings remains the place to run Live Ask and choose automatic **After each meeting** outputs. Existing quick management entries reuse the corresponding manager.
+- Transforms owns selected-text rewriting. Transcript managers never list, create, restore, or edit Transform rows. Remove the All prompts / Results / Transforms picker and redundant category badges. Use Transcript prompts or ordinary output language instead of Results as a management category.
+- Existing Prompt/QuickPrompt IDs, stored categories, history, pinning, shortcuts, collections, availability policies, auto-run behavior, and CLI contracts remain intact. No migration or shared replacement data model.
+
+## Implementation
+
+1. Add a small Prompts workspace that defaults to Transcript prompts and selects Transcript prompts or Live Ask. Reuse PromptLibraryView and AskPromptsSheet rather than creating new CRUD implementations. Make the existing Ask manager embeddable without an inappropriate Done button or sheet-only sizing. Use the already configured QuickPromptsViewModel from the Meetings workspace.
+2. Make PromptLibraryView transcript-only in every presentation. Scope active rows, Trash, creation defaults and editor category consistently. Preserve filtering/search and prompt settings. The transcript presentation remains usable in completed-transcript and Meetings management sheets.
+3. Leave TransformsView, its editor, bindings, and view model unchanged, as explicitly requested by the user. Do not add an advanced manager or expand its feature set. Existing stored Transform versions/collections/settings remain intact and accessible through existing CLI commands; advanced controls formerly in the mixed Prompts view are not being moved into the Transform UI in this PR.
+4. Keep Live Ask CRUD/pinning/grouping unchanged, and refresh the same repository-backed manager from either navigation entry. Collections apply to transcript/Transform instruction records; Live Ask retains its existing question grouping, with no collection controls incorrectly applied to it.
+5. Update governing UI spec and relevant README/integration guidance to explain the navigation. Preserve technical category `result` and existing CLI commands; this is presentation, not a wire-format rename.
+
+## Verification and review
+
+- Focused tests for presentation scope, default creation category, and existing prompt/QuickPrompt/Transform state where affected. Verify active and deleted rows cannot cross scopes.
+- Check Live Ask create/edit/pin access from Prompts and Meetings, shared-manager dismissal/refresh, and the existing Transforms screen remaining unchanged.
+- No user database mutation for automated QA. Reuse existing build cache in the clean owning worktree; do not touch unrelated worktrees or user app state.
+- Independent correctness/maintainability review, PR checks and review threads before merge. Full suite runs through CI; avoid redundant local full-suite runs.
+- Open a real PR from feat/prompt-management-navigation; merge only its reviewed, passing head. User explicitly authorized implementation, PR and merge, but no release publication.
+
+## Deliberate limits
+
+No editor framework, database migration, new prompt type, collection migration, CLI renaming, or changes to when prompts execute. Transforms is explicitly outside this PR. Do not introduce another manager or consolidate its editor.
+
+## Verification record
+
+Independent source review found no remaining blocker after lifecycle and wording fixes. Focused local Release tests could not execute: the build exhausted local disk while compiling SwiftSyntax. CI owns the full test gate for this change; this failed local attempt is not a passing test result. No user database was changed for QA.

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -552,9 +552,11 @@ These commands accept `--database <path>` for an isolated automation database.
 Set source-specific auto-run (`--source`) in a separate command from collection
 assignment; the CLI rejects combining those mutations.
 
-The GUI's meeting-specific prompt manager shows transcript prompts only.
-Transforms remain available in their dedicated GUI destination and CLI
-commands; Live Ask uses the separate quick-prompt commands below.
+The GUI's Prompts destination contains Transcript prompts and Live Ask.
+Meetings provides contextual access to the same managers. Transforms remains
+its own selected-text rewrite destination. This navigation does not change
+CLI categories or storage: Live Ask uses the separate quick-prompt commands
+below, and existing prompt/version commands continue to support Transforms.
 
 ### Manage live Ask quick prompts
 

--- a/spec/04-ui-patterns.md
+++ b/spec/04-ui-patterns.md
@@ -1256,22 +1256,33 @@ Button to re-run onboarding flow: "Run Onboarding Again..."
 
 ## Prompts
 
-The sidebar **Prompts** destination and generation-popover management action
-share `PromptLibraryView`. A single searchable list has prompt-kind and optional
-collection filters. **New prompt** opens creation in a sheet; **Manage
-collections** opens collection creation, renaming, reordering and deletion in a
-separate sheet. Built-in provenance is shown on rows, without separate built-in
-and custom sections or an always-visible creation form. No search matches is a
-filter empty state, not a claim that the user has no custom prompts.
+The sidebar **Prompts** destination is the management home for **Transcript
+prompts** and **Live Ask**. Transcript prompts generate outputs from completed
+meeting, file, podcast and video transcripts. Live Ask manages reusable questions
+for ongoing meetings using the existing QuickPrompt model and manager. These are
+clearly named sections, not an All prompts / Results / Transforms type picker.
 
-The Meetings **After Each Meeting → Prompts** entry opens the same manager
-in a meeting presentation: active and deleted lists contain only transcript
-result prompts, creation is fixed to that kind, and the Transform kind picker
-is absent. It receives the same collection, version, editing and label-policy
-dependencies as the standalone manager. Collections remain shared prompt
-organization; they are distinct from recording labels and availability rules.
-Live Ask keeps its separate quick-question manager. Auto-Run help uses native
-help so it is not clipped by a row or sheet and does not intercept clicks.
+**Transforms** remains its existing self-contained selected-text rewrite
+surface. This navigation change does not add another Transform manager or change
+its editor. Transcript management does not expose Transform rows, including
+creation and Trash. Stored categories, versions, metadata and CLI commands remain
+compatible; advanced Transform controls formerly exposed through the mixed
+Prompts manager are outside this UI change.
+
+Transcript prompt lists retain search and optional collection filtering. **New
+prompt** creates a transcript prompt; **Manage collections** opens collection
+creation, renaming, reordering and deletion. Built-in provenance is shown on rows,
+without redundant Result/Transform category badges. No search matches is a filter
+empty state, not a claim that the user has no custom prompts.
+
+The Meetings **After each meeting → Prompts** entry reuses transcript management;
+Live Ask contextual management reuses the same question manager available from
+Prompts. Meetings remains the place to use live questions and choose automatic
+post-meeting outputs. All entries receive their configured repositories and
+editing services. Collections organize transcript/Transform instruction records;
+recording labels classify recordings and gate availability. Live Ask retains its
+existing question groups and pinning, without a collection migration. Auto-Run
+help uses native help so it is not clipped and does not intercept clicks.
 
 The editor retains Markdown source/preview, notes-context opt-in, collection
 assignment, model override, and collapsed generation settings. **Version history**


### PR DESCRIPTION
## What changes

Prompts previously mixed transcript instructions with Transforms, while Live Ask management was available only through Meetings. Prompts now opens on **Transcript prompts**, with **Live Ask** beside it. Both sections reuse their existing managers and data.

- Remove the All prompts / Results / Transforms picker and redundant category badges.
- Keep active rows, Trash, creation and editing strictly scoped to transcript prompts.
- Embed the existing Live Ask manager, refresh the configured shared view model and clear unfinished editor state when leaving the section.
- Preserve contextual management from Meetings and update the UI spec, plan and integration guide.

## Scope

Transforms stays unchanged and self-contained. Stored categories, versions, collections, execution policies and CLI commands remain compatible. Advanced Transform controls formerly exposed by the mixed manager are not moved into the Transform editor in this PR. No database migration or user-data mutation.

## Validation

- Independent correctness/lifecycle review is LGTM on exact head `852d0621`; CodeRabbit completed with no actionable comments.
- `git diff --check` and formatter lint on new Swift files passed.
- Added presentation scope/default tests.
- Final-source Xcode Release build passed; dev app rebuilt, signed and restarted on `852d0621`. Deep/strict code-sign verification passed.
- CI passed all gates on `852d0621`: Release build, CLI contract smoke, app bundle smoke, concurrency safety, Swift 6 language mode, and all 5,870 tests (including both new presentation cases).
- Local focused Release test compilation exhausted disk before tests executed; the subsequent local Xcode build and full CI gate passed.
- no-mistakes is unavailable; local Greptile is installed but unauthenticated. Independent review and GitHub review/checks are used.

Plan: `docs/plans/2026-09-08-prompt-management-navigation.md`.

## Visual QA

The dev app is running this head; these interactions remain for manual visual review:

1. Open Prompts: Transcript prompts is selected, with no mixed-type picker or Result badges.
2. Switch to Live Ask: existing questions, pinning and editing are available; the embedded manager has no Done button.
3. Open the managers from Meetings: transcript management and Live Ask keep their contextual entry points.
4. Open Transforms: its existing editor and behavior are unchanged.
