### PR TITLE
fix(dev): isolate app state from stable installation

### DIFF
--- a/Sources/MacParakeetCore/Database/README.md
+++ b/Sources/MacParakeetCore/Database/README.md
@@ -171,6 +171,7 @@ the migration for the column, and the `resetLifetimeStats()` path.
   previous-version snapshot.
 - `swift test` — full suite. Schema changes ripple through services
   and view models.
-- Manual: launch a DEBUG build with `MACPARAKEET_DEBUG_APP_STATE_DIR` set to
-  a new temporary directory, then confirm migrations initialize its empty
-  database. Never delete or reset the normal app database for verification.
+- Manual: `scripts/dev/run_app.sh` uses an isolated Dev state directory by
+  default. For a one-off smoke run, set `MACPARAKEET_DEBUG_APP_STATE_DIR` to a
+  new temporary directory and confirm migrations initialize its empty database.
+  Never delete or reset the normal app database for verification.

--- a/Sources/MacParakeetCore/Services/AppPaths.swift
+++ b/Sources/MacParakeetCore/Services/AppPaths.swift
@@ -5,9 +5,7 @@ import Foundation
 public enum AppPaths {
     public static let preferencesSuiteName = "com.macparakeet.MacParakeet"
     public static let meetingArtifactsFolderKey = "meetingArtifactsFolder"
-    #if DEBUG
     public static let debugAppStateDirEnvironmentKey = "MACPARAKEET_DEBUG_APP_STATE_DIR"
-    #endif
 
     /// Application Support directory
     public static var appSupportDir: String {
@@ -15,11 +13,9 @@ public enum AppPaths {
     }
 
     static func resolvedAppSupportDir(environment: [String: String]) -> String {
-        #if DEBUG
         if let override = debugAppStateDir(environment: environment) {
             return override
         }
-        #endif
         let path =
             FileManager.default
             .urls(for: .applicationSupportDirectory, in: .userDomainMask)
@@ -69,11 +65,9 @@ public enum AppPaths {
         defaults: UserDefaults = .standard,
         environment: [String: String]
     ) -> String {
-        #if DEBUG
         if debugAppStateDir(environment: environment) != nil {
             return defaultMeetingRecordingsDir(environment: environment)
         }
-        #endif
         if let raw = defaults.string(forKey: meetingArtifactsFolderKey),
             let path = normalizedMeetingArtifactsFolder(raw)
         {
@@ -120,11 +114,9 @@ public enum AppPaths {
 
     /// Local diagnostic logs directory.
     public static var logsDir: String {
-        #if DEBUG
         if let override = debugAppStateDir(environment: ProcessInfo.processInfo.environment) {
             return "\(override)/logs"
         }
-        #endif
         let path =
             FileManager.default
             .urls(for: .libraryDirectory, in: .userDomainMask)
@@ -147,7 +139,7 @@ public enum AppPaths {
     /// FluidAudio model cache base.
     ///
     /// Production intentionally delegates to FluidAudio's own default resolver.
-    /// Debug/test runs with `MACPARAKEET_DEBUG_APP_STATE_DIR` keep FluidAudio
+    /// Developer/test runs with `MACPARAKEET_DEBUG_APP_STATE_DIR` keep FluidAudio
     /// models inside the same throwaway state root as the rest of MacParakeet.
     public static var fluidAudioModelsDir: String {
         fluidAudioModelsDirURL.path
@@ -162,11 +154,7 @@ public enum AppPaths {
     }
 
     static func hasDebugAppStateDirOverride(environment: [String: String]) -> Bool {
-        #if DEBUG
         debugAppStateDir(environment: environment) != nil
-        #else
-        false
-        #endif
     }
 
     static var fluidAudioBaseDirURL: URL {
@@ -182,14 +170,12 @@ public enum AppPaths {
     }
 
     static func resolvedFluidAudioModelsDir(environment: [String: String]) -> URL {
-        #if DEBUG
         if let override = debugAppStateDir(environment: environment) {
             return URL(fileURLWithPath: override, isDirectory: true)
                 .appendingPathComponent("FluidAudio", isDirectory: true)
                 .appendingPathComponent("Models", isDirectory: true)
                 .standardizedFileURL
         }
-        #endif
         return MLModelConfigurationUtils.defaultModelsDirectory()
     }
 
@@ -280,7 +266,6 @@ public enum AppPaths {
         return FileManager.default.isExecutableFile(atPath: ffmpegPath) ? ffmpegPath : nil
     }
 
-    #if DEBUG
     private static func debugAppStateDir(environment: [String: String]) -> String? {
         guard
             let raw = environment[debugAppStateDirEnvironmentKey]?
@@ -295,5 +280,4 @@ public enum AppPaths {
         }
         return URL(fileURLWithPath: expanded).standardizedFileURL.path
     }
-    #endif
 }

--- a/Tests/MacParakeetTests/Services/AppPathsTests.swift
+++ b/Tests/MacParakeetTests/Services/AppPathsTests.swift
@@ -62,8 +62,7 @@ final class AppPathsTests: XCTestCase {
         XCTAssertEqual(AppPaths.configuredMeetingRecordingsDir(defaults: defaults), custom)
     }
 
-    #if DEBUG
-    func testDebugAppStateDirOverridesAppSupport() {
+    func testDeveloperAppStateDirOverridesAppSupport() {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("macparakeet-debug-state-\(UUID().uuidString)", isDirectory: true)
             .standardizedFileURL
@@ -73,7 +72,7 @@ final class AppPathsTests: XCTestCase {
         XCTAssertEqual(AppPaths.defaultMeetingRecordingsDir(environment: environment), root.appendingPathComponent("meeting-recordings").path)
     }
 
-    func testDebugAppStateDirScopesFluidAudioModelsInsideThrowawayRoot() {
+    func testDeveloperAppStateDirScopesFluidAudioModelsInsideThrowawayRoot() {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("macparakeet-debug-state-\(UUID().uuidString)", isDirectory: true)
             .standardizedFileURL
@@ -93,7 +92,7 @@ final class AppPathsTests: XCTestCase {
         )
     }
 
-    func testDebugAppStateDirKeepsMeetingRecordingsInsideThrowawayRoot() {
+    func testDeveloperAppStateDirKeepsMeetingRecordingsInsideThrowawayRoot() {
         let suiteName = "macparakeet.test.paths.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!
         defer { defaults.removePersistentDomain(forName: suiteName) }
@@ -113,8 +112,6 @@ final class AppPathsTests: XCTestCase {
             root.appendingPathComponent("meeting-recordings").path
         )
     }
-    #endif
-
     func testLogsDirIsInsideUserLogs() {
         XCTAssertTrue(AppPaths.logsDir.contains("Library/Logs"))
         XCTAssertTrue(AppPaths.logsDir.hasSuffix("MacParakeet"))

--- a/docs/cli-testing.md
+++ b/docs/cli-testing.md
@@ -528,7 +528,7 @@ Parakeet build, the Nemotron Beta model, Cohere Transcribe, or the Whisper
 variant - and protects the active model plus Parakeet's configured build unless `--force` is passed;
 `models clear` still wipes everything.
 
-When running DEBUG builds with `MACPARAKEET_DEBUG_APP_STATE_DIR` set, CLI state
+When running with `MACPARAKEET_DEBUG_APP_STATE_DIR` set, CLI state
 is scoped to that throwaway directory. This includes MacParakeet's app support
 files and FluidAudio's speech/speaker model cache, so destructive model commands
 such as `models delete` and `models clear` do not touch the real user cache.

--- a/docs/human-qa-guide.md
+++ b/docs/human-qa-guide.md
@@ -44,14 +44,14 @@ scripts/dev/run_app.sh
 
 Builds, signs, and launches the dev build. Its separate bundle identifier
 (`com.macparakeet.dev`) separates standard GUI preferences and macOS permissions.
-It still uses the normal MacParakeet database and artifact paths by default.
+It also uses `~/Library/Application Support/MacParakeet-Dev` for its database,
+artifacts, model caches, and logs, keeping stable app data untouched.
 
-Destructive QA requires verified throwaway data. A **DEBUG** binary supports
-`MACPARAKEET_DEBUG_APP_STATE_DIR` as an explicit override for app data, artifacts,
-model caches, and logs. Release builds ignore it. The script's `open --env`
-arguments currently forward build metadata only; setting the override in the
-calling shell does not establish that the launched app received it. Verify the
-running process's environment and resolved paths before testing deletion or recovery.
+Destructive QA requires verified throwaway data. Set
+`MACPARAKEET_DEBUG_APP_STATE_DIR` to an absolute temporary directory to replace
+the default Dev state root for app data, artifacts, model caches, and logs. The
+launcher forwards that override in both Debug and optimized Release configurations.
+Verify the resolved path before testing deletion or recovery.
 
 The data override does not isolate preferences or Keychain. CLI configuration
 commands still use `com.macparakeet.MacParakeet` preferences, and GUI LLM credentials

--- a/docs/local-audio-diagnostics-query.md
+++ b/docs/local-audio-diagnostics-query.md
@@ -11,8 +11,8 @@ python3 scripts/dev/query_audio_diagnostics.py --path /tmp/copied-audio.log --pr
 It reads `~/Library/Logs/MacParakeet/dictation-audio.log`, performs no network
 requests, and never modifies the source. `--path` overrides
 `MACPARAKEET_AUDIO_DIAGNOSTICS_LOG_PATH`, which overrides the usual location.
-When `MACPARAKEET_DEBUG_APP_STATE_DIR` is set for a debug app, the default is
-`<debug-root>/logs/dictation-audio.log`. Explicit paths are useful for copied
+When `MACPARAKEET_DEBUG_APP_STATE_DIR` is set, the default is
+`<state-root>/logs/dictation-audio.log`. Explicit paths are useful for copied
 support attachments. The utility does not open audio, transcripts, or databases.
 
 JSON output has `schema_version: 1`. `records` contains timestamp, event, and

--- a/scripts/dev/run_app.sh
+++ b/scripts/dev/run_app.sh
@@ -17,6 +17,9 @@ APP_BUNDLE="$PRODUCT_DIR/MacParakeet-Dev.app"
 LOG_FILE="${TMPDIR:-/tmp}/macparakeet-dev.log"
 BUILD_LOG_FILE="${TMPDIR:-/tmp}/macparakeet-dev-build.log"
 APP_MACOS_BIN="$APP_BUNDLE/Contents/MacOS/MacParakeet"
+# Keep every Dev bundle off the stable app's database and media directories.
+# The override is honored in both Debug and optimized Release configurations.
+APP_STATE_DIR="${MACPARAKEET_DEBUG_APP_STATE_DIR:-$HOME/Library/Application Support/MacParakeet-Dev}"
 
 pick_codesign_identity() {
   local preferred="${MACPARAKEET_CODESIGN_IDENTITY:-}"
@@ -236,7 +239,8 @@ BUILD_DATE_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 BUILD_SOURCE="dev-run-xcodebuild-$(echo "$CONFIG" | tr '[:upper:]' '[:lower:]')"
 
 echo "[4/5] Launching ${CONFIG} app…"
-open -n "$APP_BUNDLE" --env MACPARAKEET_GIT_COMMIT="$GIT_COMMIT" \
+open -n "$APP_BUNDLE" --env MACPARAKEET_DEBUG_APP_STATE_DIR="$APP_STATE_DIR" \
+  --env MACPARAKEET_GIT_COMMIT="$GIT_COMMIT" \
   --env MACPARAKEET_BUILD_DATE_UTC="$BUILD_DATE_UTC" \
   --env MACPARAKEET_BUILD_SOURCE="$BUILD_SOURCE" >"$LOG_FILE" 2>&1
 
@@ -245,6 +249,7 @@ echo "  bundle: $APP_BUNDLE"
 echo "  source: $BUILD_SOURCE"
 echo "  commit: $GIT_COMMIT"
 echo "  built-at: $BUILD_DATE_UTC"
+echo "  state: $APP_STATE_DIR"
 echo "  codesign: $CODESIGN_IDENTITY"
 echo "  log: $LOG_FILE"
 echo "  build-log: $BUILD_LOG_FILE"

--- a/spec/09-testing.md
+++ b/spec/09-testing.md
@@ -142,7 +142,7 @@ timing instead of ignoring it.
 - `transforms` saved-prompt CRUD/run JSON envelopes and local history commands
 - `vocab` process/words/snippets command parsing and JSON output
 
-**Tip:** For runtime smoke runs, use a throwaway database path (e.g. `--database /tmp/macparakeet-cli-test.db`) to avoid polluting the real app database. For DEBUG app-level smoke runs, set `MACPARAKEET_DEBUG_APP_STATE_DIR` to an absolute throwaway directory before launching the app so the database, meeting artifacts, AppPaths-managed helper caches, the FluidAudio speech/speaker model cache, and logs stay away from real user state — including destructive `models delete`/`models clear` runs.
+**Tip:** For runtime smoke runs, use a throwaway database path (e.g. `--database /tmp/macparakeet-cli-test.db`) to avoid polluting the real app database. `scripts/dev/run_app.sh` uses an isolated Dev state root by default; set `MACPARAKEET_DEBUG_APP_STATE_DIR` to an absolute throwaway directory when a unique app-level smoke state is required. The override scopes the database, meeting artifacts, AppPaths-managed helper caches, the FluidAudio speech/speaker model cache, and logs away from real user state — including destructive `models delete`/`models clear` runs.
 
 ### LLM Metadata + Transforms Tests
 


### PR DESCRIPTION
Development app launches now use an isolated `MacParakeet-Dev` state directory by default, so testing migrations and other data changes cannot modify the stable app's database, recordings, caches, or logs. The explicit state-directory override now works in both Debug and optimized Release configurations, matching how the developer launcher builds the app.

The stable app's preferences and Keychain access remain unchanged. Documentation now describes the actual isolation boundary and the tests cover the state override without depending on a Debug-only compiler flag.

Validation:

- `swift build -c release --target MacParakeetCore`
- `swift test` — 5,900 tests passed, 21 expected skips, 0 failures
- `bash -n scripts/dev/run_app.sh`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Development launches previously used the stable app’s state paths by default; they now use an isolated `MacParakeet-Dev` state root. This keeps migrations and destructive data tests from changing the stable database, recordings, caches, or logs, while leaving stable preferences and Keychain access unchanged.

- `MACPARAKEET_DEBUG_APP_STATE_DIR` overrides the default root and works in both Debug and optimized Release builds.
- The override also scopes FluidAudio models, helper caches, meeting artifacts, and logs.
- App path tests now run without a Debug-only compiler flag, and the documentation reflects the isolation boundary.

<sup>Written for commit 7487f6161600e44bbf18122027cae339c03a7e2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/999?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Development builds now use a dedicated application data directory by default, keeping databases, logs, recordings, and model caches isolated from production data.
  * Custom application state directories can now be used across all build configurations.

* **Documentation**
  * Updated development, CLI testing, diagnostics, and QA guidance to reflect isolated state directories and temporary smoke-test locations.

* **Tests**
  * Expanded app-state directory coverage to apply across build configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->