### PR TITLE
Make prompt generation settings model-aware

### DIFF
--- a/Sources/CLI/CHANGELOG.md
+++ b/Sources/CLI/CHANGELOG.md
@@ -117,6 +117,11 @@ by checking exit code first: `2` = misuse, `1` = runtime, `0` = success.
 
 ### Changed
 
+- Gemini 3 prompt generation and `llm summarize` inherit provider sampling
+  defaults instead of injecting temperature 0.7. Explicit saved overrides and
+  historical execution receipts retain their values; CLI flags and JSON shapes
+  are unchanged.
+
 - Prompt availability can be updated with `prompts set --label LABEL` or
   `--all-labels`, plus `--available`/`--unavailable`. Writes now affect the same
   label rules used by execution and preserve existing exceptions. JSON returns

--- a/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
+++ b/Sources/MacParakeet/App/AppEnvironmentConfigurer.swift
@@ -192,7 +192,9 @@ final class AppEnvironmentConfigurer {
             collectionRepo: env.promptCollectionRepo,
             editingService: env.promptEditingService,
             labelRepository: env.meetingLabelRepo,
-            labelPolicyRepository: env.promptLabelPolicyRepo
+            labelPolicyRepository: env.promptLabelPolicyRepo,
+            configStore: env.llmConfigStore,
+            llmClient: env.llmClient
         )
         promptsViewModel.onTransformsChanged = {
             NotificationCenter.default.post(name: .transformsBindingsChanged, object: nil)
@@ -587,6 +589,7 @@ final class AppEnvironmentConfigurer {
             cardGenerator: hasConfig ? env.cardGenerationService : nil
         )
         transformsViewModel.setHasLLMProvider(hasConfig)
+        promptsViewModel.refreshGenerationSettingsContext()
         liveMeetingCoordinator?.updateLLMService(service)
     }
 }

