### PR TITLE
feat(diarization): surface speaker embeddings through the diarization adapter

### DIFF
--- a/Sources/MacParakeetCore/Services/Diarization/DiarizationService.swift
+++ b/Sources/MacParakeetCore/Services/Diarization/DiarizationService.swift
@@ -14,6 +14,12 @@ public struct MacParakeetDiarizationResult: Sendable {
     /// exclusive, so these are plain sums.
     public let speechMsBySpeaker: [String: Int]
 
+    /// - Parameters:
+    ///   - speakerEmbeddings: keyed by the same stable ids as `speakers`, and
+    ///     empty when the diarizer produced none. Callers must treat a missing
+    ///     entry as "not matchable", never as an error.
+    ///   - speechMsBySpeaker: total speech per speaker id. Offline segments are
+    ///     exclusive, so these are plain sums.
     public init(
         segments: [SpeakerSegment],
         speakerCount: Int,

--- a/Sources/MacParakeetCore/Services/Diarization/DiarizationService.swift
+++ b/Sources/MacParakeetCore/Services/Diarization/DiarizationService.swift
@@ -6,20 +6,12 @@ public struct MacParakeetDiarizationResult: Sendable {
     public let segments: [SpeakerSegment]
     public let speakerCount: Int
     public let speakers: [SpeakerInfo]
-    /// Voice embedding per detected speaker, keyed by the same stable ids as
-    /// `speakers`. A speaker is absent when its centroid carried no usable
-    /// direction; it keeps its segments and its `SpeakerInfo` either way.
+    /// Keyed by the same stable ids as `speakers`. A speaker is absent when its
+    /// centroid carried no direction; it keeps its segments and label either way.
     public let speakerEmbeddings: [String: SpeakerEmbedding]
-    /// Total speech per speaker id, in milliseconds. Offline segments are
-    /// exclusive, so these are plain sums.
+    /// Offline segments are exclusive, so these are plain sums.
     public let speechMsBySpeaker: [String: Int]
 
-    /// - Parameters:
-    ///   - speakerEmbeddings: keyed by the same stable ids as `speakers`, and
-    ///     empty when the diarizer produced none. Callers must treat a missing
-    ///     entry as "not matchable", never as an error.
-    ///   - speechMsBySpeaker: total speech per speaker id. Offline segments are
-    ///     exclusive, so these are plain sums.
     public init(
         segments: [SpeakerSegment],
         speakerCount: Int,
@@ -34,16 +26,11 @@ public struct MacParakeetDiarizationResult: Sendable {
         self.speechMsBySpeaker = speechMsBySpeaker
     }
 
-    /// Speech for one speaker, in seconds.
+    /// Speech for one speaker, in seconds; 0 when it has none.
     ///
-    /// The single conversion point between this type's milliseconds — the unit
-    /// every other diarization value uses — and the seconds that duration gates
-    /// are expressed in. Dividing at each call site invites the one mistake
-    /// nothing would catch: a factor of a thousand turns a three-second gate
-    /// into a fifty-minute one, so every speaker silently stops qualifying and
-    /// the feature just never fires.
-    ///
-    /// Returns 0 for a speaker with no recorded speech.
+    /// The single conversion point to the unit the duration gates use. A stray
+    /// factor of a thousand turns a 3 s gate into 50 minutes, and nothing would
+    /// catch it: every speaker would just silently stop qualifying.
     public func speechSeconds(forSpeaker speakerId: String) -> Double {
         Double(speechMsBySpeaker[speakerId] ?? 0) / 1000
     }
@@ -306,17 +293,14 @@ public actor DiarizationService: DiarizationServiceProtocol {
         )
     }
 
-    /// Rekeys FluidAudio's speaker database onto our stable ids and normalizes
+    /// Rekeys FluidAudio's speaker database onto our stable ids, normalizing
     /// each centroid.
     ///
-    /// The remap is not cosmetic: FluidAudio also names its clusters `S1`, `S2`,
-    /// but numbered by cluster index, while ours are numbered by who speaks
-    /// first. Carrying the keys over untouched would silently attach one
-    /// speaker's voice to another's label.
-    ///
-    /// Speakers whose centroid fails validation are dropped from the dictionary
-    /// only. They keep their segments, their `SpeakerInfo` and their duration —
-    /// diarization output is unchanged, and they are merely unmatchable.
+    /// The remap is load-bearing: FluidAudio also uses `S1`/`S2`, numbered by
+    /// cluster index where ours are numbered by who speaks first, so copying the
+    /// keys would attach one speaker's voice to another's label. Centroids that
+    /// fail validation are dropped from this dictionary only — the speaker keeps
+    /// its segments and label, and is merely unmatchable.
     static func speakerEmbeddings(
         from speakerDatabase: [String: [Float]]?,
         idMapping: [String: String],
@@ -475,22 +459,18 @@ public actor DiarizationService: DiarizationServiceProtocol {
         return config
     }
 
-    /// The WeSpeaker embedding model behind FluidAudio's offline diarizer.
-    /// Change it only when the model itself changes: vectors from two different
-    /// models share no space and are never compared.
+    /// Change only when the model changes: vectors from two models share no
+    /// space and are never compared.
     public nonisolated static let embeddingModelId = "fluidaudio-wespeaker-256"
 
     /// Bump on any FluidAudio upgrade that could move the clustering centroid,
     /// even when the embedding model is untouched.
     private nonisolated static let pipelineRevision = "fluidaudio-0.15.6"
 
-    /// Identity of the representation `config` produces.
-    ///
-    /// The centroid depends on the clustering configuration as much as on the
-    /// model, so the aggregation half hashes every setting that can move it.
-    /// The per-run speaker-count constraint is deliberately excluded: it varies
-    /// call to call, and folding it in would make a profile enrolled under a
-    /// count hint incomparable with the same voice heard without one.
+    /// Identity of the representation `config` produces. The aggregation half
+    /// hashes every setting that can move the centroid. The per-run speaker
+    /// count is excluded on purpose: it varies call to call, and folding it in
+    /// would make a profile enrolled under a hint incomparable without one.
     /// Identity of the representation the shipping configuration produces.
     nonisolated static var defaultModelIdentity: SpeakerModelIdentity {
         modelIdentity(for: highAccuracyConfig)

--- a/Sources/MacParakeetCore/Services/Diarization/DiarizationService.swift
+++ b/Sources/MacParakeetCore/Services/Diarization/DiarizationService.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import FluidAudio
 import Foundation
 
@@ -5,11 +6,26 @@ public struct MacParakeetDiarizationResult: Sendable {
     public let segments: [SpeakerSegment]
     public let speakerCount: Int
     public let speakers: [SpeakerInfo]
+    /// Voice embedding per detected speaker, keyed by the same stable ids as
+    /// `speakers`. A speaker is absent when its centroid carried no usable
+    /// direction; it keeps its segments and its `SpeakerInfo` either way.
+    public let speakerEmbeddings: [String: SpeakerEmbedding]
+    /// Total speech per speaker id, in milliseconds. Offline segments are
+    /// exclusive, so these are plain sums.
+    public let speechMsBySpeaker: [String: Int]
 
-    public init(segments: [SpeakerSegment], speakerCount: Int, speakers: [SpeakerInfo]) {
+    public init(
+        segments: [SpeakerSegment],
+        speakerCount: Int,
+        speakers: [SpeakerInfo],
+        speakerEmbeddings: [String: SpeakerEmbedding] = [:],
+        speechMsBySpeaker: [String: Int] = [:]
+    ) {
         self.segments = segments
         self.speakerCount = speakerCount
         self.speakers = speakers
+        self.speakerEmbeddings = speakerEmbeddings
+        self.speechMsBySpeaker = speechMsBySpeaker
     }
 }
 
@@ -151,6 +167,7 @@ public actor DiarizationService: DiarizationServiceProtocol {
     private let modelsDirectory: URL
     private let inferenceGate: ANEInferenceGate
     private let explicitConstraint: SpeakerDiarizationConstraint?
+    private let modelIdentity: SpeakerModelIdentity
     private var managerFactory: ManagerFactory?
     private var preparation: Task<Void, Error>?
 
@@ -163,7 +180,8 @@ public actor DiarizationService: DiarizationServiceProtocol {
         self.init(
             loadManagerFactory: Self.modelLoader(config: config),
             modelsDirectory: modelsDirectory ?? AppPaths.fluidAudioModelsDirURL,
-            explicitConstraint: nil
+            explicitConstraint: nil,
+            modelIdentity: Self.modelIdentity(for: config)
         )
     }
 
@@ -174,7 +192,8 @@ public actor DiarizationService: DiarizationServiceProtocol {
         self.init(
             loadManagerFactory: Self.modelLoader(config: Self.highAccuracyConfig),
             modelsDirectory: modelsDirectory ?? AppPaths.fluidAudioModelsDirURL,
-            explicitConstraint: speakerConstraint
+            explicitConstraint: speakerConstraint,
+            modelIdentity: Self.modelIdentity(for: Self.highAccuracyConfig)
         )
     }
 
@@ -182,12 +201,14 @@ public actor DiarizationService: DiarizationServiceProtocol {
         loadManagerFactory: @escaping ManagerFactoryLoader,
         modelsDirectory: URL,
         explicitConstraint: SpeakerDiarizationConstraint? = nil,
-        inferenceGate: ANEInferenceGate = .shared
+        inferenceGate: ANEInferenceGate = .shared,
+        modelIdentity: SpeakerModelIdentity = DiarizationService.defaultModelIdentity
     ) {
         self.loadManagerFactory = loadManagerFactory
         self.modelsDirectory = modelsDirectory.standardizedFileURL
         self.explicitConstraint = explicitConstraint
         self.inferenceGate = inferenceGate
+        self.modelIdentity = modelIdentity
     }
 
     public func diarize(
@@ -247,11 +268,49 @@ public actor DiarizationService: DiarizationServiceProtocol {
                 return SpeakerInfo(id: stableId, label: "Speaker \(number)")
             }
 
+        var speechMsBySpeaker: [String: Int] = [:]
+        for segment in segments {
+            speechMsBySpeaker[segment.speakerId, default: 0] += max(0, segment.endMs - segment.startMs)
+        }
+
         return MacParakeetDiarizationResult(
             segments: segments,
             speakerCount: speakers.count,
-            speakers: speakers
+            speakers: speakers,
+            speakerEmbeddings: Self.speakerEmbeddings(
+                from: fluidResult.speakerDatabase,
+                idMapping: idMapping,
+                identity: modelIdentity
+            ),
+            speechMsBySpeaker: speechMsBySpeaker
         )
+    }
+
+    /// Rekeys FluidAudio's speaker database onto our stable ids and normalizes
+    /// each centroid.
+    ///
+    /// The remap is not cosmetic: FluidAudio also names its clusters `S1`, `S2`,
+    /// but numbered by cluster index, while ours are numbered by who speaks
+    /// first. Carrying the keys over untouched would silently attach one
+    /// speaker's voice to another's label.
+    ///
+    /// Speakers whose centroid fails validation are dropped from the dictionary
+    /// only. They keep their segments, their `SpeakerInfo` and their duration —
+    /// diarization output is unchanged, and they are merely unmatchable.
+    static func speakerEmbeddings(
+        from speakerDatabase: [String: [Float]]?,
+        idMapping: [String: String],
+        identity: SpeakerModelIdentity
+    ) -> [String: SpeakerEmbedding] {
+        guard let speakerDatabase else { return [:] }
+
+        var embeddings: [String: SpeakerEmbedding] = [:]
+        for (fluidID, rawVector) in speakerDatabase {
+            guard let stableID = idMapping[fluidID] else { continue }
+            guard let embedding = SpeakerEmbedding(rawVector: rawVector, identity: identity) else { continue }
+            embeddings[stableID] = embedding
+        }
+        return embeddings
     }
 
     public func prepareModels(onProgress: (@Sendable (String) -> Void)? = nil) async throws {
@@ -394,6 +453,49 @@ public actor DiarizationService: DiarizationServiceProtocol {
         // the surrounding speaker).
         config.zeroVoteReembed = OfflineDiarizerConfig.ZeroVoteReembed(enabled: true)
         return config
+    }
+
+    /// The WeSpeaker embedding model behind FluidAudio's offline diarizer.
+    /// Change it only when the model itself changes: vectors from two different
+    /// models share no space and are never compared.
+    public nonisolated static let embeddingModelId = "fluidaudio-wespeaker-256"
+
+    /// Bump on any FluidAudio upgrade that could move the clustering centroid,
+    /// even when the embedding model is untouched.
+    private nonisolated static let pipelineRevision = "fluidaudio-0.15.6"
+
+    /// Identity of the representation `config` produces.
+    ///
+    /// The centroid depends on the clustering configuration as much as on the
+    /// model, so the aggregation half hashes every setting that can move it.
+    /// The per-run speaker-count constraint is deliberately excluded: it varies
+    /// call to call, and folding it in would make a profile enrolled under a
+    /// count hint incomparable with the same voice heard without one.
+    /// Identity of the representation the shipping configuration produces.
+    nonisolated static var defaultModelIdentity: SpeakerModelIdentity {
+        modelIdentity(for: highAccuracyConfig)
+    }
+
+    nonisolated static func modelIdentity(for config: OfflineDiarizerConfig) -> SpeakerModelIdentity {
+        let canonical = [
+            "pipeline=\(pipelineRevision)",
+            "windowDuration=\(config.segmentation.windowDurationSeconds)",
+            "stepRatio=\(config.segmentation.stepRatio)",
+            "minSegmentDuration=\(config.embedding.minSegmentDurationSeconds)",
+            "excludeOverlap=\(config.embedding.excludeOverlap)",
+            "clusteringThreshold=\(config.clustering.threshold)",
+            "constrainedAssignment=\(config.clustering.constrainedAssignment)",
+            "warmStartFa=\(config.clustering.warmStartFa)",
+            "warmStartFb=\(config.clustering.warmStartFb)",
+            "zeroVoteReembed=\(config.zeroVoteReembed.enabled)",
+            "zeroVoteMinDuration=\(config.zeroVoteReembed.minDurationSeconds)",
+        ].joined(separator: ";")
+
+        let digest = SHA256.hash(data: Data(canonical.utf8))
+        return SpeakerModelIdentity(
+            embeddingModelId: embeddingModelId,
+            aggregationProfileId: digest.prefix(8).map { String(format: "%02x", $0) }.joined()
+        )
     }
 
     nonisolated static func offlineConfig(

--- a/Sources/MacParakeetCore/Services/Diarization/DiarizationService.swift
+++ b/Sources/MacParakeetCore/Services/Diarization/DiarizationService.swift
@@ -468,9 +468,14 @@ public actor DiarizationService: DiarizationServiceProtocol {
     private nonisolated static let pipelineRevision = "fluidaudio-0.15.6"
 
     /// Identity of the representation `config` produces. The aggregation half
-    /// hashes every setting that can move the centroid. The per-run speaker
-    /// count is excluded on purpose: it varies call to call, and folding it in
-    /// would make a profile enrolled under a hint incomparable without one.
+    /// hashes the settings that shape the centroid, VBx refinement included,
+    /// so a FluidAudio upgrade that retunes them is caught without anyone
+    /// remembering to bump `pipelineRevision`.
+    ///
+    /// The per-run speaker count is excluded on purpose. It is derived from the
+    /// calendar attendee count, so it changes from meeting to meeting: folding
+    /// it in would make a profile cross-aggregation against its own samples and
+    /// keep tau permanently reduced by `crossAggregationPenalty`.
     /// Identity of the representation the shipping configuration produces.
     nonisolated static var defaultModelIdentity: SpeakerModelIdentity {
         modelIdentity(for: highAccuracyConfig)
@@ -489,6 +494,8 @@ public actor DiarizationService: DiarizationServiceProtocol {
             "warmStartFb=\(config.clustering.warmStartFb)",
             "zeroVoteReembed=\(config.zeroVoteReembed.enabled)",
             "zeroVoteMinDuration=\(config.zeroVoteReembed.minDurationSeconds)",
+            "vbxMaxIterations=\(config.vbx.maxIterations)",
+            "vbxConvergenceTolerance=\(config.vbx.convergenceTolerance)",
         ].joined(separator: ";")
 
         let digest = SHA256.hash(data: Data(canonical.utf8))

--- a/Sources/MacParakeetCore/Services/Diarization/DiarizationService.swift
+++ b/Sources/MacParakeetCore/Services/Diarization/DiarizationService.swift
@@ -33,6 +33,20 @@ public struct MacParakeetDiarizationResult: Sendable {
         self.speakerEmbeddings = speakerEmbeddings
         self.speechMsBySpeaker = speechMsBySpeaker
     }
+
+    /// Speech for one speaker, in seconds.
+    ///
+    /// The single conversion point between this type's milliseconds — the unit
+    /// every other diarization value uses — and the seconds that duration gates
+    /// are expressed in. Dividing at each call site invites the one mistake
+    /// nothing would catch: a factor of a thousand turns a three-second gate
+    /// into a fifty-minute one, so every speaker silently stops qualifying and
+    /// the feature just never fires.
+    ///
+    /// Returns 0 for a speaker with no recorded speech.
+    public func speechSeconds(forSpeaker speakerId: String) -> Double {
+        Double(speechMsBySpeaker[speakerId] ?? 0) / 1000
+    }
 }
 
 public struct SpeakerSegment: Sendable {

--- a/Sources/MacParakeetCore/Services/Diarization/DiarizationService.swift
+++ b/Sources/MacParakeetCore/Services/Diarization/DiarizationService.swift
@@ -467,20 +467,28 @@ public actor DiarizationService: DiarizationServiceProtocol {
     /// even when the embedding model is untouched.
     private nonisolated static let pipelineRevision = "fluidaudio-0.15.6"
 
-    /// Identity of the representation `config` produces. The aggregation half
-    /// hashes the settings that shape the centroid, VBx refinement included,
-    /// so a FluidAudio upgrade that retunes them is caught without anyone
-    /// remembering to bump `pipelineRevision`.
-    ///
-    /// The per-run speaker count is excluded on purpose. It is derived from the
-    /// calendar attendee count, so it changes from meeting to meeting: folding
-    /// it in would make a profile cross-aggregation against its own samples and
-    /// keep tau permanently reduced by `crossAggregationPenalty`.
     /// Identity of the representation the shipping configuration produces.
     nonisolated static var defaultModelIdentity: SpeakerModelIdentity {
         modelIdentity(for: highAccuracyConfig)
     }
 
+    /// Identity of the representation `config` produces. The aggregation half
+    /// hashes the settings that shape the centroid, VBx refinement included,
+    /// so a FluidAudio upgrade that retunes them is caught without anyone
+    /// remembering to bump `pipelineRevision`.
+    ///
+    /// The per-run speaker count is excluded on purpose, even though it reaches
+    /// the clusterer through `config`. It comes from the calendar attendee
+    /// count, so it changes from meeting to meeting: folding it in would make a
+    /// profile cross-aggregation against its own samples and keep tau
+    /// permanently reduced by `crossAggregationPenalty` — below the worst true
+    /// positive Phase 0b measured, so correct pairs would start being refused.
+    ///
+    /// What the app passes is also a cap, never an exact count
+    /// (`MeetingSpeakerPrior` bounds are `min 1, max n + 1`), so it re-clusters
+    /// nothing unless the diarizer oversplits past it. The exact form that does
+    /// move the partition (FluidAudio #801) arrives only from the CLI's
+    /// `--speaker-count`, and that path enrolls nothing in v1.
     nonisolated static func modelIdentity(for config: OfflineDiarizerConfig) -> SpeakerModelIdentity {
         let canonical = [
             "pipeline=\(pipelineRevision)",

--- a/Sources/MacParakeetCore/Services/Diarization/SpeakerEmbedding.swift
+++ b/Sources/MacParakeetCore/Services/Diarization/SpeakerEmbedding.swift
@@ -26,6 +26,11 @@ public struct SpeakerModelIdentity: Sendable, Equatable, Hashable, Codable {
     /// comparable but less trustworthy, so callers tighten their threshold.
     public let aggregationProfileId: String
 
+    /// - Parameters:
+    ///   - embeddingModelId: the model that produced the vector.
+    ///   - aggregationProfileId: the clustering configuration that shaped the
+    ///     centroid, so a configuration change is visible even when the model
+    ///     is unchanged.
     public init(embeddingModelId: String, aggregationProfileId: String) {
         self.embeddingModelId = embeddingModelId
         self.aggregationProfileId = aggregationProfileId

--- a/Sources/MacParakeetCore/Services/Diarization/SpeakerEmbedding.swift
+++ b/Sources/MacParakeetCore/Services/Diarization/SpeakerEmbedding.swift
@@ -1,0 +1,130 @@
+import Foundation
+
+/// Where a voice sample was captured.
+///
+/// Embeddings only compare meaningfully inside one domain: the same person
+/// heard over a compressed conference stream and over a local microphone lands
+/// in different regions of the embedding space. Every stored sample carries its
+/// domain so matching can prefer like-for-like references.
+public enum SpeakerCaptureDomain: String, Sendable, Codable, CaseIterable {
+    case system
+    case microphone
+    case file
+}
+
+/// Identifies the representation an embedding was produced in.
+///
+/// Two identifiers rather than one, because the vector FluidAudio hands back is
+/// the VBx *clustering* centroid, not a raw model output. It therefore moves
+/// when the clustering configuration moves, even if the embedding model itself
+/// is untouched — a change that a model-only identifier would miss. See the
+/// 2026-09-09 amendment to `plans/active/2026-07-03-speaker-voiceprints.md`.
+public struct SpeakerModelIdentity: Sendable, Equatable, Hashable, Codable {
+    /// The embedding model. A mismatch makes two vectors incomparable.
+    public let embeddingModelId: String
+    /// The aggregation configuration that produced the centroid. A mismatch is
+    /// comparable but less trustworthy, so callers tighten their threshold.
+    public let aggregationProfileId: String
+
+    public init(embeddingModelId: String, aggregationProfileId: String) {
+        self.embeddingModelId = embeddingModelId
+        self.aggregationProfileId = aggregationProfileId
+    }
+}
+
+/// A speaker voice embedding, L2-normalized on construction.
+///
+/// Normalization happens here and nowhere else. FluidAudio's `speakerDatabase`
+/// vectors are un-normalized centroids, and comparing them with a bare dot
+/// product scales every distance by `‖a‖·‖b‖` — which silently pushes
+/// same-speaker pairs past any calibrated threshold, with no error to observe.
+/// Worse, the centroid norm shrinks as a cluster gets noisier, so the bias is
+/// anti-correlated with signal quality. Normalizing at the boundary makes every
+/// downstream comparison correct by construction.
+public struct SpeakerEmbedding: Sendable, Equatable {
+    /// WeSpeaker embedding width.
+    public static let dimension = 256
+    /// Serialized size: 256 × Float32.
+    public static let byteCount = dimension * MemoryLayout<Float32>.size
+    /// Below this, a vector carries no usable direction. FluidAudio emits an
+    /// all-zero centroid when a cluster's responsibility denominator is zero.
+    static let minimumNorm: Float = 1e-6
+    /// Tolerance when re-reading a stored vector that is already normalized.
+    static let normTolerance: Float = 1e-3
+
+    /// Unit-length, `dimension` values.
+    public let vector: [Float]
+    public let identity: SpeakerModelIdentity
+
+    /// Normalizes `rawVector`. Returns `nil` for the wrong width, non-finite
+    /// values, or a vector too short to carry a direction.
+    public init?(rawVector: [Float], identity: SpeakerModelIdentity) {
+        guard rawVector.count == Self.dimension else { return nil }
+        guard rawVector.allSatisfy(\.isFinite) else { return nil }
+
+        let norm = Self.norm(of: rawVector)
+        guard norm.isFinite, norm >= Self.minimumNorm else { return nil }
+
+        self.vector = rawVector.map { $0 / norm }
+        self.identity = identity
+    }
+
+    /// Rebuilds a vector previously produced by ``data``.
+    ///
+    /// Deliberately does not re-normalize: the bytes are already unit-length, and
+    /// dividing again by a norm that floating-point rounding puts at 0.99999994
+    /// would make a store/load round trip lossy. The norm is validated instead,
+    /// so corruption is rejected rather than silently rescaled.
+    public init?(data: Data, identity: SpeakerModelIdentity) {
+        guard data.count == Self.byteCount else { return nil }
+
+        var values = [Float]()
+        values.reserveCapacity(Self.dimension)
+        for index in 0..<Self.dimension {
+            let start = data.startIndex + index * MemoryLayout<Float32>.size
+            let bits = data[start..<start + MemoryLayout<Float32>.size]
+                .withUnsafeBytes { $0.loadUnaligned(as: UInt32.self) }
+            values.append(Float(bitPattern: UInt32(littleEndian: bits)))
+        }
+
+        guard values.allSatisfy(\.isFinite) else { return nil }
+        guard abs(Self.norm(of: values) - 1) <= Self.normTolerance else { return nil }
+
+        self.vector = values
+        self.identity = identity
+    }
+
+    /// Little-endian Float32, `byteCount` bytes. The stored form.
+    public var data: Data {
+        var output = Data(capacity: Self.byteCount)
+        for value in vector {
+            withUnsafeBytes(of: value.bitPattern.littleEndian) { output.append(contentsOf: $0) }
+        }
+        return output
+    }
+
+    /// Cosine distance in FluidAudio's convention: 0 is identical, 1 is
+    /// unrelated. Both operands are unit-length, so the dot product is the
+    /// cosine and no rescaling is needed.
+    ///
+    /// Returns `nil` when the embedding models differ, since vectors from
+    /// different models share no space. A differing aggregation profile is
+    /// comparable and left to the caller's threshold policy.
+    public func cosineDistance(to other: SpeakerEmbedding) -> Double? {
+        guard identity.embeddingModelId == other.identity.embeddingModelId else { return nil }
+
+        var dot: Float = 0
+        for index in 0..<Self.dimension {
+            dot += vector[index] * other.vector[index]
+        }
+        return 1 - Double(min(max(dot, -1), 1))
+    }
+
+    private static func norm(of values: [Float]) -> Float {
+        var sumOfSquares: Float = 0
+        for value in values {
+            sumOfSquares += value * value
+        }
+        return sumOfSquares.squareRoot()
+    }
+}

--- a/Sources/MacParakeetCore/Services/Diarization/SpeakerEmbedding.swift
+++ b/Sources/MacParakeetCore/Services/Diarization/SpeakerEmbedding.swift
@@ -1,11 +1,8 @@
 import Foundation
 
-/// Where a voice sample was captured.
-///
-/// Embeddings only compare meaningfully inside one domain: the same person
-/// heard over a compressed conference stream and over a local microphone lands
-/// in different regions of the embedding space. Every stored sample carries its
-/// domain so matching can prefer like-for-like references.
+/// Where a voice sample was captured. The same person lands in a different
+/// region of the embedding space over a compressed stream than over a local
+/// microphone, so matching prefers like-for-like references.
 public enum SpeakerCaptureDomain: String, Sendable, Codable, CaseIterable {
     case system
     case microphone
@@ -14,23 +11,14 @@ public enum SpeakerCaptureDomain: String, Sendable, Codable, CaseIterable {
 
 /// Identifies the representation an embedding was produced in.
 ///
-/// Two identifiers rather than one, because the vector FluidAudio hands back is
-/// the VBx *clustering* centroid, not a raw model output. It therefore moves
-/// when the clustering configuration moves, even if the embedding model itself
-/// is untouched — a change that a model-only identifier would miss. See the
-/// 2026-09-09 amendment to `plans/active/2026-07-03-speaker-voiceprints.md`.
+/// Two ids, not one: FluidAudio returns the VBx clustering centroid, which
+/// moves when the clustering configuration moves even if the model does not.
 public struct SpeakerModelIdentity: Sendable, Equatable, Hashable, Codable {
-    /// The embedding model. A mismatch makes two vectors incomparable.
+    /// A mismatch makes two vectors incomparable.
     public let embeddingModelId: String
-    /// The aggregation configuration that produced the centroid. A mismatch is
-    /// comparable but less trustworthy, so callers tighten their threshold.
+    /// A mismatch is comparable but less trusted, so callers tighten tau.
     public let aggregationProfileId: String
 
-    /// - Parameters:
-    ///   - embeddingModelId: the model that produced the vector.
-    ///   - aggregationProfileId: the clustering configuration that shaped the
-    ///     centroid, so a configuration change is visible even when the model
-    ///     is unchanged.
     public init(embeddingModelId: String, aggregationProfileId: String) {
         self.embeddingModelId = embeddingModelId
         self.aggregationProfileId = aggregationProfileId
@@ -39,30 +27,23 @@ public struct SpeakerModelIdentity: Sendable, Equatable, Hashable, Codable {
 
 /// A speaker voice embedding, L2-normalized on construction.
 ///
-/// Normalization happens here and nowhere else. FluidAudio's `speakerDatabase`
-/// vectors are un-normalized centroids, and comparing them with a bare dot
-/// product scales every distance by `‖a‖·‖b‖` — which silently pushes
-/// same-speaker pairs past any calibrated threshold, with no error to observe.
-/// Worse, the centroid norm shrinks as a cluster gets noisier, so the bias is
-/// anti-correlated with signal quality. Normalizing at the boundary makes every
-/// downstream comparison correct by construction.
+/// Normalization happens here and nowhere else: FluidAudio's centroids are
+/// un-normalized, so a bare dot product scales distances by `‖a‖·‖b‖` and
+/// silently pushes same-speaker pairs past tau. The centroid norm also shrinks
+/// as a cluster gets noisier, making the bias worst where accuracy matters most.
 public struct SpeakerEmbedding: Sendable, Equatable {
-    /// WeSpeaker embedding width.
     public static let dimension = 256
-    /// Serialized size: 256 × Float32.
     public static let byteCount = dimension * MemoryLayout<Float32>.size
-    /// Below this, a vector carries no usable direction. FluidAudio emits an
-    /// all-zero centroid when a cluster's responsibility denominator is zero.
+    /// FluidAudio emits an all-zero centroid when a cluster's responsibility
+    /// denominator is zero; below this a vector carries no direction.
     static let minimumNorm: Float = 1e-6
-    /// Tolerance when re-reading a stored vector that is already normalized.
     static let normTolerance: Float = 1e-3
 
     /// Unit-length, `dimension` values.
     public let vector: [Float]
     public let identity: SpeakerModelIdentity
 
-    /// Normalizes `rawVector`. Returns `nil` for the wrong width, non-finite
-    /// values, or a vector too short to carry a direction.
+    /// Returns `nil` for the wrong width, non-finite values, or no direction.
     public init?(rawVector: [Float], identity: SpeakerModelIdentity) {
         guard rawVector.count == Self.dimension else { return nil }
         guard rawVector.allSatisfy(\.isFinite) else { return nil }
@@ -74,12 +55,9 @@ public struct SpeakerEmbedding: Sendable, Equatable {
         self.identity = identity
     }
 
-    /// Rebuilds a vector previously produced by ``data``.
-    ///
-    /// Deliberately does not re-normalize: the bytes are already unit-length, and
-    /// dividing again by a norm that floating-point rounding puts at 0.99999994
-    /// would make a store/load round trip lossy. The norm is validated instead,
-    /// so corruption is rejected rather than silently rescaled.
+    /// Rebuilds a vector produced by ``data``. Does not re-normalize — dividing
+    /// again by a norm rounding puts at 0.99999994 would make the round trip
+    /// lossy — but validates it, so corruption is rejected not rescaled.
     public init?(data: Data, identity: SpeakerModelIdentity) {
         guard data.count == Self.byteCount else { return nil }
 
@@ -108,13 +86,9 @@ public struct SpeakerEmbedding: Sendable, Equatable {
         return output
     }
 
-    /// Cosine distance in FluidAudio's convention: 0 is identical, 1 is
-    /// unrelated. Both operands are unit-length, so the dot product is the
-    /// cosine and no rescaling is needed.
-    ///
-    /// Returns `nil` when the embedding models differ, since vectors from
-    /// different models share no space. A differing aggregation profile is
-    /// comparable and left to the caller's threshold policy.
+    /// Cosine distance, FluidAudio's convention: 0 identical, 1 unrelated.
+    /// `nil` when the embedding models differ, since they share no space; a
+    /// differing aggregation profile is left to the caller's threshold policy.
     public func cosineDistance(to other: SpeakerEmbedding) -> Double? {
         guard identity.embeddingModelId == other.identity.embeddingModelId else { return nil }
 

--- a/Tests/MacParakeetTests/Services/Diarization/DiarizationServiceEmbeddingTests.swift
+++ b/Tests/MacParakeetTests/Services/Diarization/DiarizationServiceEmbeddingTests.swift
@@ -146,6 +146,17 @@ final class DiarizationServiceEmbeddingTests: XCTestCase {
         XCTAssertNotEqual(baseIdentity.aggregationProfileId, alteredIdentity.aggregationProfileId)
     }
 
+    func testAggregationProfileChangesWithVBxRefinement() {
+        let base = DiarizationService.highAccuracyConfig
+        var altered = base
+        altered.vbx.maxIterations += 1
+
+        XCTAssertNotEqual(
+            DiarizationService.modelIdentity(for: base).aggregationProfileId,
+            DiarizationService.modelIdentity(for: altered).aggregationProfileId
+        )
+    }
+
     /// A per-run speaker count is a caller hint, not a different representation:
     /// folding it into the identity would make a profile enrolled under a hint
     /// incomparable with the same voice heard without one.

--- a/Tests/MacParakeetTests/Services/Diarization/DiarizationServiceEmbeddingTests.swift
+++ b/Tests/MacParakeetTests/Services/Diarization/DiarizationServiceEmbeddingTests.swift
@@ -118,6 +118,20 @@ final class DiarizationServiceEmbeddingTests: XCTestCase {
         XCTAssertTrue(result.speakerEmbeddings.isEmpty)
     }
 
+    /// The gates are in seconds and everything else here is in milliseconds, so
+    /// the conversion lives in one tested place rather than at each call site.
+    func testSpeechSecondsConvertsFromMilliseconds() {
+        let result = MacParakeetDiarizationResult(
+            segments: [],
+            speakerCount: 1,
+            speakers: [SpeakerInfo(id: "S1", label: "Speaker 1")],
+            speechMsBySpeaker: ["S1": 12_500]
+        )
+
+        XCTAssertEqual(result.speechSeconds(forSpeaker: "S1"), 12.5, accuracy: 1e-9)
+        XCTAssertEqual(result.speechSeconds(forSpeaker: "S2"), 0)
+    }
+
     // MARK: Model identity
 
     func testAggregationProfileChangesWithClusteringConfiguration() {

--- a/Tests/MacParakeetTests/Services/Diarization/DiarizationServiceEmbeddingTests.swift
+++ b/Tests/MacParakeetTests/Services/Diarization/DiarizationServiceEmbeddingTests.swift
@@ -1,0 +1,189 @@
+import XCTest
+import FluidAudio
+@testable import MacParakeetCore
+
+/// Covers what the diarization adapter now carries out of FluidAudio:
+/// per-speaker embeddings, rekeyed onto our stable ids, plus speech durations.
+final class DiarizationServiceEmbeddingTests: XCTestCase {
+
+    private static let identity = SpeakerModelIdentity(
+        embeddingModelId: "test-model",
+        aggregationProfileId: "test-aggregation"
+    )
+
+    private func unitVector(_ index: Int, scale: Float = 1) -> [Float] {
+        var values = [Float](repeating: 0, count: SpeakerEmbedding.dimension)
+        values[index] = scale
+        return values
+    }
+
+    // MARK: Rekeying
+
+    /// FluidAudio numbers clusters by cluster index; we renumber by who speaks
+    /// first. Both use the "S1", "S2" shape, so carrying the database keys over
+    /// untouched would attach one speaker's voice to another's label without
+    /// any type error to catch it.
+    func testEmbeddingsFollowTheChronologicalRemapNotTheFluidAudioKeys() throws {
+        let embeddings = DiarizationService.speakerEmbeddings(
+            from: ["S1": unitVector(0), "S2": unitVector(1)],
+            idMapping: ["S2": "S1", "S1": "S2"],
+            identity: Self.identity
+        )
+
+        XCTAssertEqual(embeddings.count, 2)
+        XCTAssertEqual(try XCTUnwrap(embeddings["S1"]).vector, unitVector(1))
+        XCTAssertEqual(try XCTUnwrap(embeddings["S2"]).vector, unitVector(0))
+    }
+
+    func testEmbeddingsAreNormalizedOnTheWayOut() throws {
+        let embeddings = DiarizationService.speakerEmbeddings(
+            from: ["S1": unitVector(0, scale: 0.42)],
+            idMapping: ["S1": "S1"],
+            identity: Self.identity
+        )
+
+        XCTAssertEqual(try XCTUnwrap(embeddings["S1"]).vector, unitVector(0))
+    }
+
+    func testUnmappedSpeakersAreDropped() {
+        let embeddings = DiarizationService.speakerEmbeddings(
+            from: ["S1": unitVector(0), "S9": unitVector(1)],
+            idMapping: ["S1": "S1"],
+            identity: Self.identity
+        )
+
+        XCTAssertEqual(Set(embeddings.keys), ["S1"])
+    }
+
+    func testZeroVectorSpeakerIsDroppedFromTheDictionary() {
+        let embeddings = DiarizationService.speakerEmbeddings(
+            from: [
+                "S1": [Float](repeating: 0, count: SpeakerEmbedding.dimension),
+                "S2": unitVector(1),
+            ],
+            idMapping: ["S1": "S1", "S2": "S2"],
+            identity: Self.identity
+        )
+
+        XCTAssertEqual(Set(embeddings.keys), ["S2"])
+    }
+
+    func testMissingSpeakerDatabaseYieldsNoEmbeddings() {
+        XCTAssertTrue(
+            DiarizationService.speakerEmbeddings(
+                from: nil,
+                idMapping: ["S1": "S1"],
+                identity: Self.identity
+            ).isEmpty
+        )
+    }
+
+    // MARK: End to end through the service
+
+    func testDiarizeSurfacesEmbeddingsAndDurationsWithoutChangingLabels() async throws {
+        let service = makeService(
+            result: DiarizationResult(
+                segments: [
+                    // FluidAudio's "S2" speaks first, so it becomes our "S1".
+                    segment(speakerId: "S2", from: 0, to: 4),
+                    segment(speakerId: "S1", from: 4, to: 10),
+                    segment(speakerId: "S2", from: 10, to: 12),
+                ],
+                speakerDatabase: ["S1": unitVector(0), "S2": unitVector(1, scale: 0.6)]
+            )
+        )
+
+        let result = try await service.diarize(audioURL: URL(fileURLWithPath: "/tmp/meeting.wav"))
+
+        XCTAssertEqual(result.speakers.map(\.id), ["S1", "S2"])
+        XCTAssertEqual(result.speakers.map(\.label), ["Speaker 1", "Speaker 2"])
+        XCTAssertEqual(result.speakerCount, 2)
+
+        // 4 s + 2 s for the first speaker, 6 s for the second.
+        XCTAssertEqual(result.speechMsBySpeaker, ["S1": 6000, "S2": 6000])
+
+        XCTAssertEqual(try XCTUnwrap(result.speakerEmbeddings["S1"]).vector, unitVector(1))
+        XCTAssertEqual(try XCTUnwrap(result.speakerEmbeddings["S2"]).vector, unitVector(0))
+    }
+
+    func testDiarizeWithoutEmbeddingsStillReturnsSegments() async throws {
+        let service = makeService(
+            result: DiarizationResult(segments: [segment(speakerId: "S1", from: 0, to: 3)])
+        )
+
+        let result = try await service.diarize(audioURL: URL(fileURLWithPath: "/tmp/meeting.wav"))
+
+        XCTAssertEqual(result.segments.count, 1)
+        XCTAssertEqual(result.speechMsBySpeaker, ["S1": 3000])
+        XCTAssertTrue(result.speakerEmbeddings.isEmpty)
+    }
+
+    // MARK: Model identity
+
+    func testAggregationProfileChangesWithClusteringConfiguration() {
+        let base = DiarizationService.highAccuracyConfig
+        var altered = base
+        altered.clustering.threshold += 0.1
+
+        let baseIdentity = DiarizationService.modelIdentity(for: base)
+        let alteredIdentity = DiarizationService.modelIdentity(for: altered)
+
+        XCTAssertEqual(baseIdentity.embeddingModelId, alteredIdentity.embeddingModelId)
+        XCTAssertNotEqual(baseIdentity.aggregationProfileId, alteredIdentity.aggregationProfileId)
+    }
+
+    /// A per-run speaker count is a caller hint, not a different representation:
+    /// folding it into the identity would make a profile enrolled under a hint
+    /// incomparable with the same voice heard without one.
+    func testAggregationProfileIgnoresPerRunSpeakerConstraints() {
+        let base = DiarizationService.highAccuracyConfig
+        let constrained = DiarizationService.applying(.exact(3), to: base)
+
+        XCTAssertEqual(
+            DiarizationService.modelIdentity(for: base),
+            DiarizationService.modelIdentity(for: constrained)
+        )
+    }
+
+    func testAggregationProfileIsStableAcrossCalls() {
+        XCTAssertEqual(
+            DiarizationService.modelIdentity(for: DiarizationService.highAccuracyConfig),
+            DiarizationService.modelIdentity(for: DiarizationService.highAccuracyConfig)
+        )
+    }
+
+    // MARK: Helpers
+
+    private func segment(speakerId: String, from start: Float, to end: Float) -> TimedSpeakerSegment {
+        TimedSpeakerSegment(
+            speakerId: speakerId,
+            embedding: [Float](repeating: 0, count: SpeakerEmbedding.dimension),
+            startTimeSeconds: start,
+            endTimeSeconds: end,
+            qualityScore: 1
+        )
+    }
+
+    private func makeService(result: DiarizationResult) -> DiarizationService {
+        let manager = StubOfflineDiarizerManager(result: result)
+        return DiarizationService(
+            loadManagerFactory: { _ in { _ in manager } },
+            modelsDirectory: FileManager.default.temporaryDirectory,
+            explicitConstraint: nil,
+            inferenceGate: ANEInferenceGate(serializationRequired: false),
+            modelIdentity: Self.identity
+        )
+    }
+}
+
+private final class StubOfflineDiarizerManager: OfflineDiarizerManaging, @unchecked Sendable {
+    private let result: DiarizationResult
+
+    init(result: DiarizationResult) {
+        self.result = result
+    }
+
+    func process(audioURL: URL) async throws -> DiarizationResult {
+        result
+    }
+}

--- a/Tests/MacParakeetTests/Services/Diarization/SpeakerEmbeddingTests.swift
+++ b/Tests/MacParakeetTests/Services/Diarization/SpeakerEmbeddingTests.swift
@@ -1,0 +1,164 @@
+import XCTest
+@testable import MacParakeetCore
+
+final class SpeakerEmbeddingTests: XCTestCase {
+
+    // MARK: Fixtures
+
+    /// Orthonormal basis vectors from a fixed seed, so distances are exact
+    /// rather than approximate: a voice is `e_i`, and a noisy observation at
+    /// angle theta is `cos(theta) * e_i + sin(theta) * e_j`, whose cosine
+    /// distance to `e_i` is exactly `1 - cos(theta)`.
+    private static func basisVector(_ index: Int) -> [Float] {
+        var values = [Float](repeating: 0, count: SpeakerEmbedding.dimension)
+        values[index] = 1
+        return values
+    }
+
+    private static func observation(of speaker: Int, towards other: Int, degrees: Double) -> [Float] {
+        let radians = degrees * .pi / 180
+        var values = [Float](repeating: 0, count: SpeakerEmbedding.dimension)
+        values[speaker] = Float(cos(radians))
+        values[other] = Float(sin(radians))
+        return values
+    }
+
+    private static let identity = SpeakerModelIdentity(
+        embeddingModelId: "test-model",
+        aggregationProfileId: "test-aggregation"
+    )
+
+    private func embedding(
+        _ raw: [Float],
+        identity: SpeakerModelIdentity = SpeakerEmbeddingTests.identity
+    ) -> SpeakerEmbedding {
+        guard let embedding = SpeakerEmbedding(rawVector: raw, identity: identity) else {
+            preconditionFailure("fixture vector must be valid")
+        }
+        return embedding
+    }
+
+    // MARK: Normalization
+
+    func testInitNormalizesToUnitLength() {
+        let scaled = Self.observation(of: 0, towards: 1, degrees: 25).map { $0 * 0.83 }
+        let embedding = embedding(scaled)
+
+        let norm = embedding.vector.reduce(Float(0)) { $0 + $1 * $1 }.squareRoot()
+        XCTAssertEqual(norm, 1, accuracy: 1e-5)
+    }
+
+    /// The regression that matters: an un-normalized pair must produce the same
+    /// decision as a normalized one, *and* the bare dot product must be shown to
+    /// differ — otherwise this test would still pass if normalization were
+    /// removed.
+    func testScalingDoesNotChangeDistanceButWouldChangeABareDotProduct() throws {
+        let rawA = Self.basisVector(0).map { $0 * 0.85 }
+        let rawB = Self.observation(of: 0, towards: 1, degrees: 25).map { $0 * 0.85 }
+
+        let distance = try XCTUnwrap(embedding(rawA).cosineDistance(to: embedding(rawB)))
+        let expected = 1 - cos(25 * Double.pi / 180)
+        XCTAssertEqual(distance, expected, accuracy: 1e-5)
+
+        // What the July plan's "embeddings are already normalized" shortcut
+        // would have computed instead.
+        let bareDot = zip(rawA, rawB).reduce(Float(0)) { $0 + $1.0 * $1.1 }
+        let bareDistance = 1 - Double(bareDot)
+        XCTAssertGreaterThan(bareDistance - distance, 0.15)
+    }
+
+    func testDistanceToOwnScaledCopyIsZero() throws {
+        let raw = Self.observation(of: 3, towards: 7, degrees: 40)
+        let distance = try XCTUnwrap(
+            embedding(raw).cosineDistance(to: embedding(raw.map { $0 * 0.5 }))
+        )
+        XCTAssertEqual(distance, 0, accuracy: 1e-6)
+    }
+
+    func testDistanceMatchesTheFixtureAngle() throws {
+        for degrees in [0.0, 25.0, 41.4, 60.0] {
+            let distance = try XCTUnwrap(
+                embedding(Self.basisVector(0))
+                    .cosineDistance(to: embedding(Self.observation(of: 0, towards: 1, degrees: degrees)))
+            )
+            XCTAssertEqual(distance, 1 - cos(degrees * .pi / 180), accuracy: 1e-5)
+        }
+    }
+
+    // MARK: Rejected input
+
+    func testRejectsZeroVector() {
+        // FluidAudio emits this when a cluster's responsibility denominator is zero.
+        let zeros = [Float](repeating: 0, count: SpeakerEmbedding.dimension)
+        XCTAssertNil(SpeakerEmbedding(rawVector: zeros, identity: Self.identity))
+    }
+
+    func testRejectsVectorBelowMinimumNorm() {
+        let tiny = Self.basisVector(0).map { $0 * 1e-9 }
+        XCTAssertNil(SpeakerEmbedding(rawVector: tiny, identity: Self.identity))
+    }
+
+    func testRejectsNonFiniteValues() {
+        var withNaN = Self.basisVector(0)
+        withNaN[5] = .nan
+        XCTAssertNil(SpeakerEmbedding(rawVector: withNaN, identity: Self.identity))
+
+        var withInfinity = Self.basisVector(0)
+        withInfinity[5] = .infinity
+        XCTAssertNil(SpeakerEmbedding(rawVector: withInfinity, identity: Self.identity))
+    }
+
+    func testRejectsWrongDimension() {
+        XCTAssertNil(SpeakerEmbedding(rawVector: [1, 0, 0], identity: Self.identity))
+        XCTAssertNil(
+            SpeakerEmbedding(
+                rawVector: [Float](repeating: 0.1, count: SpeakerEmbedding.dimension + 1),
+                identity: Self.identity
+            )
+        )
+    }
+
+    // MARK: Storage round trip
+
+    func testDataRoundTripIsBitExact() throws {
+        let original = embedding(Self.observation(of: 2, towards: 9, degrees: 33))
+        let data = original.data
+        XCTAssertEqual(data.count, SpeakerEmbedding.byteCount)
+        XCTAssertEqual(data.count, 1024)
+
+        let restored = try XCTUnwrap(SpeakerEmbedding(data: data, identity: Self.identity))
+        XCTAssertEqual(restored.vector, original.vector)
+        XCTAssertEqual(restored, original)
+    }
+
+    func testRejectsDataOfWrongLength() {
+        let short = Data(repeating: 0, count: SpeakerEmbedding.byteCount - 4)
+        XCTAssertNil(SpeakerEmbedding(data: short, identity: Self.identity))
+    }
+
+    func testRejectsDataThatIsNotUnitLength() {
+        // A vector that never went through `init?(rawVector:)`, so the stored
+        // invariant does not hold: reject rather than silently rescale.
+        var raw = Data()
+        for _ in 0..<SpeakerEmbedding.dimension {
+            withUnsafeBytes(of: Float(0.5).bitPattern.littleEndian) { raw.append(contentsOf: $0) }
+        }
+        XCTAssertNil(SpeakerEmbedding(data: raw, identity: Self.identity))
+    }
+
+    // MARK: Model identity
+
+    func testDistanceIsUnavailableAcrossEmbeddingModels() {
+        let other = SpeakerModelIdentity(embeddingModelId: "other-model", aggregationProfileId: "test-aggregation")
+        let lhs = embedding(Self.basisVector(0))
+        let rhs = embedding(Self.basisVector(0), identity: other)
+        XCTAssertNil(lhs.cosineDistance(to: rhs))
+    }
+
+    func testDistanceIsAvailableAcrossAggregationProfiles() throws {
+        let other = SpeakerModelIdentity(embeddingModelId: "test-model", aggregationProfileId: "other-aggregation")
+        let lhs = embedding(Self.basisVector(0))
+        let rhs = embedding(Self.basisVector(0), identity: other)
+        XCTAssertEqual(try XCTUnwrap(lhs.cosineDistance(to: rhs)), 0, accuracy: 1e-6)
+    }
+}


### PR DESCRIPTION
PR 1 of the voiceprints plan (`plans/active/2026-07-03-speaker-voiceprints.md`, as
amended in #993). **No product behaviour changes** — nothing reads the new fields yet.

## What

`DiarizationService` already received a 256-d voice embedding per detected speaker from
FluidAudio and threw it away when building `MacParakeetDiarizationResult`. It now carries
them, alongside per-speaker speech duration — the only gate the matcher will have in v1.

New types in `Sources/MacParakeetCore/Services/Diarization/SpeakerEmbedding.swift`:
`SpeakerEmbedding`, `SpeakerCaptureDomain`, `SpeakerModelIdentity`.

`speechSeconds(forSpeaker:)` is the single conversion point to the unit the duration gates
use. The result carries milliseconds like every other diarization value; dividing at each
call site invites a stray factor of a thousand, which would turn a 3 s gate into 50 minutes
and silently stop every speaker from qualifying.

## Three decisions worth reviewing

**Normalization happens once, at the boundary.** FluidAudio's `speakerDatabase` holds
un-normalized VBx clustering centroids, not unit vectors. Comparing them with a bare dot
product scales every distance by `‖a‖·‖b‖`: for two centroids of norm 0.85 with true
similarity 0.90, the naive distance is 0.350 instead of 0.10 — past any calibrated
threshold, with no error, no log, no crash. The centroid norm also shrinks as a cluster
gets noisier, so the bias is anti-correlated with signal quality. `SpeakerEmbedding.init?`
normalizes and rejects non-finite values and norms below 1e-6.

**Keys are remapped, not copied.** FluidAudio numbers clusters by index; we renumber by
who speaks first. Both use the `S1`/`S2` shape, so carrying the database keys over
untouched would attach one speaker's voice to another's label with nothing to catch it.
`speakerEmbeddings(from:idMapping:identity:)` goes through the same mapping as the
segments, and there is a test that fails if it does not.

**Model identity is two identifiers.** The vector is a clustering centroid, so it moves
when the clustering configuration moves even if the embedding model is untouched — a
change a model-only identifier would miss. `aggregationProfileId` hashes the settings that
can move it. Per-run speaker-count constraints are deliberately excluded: they vary call
to call, and folding them in would make a profile enrolled under a count hint incomparable
with the same voice heard without one.

Speakers whose centroid fails validation — including the all-zero vector FluidAudio emits
when a cluster's responsibility denominator is zero — are dropped from the embedding
dictionary only. They keep their segments, their `SpeakerInfo` and their duration, so
diarization output is unchanged and they are merely unmatchable.

## Tests

24 tests over exact geometry rather than random vectors: a speaker is a basis vector, and
an observation at angle θ has cosine distance exactly `1 − cos θ`, so thresholds read in
degrees.

The one that matters is `testScalingDoesNotChangeDistanceButWouldChangeABareDotProduct`:
it asserts the decision is unchanged **and** that the bare dot product would have differed
by more than 0.15 — so it genuinely fails if normalization is ever removed.

Refs #662

https://claude.ai/code/session_01X2zJL7MPo6Yppd6ned9mAe


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Diarization results now include speaker embeddings for consistent speaker identification.
  - Added per-speaker speech duration totals, with convenient conversion to seconds.
  - Speaker identifiers remain stable across diarization results.
  - Added validation and compatibility checks for speaker embedding data and models.
  - Diarization model identity now reflects relevant configuration settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->