### PR TITLE
Serialize Parakeet TDT long-file chunks on macOS 14

### DIFF
--- a/Sources/MacParakeetCore/STT/ParakeetTDTASRConfig.swift
+++ b/Sources/MacParakeetCore/STT/ParakeetTDTASRConfig.swift
@@ -1,0 +1,17 @@
+import FluidAudio
+import Foundation
+
+/// FluidAudio `ASRConfig` for MacParakeet's Parakeet TDT `AsrManager`s.
+///
+/// Long files are split into 15 s windows. FluidAudio's default runs four of
+/// those windows at once on the same compiled `MLModel`s. macOS 14's Neural
+/// Engine prediction path is not reentrant for that (issue #997), and
+/// ``ANEInferenceGate`` only wraps the outer `transcribe` call.
+enum ParakeetTDTASRConfig {
+    static func make(
+        serializationRequired: Bool = ANEInferenceGate.serializationRequiredForCurrentOS
+    ) -> ASRConfig {
+        guard serializationRequired else { return .default }
+        return ASRConfig(parallelChunkConcurrency: 1)
+    }
+}

--- a/Sources/MacParakeetCore/STT/README.md
+++ b/Sources/MacParakeetCore/STT/README.md
@@ -210,6 +210,18 @@ gate close over inline. A new call site that invokes `AsrManager.transcribe`
 directly **must** wrap it the same way — calling the manager bare reopens the
 crash for whichever lane runs unguarded.
 