--- a/Sources/MacParakeet/Views/Transcription/PromptLibraryView.swift
+++ b/Sources/MacParakeet/Views/Transcription/PromptLibraryView.swift
@@ -260,6 +260,7 @@ struct PromptLibraryView: View {
 
     private func beginCreatingPrompt() {
         viewModel.newPromptCategory = presentation.creationCategory
+        viewModel.refreshGenerationSettingsContext()
         librarySheet = .create
     }
 
@@ -810,6 +811,7 @@ struct PromptLibraryView: View {
                     draft: $viewModel.newInferenceSettings,
                     modelOverride: $viewModel.newModelOverride,
                     errors: viewModel.newInferenceValidationErrors,
+                    viewModel: viewModel,
                     onReset: {
                         viewModel.resetNewInferenceSettings()
                         viewModel.newModelOverride = ""
@@ -917,6 +919,7 @@ struct PromptLibraryView: View {
                         draft: $viewModel.editingInferenceSettings,
                         modelOverride: $viewModel.editingModelOverride,
                         errors: viewModel.editingInferenceValidationErrors,
+                        viewModel: viewModel,
                         onReset: {
                             viewModel.resetEditingInferenceSettings()
                             viewModel.editingModelOverride = ""
@@ -1001,9 +1004,11 @@ struct PromptLibraryView: View {
             if hasCustomRules {
                 Label("Custom availability rules", systemImage: "slider.horizontal.3")
                     .font(DesignSystem.Typography.body.weight(.medium))
-                Text("Existing exceptions stay unchanged. Choose All transcriptions or labels below to replace them when you save.")
-                    .font(DesignSystem.Typography.caption)
-                    .foregroundStyle(DesignSystem.Colors.textSecondary)
+                Text(
+                    "Existing exceptions stay unchanged. Choose All transcriptions or labels below to replace them when you save."
+                )
+                .font(DesignSystem.Typography.caption)
+                .foregroundStyle(DesignSystem.Colors.textSecondary)
             }
 
             FlowLayout(spacing: 7) {
@@ -1406,104 +1411,79 @@ struct PromptLibraryView: View {
 }
 
 private struct GenerationSettingsEditor: View {
+    private static let fieldOrder: [PromptInferenceSettings.Field] = [
+        .temperature, .topP, .topK, .maxTokens, .thinkingMode, .reasoningEffort,
+    ]
+
     @Binding var draft: PromptsViewModel.InferenceSettingsDraft
     @Binding var modelOverride: String
     let errors: PromptsViewModel.InferenceValidationErrors
+    let viewModel: PromptsViewModel
     let onReset: () -> Void
 
     @State private var isExpanded = false
+    @State private var customizingFields: Set<PromptInferenceSettings.Field> = []
+    @State private var modelSelection = PromptsViewModel.GenerationModelSelection()
 
     var body: some View {
         DisclosureGroup(isExpanded: $isExpanded) {
             VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
-                Text("Blank fields inherit MacParakeet's current defaults for the selected provider and model.")
+                if presentation == nil {
+                    Text(
+                        "Set up AI in Settings to see which options this prompt will use. Saved values stay as entered."
+                    )
                     .font(DesignSystem.Typography.caption)
                     .foregroundStyle(DesignSystem.Colors.textSecondary)
                     .fixedSize(horizontal: false, vertical: true)
-
-                VStack(alignment: .leading, spacing: 5) {
-                    Text("Model override")
-                        .font(DesignSystem.Typography.caption.weight(.medium))
-                        .foregroundStyle(DesignSystem.Colors.textSecondary)
-                    TextField("Current provider model", text: $modelOverride)
-                        .textFieldStyle(.roundedBorder)
-                        .accessibilityLabel("Model override")
-                    Text("Use a model identifier supported by the active provider, or leave blank to inherit it.")
-                        .font(DesignSystem.Typography.caption)
-                        .foregroundStyle(DesignSystem.Colors.textTertiary)
+                } else {
+                    providerSummary
                 }
 
-                LazyVGrid(
-                    columns: [
-                        GridItem(.flexible(), spacing: DesignSystem.Spacing.md),
-                        GridItem(.flexible(), spacing: DesignSystem.Spacing.md),
-                    ],
-                    alignment: .leading,
-                    spacing: DesignSystem.Spacing.md
-                ) {
-                    numberField(
-                        title: "Temperature",
-                        placeholder: "Default (0–2)",
-                        text: $draft.temperature,
-                        field: .temperature
-                    )
-                    numberField(
-                        title: "Top P",
-                        placeholder: "Default (0–1)",
-                        text: $draft.topP,
-                        field: .topP
-                    )
-                    numberField(
-                        title: "Top K",
-                        placeholder: "Default (0–1000)",
-                        text: $draft.topK,
-                        field: .topK
-                    )
-                    numberField(
-                        title: "Maximum output tokens",
-                        placeholder: "Default (1–131072)",
-                        text: $draft.maxTokens,
-                        field: .maxTokens
-                    )
-                    VStack(alignment: .leading, spacing: 5) {
-                        Text("Thinking")
-                            .font(DesignSystem.Typography.caption.weight(.medium))
-                            .foregroundStyle(DesignSystem.Colors.textSecondary)
-                        Picker("Thinking", selection: $draft.thinkingMode) {
-                            Text("Default").tag(PromptInferenceSettings.ThinkingMode.providerDefault)
-                            Text("Enabled").tag(PromptInferenceSettings.ThinkingMode.enabled)
-                            Text("Disabled").tag(PromptInferenceSettings.ThinkingMode.disabled)
-                        }
-                        .labelsHidden()
-                        .pickerStyle(.menu)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .onChange(of: draft.thinkingMode) { _, mode in
-                            if mode != .enabled {
-                                draft.reasoningEffort = nil
-                            }
-                        }
-                    }
+                modelSection
 
-                    if draft.thinkingMode == .enabled {
-                        VStack(alignment: .leading, spacing: 5) {
-                            Text("Reasoning effort")
-                                .font(DesignSystem.Typography.caption.weight(.medium))
-                                .foregroundStyle(DesignSystem.Colors.textSecondary)
-                            Picker("Reasoning effort", selection: $draft.reasoningEffort) {
-                                Text("Default").tag(PromptInferenceSettings.ReasoningEffort?.none)
-                                ForEach(PromptInferenceSettings.ReasoningEffort.allCases, id: \.self) { effort in
-                                    Text(PromptsViewModel.displayName(for: effort)).tag(Optional(effort))
-                                }
-                            }
-                            .labelsHidden()
-                            .pickerStyle(.menu)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            Text("Available levels depend on the endpoint and model template.")
-                                .font(DesignSystem.Typography.micro)
-                                .foregroundStyle(DesignSystem.Colors.textSecondary)
-                                .fixedSize(horizontal: false, vertical: true)
+                if let warning = overrideWarning {
+                    Text(warning)
+                        .font(DesignSystem.Typography.caption)
+                        .foregroundStyle(DesignSystem.Colors.warningAmber)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                if let combinationNote = combinationNote {
+                    Text(combinationNote)
+                        .font(DesignSystem.Typography.caption)
+                        .foregroundStyle(DesignSystem.Colors.textSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                if let unverifiedNote = unverifiedSectionNote {
+                    Text(unverifiedNote)
+                        .font(DesignSystem.Typography.caption)
+                        .foregroundStyle(DesignSystem.Colors.textSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
+                    ForEach(editableFields, id: \.self) { field in
+                        settingRow(for: field)
+                    }
+                }
+
+                if !inactiveFields.isEmpty {
+                    VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+                        Text("Not sent with this provider or model")
+                            .font(DesignSystem.Typography.caption.weight(.semibold))
+                            .foregroundStyle(DesignSystem.Colors.textSecondary)
+                        Text(
+                            "These saved values are kept until you remove them. They are not sent with the current provider and model."
+                        )
+                        .font(DesignSystem.Typography.caption)
+                        .foregroundStyle(DesignSystem.Colors.textTertiary)
+                        .fixedSize(horizontal: false, vertical: true)
+                        ForEach(inactiveFields, id: \.self) { field in
+                            inactiveRow(for: field)
                         }
                     }
+                    .padding(.top, DesignSystem.Spacing.xs)
                 }
 
                 HStack {
@@ -1514,10 +1494,8 @@ private struct GenerationSettingsEditor: View {
                             .lineLimit(2)
                     }
                     Spacer()
-                    Button("Reset to defaults", action: onReset)
-                        .buttonStyle(.plain)
-                        .font(DesignSystem.Typography.caption.weight(.medium))
-                        .foregroundStyle(DesignSystem.Colors.accent)
+                    Button("Reset to defaults", action: resetAll)
+                        .parakeetAction(.subtle)
                         .disabled(
                             !PromptsViewModel.hasCustomGenerationSettings(
                                 draft: draft,
@@ -1528,55 +1506,507 @@ private struct GenerationSettingsEditor: View {
             }
             .padding(.top, DesignSystem.Spacing.md)
         } label: {
-            HStack(spacing: DesignSystem.Spacing.sm) {
-                Label("Generation settings", systemImage: "slider.horizontal.3")
-                    .font(DesignSystem.Typography.body.weight(.semibold))
-                Spacer()
-                if PromptsViewModel.hasCustomGenerationSettings(
-                    draft: draft,
-                    modelOverride: modelOverride
-                ) {
-                    Text("Custom")
-                        .font(DesignSystem.Typography.micro.weight(.bold))
-                        .foregroundStyle(DesignSystem.Colors.accentDark)
-                        .padding(.horizontal, 7)
-                        .padding(.vertical, 3)
-                        .background(DesignSystem.Colors.accentLight)
-                        .clipShape(Capsule())
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: DesignSystem.Spacing.sm) {
+                    Label("Generation settings", systemImage: "slider.horizontal.3")
+                        .font(DesignSystem.Typography.body.weight(.semibold))
+                    Spacer()
+                    if PromptsViewModel.hasCustomGenerationSettings(
+                        draft: draft,
+                        modelOverride: modelOverride
+                    ) {
+                        Text("Custom")
+                            .font(DesignSystem.Typography.micro.weight(.bold))
+                            .foregroundStyle(DesignSystem.Colors.accentDark)
+                            .padding(.horizontal, 7)
+                            .padding(.vertical, 3)
+                            .background(DesignSystem.Colors.accentLight)
+                            .clipShape(Capsule())
+                    }
+                }
+                if let summary = collapsedSummary {
+                    Text(summary)
+                        .font(DesignSystem.Typography.caption)
+                        .foregroundStyle(DesignSystem.Colors.textSecondary)
+                        .lineLimit(2)
                 }
             }
             .foregroundStyle(DesignSystem.Colors.textPrimary)
+        }
+        .onAppear {
+            viewModel.refreshGenerationSettingsContext()
+            seedExplicitCustomization()
+            modelSelection = PromptsViewModel.GenerationModelSelection(
+                modelOverride: modelOverride,
+                availableModels: viewModel.generationAvailableModels
+            )
         }
         .onChange(of: errors) { _, newErrors in
             if !newErrors.isEmpty {
                 isExpanded = true
             }
         }
+        .onChange(of: draft) { _, newDraft in
+            if newDraft.isDefault {
+                customizingFields = []
+            }
+        }
+        .onChange(of: modelOverride) { _, _ in
+            modelSelection.reconcile(
+                modelOverride: modelOverride,
+                availableModels: viewModel.generationAvailableModels
+            )
+        }
+        .onChange(of: viewModel.generationAvailableModels) { _, models in
+            modelSelection.reconcile(modelOverride: modelOverride, availableModels: models)
+        }
     }
 
-    private func numberField(
-        title: String,
-        placeholder: String,
-        text: Binding<String>,
-        field: PromptInferenceSettings.Field
-    ) -> some View {
-        VStack(alignment: .leading, spacing: 5) {
-            Text(title)
+    private var presentation: PromptInferencePresentation? {
+        viewModel.generationSettingsPresentation(draft: draft, modelOverride: modelOverride)
+    }
+
+    private var inheritedPresentation: PromptInferencePresentation? {
+        viewModel.generationSettingsPresentation(draft: .init(), modelOverride: modelOverride)
+    }
+
+    private var collapsedSummary: String? {
+        viewModel.generationSettingsCollapsedSummary(draft: draft, modelOverride: modelOverride)
+    }
+
+    private var draftSummary: String? {
+        PromptsViewModel.compactInferenceDraftSummary(draft)
+    }
+
+    private var providerSummary: some View {
+        let providerName = viewModel.generationProviderID?.displayName ?? "AI"
+        let effectiveModel =
+            presentation?.effectiveModel
+            ?? viewModel.generationModelName
+        return VStack(alignment: .leading, spacing: 2) {
+            Text("Using \(providerName)")
                 .font(DesignSystem.Typography.caption.weight(.medium))
                 .foregroundStyle(DesignSystem.Colors.textSecondary)
-            TextField(placeholder, text: text)
+            if !effectiveModel.isEmpty {
+                Text(effectiveModel)
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundStyle(DesignSystem.Colors.textSecondary)
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Using \(providerName) \(effectiveModel)")
+    }
+
+    private var modelModeBinding: Binding<PromptsViewModel.GenerationModelSelection.Source> {
+        Binding(
+            get: { modelSelection.source },
+            set: { mode in
+                switch mode {
+                case .useAISettings:
+                    modelSelection.selectUseAISettings()
+                    modelOverride = ""
+                case .custom:
+                    modelSelection.selectCustom(availableModels: viewModel.generationAvailableModels)
+                }
+            }
+        )
+    }
+
+    private var overrideWarning: String? {
+        guard case .invalid(let reason) = presentation?.modelOverrideStatus else { return nil }
+        return "This model isn't available with the current provider: \(reason)"
+    }
+
+    private var combinationNote: String? {
+        guard presentation?.provider == .anthropic else { return nil }
+        let temperatureCapability = capability(for: .temperature)
+        let topPCapability = capability(for: .topP)
+        guard
+            temperatureCapability?.availability == .supported
+                || topPCapability?.availability == .supported
+        else { return nil }
+        if draft.hasExplicitValue(for: .topP) && draft.hasExplicitValue(for: .temperature) {
+            return "Top P is used instead of Temperature. Temperature is 0 to 1."
+        }
+        return "If you set Top P, it is used instead of Temperature. Temperature is 0 to 1."
+    }
+
+    private var unverifiedSectionNote: String? {
+        let hasUnverified = editableFields.contains { capability(for: $0)?.availability == .unverified }
+        guard hasUnverified else { return nil }
+        if presentation?.provider == .ollama {
+            return
+                "Thinking support for this Ollama model is unverified. It is sent as requested and the model may reject or ignore it."
+        }
+        return
+            "Custom endpoint support is unverified. Values are sent as requested and the endpoint may reject or ignore them."
+    }
+
+    private var editableFields: [PromptInferenceSettings.Field] {
+        Self.fieldOrder.filter { field in
+            if field == .reasoningEffort, draft.thinkingMode != .enabled {
+                return false
+            }
+            if inactiveFields.contains(field) { return false }
+            return isEditable(field)
+        }
+    }
+
+    private var inactiveFields: [PromptInferenceSettings.Field] {
+        Self.fieldOrder.filter { field in
+            draft.hasExplicitValue(for: field) && capability(for: field)?.availability == .unsupported
+        }
+    }
+
+    private func isEditable(_ field: PromptInferenceSettings.Field) -> Bool {
+        guard let capability = capability(for: field) else { return true }
+        switch capability.availability {
+        case .supported, .unverified:
+            return true
+        case .unsupported:
+            return false
+        }
+    }
+
+    private func capability(for field: PromptInferenceSettings.Field) -> PromptInferenceFieldCapability? {
+        presentation?.fieldCapabilities[field]
+    }
+
+    private var modelSection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Model")
+                .font(DesignSystem.Typography.caption.weight(.medium))
+                .foregroundStyle(DesignSystem.Colors.textSecondary)
+            Picker("Model source", selection: modelModeBinding) {
+                Text("Use AI settings").tag(PromptsViewModel.GenerationModelSelection.Source.useAISettings)
+                Text("Custom").tag(PromptsViewModel.GenerationModelSelection.Source.custom)
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+            .accessibilityLabel("Model source")
+
+            if modelSelection.source == .useAISettings {
+                Text(inheritedModelCaption)
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundStyle(DesignSystem.Colors.textTertiary)
+            } else {
+                customModelControls
+            }
+        }
+    }
+
+    private var inheritedModelCaption: String {
+        let name = viewModel.generationModelName
+        if name.isEmpty {
+            return "Uses the model from Settings."
+        }
+        return "Uses \(name)"
+    }
+
+    @ViewBuilder
+    private var customModelControls: some View {
+        let models = viewModel.generationAvailableModels
+        if modelSelection.showsCustomIDField(availableModels: models) {
+            TextField("Model ID", text: $modelOverride)
                 .textFieldStyle(.roundedBorder)
+                .accessibilityLabel("Custom model ID")
+            if !models.isEmpty {
+                Button("Choose from list") {
+                    modelSelection.chooseFromList()
+                }
+                .parakeetAction(.subtle)
+            } else {
+                Text("Enter a model ID. You can still save it if the list isn't available.")
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundStyle(DesignSystem.Colors.textTertiary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        } else {
+            Menu {
+                ForEach(models, id: \.self) { model in
+                    Button(model) { modelOverride = model }
+                }
+            } label: {
+                HStack {
+                    Text(
+                        models.contains(modelOverride.trimmingCharacters(in: .whitespacesAndNewlines))
+                            ? modelOverride : "Choose a model"
+                    )
+                    .lineLimit(1)
+                    Image(systemName: "chevron.up.chevron.down")
+                        .font(.system(size: 8, weight: .semibold))
+                }
+            }
+            .menuStyle(.borderlessButton)
+            .accessibilityLabel("Custom model")
+            Button("Use custom model") {
+                modelSelection.useCustomModelID()
+            }
+            .parakeetAction(.subtle)
+        }
+    }
+
+    @ViewBuilder
+    private func settingRow(for field: PromptInferenceSettings.Field) -> some View {
+        switch field {
+        case .temperature, .topP, .topK, .maxTokens:
+            numericRow(for: field)
+        case .thinkingMode:
+            thinkingRow
+        case .reasoningEffort:
+            reasoningEffortRow
+        }
+    }
+
+    private func numericRow(for field: PromptInferenceSettings.Field) -> some View {
+        let fieldCapability = capability(for: field)
+        let isCustom = isCustomizing(field)
+        return VStack(alignment: .leading, spacing: 5) {
+            Text(PromptsViewModel.displayName(for: field))
+                .font(DesignSystem.Typography.caption.weight(.medium))
+                .foregroundStyle(DesignSystem.Colors.textSecondary)
+            Picker(
+                PromptsViewModel.displayName(for: field),
+                selection: customizingBinding(for: field)
+            ) {
+                Text("Automatic").tag(false)
+                Text("Custom").tag(true)
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+            if isCustom {
+                TextField(customPlaceholder(for: field, capability: fieldCapability), text: numericBinding(for: field))
+                    .textFieldStyle(.roundedBorder)
+            } else if let caption = automaticCaption(for: field) {
+                Text(caption)
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundStyle(DesignSystem.Colors.textTertiary)
+            }
             if let error = errors[field] {
                 Text(error)
                     .font(DesignSystem.Typography.micro)
                     .foregroundStyle(DesignSystem.Colors.errorRed)
                     .fixedSize(horizontal: false, vertical: true)
+            } else if let help = supportedFieldHelp(fieldCapability) {
+                Text(help)
+                    .font(DesignSystem.Typography.micro)
+                    .foregroundStyle(DesignSystem.Colors.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
             }
         }
     }
 
-    private var draftSummary: String? {
-        PromptsViewModel.compactInferenceDraftSummary(draft)
+    private var thinkingRow: some View {
+        let fieldCapability = capability(for: .thinkingMode)
+        return VStack(alignment: .leading, spacing: 5) {
+            Text("Thinking")
+                .font(DesignSystem.Typography.caption.weight(.medium))
+                .foregroundStyle(DesignSystem.Colors.textSecondary)
+            Picker("Thinking", selection: $draft.thinkingMode) {
+                Text("Automatic").tag(PromptInferenceSettings.ThinkingMode.providerDefault)
+                Text("On").tag(PromptInferenceSettings.ThinkingMode.enabled)
+                Text("Off").tag(PromptInferenceSettings.ThinkingMode.disabled)
+            }
+            .labelsHidden()
+            .pickerStyle(.menu)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .onChange(of: draft.thinkingMode) { _, mode in
+                if mode != .enabled {
+                    draft.reasoningEffort = nil
+                }
+            }
+            if draft.thinkingMode == .providerDefault, let caption = automaticCaption(for: .thinkingMode) {
+                Text(caption)
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundStyle(DesignSystem.Colors.textTertiary)
+            }
+            if let error = errors[.thinkingMode] {
+                Text(error)
+                    .font(DesignSystem.Typography.micro)
+                    .foregroundStyle(DesignSystem.Colors.errorRed)
+                    .fixedSize(horizontal: false, vertical: true)
+            } else if let help = supportedFieldHelp(fieldCapability) {
+                Text(help)
+                    .font(DesignSystem.Typography.micro)
+                    .foregroundStyle(DesignSystem.Colors.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    private var reasoningEffortRow: some View {
+        let fieldCapability = capability(for: .reasoningEffort)
+        let allowed =
+            fieldCapability?.allowedReasoningEfforts
+            ?? PromptInferenceSettings.ReasoningEffort.allCases
+        return VStack(alignment: .leading, spacing: 5) {
+            Text("Reasoning effort")
+                .font(DesignSystem.Typography.caption.weight(.medium))
+                .foregroundStyle(DesignSystem.Colors.textSecondary)
+            Picker("Reasoning effort", selection: $draft.reasoningEffort) {
+                Text("Automatic").tag(PromptInferenceSettings.ReasoningEffort?.none)
+                ForEach(allowed, id: \.self) { effort in
+                    Text(PromptsViewModel.displayName(for: effort)).tag(Optional(effort))
+                }
+            }
+            .labelsHidden()
+            .pickerStyle(.menu)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            if let error = errors[.reasoningEffort] {
+                Text(error)
+                    .font(DesignSystem.Typography.micro)
+                    .foregroundStyle(DesignSystem.Colors.errorRed)
+                    .fixedSize(horizontal: false, vertical: true)
+            } else if let help = supportedFieldHelp(fieldCapability) {
+                Text(help)
+                    .font(DesignSystem.Typography.micro)
+                    .foregroundStyle(DesignSystem.Colors.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    private func inactiveRow(for field: PromptInferenceSettings.Field) -> some View {
+        HStack(alignment: .firstTextBaseline) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(inactiveValueLabel(for: field))
+                    .font(DesignSystem.Typography.caption)
+                    .foregroundStyle(DesignSystem.Colors.textSecondary)
+                if let reason = capability(for: field)?.reason {
+                    Text(reason)
+                        .font(DesignSystem.Typography.micro)
+                        .foregroundStyle(DesignSystem.Colors.textTertiary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+            Spacer()
+            Button("Remove") {
+                draft.clearField(field)
+                customizingFields.remove(field)
+            }
+            .parakeetAction(.subtle)
+            .accessibilityLabel("Remove \(PromptsViewModel.displayName(for: field))")
+        }
+    }
+
+    private func inactiveValueLabel(for field: PromptInferenceSettings.Field) -> String {
+        let title = PromptsViewModel.displayName(for: field)
+        switch field {
+        case .temperature:
+            return "\(title) \(draft.temperature.trimmingCharacters(in: .whitespacesAndNewlines))"
+        case .topP:
+            return "\(title) \(draft.topP.trimmingCharacters(in: .whitespacesAndNewlines))"
+        case .topK:
+            return "\(title) \(draft.topK.trimmingCharacters(in: .whitespacesAndNewlines))"
+        case .maxTokens:
+            return "\(title) \(draft.maxTokens.trimmingCharacters(in: .whitespacesAndNewlines))"
+        case .thinkingMode:
+            return "\(title) \(PromptsViewModel.displayName(for: draft.thinkingMode))"
+        case .reasoningEffort:
+            if let effort = draft.reasoningEffort {
+                return "\(title) \(PromptsViewModel.displayName(for: effort))"
+            }
+            return title
+        }
+    }
+
+    private func isCustomizing(_ field: PromptInferenceSettings.Field) -> Bool {
+        customizingFields.contains(field) || draft.hasExplicitValue(for: field)
+    }
+
+    private func customizingBinding(for field: PromptInferenceSettings.Field) -> Binding<Bool> {
+        Binding(
+            get: { isCustomizing(field) },
+            set: { isCustom in
+                if isCustom {
+                    customizingFields.insert(field)
+                } else {
+                    customizingFields.remove(field)
+                    draft.clearField(field)
+                }
+            }
+        )
+    }
+
+    private func numericBinding(for field: PromptInferenceSettings.Field) -> Binding<String> {
+        switch field {
+        case .temperature: return $draft.temperature
+        case .topP: return $draft.topP
+        case .topK: return $draft.topK
+        case .maxTokens: return $draft.maxTokens
+        case .thinkingMode, .reasoningEffort:
+            return .constant("")
+        }
+    }
+
+    private func customPlaceholder(
+        for field: PromptInferenceSettings.Field,
+        capability: PromptInferenceFieldCapability?
+    ) -> String {
+        if let range = capability?.knownRange {
+            return
+                "\(PromptsViewModel.InferenceSettingsDraft.renderNumber(range.minimum))–\(PromptsViewModel.InferenceSettingsDraft.renderNumber(range.maximum))"
+        }
+        switch field {
+        case .temperature: return "0–2"
+        case .topP: return "0–1"
+        case .topK: return "0–1000"
+        case .maxTokens: return "1–131072"
+        case .thinkingMode, .reasoningEffort: return ""
+        }
+    }
+
+    private func automaticCaption(for field: PromptInferenceSettings.Field) -> String? {
+        let capability = inheritedPresentation?.fieldCapabilities[field] ?? capability(for: field)
+        switch capability?.defaultSource {
+        case .application:
+            let inherited = inheritedPresentation?.effectiveSettings
+            switch field {
+            case .temperature:
+                return inherited?.temperature.map {
+                    "App default \(PromptsViewModel.InferenceSettingsDraft.renderNumber($0))"
+                }
+            case .topP:
+                return inherited?.topP.map {
+                    "App default \(PromptsViewModel.InferenceSettingsDraft.renderNumber($0))"
+                }
+            case .topK:
+                return inherited?.topK.map { "App default \($0)" }
+            case .maxTokens:
+                if let value = inherited?.maxTokens {
+                    return "App default \(value)"
+                }
+                return nil
+            case .thinkingMode:
+                guard let mode = inherited?.thinkingMode, mode != .providerDefault else { return nil }
+                return "App default \(PromptsViewModel.displayName(for: mode))"
+            case .reasoningEffort:
+                return nil
+            }
+        case .provider:
+            return "Provider chooses"
+        case .unknown:
+            return "Automatic value isn't known for this endpoint"
+        case .notApplicable, nil:
+            return nil
+        }
+    }
+
+    private func supportedFieldHelp(_ capability: PromptInferenceFieldCapability?) -> String? {
+        guard capability?.availability == .supported else { return nil }
+        return capability?.reason
+    }
+
+    private func seedExplicitCustomization() {
+        customizingFields = Set(
+            Self.fieldOrder.filter { draft.hasExplicitValue(for: $0) }
+        )
+    }
+
+    private func resetAll() {
+        customizingFields = []
+        modelSelection.reset()
+        onReset()
     }
 }
 

--- a/Sources/MacParakeet/Views/Transcription/PromptLibraryView.swift
+++ b/Sources/MacParakeet/Views/Transcription/PromptLibraryView.swift
@@ -1546,11 +1546,6 @@ private struct GenerationSettingsEditor: View {
                 isExpanded = true
             }
         }
-        .onChange(of: draft) { _, newDraft in
-            if newDraft.isDefault {
-                customizingFields = []
-            }
-        }
         .onChange(of: modelOverride) { _, _ in
             modelSelection.reconcile(
                 modelOverride: modelOverride,

--- a/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
+++ b/Sources/MacParakeet/Views/Transcription/TranscriptResultView.swift
@@ -3245,11 +3245,15 @@ struct TranscriptResultView: View {
             // Prompt chips
             promptChips
 
-            if let summary = promptResultsViewModel.selectedPromptInferenceSummary {
+            if promptResultsViewModel.selectedPromptInferenceSummary != nil
+                || promptResultsViewModel.selectedPromptInferenceCompatibilityMessage != nil
+            {
                 VStack(alignment: .leading, spacing: DesignSystem.Spacing.xs) {
-                    Label(summary, systemImage: "slider.horizontal.3")
-                        .font(DesignSystem.Typography.caption)
-                        .foregroundStyle(DesignSystem.Colors.textSecondary)
+                    if let summary = promptResultsViewModel.selectedPromptInferenceSummary {
+                        Label(summary, systemImage: "slider.horizontal.3")
+                            .font(DesignSystem.Typography.caption)
+                            .foregroundStyle(DesignSystem.Colors.textSecondary)
+                    }
 
                     if let compatibility = promptResultsViewModel.selectedPromptInferenceCompatibilityMessage {
                         Text(compatibility)

--- a/Sources/MacParakeetCore/Models/LLMProvider.swift
+++ b/Sources/MacParakeetCore/Models/LLMProvider.swift
@@ -442,3 +442,61 @@ public struct LLMProviderConfig: Codable, Sendable, Equatable {
     }
 
 }
+
+/// A model override checked against the provider rules that can be evaluated
+/// without making a network request. Endpoint-specific providers deliberately
+/// retain arbitrary non-empty model IDs for the generation endpoint to verify.
+public enum LLMModelOverrideResolution: Sendable, Equatable {
+    case resolved(LLMProviderConfig)
+    case invalid(model: String, reason: String)
+}
+
+public extension LLMProviderConfig {
+    /// Produces a request-scoped configuration without mutating stored settings.
+    /// The same rule is used before dispatch and when presenting prompt settings.
+    func resolvingModelOverride(_ rawModelOverride: String?) -> LLMModelOverrideResolution {
+        guard let rawModelOverride else { return .resolved(self) }
+        let modelOverride = rawModelOverride.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !modelOverride.isEmpty else {
+            return .invalid(model: rawModelOverride, reason: "the model name is empty.")
+        }
+        guard Self.isLocallyCompatible(modelOverride, with: id) else {
+            return .invalid(
+                model: modelOverride,
+                reason: "the model identifier does not match this provider."
+            )
+        }
+        guard modelOverride != modelName else { return .resolved(self) }
+        guard id != .localCLI else {
+            return .invalid(
+                model: modelOverride,
+                reason: "the configured CLI command controls its model. "
+                    + "Remove the override or change the command in Settings."
+            )
+        }
+        return .resolved(
+            LLMProviderConfig(
+                id: id,
+                baseURL: baseURL,
+                apiKey: apiKey,
+                modelName: modelOverride,
+                isLocal: isLocal
+            )
+        )
+    }
+
+    private static func isLocallyCompatible(_ model: String, with provider: LLMProviderID) -> Bool {
+        switch provider {
+        case .anthropic:
+            return model.hasPrefix("claude-")
+        case .gemini:
+            let lowered = model.lowercased()
+            return lowered.hasPrefix("gemini-") || lowered.hasPrefix("gemma-")
+        case .openrouter:
+            let components = model.split(separator: "/", omittingEmptySubsequences: false)
+            return components.count == 2 && components.allSatisfy { !$0.isEmpty }
+        case .openai, .openaiCompatible, .ollama, .lmstudio, .localCLI, .inProcessLocal:
+            return true
+        }
+    }
+}

--- a/Sources/MacParakeetCore/Models/PromptInferenceSettings.swift
+++ b/Sources/MacParakeetCore/Models/PromptInferenceSettings.swift
@@ -144,7 +144,173 @@ public struct PromptInferenceResolution: Sendable, Equatable {
     }
 }
 
+/// Presentation-only information for a prompt's effective provider and model.
+/// It intentionally preserves requested values even when dispatch validation
+/// would reject them, so callers can explain and remove an incompatible draft.
+public struct PromptInferencePresentation: Sendable, Equatable {
+    public enum ModelOverrideStatus: Sendable, Equatable {
+        case inherited
+        case applied
+        case invalid(reason: String)
+    }
+
+    public let provider: LLMProviderID
+    public let configuredModel: String
+    public let requestedModelOverride: String?
+    /// Nil when the requested override is locally incompatible.
+    public let effectiveModel: String?
+    public let modelOverrideStatus: ModelOverrideStatus
+    /// The caller's unmodified settings, including values that are currently unavailable.
+    public let requestedSettings: PromptInferenceSettings?
+    /// The settings that would be sent after resolver filtering, when valid.
+    public let effectiveSettings: PromptInferenceSettings?
+    /// Dispatch validation failure for `requestedSettings`, without dropping it.
+    public let validationError: PromptInferenceSettings.ValidationError?
+    public let fieldCapabilities: [PromptInferenceSettings.Field: PromptInferenceFieldCapability]
+
+    public init(
+        provider: LLMProviderID,
+        configuredModel: String,
+        requestedModelOverride: String?,
+        effectiveModel: String?,
+        modelOverrideStatus: ModelOverrideStatus,
+        requestedSettings: PromptInferenceSettings?,
+        effectiveSettings: PromptInferenceSettings?,
+        validationError: PromptInferenceSettings.ValidationError?,
+        fieldCapabilities: [PromptInferenceSettings.Field: PromptInferenceFieldCapability]
+    ) {
+        self.provider = provider
+        self.configuredModel = configuredModel
+        self.requestedModelOverride = requestedModelOverride
+        self.effectiveModel = effectiveModel
+        self.modelOverrideStatus = modelOverrideStatus
+        self.requestedSettings = requestedSettings
+        self.effectiveSettings = effectiveSettings
+        self.validationError = validationError
+        self.fieldCapabilities = fieldCapabilities
+    }
+}
+
+public struct PromptInferenceFieldCapability: Sendable, Equatable {
+    public enum Availability: String, Sendable, Equatable {
+        /// The current adapter has a documented request mapping for this field.
+        case supported
+        /// The current adapter does not send this field for the effective provider/model.
+        case unsupported
+        /// Explicit values are serialized, but endpoint or model acceptance is not known.
+        case unverified
+    }
+
+    public enum DefaultSource: String, Sendable, Equatable {
+        /// The application supplies a value when this field is left automatic.
+        case application
+        /// The application omits the field and lets the provider choose its default.
+        case provider
+        /// The integration cannot identify the automatic value's source.
+        case unknown
+        case notApplicable
+    }
+
+    /// A provider-documented range. Application validation bounds are never
+    /// represented here as a model limit.
+    public struct KnownRange: Sendable, Equatable {
+        public let minimum: Double
+        public let maximum: Double
+
+        public init(minimum: Double, maximum: Double) {
+            self.minimum = minimum
+            self.maximum = maximum
+        }
+    }
+
+    public let availability: Availability
+    public let allowedThinkingModes: [PromptInferenceSettings.ThinkingMode]
+    public let allowedReasoningEfforts: [PromptInferenceSettings.ReasoningEffort]
+    public let knownRange: KnownRange?
+    public let defaultSource: DefaultSource
+    public let reason: String?
+    public let isDiscouraged: Bool
+
+    public init(
+        availability: Availability,
+        allowedThinkingModes: [PromptInferenceSettings.ThinkingMode] = [],
+        allowedReasoningEfforts: [PromptInferenceSettings.ReasoningEffort] = [],
+        knownRange: KnownRange? = nil,
+        defaultSource: DefaultSource,
+        reason: String? = nil,
+        isDiscouraged: Bool = false
+    ) {
+        self.availability = availability
+        self.allowedThinkingModes = allowedThinkingModes
+        self.allowedReasoningEfforts = allowedReasoningEfforts
+        self.knownRange = knownRange
+        self.defaultSource = defaultSource
+        self.reason = reason
+        self.isDiscouraged = isDiscouraged
+    }
+}
+
 public enum PromptInferenceCapabilityResolver {
+    /// Returns editor and compatibility metadata without validating away a
+    /// saved draft. `resolve` remains the sole dispatch-validation path.
+    public static func presentation(
+        config: LLMProviderConfig,
+        modelOverride: String?,
+        baseline: ChatCompletionOptions = .default,
+        requested: PromptInferenceSettings?
+    ) -> PromptInferencePresentation {
+        let overrideResolution = config.resolvingModelOverride(modelOverride)
+        let effectiveConfig: LLMProviderConfig
+        let modelOverrideStatus: PromptInferencePresentation.ModelOverrideStatus
+        let effectiveModel: String?
+
+        switch overrideResolution {
+        case .resolved(let resolvedConfig):
+            effectiveConfig = resolvedConfig
+            effectiveModel = resolvedConfig.modelName
+            modelOverrideStatus = modelOverride == nil ? .inherited : .applied
+        case .invalid(_, let reason):
+            effectiveConfig = config
+            effectiveModel = nil
+            modelOverrideStatus = .invalid(reason: reason)
+        }
+
+        let effectiveSettings: PromptInferenceSettings?
+        let validationError: PromptInferenceSettings.ValidationError?
+        switch overrideResolution {
+        case .invalid:
+            effectiveSettings = nil
+            validationError = nil
+        case .resolved:
+            do {
+                effectiveSettings = try resolve(
+                    config: effectiveConfig,
+                    baseline: baseline,
+                    requested: requested
+                ).effectiveSettings
+                validationError = nil
+            } catch let error as PromptInferenceSettings.ValidationError {
+                effectiveSettings = nil
+                validationError = error
+            } catch {
+                effectiveSettings = nil
+                validationError = nil
+            }
+        }
+
+        return PromptInferencePresentation(
+            provider: config.id,
+            configuredModel: config.modelName,
+            requestedModelOverride: modelOverride,
+            effectiveModel: effectiveModel,
+            modelOverrideStatus: modelOverrideStatus,
+            requestedSettings: requested,
+            effectiveSettings: effectiveSettings,
+            validationError: validationError,
+            fieldCapabilities: fieldCapabilities(for: effectiveConfig, baseline: baseline)
+        )
+    }
+
     public static func resolve(
         config: LLMProviderConfig,
         baseline: ChatCompletionOptions = .default,
@@ -153,7 +319,11 @@ public enum PromptInferenceCapabilityResolver {
         let requested = try requested?.validated()
         var supported = supportedFields(for: config)
 
-        var resolvedOptions = legacyBaseline(config: config, baseline: baseline).applying(requested)
+        var resolvedOptions = legacyBaseline(
+            config: config,
+            baseline: baseline,
+            requested: requested
+        ).applying(requested)
         // Anthropic accepts one sampling control at a time. Top P wins over
         // both an explicit temperature and the inherited 0.7 default, so a
         // saved Top P receipt also remains stable when regenerated.
@@ -209,8 +379,21 @@ public enum PromptInferenceCapabilityResolver {
         case .ollama:
             return [.temperature, .topP, .topK, .maxTokens, .thinkingMode]
         case .openaiCompatible:
+            if OpenAIModelPolicy.requiresMaxCompletionTokens(model: config.modelName) {
+                var fields: Set<PromptInferenceSettings.Field> = [.maxTokens]
+                if !OpenAIModelPolicy.shouldOmitSampling(model: config.modelName) {
+                    fields.formUnion([.temperature, .topP])
+                }
+                return fields
+            }
             return [.temperature, .topP, .topK, .maxTokens, .thinkingMode, .reasoningEffort]
-        case .gemini, .openrouter, .lmstudio:
+        case .openrouter:
+            var fields: Set<PromptInferenceSettings.Field> = [.maxTokens]
+            if !OpenAIModelPolicy.shouldOmitSampling(model: config.modelName) {
+                fields.insert(.temperature)
+            }
+            return fields
+        case .gemini, .lmstudio:
             return [.temperature, .maxTokens]
         case .localCLI:
             return []
@@ -249,16 +432,148 @@ public enum PromptInferenceCapabilityResolver {
         )
     }
 
-    private static func legacyBaseline(
+    private static func fieldCapabilities(
+        for config: LLMProviderConfig,
+        baseline: ChatCompletionOptions
+    ) -> [PromptInferenceSettings.Field: PromptInferenceFieldCapability] {
+        Dictionary(
+            uniqueKeysWithValues: PromptInferenceSettings.Field.allCases.map { field in
+                (field, fieldCapability(for: field, config: config, baseline: baseline))
+            }
+        )
+    }
+
+    private static func fieldCapability(
+        for field: PromptInferenceSettings.Field,
         config: LLMProviderConfig,
         baseline: ChatCompletionOptions
+    ) -> PromptInferenceFieldCapability {
+        let supported = supportedFields(for: config).contains(field)
+        let availability: PromptInferenceFieldCapability.Availability
+        if !supported {
+            availability = .unsupported
+        } else if config.id == .openaiCompatible || config.id == .openrouter
+            || (config.id == .ollama && field == .thinkingMode)
+        {
+            availability = .unverified
+        } else {
+            availability = .supported
+        }
+
+        let isGemini3Temperature =
+            field == .temperature && config.id == .gemini && isGemini3(config.modelName)
+        let knownRange: PromptInferenceFieldCapability.KnownRange?
+        if field == .temperature,
+            config.id == .anthropic,
+            AnthropicModelPolicy.acceptsSampling(model: config.modelName)
+        {
+            knownRange = .init(minimum: 0, maximum: 1)
+        } else {
+            knownRange = nil
+        }
+
+        let allowedThinkingModes: [PromptInferenceSettings.ThinkingMode]
+        if field == .thinkingMode && availability != .unsupported,
+            config.id == .ollama || config.id == .openaiCompatible
+        {
+            allowedThinkingModes = PromptInferenceSettings.ThinkingMode.allCases
+        } else {
+            allowedThinkingModes = []
+        }
+
+        let allowedReasoningEfforts: [PromptInferenceSettings.ReasoningEffort]
+        if field == .reasoningEffort && availability != .unsupported, config.id == .openaiCompatible {
+            allowedReasoningEfforts = PromptInferenceSettings.ReasoningEffort.allCases
+        } else {
+            allowedReasoningEfforts = []
+        }
+
+        let reason: String?
+        switch availability {
+        case .supported:
+            reason = isGemini3Temperature
+                ? "Gemini 3 recommends automatic sampling for this setting."
+                : nil
+        case .unsupported:
+            reason = field == .thinkingMode || field == .reasoningEffort
+                ? "Not available with this provider or model."
+                : "This provider or model does not support this setting."
+        case .unverified:
+            reason = config.id == .ollama
+                ? "Thinking support depends on the selected Ollama model; sent as requested."
+                : "Custom endpoint support is unverified; sent as requested."
+        }
+
+        return PromptInferenceFieldCapability(
+            availability: availability,
+            allowedThinkingModes: allowedThinkingModes,
+            allowedReasoningEfforts: allowedReasoningEfforts,
+            knownRange: knownRange,
+            defaultSource: defaultSource(for: field, config: config, baseline: baseline, availability: availability),
+            reason: reason,
+            isDiscouraged: isGemini3Temperature && availability == .supported
+        )
+    }
+
+    private static func defaultSource(
+        for field: PromptInferenceSettings.Field,
+        config: LLMProviderConfig,
+        baseline: ChatCompletionOptions,
+        availability: PromptInferenceFieldCapability.Availability
+    ) -> PromptInferenceFieldCapability.DefaultSource {
+        guard availability != .unsupported else { return .notApplicable }
+        if field == .maxTokens, config.id == .anthropic { return .application }
+        if field == .thinkingMode, config.id == .ollama { return .application }
+
+        let automatic = legacyBaseline(config: config, baseline: baseline, requested: nil)
+        let appliesApplicationValue: Bool
+        switch field {
+        case .temperature: appliesApplicationValue = automatic.temperature != nil
+        case .topP: appliesApplicationValue = automatic.topP != nil
+        case .topK: appliesApplicationValue = automatic.topK != nil
+        case .maxTokens: appliesApplicationValue = automatic.maxTokens != nil
+        case .thinkingMode: appliesApplicationValue = automatic.thinkingMode != .providerDefault
+        case .reasoningEffort: appliesApplicationValue = automatic.reasoningEffort != nil
+        }
+        return appliesApplicationValue ? .application : .provider
+    }
+
+    private static func legacyBaseline(
+        config: LLMProviderConfig,
+        baseline: ChatCompletionOptions,
+        requested: PromptInferenceSettings?
     ) -> ChatCompletionOptions {
-        guard config.id == .ollama else { return baseline }
+        if config.id == .ollama {
+            return ChatCompletionOptions(
+                thinkingMode: .disabled,
+                responseFormat: baseline.responseFormat,
+                conversationID: baseline.conversationID
+            )
+        }
+        // Prompt-generation callers inherit `.default`. Gemini 3 recommends
+        // omitting that legacy 0.7 baseline so its provider default applies.
+        // An explicit prompt temperature, including a historical 0.7 receipt,
+        // is overlaid below and therefore remains an explicit request.
+        guard config.id == .gemini,
+            isGemini3(config.modelName),
+            baseline == .default,
+            requested?.temperature == nil
+        else {
+            return baseline
+        }
         return ChatCompletionOptions(
-            thinkingMode: .disabled,
+            topP: baseline.topP,
+            topK: baseline.topK,
+            maxTokens: baseline.maxTokens,
+            thinkingMode: baseline.thinkingMode,
+            reasoningEffort: baseline.reasoningEffort,
             responseFormat: baseline.responseFormat,
             conversationID: baseline.conversationID
         )
+    }
+
+    private static func isGemini3(_ model: String) -> Bool {
+        model.lowercased().hasPrefix("gemini-3")
     }
 
     private static func effectiveSettings(
@@ -307,22 +622,46 @@ private extension ChatCompletionOptions {
 }
 
 enum OpenAIModelPolicy {
-    static func shouldOmitSampling(model: String) -> Bool {
+    /// Last path component of a provider-prefixed ID (`openai/gpt-5.6-luna` →
+    /// `gpt-5.6-luna`). Gateways use this form; native OpenAI IDs are unchanged.
+    static func canonicalModelID(_ model: String) -> String {
         let lowered = model.lowercased()
-        if isReasoningModel(lowered) { return true }
-        if lowered.contains("chat") { return false }
-        guard lowered.hasPrefix("gpt-") else { return false }
-        let digits = lowered.dropFirst(4).prefix(while: { $0.isNumber })
-        return (Int(digits) ?? 0) >= 5
+        guard let slash = lowered.lastIndex(of: "/") else { return lowered }
+        return String(lowered[lowered.index(after: slash)...])
     }
 
-    private static func isReasoningModel(_ model: String) -> Bool {
-        guard model.hasPrefix("o") else { return false }
-        let suffix = model.dropFirst()
+    static func shouldOmitSampling(model: String) -> Bool {
+        let id = canonicalModelID(model)
+        if isReasoningModel(id) { return true }
+        if id.contains("chat") { return false }
+        return gptMajorVersion(id).map { $0 >= 5 } ?? false
+    }
+
+    static func requiresMaxCompletionTokens(model: String) -> Bool {
+        let id = canonicalModelID(model)
+        if isReasoningModel(id) { return true }
+        return gptMajorVersion(id).map { $0 >= 5 } ?? false
+    }
+
+    static func isReasoningModelID(_ model: String) -> Bool {
+        isReasoningModel(canonicalModelID(model))
+    }
+
+    /// Major version of a `gpt-<n>...` model ID, accepting gateway prefixes.
+    static func gptMajorVersion(_ model: String) -> Int? {
+        let id = canonicalModelID(model)
+        guard id.hasPrefix("gpt-") else { return nil }
+        let digits = id.dropFirst(4).prefix(while: { $0.isNumber })
+        return Int(digits)
+    }
+
+    private static func isReasoningModel(_ id: String) -> Bool {
+        guard id.hasPrefix("o") else { return false }
+        let suffix = id.dropFirst()
         guard let generation = suffix.first, generation.isNumber else { return false }
         let prefix = "o\(generation)"
-        let boundary = model.dropFirst(prefix.count).first
-        return model.hasPrefix(prefix) && (boundary == nil || boundary == "-")
+        let boundary = id.dropFirst(prefix.count).first
+        return id.hasPrefix(prefix) && (boundary == nil || boundary == "-")
     }
 }
 

--- a/Sources/MacParakeetCore/Services/LLM/LLMService.swift
+++ b/Sources/MacParakeetCore/Services/LLM/LLMService.swift
@@ -1443,63 +1443,18 @@ public final class LLMService: LLMServiceProtocol, Sendable {
         _ context: LLMExecutionContext,
         overridingModelWith modelOverride: String?
     ) throws -> LLMExecutionContext {
-        guard let rawModelOverride = modelOverride else { return context }
-        let modelOverride = rawModelOverride.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !modelOverride.isEmpty else {
+        switch context.providerConfig.resolvingModelOverride(modelOverride) {
+        case .resolved(let providerConfig):
+            return LLMExecutionContext(
+                providerConfig: providerConfig,
+                localCLIConfig: context.localCLIConfig
+            )
+        case .invalid(let model, let reason):
             throw LLMError.invalidModelOverride(
-                model: rawModelOverride,
+                model: model,
                 provider: context.providerConfig.id,
-                reason: "the model name is empty."
+                reason: reason
             )
-        }
-        guard Self.isLocallyCompatible(modelOverride, with: context.providerConfig.id) else {
-            throw LLMError.invalidModelOverride(
-                model: modelOverride,
-                provider: context.providerConfig.id,
-                reason: "the model identifier does not match this provider."
-            )
-        }
-        guard modelOverride != context.providerConfig.modelName else { return context }
-
-        guard context.providerConfig.id != .localCLI else {
-            throw LLMError.invalidModelOverride(
-                model: modelOverride,
-                provider: .localCLI,
-                reason: "the configured CLI command controls its model. "
-                    + "Remove the override or change the command in Settings."
-            )
-        }
-
-        let config = context.providerConfig
-        return LLMExecutionContext(
-            providerConfig: LLMProviderConfig(
-                id: config.id,
-                baseURL: config.baseURL,
-                apiKey: config.apiKey,
-                modelName: modelOverride,
-                isLocal: config.isLocal
-            ),
-            localCLIConfig: context.localCLIConfig
-        )
-    }
-
-    /// Rejects provider/model combinations that can be disproved without a
-    /// network request. OpenAI-compatible and local runtimes intentionally
-    /// accept arbitrary non-empty identifiers because their installed model
-    /// sets are endpoint-specific. Discovery lists can omit valid aliases, so
-    /// the generation endpoint validates existence without a fallback model.
-    private static func isLocallyCompatible(_ model: String, with provider: LLMProviderID) -> Bool {
-        switch provider {
-        case .anthropic:
-            return model.hasPrefix("claude-")
-        case .gemini:
-            let lowered = model.lowercased()
-            return lowered.hasPrefix("gemini-") || lowered.hasPrefix("gemma-")
-        case .openrouter:
-            let components = model.split(separator: "/", omittingEmptySubsequences: false)
-            return components.count == 2 && components.allSatisfy { !$0.isEmpty }
-        case .openai, .openaiCompatible, .ollama, .lmstudio, .localCLI, .inProcessLocal:
-            return true
         }
     }
 

--- a/Sources/MacParakeetViewModels/PromptResultsViewModel.swift
+++ b/Sources/MacParakeetViewModels/PromptResultsViewModel.swift
@@ -206,12 +206,13 @@ public final class PromptResultsViewModel {
     }
 
     public var selectedPromptInferenceCompatibilityMessage: String? {
-        guard let settings = selectedPrompt?.inferenceSettings,
+        guard let prompt = selectedPrompt,
               let config = try? configStore?.loadConfig()
         else { return nil }
         return PromptsViewModel.inferenceCompatibilityMessage(
-            settings: settings,
-            config: config
+            settings: prompt.inferenceSettings,
+            config: config,
+            modelOverride: prompt.modelOverride
         )
     }
 

--- a/Sources/MacParakeetViewModels/PromptsViewModel.swift
+++ b/Sources/MacParakeetViewModels/PromptsViewModel.swift
@@ -64,6 +64,12 @@ public final class PromptsViewModel {
     public private(set) var promptVersions: [PromptVersion] = []
     public private(set) var availableLabels: [MeetingLabel] = []
     public private(set) var labelIDsByPromptID: [UUID: Set<UUID>] = [:]
+    /// The configured AI provider and model shown by prompt-level generation
+    /// settings. Keep the configuration itself private because it can carry an
+    /// API key; views only need this display-safe projection.
+    public private(set) var generationProviderID: LLMProviderID?
+    public private(set) var generationModelName = ""
+    public private(set) var generationAvailableModels: [String] = []
     public var newName: String = "" {
         didSet { resetValidationError() }
     }
@@ -134,6 +140,12 @@ public final class PromptsViewModel {
     private var editingService: PromptEditingServiceProtocol?
     private var labelRepository: MeetingLabelRepositoryProtocol?
     private var labelPolicyRepository: PromptLabelPolicyRepositoryProtocol?
+    private var configStore: LLMConfigStoreProtocol?
+    private var llmClient: LLMClientProtocol?
+    private var generationConfig: LLMProviderConfig?
+    private var generationConfigLoadTask: Task<Void, Never>?
+    private var generationModelListTask: Task<Void, Never>?
+    private var generationContextRevision = 0
 
     public init() {}
 
@@ -143,7 +155,9 @@ public final class PromptsViewModel {
         collectionRepo: PromptCollectionRepositoryProtocol? = nil,
         editingService: PromptEditingServiceProtocol? = nil,
         labelRepository: MeetingLabelRepositoryProtocol? = nil,
-        labelPolicyRepository: PromptLabelPolicyRepositoryProtocol? = nil
+        labelPolicyRepository: PromptLabelPolicyRepositoryProtocol? = nil,
+        configStore: LLMConfigStoreProtocol? = nil,
+        llmClient: LLMClientProtocol? = nil
     ) {
         self.repo = repo
         self.versionRepo = versionRepo
@@ -151,10 +165,13 @@ public final class PromptsViewModel {
         self.editingService = editingService
         self.labelRepository = labelRepository
         self.labelPolicyRepository = labelPolicyRepository
+        self.configStore = configStore
+        self.llmClient = llmClient
         loadPrompts()
         loadDeletedPrompts()
         loadCollections()
         loadLabels()
+        refreshGenerationSettingsContext()
     }
 
     public func loadPrompts() {
@@ -174,6 +191,65 @@ public final class PromptsViewModel {
         loadDeletedPrompts()
         loadCollections()
         loadLabels()
+        refreshGenerationSettingsContext()
+    }
+
+    /// Refreshes the display-safe provider/model context used by prompt-level
+    /// settings. Configuration access is kept off the main actor; the existing
+    /// model-list helper owns network work and its configuration staleness
+    /// guard.
+    public func refreshGenerationSettingsContext() {
+        generationConfigLoadTask?.cancel()
+        generationModelListTask?.cancel()
+        generationContextRevision += 1
+        let revision = generationContextRevision
+
+        guard let configStore else {
+            applyGenerationSettingsConfig(nil, revision: revision)
+            return
+        }
+
+        let llmClient = self.llmClient
+        generationConfigLoadTask = Task { [weak self, configStore] in
+            let config = await Task.detached(priority: .utility) {
+                try? configStore.loadConfig()
+            }.value
+            guard !Task.isCancelled else { return }
+            self?.applyGenerationSettingsConfig(
+                config,
+                llmClient: llmClient,
+                revision: revision
+            )
+        }
+    }
+
+    private func applyGenerationSettingsConfig(
+        _ config: LLMProviderConfig?,
+        llmClient: LLMClientProtocol? = nil,
+        revision: Int
+    ) {
+        guard revision == generationContextRevision else { return }
+        generationConfig = config
+        generationProviderID = config?.id
+        generationModelName = config?.modelName ?? ""
+
+        guard let config else {
+            generationAvailableModels = []
+            return
+        }
+
+        generationAvailableModels = LLMModelAvailability.pickerModels(
+            for: config,
+            discoveredModels: []
+        )
+        generationModelListTask = LLMModelAvailability.refreshPickerModelsTask(
+            for: config,
+            llmClient: llmClient,
+            configStore: configStore
+        ) { [weak self] models in
+            guard self?.generationContextRevision == revision else { return }
+            self?.generationAvailableModels = models
+        }
     }
 
     public func addPrompt() {

--- a/Sources/MacParakeetViewModels/PromptsViewModel.swift
+++ b/Sources/MacParakeetViewModels/PromptsViewModel.swift
@@ -46,12 +46,147 @@ public final class PromptsViewModel {
                 && reasoningEffort == nil
         }
 
-        fileprivate static func renderNumber(_ value: Double) -> String {
+        var unvalidatedSettings: PromptInferenceSettings? {
+            PromptInferenceSettings(
+                temperature: Self.parseUnvalidatedDouble(temperature),
+                topP: Self.parseUnvalidatedDouble(topP),
+                topK: Self.parseUnvalidatedInt(topK),
+                maxTokens: Self.parseUnvalidatedInt(maxTokens),
+                thinkingMode: thinkingMode,
+                reasoningEffort: reasoningEffort
+            ).normalized
+        }
+
+        nonisolated public static func renderNumber(_ value: Double) -> String {
             var rendered = String(value)
             if rendered.hasSuffix(".0") {
                 rendered.removeLast(2)
             }
             return rendered
+        }
+
+        public func hasExplicitValue(for field: PromptInferenceSettings.Field) -> Bool {
+            switch field {
+            case .temperature:
+                return !temperature.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            case .topP:
+                return !topP.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            case .topK:
+                return !topK.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            case .maxTokens:
+                return !maxTokens.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            case .thinkingMode:
+                return thinkingMode != .providerDefault
+            case .reasoningEffort:
+                return reasoningEffort != nil
+            }
+        }
+
+        public mutating func clearField(_ field: PromptInferenceSettings.Field) {
+            switch field {
+            case .temperature: temperature = ""
+            case .topP: topP = ""
+            case .topK: topK = ""
+            case .maxTokens: maxTokens = ""
+            case .thinkingMode:
+                thinkingMode = .providerDefault
+                reasoningEffort = nil
+            case .reasoningEffort:
+                reasoningEffort = nil
+            }
+        }
+
+        private static func parseUnvalidatedDouble(_ rawValue: String) -> Double? {
+            let value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !value.isEmpty, let parsed = Double(value), parsed.isFinite else { return nil }
+            return parsed
+        }
+
+        private static func parseUnvalidatedInt(_ rawValue: String) -> Int? {
+            let value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !value.isEmpty else { return nil }
+            return Int(value)
+        }
+    }
+
+    /// Editor intent for the prompt model chooser. Independent of the stored
+    /// override string so choosing Custom does not require writing a model ID,
+    /// and Use AI settings can clear an override without losing the next Custom
+    /// interaction.
+    public struct GenerationModelSelection: Equatable, Sendable {
+        public enum Source: Equatable, Sendable, Hashable {
+            case useAISettings
+            case custom
+        }
+
+        public var source: Source
+        public var prefersCustomModelID: Bool
+
+        public init(source: Source = .useAISettings, prefersCustomModelID: Bool = false) {
+            self.source = source
+            self.prefersCustomModelID = prefersCustomModelID
+        }
+
+        public init(modelOverride: String, availableModels: [String]) {
+            let override = modelOverride.trimmingCharacters(in: .whitespacesAndNewlines)
+            if override.isEmpty {
+                source = .useAISettings
+                prefersCustomModelID = false
+            } else {
+                source = .custom
+                prefersCustomModelID = !availableModels.contains(override)
+            }
+        }
+
+        public var showsCustomControls: Bool { source == .custom }
+
+        public func showsCustomIDField(availableModels: [String]) -> Bool {
+            source == .custom && (prefersCustomModelID || availableModels.isEmpty)
+        }
+
+        public func showsModelList(availableModels: [String]) -> Bool {
+            source == .custom && !prefersCustomModelID && !availableModels.isEmpty
+        }
+
+        public mutating func selectUseAISettings() {
+            source = .useAISettings
+            prefersCustomModelID = false
+        }
+
+        public mutating func selectCustom(availableModels: [String]) {
+            source = .custom
+            prefersCustomModelID = availableModels.isEmpty
+        }
+
+        public mutating func chooseFromList() {
+            source = .custom
+            prefersCustomModelID = false
+        }
+
+        public mutating func useCustomModelID() {
+            source = .custom
+            prefersCustomModelID = true
+        }
+
+        public mutating func reset() {
+            selectUseAISettings()
+        }
+
+        /// Updates list-versus-ID presentation from a saved or typed override
+        /// without snapping Custom back to Use AI settings when the override
+        /// is still empty.
+        public mutating func reconcile(modelOverride: String, availableModels: [String]) {
+            let override = modelOverride.trimmingCharacters(in: .whitespacesAndNewlines)
+            if source == .useAISettings {
+                if !override.isEmpty {
+                    source = .custom
+                    prefersCustomModelID = !availableModels.contains(override)
+                }
+                return
+            }
+            if !override.isEmpty, !availableModels.contains(override) {
+                prefersCustomModelID = true
+            }
         }
     }
 
@@ -271,7 +406,7 @@ public final class PromptsViewModel {
         }
 
         let inferenceSettings: PromptInferenceSettings?
-        switch Self.validateInferenceSettings(newInferenceSettings) {
+        switch validateInferenceSettings(newInferenceSettings, modelOverride: newModelOverride) {
         case .valid(let settings):
             inferenceSettings = settings
             newInferenceValidationErrors = [:]
@@ -347,7 +482,9 @@ public final class PromptsViewModel {
             ? editingInferenceSettings
             : InferenceSettingsDraft(settings: prompt.inferenceSettings)
         let inferenceSettings: PromptInferenceSettings?
-        switch Self.validateInferenceSettings(inferenceDraft) {
+        let modelOverrideForValidation =
+            ownsEditingState ? editingModelOverride : (prompt.modelOverride ?? "")
+        switch validateInferenceSettings(inferenceDraft, modelOverride: modelOverrideForValidation) {
         case .valid(let settings):
             inferenceSettings = settings
             if ownsEditingState { editingInferenceValidationErrors = [:] }
@@ -410,6 +547,7 @@ public final class PromptsViewModel {
     }
 
     public func beginEditing(_ prompt: Prompt) {
+        refreshGenerationSettingsContext()
         editingIncludeMeetingNotes = prompt.includeMeetingNotes
         editingInferenceSettings = InferenceSettingsDraft(settings: prompt.inferenceSettings)
         editingModelOverride = prompt.modelOverride ?? ""
@@ -480,6 +618,44 @@ public final class PromptsViewModel {
         !draft.isDefault || !modelOverride.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
+    /// Presentation metadata for the current draft. Invalid numeric text is
+    /// omitted from `requestedSettings` but field availability still comes from
+    /// the saved provider and effective model. The saved configuration stays
+    /// private so API keys never reach the editor.
+    public func generationSettingsPresentation(
+        draft: InferenceSettingsDraft,
+        modelOverride: String
+    ) -> PromptInferencePresentation? {
+        guard let config = generationConfig else { return nil }
+        return PromptInferenceCapabilityResolver.presentation(
+            config: config,
+            modelOverride: normalizedOptional(modelOverride),
+            requested: draft.unvalidatedSettings
+        )
+    }
+
+    public func generationSettingsCollapsedSummary(
+        draft: InferenceSettingsDraft,
+        modelOverride: String
+    ) -> String? {
+        var parts: [String] = []
+        if let providerID = generationProviderID {
+            parts.append(providerID.displayName)
+        }
+        let override = normalizedOptional(modelOverride)
+        if let override {
+            parts.append(override)
+        } else if !generationModelName.isEmpty {
+            parts.append(generationModelName)
+        }
+        if let draftSummary = Self.compactInferenceDraftSummary(draft) {
+            parts.append(draftSummary)
+        } else if let requested = draft.unvalidatedSettings {
+            parts.append(contentsOf: Self.compactRequestedParts(requested))
+        }
+        return parts.isEmpty ? nil : parts.joined(separator: " · ")
+    }
+
     public static func compactInferenceSummary(_ settings: PromptInferenceSettings?) -> String? {
         guard let settings = settings?.normalized else { return nil }
         var parts: [String] = []
@@ -510,20 +686,26 @@ public final class PromptsViewModel {
 
     public static func inferenceCompatibilityMessage(
         settings: PromptInferenceSettings?,
-        config: LLMProviderConfig
+        config: LLMProviderConfig,
+        modelOverride: String? = nil
     ) -> String? {
-        do {
-            let unsupported = try PromptInferenceCapabilityResolver.resolve(
-                config: config,
-                requested: settings
-            ).unsupportedSettings
-            guard !unsupported.isEmpty else { return nil }
-            let names = PromptInferenceSettings.Field.allCases
-                .filter { unsupported.contains($0) }
-                .map(Self.displayName)
-            return "Not applied with this provider/model and setting combination: \(names.joined(separator: ", "))."
-        } catch {
-            return "Cannot generate with this provider/model: \(error.localizedDescription)"
+        switch config.resolvingModelOverride(modelOverride) {
+        case .invalid(_, let reason):
+            return "This prompt's model isn't available with \(config.id.displayName): \(reason)"
+        case .resolved(let effectiveConfig):
+            do {
+                let unsupported = try PromptInferenceCapabilityResolver.resolve(
+                    config: effectiveConfig,
+                    requested: settings
+                ).unsupportedSettings
+                guard !unsupported.isEmpty else { return nil }
+                let names = PromptInferenceSettings.Field.allCases
+                    .filter { unsupported.contains($0) }
+                    .map(Self.displayName)
+                return "Not applied with this provider/model and setting combination: \(names.joined(separator: ", "))."
+            } catch {
+                return "Cannot generate with this provider/model: \(error.localizedDescription)"
+            }
         }
     }
 
@@ -748,15 +930,17 @@ public final class PromptsViewModel {
         do {
             let policies = try labelPolicyRepository.fetchPolicies(promptIds: Set(prompts.map(\.id)))
             let grouped = Dictionary(grouping: policies, by: \.promptId)
-            customTargetingPromptIDs = Set(grouped.compactMap { promptID, rules in
-                let fallbacks = rules.filter { $0.scopeKind == .all }
-                let labels = rules.filter { $0.scopeKind == .label }
-                let representsAll = rules.count == 1 && fallbacks.first?.isAvailable == true
-                let representsSelectedLabels = fallbacks.count == 1
-                    && fallbacks.first?.isAvailable == false && !labels.isEmpty
-                    && labels.allSatisfy { $0.isAvailable && $0.labelId != nil }
-                return representsAll || representsSelectedLabels ? nil : promptID
-            })
+            customTargetingPromptIDs = Set(
+                grouped.compactMap { promptID, rules in
+                    let fallbacks = rules.filter { $0.scopeKind == .all }
+                    let labels = rules.filter { $0.scopeKind == .label }
+                    let representsAll = rules.count == 1 && fallbacks.first?.isAvailable == true
+                    let representsSelectedLabels =
+                        fallbacks.count == 1
+                        && fallbacks.first?.isAvailable == false && !labels.isEmpty
+                        && labels.allSatisfy { $0.isAvailable && $0.labelId != nil }
+                    return representsAll || representsSelectedLabels ? nil : promptID
+                })
             labelIDsByPromptID = grouped.reduce(into: [:]) { result, entry in
                 let hasRestrictedFallback = entry.value.contains {
                     $0.scopeKind == .all && !$0.isAvailable
@@ -765,9 +949,10 @@ public final class PromptsViewModel {
                     result[entry.key] = []
                     return
                 }
-                result[entry.key] = Set(entry.value.compactMap {
-                    $0.scopeKind == .label && $0.isAvailable ? $0.labelId : nil
-                })
+                result[entry.key] = Set(
+                    entry.value.compactMap {
+                        $0.scopeKind == .label && $0.isAvailable ? $0.labelId : nil
+                    })
             }
         } catch {
             labelIDsByPromptID = [:]
@@ -803,6 +988,76 @@ public final class PromptsViewModel {
         case invalid(InferenceValidationErrors)
     }
 
+    private func validateInferenceSettings(
+        _ draft: InferenceSettingsDraft,
+        modelOverride: String
+    ) -> InferenceDraftValidationResult {
+        switch Self.validateInferenceSettings(draft) {
+        case .invalid(let errors):
+            return .invalid(errors)
+        case .valid(let settings):
+            guard let config = generationConfig else {
+                return .valid(settings)
+            }
+            let presentation = PromptInferenceCapabilityResolver.presentation(
+                config: config,
+                modelOverride: normalizedOptional(modelOverride),
+                requested: settings
+            )
+            guard let error = presentation.validationError else {
+                return .valid(settings)
+            }
+            return .invalid(Self.fieldErrors(from: error))
+        }
+    }
+
+    private static func fieldErrors(
+        from error: PromptInferenceSettings.ValidationError
+    ) -> InferenceValidationErrors {
+        switch error {
+        case .outOfRange(let field, let minimum, let maximum):
+            return [field: rangeValidationMessage(for: field, minimum: minimum, maximum: maximum)]
+        case .nonFinite(let field):
+            return [field: validationMessage(for: field)]
+        case .unsupportedPromptCategory:
+            return [:]
+        }
+    }
+
+    private static func rangeValidationMessage(
+        for field: PromptInferenceSettings.Field,
+        minimum: Double,
+        maximum: Double
+    ) -> String {
+        switch field {
+        case .temperature, .topP:
+            return
+                "Enter a number from \(InferenceSettingsDraft.renderNumber(minimum)) to \(InferenceSettingsDraft.renderNumber(maximum))."
+        case .topK, .maxTokens:
+            return "Enter a whole number from \(Int(minimum)) to \(Int(maximum))."
+        case .thinkingMode, .reasoningEffort:
+            return validationMessage(for: field)
+        }
+    }
+
+    private static func compactRequestedParts(_ settings: PromptInferenceSettings) -> [String] {
+        var parts: [String] = []
+        if let temperature = settings.temperature {
+            parts.append("Temp \(InferenceSettingsDraft.renderNumber(temperature))")
+        }
+        if let topP = settings.topP {
+            parts.append("Top P \(InferenceSettingsDraft.renderNumber(topP))")
+        }
+        if let topK = settings.topK { parts.append("Top K \(topK)") }
+        if let maxTokens = settings.maxTokens { parts.append("Max \(maxTokens)") }
+        switch settings.thinkingMode {
+        case .providerDefault: break
+        case .enabled: parts.append("Thinking on")
+        case .disabled: parts.append("Thinking off")
+        }
+        return parts
+    }
+
     private static func validateInferenceSettings(
         _ draft: InferenceSettingsDraft
     ) -> InferenceDraftValidationResult {
@@ -836,14 +1091,15 @@ public final class PromptsViewModel {
             errors: &nextErrors
         )
         if nextErrors.isEmpty {
-            return .valid(PromptInferenceSettings(
-                temperature: temperature,
-                topP: topP,
-                topK: topK,
-                maxTokens: maxTokens,
-                thinkingMode: draft.thinkingMode,
-                reasoningEffort: draft.reasoningEffort
-            ).normalized)
+            return .valid(
+                PromptInferenceSettings(
+                    temperature: temperature,
+                    topP: topP,
+                    topK: topK,
+                    maxTokens: maxTokens,
+                    thinkingMode: draft.thinkingMode,
+                    reasoningEffort: draft.reasoningEffort
+                ).normalized)
         }
 
         return .invalid(nextErrors)
@@ -900,6 +1156,16 @@ public final class PromptsViewModel {
         case .maxTokens: return "Maximum output tokens"
         case .thinkingMode: return "Thinking"
         case .reasoningEffort: return "Reasoning effort"
+        }
+    }
+
+    nonisolated public static func displayName(
+        for mode: PromptInferenceSettings.ThinkingMode
+    ) -> String {
+        switch mode {
+        case .providerDefault: return "Automatic"
+        case .enabled: return "On"
+        case .disabled: return "Off"
         }
     }
 

--- a/Tests/MacParakeetTests/Models/PromptInferenceSettingsTests.swift
+++ b/Tests/MacParakeetTests/Models/PromptInferenceSettingsTests.swift
@@ -177,6 +177,105 @@ final class PromptInferenceSettingsTests: XCTestCase {
         XCTAssertNil(openAIReasoning.effectiveSettings)
     }
 
+    func testGemini3AutomaticSamplingOmitsOnlyTheInheritedApplicationBaseline() throws {
+        let config = LLMProviderConfig.gemini(apiKey: "key", model: "gemini-3.5-flash")
+
+        let automatic = try PromptInferenceCapabilityResolver.resolve(config: config, requested: nil)
+        XCTAssertNil(automatic.options.temperature)
+        XCTAssertNil(automatic.effectiveSettings)
+
+        let historicalReceipt = try PromptInferenceCapabilityResolver.resolve(
+            config: config,
+            requested: PromptInferenceSettings(temperature: 0.7)
+        )
+        XCTAssertEqual(historicalReceipt.options.temperature, 0.7)
+        XCTAssertEqual(historicalReceipt.effectiveSettings, PromptInferenceSettings(temperature: 0.7))
+
+        let explicitBaseline = try PromptInferenceCapabilityResolver.resolve(
+            config: config,
+            baseline: ChatCompletionOptions(temperature: 0.1),
+            requested: nil
+        )
+        XCTAssertEqual(explicitBaseline.options.temperature, 0.1)
+        XCTAssertEqual(explicitBaseline.effectiveSettings, PromptInferenceSettings(temperature: 0.1))
+    }
+
+    func testPresentationPreservesInvalidDraftAndUsesCompatibleOverrideForMetadata() {
+        let config = LLMProviderConfig.gemini(apiKey: "key", model: "gemini-3.5-flash")
+        let invalidDraft = PromptInferenceSettings(temperature: 3)
+
+        let invalidSettings = PromptInferenceCapabilityResolver.presentation(
+            config: config,
+            modelOverride: nil,
+            requested: invalidDraft
+        )
+        XCTAssertEqual(invalidSettings.requestedSettings, invalidDraft)
+        XCTAssertEqual(
+            invalidSettings.validationError,
+            .outOfRange(field: .temperature, minimum: 0, maximum: 2)
+        )
+        XCTAssertEqual(invalidSettings.effectiveModel, "gemini-3.5-flash")
+        XCTAssertEqual(
+            invalidSettings.fieldCapabilities[.temperature]?.availability,
+            .supported
+        )
+        XCTAssertTrue(invalidSettings.fieldCapabilities[.temperature]?.isDiscouraged == true)
+
+        let invalidModel = PromptInferenceCapabilityResolver.presentation(
+            config: config,
+            modelOverride: "claude-sonnet-5",
+            requested: PromptInferenceSettings(temperature: 0.7)
+        )
+        XCTAssertEqual(invalidModel.requestedModelOverride, "claude-sonnet-5")
+        XCTAssertNil(invalidModel.effectiveModel)
+        XCTAssertEqual(
+            invalidModel.modelOverrideStatus,
+            .invalid(reason: "the model identifier does not match this provider.")
+        )
+        XCTAssertEqual(
+            invalidModel.fieldCapabilities[.temperature]?.defaultSource,
+            .provider
+        )
+    }
+
+    func testPresentationReportsImplementedReasoningChoicesWithoutInventingNativeMappings() {
+        let openAI = PromptInferenceCapabilityResolver.presentation(
+            config: .openai(apiKey: "key", model: "gpt-5.5"),
+            modelOverride: nil,
+            requested: nil
+        )
+        XCTAssertEqual(openAI.fieldCapabilities[.thinkingMode]?.availability, .unsupported)
+        XCTAssertTrue(openAI.fieldCapabilities[.thinkingMode]?.allowedThinkingModes.isEmpty == true)
+        XCTAssertTrue(openAI.fieldCapabilities[.reasoningEffort]?.allowedReasoningEfforts.isEmpty == true)
+
+        let custom = PromptInferenceCapabilityResolver.presentation(
+            config: .openaiCompatible(
+                model: "manual-model",
+                baseURL: URL(string: "http://localhost:8080/v1")!
+            ),
+            modelOverride: nil,
+            requested: nil
+        )
+        XCTAssertEqual(custom.fieldCapabilities[.thinkingMode]?.availability, .unverified)
+        XCTAssertEqual(
+            custom.fieldCapabilities[.thinkingMode]?.allowedThinkingModes,
+            PromptInferenceSettings.ThinkingMode.allCases
+        )
+        XCTAssertEqual(
+            custom.fieldCapabilities[.reasoningEffort]?.allowedReasoningEfforts,
+            PromptInferenceSettings.ReasoningEffort.allCases
+        )
+
+        let ollama = PromptInferenceCapabilityResolver.presentation(
+            config: .ollama(model: "qwen3.5:9b"),
+            modelOverride: nil,
+            requested: nil
+        )
+        XCTAssertEqual(ollama.fieldCapabilities[.thinkingMode]?.availability, .unverified)
+        XCTAssertEqual(ollama.fieldCapabilities[.reasoningEffort]?.availability, .unsupported)
+        XCTAssertTrue(ollama.fieldCapabilities[.reasoningEffort]?.allowedReasoningEfforts.isEmpty == true)
+    }
+
     func testAnthropicTopPReplacesInheritedTemperatureAndRegeneratesUnchanged() throws {
         let config = LLMProviderConfig.anthropic(apiKey: "key", model: "claude-haiku-4-5")
         for topP in [0.0, 0.9] {

--- a/Tests/MacParakeetTests/Services/LLM/LLMHTTPAdapterTests.swift
+++ b/Tests/MacParakeetTests/Services/LLM/LLMHTTPAdapterTests.swift
@@ -529,6 +529,30 @@ final class LLMHTTPAdapterTests: XCTestCase {
         }
     }
 
+    func testGemini3PromptResolutionOmitsInheritedTemperatureButSendsHistoricalOverride() throws {
+        let config = LLMProviderConfig.gemini(apiKey: "key", model: "gemini-3.5-flash")
+        let automatic = try PromptInferenceCapabilityResolver.resolve(config: config, requested: nil)
+        let automaticRequest = try openAIAdapter.buildRequest(
+            messages: goldenMessages,
+            config: config,
+            options: automatic.options,
+            stream: false
+        )
+        XCTAssertNil(try jsonBody(from: automaticRequest)["temperature"])
+
+        let historicalReceipt = try PromptInferenceCapabilityResolver.resolve(
+            config: config,
+            requested: PromptInferenceSettings(temperature: 0.7)
+        )
+        let historicalRequest = try openAIAdapter.buildRequest(
+            messages: goldenMessages,
+            config: config,
+            options: historicalReceipt.options,
+            stream: false
+        )
+        XCTAssertEqual(try jsonBody(from: historicalRequest)["temperature"] as? Double, 0.7)
+    }
+
     func testOpenAICompatibleAdapterEncodesNullableKnowledgeCardOwnerSchema() async throws {
         var capturedRequest: URLRequest?
 

--- a/Tests/MacParakeetTests/Services/LLM/LLMServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/LLM/LLMServiceTests.swift
@@ -110,16 +110,36 @@ final class MockLLMClient: LLMClientProtocol, @unchecked Sendable {
     var modelsList: [String] = []
     var listModelsError: Error?
     var listModelsCallCount = 0
+    var listModelsCompletedCount = 0
     var listModelsDelayNs: UInt64 = 0
+    var holdListModels = false
+    private var listModelsHoldContinuation: CheckedContinuation<Void, Never>?
 
+    @MainActor
+    func releaseHeldListModels() {
+        holdListModels = false
+        listModelsHoldContinuation?.resume()
+        listModelsHoldContinuation = nil
+    }
+
+    @MainActor
     func listModels(context: LLMExecutionContext) async throws -> [String] {
-        listModelsCallCount += 1
         capturedContext = context
         let snapshot = modelsList
-        if listModelsDelayNs > 0 {
-            try await Task.sleep(nanoseconds: listModelsDelayNs)
+        let error = listModelsError
+        let delayNs = listModelsDelayNs
+        let shouldHold = holdListModels
+        listModelsCallCount += 1
+        defer { listModelsCompletedCount += 1 }
+        if shouldHold {
+            await withCheckedContinuation { continuation in
+                listModelsHoldContinuation = continuation
+            }
         }
-        if let error = listModelsError { throw error }
+        if delayNs > 0 {
+            try await Task.sleep(nanoseconds: delayNs)
+        }
+        if let error { throw error }
         return snapshot
     }
 

--- a/Tests/MacParakeetTests/Services/LLM/LLMServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/LLM/LLMServiceTests.swift
@@ -86,13 +86,15 @@ final class MockLLMClient: LLMClientProtocol, @unchecked Sendable {
             for token in tokens {
                 continuation.yield(.text(token))
             }
-            continuation.yield(.completed(LLMStreamTerminal(
-                provider: context.providerConfig.id.rawValue,
-                model: responseModel,
-                usage: responseUsage.map(LLMUsage.init),
-                stopReason: responseFinishReason,
-                effectiveSettings: options.effectiveInferenceSettings
-            )))
+            continuation.yield(
+                .completed(
+                    LLMStreamTerminal(
+                        provider: context.providerConfig.id.rawValue,
+                        model: responseModel,
+                        usage: responseUsage.map(LLMUsage.init),
+                        stopReason: responseFinishReason,
+                        effectiveSettings: options.effectiveInferenceSettings
+                    )))
             continuation.finish()
         }
     }
@@ -108,12 +110,17 @@ final class MockLLMClient: LLMClientProtocol, @unchecked Sendable {
     var modelsList: [String] = []
     var listModelsError: Error?
     var listModelsCallCount = 0
+    var listModelsDelayNs: UInt64 = 0
 
     func listModels(context: LLMExecutionContext) async throws -> [String] {
         listModelsCallCount += 1
         capturedContext = context
+        let snapshot = modelsList
+        if listModelsDelayNs > 0 {
+            try await Task.sleep(nanoseconds: listModelsDelayNs)
+        }
         if let error = listModelsError { throw error }
-        return modelsList
+        return snapshot
     }
 
     func withInProcessLocalModelRemoval(_ operation: @Sendable () async throws -> Void) async throws {
@@ -498,7 +505,6 @@ final class LLMServiceTests: XCTestCase {
         XCTAssertEqual(mockClient.capturedMessages.count, 2)
         XCTAssertEqual(mockClient.capturedMessages[1].content, "input text")
     }
-
 
     func testLegacyServiceConformerRejectsSettingsInsteadOfIgnoringThem() async {
         let legacy: any LLMServiceProtocol = MockTransformLLMService()

--- a/Tests/MacParakeetTests/ViewModels/PromptResultsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/PromptResultsViewModelTests.swift
@@ -59,6 +59,69 @@ final class PromptResultsViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.canGenerateManualPromptResult)
     }
 
+    func testSelectedPromptInferenceCompatibilityUsesModelOverrideWhenSettingsAreNil() {
+        let store = MockLLMConfigStore()
+        store.config = .gemini(apiKey: "key", model: "gemini-3.5-flash")
+        let prompt = Prompt(
+            name: "Override only",
+            content: "Summarize.",
+            modelOverride: "claude-sonnet-5"
+        )
+        promptRepo.prompts = [prompt]
+        viewModel.configure(
+            llmService: llm,
+            promptRepo: promptRepo,
+            promptResultRepo: promptResultRepo,
+            configStore: store
+        )
+        viewModel.selectedPrompt = prompt
+
+        XCTAssertNil(viewModel.selectedPromptInferenceSummary)
+        XCTAssertEqual(
+            viewModel.selectedPromptInferenceCompatibilityMessage,
+            "This prompt's model isn't available with Google Gemini: the model identifier does not match this provider."
+        )
+    }
+
+    func testSelectedPromptInferenceCompatibilityUsesOverrideForUnsupportedSampling() {
+        let store = MockLLMConfigStore()
+        store.config = .openai(apiKey: "key", model: "gpt-4.1")
+        let prompt = Prompt(
+            name: "Sampling",
+            content: "Summarize.",
+            inferenceSettings: PromptInferenceSettings(temperature: 0.2),
+            modelOverride: "gpt-5.5"
+        )
+        promptRepo.prompts = [prompt]
+        viewModel.configure(
+            llmService: llm,
+            promptRepo: promptRepo,
+            promptResultRepo: promptResultRepo,
+            configStore: store
+        )
+        viewModel.selectedPrompt = prompt
+
+        XCTAssertEqual(
+            viewModel.selectedPromptInferenceCompatibilityMessage,
+            "Not applied with this provider/model and setting combination: Temperature."
+        )
+    }
+
+    func testSelectedPromptInferenceCompatibilityIsSilentForInheritedModelWithoutSettings() {
+        let store = MockLLMConfigStore()
+        store.config = .openai(apiKey: "key", model: "gpt-5.5")
+        let prompt = Prompt(name: "Plain", content: "Summarize.")
+        promptRepo.prompts = [prompt]
+        viewModel.configure(
+            llmService: llm,
+            promptRepo: promptRepo,
+            promptResultRepo: promptResultRepo,
+            configStore: store
+        )
+        viewModel.selectedPrompt = prompt
+
+        XCTAssertNil(viewModel.selectedPromptInferenceCompatibilityMessage)
+    }
 
     func testRefreshModelInfoLoadsDiscoveredOllamaModelsForPromptSelector() async throws {
         let configStore = MockLLMConfigStore()
@@ -966,10 +1029,11 @@ final class PromptResultsViewModelTests: XCTestCase {
         )
         viewModel.loadPromptResults(transcriptionId: displayedID)
         llm.streamTokens = []
-        let generationID = try XCTUnwrap(viewModel.autoGeneratePromptResults(
-            transcript: "Background transcript", transcriptionId: meetingID,
-            sourceType: .meeting, runInBackground: true
-        ).first)
+        let generationID = try XCTUnwrap(
+            viewModel.autoGeneratePromptResults(
+                transcript: "Background transcript", transcriptionId: meetingID,
+                sourceType: .meeting, runInBackground: true
+            ).first)
         try await waitUntil { !self.viewModel.pendingGenerations.contains { $0.state.isActive } }
         guard case .failed = viewModel.pendingGeneration(id: generationID)?.state else {
             return XCTFail("Expected the empty response to fail")
@@ -1158,7 +1222,7 @@ final class PromptResultsViewModelTests: XCTestCase {
                     isAvailable: true,
                     isAutoRun: true,
                     sortOrder: 10
-                ),
+                )
             ],
         ]
         llm.streamDelayNs = 1_000_000_000
@@ -1194,10 +1258,10 @@ final class PromptResultsViewModelTests: XCTestCase {
                     meetingTypeId: meetingTypeID,
                     isAvailable: false,
                     isAutoRun: false
-                ),
+                )
             ],
             later.id: [
-                .allMeetings(promptId: later.id, isAvailable: true, isAutoRun: false, sortOrder: 20),
+                .allMeetings(promptId: later.id, isAvailable: true, isAutoRun: false, sortOrder: 20)
             ],
             first.id: [
                 .meetingType(
@@ -1206,15 +1270,16 @@ final class PromptResultsViewModelTests: XCTestCase {
                     isAvailable: true,
                     isAutoRun: false,
                     sortOrder: 10
-                ),
+                )
             ],
         ]
-        try transcriptionRepo.save(Transcription(
-            id: transcriptionID,
-            fileName: "meeting.m4a",
-            sourceType: .meeting,
-            meetingTypeId: meetingTypeID
-        ))
+        try transcriptionRepo.save(
+            Transcription(
+                id: transcriptionID,
+                fileName: "meeting.m4a",
+                sourceType: .meeting,
+                meetingTypeId: meetingTypeID
+            ))
         viewModel.configure(
             llmService: llm,
             promptRepo: promptRepo,
@@ -1741,24 +1806,28 @@ private final class PromptLabelPolicyRepositoryMock: PromptLabelPolicyRepository
 
     func replaceTargetLabels(promptId: UUID, labelIds: Set<UUID>) throws {
         let now = Date()
-        policiesByPromptID[promptId] = labelIds.isEmpty
+        policiesByPromptID[promptId] =
+            labelIds.isEmpty
             ? []
-            : [PromptLabelPolicy(
-                promptId: promptId,
-                scopeKind: .all,
-                isAvailable: false,
-                createdAt: now,
-                updatedAt: now
-            )] + labelIds.map {
+            : [
                 PromptLabelPolicy(
                     promptId: promptId,
-                    scopeKind: .label,
-                    labelId: $0,
-                    isAvailable: true,
+                    scopeKind: .all,
+                    isAvailable: false,
                     createdAt: now,
                     updatedAt: now
                 )
-            }
+            ]
+                + labelIds.map {
+                    PromptLabelPolicy(
+                        promptId: promptId,
+                        scopeKind: .label,
+                        labelId: $0,
+                        isAvailable: true,
+                        createdAt: now,
+                        updatedAt: now
+                    )
+                }
     }
 }
 

--- a/Tests/MacParakeetTests/ViewModels/PromptsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/PromptsViewModelTests.swift
@@ -905,11 +905,12 @@ final class PromptsViewModelTests: XCTestCase {
         let store = MockLLMConfigStore()
         store.config = .openai(apiKey: "key", model: "gpt-5.5")
         let client = MockLLMClient()
+        client.modelsList = ["discovered-model"]
         client.listModelsError = LLMError.connectionFailed("offline")
         viewModel.configure(repo: repo, configStore: store, llmClient: client)
-        try await waitUntil { self.viewModel.generationProviderID == .openai }
-        try await Task.sleep(for: .milliseconds(50))
+        try await waitUntil(timeout: .seconds(2)) { client.listModelsCompletedCount >= 1 }
 
+        XCTAssertEqual(client.listModelsCallCount, 1)
         XCTAssertTrue(viewModel.generationAvailableModels.contains("gpt-5.5"))
         XCTAssertFalse(viewModel.generationAvailableModels.contains("discovered-model"))
     }
@@ -919,19 +920,28 @@ final class PromptsViewModelTests: XCTestCase {
         store.config = .openai(apiKey: "key", model: "gpt-5.5")
         let client = MockLLMClient()
         client.modelsList = ["stale-openai-model"]
-        client.listModelsDelayNs = 250_000_000
+        client.holdListModels = true
+        defer { client.releaseHeldListModels() }
         viewModel.configure(repo: repo, configStore: store, llmClient: client)
-        try await waitUntil { self.viewModel.generationProviderID == .openai }
+        try await waitUntil(timeout: .seconds(2)) { client.listModelsCallCount >= 1 }
 
         store.config = .anthropic(apiKey: "key", model: "claude-haiku-4-5")
         client.modelsList = ["claude-discovered"]
-        client.listModelsDelayNs = 0
+        client.holdListModels = false
         viewModel.refreshGenerationSettingsContext()
-        try await waitUntil { self.viewModel.generationProviderID == .anthropic }
-        try await Task.sleep(for: .milliseconds(400))
+        try await waitUntil(timeout: .seconds(2)) { client.listModelsCallCount >= 2 }
+        try await waitUntil(timeout: .seconds(2)) {
+            self.viewModel.generationAvailableModels.contains("claude-discovered")
+        }
 
+        XCTAssertEqual(client.listModelsCompletedCount, 1)
         XCTAssertFalse(viewModel.generationAvailableModels.contains("stale-openai-model"))
-        XCTAssertTrue(viewModel.generationAvailableModels.contains("claude-haiku-4-5"))
+        XCTAssertTrue(viewModel.generationAvailableModels.contains("claude-discovered"))
+
+        client.releaseHeldListModels()
+        try await waitUntil(timeout: .seconds(2)) { client.listModelsCompletedCount >= 2 }
+        XCTAssertFalse(viewModel.generationAvailableModels.contains("stale-openai-model"))
+        XCTAssertTrue(viewModel.generationAvailableModels.contains("claude-discovered"))
     }
 
     private func loadGenerationConfig(_ config: LLMProviderConfig) async throws {

--- a/Tests/MacParakeetTests/ViewModels/PromptsViewModelTests.swift
+++ b/Tests/MacParakeetTests/ViewModels/PromptsViewModelTests.swift
@@ -49,10 +49,12 @@ final class PromptsViewModelTests: XCTestCase {
         subject.deletePrompt(prompt)
         subject.restoreDeletedPrompt(prompt)
 
-        XCTAssertEqual(snapshots, [
-            ["Original instructions"], ["Edited instructions"], ["Original instructions"],
-            [], ["Original instructions"], [], ["Original instructions"],
-        ])
+        XCTAssertEqual(
+            snapshots,
+            [
+                ["Original instructions"], ["Edited instructions"], ["Original instructions"],
+                [], ["Original instructions"], [], ["Original instructions"],
+            ])
     }
 
     func testFailedTransformEditDoesNotInvalidateBindings() throws {
@@ -97,9 +99,10 @@ final class PromptsViewModelTests: XCTestCase {
         )
         XCTAssertEqual(subject.labelIDsByPromptID[created.id], [customer.id])
         XCTAssertEqual(
-            Set(try policyRepository.fetchPolicies(promptId: created.id).compactMap {
-                $0.scopeKind == .label && $0.isAvailable ? $0.labelId : nil
-            }),
+            Set(
+                try policyRepository.fetchPolicies(promptId: created.id).compactMap {
+                    $0.scopeKind == .label && $0.isAvailable ? $0.labelId : nil
+                }),
             [customer.id]
         )
     }
@@ -133,10 +136,11 @@ final class PromptsViewModelTests: XCTestCase {
         XCTAssertNil(subject.errorMessage)
         XCTAssertTrue(try policies.fetchPolicies(promptId: prompt.id).isEmpty)
         XCTAssertFalse(subject.hasCustomTargetingRules(for: prompt))
-        XCTAssertTrue(PromptLabelApplicabilityResolver.resolve(
-            prompt: prompt, sourceType: .meeting, transcriptionLabelIDs: [],
-            policies: try policies.fetchPolicies(promptId: prompt.id)
-        ).isAvailable)
+        XCTAssertTrue(
+            PromptLabelApplicabilityResolver.resolve(
+                prompt: prompt, sourceType: .meeting, transcriptionLabelIDs: [],
+                policies: try policies.fetchPolicies(promptId: prompt.id)
+            ).isAvailable)
     }
 
     func testStandardLabelSelectionDoesNotDisplayAsCustomRules() throws {
@@ -552,7 +556,6 @@ final class PromptsViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.prompts.contains { $0.id == builtIn.id })
     }
 
-
     func testBeginEditingLoadsNewestVersions() {
         let prompt = viewModel.prompts[0]
         let versionRepo = MockPromptVersionRepository()
@@ -654,6 +657,306 @@ final class PromptsViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.deletedPrompts.isEmpty)
         XCTAssertTrue(viewModel.managedPrompts.contains { $0.id == builtIn.id })
         XCTAssertTrue(viewModel.managedPrompts.contains { $0.id == custom.id })
+    }
+
+    func testBlankDraftPresentationDoesNotMaterializeInheritedGeminiTemperature() async throws {
+        try await loadGenerationConfig(.gemini(apiKey: "sk-secret-test-key", model: "gemini-3.5-flash"))
+
+        let presentation = try XCTUnwrap(
+            viewModel.generationSettingsPresentation(
+                draft: .init(),
+                modelOverride: ""
+            )
+        )
+        XCTAssertNil(presentation.requestedSettings)
+        XCTAssertNil(presentation.effectiveSettings)
+        XCTAssertEqual(presentation.fieldCapabilities[.temperature]?.defaultSource, .provider)
+        XCTAssertEqual(presentation.effectiveModel, "gemini-3.5-flash")
+        XCTAssertFalse("\(presentation)".contains("sk-secret-test-key"))
+        XCTAssertFalse(
+            String(describing: viewModel.generationProviderID).contains("sk-secret-test-key")
+        )
+    }
+
+    func testInvalidDraftTextKeepsFieldMetadataAndStillReportsValidation() async throws {
+        try await loadGenerationConfig(.gemini(apiKey: "key", model: "gemini-3.5-flash"))
+        viewModel.newInferenceSettings.temperature = "abc"
+        viewModel.newName = "Invalid text"
+        viewModel.newContent = "Keep metadata."
+
+        let presentation = try XCTUnwrap(
+            viewModel.generationSettingsPresentation(
+                draft: viewModel.newInferenceSettings,
+                modelOverride: ""
+            )
+        )
+        XCTAssertNil(presentation.requestedSettings?.temperature)
+        XCTAssertEqual(presentation.fieldCapabilities[.temperature]?.availability, .supported)
+        XCTAssertTrue(presentation.fieldCapabilities[.temperature]?.isDiscouraged == true)
+
+        viewModel.addPrompt()
+        XCTAssertFalse(viewModel.prompts.contains { $0.name == "Invalid text" })
+        XCTAssertNotNil(viewModel.newInferenceValidationErrors[.temperature])
+    }
+
+    func testResetInferenceSettingsLeavesInheritanceUnset() throws {
+        viewModel.newName = "Reset"
+        viewModel.newContent = "Use inherited settings."
+        viewModel.newInferenceSettings.temperature = "0.2"
+        viewModel.newInferenceSettings.maxTokens = "4096"
+        viewModel.resetNewInferenceSettings()
+
+        XCTAssertTrue(viewModel.newInferenceSettings.isDefault)
+        viewModel.addPrompt()
+        let prompt = try XCTUnwrap(viewModel.prompts.first { $0.name == "Reset" })
+        XCTAssertNil(prompt.inferenceSettings)
+    }
+
+    func testAnthropicKnownRangeIsValidatedBeforeSave() async throws {
+        try await loadGenerationConfig(.anthropic(apiKey: "key", model: "claude-haiku-4-5"))
+        viewModel.newName = "Anthropic range"
+        viewModel.newContent = "Summarize."
+        viewModel.newInferenceSettings.temperature = "1.5"
+
+        viewModel.addPrompt()
+        XCTAssertFalse(viewModel.prompts.contains { $0.name == "Anthropic range" })
+        XCTAssertEqual(
+            viewModel.newInferenceValidationErrors[.temperature],
+            "Enter a number from 0 to 1."
+        )
+
+        viewModel.newInferenceSettings.temperature = "0.8"
+        viewModel.addPrompt()
+        let prompt = try XCTUnwrap(viewModel.prompts.first { $0.name == "Anthropic range" })
+        XCTAssertEqual(prompt.inferenceSettings?.temperature, 0.8)
+    }
+
+    func testUnsupportedSavedValuesRemainWhenTheCurrentModelOmitsThem() async throws {
+        try await loadGenerationConfig(.openai(apiKey: "key", model: "gpt-5.5"))
+        viewModel.newName = "GPT-5 sampling"
+        viewModel.newContent = "Summarize."
+        viewModel.newInferenceSettings.temperature = "0.2"
+        viewModel.newInferenceSettings.thinkingMode = .enabled
+
+        viewModel.addPrompt()
+        let prompt = try XCTUnwrap(viewModel.prompts.first { $0.name == "GPT-5 sampling" })
+        XCTAssertEqual(prompt.inferenceSettings?.temperature, 0.2)
+        XCTAssertEqual(prompt.inferenceSettings?.thinkingMode, .enabled)
+
+        viewModel.beginEditing(prompt)
+        try await waitUntil { self.viewModel.generationProviderID == .openai }
+        let presentation = try XCTUnwrap(
+            viewModel.generationSettingsPresentation(
+                draft: viewModel.editingInferenceSettings,
+                modelOverride: viewModel.editingModelOverride
+            )
+        )
+        XCTAssertEqual(presentation.requestedSettings?.temperature, 0.2)
+        XCTAssertEqual(presentation.fieldCapabilities[.temperature]?.availability, .unsupported)
+        XCTAssertEqual(presentation.fieldCapabilities[.thinkingMode]?.availability, .unsupported)
+
+        viewModel.updatePrompt(prompt, name: "GPT-5 sampling renamed", content: prompt.content)
+        let updated = try XCTUnwrap(viewModel.prompts.first { $0.id == prompt.id })
+        XCTAssertEqual(updated.inferenceSettings?.temperature, 0.2)
+        XCTAssertEqual(updated.inferenceSettings?.thinkingMode, .enabled)
+        XCTAssertEqual(updated.name, "GPT-5 sampling renamed")
+    }
+
+    func testModelOverrideDrivesPresentationAndCompatibilityWarning() async throws {
+        try await loadGenerationConfig(.openai(apiKey: "key", model: "gpt-4.1"))
+        let presentation = try XCTUnwrap(
+            viewModel.generationSettingsPresentation(
+                draft: .init(temperature: "0.2"),
+                modelOverride: "gpt-5.5"
+            )
+        )
+        XCTAssertEqual(presentation.modelOverrideStatus, .applied)
+        XCTAssertEqual(presentation.effectiveModel, "gpt-5.5")
+        XCTAssertEqual(presentation.fieldCapabilities[.temperature]?.availability, .unsupported)
+
+        try await loadGenerationConfig(.gemini(apiKey: "key", model: "gemini-3.5-flash"))
+        let invalid = try XCTUnwrap(
+            viewModel.generationSettingsPresentation(
+                draft: .init(),
+                modelOverride: "claude-sonnet-5"
+            )
+        )
+        XCTAssertEqual(
+            invalid.modelOverrideStatus,
+            .invalid(reason: "the model identifier does not match this provider.")
+        )
+
+        let warning = PromptsViewModel.inferenceCompatibilityMessage(
+            settings: nil,
+            config: .gemini(apiKey: "key", model: "gemini-3.5-flash"),
+            modelOverride: "claude-sonnet-5"
+        )
+        XCTAssertEqual(
+            warning,
+            "This prompt's model isn't available with Google Gemini: the model identifier does not match this provider."
+        )
+    }
+
+    func testGenerationModelSelectionCustomFromEmptyOverrideRevealsListAndCustomID() {
+        let models = ["gpt-5.5", "gpt-4.1"]
+        var override = ""
+        var selection = PromptsViewModel.GenerationModelSelection(
+            modelOverride: override,
+            availableModels: models
+        )
+        XCTAssertFalse(selection.showsCustomControls)
+        XCTAssertFalse(selection.showsModelList(availableModels: models))
+        XCTAssertFalse(selection.showsCustomIDField(availableModels: models))
+
+        selection.selectCustom(availableModels: models)
+        XCTAssertTrue(selection.showsCustomControls)
+        XCTAssertTrue(selection.showsModelList(availableModels: models))
+        XCTAssertFalse(selection.showsCustomIDField(availableModels: models))
+        XCTAssertEqual(override, "")
+        selection.reconcile(modelOverride: "", availableModels: models)
+        XCTAssertTrue(selection.showsCustomControls)
+        XCTAssertTrue(selection.showsModelList(availableModels: models))
+
+        selection.useCustomModelID()
+        XCTAssertTrue(selection.showsCustomIDField(availableModels: models))
+        XCTAssertFalse(selection.showsModelList(availableModels: models))
+        XCTAssertEqual(override, "")
+
+        override = "house-model"
+        selection.reconcile(modelOverride: override, availableModels: models)
+        XCTAssertTrue(selection.showsCustomIDField(availableModels: models))
+
+        selection.chooseFromList()
+        XCTAssertTrue(selection.showsModelList(availableModels: models))
+        XCTAssertEqual(override, "house-model")
+    }
+
+    func testGenerationModelSelectionEmptyListStartsOnCustomIDAndDoesNotMaterializeInheritance() {
+        let override = ""
+        var selection = PromptsViewModel.GenerationModelSelection(
+            modelOverride: override,
+            availableModels: []
+        )
+        selection.selectCustom(availableModels: [])
+        XCTAssertTrue(selection.showsCustomIDField(availableModels: []))
+        XCTAssertFalse(selection.showsModelList(availableModels: []))
+        XCTAssertEqual(override, "")
+
+        selection.reconcile(modelOverride: "", availableModels: [])
+        XCTAssertTrue(selection.showsCustomControls)
+        XCTAssertEqual(override, "")
+    }
+
+    func testGenerationModelSelectionUseAISettingsAndResetRestoreInheritance() {
+        let models = ["gpt-5.5"]
+        var override = "gpt-5.5"
+        var selection = PromptsViewModel.GenerationModelSelection(
+            modelOverride: override,
+            availableModels: models
+        )
+        XCTAssertTrue(selection.showsModelList(availableModels: models))
+
+        selection.selectUseAISettings()
+        override = ""
+        XCTAssertFalse(selection.showsCustomControls)
+        XCTAssertEqual(override, "")
+
+        override = "house-model"
+        selection = PromptsViewModel.GenerationModelSelection(
+            modelOverride: override,
+            availableModels: models
+        )
+        XCTAssertTrue(selection.showsCustomIDField(availableModels: models))
+        selection.reset()
+        override = ""
+        XCTAssertFalse(selection.showsCustomControls)
+        XCTAssertEqual(override, "")
+    }
+
+    func testSavedInvalidModelOverrideStaysWarningOnlyAndCustomID() async throws {
+        let models = ["gpt-5.5"]
+        var selection = PromptsViewModel.GenerationModelSelection(
+            modelOverride: "claude-sonnet-5",
+            availableModels: models
+        )
+        XCTAssertTrue(selection.showsCustomIDField(availableModels: models))
+        selection.reconcile(modelOverride: "claude-sonnet-5", availableModels: models)
+        XCTAssertTrue(selection.showsCustomIDField(availableModels: models))
+
+        try await loadGenerationConfig(.gemini(apiKey: "key", model: "gemini-3.5-flash"))
+        viewModel.newName = "Invalid override"
+        viewModel.newContent = "Summarize."
+        viewModel.newModelOverride = "claude-sonnet-5"
+        viewModel.addPrompt()
+
+        let prompt = try XCTUnwrap(viewModel.prompts.first { $0.name == "Invalid override" })
+        XCTAssertEqual(prompt.modelOverride, "claude-sonnet-5")
+        XCTAssertTrue(viewModel.newInferenceValidationErrors.isEmpty)
+        XCTAssertEqual(
+            viewModel.generationSettingsPresentation(
+                draft: .init(),
+                modelOverride: prompt.modelOverride ?? ""
+            )?.modelOverrideStatus,
+            .invalid(reason: "the model identifier does not match this provider.")
+        )
+    }
+
+    func testGenerationModelListKeepsFallbackWhenDiscoveryFails() async throws {
+        let store = MockLLMConfigStore()
+        store.config = .openai(apiKey: "key", model: "gpt-5.5")
+        let client = MockLLMClient()
+        client.listModelsError = LLMError.connectionFailed("offline")
+        viewModel.configure(repo: repo, configStore: store, llmClient: client)
+        try await waitUntil { self.viewModel.generationProviderID == .openai }
+        try await Task.sleep(for: .milliseconds(50))
+
+        XCTAssertTrue(viewModel.generationAvailableModels.contains("gpt-5.5"))
+        XCTAssertFalse(viewModel.generationAvailableModels.contains("discovered-model"))
+    }
+
+    func testGenerationModelListIgnoresStaleResultAfterProviderChange() async throws {
+        let store = MockLLMConfigStore()
+        store.config = .openai(apiKey: "key", model: "gpt-5.5")
+        let client = MockLLMClient()
+        client.modelsList = ["stale-openai-model"]
+        client.listModelsDelayNs = 250_000_000
+        viewModel.configure(repo: repo, configStore: store, llmClient: client)
+        try await waitUntil { self.viewModel.generationProviderID == .openai }
+
+        store.config = .anthropic(apiKey: "key", model: "claude-haiku-4-5")
+        client.modelsList = ["claude-discovered"]
+        client.listModelsDelayNs = 0
+        viewModel.refreshGenerationSettingsContext()
+        try await waitUntil { self.viewModel.generationProviderID == .anthropic }
+        try await Task.sleep(for: .milliseconds(400))
+
+        XCTAssertFalse(viewModel.generationAvailableModels.contains("stale-openai-model"))
+        XCTAssertTrue(viewModel.generationAvailableModels.contains("claude-haiku-4-5"))
+    }
+
+    private func loadGenerationConfig(_ config: LLMProviderConfig) async throws {
+        let store = MockLLMConfigStore()
+        store.config = config
+        viewModel.configure(repo: repo, configStore: store)
+        try await waitUntil { self.viewModel.generationProviderID == config.id }
+    }
+
+    private func waitUntil(
+        timeout: Duration = .seconds(1),
+        pollInterval: Duration = .milliseconds(10),
+        file: StaticString = #filePath,
+        line: UInt = #line,
+        _ condition: () -> Bool
+    ) async throws {
+        let clock = ContinuousClock()
+        let deadline = clock.now + timeout
+        while !condition() {
+            if clock.now >= deadline {
+                XCTFail("Timed out waiting for condition", file: file, line: line)
+                return
+            }
+            try await Task.sleep(for: pollInterval)
+        }
     }
 
 }

--- a/docs/audits/2026-09-08-generation-settings-review.md
+++ b/docs/audits/2026-09-08-generation-settings-review.md
@@ -1,0 +1,74 @@
+# Generation settings: compatibility and UX review
+
+Reviewed 2026-09-08 against main `75d75e5ab313e9a5a9693d1e2b171ba90b9d328d`. Review only; no production code or user settings changed. Evidence is source inspection, existing test inspection and current official provider documentation; no paid API requests or new runtime tests were run.
+
+## Verdict
+
+The optional override model and runtime capability resolver are useful foundations. The editor does not currently communicate the actual support or defaults of the effective provider/model. Treat this as a compatibility and clarity fix before the release, rather than adding more generic fields.
+
+A robust interface cannot promise all present and future models support the same knobs. It should distinguish supported, unsupported and unknown capabilities, inherit safe defaults, and accurately report what will be sent.
+
+## Findings
+
+1. **The form has no effective provider/model context.** `GenerationSettingsEditor` in `Sources/MacParakeet/Views/Transcription/PromptLibraryView.swift:1408` receives draft values, a model string and generic errors. It renders every sampling control and Thinking for every provider. The draft validates generic ranges, not the selected model's limits or cross-parameter restrictions.
+2. **Visible controls exceed integration support.** `PromptInferenceCapabilityResolver.supportedFields` in `Sources/MacParakeetCore/Models/PromptInferenceSettings.swift` filters thinking/effort for direct OpenAI, Anthropic and Gemini. Custom OpenAI-compatible endpoints get a broad support set and encode thinking through `chat_template_kwargs`; this is not universal reasoning support. Ollama supports a thinking switch in this integration but effort is filtered. Selecting a control is not evidence it will reach the model.
+3. **Defaults have multiple meanings.** `ChatCompletionOptions.default` in `Sources/MacParakeetCore/Models/LLMTypes.swift:186` supplies temperature 0.7. Anthropic defaults max_tokens to 4096 in its adapter; the resolver gives Ollama legacy behavior with thinking disabled and omitted sampling. Empty fields therefore do not uniformly mean provider default. The form exposes ranges, not effective values or their source. The configured default Gemini model is gemini-3.5-flash, which inherits the app's 0.7 sampling baseline on ordinary prompt generation.
+4. **Model rules are uneven.** The OpenAI policy conservatively omits sampling for GPT-5-and-later non-chat names; it does not represent mode-dependent exceptions. The Anthropic legacy allow-list protects newer direct models from unsupported sampling. That protection does not automatically apply to the same model behind OpenRouter or an arbitrary OpenAI-compatible endpoint. Provider routing and endpoint implementation matter as well as the model name.
+5. **Compatibility feedback uses the wrong model when an override exists.** `PromptResultsViewModel.selectedPromptInferenceCompatibilityMessage` loads the global config without applying the selected prompt's model override. `LLMService.generatePromptResultDetailed` applies the override before resolving options. The warning and actual request can disagree. The prompt editor itself does not display this compatibility feedback.
+6. **Numeric bounds are application-wide bounds, not model guarantees.** Temperature 0–2 is inaccurate for sampling-capable Anthropic models, whose sent temperature is checked at 0–1 downstream. The universal output-token limit does not describe individual model ceilings. On OpenAI reasoning models, the existing adapter uses max_completion_tokens, which budgets reasoning as well as visible output; the UI label should explain that where relevant.
+7. **Model override is unnecessarily opaque.** Settings already offers a model list and custom-ID escape hatch; prompt editing only provides a free-text ID. Provider changes can leave an incompatible saved model override. Re-evaluate compatibility whenever the provider, endpoint, model or reasoning selection changes, without silently replacing saved intent.
+
+## Current official guidance
+
+- [OpenAI GPT-5.2 parameter compatibility](https://developers.openai.com/api/docs/guides/latest-model?model=gpt-5.2): temperature/top_p support depends on reasoning effort. This demonstrates why a provider-wide boolean or a model-name prefix alone is insufficient.
+- [Claude thinking compatibility](https://platform.claude.com/docs/en/build-with-claude/thinking): newer listed models reject non-default sampling values; older models have additional restrictions while thinking. Effort and thinking support vary by model.
+- [Gemini 3.x parameter guidance](https://ai.google.dev/gemini-api/docs/whats-new-gemini-3.5): Google recommends omitting sampling overrides and using supported thinking levels. This is a recommendation, not proof that every custom temperature request fails.
+- [Gemini OpenAI compatibility](https://ai.google.dev/gemini-api/docs/openai): reasoning can be represented through the compatibility API, but accepted levels depend on the Gemini model. The current app adapter does not implement those controls.
+- [OpenRouter model metadata](https://openrouter.ai/docs/guides/overview/models): supported_parameters and default_parameters can supply useful provider metadata. They are not a universal discovery mechanism for arbitrary endpoints or a guarantee about every routing choice. [Routing parameter requirements](https://openrouter.ai/docs/guides/routing/provider-selection) also matter.
+
+## Recommended UX
+
+Keep Generation settings collapsed by default. Its collapsed summary should say **Uses AI settings** or **3 overrides**, rather than an unexplained Custom marker alone.
+
+When expanded:
+
+- **Model:** default to **Use AI settings**, followed by the actual provider and model. Offer **Choose another model…** using the existing model-list/custom-ID pattern. Do not require typing a model ID for the common case.
+- **Reasoning:** show **Automatic** and only the modes/levels implemented and supported for the effective model. Do not offer Disabled when the model requires reasoning; do not invent a mapping from High to token budgets across providers. If the integration cannot control reasoning, say it is model-managed rather than showing a working-looking switch.
+- **Response limit:** offer **Automatic** or **Custom**, with a validated numeric control and known model limit. Explain when the budget includes reasoning. Do not present an unknown limit as a precise guaranteed maximum.
+- **Sampling:** keep Temperature, Top P and Top K in a secondary advanced section, only where supported. Explain conflicts before save. For Gemini 3, keep the recommended automatic state prominent; supported-but-discouraged differs from unsupported.
+- **Inheritance:** show effective values as secondary read-only text where known, such as **Inherited from AI settings**, **App default: 4096**, or **Model default**. Never invent an exact default if the provider has not supplied it. Opening/saving the editor must not turn inherited values into explicit overrides.
+- **Reset:** use **Use defaults** to clear explicit overrides. Keep unavailable existing values visible with a concise explanation and a remove action, so switching providers does not invisibly destroy them.
+- **Unknown/custom endpoints:** preserve manual configuration for power users but mark capabilities unverified. Do not assume every OpenAI-shaped endpoint accepts top_k or chat_template_kwargs. Omit optional knobs by default and provide actionable errors for rejected explicit overrides; no silent retry that changes the requested behavior.
+
+Example presentation (illustrative, not a claim about current global settings):
+
+    Generation settings                 Uses AI settings
+    Model             Use AI settings
+                      Google Gemini · gemini-3.5-flash
+    Reasoning         Automatic
+    Response limit    Automatic
+    Sampling          Model defaults (recommended)
+                      Customize…
+
+Numeric inheritance is not a request for another new global settings layer. Settings currently manages provider/model/connection configuration, not a parallel numeric generation-settings form. Reuse its model selection behavior and keep the existing prompt-level override ownership.
+
+## Simple implementation boundary
+
+Extend the existing capability resolver with the small amount of metadata the editor needs: support state, permitted values/ranges, known effective defaults and a short reason. Use the same resolved effective provider/model in UI validation and request serialization. Keep provider-specific wire mapping in the existing adapters. Do not build a plugin framework, giant speculative model catalog, or automatic paid probing system.
+
+The CLI should consume the same capability/validation contract and distinguish requested from effective settings. Preserve existing stored overrides and historical generation receipts; do not rewrite them while changing the editor. A provider-default baseline change for new generations is a behavior change that deserves explicit tests and documentation.
+
+For the release, prioritize truthful UI support, the model-override warning mismatch, and known request/default compatibility. Native reasoning controls that are not currently implemented can remain unavailable with clear explanation; adding every provider's advanced features is separate work.
+
+## Verification needed for implementation
+
+- Unsupported fields omitted for direct providers and handled explicitly for compatible/router endpoints.
+- Valid combinations across legacy sampling models, modern reasoning models, and thinking modes.
+- Gemini automatic requests do not inject an unintended sampling override.
+- Editor-open/save preserves nil inheritance; customization and reset change only the intended overrides.
+- Compatibility preview applies prompt model overrides and updates after provider/model changes.
+- Existing incompatible settings survive provider switching and remain discoverable/removable.
+- Actual request serialization and effective receipts match the UI, including CLI paths.
+- Unknown endpoint/model behavior is conservative and explicit; existing offline/manual model entry continues working.
+
+Existing resolver and HTTP adapter tests cover several legacy safeguards, but they do not establish all-model compatibility or correctness of this proposed UI.

--- a/docs/audits/2026-09-08-provider-generation-contracts.md
+++ b/docs/audits/2026-09-08-provider-generation-contracts.md
@@ -1,0 +1,227 @@
+# Provider generation contracts
+
+Research date: 2026-09-08. Scope: the existing Chat Completions / Messages
+integrations and the six generation fields already persisted by
+`PromptInferenceSettings`. This is evidence for
+[the approved model-aware settings plan](../plans/2026-09-08-model-aware-generation-settings.md);
+it does not authorize a provider-capability service, a new reasoning feature,
+or live requests.
+
+## Reading the contracts
+
+- **Supported** means the provider documents that the field is accepted for the
+  selected model and endpoint.
+- **Discouraged** means the provider says the field is accepted but recommends
+  omission. It must remain distinct from unsupported.
+- **Unknown** means an OpenAI-compatible server or a gateway model has not
+  published support metadata. Do not claim a universal value, ceiling or
+  thinking mapping in that case.
+
+## Current PR boundary
+
+This PR retains the existing adapter request shapes and application baselines.
+When a baseline remains in a payload, the UI must call it an **app default**,
+not an inherited provider default. The one requested automatic-behavior change
+is ordinary Gemini 3 prompt generation: it must omit the legacy temperature
+0.7. Explicit saved settings and historical result receipts retain their
+meaning.
+
+The evidence below also identifies future provider integrations. Those are
+not acceptance requirements here: no new OpenRouter capability metadata,
+server templates, LM Studio top-p/top-k wire support, native reasoning
+mapping, or custom-endpoint discovery is introduced by this PR.
+
+## Anthropic Messages
+
+| Field | Current primary-source contract | Product implication |
+| --- | --- | --- |
+| `max_tokens` | A Messages request has a total output ceiling. For manual extended thinking, thinking tokens count toward it; `budget_tokens` must normally be at least 1,024 and less than `max_tokens`. [Extended thinking](https://platform.claude.com/docs/en/build-with-claude/extended-thinking#budget-rules-and-tuning) | Keep one explicit output-token control. Do not show a generic 131,072 maximum as a known Claude model limit. The current adapter's 4,096 fallback is an **app default**, not a documented provider default. |
+| `temperature`, `top_p`, `top_k` | Anthropic documents all three as deprecated and says a non-default value returns HTTP 400 on **Claude Opus 4.7 and later** and Claude Mythos Preview. [Model deprecations](https://platform.claude.com/docs/en/about-claude/model-deprecations#api-parameter-deprecations) | These are not merely ignored for those models: hide them and omit them. For legacy models, preserve the existing temperature/top-p adapter behavior; do not add `top_k` until the direct adapter maps and tests it. If both legacy temperature and top-p are present, retain the existing documented app precedence of top-p rather than sending a conflicting pair. |
+| Thinking / effort | Manual `thinking: {type: "enabled", budget_tokens: ...}` is rejected on Claude 4.7+; newer models use `thinking: {type: "adaptive"}` with `output_config.effort`. The documented migration explicitly changes both request shapes. [Extended-thinking migration](https://platform.claude.com/docs/en/build-with-claude/extended-thinking#migrating-to-adaptive-thinking) | The current generic enabled/disabled picker cannot honestly drive Claude native reasoning. Keep it unavailable for the direct Anthropic adapter in this change. Do not turn effort labels into a budget formula. |
+
+### Concrete Anthropic safeguard
+
+The current resolver uses a frozen legacy allowlist that ends at Claude 4.6;
+its configured fallback catalog separately includes `claude-opus-4-8`. The
+allowlist already correctly keeps that fallback from inheriting the app's
+`temperature: 0.7`. Preserve that conservative default when updating model
+names: new or unknown direct models must omit sampling unless their contract
+is explicitly verified, rather than being added to a broad family rule.
+
+Required fixture assertion: for `claude-opus-4-8`, both automatic settings
+and a saved temperature/top-p/top-k override must produce a Messages JSON body
+without those keys; the explicit override is retained as inactive editor state,
+not silently deleted. A legacy model fixture should still prove the supported
+temperature or top-p request path.
+
+## Direct OpenAI Chat Completions
+
+The current GPT-5.2 guidance says `temperature` and `top_p` work only
+with `reasoning_effort: "none"`; other reasoning efforts, and older GPT-5
+requests, reject them. [GPT-5.2 parameter compatibility](https://developers.openai.com/api/docs/guides/latest-model?model=gpt-5.2)
+
+The current direct OpenAI adapter does not encode `reasoning_effort`.
+Therefore its existing conservative policy—omit sampling for GPT-5 reasoning
+and o-series models—is correct for this PR. It must not expose a direct
+OpenAI thinking/effort picker merely because the public API has one. A later
+adapter addition can make the model/effort-conditioned sampling combination
+available with dedicated tests.
+
+Required fixture assertions:
+
+- a GPT-5.2 request with automatic settings omits `temperature` and
+  `top_p`, while retaining the appropriate output-token key;
+- a legacy sampling-capable OpenAI model can still receive an explicit
+  temperature/top-p value;
+- no request claims an OpenAI `reasoning_effort` until the adapter actually
+  serializes it.
+
+## Google Gemini OpenAI-compatible endpoint
+
+Gemini 3 guidance strongly recommends omitting sampling controls and using the
+backend default temperature of 1.0; Google warns that lower explicit values
+can cause looping or degraded performance. That is **discouraged**, not a
+generic unsupported claim. [Gemini 3 guide](https://ai.google.dev/gemini-api/docs/gemini-3)
+
+The Models API publishes model-specific `temperature`, `maxTemperature`,
+`topP`, `topK`, `outputTokenLimit`, and `thinking` values. A blank
+`topK` means the model does not permit top-k. [Gemini Models API](https://ai.google.dev/api/models)
+This is useful future evidence, not a request to add a capability-discovery
+service or static model catalog in this PR.
+
+The API has model-specific thinking controls, but the current Gemini adapter
+does not encode them. Keep thinking/effort unavailable here; do not represent
+an app-side boolean as native Gemini thinking.
+
+Required fixture assertions:
+
+- an ordinary Gemini 3 prompt with automatic settings has no sampling fields
+  in the wire payload or effective receipt;
+- an explicitly saved temperature override remains explicit and is sent as
+  such, with a discouraged-use explanation rather than silently removed;
+- a historical receipt containing temperature 0.7 regenerates with 0.7, so
+  the behavior change does not rewrite history.
+
+## Ollama native Chat API
+
+Ollama's native chat endpoint accepts `options` and a model-dependent
+`think` value: supported models may accept a Boolean or
+`"low"`/`"medium"`/`"high"` string. [Chat API](https://docs.ollama.com/api/chat)
+and [thinking capability](https://docs.ollama.com/capabilities/thinking).
+Its Modelfile also defines `temperature`, `top_p`, `top_k`, and
+`num_predict`, but those are model/runtime defaults rather than universal
+provider values. [Modelfile parameters](https://docs.ollama.com/modelfile)
+
+The current adapter sends numeric sampling in `options`, maps maximum
+output to `num_predict`, and sends only Boolean `think`. The current PR
+keeps that behavior and leaves generic reasoning effort unavailable. It does
+not add model-level Ollama thinking discovery or alter the documented legacy
+thinking-off behavior.
+
+Existing adapter tests already cover the current wire shape: explicit
+temperature/top-p/top-k/max-tokens produce `options.temperature`,
+`options.top_p`, `options.top_k`, and `options.num_predict`; enabled
+thinking produces `think: true`. A model-specific effort integration would
+need separate fixtures in a later change.
+
+## OpenRouter Chat Completions
+
+OpenRouter is a gateway, so its capabilities are **per model**, not a property
+of the `openrouter` provider enum.
+
+- Its Models API exposes each model's `supported_parameters`, its
+  `top_provider.max_completion_tokens`, and model identity. The list may be
+  filtered by `supported_parameters`. See [Models guide](https://openrouter.ai/docs/guides/overview/models#models-api-standard)
+  and [model response schema](https://openrouter.ai/docs/guides/overview/models#model-object-schema).
+- The documented chat endpoint accepts fields including `temperature`,
+  `top_p`, `top_k`, `max_tokens`, `max_completion_tokens`,
+  `reasoning`, and `reasoning_effort`; acceptance still depends on the
+  selected model and route. [Chat Completions reference](https://openrouter.ai/docs/api/api-reference/chat/send-chat-completion-request).
+- Reasoning metadata can name only supported effort values, mark reasoning as
+  mandatory, and say whether a model accepts a reasoning token budget. A
+  model with mandatory reasoning must not receive an “off” request. [Reasoning
+  tokens](https://openrouter.ai/docs/guides/best-practices/reasoning-tokens#discovering-per-model-reasoning-options).
+
+The current static `[temperature, maxTokens]` treatment is a conservative
+subset, not an accurate gateway-wide capability statement. This PR preserves
+that scope and does not add OpenRouter metadata parsing, capability UI or new
+payload mappings. It must not claim that the existing generic thinking mode
+maps to routed models.
+
+Future integration evidence, not current acceptance requirements:
+
+1. A model record with only `temperature`, `top_p`, and `max_tokens`
+   permits those exact JSON keys and omits `top_k` and `reasoning`.
+2. A reasoning record with `mandatory: true` has no disable control and
+   never emits an off/none request. A record without a reasoning object does
+   not expose an effort control.
+3. If `top_provider.max_completion_tokens` is present, validate an explicit
+   request against that value; if absent, show no invented ceiling.
+4. Per-model automatic behavior could omit optional generation keys. Any
+   retained application baseline would first need a deliberately labelled
+   migration.
+
+## OpenAI-compatible servers
+
+“OpenAI-compatible” describes an endpoint shape, not a common model contract.
+Capabilities must be narrowed to a known server/model, or remain unknown.
+
+### LM Studio
+
+LM Studio documents its **Chat Completions** payload as supporting
+`temperature`, `top_p`, `top_k`, and `max_tokens`.
+[LM Studio Chat Completions](https://lmstudio.ai/docs/developer/openai-compat/chat-completions)
+It also documents a separate REST/Responses reasoning interface; that is not
+evidence that its Chat Completions endpoint accepts the app's current
+`chat_template_kwargs` shape.
+
+The documentation supports a possible later LM Studio expansion, but it is
+not current scope. This PR retains the existing LM Studio mapping; it does
+not add top-p/top-k payload support, server capability templates or a claimed
+model output ceiling. Native thinking/effort stays unavailable.
+
+### vLLM and arbitrary custom endpoints
+
+vLLM documents `top_k` as a non-OpenAI extension and tells SDK clients to
+place it in `extra_body`. Direct HTTP callers may merge its extra parameters
+into JSON. More importantly, vLLM applies a model repository's
+`generation_config.json` by default, so its sampling defaults can be
+model-author-defined; `--generation-config vllm` changes that behavior.
+[vLLM OpenAI-compatible server](https://docs.vllm.ai/en/latest/serving/openai_compatible_server/)
+
+For this PR, an unknown custom endpoint retains its existing explicitly saved
+controls as editable **Unverified—sent as requested** settings. Do not
+silently delete, inactivate or reinterpret them, and do not claim their
+values are server defaults. Automatic preserves the existing application
+baseline and labels it accurately. Top-k extensions, model templates and
+universal omission rules are future work; a dedicated vLLM wire fixture would
+belong with that work.
+
+## Resulting small implementation boundary
+
+1. Compute presentation from the already effective provider/model using the
+   existing resolver and adapter knowledge. Keep that presentation small; no
+   provider catalog or new discovery service.
+2. Keep the resolver and adapter as the execution authority. The editor
+   prevents known-invalid direct-provider requests, labels retained app
+   baselines, and preserves custom endpoint intent.
+3. Do not map the generic thinking toggle to Anthropic adaptive thinking,
+   OpenRouter reasoning, LM Studio Responses reasoning, or arbitrary
+   OpenAI-compatible `chat_template_kwargs`. Those are future, distinct
+   request contracts.
+4. Add exact-payload absence checks for the Gemini 3 automatic change and
+   preserve historical receipt regeneration. Keep existing adapter tests for
+   unchanged providers; do not create speculative provider fixtures.
+
+## Sources
+
+- OpenAI: [GPT-5.2 parameter compatibility](https://developers.openai.com/api/docs/guides/latest-model?model=gpt-5.2).
+- Anthropic: [API parameter deprecations](https://platform.claude.com/docs/en/about-claude/model-deprecations#api-parameter-deprecations), [extended thinking](https://platform.claude.com/docs/en/build-with-claude/extended-thinking).
+- Google: [Gemini 3 guide](https://ai.google.dev/gemini-api/docs/gemini-3), [Models API](https://ai.google.dev/api/models).
+- Ollama: [Chat API](https://docs.ollama.com/api/chat), [thinking capability](https://docs.ollama.com/capabilities/thinking), [Modelfile parameters](https://docs.ollama.com/modelfile).
+- OpenRouter: [Models API](https://openrouter.ai/docs/guides/overview/models), [chat completion request](https://openrouter.ai/docs/api/api-reference/chat/send-chat-completion-request), [reasoning tokens](https://openrouter.ai/docs/guides/best-practices/reasoning-tokens).
+- LM Studio: [OpenAI-compatible chat completions](https://lmstudio.ai/docs/developer/openai-compat/chat-completions).
+- vLLM: [OpenAI-compatible server](https://docs.vllm.ai/en/latest/serving/openai_compatible_server/).
+
+All source claims were read on 2026-09-08. No credentials, paid endpoints or
+live generation requests were used.

--- a/docs/audits/2026-09-08-provider-generation-contracts.md
+++ b/docs/audits/2026-09-08-provider-generation-contracts.md
@@ -197,6 +197,28 @@ baseline and labels it accurately. Top-k extensions, model templates and
 universal omission rules are future work; a dedicated vLLM wire fixture would
 belong with that work.
 
+## xAI and DeepSeek custom endpoints
+
+A supplemental Grok/Cursor review checked two hosted OpenAI-compatible APIs.
+Their native reasoning shapes differ from the custom adapter's existing
+`chat_template_kwargs` mapping:
+
+- xAI documents reasoning effort separately from sampling, with model-specific
+  restrictions. Its Chat Completions and Responses interfaces also have different
+  token-budget semantics. See [reasoning](https://docs.x.ai/developers/model-capabilities/text/reasoning)
+  and [API comparison](https://docs.x.ai/developers/model-capabilities/text/comparison).
+- DeepSeek documents top-level `thinking` and `reasoning_effort`, uses
+  `max_tokens` for Chat Completions, and states that sampling controls have no
+  effect in thinking mode. See [Chat Completions](https://api-docs.deepseek.com/api/create-chat-completion/)
+  and [thinking mode](https://api-docs.deepseek.com/guides/thinking_mode/).
+
+Neither is evidence that the app's generic local-template thinking controls
+configure that vendor's reasoning. Retain existing manual custom settings as
+unverified, explain that an endpoint may reject or ignore them, and never show
+vendor-specific thinking defaults or output ceilings as known custom-endpoint
+values. Native vendor mappings, additional token-key policies and Responses
+integrations remain future work. No paid inference calls were made.
+
 ## Resulting small implementation boundary
 
 1. Compute presentation from the already effective provider/model using the

--- a/docs/plans/2026-09-08-model-aware-generation-settings.md
+++ b/docs/plans/2026-09-08-model-aware-generation-settings.md
@@ -1,6 +1,6 @@
 # Model-aware generation settings
 
-Status: approved for implementation. Base: main `75d75e5ab313e9a5a9693d1e2b171ba90b9d328d`. Review evidence: [generation-settings audit](../audits/2026-09-08-generation-settings-review.md).
+Status: implemented; focused verification passed; PR/full CI pending. Base: main `75d75e5ab313e9a5a9693d1e2b171ba90b9d328d`. Integrated concurrent gateway-policy main `6e421dbbab09bdaaa9c37d7097fb0f4d023919e7` before completing implementation. Review evidence: [generation-settings audit](../audits/2026-09-08-generation-settings-review.md).
 
 ## Problem and intended behavior
 
@@ -43,3 +43,14 @@ The editor must show the effective provider/model, distinguish inherited setting
 ## Shipping
 
 Branch from origin/main, commit plan/spec/implementation together, open a real PR, resolve actionable review findings, and merge only the exact reviewed passing head. User authorized implementation, PR and merge. No public app release publication in this task.
+
+## Implementation verification
+
+- Normal-dependency focused `swift test` run: 469 XCTest cases passed, zero
+  failures. Coverage includes resolver and HTTP payloads, prompt and result
+  view models, model-selection intent, and public CLI prompt commands.
+- Independent Grok/Cursor Core and UI reviews reached LGTM after fixing custom
+  model selection from an empty override, override-only warning visibility,
+  action styling, and repeated unverified-endpoint help.
+- No storage/CLI schema changes, paid provider probes or user-data mutations.
+  Full-suite CI and the release app build remain the final shipping gates.

--- a/docs/plans/2026-09-08-model-aware-generation-settings.md
+++ b/docs/plans/2026-09-08-model-aware-generation-settings.md
@@ -1,0 +1,45 @@
+# Model-aware generation settings
+
+Status: approved for implementation. Base: main `75d75e5ab313e9a5a9693d1e2b171ba90b9d328d`. Review evidence: [generation-settings audit](../audits/2026-09-08-generation-settings-review.md).
+
+## Problem and intended behavior
+
+The prompt editor currently exposes every sampling/thinking control without knowing the effective provider and model. Generic validation accepts some values that fail at dispatch, other settings are filtered without edit-time explanation, and compatibility warnings ignore prompt model overrides. Blank fields conceal whether defaults come from the app or provider.
+
+The editor must show the effective provider/model, distinguish inherited settings from explicit overrides, and distinguish verified controls from explicit, unverified custom-endpoint settings. UI validation, compatibility feedback and dispatch must use the existing capability resolver consistently.
+
+## Scope and invariants
+
+- One focused PR. Extend existing resolver/adapters/managers; no new settings framework, speculative model catalog, database migration, or global numeric settings layer.
+- Keep Transforms UI self-contained and unchanged. Shared execution fixes may apply where existing shared logic is used.
+- Preserve stored fields, technical category names, existing CLI flags/JSON shapes and historical generation receipts. Opening/saving an untouched editor must not materialize inherited numbers as explicit overrides.
+- No user database or credential mutation during automated QA; use fixtures and mocked transports. No paid generation probes. Model-list discovery uses only the existing configured-provider integration, as Settings already does.
+- Provider default means omitting the optional parameter; if the app supplies a value, identify it as an app default. Never display an unknown provider default or output ceiling as an exact known number.
+- Native reasoning features not implemented by an adapter stay unavailable. Do not add native reasoning integrations in this PR or map effort levels to invented universal token budgets.
+
+## Implementation contract
+
+1. Resolve saved provider/endpoint plus prompt model override before deriving capabilities, validation or compatibility feedback. Fix the existing result-screen warning to use that same effective model. Reevaluate draft presentation when its model changes and refresh provider configuration when the editor opens.
+2. Extend `PromptInferenceCapabilityResolver` with minimal reusable presentation information: supported fields, known restrictions/ranges, inherited effective values and explanations. Keep actual request mapping in adapters. Represent unknown/custom endpoint capabilities honestly without deleting existing manually configured settings or pretending arbitrary OpenAI-compatible servers have identical features.
+3. Replace the raw default model field with **Use AI settings** plus the actual provider/model. Reuse the existing Settings model-list/custom-ID pattern and loading services. Preserve custom IDs if discovery is unavailable; loading errors do not invalidate manual entry. Bound asynchronous work and prevent stale model-list responses from replacing a newer provider's options.
+4. Keep Generation settings collapsed by default with an inheritance/override summary. Expanded controls use **Automatic** versus **Custom** where appropriate; inherited values are secondary read-only information. Supported controls are editable; existing custom-endpoint controls remain editable with an unverified, sent-as-requested explanation. Preserve saved unavailable fields in an explained inactive section with explicit removal. Clearly explain incompatible combinations before saving (including Anthropic Top P taking precedence over Temperature).
+5. Label known values and bounds accurately. Response limits can include reasoning tokens for applicable OpenAI models. Supported-but-discouraged Gemini sampling is different from unsupported sampling. No exact model limit is invented when unavailable.
+6. Correct Gemini 3 inherited sampling: ordinary inherited prompt-generation requests must not inject the app's legacy temperature 0.7. An explicit saved override remains explicit; historical receipts are not rewritten. Audit receipt-based regeneration so previously recorded settings retain their meaning.
+7. Reuse the same validation/capability authority in CLI execution; document changed default behavior and leave public schemas/flags intact. Update governing UI and CLI contracts deliberately. This review does not authorize new CLI commands or a separate provider-capability discovery service.
+
+## Acceptance evidence
+
+- Known direct-provider unsupported fields stay out of actual payloads; custom-compatible support remains available with truthful uncertainty.
+- Gemini 3 automatic sampling is omitted; explicit overrides and recorded historical values remain explicit.
+- Provider/model-specific validation prevents known invalid values and explains combination precedence before save.
+- Blank/open/save/reset preserve inheritance; editing one field does not freeze other defaults.
+- Saved unsupported overrides survive model/provider changes and can be removed intentionally.
+- Model overrides drive both presentation and result-screen compatibility feedback.
+- Model-list errors, unavailable configuration and stale asynchronous responses have defined conservative UI behavior.
+- GUI/CLI requests and effective-setting receipts agree; persisted format remains compatible.
+- Focused resolver, adapter, view-model and CLI regression tests; independent correctness/maintainability review and PR checks. Full suite at most once locally; prefer the CI full-suite gate to avoid duplicating expensive simulations.
+- Release app builds and normal dev restart after merge, then user visual QA. Never force quit or discard unsaved user work.
+
+## Shipping
+
+Branch from origin/main, commit plan/spec/implementation together, open a real PR, resolve actionable review findings, and merge only the exact reviewed passing head. User authorized implementation, PR and merge. No public app release publication in this task.

--- a/docs/plans/2026-09-08-model-aware-generation-settings.md
+++ b/docs/plans/2026-09-08-model-aware-generation-settings.md
@@ -1,6 +1,6 @@
 # Model-aware generation settings
 
-Status: implemented; focused verification passed; PR/full CI pending. Base: main `75d75e5ab313e9a5a9693d1e2b171ba90b9d328d`. Integrated concurrent gateway-policy main `6e421dbbab09bdaaa9c37d7097fb0f4d023919e7` before completing implementation. Review evidence: [generation-settings audit](../audits/2026-09-08-generation-settings-review.md).
+Status: implemented; focused verification passed. [PR #991](https://github.com/moona3k/macparakeet/pull/991) records final CI, review and merge evidence. Base: main `75d75e5ab313e9a5a9693d1e2b171ba90b9d328d`. Integrated concurrent gateway-policy main `6e421dbbab09bdaaa9c37d7097fb0f4d023919e7` before completing implementation. Review evidence: [generation-settings audit](../audits/2026-09-08-generation-settings-review.md).
 
 ## Problem and intended behavior
 

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -490,6 +490,15 @@ prompt-result defaults. `prompts run --json` includes additive optional
 provider/model-filtered receipt of settings actually sent, not a copy of the
 unfiltered prompt request. Automations should treat either field as optional
 and must not infer provider support from `inferenceSettings` alone.
+
+The prompt editor derives available controls from the effective provider/model,
+including a prompt's model override. Inherited values stay unset until explicitly
+customized; custom endpoint capabilities are not assumed to match native vendor
+APIs. For Gemini 3, inherited prompt sampling omits temperature instead of sending
+the app's legacy default. Explicit overrides and historical execution receipts
+retain their values. The same resolver serves `prompts run` and `llm summarize`;
+this changes no command flags or JSON field names.
+
 `prompts set` configures these settings through `--temperature`, `--top-p`,
 `--top-k`, `--max-tokens`, `--thinking-mode`, and `--reasoning-effort`. Use
 `--model` for a model override, `--active-model` to clear that override, or

--- a/spec/04-ui-patterns.md
+++ b/spec/04-ui-patterns.md
@@ -1290,6 +1290,27 @@ retains version metadata, text/settings comparisons, and restore-as-new-version.
 Restoring requires explicit confirmation; cancelling ordinary edits does not
 silently discard or restore a version. Deleted prompts remain recoverable.
 
+Generation settings use the effective provider and model, including any prompt
+model override. The collapsed summary distinguishes inherited AI settings from
+explicit overrides. **Use AI settings** shows the current provider/model; the
+model chooser retains custom-ID entry when model discovery is unavailable.
+Opening and saving an untouched editor preserves inheritance rather than saving
+displayed defaults as explicit values.
+
+Controls reflect what the integration sends and identify unverified custom
+endpoint support. Known model/provider restrictions and setting combinations apply before save; inherited values are
+identified as app or provider defaults. Unknown defaults and model limits are
+not presented as exact numbers. Existing unsupported overrides remain visible
+with an explanation and an explicit removal action. Custom compatible endpoints
+retain manual configuration with an unverified-support explanation. Reasoning
+controls are unavailable when the adapter cannot send them. The same effective
+model drives run-screen compatibility feedback and request resolution.
+
+Gemini 3 inherited prompt sampling uses the provider default instead of injecting
+the app's legacy temperature. Explicit settings and historical execution receipts
+remain intact. This does not introduce a separate global numeric settings layer
+or change the Transforms editor.
+
 Availability and automatic generation are separate controls. **All transcriptions**
 is the common default; selected labels permit any matching transcription,
 independent of its source. Source-aware auto-run only runs an available prompt.

--- a/spec/14-per-prompt-inference-settings.md
+++ b/spec/14-per-prompt-inference-settings.md
@@ -52,11 +52,20 @@ the context and token budget unnecessarily.
 ### Prompt Library
 
 The create and edit forms expose a collapsed **Generation settings** section.
-Every field starts at **Default**. This means inheriting MacParakeet's current
-prompt-result and adapter behavior, not forcing the upstream provider to omit
-the parameter. The user may set only the values needed by that prompt.
+Transcript-prompt controls start at **Automatic**, preserving unset stored values.
+The editor identifies whether the effective value comes from an app default or
+an omitted parameter chosen by the provider. Showing a default never saves that
+number as an explicit override. The user may set only the values needed by that
+prompt. The Transforms editor remains unchanged.
 
-Controls:
+The model chooser defaults to **Use AI settings** and displays the actual
+provider/model. Discovered models and custom IDs use the same selection pattern
+as AI Settings. The effective model override drives field availability,
+validation and run-screen compatibility notes. Unsupported saved fields remain
+visible and explicitly removable; custom endpoint fields that are sent without
+verified model support remain editable and are marked unverified.
+
+Persisted fields and application validation bounds (not universal model limits):
 
 | Setting | UI | Accepted value |
 | --- | --- | --- |
@@ -245,9 +254,9 @@ OpenAI-compatible mapping is:
 ```
 
 The accepted levels are endpoint- and model-template-dependent. MacParakeet
-offers the common typed superset and reports the field as supported for custom
-OpenAI-compatible endpoints without claiming that every endpoint implements
-every value.
+retains its existing typed controls but identifies custom endpoint acceptance
+as unverified. An explicit value is sent using the existing mapping; this is
+not a claim that every endpoint implements that field or value.
 
 The neutral numeric limits are application bounds, not a guarantee that every
 model accepts every output-token limit. Per-model token maxima and custom
@@ -303,14 +312,17 @@ model, because provider/model filtering belongs in the adapter layer.
 ## Backward compatibility and safety
 
 - Existing database rows decode with `nil` settings.
-- Unset settings preserve historical request parameters, including the current
-  `.default` temperature. Input budgeting reserves Anthropic's inherited 4096
+- Unset settings preserve existing app defaults except that Gemini 3 shared
+  prompt/Transform generation omits the inherited temperature 0.7. Explicit
+  temperature values, including historical result receipts, remain explicit.
+  Input budgeting reserves Anthropic's inherited 4096
   output tokens on initial runs and regeneration alike; near-limit transcripts
   may therefore be truncated earlier than before this correction.
 - Provider-specific keys are allow-listed; arbitrary nested JSON is out of
   scope.
-- Settings affect Prompt Library result generation only. They do not alter
-  transcription, knowledge cards, chat, transforms, or formatter defaults.
+- These settings apply through the shared prompt/Transform resolver. This
+  amendment changes only the transcript-prompt editor; transcription, knowledge
+  cards, ordinary chat, formatter controls and Transforms UI remain unchanged.
 - CLI prompt commands and built-in reconciliation preserve settings they do
   not edit. This feature adds no result-prompt export/import workflow.
 - No prompt, transcript, output, API key, or request body is added to telemetry

--- a/spec/contracts/cli-json-v1.md
+++ b/spec/contracts/cli-json-v1.md
@@ -162,7 +162,10 @@ with human progress/status kept off stdout.
   effective receipt is available; callers must not reinterpret it as raw
   upstream-provider defaults. `llm summarize --json` uses the same generation
   path and may report its resolved baseline settings without loading a saved
-  prompt. Chat and Transform commands omit this receipt.
+  prompt. For Gemini 3 models, inherited prompt-generation sampling omits
+  temperature so the provider chooses its default; an explicit saved temperature
+  remains an override. This applies to `prompts run` and the shared `llm summarize`
+  path. Historical receipts are not rewritten. Chat and Transform commands omit this receipt.
   `prompts set` can create or clear versioned model and inference overrides with
   `--model|--active-model`, sampling, thinking, and
   `--provider-default-settings` flags. Results do not include requested-settings


### PR DESCRIPTION
The prompt editor exposed the same generation controls for every model, and compatibility warnings ignored prompt model overrides. This change shows the effective provider/model, offers a model picker with custom-ID entry, and explains which settings are applied, unavailable, or unverified for a custom endpoint.

Automatic fields keep their stored values unset and identify app defaults versus provider-chosen defaults. Existing unavailable overrides remain visible and removable. Known provider restrictions are validated before save, and model-only compatibility warnings now appear in the generation popover. Gemini 3 shared prompt generation stops injecting the legacy temperature 0.7; explicit settings and historical receipts retain their meaning.

The change reuses the resolver and model discovery service. Transforms UI, stored formats, and CLI flags/JSON shapes remain unchanged. Native reasoning integrations and model-capability catalogs are outside scope.

Validation:

- 469 focused XCTest cases passed with the normal dependency graph, including HTTP payloads, inheritance/receipts, prompt view models, stale model discovery, and CLI prompt commands.
- 196 relevant tests passed again after review fixes for Custom-field editing and deterministic stale-discovery coverage. Both CodeRabbit findings are addressed and resolved.
- Independent Grok/Cursor Core and UI reviews reached LGTM after correcting custom model selection, override-only warning visibility, action styling, and repeated help text.
- `git diff --check` and the local Xcode Release app build pass. Final-head CI passed: full `swift test --parallel`, Release build, CLI contract smoke, packaged app smoke, concurrency safety, and Swift 6 language mode. [CI evidence](https://github.com/moona3k/macparakeet/actions/runs/34320892604).
- No live paid inference calls or user-data mutations. Visual and VoiceOver QA are not claimed.

Review tooling: the installed no-mistakes daemon selects Claude and cannot select Grok per run, so this task follows the user's explicit Grok preference using independent Cursor/Grok reviews plus the standard GitHub checks. Local Greptile is installed but not authenticated.

[Plan](https://github.com/moona3k/macparakeet/blob/f6a8f8ee862e7b92ad43d9a0fa0282a97172f5f9/docs/plans/2026-09-08-model-aware-generation-settings.md) · [Provider API audit](https://github.com/moona3k/macparakeet/blob/f6a8f8ee862e7b92ad43d9a0fa0282a97172f5f9/docs/audits/2026-09-08-provider-generation-contracts.md)