+**Long-file TDT chunk workers are serialized on macOS 14 (issue #997).**
+`ANEInferenceGate` wraps the outer `transcribe(audioURL:)` call only. FluidAudio
+still splits hour-class files into 15 s windows and, with `ASRConfig.default`,
+runs four Core ML `prediction()` calls on the same compiled models. That inner
+pool is what crashed Sonoma file / YouTube / meeting jobs with Apple's
+"asynchronous prediction using ML Program" error. `ParakeetTDTASRConfig.make()`
+sets `parallelChunkConcurrency: 1` when the ANE gate requires serialization
+(macOS 14) and keeps FluidAudio's default of 4 on macOS 15+. Dictation is
+unaffected (single window). Do not construct TDT `AsrManager(config: .default)`
+from a new site — go through `ParakeetTDTASRConfig`. Diagnosis:
+`docs/research/2026-09-09-issue-997-coreml-long-file-stt/`.
+
 **Engine routing is per-job.** Parakeet stays default. Settings persists Live
 Speech plus an optional Final Transcription override. Missing override state
 inherits Live Speech, so upgrades preserve the old single-choice behavior. New

--- a/Sources/MacParakeetCore/STT/STTRuntime.swift
+++ b/Sources/MacParakeetCore/STT/STTRuntime.swift
@@ -2343,8 +2343,11 @@ public actor STTRuntime: STTRuntimeProtocol {
             do {
                 // FluidAudio progress is manager-scoped, so each slot keeps its
                 // own manager while the read-only model bundle stays shared.
-                let loadedInteractiveManager = AsrManager(config: .default)
-                let loadedBackgroundManager = AsrManager(config: .default)
+                // `ParakeetTDTASRConfig` drops long-file chunk concurrency to 1
+                // on macOS 14 (issue #997); 15+ keeps FluidAudio's default of 4.
+                let asrConfig = ParakeetTDTASRConfig.make()
+                let loadedInteractiveManager = AsrManager(config: asrConfig)
+                let loadedBackgroundManager = AsrManager(config: asrConfig)
                 interactiveManager = loadedInteractiveManager
                 backgroundManager = loadedBackgroundManager
                 try await loadedInteractiveManager.loadModels(downloadedModels)

--- a/Tests/MacParakeetTests/STT/ParakeetTDTASRConfigTests.swift
+++ b/Tests/MacParakeetTests/STT/ParakeetTDTASRConfigTests.swift
@@ -1,0 +1,27 @@
+import FluidAudio
+@testable import MacParakeetCore
+import XCTest
+
+/// Pins the #997 long-file macOS 14 invariant: FluidAudio's default 4-wide
+/// chunk pool must not run on the OS where ANE prediction is not reentrant.
+///
+/// CI is macOS 15+, so these tests inject the serialization flag instead of
+/// reading the host OS. They cannot exercise Core ML itself.
+final class ParakeetTDTASRConfigTests: XCTestCase {
+    func testUsesSingleChunkWorkerWhenANESerializationIsRequired() {
+        let config = ParakeetTDTASRConfig.make(serializationRequired: true)
+        XCTAssertEqual(
+            config.parallelChunkConcurrency,
+            1,
+            "macOS 14 long-file TDT must not run concurrent Core ML predictions on shared models"
+        )
+    }
+
+    func testKeepsFluidAudioDefaultChunkConcurrencyWhenANESerializationIsNotRequired() {
+        let config = ParakeetTDTASRConfig.make(serializationRequired: false)
+        XCTAssertEqual(
+            config.parallelChunkConcurrency,
+            ASRConfig.default.parallelChunkConcurrency
+        )
+    }
+}

--- a/docs/research/2026-09-09-issue-997-coreml-long-file-stt/README.md
+++ b/docs/research/2026-09-09-issue-997-coreml-long-file-stt/README.md
@@ -1,0 +1,18 @@
+# Issue 997 — long-file Parakeet STT Core ML failure
+
+Date: 2026-09-09
+Status: diagnosis + fix (`ParakeetTDTASRConfig`, `parallelChunkConcurrency: 1` on macOS 14).
+
+**Verdict:** Hour-class Parakeet TDT file / YouTube / meeting transcription was
+broken on macOS 14. The YouTube URL in
+[#997](https://github.com/moona3k/macparakeet/issues/997) is valid. The crash is
+four concurrent Core ML `prediction()` calls on a shared ANE model, which
+FluidAudio documents as non-reentrant. MacParakeet's `ANEInferenceGate` does
+not serialize those inner workers. macOS 15+ rewrote the ANE runtime and
+succeeds at ~99%.
+
+The product fix is `ParakeetTDTASRConfig.make()`: concurrency 1 on macOS 14,
+FluidAudio default 4 on 15+. Dictation is unchanged.
+
+Read [report.md](report.md). Telemetry SQL is in
+[evidence/d1-queries.md](evidence/d1-queries.md).

--- a/docs/research/2026-09-09-issue-997-coreml-long-file-stt/evidence/d1-queries.md
+++ b/docs/research/2026-09-09-issue-997-coreml-long-file-stt/evidence/d1-queries.md
@@ -1,0 +1,85 @@
+# D1 queries used for issue 997
+
+Database: Cloudflare D1 `macparakeet-telemetry`
+(`7372263e-6a0b-4c70-8188-8f1d6d16bf31`). Run from `macparakeet-website`:
+
+```bash
+npx wrangler d1 execute macparakeet-telemetry --remote --json --command "…"
+```
+
+Window unless noted: `app_ver='0.7.3'` and `ts >= '2026-08-10T00:00:00Z'`.
+Issue timestamps are 2026-09-09T16:23Z–16:45Z.
+
+0.7.3 `transcription_failed` / `transcription_operation` rows do **not** store
+`error_detail`. The Core ML string exists only on the GitHub toast.
+
+## Reporter window
+
+```sql
+SELECT ts, app_ver, os_ver, chip, locale, country,
+       json_extract(props,'$.source') AS source,
+       json_extract(props,'$.stage') AS stage,
+       json_extract(props,'$.error_type') AS error_type,
+       session
+FROM events
+WHERE event='transcription_failed'
+  AND ts >= '2026-09-09T15:00:00Z'
+  AND ts <= '2026-09-09T18:00:00Z'
+ORDER BY ts;
+```
+
+Per-session `transcription_*` props (file session then YouTube session) used
+`session='…'` filters on those two UUIDs from the window query.
+
+## Long-file STTError.transcriptionFailed by source
+
+```sql
+SELECT json_extract(props,'$.source') AS source,
+       json_extract(props,'$.stage') AS stage,
+       COUNT(*) AS n,
+       COUNT(DISTINCT session) AS sessions
+FROM events
+WHERE event='transcription_failed'
+  AND app_ver='0.7.3'
+  AND json_extract(props,'$.error_type')='STTError.transcriptionFailed'
+  AND ts >= '2026-08-10T00:00:00Z'
+GROUP BY 1, 2
+ORDER BY n DESC;
+```
+
+## Hour-class file/YouTube/drag-drop outcomes by OS
+
+```sql
+SELECT CASE WHEN os_ver LIKE '14.%' THEN 'macos14' ELSE 'macos15plus' END AS os,
+       json_extract(props,'$.outcome') AS outcome,
+       COUNT(*) n,
+       COUNT(DISTINCT session) sessions
+FROM events
+WHERE event='transcription_operation'
+  AND app_ver='0.7.3'
+  AND json_extract(props,'$.source') IN ('youtube','file','drag_drop')
+  AND CAST(json_extract(props,'$.audio_duration_seconds') AS REAL) >= 3000
+  AND ts >= '2026-08-10T00:00:00Z'
+GROUP BY 1, 2
+ORDER BY 1, 2;
+```
+
+## Hour-class meeting outcomes by OS
+
+Same query with `json_extract(props,'$.source')='meeting'`.
+
+## Observed 2026-09-09T18:00Z
+
+File / YouTube / drag-drop, audio ≥ 3000 s:
+
+| OS | success | failure | cancelled |
+|---|---:|---:|---:|
+| macOS 14 | 2 (1 session) | 33 (19 sessions) | 2 |
+| macOS 15+ | 1412 (726 sessions) | 19 (14 sessions) | 44 |
+
+Meetings, audio ≥ 3000 s:
+
+| OS | success | failure | cancelled |
+|---|---:|---:|---:|
+| macOS 14 | 0 | 11 (9 sessions) | 0 |
+| macOS 15+ | 2836 (1585 sessions) | 23 (15 sessions) | 30 |

--- a/docs/research/2026-09-09-issue-997-coreml-long-file-stt/report.md
+++ b/docs/research/2026-09-09-issue-997-coreml-long-file-stt/report.md
@@ -1,0 +1,336 @@
+# Long-file Parakeet STT dies on macOS 14 with a Core ML ML Program error
+
+Date: 2026-09-09
+Issues: [#997](https://github.com/moona3k/macparakeet/issues/997) (open),
+[#995](https://github.com/moona3k/macparakeet/issues/995) (closed as duplicate)
+App: 0.7.3 (`d6321f87`, build `20260717011712`)
+Pin: FluidAudio **0.15.6** on current `main` (was 0.15.4 on 0.7.3). Default
+`parallelChunkConcurrency` is still **4** in 0.15.6.
+Method: GitHub feedback + Cloudflare D1 `macparakeet-telemetry` + FluidAudio
+0.15.4 checkout under `.build/checkouts/FluidAudio` + MacParakeet STT path.
+No hardware repro on this host (M4 Pro / macOS 26, disk full, googlevideo 403).
+
+## Verdict
+
+The YouTube video is valid. The user hit the same Parakeet TDT Core ML crash
+four times in twenty minutes (local mp3, local mov, drag-drop mp3, YouTube).
+
+The encoder never sees 55 minutes of audio. FluidAudio splits long files into
+fixed **15 s / 240,000-sample** windows and, by default, runs **four of those
+windows at once** on **the same** `MLModel` instances. FluidAudio's own
+architecture notes say Core ML prediction is **not reentrant**. On macOS 14
+that concurrent ANE use is the class of bug `ANEInferenceGate` was added to
+stop ([#614](https://github.com/moona3k/macparakeet/pull/614) /
+FluidAudio [#661](https://github.com/FluidInference/FluidAudio/issues/661)).
+The gate wraps the outer `transcribe(audioURL:)` call. It does **not** wrap the
+four inner chunk workers.
+
+Production telemetry for 0.7.3 since 2026-08-10, jobs with
+`audio_duration_seconds >= 3000`:
+
+| Surface | macOS 14 success | macOS 14 failure | macOS 15+ success | macOS 15+ failure |
+|---|---:|---:|---:|---:|
+| file / YouTube / drag-drop | 2 | 33 | 1412 | 19 |
+| meeting | 0 | 11 | 2836 | 23 |
+
+Hour-class Parakeet TDT on Sonoma is ~0–6% successful. On Sequoia/Tahoe it is
+~99%. That is not a bad sermon and not a YouTube CDN problem.
+
+**Shipping 0.8.0 without `ParakeetTDTASRConfig` does not fix this.** Current
+`main` pins FluidAudio 0.15.6; the default is still `parallelChunkConcurrency: 4`.
+
+## What the reporter did
+
+In-app feedback, both from `0.7.3` / macOS `14.6.1` / Apple M2 / US:
+
+```
+Transcription failed: Unable to compute the asynchronous prediction using ML Program.
+It can be an invalid input data or broken/unsupported model.
+```
+
+[#995](https://github.com/moona3k/macparakeet/issues/995) at 16:24:25Z, no URL.
+[#997](https://github.com/moona3k/macparakeet/issues/997) at 16:45:46Z with
+`https://youtu.be/613IwdXRQT4` — public ~55 min sermon, duration **3311 s**.
+
+0.7.3 telemetry does not store `error_detail` on `transcription_failed`, so D1
+cannot repeat the Core ML string. The session timeline still matches the
+toasts.
+
+Two consecutive GUI sessions, same chip/OS/locale:
+
+| UTC | Input | Audio | Wall | Stage |
+|---|---|---|---|---|
+| 16:23:24 | file `mp3` 10–100 MB | 3367 s | 12.8 s | `stt` fail |
+| 16:23:31 | `model_loaded` Parakeet **v3** | | 37.6 s warm-up **success** | |
+| 16:24:25 | filed #995 | | | |
+| 16:24:55 | file `mov` ≥1 GB | 3376 s | 12.2 s | `stt` fail |
+| 16:31:13 | drag-drop same `mp3` | 3367 s | 8.9 s | `stt` fail |
+| 16:45:08 | YouTube | **3311.0 s** | | started |
+| 16:45:19 | YouTube | 3311 s | 50.3 s | `stt` fail |
+| 16:45:46 | filed #997 | | | |
+
+`diarization_requested=true`, `diarization_applied=false` on every attempt.
+Diarization never started. yt-dlp worked: the YouTube job recorded the true
+video duration before STT threw.
+
+The 8–13 s local walls are conversion of a 56-minute file to 16 kHz WAV, then
+an immediate first Core ML batch. They are not “transcribed 8 seconds of
+speech.” YouTube’s extra ~40 s is the 51 MB m4a download.
+
+## Mechanism
+
+### 1. MacParakeet hands FluidAudio a WAV and waits
+
+File / YouTube / meeting finalize all convert to 16 kHz mono WAV, then call
+`STTRuntime` → `AsrManager.transcribe(audioURL:)` under `ANEInferenceGate`:
+
+```734:736:Sources/MacParakeetCore/STT/STTRuntime.swift
+            let result = try await inferenceGate.withExclusiveAccess {
+                try await manager.transcribe(audioURL, decoderState: &decoderState)
+            }
+```
+
+Managers are created with the FluidAudio default config:
+
+```2346:2347:Sources/MacParakeetCore/STT/STTRuntime.swift
+                let loadedInteractiveManager = AsrManager(config: .default)
+                let loadedBackgroundManager = AsrManager(config: .default)
+```
+
+Core ML errors map to `STTError.transcriptionFailed(localizedDescription)`,
+which is exactly the toast prefix `Transcription failed: …`.
+
+File/YouTube diarization failures are caught and the transcript still
+completes. A diarization ANE fault cannot produce this toast. The job died
+in STT.
+
+### 2. The encoder window is 15 seconds, not 55 minutes
+
+```8:12:.build/checkouts/FluidAudio/Sources/FluidAudio/Shared/ASRConstants.swift
+    /// Maximum audio duration supported by CoreML encoder (seconds)
+    public static let maxDurationSeconds: Double = 15.0
+    /// Maximum audio samples supported by CoreML encoder (sampleRate × maxDurationSeconds)
+    public static let maxModelSamples: Int = 240_000
+```
+
+3311 s × 16 kHz = 52,976,000 samples. That is ~221 encoder windows. Anything
+over `streamingThreshold` (480,000 samples, ~30 s) uses disk-backed
+`ChunkProcessor`. Each Core ML call is padded to shape `[1, 240000]`.
+
+Default visible chunk with `melChunkContext = true`:
+
+| Quantity | Samples | Seconds |
+|---|---:|---:|
+| Encoder window | 240,000 | 15.00 |
+| Visible chunk | 238,080 | 14.880 |
+| Overlap | 32,000 | 2.000 |
+| Stride | 206,080 | 12.880 |
+| Chunks for 3311 s | 258 | |
+
+The whole-file-as-one-tensor hypothesis is false.
+
+### 3. Default is four workers sharing one compiled model
+
+```70:79:.build/checkouts/FluidAudio/Sources/FluidAudio/ASR/Parakeet/AsrTypes.swift
+        parallelChunkConcurrency: Int = 4,
+        ...
+        self.parallelChunkConcurrency = max(1, parallelChunkConcurrency)
+```
+
+```96:99:.build/checkouts/FluidAudio/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrManager.swift
+    internal func makeWorkerClone() -> AsrManager? {
+        guard let models = asrModels else { return nil }
+        return AsrManager(config: config, models: models)
+    }
+```
+
+The clone copies the **same** `preprocessor` / `encoder` / `decoder` / `joint`
+`MLModel` references. `ChunkProcessor.makeWorkerPool` builds four
+`AsrManager` actors on those shared models, then a `ThrowingTaskGroup`
+runs four `transcribeChunk` calls at once.
+
+Preprocessor and encoder use the async Core ML API:
+
+```30:32:.build/checkouts/FluidAudio/Sources/FluidAudio/ASR/Parakeet/SlidingWindow/TDT/AsrManager+Pipeline.swift
+            let preprocessorOutput = try await preprocessorModel.compatPrediction(
+                from: preprocessorInput,
+                options: predictionOptions
+            )
+```
+
+`compatPrediction` is `try await prediction(from:options:)`. Apple wraps ANE
+`processRequest` failures as:
+
+> Unable to compute the **asynchronous** prediction using ML Program.
+> It can be an invalid input data or broken/unsupported model.
+
+Decoder/joint use sync `prediction`, which would say “the prediction”, not
+“the asynchronous prediction.” The toast therefore points at preprocessor or
+encoder, i.e. the first STT inference, not a later merge step.
+
+Compute units default to `.cpuAndNeuralEngine`.
+
+### 4. FluidAudio already says this is unsafe
+
+From FluidAudio `Documentation/Architecture.md`:
+
+> CoreML's `MLModel` load and prediction APIs are async but **not
+> reentrant** concurrent calls can corrupt internal scratch buffers.
+> Actor isolation serializes access without manual locking.
+
+Actor isolation is **per `AsrManager`**. Four clones are four actors. They do
+not serialize `MLModel.prediction`. FluidAudio's long-form doc even states
+the clones “reuse the already-loaded encoder/decoder/joint Core ML models.”
+Their 4-wide speedup numbers were measured on M3, not M2 + Sonoma 14.6.1.
+
+`ANEInferenceGate` exists because macOS 14 ANE SIGBUS'd when two inferences
+overlapped (dictation vs file, or STT vs diarization). It is a process-wide
+mutex around the **outer** call, and a no-op on macOS 15+:
+
+```40:42:Sources/MacParakeetCore/Services/ANEInferenceGate.swift
+    public static var serializationRequiredForCurrentOS: Bool {
+        if #available(macOS 15.0, *) { false } else { true }
+    }
+```
+
+Inside the gated `transcribe(audioURL:)`, macOS 14 still runs four ANE
+predictions at once. The gate cannot see them.
+
+### 5. Why 8–13 seconds, and why four containers failed the same way
+
+Order of work:
+
+1. MacParakeet ffmpeg → 16 kHz mono WAV (~106 MB for 56 min). Dominates the
+   local 8–13 s.
+2. FluidAudio resamples that WAV to a disk-backed float32 `.raw` (~202 MB) and
+   mmaps it.
+3. Four workers immediately run encoder windows 0 / 12.88 / 25.76 / 38.64 s.
+4. First async `prediction` throws. Task group cancels the rest.
+5. Diarization never runs.
+
+mp3, mov, and YouTube m4a all reach step 3 as the same WAV shape, so they
+fail the same way. Model load already succeeded, so this is not a broken
+`.mlmodelc` on disk.
+
+Short dictation never takes this path: clips ≤ 15 s are a single padded
+window on one `AsrManager`. That matches “dictation works, hour files die.”
+
+## Telemetry
+
+Queries and tables: [evidence/d1-queries.md](evidence/d1-queries.md).
+
+Since 2026-08-10 on 0.7.3, `STTError.transcriptionFailed` at stage `stt`:
+72 meeting, 45 file, 13 drag-drop, 7 YouTube, 1 podcast (event counts).
+
+Duration for file/YouTube/drag-drop with that error type: 35 of 65 events are
+≥ 60 min; 11 more are 30–60 min. Typical wall clock on the hour-class
+Sonoma failures is **7–15 s**, same as #997.
+
+The OS split for **all** hour-class file/YouTube/drag-drop operations (any
+error type) is the decisive result: Sonoma almost never completes; 15+ almost
+always does. Hour-class **meetings** on Sonoma: **zero** successes in that
+window. Same STT function, same chunk pool.
+
+This is a platform bug in our configuration, not a one-user sermon.
+
+## Ruled out
+
+| Hypothesis | Why not |
+|---|---|
+| Invalid / private YouTube URL | Public 3311 s video; job recorded that duration; local mp3/mov failed first |
+| yt-dlp / 403 / sign-in | Download completed; #310 is a different failure |
+| Diarization ANE fault | Caught; transcript would complete; `stage=stt` |
+| Whole file as one Core ML tensor | Encoder hard-limit 240k samples; 258 chunks |
+| Corrupt Parakeet v3 weights | `model_loaded` / warm-up succeeded in 37.6 s |
+| Chunk-seam quality bugs (FluidAudio #212, #747) | Missing words or blank last window, not a throw at t=0 |
+| macOS 26 ANE compiler (FluidAudio PR #482) | Reporter is 14.6.1 |
+| Idle-first-prediction (VoiceInk #614) | Four retries in 20 minutes all failed |
+| [#883](https://github.com/moona3k/macparakeet/issues/883) E5RT zero-shape | Post-success log on macOS 26 CLI / Unified; different error |
+
+Related but different: FluidAudio [#320](https://github.com/FluidInference/FluidAudio/issues/320)
+is the same OS (14.6.1) and model (v3 TDT) with E5RT/IOSurface allocation
+failure **later** in a long sequential run (`chunk 80/160`). Same ANE family,
+not the 8 s first-batch signature. [#661](https://github.com/FluidInference/FluidAudio/issues/661)
+is the concurrent-prediction SIGBUS that `ANEInferenceGate` targeted at the
+wrong granularity.
+
+## What 0.8.0 does and does not change
+
+Still true on current main / freeze:
+
+- `Package.swift` exact FluidAudio `0.15.4`
+- `AsrManager(config: .default)` → `parallelChunkConcurrency = 4`
+- `ANEInferenceGate` still outer-only, still no-op on 15+
+- Current main **does** attach sanitized `error_detail` on
+  `transcription_failed`. 0.7.3 did not. After 0.8.0 ships, D1 should show
+  the ML Program string on new events.
+
+No FluidAudio 0.15.5/0.15.6 release notes a fix for this throw. Those
+releases are diarization/quality. Do not treat a pin bump as the repair.
+
+## Repair
+
+`ParakeetTDTASRConfig.make()` returns `ASRConfig(parallelChunkConcurrency: 1)`
+when `ANEInferenceGate.serializationRequiredForCurrentOS` is true, otherwise
+`ASRConfig.default`. Both TDT `AsrManager`s in `STTRuntime.ensureInitialized`
+use that config.
+
+Concurrency 1 still uses `ChunkProcessor`; it only collapses the pool to the
+calling manager. FluidAudio documents this as the pre-parallel behavior.
+Hour-class Sonoma jobs should complete instead of throwing; they are slower
+than the 4-wide 15+ path (FluidAudio measured ~2.2–2.8× speedup from 4-wide
+on M3).
+
+If concurrency 1 still throws on 14, the next lever is encoder
+`computeUnits: .cpuAndGPU`. Do not do that first.
+
+Do not “fix” this by splitting files in the UI. The model already chunks.
+
+0.8.0+ `error_detail` on `transcription_failed` will show the ML Program
+string on new events. 0.7.3 did not store it.
+
+## How to confirm on hardware
+
+Needs a macOS 14 Apple Silicon Mac (M2 preferred). This investigation host
+cannot: googlevideo 403, ~197 MB free, and it is macOS 26 where the job
+would likely succeed anyway.
+
+1. Isolated state (`MACPARAKEET_DEBUG_APP_STATE_DIR` on debug builds) so
+   production databases are untouched.
+2. 20 s clip of the same sermon → expect success (single window).
+3. Full ~55 min file, Parakeet v3, speaker detection off, **before this
+   fix** → expect STT throw in ~10 s after conversion with concurrency 4.
+4. Same file **after this fix** (`parallelChunkConcurrency: 1` on macOS 14)
+   → expect completion (wall clock ~55 min / ~80× ≈ 40 s plus conversion,
+   not 10 s).
+5. Repeat on macOS 15+ with default 4 → expect success (telemetry already
+   shows this).
+
+## Limits
+
+- No local Core ML throw captured on this machine.
+- 0.7.3 D1 rows have no `error_detail`; the ML Program string is only in
+  GitHub feedback. Attribution to preprocessor/encoder async prediction is
+  from FluidAudio call sites plus Apple’s wording, not a captured
+  `NSUnderlyingError`.
+- The two macOS 14 file successes (one session) were not inspected
+  chunk-by-chunk; they do not change the 94% failure rate.
+- Unified / Nemotron / Whisper / Cohere paths were not part of this
+  reporter’s job (`engine_variant` v3 TDT). They may or may not share the
+  4-wide pool.
+
+## Sources
+
+- GitHub [#997](https://github.com/moona3k/macparakeet/issues/997),
+  [#995](https://github.com/moona3k/macparakeet/issues/995)
+- D1 `macparakeet-telemetry`, queries in
+  [evidence/d1-queries.md](evidence/d1-queries.md)
+- FluidAudio 0.15.4: `ASRConstants.swift`, `AsrTypes.swift`,
+  `AsrManager.swift`, `ChunkProcessor.swift`, `AsrManager+Pipeline.swift`,
+  `Documentation/Architecture.md`, `Documentation/ASR/LongTranscription.md`
+- MacParakeet: `STTRuntime.swift`, `ANEInferenceGate.swift`,
+  `TranscriptionService.swift`, `STTClientProtocol.swift`,
+  `TelemetryEvent.swift`
+- FluidAudio [#661](https://github.com/FluidInference/FluidAudio/issues/661),
+  [#320](https://github.com/FluidInference/FluidAudio/issues/320)
+- MacParakeet [#614](https://github.com/moona3k/macparakeet/pull/614)

--- a/spec/06-stt-engine.md
+++ b/spec/06-stt-engine.md
@@ -555,6 +555,8 @@ These figures are Apple M4 Pro benchmark evidence from `benchmarks/asr/`, not un
 
 For dictation (the primary use case), transcription time is imperceptible. For long file transcription, the ANE path is still remarkably fast.
 
+On macOS 14 (Sonoma), Parakeet TDT long-form file, YouTube, and meeting jobs run FluidAudio's 15-second windows **one at a time** (`parallelChunkConcurrency: 1`). FluidAudio's default of four concurrent Core ML predictions on shared models is not reentrant on Sonoma's Neural Engine and surfaces as `Transcription failed: Unable to compute the asynchronous prediction using ML Program` (GitHub #997). macOS 15+ keeps the four-wide default. Dictation is unchanged. See `ParakeetTDTASRConfig` and `docs/research/2026-09-09-issue-997-coreml-long-file-stt/`.
+
 ### Memory Budget
 
 - Parakeet STT: 115-131 MB peak RSS in the non-boosted M4 Pro speed/memory benchmark, depending on build


### PR DESCRIPTION
## Summary
Hour-class Parakeet TDT file, YouTube, and meeting transcription almost never completes on **macOS 14**. [#997](https://github.com/moona3k/macparakeet/issues/997) looked like a bad YouTube URL; the video is valid. The same user failed on local mp3, mov, drag-drop, and YouTube with Apple's Core ML `ML Program` error.

FluidAudio splits long audio into 15 s windows and, by default, runs **four** Core ML `prediction()` calls on the **same** compiled models. That is not reentrant on Sonoma's Neural Engine. `ANEInferenceGate` only wraps the outer `transcribe` call, so the inner workers still race. macOS 15+ succeeds at ~99%.

This PR sets `parallelChunkConcurrency: 1` on macOS 14 only (`ParakeetTDTASRConfig`). 15+ stays at 4. Dictation is unchanged.

Fixes #997

## Design
- Same OS predicate as the existing ANE gate (`serializationRequiredForCurrentOS`).
- Still uses FluidAudio `ChunkProcessor`; concurrency 1 only collapses the worker pool.
- Do not drop Sonoma, bump FluidAudio, or split files in the UI.
- Current `main` already pins FluidAudio 0.15.6; that pin still defaults to 4-wide. This is the product fix.

```mermaid
flowchart TD
  file["Hour-class file / YouTube / meeting"] --> convert["Convert to 16 kHz WAV"]
  convert --> transcribe["AsrManager.transcribe under ANEInferenceGate"]
  transcribe --> chunks["ChunkProcessor 15 s windows"]
  chunks --> sonoma{"macOS 14?"}
  sonoma -->|"yes: concurrency 1"| serial["One Core ML prediction at a time"]
  sonoma -->|"no: default 4"| parallel["Four predictions on shared MLModel"]
  serial --> done["Transcript completes"]
  parallel --> ane["ANE processRequest"]
  ane --> ok["Usually succeeds on 15+"]
```

## Risk surface
- Sonoma long-file jobs get slower (~2–3× vs 4-wide) instead of crashing. That is the intended trade.
- macOS 15+ path is unchanged.
- Did **not** capture a Core ML throw on this M4 / macOS 26 host. Confidence is D1 + FluidAudio source.
- Unified / Whisper / Cohere / Nemotron are out of scope (reporter was Parakeet v3 TDT).
- If concurrency 1 still throws on 14, next lever is encoder `.cpuAndGPU`, not this PR.

## Test plan
- [x] `swift test --filter ParakeetTDTASRConfigTests` — concurrency 1 when serialization required, FluidAudio default when not
- [x] `swift test --filter ANEInferenceGateTests --filter STTRuntimeInferenceGatingTests` — 7 tests, 0 failures
- [ ] Manual on a **macOS 14** Apple Silicon Mac: ~55 min file, Parakeet v3, speaker detection off — should complete instead of failing in ~10 s
- [ ] macOS 15+ smoke: a long file still transcribes (4-wide unchanged)

Full diagnosis: `docs/research/2026-09-09-issue-997-coreml-long-file-stt/`

## Author's Notes
[#995](https://github.com/moona3k/macparakeet/issues/995) is the same machine, 21 minutes earlier, no URL; already closed as duplicate. 0.7.3 telemetry does not store `error_detail`; the ML Program string is only in the GitHub toast.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes hour-class Parakeet TDT transcription on macOS 14, where FluidAudio's default four concurrent Core ML predictions on shared models crash the Neural Engine. Now serializes chunk processing (`parallelChunkConcurrency: 1`) only on macOS 14 via new `ParakeetTDTASRConfig`; macOS 15+ keeps the default 4-wide path and dictation is unchanged.

- Adds `ParakeetTDTASRConfig` to select concurrency based on the same OS check as `ANEInferenceGate`.
- Wires both TDT `AsrManager`s in `STTRuntime` to use the new config.
- Adds unit tests and documentation; spec updated.

<sup>Written for commit 99e696d235d6ce1adf26115e67adc3a10543c4b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/998?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of long-form Parakeet speech-to-text jobs on macOS 14 by processing audio chunks sequentially.
  - macOS 15 and later retain the existing concurrent processing behavior.
  - Dictation behavior is unchanged.

- **Documentation**
  - Added technical documentation and research findings covering the macOS 14 transcription issue, affected workflows, and platform-specific behavior.

- **Tests**
  - Added coverage confirming the appropriate chunk-processing limits for supported macOS configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->