### PR TITLE
feat(diarization): add the voiceprint matcher

### DIFF
--- a/Sources/MacParakeetCore/Database/DatabaseManager.swift
+++ b/Sources/MacParakeetCore/Database/DatabaseManager.swift
@@ -1951,6 +1951,84 @@ public final class DatabaseManager: Sendable {
             }
         }
 
+        // v0.39 — Persistent speaker profiles (voiceprints). Enrolled voices
+        // live here so the same person can be recognized across recordings.
+        // Biometric data: every row is local-only, excluded from exports, and
+        // removable. See plans/active/2026-07-03-speaker-voiceprints.md.
+        migrator.registerMigration("v0.39-speaker-voiceprints") { db in
+            try db.execute(sql: """
+                CREATE TABLE speaker_profiles (
+                    id TEXT PRIMARY KEY NOT NULL,
+                    displayName TEXT NOT NULL,
+                    embeddingModelId TEXT NOT NULL,
+                    aggregationProfileId TEXT NOT NULL,
+                    createdAt TEXT NOT NULL,
+                    updatedAt TEXT NOT NULL,
+                    lastMatchedAt TEXT,
+                    lastEvaluatedAt TEXT,
+                    lastEvaluatedDistance REAL
+                )
+                """)
+            // Renaming a second speaker to an enrolled name must add a sample
+            // to that profile, not create a rival profile with the same name.
+            try db.execute(sql: """
+                CREATE UNIQUE INDEX idx_speaker_profiles_name
+                ON speaker_profiles (displayName COLLATE NOCASE)
+                """)
+            try db.execute(sql: """
+                CREATE TABLE speaker_profile_exemplars (
+                    id TEXT PRIMARY KEY NOT NULL,
+                    profileId TEXT NOT NULL
+                        REFERENCES speaker_profiles(id) ON DELETE CASCADE,
+                    vector BLOB NOT NULL CHECK (length(vector) = 1024),
+                    speechSeconds REAL NOT NULL CHECK (speechSeconds > 0),
+                    captureDomain TEXT NOT NULL CHECK (
+                        captureDomain IN ('system', 'microphone', 'file')
+                    ),
+                    origin TEXT NOT NULL CHECK (
+                        origin IN ('manualEnrollment', 'confirmedSuggestion')
+                    ),
+                    embeddingModelId TEXT NOT NULL,
+                    aggregationProfileId TEXT NOT NULL,
+                    sourceTranscriptionId TEXT
+                        REFERENCES transcriptions(id) ON DELETE SET NULL,
+                    sourceSpeakerId TEXT,
+                    createdAt TEXT NOT NULL,
+                    UNIQUE (profileId, sourceTranscriptionId)
+                )
+                """)
+            try db.execute(sql: """
+                CREATE INDEX idx_speaker_profile_exemplars_profile
+                ON speaker_profile_exemplars (profileId, createdAt)
+                """)
+            // Suggestion decisions, scoped by fingerprint like
+            // speaker_corrections: once a transcript is re-diarized the old
+            // rows no longer apply, so a stale dismissal cannot permanently
+            // suppress a legitimate suggestion.
+            try db.execute(sql: """
+                CREATE TABLE speaker_profile_links (
+                    transcriptionId TEXT NOT NULL
+                        REFERENCES transcriptions(id) ON DELETE CASCADE,
+                    speakerId TEXT NOT NULL,
+                    transcriptFingerprint TEXT NOT NULL,
+                    profileId TEXT NOT NULL
+                        REFERENCES speaker_profiles(id) ON DELETE CASCADE,
+                    status TEXT NOT NULL CHECK (
+                        status IN ('suggested', 'confirmed', 'dismissed')
+                    ),
+                    distance REAL NOT NULL,
+                    runnerUpDistance REAL,
+                    createdAt TEXT NOT NULL,
+                    updatedAt TEXT NOT NULL,
+                    PRIMARY KEY (transcriptionId, speakerId, transcriptFingerprint)
+                )
+                """)
+            try db.execute(sql: """
+                CREATE INDEX idx_speaker_profile_links_profile
+                ON speaker_profile_links (profileId)
+                """)
+        }
+
         return migrator
     }
 

--- a/Sources/MacParakeetCore/Database/DatabaseManager.swift
+++ b/Sources/MacParakeetCore/Database/DatabaseManager.swift
@@ -1951,10 +1951,9 @@ public final class DatabaseManager: Sendable {
             }
         }
 
-        // v0.39 — Persistent speaker profiles (voiceprints). Enrolled voices
-        // live here so the same person can be recognized across recordings.
-        // Biometric data: every row is local-only, excluded from exports, and
-        // removable. See plans/active/2026-07-03-speaker-voiceprints.md.
+        // v0.39 — Persistent speaker profiles (voiceprints). Biometric data:
+        // local-only, excluded from exports, removable.
+        // See plans/active/2026-07-03-speaker-voiceprints.md.
         migrator.registerMigration("v0.39-speaker-voiceprints") { db in
             try db.execute(sql: """
                 CREATE TABLE speaker_profiles (
@@ -1970,15 +1969,9 @@ public final class DatabaseManager: Sendable {
                     lastEvaluatedDistance REAL
                 )
                 """)
-            // Renaming a second speaker to an enrolled name must add a sample
-            // to that profile, not create a rival profile with the same name.
-            //
-            // Uniqueness is on the normalized key rather than on
-            // `displayName COLLATE NOCASE`, because NOCASE folds only the 26
-            // ASCII letters: under it "José" and "JOSÉ" are distinct rows, and
-            // a lookup that folds the whole of Unicode would then match both
-            // with no defined winner. The stored key is what both sides agree
-            // on, so the constraint and the lookup cannot drift apart.
+            // On the normalized key, not `displayName COLLATE NOCASE`: NOCASE
+            // folds only ASCII, so "José" and "JOSÉ" would be distinct rows
+            // that a Unicode-aware lookup then matches both of.
             try db.execute(sql: """
                 CREATE UNIQUE INDEX idx_speaker_profiles_normalized_name
                 ON speaker_profiles (normalizedName)
@@ -2009,10 +2002,9 @@ public final class DatabaseManager: Sendable {
                 CREATE INDEX idx_speaker_profile_exemplars_profile
                 ON speaker_profile_exemplars (profileId, createdAt)
                 """)
-            // Suggestion decisions, scoped by fingerprint like
-            // speaker_corrections: once a transcript is re-diarized the old
-            // rows no longer apply, so a stale dismissal cannot permanently
-            // suppress a legitimate suggestion.
+            // Scoped by fingerprint like speaker_corrections: after
+            // re-diarization the old rows no longer apply, so a stale dismissal
+            // cannot permanently suppress a legitimate suggestion.
             try db.execute(sql: """
                 CREATE TABLE speaker_profile_links (
                     transcriptionId TEXT NOT NULL

--- a/Sources/MacParakeetCore/Database/DatabaseManager.swift
+++ b/Sources/MacParakeetCore/Database/DatabaseManager.swift
@@ -1960,6 +1960,7 @@ public final class DatabaseManager: Sendable {
                 CREATE TABLE speaker_profiles (
                     id TEXT PRIMARY KEY NOT NULL,
                     displayName TEXT NOT NULL,
+                    normalizedName TEXT NOT NULL,
                     embeddingModelId TEXT NOT NULL,
                     aggregationProfileId TEXT NOT NULL,
                     createdAt TEXT NOT NULL,
@@ -1971,9 +1972,16 @@ public final class DatabaseManager: Sendable {
                 """)
             // Renaming a second speaker to an enrolled name must add a sample
             // to that profile, not create a rival profile with the same name.
+            //
+            // Uniqueness is on the normalized key rather than on
+            // `displayName COLLATE NOCASE`, because NOCASE folds only the 26
+            // ASCII letters: under it "José" and "JOSÉ" are distinct rows, and
+            // a lookup that folds the whole of Unicode would then match both
+            // with no defined winner. The stored key is what both sides agree
+            // on, so the constraint and the lookup cannot drift apart.
             try db.execute(sql: """
-                CREATE UNIQUE INDEX idx_speaker_profiles_name
-                ON speaker_profiles (displayName COLLATE NOCASE)
+                CREATE UNIQUE INDEX idx_speaker_profiles_normalized_name
+                ON speaker_profiles (normalizedName)
                 """)
             try db.execute(sql: """
                 CREATE TABLE speaker_profile_exemplars (

--- a/Sources/MacParakeetCore/Database/DatabaseManager.swift
+++ b/Sources/MacParakeetCore/Database/DatabaseManager.swift
@@ -1958,15 +1958,16 @@ public final class DatabaseManager: Sendable {
             try db.execute(sql: """
                 CREATE TABLE speaker_profiles (
                     id TEXT PRIMARY KEY NOT NULL,
-                    displayName TEXT NOT NULL,
-                    normalizedName TEXT NOT NULL,
+                    displayName TEXT NOT NULL CHECK (length(trim(displayName)) > 0),
+                    normalizedName TEXT NOT NULL CHECK (length(normalizedName) > 0),
                     embeddingModelId TEXT NOT NULL,
                     aggregationProfileId TEXT NOT NULL,
                     createdAt TEXT NOT NULL,
                     updatedAt TEXT NOT NULL,
                     lastMatchedAt TEXT,
                     lastEvaluatedAt TEXT,
-                    lastEvaluatedDistance REAL
+                    lastEvaluatedDistance REAL,
+                    UNIQUE (id, embeddingModelId)
                 )
                 """)
             // On the normalized key, not `displayName COLLATE NOCASE`: NOCASE
@@ -1979,8 +1980,7 @@ public final class DatabaseManager: Sendable {
             try db.execute(sql: """
                 CREATE TABLE speaker_profile_exemplars (
                     id TEXT PRIMARY KEY NOT NULL,
-                    profileId TEXT NOT NULL
-                        REFERENCES speaker_profiles(id) ON DELETE CASCADE,
+                    profileId TEXT NOT NULL,
                     vector BLOB NOT NULL CHECK (length(vector) = 1024),
                     speechSeconds REAL NOT NULL CHECK (speechSeconds > 0),
                     captureDomain TEXT NOT NULL CHECK (
@@ -1995,7 +1995,17 @@ public final class DatabaseManager: Sendable {
                         REFERENCES transcriptions(id) ON DELETE SET NULL,
                     sourceSpeakerId TEXT,
                     createdAt TEXT NOT NULL,
-                    UNIQUE (profileId, sourceTranscriptionId)
+                    UNIQUE (profileId, sourceTranscriptionId),
+                    -- Composite key rather than a plain reference to the id: a
+                    -- sample from another embedding model shares no space with
+                    -- the profile's, so it could be stored and shown while
+                    -- never scoring against anything. No ON UPDATE CASCADE —
+                    -- changing a profile's model must fail while samples in the
+                    -- old one exist. aggregationProfileId stays out: those
+                    -- remain comparable at a tightened threshold.
+                    FOREIGN KEY (profileId, embeddingModelId)
+                        REFERENCES speaker_profiles(id, embeddingModelId)
+                        ON DELETE CASCADE
                 )
                 """)
             try db.execute(sql: """

--- a/Sources/MacParakeetCore/Database/SpeakerProfileRepository.swift
+++ b/Sources/MacParakeetCore/Database/SpeakerProfileRepository.swift
@@ -9,6 +9,12 @@ public enum SpeakerProfileStoreError: Error, Equatable {
     /// A profile's embedding model cannot change while it holds samples in the
     /// old one. Re-enrollment creates fresh samples instead.
     case embeddingModelChangeWithExemplars(UUID)
+    /// A name that normalizes to nothing has no lookup key, so it could neither
+    /// be found again nor keep a second blank name from colliding with it.
+    case emptyDisplayName
+    /// A decision the user already made is not overwritten by a fresh
+    /// suggestion.
+    case terminalDecisionAlreadyRecorded(status: SpeakerProfileLink.Status)
 }
 
 public protocol SpeakerProfileRepositoryProtocol: Sendable {
@@ -77,7 +83,11 @@ public final class SpeakerProfileRepository: SpeakerProfileRepositoryProtocol {
     /// unscoreable, leaving a profile that looks populated and matches nothing.
     public func save(_ profile: SpeakerProfile) throws {
         var profile = profile
+        profile.displayName = profile.displayName.trimmingCharacters(in: .whitespacesAndNewlines)
         profile.normalizedName = SpeakerProfile.normalizedName(for: profile.displayName)
+        guard !profile.normalizedName.isEmpty else {
+            throw SpeakerProfileStoreError.emptyDisplayName
+        }
         try dbQueue.write { db in
             if let existing = try SpeakerProfile.fetchOne(db, key: profile.id),
                existing.embeddingModelId != profile.embeddingModelId,
@@ -160,6 +170,14 @@ public final class SpeakerProfileRepository: SpeakerProfileRepositoryProtocol {
                 .filter(Column("transcriptFingerprint") == link.transcriptFingerprint)
                 .fetchOne(db)
             if let existing {
+                // A suggestion may become confirmed or dismissed, never the
+                // other way round: a second evaluation of the same transcript
+                // would otherwise erase what the user answered.
+                if link.status == .suggested, existing.status != .suggested {
+                    throw SpeakerProfileStoreError.terminalDecisionAlreadyRecorded(
+                        status: existing.status
+                    )
+                }
                 link.createdAt = existing.createdAt
             }
             try link.save(db)

--- a/Sources/MacParakeetCore/Database/SpeakerProfileRepository.swift
+++ b/Sources/MacParakeetCore/Database/SpeakerProfileRepository.swift
@@ -1,0 +1,128 @@
+import Foundation
+import GRDB
+
+public protocol SpeakerProfileRepositoryProtocol: Sendable {
+    func profiles() throws -> [SpeakerProfile]
+    func profile(id: UUID) throws -> SpeakerProfile?
+    func profile(named name: String) throws -> SpeakerProfile?
+    func save(_ profile: SpeakerProfile) throws
+    func exemplars(profileId: UUID) throws -> [SpeakerProfileExemplar]
+    func exemplarsByProfile() throws -> [UUID: [SpeakerProfileExemplar]]
+    func insert(_ exemplar: SpeakerProfileExemplar) throws
+    func deleteExemplar(id: UUID) throws -> Bool
+    func links(transcriptionId: UUID, fingerprint: String) throws -> [SpeakerProfileLink]
+    func save(_ link: SpeakerProfileLink) throws
+    func deleteProfile(id: UUID) throws -> Bool
+    func deleteAllProfiles() throws
+}
+
+/// Stores enrolled voices. Persistence only: thresholds, gates and matching
+/// policy live in the matcher, and nothing here decides whether two voices are
+/// the same person.
+public final class SpeakerProfileRepository: SpeakerProfileRepositoryProtocol {
+    private let dbQueue: DatabaseQueue
+
+    public init(dbQueue: DatabaseQueue) {
+        self.dbQueue = dbQueue
+    }
+
+    // MARK: Profiles
+
+    public func profiles() throws -> [SpeakerProfile] {
+        try dbQueue.read { db in
+            try SpeakerProfile
+                .order(Column("displayName").collating(.localizedCaseInsensitiveCompare))
+                .fetchAll(db)
+        }
+    }
+
+    public func profile(id: UUID) throws -> SpeakerProfile? {
+        try dbQueue.read { db in
+            try SpeakerProfile.fetchOne(db, key: id)
+        }
+    }
+
+    /// Case-insensitive, matching the unique index: "sarah" and "Sarah" are the
+    /// same person as far as enrollment is concerned.
+    public func profile(named name: String) throws -> SpeakerProfile? {
+        try dbQueue.read { db in
+            try SpeakerProfile
+                .filter(Column("displayName").collating(.nocase) == name)
+                .fetchOne(db)
+        }
+    }
+
+    public func save(_ profile: SpeakerProfile) throws {
+        try dbQueue.write { db in
+            try profile.save(db)
+        }
+    }
+
+    // MARK: Exemplars
+
+    public func exemplars(profileId: UUID) throws -> [SpeakerProfileExemplar] {
+        try dbQueue.read { db in
+            try SpeakerProfileExemplar
+                .filter(Column("profileId") == profileId)
+                .order(Column("createdAt"))
+                .fetchAll(db)
+        }
+    }
+
+    /// Every exemplar, grouped by profile — one read for a whole matching pass
+    /// rather than one per profile.
+    public func exemplarsByProfile() throws -> [UUID: [SpeakerProfileExemplar]] {
+        let all = try dbQueue.read { db in
+            try SpeakerProfileExemplar.order(Column("createdAt")).fetchAll(db)
+        }
+        return Dictionary(grouping: all, by: \.profileId)
+    }
+
+    public func insert(_ exemplar: SpeakerProfileExemplar) throws {
+        try dbQueue.write { db in
+            try exemplar.insert(db)
+        }
+    }
+
+    public func deleteExemplar(id: UUID) throws -> Bool {
+        try dbQueue.write { db in
+            try SpeakerProfileExemplar.deleteOne(db, key: id)
+        }
+    }
+
+    // MARK: Links
+
+    public func links(transcriptionId: UUID, fingerprint: String) throws -> [SpeakerProfileLink] {
+        try dbQueue.read { db in
+            try SpeakerProfileLink
+                .filter(Column("transcriptionId") == transcriptionId)
+                .filter(Column("transcriptFingerprint") == fingerprint)
+                .fetchAll(db)
+        }
+    }
+
+    public func save(_ link: SpeakerProfileLink) throws {
+        try dbQueue.write { db in
+            try link.save(db)
+        }
+    }
+
+    // MARK: Deletion
+
+    /// Removes a profile and everything it owns in one transaction.
+    ///
+    /// Exemplars and links go with it through their cascades; transcripts and
+    /// any label already applied are untouched, because deleting a voiceprint
+    /// must not rewrite the user's history.
+    public func deleteProfile(id: UUID) throws -> Bool {
+        try dbQueue.write { db in
+            try SpeakerProfile.deleteOne(db, key: id)
+        }
+    }
+
+    public func deleteAllProfiles() throws {
+        try dbQueue.write { db in
+            _ = try SpeakerProfile.deleteAll(db)
+        }
+    }
+}

--- a/Sources/MacParakeetCore/Database/SpeakerProfileRepository.swift
+++ b/Sources/MacParakeetCore/Database/SpeakerProfileRepository.swift
@@ -42,12 +42,19 @@ public final class SpeakerProfileRepository: SpeakerProfileRepositoryProtocol {
         }
     }
 
-    /// Case-insensitive, matching the unique index: "sarah" and "Sarah" are the
-    /// same person as far as enrollment is concerned.
+    /// Case-insensitive lookup: "sarah" and "Sarah" are the same person as far
+    /// as enrollment is concerned.
+    ///
+    /// Uses a localized collation rather than SQLite's `NOCASE`, which folds
+    /// only the 26 ASCII letters — under it "josé" and "JOSÉ" would be two
+    /// different people, and the second enrollment would silently create a
+    /// rival profile instead of adding a sample. The unique index keeps
+    /// `NOCASE` as a backstop, so this lookup is deliberately the wider of the
+    /// two.
     public func profile(named name: String) throws -> SpeakerProfile? {
         try dbQueue.read { db in
             try SpeakerProfile
-                .filter(Column("displayName").collating(.nocase) == name)
+                .filter(Column("displayName").collating(.localizedCaseInsensitiveCompare) == name)
                 .fetchOne(db)
         }
     }
@@ -101,8 +108,24 @@ public final class SpeakerProfileRepository: SpeakerProfileRepositoryProtocol {
         }
     }
 
+    /// Upserts a decision, keeping the original `createdAt`.
+    ///
+    /// A link is saved again whenever its status moves — suggested, then
+    /// confirmed or dismissed — and each caller builds a fresh value. Without
+    /// this, the moment the suggestion was first made would be overwritten by
+    /// the moment the user answered, and the journal would lose the interval
+    /// between them.
     public func save(_ link: SpeakerProfileLink) throws {
         try dbQueue.write { db in
+            var link = link
+            let existing = try SpeakerProfileLink
+                .filter(Column("transcriptionId") == link.transcriptionId)
+                .filter(Column("speakerId") == link.speakerId)
+                .filter(Column("transcriptFingerprint") == link.transcriptFingerprint)
+                .fetchOne(db)
+            if let existing {
+                link.createdAt = existing.createdAt
+            }
             try link.save(db)
         }
     }

--- a/Sources/MacParakeetCore/Database/SpeakerProfileRepository.swift
+++ b/Sources/MacParakeetCore/Database/SpeakerProfileRepository.swift
@@ -15,6 +15,21 @@ public enum SpeakerProfileStoreError: Error, Equatable {
     /// A decision the user already made is not overwritten by a fresh
     /// suggestion.
     case terminalDecisionAlreadyRecorded(status: SpeakerProfileLink.Status)
+    /// Another profile already holds this name. Raised instead of letting the
+    /// unique index surface a raw `DatabaseError`, so a caller racing another
+    /// enrollment of the same name can add a sample to the winner instead.
+    case nameAlreadyTaken(normalizedName: String)
+}
+
+/// What the store did with a sample offered under a cap.
+public enum SpeakerExemplarInsertion: Sendable, Equatable {
+    case inserted
+    /// The cap was reached, so this sample replaced the evicted one.
+    case insertedEvicting(UUID)
+    /// The cap is reached and nothing may be evicted.
+    case rejectedProfileFull
+    /// The profile already holds a sample from this recording.
+    case rejectedAlreadySampled
 }
 
 public protocol SpeakerProfileRepositoryProtocol: Sendable {
@@ -23,11 +38,24 @@ public protocol SpeakerProfileRepositoryProtocol: Sendable {
     /// Case-insensitive; what enrollment uses to choose between adding a sample
     /// and creating a profile.
     func profile(named name: String) throws -> SpeakerProfile?
+    /// Creates a profile, claiming its name in the same transaction. Use this
+    /// rather than `save` for a new profile: a lookup followed by `save` lets
+    /// two concurrent enrollments of one name both find nothing.
+    func insert(_ profile: SpeakerProfile) throws
     func save(_ profile: SpeakerProfile) throws
     func exemplars(profileId: UUID) throws -> [SpeakerProfileExemplar]
     /// One read for a whole matching pass.
     func exemplarsByProfile() throws -> [UUID: [SpeakerProfileExemplar]]
     func insert(_ exemplar: SpeakerProfileExemplar) throws
+    /// Enforces the sample cap in the same transaction as the insert, evicting
+    /// the oldest sample of `evicting` to make room. Checking the count from
+    /// outside cannot hold the cap: two callers both read a count below it and
+    /// both insert.
+    func insertExemplar(
+        _ exemplar: SpeakerProfileExemplar,
+        maxPerProfile: Int,
+        evicting: SpeakerProfileExemplar.Origin
+    ) throws -> SpeakerExemplarInsertion
     func deleteExemplar(id: UUID) throws -> Bool
     /// Rows from an earlier fingerprint are deliberately invisible here.
     func links(transcriptionId: UUID, fingerprint: String) throws -> [SpeakerProfileLink]
@@ -74,6 +102,26 @@ public final class SpeakerProfileRepository: SpeakerProfileRepositoryProtocol {
         }
     }
 
+    /// Claims the name in the transaction that creates the profile. A caller
+    /// that looks the name up first and then saves leaves a window where two
+    /// enrollments of "Sarah" both find nothing; the unique index would then
+    /// fail the loser with a raw `DatabaseError` instead of a refusal it can
+    /// act on.
+    public func insert(_ profile: SpeakerProfile) throws {
+        let profile = try normalized(profile)
+        try dbQueue.write { db in
+            if try SpeakerProfile
+                .filter(Column("normalizedName") == profile.normalizedName)
+                .fetchCount(db) > 0
+            {
+                throw SpeakerProfileStoreError.nameAlreadyTaken(
+                    normalizedName: profile.normalizedName
+                )
+            }
+            try profile.insert(db)
+        }
+    }
+
     /// Recomputes the normalized key before writing: `displayName` is mutable,
     /// so a rename would otherwise leave the old key enforcing uniqueness while
     /// a lookup by the new name found nothing.
@@ -82,12 +130,7 @@ public final class SpeakerProfileRepository: SpeakerProfileRepositoryProtocol {
     /// samples: those samples would stay in the old representation and become
     /// unscoreable, leaving a profile that looks populated and matches nothing.
     public func save(_ profile: SpeakerProfile) throws {
-        var profile = profile
-        profile.displayName = profile.displayName.trimmingCharacters(in: .whitespacesAndNewlines)
-        profile.normalizedName = SpeakerProfile.normalizedName(for: profile.displayName)
-        guard !profile.normalizedName.isEmpty else {
-            throw SpeakerProfileStoreError.emptyDisplayName
-        }
+        let profile = try normalized(profile)
         try dbQueue.write { db in
             if let existing = try SpeakerProfile.fetchOne(db, key: profile.id),
                existing.embeddingModelId != profile.embeddingModelId,
@@ -99,6 +142,16 @@ public final class SpeakerProfileRepository: SpeakerProfileRepositoryProtocol {
             }
             try profile.save(db)
         }
+    }
+
+    private func normalized(_ profile: SpeakerProfile) throws -> SpeakerProfile {
+        var profile = profile
+        profile.displayName = profile.displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+        profile.normalizedName = SpeakerProfile.normalizedName(for: profile.displayName)
+        guard !profile.normalizedName.isEmpty else {
+            throw SpeakerProfileStoreError.emptyDisplayName
+        }
+        return profile
     }
 
     // MARK: Exemplars
@@ -138,6 +191,52 @@ public final class SpeakerProfileRepository: SpeakerProfileRepositoryProtocol {
                 )
             }
             try exemplar.insert(db)
+        }
+    }
+
+    /// Count, eviction and insert in one transaction, so the cap holds under
+    /// concurrent enrollments. The caller owns the policy — how many, and which
+    /// origin may be evicted — while the store owns the atomicity.
+    ///
+    /// `rejectedAlreadySampled` comes from the schema's
+    /// `UNIQUE (profileId, sourceTranscriptionId)` rather than a prior read, so
+    /// the answer reflects the state the insert actually met.
+    public func insertExemplar(
+        _ exemplar: SpeakerProfileExemplar,
+        maxPerProfile: Int,
+        evicting: SpeakerProfileExemplar.Origin
+    ) throws -> SpeakerExemplarInsertion {
+        try dbQueue.write { db in
+            if let profile = try SpeakerProfile.fetchOne(db, key: exemplar.profileId),
+               profile.embeddingModelId != exemplar.embeddingModelId
+            {
+                throw SpeakerProfileStoreError.incompatibleEmbeddingModel(
+                    profile: profile.embeddingModelId,
+                    exemplar: exemplar.embeddingModelId
+                )
+            }
+
+            let existing = try SpeakerProfileExemplar
+                .filter(Column("profileId") == exemplar.profileId)
+                .order(Column("createdAt"))
+                .fetchAll(db)
+            if let sampled = exemplar.sourceTranscriptionId,
+               existing.contains(where: { $0.sourceTranscriptionId == sampled })
+            {
+                return .rejectedAlreadySampled
+            }
+
+            var evicted: UUID?
+            if existing.count >= max(0, maxPerProfile) {
+                guard let target = existing.first(where: { $0.origin == evicting }) else {
+                    return .rejectedProfileFull
+                }
+                _ = try SpeakerProfileExemplar.deleteOne(db, key: target.id)
+                evicted = target.id
+            }
+
+            try exemplar.insert(db)
+            return evicted.map { .insertedEvicting($0) } ?? .inserted
         }
     }
 

--- a/Sources/MacParakeetCore/Database/SpeakerProfileRepository.swift
+++ b/Sources/MacParakeetCore/Database/SpeakerProfileRepository.swift
@@ -1,6 +1,16 @@
 import Foundation
 import GRDB
 
+/// Refusals the store raises to keep a profile's samples comparable.
+public enum SpeakerProfileStoreError: Error, Equatable {
+    /// The exemplar was produced by a different embedding model than the
+    /// profile it targets, so matching could never score it.
+    case incompatibleEmbeddingModel(profile: String, exemplar: String)
+    /// A profile's embedding model cannot change while it holds samples in the
+    /// old one. Re-enrollment creates fresh samples instead.
+    case embeddingModelChangeWithExemplars(UUID)
+}
+
 public protocol SpeakerProfileRepositoryProtocol: Sendable {
     func profiles() throws -> [SpeakerProfile]
     func profile(id: UUID) throws -> SpeakerProfile?
@@ -61,10 +71,22 @@ public final class SpeakerProfileRepository: SpeakerProfileRepositoryProtocol {
     /// Recomputes the normalized key before writing: `displayName` is mutable,
     /// so a rename would otherwise leave the old key enforcing uniqueness while
     /// a lookup by the new name found nothing.
+    ///
+    /// Throws when the embedding model changes on a profile that already holds
+    /// samples: those samples would stay in the old representation and become
+    /// unscoreable, leaving a profile that looks populated and matches nothing.
     public func save(_ profile: SpeakerProfile) throws {
         var profile = profile
         profile.normalizedName = SpeakerProfile.normalizedName(for: profile.displayName)
         try dbQueue.write { db in
+            if let existing = try SpeakerProfile.fetchOne(db, key: profile.id),
+               existing.embeddingModelId != profile.embeddingModelId,
+               try SpeakerProfileExemplar
+                   .filter(Column("profileId") == profile.id)
+                   .fetchCount(db) > 0
+            {
+                throw SpeakerProfileStoreError.embeddingModelChangeWithExemplars(profile.id)
+            }
             try profile.save(db)
         }
     }
@@ -88,8 +110,23 @@ public final class SpeakerProfileRepository: SpeakerProfileRepositoryProtocol {
         return Dictionary(grouping: all, by: \.profileId)
     }
 
+    /// Throws when the exemplar comes from a different embedding model than its
+    /// profile. Vectors from two models share no space, so such a sample would
+    /// be stored, counted and shown to the user while never scoring against
+    /// anything — a ghost with no signal to reveal it.
+    ///
+    /// A differing aggregation profile is accepted: that stays comparable, at a
+    /// tightened threshold the matcher applies.
     public func insert(_ exemplar: SpeakerProfileExemplar) throws {
         try dbQueue.write { db in
+            if let profile = try SpeakerProfile.fetchOne(db, key: exemplar.profileId),
+               profile.embeddingModelId != exemplar.embeddingModelId
+            {
+                throw SpeakerProfileStoreError.incompatibleEmbeddingModel(
+                    profile: profile.embeddingModelId,
+                    exemplar: exemplar.embeddingModelId
+                )
+            }
             try exemplar.insert(db)
         }
     }

--- a/Sources/MacParakeetCore/Database/SpeakerProfileRepository.swift
+++ b/Sources/MacParakeetCore/Database/SpeakerProfileRepository.swift
@@ -2,40 +2,28 @@ import Foundation
 import GRDB
 
 public protocol SpeakerProfileRepositoryProtocol: Sendable {
-    /// Every enrolled voice, ordered by name.
     func profiles() throws -> [SpeakerProfile]
     func profile(id: UUID) throws -> SpeakerProfile?
-    /// Case-insensitive lookup, the one enrollment uses to decide between
-    /// adding a sample and creating a profile.
+    /// Case-insensitive; what enrollment uses to choose between adding a sample
+    /// and creating a profile.
     func profile(named name: String) throws -> SpeakerProfile?
-    /// Inserts or updates. Names are unique, so saving a second profile under
-    /// an existing name throws rather than creating a duplicate.
     func save(_ profile: SpeakerProfile) throws
-    /// A profile's samples, oldest first.
     func exemplars(profileId: UUID) throws -> [SpeakerProfileExemplar]
-    /// Every sample grouped by profile — one read for a whole matching pass.
+    /// One read for a whole matching pass.
     func exemplarsByProfile() throws -> [UUID: [SpeakerProfileExemplar]]
-    /// Adds a sample. Throws when the profile already holds one from the same
-    /// recording, which the schema forbids.
     func insert(_ exemplar: SpeakerProfileExemplar) throws
-    /// Removes one sample, leaving its profile in place. `false` when it was
-    /// already gone.
     func deleteExemplar(id: UUID) throws -> Bool
-    /// Decisions recorded for one transcript at one fingerprint. Rows from an
-    /// earlier fingerprint are deliberately invisible here.
+    /// Rows from an earlier fingerprint are deliberately invisible here.
     func links(transcriptionId: UUID, fingerprint: String) throws -> [SpeakerProfileLink]
-    /// Inserts or updates a decision, preserving its original creation time.
     func save(_ link: SpeakerProfileLink) throws
-    /// Removes a profile with its samples and decisions, in one transaction.
+    /// Removes a profile with its samples and decisions in one transaction.
     /// Transcripts and labels already applied are untouched.
     func deleteProfile(id: UUID) throws -> Bool
-    /// Forgets every voice. Same guarantees as `deleteProfile`, applied at once.
     func deleteAllProfiles() throws
 }
 
-/// Stores enrolled voices. Persistence only: thresholds, gates and matching
-/// policy live in the matcher, and nothing here decides whether two voices are
-/// the same person.
+/// Stores enrolled voices. Persistence only — thresholds and matching policy
+/// live in the matcher.
 public final class SpeakerProfileRepository: SpeakerProfileRepositoryProtocol {
     private let dbQueue: DatabaseQueue
 
@@ -59,14 +47,10 @@ public final class SpeakerProfileRepository: SpeakerProfileRepositoryProtocol {
         }
     }
 
-    /// Case-insensitive lookup: "sarah" and "Sarah" are the same person as far
-    /// as enrollment is concerned.
-    ///
-    /// Queries the stored normalized key, the same one the unique index is
-    /// built on. Matching on a collation instead would let the lookup and the
-    /// constraint disagree — SQLite's `NOCASE` folds only ASCII, so two rows
-    /// that a Unicode-aware lookup considers equal could both exist, and
-    /// `fetchOne` would pick between them arbitrarily.
+    /// Queries the stored normalized key, the same one the unique index uses.
+    /// A collation here instead would let lookup and constraint disagree:
+    /// `NOCASE` folds only ASCII, so two rows a Unicode-aware lookup considers
+    /// equal could both exist and `fetchOne` would pick arbitrarily.
     public func profile(named name: String) throws -> SpeakerProfile? {
         let key = SpeakerProfile.normalizedName(for: name)
         return try dbQueue.read { db in
@@ -91,8 +75,7 @@ public final class SpeakerProfileRepository: SpeakerProfileRepositoryProtocol {
         }
     }
 
-    /// Every exemplar, grouped by profile — one read for a whole matching pass
-    /// rather than one per profile.
+    /// One read for a whole matching pass rather than one per profile.
     public func exemplarsByProfile() throws -> [UUID: [SpeakerProfileExemplar]] {
         let all = try dbQueue.read { db in
             try SpeakerProfileExemplar.order(Column("createdAt")).fetchAll(db)
@@ -123,13 +106,9 @@ public final class SpeakerProfileRepository: SpeakerProfileRepositoryProtocol {
         }
     }
 
-    /// Upserts a decision, keeping the original `createdAt`.
-    ///
-    /// A link is saved again whenever its status moves — suggested, then
-    /// confirmed or dismissed — and each caller builds a fresh value. Without
-    /// this, the moment the suggestion was first made would be overwritten by
-    /// the moment the user answered, and the journal would lose the interval
-    /// between them.
+    /// Upserts a decision, keeping the original `createdAt`: status moves from
+    /// suggested to confirmed or dismissed, and each caller builds a fresh
+    /// value, so otherwise the offer time is overwritten by the answer time.
     public func save(_ link: SpeakerProfileLink) throws {
         try dbQueue.write { db in
             var link = link
@@ -147,11 +126,8 @@ public final class SpeakerProfileRepository: SpeakerProfileRepositoryProtocol {
 
     // MARK: Deletion
 
-    /// Removes a profile and everything it owns in one transaction.
-    ///
     /// Exemplars and links go with it through their cascades; transcripts and
-    /// any label already applied are untouched, because deleting a voiceprint
-    /// must not rewrite the user's history.
+    /// any label already applied are untouched.
     public func deleteProfile(id: UUID) throws -> Bool {
         try dbQueue.write { db in
             try SpeakerProfile.deleteOne(db, key: id)

--- a/Sources/MacParakeetCore/Database/SpeakerProfileRepository.swift
+++ b/Sources/MacParakeetCore/Database/SpeakerProfileRepository.swift
@@ -62,17 +62,15 @@ public final class SpeakerProfileRepository: SpeakerProfileRepositoryProtocol {
     /// Case-insensitive lookup: "sarah" and "Sarah" are the same person as far
     /// as enrollment is concerned.
     ///
-    /// Uses a localized collation rather than SQLite's `NOCASE`, which folds
-    /// only the 26 ASCII letters — under it "josé" and "JOSÉ" would be two
-    /// different people, and the second enrollment would silently create a
-    /// rival profile instead of adding a sample. The unique index keeps
-    /// `NOCASE` as a backstop, so this lookup is deliberately the wider of the
-    /// two.
+    /// Queries the stored normalized key, the same one the unique index is
+    /// built on. Matching on a collation instead would let the lookup and the
+    /// constraint disagree — SQLite's `NOCASE` folds only ASCII, so two rows
+    /// that a Unicode-aware lookup considers equal could both exist, and
+    /// `fetchOne` would pick between them arbitrarily.
     public func profile(named name: String) throws -> SpeakerProfile? {
-        try dbQueue.read { db in
-            try SpeakerProfile
-                .filter(Column("displayName").collating(.localizedCaseInsensitiveCompare) == name)
-                .fetchOne(db)
+        let key = SpeakerProfile.normalizedName(for: name)
+        return try dbQueue.read { db in
+            try SpeakerProfile.filter(Column("normalizedName") == key).fetchOne(db)
         }
     }
 

--- a/Sources/MacParakeetCore/Database/SpeakerProfileRepository.swift
+++ b/Sources/MacParakeetCore/Database/SpeakerProfileRepository.swift
@@ -58,7 +58,12 @@ public final class SpeakerProfileRepository: SpeakerProfileRepositoryProtocol {
         }
     }
 
+    /// Recomputes the normalized key before writing: `displayName` is mutable,
+    /// so a rename would otherwise leave the old key enforcing uniqueness while
+    /// a lookup by the new name found nothing.
     public func save(_ profile: SpeakerProfile) throws {
+        var profile = profile
+        profile.normalizedName = SpeakerProfile.normalizedName(for: profile.displayName)
         try dbQueue.write { db in
             try profile.save(db)
         }

--- a/Sources/MacParakeetCore/Database/SpeakerProfileRepository.swift
+++ b/Sources/MacParakeetCore/Database/SpeakerProfileRepository.swift
@@ -2,17 +2,34 @@ import Foundation
 import GRDB
 
 public protocol SpeakerProfileRepositoryProtocol: Sendable {
+    /// Every enrolled voice, ordered by name.
     func profiles() throws -> [SpeakerProfile]
     func profile(id: UUID) throws -> SpeakerProfile?
+    /// Case-insensitive lookup, the one enrollment uses to decide between
+    /// adding a sample and creating a profile.
     func profile(named name: String) throws -> SpeakerProfile?
+    /// Inserts or updates. Names are unique, so saving a second profile under
+    /// an existing name throws rather than creating a duplicate.
     func save(_ profile: SpeakerProfile) throws
+    /// A profile's samples, oldest first.
     func exemplars(profileId: UUID) throws -> [SpeakerProfileExemplar]
+    /// Every sample grouped by profile — one read for a whole matching pass.
     func exemplarsByProfile() throws -> [UUID: [SpeakerProfileExemplar]]
+    /// Adds a sample. Throws when the profile already holds one from the same
+    /// recording, which the schema forbids.
     func insert(_ exemplar: SpeakerProfileExemplar) throws
+    /// Removes one sample, leaving its profile in place. `false` when it was
+    /// already gone.
     func deleteExemplar(id: UUID) throws -> Bool
+    /// Decisions recorded for one transcript at one fingerprint. Rows from an
+    /// earlier fingerprint are deliberately invisible here.
     func links(transcriptionId: UUID, fingerprint: String) throws -> [SpeakerProfileLink]
+    /// Inserts or updates a decision, preserving its original creation time.
     func save(_ link: SpeakerProfileLink) throws
+    /// Removes a profile with its samples and decisions, in one transaction.
+    /// Transcripts and labels already applied are untouched.
     func deleteProfile(id: UUID) throws -> Bool
+    /// Forgets every voice. Same guarantees as `deleteProfile`, applied at once.
     func deleteAllProfiles() throws
 }
 

--- a/Sources/MacParakeetCore/Models/SpeakerProfile.swift
+++ b/Sources/MacParakeetCore/Models/SpeakerProfile.swift
@@ -24,6 +24,11 @@ public struct SpeakerProfile: Codable, Identifiable, Sendable, Equatable {
     public var lastEvaluatedAt: Date?
     public var lastEvaluatedDistance: Double?
 
+    /// - Parameters:
+    ///   - displayName: unique case-insensitively; enrollment looks a profile
+    ///     up by this name before deciding to create one.
+    ///   - identity: the representation this profile's samples live in. Samples
+    ///     from another embedding model are never compared against it.
     public init(
         id: UUID = UUID(),
         displayName: String,
@@ -89,6 +94,11 @@ public struct SpeakerProfileExemplar: Codable, Identifiable, Sendable, Equatable
     public var sourceSpeakerId: String?
     public var createdAt: Date
 
+    /// - Parameters:
+    ///   - embedding: stored as bytes; its model identity is copied alongside
+    ///     so a later upgrade can tell which representation this sample is in.
+    ///   - sourceTranscriptionId: the recording it came from, cleared rather
+    ///     than cascaded when that recording is deleted.
     public init(
         id: UUID = UUID(),
         profileId: UUID,
@@ -159,6 +169,11 @@ public struct SpeakerProfileLink: Codable, Sendable, Equatable {
     public var createdAt: Date
     public var updatedAt: Date
 
+    /// - Parameters:
+    ///   - speakerId: the diarizer's positional id, meaningful only together
+    ///     with `transcriptFingerprint`.
+    ///   - distance: what the decision was based on, kept so calibration can
+    ///     read it back.
     public init(
         transcriptionId: UUID,
         speakerId: String,

--- a/Sources/MacParakeetCore/Models/SpeakerProfile.swift
+++ b/Sources/MacParakeetCore/Models/SpeakerProfile.swift
@@ -1,0 +1,187 @@
+import Foundation
+import GRDB
+
+/// A voice the user has explicitly enrolled, so the same person can be
+/// recognized across recordings.
+///
+/// Deliberately holds no centroid column: scoring takes the minimum distance
+/// over the profile's exemplars, which preserves per-domain modes, so a derived
+/// aggregate would be an unused cache with its own coherency bugs.
+public struct SpeakerProfile: Codable, Identifiable, Sendable, Equatable {
+    public var id: UUID
+    /// Unique case-insensitively: renaming another speaker to this name adds an
+    /// exemplar here rather than creating a rival profile.
+    public var displayName: String
+    public var embeddingModelId: String
+    public var aggregationProfileId: String
+    public var createdAt: Date
+    public var updatedAt: Date
+    /// Last time this profile was actually suggested for a speaker.
+    public var lastMatchedAt: Date?
+    /// Last time it was scored at all, matched or not, with its best distance.
+    /// The pair is what lets the admin screen answer "why does this profile
+    /// never match?" with a number instead of a shrug.
+    public var lastEvaluatedAt: Date?
+    public var lastEvaluatedDistance: Double?
+
+    public init(
+        id: UUID = UUID(),
+        displayName: String,
+        identity: SpeakerModelIdentity,
+        createdAt: Date = Date(),
+        updatedAt: Date = Date(),
+        lastMatchedAt: Date? = nil,
+        lastEvaluatedAt: Date? = nil,
+        lastEvaluatedDistance: Double? = nil
+    ) {
+        self.id = id
+        self.displayName = displayName
+        self.embeddingModelId = identity.embeddingModelId
+        self.aggregationProfileId = identity.aggregationProfileId
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.lastMatchedAt = lastMatchedAt
+        self.lastEvaluatedAt = lastEvaluatedAt
+        self.lastEvaluatedDistance = lastEvaluatedDistance
+    }
+
+    public var identity: SpeakerModelIdentity {
+        SpeakerModelIdentity(
+            embeddingModelId: embeddingModelId,
+            aggregationProfileId: aggregationProfileId
+        )
+    }
+}
+
+extension SpeakerProfile: FetchableRecord, PersistableRecord {
+    public static let databaseTableName = "speaker_profiles"
+}
+
+/// One recording's worth of voice evidence for a profile.
+///
+/// At most one per profile per recording, enforced by a unique constraint
+/// rather than by code: offline segment embeddings within a recording all
+/// derive from the same cluster centroid, so storing several would inflate the
+/// sample count without adding any diversity.
+public struct SpeakerProfileExemplar: Codable, Identifiable, Sendable, Equatable {
+    public enum Origin: String, Codable, Sendable {
+        /// The user named this speaker themselves.
+        case manualEnrollment
+        /// The user confirmed a suggestion, which also improves the profile.
+        case confirmedSuggestion
+    }
+
+    public var id: UUID
+    public var profileId: UUID
+    /// The embedding, 1024 bytes of little-endian Float32. Stored as a blob
+    /// rather than JSON: SQLite validates the length, and an accidental
+    /// serialization yields opaque bytes instead of a readable voiceprint.
+    public var vector: Data
+    public var speechSeconds: Double
+    public var captureDomain: SpeakerCaptureDomain
+    public var origin: Origin
+    public var embeddingModelId: String
+    public var aggregationProfileId: String
+    /// Cleared rather than cascaded when the transcript goes: the user enrolled
+    /// a person, not a recording, so tidying the library must not quietly
+    /// degrade a profile.
+    public var sourceTranscriptionId: UUID?
+    public var sourceSpeakerId: String?
+    public var createdAt: Date
+
+    public init(
+        id: UUID = UUID(),
+        profileId: UUID,
+        embedding: SpeakerEmbedding,
+        speechSeconds: Double,
+        captureDomain: SpeakerCaptureDomain,
+        origin: Origin,
+        sourceTranscriptionId: UUID? = nil,
+        sourceSpeakerId: String? = nil,
+        createdAt: Date = Date()
+    ) {
+        self.id = id
+        self.profileId = profileId
+        self.vector = embedding.data
+        self.speechSeconds = speechSeconds
+        self.captureDomain = captureDomain
+        self.origin = origin
+        self.embeddingModelId = embedding.identity.embeddingModelId
+        self.aggregationProfileId = embedding.identity.aggregationProfileId
+        self.sourceTranscriptionId = sourceTranscriptionId
+        self.sourceSpeakerId = sourceSpeakerId
+        self.createdAt = createdAt
+    }
+
+    public var identity: SpeakerModelIdentity {
+        SpeakerModelIdentity(
+            embeddingModelId: embeddingModelId,
+            aggregationProfileId: aggregationProfileId
+        )
+    }
+
+    /// Decodes the stored vector. `nil` means the blob no longer satisfies the
+    /// embedding invariants, in which case the exemplar cannot take part in
+    /// matching.
+    public var embedding: SpeakerEmbedding? {
+        SpeakerEmbedding(data: vector, identity: identity)
+    }
+}
+
+extension SpeakerProfileExemplar: FetchableRecord, PersistableRecord {
+    public static let databaseTableName = "speaker_profile_exemplars"
+}
+
+/// What was decided about one detected speaker in one transcript.
+///
+/// Carries no label: the label lives in `speaker_corrections`, which already
+/// owns provenance and undo. This table exists for the three things that layer
+/// cannot express — that a dismissal must not be repeated, that a profile has
+/// already taken a sample from this recording, and that everything disappears
+/// with its profile.
+public struct SpeakerProfileLink: Codable, Sendable, Equatable {
+    public enum Status: String, Codable, Sendable {
+        case suggested
+        case confirmed
+        case dismissed
+    }
+
+    public var transcriptionId: UUID
+    /// The diarizer's id for this run ("S1", "system:S1"). Positional, which is
+    /// exactly why rows are fingerprint-scoped: after re-diarization the same
+    /// id can mean a different person.
+    public var speakerId: String
+    public var transcriptFingerprint: String
+    public var profileId: UUID
+    public var status: Status
+    public var distance: Double
+    public var runnerUpDistance: Double?
+    public var createdAt: Date
+    public var updatedAt: Date
+
+    public init(
+        transcriptionId: UUID,
+        speakerId: String,
+        transcriptFingerprint: String,
+        profileId: UUID,
+        status: Status,
+        distance: Double,
+        runnerUpDistance: Double? = nil,
+        createdAt: Date = Date(),
+        updatedAt: Date = Date()
+    ) {
+        self.transcriptionId = transcriptionId
+        self.speakerId = speakerId
+        self.transcriptFingerprint = transcriptFingerprint
+        self.profileId = profileId
+        self.status = status
+        self.distance = distance
+        self.runnerUpDistance = runnerUpDistance
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+}
+
+extension SpeakerProfileLink: FetchableRecord, PersistableRecord {
+    public static let databaseTableName = "speaker_profile_links"
+}

--- a/Sources/MacParakeetCore/Models/SpeakerProfile.swift
+++ b/Sources/MacParakeetCore/Models/SpeakerProfile.swift
@@ -1,39 +1,27 @@
 import Foundation
 import GRDB
 
-/// A voice the user has explicitly enrolled, so the same person can be
-/// recognized across recordings.
+/// A voice the user has explicitly enrolled.
 ///
-/// Deliberately holds no centroid column: scoring takes the minimum distance
-/// over the profile's exemplars, which preserves per-domain modes, so a derived
-/// aggregate would be an unused cache with its own coherency bugs.
+/// No centroid column: scoring takes the minimum distance over the exemplars,
+/// which preserves per-domain modes, so an aggregate would be an unused cache.
 public struct SpeakerProfile: Codable, Identifiable, Sendable, Equatable {
     public var id: UUID
     /// As the user typed it. Display only — never compared directly.
     public var displayName: String
-    /// The key uniqueness and lookup both use, derived from `displayName`.
-    ///
-    /// Kept as a column rather than computed in a query so that the database
-    /// constraint and the Swift lookup can never disagree about what counts as
-    /// the same name. Set it through ``normalizedName(for:)``.
+    /// The key both uniqueness and lookup use, so the database constraint and
+    /// the Swift lookup cannot disagree on what counts as the same name.
     public var normalizedName: String
     public var embeddingModelId: String
     public var aggregationProfileId: String
     public var createdAt: Date
     public var updatedAt: Date
-    /// Last time this profile was actually suggested for a speaker.
     public var lastMatchedAt: Date?
-    /// Last time it was scored at all, matched or not, with its best distance.
-    /// The pair is what lets the admin screen answer "why does this profile
-    /// never match?" with a number instead of a shrug.
+    /// Scored at all, matched or not: what answers "why does this profile never
+    /// match?" with a number.
     public var lastEvaluatedAt: Date?
     public var lastEvaluatedDistance: Double?
 
-    /// - Parameters:
-    ///   - displayName: unique case-insensitively; enrollment looks a profile
-    ///     up by this name before deciding to create one.
-    ///   - identity: the representation this profile's samples live in. Samples
-    ///     from another embedding model are never compared against it.
     public init(
         id: UUID = UUID(),
         displayName: String,
@@ -63,14 +51,9 @@ public struct SpeakerProfile: Codable, Identifiable, Sendable, Equatable {
         )
     }
 
-    /// The comparison key for a display name: trimmed, then case-folded across
-    /// the whole of Unicode.
-    ///
-    /// Accents are deliberately kept. Folding them too would make "Jose" and
-    /// "José" one person, which is a guess about identity rather than about
-    /// typography — and the wrong guess merges two colleagues silently. When
-    /// two people really do share a name, the enrollment guard catches it by
-    /// voice instead.
+    /// Trimmed, then case-folded across all of Unicode. Accents are kept:
+    /// folding them would decide that "Jose" and "José" are one person, which
+    /// is a guess about identity, not typography.
     public static func normalizedName(for displayName: String) -> String {
         displayName
             .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -84,10 +67,9 @@ extension SpeakerProfile: FetchableRecord, PersistableRecord {
 
 /// One recording's worth of voice evidence for a profile.
 ///
-/// At most one per profile per recording, enforced by a unique constraint
-/// rather than by code: offline segment embeddings within a recording all
-/// derive from the same cluster centroid, so storing several would inflate the
-/// sample count without adding any diversity.
+/// At most one per profile per recording, enforced by the schema: segment
+/// embeddings within a recording all derive from the same centroid, so several
+/// would inflate the sample count without adding diversity.
 public struct SpeakerProfileExemplar: Codable, Identifiable, Sendable, Equatable {
     public enum Origin: String, Codable, Sendable {
         /// The user named this speaker themselves.
@@ -98,27 +80,20 @@ public struct SpeakerProfileExemplar: Codable, Identifiable, Sendable, Equatable
 
     public var id: UUID
     public var profileId: UUID
-    /// The embedding, 1024 bytes of little-endian Float32. Stored as a blob
-    /// rather than JSON: SQLite validates the length, and an accidental
-    /// serialization yields opaque bytes instead of a readable voiceprint.
+    /// 1024 bytes of little-endian Float32. A blob rather than JSON so SQLite
+    /// validates the length and an accidental serialization stays opaque.
     public var vector: Data
     public var speechSeconds: Double
     public var captureDomain: SpeakerCaptureDomain
     public var origin: Origin
     public var embeddingModelId: String
     public var aggregationProfileId: String
-    /// Cleared rather than cascaded when the transcript goes: the user enrolled
-    /// a person, not a recording, so tidying the library must not quietly
-    /// degrade a profile.
+    /// Cleared rather than cascaded: the user enrolled a person, not a
+    /// recording, so tidying the library must not degrade a profile.
     public var sourceTranscriptionId: UUID?
     public var sourceSpeakerId: String?
     public var createdAt: Date
 
-    /// - Parameters:
-    ///   - embedding: stored as bytes; its model identity is copied alongside
-    ///     so a later upgrade can tell which representation this sample is in.
-    ///   - sourceTranscriptionId: the recording it came from, cleared rather
-    ///     than cascaded when that recording is deleted.
     public init(
         id: UUID = UUID(),
         profileId: UUID,
@@ -150,9 +125,8 @@ public struct SpeakerProfileExemplar: Codable, Identifiable, Sendable, Equatable
         )
     }
 
-    /// Decodes the stored vector. `nil` means the blob no longer satisfies the
-    /// embedding invariants, in which case the exemplar cannot take part in
-    /// matching.
+    /// `nil` when the blob no longer satisfies the embedding invariants, in
+    /// which case this exemplar cannot take part in matching.
     public var embedding: SpeakerEmbedding? {
         SpeakerEmbedding(data: vector, identity: identity)
     }
@@ -164,11 +138,9 @@ extension SpeakerProfileExemplar: FetchableRecord, PersistableRecord {
 
 /// What was decided about one detected speaker in one transcript.
 ///
-/// Carries no label: the label lives in `speaker_corrections`, which already
-/// owns provenance and undo. This table exists for the three things that layer
-/// cannot express — that a dismissal must not be repeated, that a profile has
-/// already taken a sample from this recording, and that everything disappears
-/// with its profile.
+/// Carries no label — that lives in `speaker_corrections` with provenance and
+/// undo. This exists for what that layer cannot express: that a dismissal must
+/// not repeat, and that everything disappears with its profile.
 public struct SpeakerProfileLink: Codable, Sendable, Equatable {
     public enum Status: String, Codable, Sendable {
         case suggested
@@ -177,9 +149,8 @@ public struct SpeakerProfileLink: Codable, Sendable, Equatable {
     }
 
     public var transcriptionId: UUID
-    /// The diarizer's id for this run ("S1", "system:S1"). Positional, which is
-    /// exactly why rows are fingerprint-scoped: after re-diarization the same
-    /// id can mean a different person.
+    /// Positional ("S1", "system:S1"), which is why rows are fingerprint-scoped:
+    /// after re-diarization the same id can mean a different person.
     public var speakerId: String
     public var transcriptFingerprint: String
     public var profileId: UUID
@@ -189,11 +160,6 @@ public struct SpeakerProfileLink: Codable, Sendable, Equatable {
     public var createdAt: Date
     public var updatedAt: Date
 
-    /// - Parameters:
-    ///   - speakerId: the diarizer's positional id, meaningful only together
-    ///     with `transcriptFingerprint`.
-    ///   - distance: what the decision was based on, kept so calibration can
-    ///     read it back.
     public init(
         transcriptionId: UUID,
         speakerId: String,

--- a/Sources/MacParakeetCore/Models/SpeakerProfile.swift
+++ b/Sources/MacParakeetCore/Models/SpeakerProfile.swift
@@ -9,9 +9,14 @@ import GRDB
 /// aggregate would be an unused cache with its own coherency bugs.
 public struct SpeakerProfile: Codable, Identifiable, Sendable, Equatable {
     public var id: UUID
-    /// Unique case-insensitively: renaming another speaker to this name adds an
-    /// exemplar here rather than creating a rival profile.
+    /// As the user typed it. Display only — never compared directly.
     public var displayName: String
+    /// The key uniqueness and lookup both use, derived from `displayName`.
+    ///
+    /// Kept as a column rather than computed in a query so that the database
+    /// constraint and the Swift lookup can never disagree about what counts as
+    /// the same name. Set it through ``normalizedName(for:)``.
+    public var normalizedName: String
     public var embeddingModelId: String
     public var aggregationProfileId: String
     public var createdAt: Date
@@ -41,6 +46,7 @@ public struct SpeakerProfile: Codable, Identifiable, Sendable, Equatable {
     ) {
         self.id = id
         self.displayName = displayName
+        self.normalizedName = Self.normalizedName(for: displayName)
         self.embeddingModelId = identity.embeddingModelId
         self.aggregationProfileId = identity.aggregationProfileId
         self.createdAt = createdAt
@@ -55,6 +61,20 @@ public struct SpeakerProfile: Codable, Identifiable, Sendable, Equatable {
             embeddingModelId: embeddingModelId,
             aggregationProfileId: aggregationProfileId
         )
+    }
+
+    /// The comparison key for a display name: trimmed, then case-folded across
+    /// the whole of Unicode.
+    ///
+    /// Accents are deliberately kept. Folding them too would make "Jose" and
+    /// "José" one person, which is a guess about identity rather than about
+    /// typography — and the wrong guess merges two colleagues silently. When
+    /// two people really do share a name, the enrollment guard catches it by
+    /// voice instead.
+    public static func normalizedName(for displayName: String) -> String {
+        displayName
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .folding(options: [.caseInsensitive, .widthInsensitive], locale: nil)
     }
 }
 

--- a/Sources/MacParakeetCore/Services/Diarization/DiarizationService.swift
+++ b/Sources/MacParakeetCore/Services/Diarization/DiarizationService.swift
@@ -14,6 +14,12 @@ public struct MacParakeetDiarizationResult: Sendable {
     /// exclusive, so these are plain sums.
     public let speechMsBySpeaker: [String: Int]
 
+    /// - Parameters:
+    ///   - speakerEmbeddings: keyed by the same stable ids as `speakers`, and
+    ///     empty when the diarizer produced none. Callers must treat a missing
+    ///     entry as "not matchable", never as an error.
+    ///   - speechMsBySpeaker: total speech per speaker id. Offline segments are
+    ///     exclusive, so these are plain sums.
     public init(
         segments: [SpeakerSegment],
         speakerCount: Int,

--- a/Sources/MacParakeetCore/Services/Diarization/DiarizationService.swift
+++ b/Sources/MacParakeetCore/Services/Diarization/DiarizationService.swift
@@ -6,20 +6,12 @@ public struct MacParakeetDiarizationResult: Sendable {
     public let segments: [SpeakerSegment]
     public let speakerCount: Int
     public let speakers: [SpeakerInfo]
-    /// Voice embedding per detected speaker, keyed by the same stable ids as
-    /// `speakers`. A speaker is absent when its centroid carried no usable
-    /// direction; it keeps its segments and its `SpeakerInfo` either way.
+    /// Keyed by the same stable ids as `speakers`. A speaker is absent when its
+    /// centroid carried no direction; it keeps its segments and label either way.
     public let speakerEmbeddings: [String: SpeakerEmbedding]
-    /// Total speech per speaker id, in milliseconds. Offline segments are
-    /// exclusive, so these are plain sums.
+    /// Offline segments are exclusive, so these are plain sums.
     public let speechMsBySpeaker: [String: Int]
 
-    /// - Parameters:
-    ///   - speakerEmbeddings: keyed by the same stable ids as `speakers`, and
-    ///     empty when the diarizer produced none. Callers must treat a missing
-    ///     entry as "not matchable", never as an error.
-    ///   - speechMsBySpeaker: total speech per speaker id. Offline segments are
-    ///     exclusive, so these are plain sums.
     public init(
         segments: [SpeakerSegment],
         speakerCount: Int,
@@ -34,16 +26,11 @@ public struct MacParakeetDiarizationResult: Sendable {
         self.speechMsBySpeaker = speechMsBySpeaker
     }
 
-    /// Speech for one speaker, in seconds.
+    /// Speech for one speaker, in seconds; 0 when it has none.
     ///
-    /// The single conversion point between this type's milliseconds — the unit
-    /// every other diarization value uses — and the seconds that duration gates
-    /// are expressed in. Dividing at each call site invites the one mistake
-    /// nothing would catch: a factor of a thousand turns a three-second gate
-    /// into a fifty-minute one, so every speaker silently stops qualifying and
-    /// the feature just never fires.
-    ///
-    /// Returns 0 for a speaker with no recorded speech.
+    /// The single conversion point to the unit the duration gates use. A stray
+    /// factor of a thousand turns a 3 s gate into 50 minutes, and nothing would
+    /// catch it: every speaker would just silently stop qualifying.
     public func speechSeconds(forSpeaker speakerId: String) -> Double {
         Double(speechMsBySpeaker[speakerId] ?? 0) / 1000
     }
@@ -306,17 +293,14 @@ public actor DiarizationService: DiarizationServiceProtocol {
         )
     }
 
-    /// Rekeys FluidAudio's speaker database onto our stable ids and normalizes
+    /// Rekeys FluidAudio's speaker database onto our stable ids, normalizing
     /// each centroid.
     ///
-    /// The remap is not cosmetic: FluidAudio also names its clusters `S1`, `S2`,
-    /// but numbered by cluster index, while ours are numbered by who speaks
-    /// first. Carrying the keys over untouched would silently attach one
-    /// speaker's voice to another's label.
-    ///
-    /// Speakers whose centroid fails validation are dropped from the dictionary
-    /// only. They keep their segments, their `SpeakerInfo` and their duration —
-    /// diarization output is unchanged, and they are merely unmatchable.
+    /// The remap is load-bearing: FluidAudio also uses `S1`/`S2`, numbered by
+    /// cluster index where ours are numbered by who speaks first, so copying the
+    /// keys would attach one speaker's voice to another's label. Centroids that
+    /// fail validation are dropped from this dictionary only — the speaker keeps
+    /// its segments and label, and is merely unmatchable.
     static func speakerEmbeddings(
         from speakerDatabase: [String: [Float]]?,
         idMapping: [String: String],
@@ -475,22 +459,18 @@ public actor DiarizationService: DiarizationServiceProtocol {
         return config
     }
 
-    /// The WeSpeaker embedding model behind FluidAudio's offline diarizer.
-    /// Change it only when the model itself changes: vectors from two different
-    /// models share no space and are never compared.
+    /// Change only when the model changes: vectors from two models share no
+    /// space and are never compared.
     public nonisolated static let embeddingModelId = "fluidaudio-wespeaker-256"
 
     /// Bump on any FluidAudio upgrade that could move the clustering centroid,
     /// even when the embedding model is untouched.
     private nonisolated static let pipelineRevision = "fluidaudio-0.15.6"
 
-    /// Identity of the representation `config` produces.
-    ///
-    /// The centroid depends on the clustering configuration as much as on the
-    /// model, so the aggregation half hashes every setting that can move it.
-    /// The per-run speaker-count constraint is deliberately excluded: it varies
-    /// call to call, and folding it in would make a profile enrolled under a
-    /// count hint incomparable with the same voice heard without one.
+    /// Identity of the representation `config` produces. The aggregation half
+    /// hashes every setting that can move the centroid. The per-run speaker
+    /// count is excluded on purpose: it varies call to call, and folding it in
+    /// would make a profile enrolled under a hint incomparable without one.
     /// Identity of the representation the shipping configuration produces.
     nonisolated static var defaultModelIdentity: SpeakerModelIdentity {
         modelIdentity(for: highAccuracyConfig)

--- a/Sources/MacParakeetCore/Services/Diarization/DiarizationService.swift
+++ b/Sources/MacParakeetCore/Services/Diarization/DiarizationService.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import FluidAudio
 import Foundation
 
@@ -5,11 +6,26 @@ public struct MacParakeetDiarizationResult: Sendable {
     public let segments: [SpeakerSegment]
     public let speakerCount: Int
     public let speakers: [SpeakerInfo]
+    /// Voice embedding per detected speaker, keyed by the same stable ids as
+    /// `speakers`. A speaker is absent when its centroid carried no usable
+    /// direction; it keeps its segments and its `SpeakerInfo` either way.
+    public let speakerEmbeddings: [String: SpeakerEmbedding]
+    /// Total speech per speaker id, in milliseconds. Offline segments are
+    /// exclusive, so these are plain sums.
+    public let speechMsBySpeaker: [String: Int]
 
-    public init(segments: [SpeakerSegment], speakerCount: Int, speakers: [SpeakerInfo]) {
+    public init(
+        segments: [SpeakerSegment],
+        speakerCount: Int,
+        speakers: [SpeakerInfo],
+        speakerEmbeddings: [String: SpeakerEmbedding] = [:],
+        speechMsBySpeaker: [String: Int] = [:]
+    ) {
         self.segments = segments
         self.speakerCount = speakerCount
         self.speakers = speakers
+        self.speakerEmbeddings = speakerEmbeddings
+        self.speechMsBySpeaker = speechMsBySpeaker
     }
 }
 
@@ -151,6 +167,7 @@ public actor DiarizationService: DiarizationServiceProtocol {
     private let modelsDirectory: URL
     private let inferenceGate: ANEInferenceGate
     private let explicitConstraint: SpeakerDiarizationConstraint?
+    private let modelIdentity: SpeakerModelIdentity
     private var managerFactory: ManagerFactory?
     private var preparation: Task<Void, Error>?
 
@@ -163,7 +180,8 @@ public actor DiarizationService: DiarizationServiceProtocol {
         self.init(
             loadManagerFactory: Self.modelLoader(config: config),
             modelsDirectory: modelsDirectory ?? AppPaths.fluidAudioModelsDirURL,
-            explicitConstraint: nil
+            explicitConstraint: nil,
+            modelIdentity: Self.modelIdentity(for: config)
         )
     }
 
@@ -174,7 +192,8 @@ public actor DiarizationService: DiarizationServiceProtocol {
         self.init(
             loadManagerFactory: Self.modelLoader(config: Self.highAccuracyConfig),
             modelsDirectory: modelsDirectory ?? AppPaths.fluidAudioModelsDirURL,
-            explicitConstraint: speakerConstraint
+            explicitConstraint: speakerConstraint,
+            modelIdentity: Self.modelIdentity(for: Self.highAccuracyConfig)
         )
     }
 
@@ -182,12 +201,14 @@ public actor DiarizationService: DiarizationServiceProtocol {
         loadManagerFactory: @escaping ManagerFactoryLoader,
         modelsDirectory: URL,
         explicitConstraint: SpeakerDiarizationConstraint? = nil,
-        inferenceGate: ANEInferenceGate = .shared
+        inferenceGate: ANEInferenceGate = .shared,
+        modelIdentity: SpeakerModelIdentity = DiarizationService.defaultModelIdentity
     ) {
         self.loadManagerFactory = loadManagerFactory
         self.modelsDirectory = modelsDirectory.standardizedFileURL
         self.explicitConstraint = explicitConstraint
         self.inferenceGate = inferenceGate
+        self.modelIdentity = modelIdentity
     }
 
     public func diarize(
@@ -247,11 +268,49 @@ public actor DiarizationService: DiarizationServiceProtocol {
                 return SpeakerInfo(id: stableId, label: "Speaker \(number)")
             }
 
+        var speechMsBySpeaker: [String: Int] = [:]
+        for segment in segments {
+            speechMsBySpeaker[segment.speakerId, default: 0] += max(0, segment.endMs - segment.startMs)
+        }
+
         return MacParakeetDiarizationResult(
             segments: segments,
             speakerCount: speakers.count,
-            speakers: speakers
+            speakers: speakers,
+            speakerEmbeddings: Self.speakerEmbeddings(
+                from: fluidResult.speakerDatabase,
+                idMapping: idMapping,
+                identity: modelIdentity
+            ),
+            speechMsBySpeaker: speechMsBySpeaker
         )
+    }
+
+    /// Rekeys FluidAudio's speaker database onto our stable ids and normalizes
+    /// each centroid.
+    ///
+    /// The remap is not cosmetic: FluidAudio also names its clusters `S1`, `S2`,
+    /// but numbered by cluster index, while ours are numbered by who speaks
+    /// first. Carrying the keys over untouched would silently attach one
+    /// speaker's voice to another's label.
+    ///
+    /// Speakers whose centroid fails validation are dropped from the dictionary
+    /// only. They keep their segments, their `SpeakerInfo` and their duration —
+    /// diarization output is unchanged, and they are merely unmatchable.
+    static func speakerEmbeddings(
+        from speakerDatabase: [String: [Float]]?,
+        idMapping: [String: String],
+        identity: SpeakerModelIdentity
+    ) -> [String: SpeakerEmbedding] {
+        guard let speakerDatabase else { return [:] }
+
+        var embeddings: [String: SpeakerEmbedding] = [:]
+        for (fluidID, rawVector) in speakerDatabase {
+            guard let stableID = idMapping[fluidID] else { continue }
+            guard let embedding = SpeakerEmbedding(rawVector: rawVector, identity: identity) else { continue }
+            embeddings[stableID] = embedding
+        }
+        return embeddings
     }
 
     public func prepareModels(onProgress: (@Sendable (String) -> Void)? = nil) async throws {
@@ -394,6 +453,49 @@ public actor DiarizationService: DiarizationServiceProtocol {
         // the surrounding speaker).
         config.zeroVoteReembed = OfflineDiarizerConfig.ZeroVoteReembed(enabled: true)
         return config
+    }
+
+    /// The WeSpeaker embedding model behind FluidAudio's offline diarizer.
+    /// Change it only when the model itself changes: vectors from two different
+    /// models share no space and are never compared.
+    public nonisolated static let embeddingModelId = "fluidaudio-wespeaker-256"
+
+    /// Bump on any FluidAudio upgrade that could move the clustering centroid,
+    /// even when the embedding model is untouched.
+    private nonisolated static let pipelineRevision = "fluidaudio-0.15.6"
+
+    /// Identity of the representation `config` produces.
+    ///
+    /// The centroid depends on the clustering configuration as much as on the
+    /// model, so the aggregation half hashes every setting that can move it.
+    /// The per-run speaker-count constraint is deliberately excluded: it varies
+    /// call to call, and folding it in would make a profile enrolled under a
+    /// count hint incomparable with the same voice heard without one.
+    /// Identity of the representation the shipping configuration produces.
+    nonisolated static var defaultModelIdentity: SpeakerModelIdentity {
+        modelIdentity(for: highAccuracyConfig)
+    }
+
+    nonisolated static func modelIdentity(for config: OfflineDiarizerConfig) -> SpeakerModelIdentity {
+        let canonical = [
+            "pipeline=\(pipelineRevision)",
+            "windowDuration=\(config.segmentation.windowDurationSeconds)",
+            "stepRatio=\(config.segmentation.stepRatio)",
+            "minSegmentDuration=\(config.embedding.minSegmentDurationSeconds)",
+            "excludeOverlap=\(config.embedding.excludeOverlap)",
+            "clusteringThreshold=\(config.clustering.threshold)",
+            "constrainedAssignment=\(config.clustering.constrainedAssignment)",
+            "warmStartFa=\(config.clustering.warmStartFa)",
+            "warmStartFb=\(config.clustering.warmStartFb)",
+            "zeroVoteReembed=\(config.zeroVoteReembed.enabled)",
+            "zeroVoteMinDuration=\(config.zeroVoteReembed.minDurationSeconds)",
+        ].joined(separator: ";")
+
+        let digest = SHA256.hash(data: Data(canonical.utf8))
+        return SpeakerModelIdentity(
+            embeddingModelId: embeddingModelId,
+            aggregationProfileId: digest.prefix(8).map { String(format: "%02x", $0) }.joined()
+        )
     }
 
     nonisolated static func offlineConfig(

--- a/Sources/MacParakeetCore/Services/Diarization/DiarizationService.swift
+++ b/Sources/MacParakeetCore/Services/Diarization/DiarizationService.swift
@@ -468,9 +468,14 @@ public actor DiarizationService: DiarizationServiceProtocol {
     private nonisolated static let pipelineRevision = "fluidaudio-0.15.6"
 
     /// Identity of the representation `config` produces. The aggregation half
-    /// hashes every setting that can move the centroid. The per-run speaker
-    /// count is excluded on purpose: it varies call to call, and folding it in
-    /// would make a profile enrolled under a hint incomparable without one.
+    /// hashes the settings that shape the centroid, VBx refinement included,
+    /// so a FluidAudio upgrade that retunes them is caught without anyone
+    /// remembering to bump `pipelineRevision`.
+    ///
+    /// The per-run speaker count is excluded on purpose. It is derived from the
+    /// calendar attendee count, so it changes from meeting to meeting: folding
+    /// it in would make a profile cross-aggregation against its own samples and
+    /// keep tau permanently reduced by `crossAggregationPenalty`.
     /// Identity of the representation the shipping configuration produces.
     nonisolated static var defaultModelIdentity: SpeakerModelIdentity {
         modelIdentity(for: highAccuracyConfig)
@@ -489,6 +494,8 @@ public actor DiarizationService: DiarizationServiceProtocol {
             "warmStartFb=\(config.clustering.warmStartFb)",
             "zeroVoteReembed=\(config.zeroVoteReembed.enabled)",
             "zeroVoteMinDuration=\(config.zeroVoteReembed.minDurationSeconds)",
+            "vbxMaxIterations=\(config.vbx.maxIterations)",
+            "vbxConvergenceTolerance=\(config.vbx.convergenceTolerance)",
         ].joined(separator: ";")
 
         let digest = SHA256.hash(data: Data(canonical.utf8))

--- a/Sources/MacParakeetCore/Services/Diarization/DiarizationService.swift
+++ b/Sources/MacParakeetCore/Services/Diarization/DiarizationService.swift
@@ -33,6 +33,20 @@ public struct MacParakeetDiarizationResult: Sendable {
         self.speakerEmbeddings = speakerEmbeddings
         self.speechMsBySpeaker = speechMsBySpeaker
     }
+
+    /// Speech for one speaker, in seconds.
+    ///
+    /// The single conversion point between this type's milliseconds — the unit
+    /// every other diarization value uses — and the seconds that duration gates
+    /// are expressed in. Dividing at each call site invites the one mistake
+    /// nothing would catch: a factor of a thousand turns a three-second gate
+    /// into a fifty-minute one, so every speaker silently stops qualifying and
+    /// the feature just never fires.
+    ///
+    /// Returns 0 for a speaker with no recorded speech.
+    public func speechSeconds(forSpeaker speakerId: String) -> Double {
+        Double(speechMsBySpeaker[speakerId] ?? 0) / 1000
+    }
 }
 
 public struct SpeakerSegment: Sendable {

--- a/Sources/MacParakeetCore/Services/Diarization/DiarizationService.swift
+++ b/Sources/MacParakeetCore/Services/Diarization/DiarizationService.swift
@@ -467,20 +467,28 @@ public actor DiarizationService: DiarizationServiceProtocol {
     /// even when the embedding model is untouched.
     private nonisolated static let pipelineRevision = "fluidaudio-0.15.6"
 
-    /// Identity of the representation `config` produces. The aggregation half
-    /// hashes the settings that shape the centroid, VBx refinement included,
-    /// so a FluidAudio upgrade that retunes them is caught without anyone
-    /// remembering to bump `pipelineRevision`.
-    ///
-    /// The per-run speaker count is excluded on purpose. It is derived from the
-    /// calendar attendee count, so it changes from meeting to meeting: folding
-    /// it in would make a profile cross-aggregation against its own samples and
-    /// keep tau permanently reduced by `crossAggregationPenalty`.
     /// Identity of the representation the shipping configuration produces.
     nonisolated static var defaultModelIdentity: SpeakerModelIdentity {
         modelIdentity(for: highAccuracyConfig)
     }
 
+    /// Identity of the representation `config` produces. The aggregation half
+    /// hashes the settings that shape the centroid, VBx refinement included,
+    /// so a FluidAudio upgrade that retunes them is caught without anyone
+    /// remembering to bump `pipelineRevision`.
+    ///
+    /// The per-run speaker count is excluded on purpose, even though it reaches
+    /// the clusterer through `config`. It comes from the calendar attendee
+    /// count, so it changes from meeting to meeting: folding it in would make a
+    /// profile cross-aggregation against its own samples and keep tau
+    /// permanently reduced by `crossAggregationPenalty` — below the worst true
+    /// positive Phase 0b measured, so correct pairs would start being refused.
+    ///
+    /// What the app passes is also a cap, never an exact count
+    /// (`MeetingSpeakerPrior` bounds are `min 1, max n + 1`), so it re-clusters
+    /// nothing unless the diarizer oversplits past it. The exact form that does
+    /// move the partition (FluidAudio #801) arrives only from the CLI's
+    /// `--speaker-count`, and that path enrolls nothing in v1.
     nonisolated static func modelIdentity(for config: OfflineDiarizerConfig) -> SpeakerModelIdentity {
         let canonical = [
             "pipeline=\(pipelineRevision)",

--- a/Sources/MacParakeetCore/Services/Diarization/SpeakerEmbedding.swift
+++ b/Sources/MacParakeetCore/Services/Diarization/SpeakerEmbedding.swift
@@ -26,6 +26,11 @@ public struct SpeakerModelIdentity: Sendable, Equatable, Hashable, Codable {
     /// comparable but less trustworthy, so callers tighten their threshold.
     public let aggregationProfileId: String
 
+    /// - Parameters:
+    ///   - embeddingModelId: the model that produced the vector.
+    ///   - aggregationProfileId: the clustering configuration that shaped the
+    ///     centroid, so a configuration change is visible even when the model
+    ///     is unchanged.
     public init(embeddingModelId: String, aggregationProfileId: String) {
         self.embeddingModelId = embeddingModelId
         self.aggregationProfileId = aggregationProfileId

--- a/Sources/MacParakeetCore/Services/Diarization/SpeakerEmbedding.swift
+++ b/Sources/MacParakeetCore/Services/Diarization/SpeakerEmbedding.swift
@@ -1,0 +1,130 @@
+import Foundation
+
+/// Where a voice sample was captured.
+///
+/// Embeddings only compare meaningfully inside one domain: the same person
+/// heard over a compressed conference stream and over a local microphone lands
+/// in different regions of the embedding space. Every stored sample carries its
+/// domain so matching can prefer like-for-like references.
+public enum SpeakerCaptureDomain: String, Sendable, Codable, CaseIterable {
+    case system
+    case microphone
+    case file
+}
+
+/// Identifies the representation an embedding was produced in.
+///
+/// Two identifiers rather than one, because the vector FluidAudio hands back is
+/// the VBx *clustering* centroid, not a raw model output. It therefore moves
+/// when the clustering configuration moves, even if the embedding model itself
+/// is untouched — a change that a model-only identifier would miss. See the
+/// 2026-09-09 amendment to `plans/active/2026-07-03-speaker-voiceprints.md`.
+public struct SpeakerModelIdentity: Sendable, Equatable, Hashable, Codable {
+    /// The embedding model. A mismatch makes two vectors incomparable.
+    public let embeddingModelId: String
+    /// The aggregation configuration that produced the centroid. A mismatch is
+    /// comparable but less trustworthy, so callers tighten their threshold.
+    public let aggregationProfileId: String
+
+    public init(embeddingModelId: String, aggregationProfileId: String) {
+        self.embeddingModelId = embeddingModelId
+        self.aggregationProfileId = aggregationProfileId
+    }
+}
+
+/// A speaker voice embedding, L2-normalized on construction.
+///
+/// Normalization happens here and nowhere else. FluidAudio's `speakerDatabase`
+/// vectors are un-normalized centroids, and comparing them with a bare dot
+/// product scales every distance by `‖a‖·‖b‖` — which silently pushes
+/// same-speaker pairs past any calibrated threshold, with no error to observe.
+/// Worse, the centroid norm shrinks as a cluster gets noisier, so the bias is
+/// anti-correlated with signal quality. Normalizing at the boundary makes every
+/// downstream comparison correct by construction.
+public struct SpeakerEmbedding: Sendable, Equatable {
+    /// WeSpeaker embedding width.
+    public static let dimension = 256
+    /// Serialized size: 256 × Float32.
+    public static let byteCount = dimension * MemoryLayout<Float32>.size
+    /// Below this, a vector carries no usable direction. FluidAudio emits an
+    /// all-zero centroid when a cluster's responsibility denominator is zero.
+    static let minimumNorm: Float = 1e-6
+    /// Tolerance when re-reading a stored vector that is already normalized.
+    static let normTolerance: Float = 1e-3
+
+    /// Unit-length, `dimension` values.
+    public let vector: [Float]
+    public let identity: SpeakerModelIdentity
+
+    /// Normalizes `rawVector`. Returns `nil` for the wrong width, non-finite
+    /// values, or a vector too short to carry a direction.
+    public init?(rawVector: [Float], identity: SpeakerModelIdentity) {
+        guard rawVector.count == Self.dimension else { return nil }
+        guard rawVector.allSatisfy(\.isFinite) else { return nil }
+
+        let norm = Self.norm(of: rawVector)
+        guard norm.isFinite, norm >= Self.minimumNorm else { return nil }
+
+        self.vector = rawVector.map { $0 / norm }
+        self.identity = identity
+    }
+
+    /// Rebuilds a vector previously produced by ``data``.
+    ///
+    /// Deliberately does not re-normalize: the bytes are already unit-length, and
+    /// dividing again by a norm that floating-point rounding puts at 0.99999994
+    /// would make a store/load round trip lossy. The norm is validated instead,
+    /// so corruption is rejected rather than silently rescaled.
+    public init?(data: Data, identity: SpeakerModelIdentity) {
+        guard data.count == Self.byteCount else { return nil }
+
+        var values = [Float]()
+        values.reserveCapacity(Self.dimension)
+        for index in 0..<Self.dimension {
+            let start = data.startIndex + index * MemoryLayout<Float32>.size
+            let bits = data[start..<start + MemoryLayout<Float32>.size]
+                .withUnsafeBytes { $0.loadUnaligned(as: UInt32.self) }
+            values.append(Float(bitPattern: UInt32(littleEndian: bits)))
+        }
+
+        guard values.allSatisfy(\.isFinite) else { return nil }
+        guard abs(Self.norm(of: values) - 1) <= Self.normTolerance else { return nil }
+
+        self.vector = values
+        self.identity = identity
+    }
+
+    /// Little-endian Float32, `byteCount` bytes. The stored form.
+    public var data: Data {
+        var output = Data(capacity: Self.byteCount)
+        for value in vector {
+            withUnsafeBytes(of: value.bitPattern.littleEndian) { output.append(contentsOf: $0) }
+        }
+        return output
+    }
+
+    /// Cosine distance in FluidAudio's convention: 0 is identical, 1 is
+    /// unrelated. Both operands are unit-length, so the dot product is the
+    /// cosine and no rescaling is needed.
+    ///
+    /// Returns `nil` when the embedding models differ, since vectors from
+    /// different models share no space. A differing aggregation profile is
+    /// comparable and left to the caller's threshold policy.
+    public func cosineDistance(to other: SpeakerEmbedding) -> Double? {
+        guard identity.embeddingModelId == other.identity.embeddingModelId else { return nil }
+
+        var dot: Float = 0
+        for index in 0..<Self.dimension {
+            dot += vector[index] * other.vector[index]
+        }
+        return 1 - Double(min(max(dot, -1), 1))
+    }
+
+    private static func norm(of values: [Float]) -> Float {
+        var sumOfSquares: Float = 0
+        for value in values {
+            sumOfSquares += value * value
+        }
+        return sumOfSquares.squareRoot()
+    }
+}

--- a/Sources/MacParakeetCore/Services/Diarization/SpeakerEmbedding.swift
+++ b/Sources/MacParakeetCore/Services/Diarization/SpeakerEmbedding.swift
@@ -1,11 +1,8 @@
 import Foundation
 
-/// Where a voice sample was captured.
-///
-/// Embeddings only compare meaningfully inside one domain: the same person
-/// heard over a compressed conference stream and over a local microphone lands
-/// in different regions of the embedding space. Every stored sample carries its
-/// domain so matching can prefer like-for-like references.
+/// Where a voice sample was captured. The same person lands in a different
+/// region of the embedding space over a compressed stream than over a local
+/// microphone, so matching prefers like-for-like references.
 public enum SpeakerCaptureDomain: String, Sendable, Codable, CaseIterable {
     case system
     case microphone
@@ -14,23 +11,14 @@ public enum SpeakerCaptureDomain: String, Sendable, Codable, CaseIterable {
 
 /// Identifies the representation an embedding was produced in.
 ///
-/// Two identifiers rather than one, because the vector FluidAudio hands back is
-/// the VBx *clustering* centroid, not a raw model output. It therefore moves
-/// when the clustering configuration moves, even if the embedding model itself
-/// is untouched — a change that a model-only identifier would miss. See the
-/// 2026-09-09 amendment to `plans/active/2026-07-03-speaker-voiceprints.md`.
+/// Two ids, not one: FluidAudio returns the VBx clustering centroid, which
+/// moves when the clustering configuration moves even if the model does not.
 public struct SpeakerModelIdentity: Sendable, Equatable, Hashable, Codable {
-    /// The embedding model. A mismatch makes two vectors incomparable.
+    /// A mismatch makes two vectors incomparable.
     public let embeddingModelId: String
-    /// The aggregation configuration that produced the centroid. A mismatch is
-    /// comparable but less trustworthy, so callers tighten their threshold.
+    /// A mismatch is comparable but less trusted, so callers tighten tau.
     public let aggregationProfileId: String
 
-    /// - Parameters:
-    ///   - embeddingModelId: the model that produced the vector.
-    ///   - aggregationProfileId: the clustering configuration that shaped the
-    ///     centroid, so a configuration change is visible even when the model
-    ///     is unchanged.
     public init(embeddingModelId: String, aggregationProfileId: String) {
         self.embeddingModelId = embeddingModelId
         self.aggregationProfileId = aggregationProfileId
@@ -39,30 +27,23 @@ public struct SpeakerModelIdentity: Sendable, Equatable, Hashable, Codable {
 
 /// A speaker voice embedding, L2-normalized on construction.
 ///
-/// Normalization happens here and nowhere else. FluidAudio's `speakerDatabase`
-/// vectors are un-normalized centroids, and comparing them with a bare dot
-/// product scales every distance by `‖a‖·‖b‖` — which silently pushes
-/// same-speaker pairs past any calibrated threshold, with no error to observe.
-/// Worse, the centroid norm shrinks as a cluster gets noisier, so the bias is
-/// anti-correlated with signal quality. Normalizing at the boundary makes every
-/// downstream comparison correct by construction.
+/// Normalization happens here and nowhere else: FluidAudio's centroids are
+/// un-normalized, so a bare dot product scales distances by `‖a‖·‖b‖` and
+/// silently pushes same-speaker pairs past tau. The centroid norm also shrinks
+/// as a cluster gets noisier, making the bias worst where accuracy matters most.
 public struct SpeakerEmbedding: Sendable, Equatable {
-    /// WeSpeaker embedding width.
     public static let dimension = 256
-    /// Serialized size: 256 × Float32.
     public static let byteCount = dimension * MemoryLayout<Float32>.size
-    /// Below this, a vector carries no usable direction. FluidAudio emits an
-    /// all-zero centroid when a cluster's responsibility denominator is zero.
+    /// FluidAudio emits an all-zero centroid when a cluster's responsibility
+    /// denominator is zero; below this a vector carries no direction.
     static let minimumNorm: Float = 1e-6
-    /// Tolerance when re-reading a stored vector that is already normalized.
     static let normTolerance: Float = 1e-3
 
     /// Unit-length, `dimension` values.
     public let vector: [Float]
     public let identity: SpeakerModelIdentity
 
-    /// Normalizes `rawVector`. Returns `nil` for the wrong width, non-finite
-    /// values, or a vector too short to carry a direction.
+    /// Returns `nil` for the wrong width, non-finite values, or no direction.
     public init?(rawVector: [Float], identity: SpeakerModelIdentity) {
         guard rawVector.count == Self.dimension else { return nil }
         guard rawVector.allSatisfy(\.isFinite) else { return nil }
@@ -74,12 +55,9 @@ public struct SpeakerEmbedding: Sendable, Equatable {
         self.identity = identity
     }
 
-    /// Rebuilds a vector previously produced by ``data``.
-    ///
-    /// Deliberately does not re-normalize: the bytes are already unit-length, and
-    /// dividing again by a norm that floating-point rounding puts at 0.99999994
-    /// would make a store/load round trip lossy. The norm is validated instead,
-    /// so corruption is rejected rather than silently rescaled.
+    /// Rebuilds a vector produced by ``data``. Does not re-normalize — dividing
+    /// again by a norm rounding puts at 0.99999994 would make the round trip
+    /// lossy — but validates it, so corruption is rejected not rescaled.
     public init?(data: Data, identity: SpeakerModelIdentity) {
         guard data.count == Self.byteCount else { return nil }
 
@@ -108,13 +86,9 @@ public struct SpeakerEmbedding: Sendable, Equatable {
         return output
     }
 
-    /// Cosine distance in FluidAudio's convention: 0 is identical, 1 is
-    /// unrelated. Both operands are unit-length, so the dot product is the
-    /// cosine and no rescaling is needed.
-    ///
-    /// Returns `nil` when the embedding models differ, since vectors from
-    /// different models share no space. A differing aggregation profile is
-    /// comparable and left to the caller's threshold policy.
+    /// Cosine distance, FluidAudio's convention: 0 identical, 1 unrelated.
+    /// `nil` when the embedding models differ, since they share no space; a
+    /// differing aggregation profile is left to the caller's threshold policy.
     public func cosineDistance(to other: SpeakerEmbedding) -> Double? {
         guard identity.embeddingModelId == other.identity.embeddingModelId else { return nil }
 

--- a/Sources/MacParakeetCore/Services/Diarization/SpeakerVoiceprintMatcher.swift
+++ b/Sources/MacParakeetCore/Services/Diarization/SpeakerVoiceprintMatcher.swift
@@ -146,10 +146,11 @@ public enum SpeakerVoiceprintMatcher {
         let scorable = clusters.filter { $0.speechSeconds >= policy.minSpeechSecondsToMatch }
         guard !scorable.isEmpty, !profiles.isEmpty else { return [] }
 
-        // distances[clusterIndex][profileIndex], nil when incomparable.
-        let distances: [[Double?]] = scorable.map { cluster in
-            profiles.map { profile in distance(from: cluster, to: profile, policy: policy) }
+        // matches[clusterIndex][profileIndex], nil when incomparable.
+        let matches: [[ReferenceMatch?]] = scorable.map { cluster in
+            profiles.map { profile in bestReference(from: cluster, to: profile, policy: policy) }
         }
+        let distances: [[Double?]] = matches.map { $0.map(\.?.distance) }
 
         var suggestions: [SpeakerVoiceprintSuggestion] = []
         for (clusterIndex, cluster) in scorable.enumerated() {
@@ -164,7 +165,9 @@ public enum SpeakerVoiceprintMatcher {
             }
 
             let profile = profiles[best.index]
-            guard best.distance <= effectiveTau(cluster: cluster, profile: profile, policy: policy) else { continue }
+            guard let winning = matches[clusterIndex][best.index],
+                  best.distance <= effectiveTau(for: winning, policy: policy)
+            else { continue }
 
             // A side with no second candidate has nothing to be separated
             // from, so its margin is vacuously satisfied. Failing it instead
@@ -186,6 +189,18 @@ public enum SpeakerVoiceprintMatcher {
         return suggestions
     }
 
+    /// The closest reference of a profile, and whether it was aggregated the
+    /// same way as the cluster.
+    public struct ReferenceMatch: Sendable, Equatable {
+        public let distance: Double
+        /// Whether the *winning* reference shares the cluster's aggregation
+        /// profile. Carried alongside the distance rather than derived later,
+        /// because the two must describe the same reference: a profile holding
+        /// both pre- and post-upgrade exemplars would otherwise be scored on an
+        /// old reference while being trusted as if it were current.
+        public let sameAggregation: Bool
+    }
+
     /// Distance from a cluster to a profile: the closest reference, preferring
     /// one captured in the same domain when two are equally close. `nil` when
     /// no reference is comparable at all.
@@ -194,39 +209,44 @@ public enum SpeakerVoiceprintMatcher {
         to profile: SpeakerProfileCandidate,
         policy: SpeakerMatchPolicy
     ) -> Double? {
-        var best: (distance: Double, sameDomain: Bool)?
+        bestReference(from: cluster, to: profile, policy: policy)?.distance
+    }
+
+    /// As `distance`, keeping the winning reference's aggregation identity.
+    public static func bestReference(
+        from cluster: SpeakerClusterObservation,
+        to profile: SpeakerProfileCandidate,
+        policy: SpeakerMatchPolicy
+    ) -> ReferenceMatch? {
+        var best: (distance: Double, sameDomain: Bool, sameAggregation: Bool)?
 
         for reference in profile.references.prefix(policy.maxReferencesPerProfile) {
             guard let distance = cluster.embedding.cosineDistance(to: reference.embedding) else { continue }
             let sameDomain = reference.captureDomain == cluster.captureDomain
+            let sameAggregation = reference.embedding.identity.aggregationProfileId
+                == cluster.embedding.identity.aggregationProfileId
 
             guard let current = best else {
-                best = (distance, sameDomain)
+                best = (distance, sameDomain, sameAggregation)
                 continue
             }
             if distance < current.distance {
-                best = (distance, sameDomain)
+                best = (distance, sameDomain, sameAggregation)
             } else if distance == current.distance, sameDomain, !current.sameDomain {
-                best = (distance, sameDomain)
+                best = (distance, sameDomain, sameAggregation)
             }
         }
 
-        return best?.distance
+        guard let best else { return nil }
+        return ReferenceMatch(distance: best.distance, sameAggregation: best.sameAggregation)
     }
 
-    /// The threshold for this pair. A reference aggregated under a different
+    /// The threshold for one pair. A reference aggregated under a different
     /// clustering configuration is still comparable — Phase 0b leaves a 0.24
     /// gap between the worst true pair and the best impostor, and configuration
     /// drift costs hundredths — but it is trusted less.
-    private static func effectiveTau(
-        cluster: SpeakerClusterObservation,
-        profile: SpeakerProfileCandidate,
-        policy: SpeakerMatchPolicy
-    ) -> Double {
-        let sameAggregation = profile.references.contains {
-            $0.embedding.identity.aggregationProfileId == cluster.embedding.identity.aggregationProfileId
-        }
-        return sameAggregation ? policy.tau : policy.tau - policy.crossAggregationPenalty
+    private static func effectiveTau(for match: ReferenceMatch, policy: SpeakerMatchPolicy) -> Double {
+        match.sameAggregation ? policy.tau : policy.tau - policy.crossAggregationPenalty
     }
 
     private struct Candidate {

--- a/Sources/MacParakeetCore/Services/Diarization/SpeakerVoiceprintMatcher.swift
+++ b/Sources/MacParakeetCore/Services/Diarization/SpeakerVoiceprintMatcher.swift
@@ -2,14 +2,12 @@ import Foundation
 
 /// One detected speaker in one recording, as offered to the matcher.
 public struct SpeakerClusterObservation: Sendable, Equatable {
-    /// The diarizer's id for this run ("S1", "system:S1"). Positional.
+    /// Positional id for this run ("S1", "system:S1").
     public let speakerId: String
     public let embedding: SpeakerEmbedding
     public let speechSeconds: Double
     public let captureDomain: SpeakerCaptureDomain
 
-    /// - Parameter speechSeconds: total clean speech for this cluster; the
-    ///   duration gates read it, and a short cluster is never scored.
     public init(
         speakerId: String,
         embedding: SpeakerEmbedding,
@@ -25,14 +23,10 @@ public struct SpeakerClusterObservation: Sendable, Equatable {
 
 /// An enrolled voice, reduced to what scoring needs.
 public struct SpeakerProfileCandidate: Sendable, Equatable {
-    /// One stored sample of the voice, with the domain it was captured in.
     public struct Reference: Sendable, Equatable {
         public let embedding: SpeakerEmbedding
         public let captureDomain: SpeakerCaptureDomain
 
-        /// - Parameter captureDomain: preferred when two references are
-        ///   equally close, since the same voice sits elsewhere in the space
-        ///   over a compressed stream than over a local microphone.
         public init(embedding: SpeakerEmbedding, captureDomain: SpeakerCaptureDomain) {
             self.embedding = embedding
             self.captureDomain = captureDomain
@@ -43,8 +37,6 @@ public struct SpeakerProfileCandidate: Sendable, Equatable {
     public let displayName: String
     public let references: [Reference]
 
-    /// - Parameter references: scored as a set, closest wins; a profile with
-    ///   none is skipped rather than treated as distant.
     public init(profileId: UUID, displayName: String, references: [Reference]) {
         self.profileId = profileId
         self.displayName = displayName
@@ -52,26 +44,21 @@ public struct SpeakerProfileCandidate: Sendable, Equatable {
     }
 }
 
-/// Thresholds and gates. Injected rather than hard-coded so calibration changes
-/// one value and nothing else, and so tests state their own.
+/// Thresholds and gates, injected so calibration changes values and no logic.
 public struct SpeakerMatchPolicy: Sendable, Equatable {
     /// Accept only below this cosine distance.
     public let tau: Double
     /// Required separation from the runner-up, on both sides.
     public let margin: Double
-    /// A cluster below this much speech is never scored.
     public let minSpeechSecondsToMatch: Double
-    /// A cluster below this much speech may match but never enroll.
+    /// A cluster above the match gate but below this may match, never enroll.
     public let minSpeechSecondsToEnroll: Double
     public let maxReferencesPerProfile: Int
-    /// Tightening applied when the reference was aggregated under a different
-    /// clustering configuration.
+    /// Tightening when the reference came from another clustering config.
     public let crossAggregationPenalty: Double
-    /// Above this, a name-based enrollment is treated as a different person
-    /// rather than merged into the existing profile.
+    /// Above this, a name-based enrollment is a different person, not a merge.
     public let pollutionGuardDistance: Double
 
-    /// Use ``v1`` unless a test or a calibration run needs its own values.
     public init(
         tau: Double,
         margin: Double,
@@ -90,13 +77,9 @@ public struct SpeakerMatchPolicy: Sendable, Equatable {
         self.pollutionGuardDistance = pollutionGuardDistance
     }
 
-    /// Shipping values.
-    ///
-    /// `tau` sits at the bottom of the zero-false-positive plateau measured in
-    /// the Phase 0b calibration (0.25 to 0.45, worst true pair at 0.227) rather
-    /// than mid-plateau: a missed suggestion is a non-event, a false one is the
-    /// worst documented outcome, and the plateau was measured on clean audio
-    /// that real meeting captures will not match.
+    /// `tau` sits at the bottom of the Phase 0b zero-false-positive plateau
+    /// (0.25 to 0.45, worst true pair 0.227), not mid-plateau: that plateau came
+    /// from clean audio, and a false suggestion costs more than a missed one.
     public static let v1 = SpeakerMatchPolicy(
         tau: 0.25,
         margin: 0.10,
@@ -114,12 +97,9 @@ public struct SpeakerVoiceprintSuggestion: Sendable, Equatable {
     public let profileId: UUID
     public let displayName: String
     public let distance: Double
-    /// Next-best distance on either side, whichever is closer — what the
-    /// decision had to beat. `nil` when there was no second candidate at all.
+    /// What the decision had to beat; `nil` when there was no second candidate.
     public let runnerUpDistance: Double?
 
-    /// - Parameter runnerUpDistance: what this decision had to beat, or `nil`
-    ///   when there was no second candidate on either side.
     public init(
         speakerId: String,
         profileId: UUID,
@@ -135,7 +115,7 @@ public struct SpeakerVoiceprintSuggestion: Sendable, Equatable {
     }
 }
 
-/// Decides which enrolled voices to propose for the speakers of one recording.
+/// Decides which enrolled voices to propose for one recording's speakers.
 ///
 /// Stateless and I/O-free on purpose: this is where the feature can be wrong
 /// about a person, so it must be testable on fixtures alone.
@@ -181,9 +161,8 @@ public enum SpeakerVoiceprintMatcher {
             else { continue }
 
             // A side with no second candidate has nothing to be separated
-            // from, so its margin is vacuously satisfied. Failing it instead
-            // would make the very first enrolled voice unsuggestable, which is
-            // precisely when the feature is supposed to earn its keep.
+            // from, so its margin is vacuously satisfied. Failing it would make
+            // the first enrolled voice unsuggestable.
             if let runnerUp = best.runnerUp, runnerUp - best.distance < policy.margin { continue }
             if let runnerUp = bestForProfile.runnerUp, runnerUp - best.distance < policy.margin { continue }
 
@@ -200,15 +179,12 @@ public enum SpeakerVoiceprintMatcher {
         return suggestions
     }
 
-    /// The closest reference of a profile, and whether it was aggregated the
-    /// same way as the cluster.
     public struct ReferenceMatch: Sendable, Equatable {
         public let distance: Double
-        /// Whether the *winning* reference shares the cluster's aggregation
-        /// profile. Carried alongside the distance rather than derived later,
-        /// because the two must describe the same reference: a profile holding
-        /// both pre- and post-upgrade exemplars would otherwise be scored on an
-        /// old reference while being trusted as if it were current.
+        /// Of the *winning* reference, carried alongside the distance so the
+        /// two describe the same one: a profile holding both pre- and
+        /// post-upgrade exemplars would otherwise be scored on an old reference
+        /// while trusted as current.
         public let sameAggregation: Bool
     }
 
@@ -252,10 +228,8 @@ public enum SpeakerVoiceprintMatcher {
         return ReferenceMatch(distance: best.distance, sameAggregation: best.sameAggregation)
     }
 
-    /// The threshold for one pair. A reference aggregated under a different
-    /// clustering configuration is still comparable — Phase 0b leaves a 0.24
-    /// gap between the worst true pair and the best impostor, and configuration
-    /// drift costs hundredths — but it is trusted less.
+    /// A cross-aggregation reference stays comparable — Phase 0b leaves a 0.24
+    /// gap between worst true pair and best impostor — but is trusted less.
     private static func effectiveTau(for match: ReferenceMatch, policy: SpeakerMatchPolicy) -> Double {
         match.sameAggregation ? policy.tau : policy.tau - policy.crossAggregationPenalty
     }
@@ -268,9 +242,8 @@ public enum SpeakerVoiceprintMatcher {
     }
 
     /// Smallest distance in `row`, with the next smallest. An exact tie leaves
-    /// a zero margin, which the caller rejects — no tie-break by index or
-    /// insertion order, because an arbitrary winner is exactly the wrong
-    /// automatic name the design forbids.
+    /// a zero margin, which the caller rejects: no tie-break by index or
+    /// insertion order, since an arbitrary winner is a wrong automatic name.
     private static func bestCandidate(in row: [Double?]) -> Candidate? {
         var best: (index: Int, distance: Double)?
         var runnerUp: Double?

--- a/Sources/MacParakeetCore/Services/Diarization/SpeakerVoiceprintMatcher.swift
+++ b/Sources/MacParakeetCore/Services/Diarization/SpeakerVoiceprintMatcher.swift
@@ -1,0 +1,264 @@
+import Foundation
+
+/// One detected speaker in one recording, as offered to the matcher.
+public struct SpeakerClusterObservation: Sendable, Equatable {
+    /// The diarizer's id for this run ("S1", "system:S1"). Positional.
+    public let speakerId: String
+    public let embedding: SpeakerEmbedding
+    public let speechSeconds: Double
+    public let captureDomain: SpeakerCaptureDomain
+
+    public init(
+        speakerId: String,
+        embedding: SpeakerEmbedding,
+        speechSeconds: Double,
+        captureDomain: SpeakerCaptureDomain
+    ) {
+        self.speakerId = speakerId
+        self.embedding = embedding
+        self.speechSeconds = speechSeconds
+        self.captureDomain = captureDomain
+    }
+}
+
+/// An enrolled voice, reduced to what scoring needs.
+public struct SpeakerProfileCandidate: Sendable, Equatable {
+    public struct Reference: Sendable, Equatable {
+        public let embedding: SpeakerEmbedding
+        public let captureDomain: SpeakerCaptureDomain
+
+        public init(embedding: SpeakerEmbedding, captureDomain: SpeakerCaptureDomain) {
+            self.embedding = embedding
+            self.captureDomain = captureDomain
+        }
+    }
+
+    public let profileId: UUID
+    public let displayName: String
+    public let references: [Reference]
+
+    public init(profileId: UUID, displayName: String, references: [Reference]) {
+        self.profileId = profileId
+        self.displayName = displayName
+        self.references = references
+    }
+}
+
+/// Thresholds and gates. Injected rather than hard-coded so calibration changes
+/// one value and nothing else, and so tests state their own.
+public struct SpeakerMatchPolicy: Sendable, Equatable {
+    /// Accept only below this cosine distance.
+    public let tau: Double
+    /// Required separation from the runner-up, on both sides.
+    public let margin: Double
+    /// A cluster below this much speech is never scored.
+    public let minSpeechSecondsToMatch: Double
+    /// A cluster below this much speech may match but never enroll.
+    public let minSpeechSecondsToEnroll: Double
+    public let maxReferencesPerProfile: Int
+    /// Tightening applied when the reference was aggregated under a different
+    /// clustering configuration.
+    public let crossAggregationPenalty: Double
+    /// Above this, a name-based enrollment is treated as a different person
+    /// rather than merged into the existing profile.
+    public let pollutionGuardDistance: Double
+
+    public init(
+        tau: Double,
+        margin: Double,
+        minSpeechSecondsToMatch: Double,
+        minSpeechSecondsToEnroll: Double,
+        maxReferencesPerProfile: Int,
+        crossAggregationPenalty: Double,
+        pollutionGuardDistance: Double
+    ) {
+        self.tau = tau
+        self.margin = margin
+        self.minSpeechSecondsToMatch = minSpeechSecondsToMatch
+        self.minSpeechSecondsToEnroll = minSpeechSecondsToEnroll
+        self.maxReferencesPerProfile = maxReferencesPerProfile
+        self.crossAggregationPenalty = crossAggregationPenalty
+        self.pollutionGuardDistance = pollutionGuardDistance
+    }
+
+    /// Shipping values.
+    ///
+    /// `tau` sits at the bottom of the zero-false-positive plateau measured in
+    /// the Phase 0b calibration (0.25 to 0.45, worst true pair at 0.227) rather
+    /// than mid-plateau: a missed suggestion is a non-event, a false one is the
+    /// worst documented outcome, and the plateau was measured on clean audio
+    /// that real meeting captures will not match.
+    public static let v1 = SpeakerMatchPolicy(
+        tau: 0.25,
+        margin: 0.10,
+        minSpeechSecondsToMatch: 3,
+        minSpeechSecondsToEnroll: 15,
+        maxReferencesPerProfile: 10,
+        crossAggregationPenalty: 0.05,
+        pollutionGuardDistance: 0.45
+    )
+}
+
+/// A proposed name for a detected speaker. Never applied on its own.
+public struct SpeakerVoiceprintSuggestion: Sendable, Equatable {
+    public let speakerId: String
+    public let profileId: UUID
+    public let displayName: String
+    public let distance: Double
+    /// Next-best distance on either side, whichever is closer — what the
+    /// decision had to beat. `nil` when there was no second candidate at all.
+    public let runnerUpDistance: Double?
+
+    public init(
+        speakerId: String,
+        profileId: UUID,
+        displayName: String,
+        distance: Double,
+        runnerUpDistance: Double?
+    ) {
+        self.speakerId = speakerId
+        self.profileId = profileId
+        self.displayName = displayName
+        self.distance = distance
+        self.runnerUpDistance = runnerUpDistance
+    }
+}
+
+/// Decides which enrolled voices to propose for the speakers of one recording.
+///
+/// Stateless and I/O-free on purpose: this is where the feature can be wrong
+/// about a person, so it must be testable on fixtures alone.
+public enum SpeakerVoiceprintMatcher {
+
+    /// Suggestions for `clusters`, at most one per cluster and one per profile.
+    ///
+    /// A pair is accepted only when it is each other's best match, clears the
+    /// threshold, and beats its runner-up by `margin` **on both sides**. The
+    /// two-sided rule is not belt and braces: the diarizer over-splits, so one
+    /// person routinely yields two clusters, and a cluster-side margin alone
+    /// would let both of them claim the same profile and put two "Sarah"s in
+    /// one transcript.
+    public static func match(
+        clusters: [SpeakerClusterObservation],
+        profiles: [SpeakerProfileCandidate],
+        policy: SpeakerMatchPolicy
+    ) -> [SpeakerVoiceprintSuggestion] {
+        let scorable = clusters.filter { $0.speechSeconds >= policy.minSpeechSecondsToMatch }
+        guard !scorable.isEmpty, !profiles.isEmpty else { return [] }
+
+        // distances[clusterIndex][profileIndex], nil when incomparable.
+        let distances: [[Double?]] = scorable.map { cluster in
+            profiles.map { profile in distance(from: cluster, to: profile, policy: policy) }
+        }
+
+        var suggestions: [SpeakerVoiceprintSuggestion] = []
+        for (clusterIndex, cluster) in scorable.enumerated() {
+            let row = distances[clusterIndex]
+            guard let best = bestCandidate(in: row) else { continue }
+
+            let column = distances.map { $0[best.index] }
+            guard let bestForProfile = bestCandidate(in: column), bestForProfile.index == clusterIndex else {
+                // Some other cluster is a better fit for this profile, so this
+                // pairing is not mutual and nothing is proposed.
+                continue
+            }
+
+            let profile = profiles[best.index]
+            guard best.distance <= effectiveTau(cluster: cluster, profile: profile, policy: policy) else { continue }
+
+            // A side with no second candidate has nothing to be separated
+            // from, so its margin is vacuously satisfied. Failing it instead
+            // would make the very first enrolled voice unsuggestable, which is
+            // precisely when the feature is supposed to earn its keep.
+            if let runnerUp = best.runnerUp, runnerUp - best.distance < policy.margin { continue }
+            if let runnerUp = bestForProfile.runnerUp, runnerUp - best.distance < policy.margin { continue }
+
+            suggestions.append(
+                SpeakerVoiceprintSuggestion(
+                    speakerId: cluster.speakerId,
+                    profileId: profile.profileId,
+                    displayName: profile.displayName,
+                    distance: best.distance,
+                    runnerUpDistance: [best.runnerUp, bestForProfile.runnerUp].compactMap { $0 }.min()
+                )
+            )
+        }
+        return suggestions
+    }
+
+    /// Distance from a cluster to a profile: the closest reference, preferring
+    /// one captured in the same domain when two are equally close. `nil` when
+    /// no reference is comparable at all.
+    public static func distance(
+        from cluster: SpeakerClusterObservation,
+        to profile: SpeakerProfileCandidate,
+        policy: SpeakerMatchPolicy
+    ) -> Double? {
+        var best: (distance: Double, sameDomain: Bool)?
+
+        for reference in profile.references.prefix(policy.maxReferencesPerProfile) {
+            guard let distance = cluster.embedding.cosineDistance(to: reference.embedding) else { continue }
+            let sameDomain = reference.captureDomain == cluster.captureDomain
+
+            guard let current = best else {
+                best = (distance, sameDomain)
+                continue
+            }
+            if distance < current.distance {
+                best = (distance, sameDomain)
+            } else if distance == current.distance, sameDomain, !current.sameDomain {
+                best = (distance, sameDomain)
+            }
+        }
+
+        return best?.distance
+    }
+
+    /// The threshold for this pair. A reference aggregated under a different
+    /// clustering configuration is still comparable — Phase 0b leaves a 0.24
+    /// gap between the worst true pair and the best impostor, and configuration
+    /// drift costs hundredths — but it is trusted less.
+    private static func effectiveTau(
+        cluster: SpeakerClusterObservation,
+        profile: SpeakerProfileCandidate,
+        policy: SpeakerMatchPolicy
+    ) -> Double {
+        let sameAggregation = profile.references.contains {
+            $0.embedding.identity.aggregationProfileId == cluster.embedding.identity.aggregationProfileId
+        }
+        return sameAggregation ? policy.tau : policy.tau - policy.crossAggregationPenalty
+    }
+
+    private struct Candidate {
+        let index: Int
+        let distance: Double
+        /// Second-best distance, or nil when there was only one candidate.
+        let runnerUp: Double?
+    }
+
+    /// Smallest distance in `row`, with the next smallest. An exact tie leaves
+    /// a zero margin, which the caller rejects — no tie-break by index or
+    /// insertion order, because an arbitrary winner is exactly the wrong
+    /// automatic name the design forbids.
+    private static func bestCandidate(in row: [Double?]) -> Candidate? {
+        var best: (index: Int, distance: Double)?
+        var runnerUp: Double?
+
+        for (index, value) in row.enumerated() {
+            guard let value else { continue }
+            if let current = best {
+                if value < current.distance {
+                    runnerUp = current.distance
+                    best = (index, value)
+                } else if runnerUp == nil || value < runnerUp! {
+                    runnerUp = value
+                }
+            } else {
+                best = (index, value)
+            }
+        }
+
+        guard let best else { return nil }
+        return Candidate(index: best.index, distance: best.distance, runnerUp: runnerUp)
+    }
+}

--- a/Sources/MacParakeetCore/Services/Diarization/SpeakerVoiceprintMatcher.swift
+++ b/Sources/MacParakeetCore/Services/Diarization/SpeakerVoiceprintMatcher.swift
@@ -74,7 +74,10 @@ public struct SpeakerMatchPolicy: Sendable, Equatable {
         self.margin = margin
         self.minSpeechSecondsToMatch = minSpeechSecondsToMatch
         self.minSpeechSecondsToEnroll = minSpeechSecondsToEnroll
-        self.maxReferencesPerProfile = maxReferencesPerProfile
+        // Clamped rather than trusted: `prefix` precondition-fails on a
+        // negative length, and no configuration mistake should be able to bring
+        // matching down.
+        self.maxReferencesPerProfile = max(0, maxReferencesPerProfile)
         self.crossAggregationPenalty = crossAggregationPenalty
         self.pollutionGuardDistance = pollutionGuardDistance
     }
@@ -121,6 +124,12 @@ public struct SpeakerVoiceprintSuggestion: Sendable, Equatable {
 ///
 /// Stateless and I/O-free on purpose: this is where the feature can be wrong
 /// about a person, so it must be testable on fixtures alone.
+///
+/// `profileId` and `speakerId` must each be unique across the inputs. Scoring
+/// works on positions and results carry ids, so duplicates would yield two
+/// suggestions naming the same profile. Both callers satisfy this by
+/// construction — profiles come from a primary key, clusters from one
+/// diarization run.
 public enum SpeakerVoiceprintMatcher {
 
     /// Suggestions for `clusters`, at most one per cluster and one per profile.
@@ -165,8 +174,15 @@ public enum SpeakerVoiceprintMatcher {
             // A side with no second candidate has nothing to be separated
             // from, so its margin is vacuously satisfied. Failing it would make
             // the first enrolled voice unsuggestable.
-            if let runnerUp = best.runnerUp, runnerUp - best.distance < policy.margin { continue }
-            if let runnerUp = bestForProfile.runnerUp, runnerUp - best.distance < policy.margin { continue }
+            // Equality is checked before the configurable margin, which a
+            // policy may set to zero: a tie would then pass
+            // `runnerUp - best < 0` and position alone would decide.
+            if let runnerUp = best.runnerUp,
+               runnerUp == best.distance || runnerUp - best.distance < policy.margin
+            { continue }
+            if let runnerUp = bestForProfile.runnerUp,
+               runnerUp == best.distance || runnerUp - best.distance < policy.margin
+            { continue }
 
             suggestions.append(
                 SpeakerVoiceprintSuggestion(

--- a/Sources/MacParakeetCore/Services/Diarization/SpeakerVoiceprintMatcher.swift
+++ b/Sources/MacParakeetCore/Services/Diarization/SpeakerVoiceprintMatcher.swift
@@ -8,6 +8,8 @@ public struct SpeakerClusterObservation: Sendable, Equatable {
     public let speechSeconds: Double
     public let captureDomain: SpeakerCaptureDomain
 
+    /// - Parameter speechSeconds: total clean speech for this cluster; the
+    ///   duration gates read it, and a short cluster is never scored.
     public init(
         speakerId: String,
         embedding: SpeakerEmbedding,
@@ -23,10 +25,14 @@ public struct SpeakerClusterObservation: Sendable, Equatable {
 
 /// An enrolled voice, reduced to what scoring needs.
 public struct SpeakerProfileCandidate: Sendable, Equatable {
+    /// One stored sample of the voice, with the domain it was captured in.
     public struct Reference: Sendable, Equatable {
         public let embedding: SpeakerEmbedding
         public let captureDomain: SpeakerCaptureDomain
 
+        /// - Parameter captureDomain: preferred when two references are
+        ///   equally close, since the same voice sits elsewhere in the space
+        ///   over a compressed stream than over a local microphone.
         public init(embedding: SpeakerEmbedding, captureDomain: SpeakerCaptureDomain) {
             self.embedding = embedding
             self.captureDomain = captureDomain
@@ -37,6 +43,8 @@ public struct SpeakerProfileCandidate: Sendable, Equatable {
     public let displayName: String
     public let references: [Reference]
 
+    /// - Parameter references: scored as a set, closest wins; a profile with
+    ///   none is skipped rather than treated as distant.
     public init(profileId: UUID, displayName: String, references: [Reference]) {
         self.profileId = profileId
         self.displayName = displayName
@@ -63,6 +71,7 @@ public struct SpeakerMatchPolicy: Sendable, Equatable {
     /// rather than merged into the existing profile.
     public let pollutionGuardDistance: Double
 
+    /// Use ``v1`` unless a test or a calibration run needs its own values.
     public init(
         tau: Double,
         margin: Double,
@@ -109,6 +118,8 @@ public struct SpeakerVoiceprintSuggestion: Sendable, Equatable {
     /// decision had to beat. `nil` when there was no second candidate at all.
     public let runnerUpDistance: Double?
 
+    /// - Parameter runnerUpDistance: what this decision had to beat, or `nil`
+    ///   when there was no second candidate on either side.
     public init(
         speakerId: String,
         profileId: UUID,

--- a/Sources/MacParakeetCore/Services/Diarization/SpeakerVoiceprintMatcher.swift
+++ b/Sources/MacParakeetCore/Services/Diarization/SpeakerVoiceprintMatcher.swift
@@ -35,6 +35,8 @@ public struct SpeakerProfileCandidate: Sendable, Equatable {
 
     public let profileId: UUID
     public let displayName: String
+    /// Most relevant first: only the first `maxReferencesPerProfile` are scored,
+    /// so a caller passing oldest-first would hide its newest samples.
     public let references: [Reference]
 
     public init(profileId: UUID, displayName: String, references: [Reference]) {

--- a/Tests/MacParakeetTests/Database/SpeakerProfileRepositoryTests.swift
+++ b/Tests/MacParakeetTests/Database/SpeakerProfileRepositoryTests.swift
@@ -341,6 +341,158 @@ final class SpeakerProfileRepositoryTests: XCTestCase {
         )
     }
 
+    // MARK: The sample cap
+
+    func testASampleBelowTheCapIsSimplyInserted() throws {
+        let profile = try enrolledProfile(named: "Sarah")
+
+        let outcome = try repo.insertExemplar(
+            exemplar(profileId: profile.id, embedding: makeEmbedding(index: 1)),
+            maxPerProfile: 3,
+            evicting: .confirmedSuggestion
+        )
+
+        XCTAssertEqual(outcome, .inserted)
+        XCTAssertEqual(try repo.exemplars(profileId: profile.id).count, 1)
+    }
+
+    func testAtTheCapTheOldestEvictableSampleMakesRoom() throws {
+        let profile = try enrolledProfile(named: "Sarah")
+        let epoch = Date(timeIntervalSince1970: 1_757_000_000)
+        let oldest = exemplar(
+            profileId: profile.id, embedding: makeEmbedding(index: 1),
+            origin: .confirmedSuggestion, createdAt: epoch
+        )
+        try repo.insert(oldest)
+        try repo.insert(
+            exemplar(
+                profileId: profile.id, embedding: makeEmbedding(index: 2),
+                origin: .confirmedSuggestion, createdAt: epoch.addingTimeInterval(60)
+            )
+        )
+
+        let outcome = try repo.insertExemplar(
+            exemplar(profileId: profile.id, embedding: makeEmbedding(index: 3)),
+            maxPerProfile: 2,
+            evicting: .confirmedSuggestion
+        )
+
+        XCTAssertEqual(outcome, .insertedEvicting(oldest.id))
+        let stored = try repo.exemplars(profileId: profile.id)
+        XCTAssertEqual(stored.count, 2)
+        XCTAssertFalse(stored.contains { $0.id == oldest.id })
+    }
+
+    func testAtTheCapWithNothingEvictableTheSampleIsRefused() throws {
+        let profile = try enrolledProfile(named: "Sarah")
+        try repo.insert(exemplar(profileId: profile.id, embedding: makeEmbedding(index: 1)))
+
+        let outcome = try repo.insertExemplar(
+            exemplar(profileId: profile.id, embedding: makeEmbedding(index: 2)),
+            maxPerProfile: 1,
+            evicting: .confirmedSuggestion
+        )
+
+        XCTAssertEqual(outcome, .rejectedProfileFull)
+        XCTAssertEqual(try repo.exemplars(profileId: profile.id).count, 1)
+    }
+
+    func testASecondSampleFromOneRecordingIsRefused() throws {
+        let profile = try enrolledProfile(named: "Sarah")
+        let recording = try savedTranscription()
+        try repo.insert(
+            exemplar(
+                profileId: profile.id, embedding: makeEmbedding(index: 1),
+                sourceTranscriptionId: recording.id
+            )
+        )
+
+        let outcome = try repo.insertExemplar(
+            exemplar(
+                profileId: profile.id, embedding: makeEmbedding(index: 2),
+                sourceTranscriptionId: recording.id
+            ),
+            maxPerProfile: 5,
+            evicting: .confirmedSuggestion
+        )
+
+        XCTAssertEqual(outcome, .rejectedAlreadySampled)
+        XCTAssertEqual(try repo.exemplars(profileId: profile.id).count, 1)
+    }
+
+    /// The cap bounds stored biometric data, so it has to hold when several
+    /// callers offer samples at once. Counting from outside the transaction
+    /// lets each of them read a count below the cap and insert anyway.
+    func testTheCapHoldsUnderConcurrentInserts() throws {
+        let profile = try enrolledProfile(named: "Sarah")
+
+        // Built up front, and only `store` and the samples cross into the
+        // closure: reaching back through `self` for a helper would capture the
+        // test case itself.
+        let store = repo!
+        let samples = (1...12).map {
+            exemplar(profileId: profile.id, embedding: makeEmbedding(index: $0))
+        }
+
+        DispatchQueue.concurrentPerform(iterations: samples.count) { index in
+            _ = try? store.insertExemplar(
+                samples[index],
+                maxPerProfile: 3,
+                evicting: .confirmedSuggestion
+            )
+        }
+
+        XCTAssertEqual(try store.exemplars(profileId: profile.id).count, 3)
+    }
+
+    /// The guard must survive on the capped path too: a sample from another
+    /// embedding model would be stored and counted while scoring against
+    /// nothing.
+    func testTheCappedInsertStillRefusesAnotherEmbeddingModel() throws {
+        let profile = try enrolledProfile(named: "Sarah")
+        let other = SpeakerModelIdentity(
+            embeddingModelId: "other-model", aggregationProfileId: "test-aggregation"
+        )
+        var values = [Float](repeating: 0, count: SpeakerEmbedding.dimension)
+        values[4] = 1
+        let foreign = try XCTUnwrap(SpeakerEmbedding(rawVector: values, identity: other))
+
+        XCTAssertThrowsError(
+            try repo.insertExemplar(
+                exemplar(profileId: profile.id, embedding: foreign),
+                maxPerProfile: 5,
+                evicting: .confirmedSuggestion
+            )
+        )
+        XCTAssertTrue(try repo.exemplars(profileId: profile.id).isEmpty)
+    }
+
+    // MARK: Claiming a name
+
+    /// Two enrollments of one name can both find nothing before either writes,
+    /// so the check belongs in the transaction that creates the profile.
+    func testCreatingAProfileUnderATakenNameIsRefused() throws {
+        try repo.insert(SpeakerProfile(displayName: "Sarah", identity: identity))
+
+        XCTAssertThrowsError(
+            try repo.insert(SpeakerProfile(displayName: "  SARAH ", identity: identity))
+        ) { error in
+            XCTAssertEqual(
+                error as? SpeakerProfileStoreError,
+                .nameAlreadyTaken(normalizedName: "sarah")
+            )
+        }
+        XCTAssertEqual(try repo.profiles().count, 1)
+    }
+
+    func testCreatingAProfileWithABlankNameIsRefused() throws {
+        XCTAssertThrowsError(
+            try repo.insert(SpeakerProfile(displayName: "   ", identity: identity))
+        ) { error in
+            XCTAssertEqual(error as? SpeakerProfileStoreError, .emptyDisplayName)
+        }
+    }
+
     // MARK: Deletion
 
     func testDeletingAProfileRemovesItsExemplarsAndLinks() throws {
@@ -580,16 +732,19 @@ final class SpeakerProfileRepositoryTests: XCTestCase {
         profileId: UUID,
         embedding: SpeakerEmbedding,
         speechSeconds: Double = 20,
-        sourceTranscriptionId: UUID? = nil
+        origin: SpeakerProfileExemplar.Origin = .manualEnrollment,
+        sourceTranscriptionId: UUID? = nil,
+        createdAt: Date = Date()
     ) -> SpeakerProfileExemplar {
         SpeakerProfileExemplar(
             profileId: profileId,
             embedding: embedding,
             speechSeconds: speechSeconds,
             captureDomain: .system,
-            origin: .manualEnrollment,
+            origin: origin,
             sourceTranscriptionId: sourceTranscriptionId,
-            sourceSpeakerId: "S1"
+            sourceSpeakerId: "S1",
+            createdAt: createdAt
         )
     }
 

--- a/Tests/MacParakeetTests/Database/SpeakerProfileRepositoryTests.swift
+++ b/Tests/MacParakeetTests/Database/SpeakerProfileRepositoryTests.swift
@@ -150,6 +150,112 @@ final class SpeakerProfileRepositoryTests: XCTestCase {
         XCTAssertEqual(try repo.exemplars(profileId: profile.id).count, 2)
     }
 
+    func testRejectsAnExemplarFromAnotherEmbeddingModel() throws {
+        let profile = try enrolledProfile(named: "Sarah")
+        let otherModel = SpeakerModelIdentity(
+            embeddingModelId: "other-model",
+            aggregationProfileId: identity.aggregationProfileId
+        )
+        var values = [Float](repeating: 0, count: SpeakerEmbedding.dimension)
+        values[0] = 1
+        let foreign = try XCTUnwrap(SpeakerEmbedding(rawVector: values, identity: otherModel))
+
+        XCTAssertThrowsError(
+            try repo.insert(
+                SpeakerProfileExemplar(
+                    profileId: profile.id,
+                    embedding: foreign,
+                    speechSeconds: 20,
+                    captureDomain: .system,
+                    origin: .manualEnrollment
+                )
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? SpeakerProfileStoreError,
+                .incompatibleEmbeddingModel(profile: "test-model", exemplar: "other-model")
+            )
+        }
+        XCTAssertTrue(try repo.exemplars(profileId: profile.id).isEmpty)
+    }
+
+    /// A differing aggregation profile stays comparable — the matcher tightens
+    /// its threshold for it — so the store must not refuse it.
+    func testAcceptsAnExemplarFromAnotherAggregationProfile() throws {
+        let profile = try enrolledProfile(named: "Sarah")
+        let otherAggregation = SpeakerModelIdentity(
+            embeddingModelId: identity.embeddingModelId,
+            aggregationProfileId: "other-aggregation"
+        )
+        var values = [Float](repeating: 0, count: SpeakerEmbedding.dimension)
+        values[1] = 1
+        let embedding = try XCTUnwrap(SpeakerEmbedding(rawVector: values, identity: otherAggregation))
+
+        XCTAssertNoThrow(
+            try repo.insert(
+                SpeakerProfileExemplar(
+                    profileId: profile.id,
+                    embedding: embedding,
+                    speechSeconds: 20,
+                    captureDomain: .system,
+                    origin: .manualEnrollment
+                )
+            )
+        )
+        XCTAssertEqual(try repo.exemplars(profileId: profile.id).count, 1)
+    }
+
+    func testRejectsAModelChangeOnAProfileThatHasSamples() throws {
+        var profile = try enrolledProfile(named: "Sarah")
+        try repo.insert(exemplar(profileId: profile.id, embedding: makeEmbedding(index: 1)))
+
+        profile = SpeakerProfile(
+            id: profile.id,
+            displayName: profile.displayName,
+            identity: SpeakerModelIdentity(
+                embeddingModelId: "next-model",
+                aggregationProfileId: identity.aggregationProfileId
+            )
+        )
+        XCTAssertThrowsError(try repo.save(profile)) { error in
+            XCTAssertEqual(
+                error as? SpeakerProfileStoreError, .embeddingModelChangeWithExemplars(profile.id)
+            )
+        }
+        XCTAssertEqual(try repo.profile(id: profile.id)?.embeddingModelId, "test-model")
+    }
+
+    func testAModelChangeIsAllowedWhileAProfileHasNoSamples() throws {
+        let profile = try enrolledProfile(named: "Sarah")
+        let migrated = SpeakerProfile(
+            id: profile.id,
+            displayName: profile.displayName,
+            identity: SpeakerModelIdentity(
+                embeddingModelId: "next-model",
+                aggregationProfileId: identity.aggregationProfileId
+            )
+        )
+        XCTAssertNoThrow(try repo.save(migrated))
+        XCTAssertEqual(try repo.profile(id: profile.id)?.embeddingModelId, "next-model")
+    }
+
+    /// The stored key must not depend on the device locale: under a Turkish
+    /// locale, localized folding maps "I" to a dotless i, and every profile
+    /// whose name contains one would become unfindable after a locale change.
+    func testNormalizedKeyIsIndependentOfLocale() throws {
+        let profile = SpeakerProfile(displayName: "ISTANBUL", identity: identity)
+        try repo.save(profile)
+
+        XCTAssertEqual(
+            SpeakerProfile.normalizedName(for: "ISTANBUL"),
+            SpeakerProfile.normalizedName(for: "Istanbul")
+        )
+        XCTAssertEqual(try repo.profile(named: "istanbul")?.id, profile.id)
+        // Localized folding would give "ıstanbul" here; the canonical mapping
+        // must not.
+        XCTAssertEqual(SpeakerProfile.normalizedName(for: "ISTANBUL"), "istanbul")
+    }
+
     // MARK: Deletion
 
     func testDeletingAProfileRemovesItsExemplarsAndLinks() throws {

--- a/Tests/MacParakeetTests/Database/SpeakerProfileRepositoryTests.swift
+++ b/Tests/MacParakeetTests/Database/SpeakerProfileRepositoryTests.swift
@@ -77,9 +77,12 @@ final class SpeakerProfileRepositoryTests: XCTestCase {
                         INSERT INTO speaker_profile_exemplars
                         (id, profileId, vector, speechSeconds, captureDomain, origin,
                          embeddingModelId, aggregationProfileId, createdAt)
-                        VALUES (?, ?, ?, ?, 'system', 'manualEnrollment', 'm', 'a', ?)
+                        VALUES (?, ?, ?, ?, 'system', 'manualEnrollment', ?, ?, ?)
                         """,
-                    arguments: [UUID(), profile.id, Data(repeating: 0, count: 1020), 20.0, Date()]
+                    arguments: [
+                        UUID(), profile.id, Data(repeating: 0, count: 1020), 20.0,
+                        identity.embeddingModelId, identity.aggregationProfileId, Date(),
+                    ]
                 )
             }
         )
@@ -102,11 +105,12 @@ final class SpeakerProfileRepositoryTests: XCTestCase {
                             INSERT INTO speaker_profile_exemplars
                             (id, profileId, vector, speechSeconds, captureDomain, origin,
                              embeddingModelId, aggregationProfileId, createdAt)
-                            VALUES (?, ?, ?, ?, ?, ?, 'm', 'a', ?)
+                            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
                             """,
                         arguments: [
                             UUID(), profile.id, makeEmbedding(index: 1).data, 20.0,
-                            domain, origin, Date(),
+                            domain, origin,
+                            identity.embeddingModelId, identity.aggregationProfileId, Date(),
                         ]
                     )
                 }

--- a/Tests/MacParakeetTests/Database/SpeakerProfileRepositoryTests.swift
+++ b/Tests/MacParakeetTests/Database/SpeakerProfileRepositoryTests.swift
@@ -1,0 +1,350 @@
+import XCTest
+import GRDB
+@testable import MacParakeetCore
+
+final class SpeakerProfileRepositoryTests: XCTestCase {
+    private var dbQueue: DatabaseQueue!
+    private var repo: SpeakerProfileRepository!
+    private var transcriptions: TranscriptionRepository!
+
+    private let identity = SpeakerModelIdentity(
+        embeddingModelId: "test-model",
+        aggregationProfileId: "test-aggregation"
+    )
+
+    override func setUp() async throws {
+        let manager = try DatabaseManager()
+        dbQueue = manager.dbQueue
+        repo = SpeakerProfileRepository(dbQueue: manager.dbQueue)
+        transcriptions = TranscriptionRepository(dbQueue: manager.dbQueue)
+    }
+
+    // MARK: Schema
+
+    func testMigrationCreatesTheThreeVoiceprintTables() throws {
+        try dbQueue.read { db in
+            XCTAssertTrue(try db.tableExists("speaker_profiles"))
+            XCTAssertTrue(try db.tableExists("speaker_profile_exemplars"))
+            XCTAssertTrue(try db.tableExists("speaker_profile_links"))
+
+            XCTAssertEqual(
+                Set(try db.columns(in: "speaker_profiles").map(\.name)),
+                [
+                    "id", "displayName", "embeddingModelId", "aggregationProfileId",
+                    "createdAt", "updatedAt", "lastMatchedAt", "lastEvaluatedAt",
+                    "lastEvaluatedDistance",
+                ]
+            )
+            XCTAssertEqual(
+                Set(try db.columns(in: "speaker_profile_exemplars").map(\.name)),
+                [
+                    "id", "profileId", "vector", "speechSeconds", "captureDomain",
+                    "origin", "embeddingModelId", "aggregationProfileId",
+                    "sourceTranscriptionId", "sourceSpeakerId", "createdAt",
+                ]
+            )
+            XCTAssertEqual(
+                Set(try db.columns(in: "speaker_profile_links").map(\.name)),
+                [
+                    "transcriptionId", "speakerId", "transcriptFingerprint", "profileId",
+                    "status", "distance", "runnerUpDistance", "createdAt", "updatedAt",
+                ]
+            )
+        }
+    }
+
+    // MARK: Round trip
+
+    func testExemplarVectorRoundTripsBitExact() throws {
+        let profile = try enrolledProfile(named: "Sarah")
+        let embedding = makeEmbedding(index: 7)
+        try repo.insert(exemplar(profileId: profile.id, embedding: embedding))
+
+        let stored = try XCTUnwrap(try repo.exemplars(profileId: profile.id).first)
+        XCTAssertEqual(stored.vector.count, 1024)
+        XCTAssertEqual(try XCTUnwrap(stored.embedding).vector, embedding.vector)
+        XCTAssertEqual(stored.identity, identity)
+    }
+
+    // MARK: Constraints
+
+    func testRejectsVectorOfTheWrongLength() throws {
+        let profile = try enrolledProfile(named: "Sarah")
+        XCTAssertThrowsError(
+            try dbQueue.write { db in
+                try db.execute(
+                    sql: """
+                        INSERT INTO speaker_profile_exemplars
+                        (id, profileId, vector, speechSeconds, captureDomain, origin,
+                         embeddingModelId, aggregationProfileId, createdAt)
+                        VALUES (?, ?, ?, ?, 'system', 'manualEnrollment', 'm', 'a', ?)
+                        """,
+                    arguments: [UUID(), profile.id, Data(repeating: 0, count: 1020), 20.0, Date()]
+                )
+            }
+        )
+    }
+
+    func testRejectsNonPositiveSpeechDuration() throws {
+        let profile = try enrolledProfile(named: "Sarah")
+        XCTAssertThrowsError(
+            try repo.insert(exemplar(profileId: profile.id, embedding: makeEmbedding(index: 1), speechSeconds: 0))
+        )
+    }
+
+    func testRejectsUnknownCaptureDomainOrOrigin() throws {
+        let profile = try enrolledProfile(named: "Sarah")
+        for (domain, origin) in [("hologram", "manualEnrollment"), ("system", "osmosis")] {
+            XCTAssertThrowsError(
+                try dbQueue.write { db in
+                    try db.execute(
+                        sql: """
+                            INSERT INTO speaker_profile_exemplars
+                            (id, profileId, vector, speechSeconds, captureDomain, origin,
+                             embeddingModelId, aggregationProfileId, createdAt)
+                            VALUES (?, ?, ?, ?, ?, ?, 'm', 'a', ?)
+                            """,
+                        arguments: [
+                            UUID(), profile.id, makeEmbedding(index: 1).data, 20.0,
+                            domain, origin, Date(),
+                        ]
+                    )
+                }
+            )
+        }
+    }
+
+    func testNamesAreUniqueCaseInsensitively() throws {
+        _ = try enrolledProfile(named: "Sarah")
+        XCTAssertThrowsError(try repo.save(SpeakerProfile(displayName: "sarah", identity: identity)))
+    }
+
+    func testOneExemplarPerProfilePerRecording() throws {
+        let profile = try enrolledProfile(named: "Sarah")
+        let transcription = try savedTranscription()
+
+        try repo.insert(
+            exemplar(
+                profileId: profile.id,
+                embedding: makeEmbedding(index: 1),
+                sourceTranscriptionId: transcription.id
+            )
+        )
+        XCTAssertThrowsError(
+            try repo.insert(
+                exemplar(
+                    profileId: profile.id,
+                    embedding: makeEmbedding(index: 2),
+                    sourceTranscriptionId: transcription.id
+                )
+            )
+        )
+    }
+
+    /// SQLite treats NULLs as distinct in a UNIQUE constraint, which is what we
+    /// want: exemplars whose recording was deleted must not start colliding.
+    func testExemplarsWithoutARecordingDoNotCollide() throws {
+        let profile = try enrolledProfile(named: "Sarah")
+        try repo.insert(exemplar(profileId: profile.id, embedding: makeEmbedding(index: 1)))
+        try repo.insert(exemplar(profileId: profile.id, embedding: makeEmbedding(index: 2)))
+        XCTAssertEqual(try repo.exemplars(profileId: profile.id).count, 2)
+    }
+
+    // MARK: Deletion
+
+    func testDeletingAProfileRemovesItsExemplarsAndLinks() throws {
+        let profile = try enrolledProfile(named: "Sarah")
+        let transcription = try savedTranscription()
+        try repo.insert(
+            exemplar(
+                profileId: profile.id,
+                embedding: makeEmbedding(index: 1),
+                sourceTranscriptionId: transcription.id
+            )
+        )
+        try repo.save(link(transcriptionId: transcription.id, profileId: profile.id))
+
+        XCTAssertTrue(try repo.deleteProfile(id: profile.id))
+
+        try dbQueue.read { db in
+            XCTAssertEqual(try SpeakerProfileExemplar.fetchCount(db), 0)
+            XCTAssertEqual(try SpeakerProfileLink.fetchCount(db), 0)
+        }
+        // The recording itself is untouched: deleting a voiceprint never
+        // rewrites the user's transcripts.
+        XCTAssertNotNil(try transcriptions.fetch(id: transcription.id))
+    }
+
+    func testDeletingARecordingKeepsTheExemplarButClearsItsSource() throws {
+        let profile = try enrolledProfile(named: "Sarah")
+        let transcription = try savedTranscription()
+        try repo.insert(
+            exemplar(
+                profileId: profile.id,
+                embedding: makeEmbedding(index: 1),
+                sourceTranscriptionId: transcription.id
+            )
+        )
+
+        XCTAssertTrue(try transcriptions.delete(id: transcription.id))
+
+        let stored = try XCTUnwrap(try repo.exemplars(profileId: profile.id).first)
+        XCTAssertNil(stored.sourceTranscriptionId)
+        XCTAssertNotNil(stored.embedding)
+    }
+
+    func testDeletingARecordingRemovesItsLinks() throws {
+        let profile = try enrolledProfile(named: "Sarah")
+        let transcription = try savedTranscription()
+        try repo.save(link(transcriptionId: transcription.id, profileId: profile.id))
+
+        XCTAssertTrue(try transcriptions.delete(id: transcription.id))
+
+        try dbQueue.read { db in
+            XCTAssertEqual(try SpeakerProfileLink.fetchCount(db), 0)
+        }
+    }
+
+    func testDeleteAllProfilesEmptiesEveryVoiceprintTable() throws {
+        let first = try enrolledProfile(named: "Sarah")
+        let second = try enrolledProfile(named: "Dan")
+        let transcription = try savedTranscription()
+        try repo.insert(
+            exemplar(
+                profileId: first.id,
+                embedding: makeEmbedding(index: 1),
+                sourceTranscriptionId: transcription.id
+            )
+        )
+        try repo.save(link(transcriptionId: transcription.id, profileId: second.id))
+
+        try repo.deleteAllProfiles()
+
+        try dbQueue.read { db in
+            XCTAssertEqual(try SpeakerProfile.fetchCount(db), 0)
+            XCTAssertEqual(try SpeakerProfileExemplar.fetchCount(db), 0)
+            XCTAssertEqual(try SpeakerProfileLink.fetchCount(db), 0)
+        }
+        XCTAssertNotNil(try transcriptions.fetch(id: transcription.id))
+    }
+
+    func testDeleteExemplarRemovesOnlyThatSample() throws {
+        let profile = try enrolledProfile(named: "Sarah")
+        try repo.insert(exemplar(profileId: profile.id, embedding: makeEmbedding(index: 1)))
+        let second = exemplar(profileId: profile.id, embedding: makeEmbedding(index: 2))
+        try repo.insert(second)
+
+        XCTAssertTrue(try repo.deleteExemplar(id: second.id))
+        XCTAssertEqual(try repo.exemplars(profileId: profile.id).count, 1)
+        XCTAssertNotNil(try repo.profile(id: profile.id))
+    }
+
+    // MARK: Lookups
+
+    func testProfileLookupByNameIgnoresCase() throws {
+        let profile = try enrolledProfile(named: "Sarah")
+        XCTAssertEqual(try repo.profile(named: "sarah")?.id, profile.id)
+        XCTAssertEqual(try repo.profile(named: "SARAH")?.id, profile.id)
+        XCTAssertNil(try repo.profile(named: "Dan"))
+    }
+
+    func testExemplarsByProfileGroupsEveryProfile() throws {
+        let first = try enrolledProfile(named: "Sarah")
+        let second = try enrolledProfile(named: "Dan")
+        try repo.insert(exemplar(profileId: first.id, embedding: makeEmbedding(index: 1)))
+        try repo.insert(exemplar(profileId: first.id, embedding: makeEmbedding(index: 2)))
+        try repo.insert(exemplar(profileId: second.id, embedding: makeEmbedding(index: 3)))
+
+        let grouped = try repo.exemplarsByProfile()
+        XCTAssertEqual(grouped[first.id]?.count, 2)
+        XCTAssertEqual(grouped[second.id]?.count, 1)
+    }
+
+    func testLinksAreScopedToTheirFingerprint() throws {
+        let profile = try enrolledProfile(named: "Sarah")
+        let transcription = try savedTranscription()
+        try repo.save(
+            link(transcriptionId: transcription.id, profileId: profile.id, fingerprint: "before")
+        )
+
+        XCTAssertEqual(
+            try repo.links(transcriptionId: transcription.id, fingerprint: "before").count,
+            1
+        )
+        // After re-diarization the fingerprint changes and old decisions no
+        // longer apply, so a stale dismissal cannot suppress a fresh suggestion.
+        XCTAssertTrue(
+            try repo.links(transcriptionId: transcription.id, fingerprint: "after").isEmpty
+        )
+    }
+
+    func testSavingALinkTwiceUpdatesItInPlace() throws {
+        let profile = try enrolledProfile(named: "Sarah")
+        let transcription = try savedTranscription()
+        try repo.save(link(transcriptionId: transcription.id, profileId: profile.id))
+
+        var updated = link(transcriptionId: transcription.id, profileId: profile.id)
+        updated.status = .dismissed
+        try repo.save(updated)
+
+        let stored = try repo.links(transcriptionId: transcription.id, fingerprint: "fingerprint")
+        XCTAssertEqual(stored.count, 1)
+        XCTAssertEqual(stored.first?.status, .dismissed)
+    }
+
+    // MARK: Helpers
+
+    private func makeEmbedding(index: Int) -> SpeakerEmbedding {
+        var values = [Float](repeating: 0, count: SpeakerEmbedding.dimension)
+        values[index] = 1
+        guard let embedding = SpeakerEmbedding(rawVector: values, identity: identity) else {
+            preconditionFailure("fixture vector must be valid")
+        }
+        return embedding
+    }
+
+    private func enrolledProfile(named name: String) throws -> SpeakerProfile {
+        let profile = SpeakerProfile(displayName: name, identity: identity)
+        try repo.save(profile)
+        return profile
+    }
+
+    private func savedTranscription() throws -> Transcription {
+        let transcription = Transcription(fileName: "meeting.wav", sourceType: .meeting)
+        try transcriptions.save(transcription)
+        return transcription
+    }
+
+    private func exemplar(
+        profileId: UUID,
+        embedding: SpeakerEmbedding,
+        speechSeconds: Double = 20,
+        sourceTranscriptionId: UUID? = nil
+    ) -> SpeakerProfileExemplar {
+        SpeakerProfileExemplar(
+            profileId: profileId,
+            embedding: embedding,
+            speechSeconds: speechSeconds,
+            captureDomain: .system,
+            origin: .manualEnrollment,
+            sourceTranscriptionId: sourceTranscriptionId,
+            sourceSpeakerId: "S1"
+        )
+    }
+
+    private func link(
+        transcriptionId: UUID,
+        profileId: UUID,
+        fingerprint: String = "fingerprint"
+    ) -> SpeakerProfileLink {
+        SpeakerProfileLink(
+            transcriptionId: transcriptionId,
+            speakerId: "system:S1",
+            transcriptFingerprint: fingerprint,
+            profileId: profileId,
+            status: .suggested,
+            distance: 0.12,
+            runnerUpDistance: 0.44
+        )
+    }
+}

--- a/Tests/MacParakeetTests/Database/SpeakerProfileRepositoryTests.swift
+++ b/Tests/MacParakeetTests/Database/SpeakerProfileRepositoryTests.swift
@@ -256,6 +256,87 @@ final class SpeakerProfileRepositoryTests: XCTestCase {
         XCTAssertEqual(SpeakerProfile.normalizedName(for: "ISTANBUL"), "istanbul")
     }
 
+    func testRejectsAProfileWhoseNameNormalizesToNothing() throws {
+        for blank in ["", "   ", "\n\t "] {
+            XCTAssertThrowsError(
+                try repo.save(SpeakerProfile(displayName: blank, identity: identity))
+            ) { error in
+                XCTAssertEqual(error as? SpeakerProfileStoreError, .emptyDisplayName)
+            }
+        }
+        XCTAssertTrue(try repo.profiles().isEmpty)
+    }
+
+    func testASuggestionCannotOverwriteAConfirmedDecision() throws {
+        let profile = try enrolledProfile(named: "Sarah")
+        let transcription = try savedTranscription()
+
+        var confirmed = link(transcriptionId: transcription.id, profileId: profile.id)
+        confirmed.status = .confirmed
+        try repo.save(confirmed)
+
+        XCTAssertThrowsError(
+            try repo.save(link(transcriptionId: transcription.id, profileId: profile.id))
+        ) { error in
+            XCTAssertEqual(
+                error as? SpeakerProfileStoreError,
+                .terminalDecisionAlreadyRecorded(status: .confirmed)
+            )
+        }
+        XCTAssertEqual(
+            try repo.links(transcriptionId: transcription.id, fingerprint: "fingerprint")
+                .map(\.status),
+            [.confirmed]
+        )
+    }
+
+    func testASuggestionCannotOverwriteADismissedDecision() throws {
+        let profile = try enrolledProfile(named: "Sarah")
+        let transcription = try savedTranscription()
+
+        var dismissed = link(transcriptionId: transcription.id, profileId: profile.id)
+        dismissed.status = .dismissed
+        try repo.save(dismissed)
+
+        XCTAssertThrowsError(
+            try repo.save(link(transcriptionId: transcription.id, profileId: profile.id))
+        )
+    }
+
+    func testASuggestionStillBecomesTerminal() throws {
+        let profile = try enrolledProfile(named: "Sarah")
+        let transcription = try savedTranscription()
+        try repo.save(link(transcriptionId: transcription.id, profileId: profile.id))
+
+        var confirmed = link(transcriptionId: transcription.id, profileId: profile.id)
+        confirmed.status = .confirmed
+        XCTAssertNoThrow(try repo.save(confirmed))
+        XCTAssertEqual(
+            try repo.links(transcriptionId: transcription.id, fingerprint: "fingerprint")
+                .map(\.status),
+            [.confirmed]
+        )
+    }
+
+    /// The composite foreign key is what makes the model invariant structural
+    /// rather than merely enforced in Swift.
+    func testTheDatabaseItselfRefusesAMismatchedExemplarModel() throws {
+        let profile = try enrolledProfile(named: "Sarah")
+        XCTAssertThrowsError(
+            try dbQueue.write { db in
+                try db.execute(
+                    sql: """
+                        INSERT INTO speaker_profile_exemplars
+                        (id, profileId, vector, speechSeconds, captureDomain, origin,
+                         embeddingModelId, aggregationProfileId, createdAt)
+                        VALUES (?, ?, ?, ?, 'system', 'manualEnrollment', 'other-model', 'a', ?)
+                        """,
+                    arguments: [UUID(), profile.id, makeEmbedding(index: 1).data, 20.0, Date()]
+                )
+            }
+        )
+    }
+
     // MARK: Deletion
 
     func testDeletingAProfileRemovesItsExemplarsAndLinks() throws {

--- a/Tests/MacParakeetTests/Database/SpeakerProfileRepositoryTests.swift
+++ b/Tests/MacParakeetTests/Database/SpeakerProfileRepositoryTests.swift
@@ -30,7 +30,7 @@ final class SpeakerProfileRepositoryTests: XCTestCase {
             XCTAssertEqual(
                 Set(try db.columns(in: "speaker_profiles").map(\.name)),
                 [
-                    "id", "displayName", "embeddingModelId", "aggregationProfileId",
+                    "id", "displayName", "normalizedName", "embeddingModelId", "aggregationProfileId",
                     "createdAt", "updatedAt", "lastMatchedAt", "lastEvaluatedAt",
                     "lastEvaluatedDistance",
                 ]
@@ -285,6 +285,32 @@ final class SpeakerProfileRepositoryTests: XCTestCase {
         try repo.save(profile)
         XCTAssertEqual(try repo.profile(named: "josé")?.id, profile.id)
         XCTAssertEqual(try repo.profile(named: "JOSÉ")?.id, profile.id)
+    }
+
+    /// The constraint and the lookup must agree on what one name is, otherwise
+    /// two rows can exist that a lookup considers equal and picks between at
+    /// random.
+    func testNonAsciiCaseVariantsCannotBothBeStored() throws {
+        try repo.save(SpeakerProfile(displayName: "José", identity: identity))
+        XCTAssertThrowsError(try repo.save(SpeakerProfile(displayName: "JOSÉ", identity: identity)))
+    }
+
+    func testLookupIgnoresSurroundingWhitespace() throws {
+        let profile = SpeakerProfile(displayName: "Sarah", identity: identity)
+        try repo.save(profile)
+        XCTAssertEqual(try repo.profile(named: "  sarah  ")?.id, profile.id)
+    }
+
+    /// Accents are typography; dropping them would be a guess about identity.
+    /// Two colleagues named Jose and José stay two people, and the enrollment
+    /// guard is what catches a genuine name clash, by voice.
+    func testAccentsDistinguishNames() throws {
+        let plain = SpeakerProfile(displayName: "Jose", identity: identity)
+        let accented = SpeakerProfile(displayName: "José", identity: identity)
+        try repo.save(plain)
+        try repo.save(accented)
+        XCTAssertEqual(try repo.profile(named: "jose")?.id, plain.id)
+        XCTAssertEqual(try repo.profile(named: "josé")?.id, accented.id)
     }
 
     func testUpdatingALinkKeepsItsOriginalCreationTime() throws {

--- a/Tests/MacParakeetTests/Database/SpeakerProfileRepositoryTests.swift
+++ b/Tests/MacParakeetTests/Database/SpeakerProfileRepositoryTests.swift
@@ -278,6 +278,37 @@ final class SpeakerProfileRepositoryTests: XCTestCase {
         )
     }
 
+    func testProfileLookupHandlesNonAsciiCase() throws {
+        // SQLite's NOCASE folds only ASCII, so this is the case that would
+        // silently create a second profile for the same person.
+        let profile = SpeakerProfile(displayName: "José", identity: identity)
+        try repo.save(profile)
+        XCTAssertEqual(try repo.profile(named: "josé")?.id, profile.id)
+        XCTAssertEqual(try repo.profile(named: "JOSÉ")?.id, profile.id)
+    }
+
+    func testUpdatingALinkKeepsItsOriginalCreationTime() throws {
+        let profile = try enrolledProfile(named: "Sarah")
+        let transcription = try savedTranscription()
+        let suggestedAt = Date(timeIntervalSince1970: 1_000_000)
+
+        var suggestion = link(transcriptionId: transcription.id, profileId: profile.id)
+        suggestion.createdAt = suggestedAt
+        suggestion.updatedAt = suggestedAt
+        try repo.save(suggestion)
+
+        var confirmation = link(transcriptionId: transcription.id, profileId: profile.id)
+        confirmation.status = .confirmed
+        try repo.save(confirmation)
+
+        let stored = try XCTUnwrap(
+            try repo.links(transcriptionId: transcription.id, fingerprint: "fingerprint").first
+        )
+        XCTAssertEqual(stored.status, .confirmed)
+        XCTAssertEqual(stored.createdAt.timeIntervalSince1970, suggestedAt.timeIntervalSince1970, accuracy: 0.001)
+        XCTAssertGreaterThan(stored.updatedAt, suggestedAt)
+    }
+
     func testSavingALinkTwiceUpdatesItInPlace() throws {
         let profile = try enrolledProfile(named: "Sarah")
         let transcription = try savedTranscription()

--- a/Tests/MacParakeetTests/Database/SpeakerProfileRepositoryTests.swift
+++ b/Tests/MacParakeetTests/Database/SpeakerProfileRepositoryTests.swift
@@ -295,6 +295,19 @@ final class SpeakerProfileRepositoryTests: XCTestCase {
         XCTAssertThrowsError(try repo.save(SpeakerProfile(displayName: "JOSÉ", identity: identity)))
     }
 
+    func testRenamingAProfileMovesItsLookupKey() throws {
+        var profile = SpeakerProfile(displayName: "Sarah", identity: identity)
+        try repo.save(profile)
+
+        profile.displayName = "Sarah Chen"
+        try repo.save(profile)
+
+        XCTAssertEqual(try repo.profile(named: "sarah chen")?.id, profile.id)
+        XCTAssertNil(try repo.profile(named: "Sarah"))
+        // The old key must not keep enforcing uniqueness either.
+        XCTAssertNoThrow(try repo.save(SpeakerProfile(displayName: "Sarah", identity: identity)))
+    }
+
     func testLookupIgnoresSurroundingWhitespace() throws {
         let profile = SpeakerProfile(displayName: "Sarah", identity: identity)
         try repo.save(profile)

--- a/Tests/MacParakeetTests/Services/Diarization/DiarizationServiceEmbeddingTests.swift
+++ b/Tests/MacParakeetTests/Services/Diarization/DiarizationServiceEmbeddingTests.swift
@@ -146,6 +146,17 @@ final class DiarizationServiceEmbeddingTests: XCTestCase {
         XCTAssertNotEqual(baseIdentity.aggregationProfileId, alteredIdentity.aggregationProfileId)
     }
 
+    func testAggregationProfileChangesWithVBxRefinement() {
+        let base = DiarizationService.highAccuracyConfig
+        var altered = base
+        altered.vbx.maxIterations += 1
+
+        XCTAssertNotEqual(
+            DiarizationService.modelIdentity(for: base).aggregationProfileId,
+            DiarizationService.modelIdentity(for: altered).aggregationProfileId
+        )
+    }
+
     /// A per-run speaker count is a caller hint, not a different representation:
     /// folding it into the identity would make a profile enrolled under a hint
     /// incomparable with the same voice heard without one.

--- a/Tests/MacParakeetTests/Services/Diarization/DiarizationServiceEmbeddingTests.swift
+++ b/Tests/MacParakeetTests/Services/Diarization/DiarizationServiceEmbeddingTests.swift
@@ -118,6 +118,20 @@ final class DiarizationServiceEmbeddingTests: XCTestCase {
         XCTAssertTrue(result.speakerEmbeddings.isEmpty)
     }
 
+    /// The gates are in seconds and everything else here is in milliseconds, so
+    /// the conversion lives in one tested place rather than at each call site.
+    func testSpeechSecondsConvertsFromMilliseconds() {
+        let result = MacParakeetDiarizationResult(
+            segments: [],
+            speakerCount: 1,
+            speakers: [SpeakerInfo(id: "S1", label: "Speaker 1")],
+            speechMsBySpeaker: ["S1": 12_500]
+        )
+
+        XCTAssertEqual(result.speechSeconds(forSpeaker: "S1"), 12.5, accuracy: 1e-9)
+        XCTAssertEqual(result.speechSeconds(forSpeaker: "S2"), 0)
+    }
+
     // MARK: Model identity
 
     func testAggregationProfileChangesWithClusteringConfiguration() {

--- a/Tests/MacParakeetTests/Services/Diarization/DiarizationServiceEmbeddingTests.swift
+++ b/Tests/MacParakeetTests/Services/Diarization/DiarizationServiceEmbeddingTests.swift
@@ -1,0 +1,189 @@
+import XCTest
+import FluidAudio
+@testable import MacParakeetCore
+
+/// Covers what the diarization adapter now carries out of FluidAudio:
+/// per-speaker embeddings, rekeyed onto our stable ids, plus speech durations.
+final class DiarizationServiceEmbeddingTests: XCTestCase {
+
+    private static let identity = SpeakerModelIdentity(
+        embeddingModelId: "test-model",
+        aggregationProfileId: "test-aggregation"
+    )
+
+    private func unitVector(_ index: Int, scale: Float = 1) -> [Float] {
+        var values = [Float](repeating: 0, count: SpeakerEmbedding.dimension)
+        values[index] = scale
+        return values
+    }
+
+    // MARK: Rekeying
+
+    /// FluidAudio numbers clusters by cluster index; we renumber by who speaks
+    /// first. Both use the "S1", "S2" shape, so carrying the database keys over
+    /// untouched would attach one speaker's voice to another's label without
+    /// any type error to catch it.
+    func testEmbeddingsFollowTheChronologicalRemapNotTheFluidAudioKeys() throws {
+        let embeddings = DiarizationService.speakerEmbeddings(
+            from: ["S1": unitVector(0), "S2": unitVector(1)],
+            idMapping: ["S2": "S1", "S1": "S2"],
+            identity: Self.identity
+        )
+
+        XCTAssertEqual(embeddings.count, 2)
+        XCTAssertEqual(try XCTUnwrap(embeddings["S1"]).vector, unitVector(1))
+        XCTAssertEqual(try XCTUnwrap(embeddings["S2"]).vector, unitVector(0))
+    }
+
+    func testEmbeddingsAreNormalizedOnTheWayOut() throws {
+        let embeddings = DiarizationService.speakerEmbeddings(
+            from: ["S1": unitVector(0, scale: 0.42)],
+            idMapping: ["S1": "S1"],
+            identity: Self.identity
+        )
+
+        XCTAssertEqual(try XCTUnwrap(embeddings["S1"]).vector, unitVector(0))
+    }
+
+    func testUnmappedSpeakersAreDropped() {
+        let embeddings = DiarizationService.speakerEmbeddings(
+            from: ["S1": unitVector(0), "S9": unitVector(1)],
+            idMapping: ["S1": "S1"],
+            identity: Self.identity
+        )
+
+        XCTAssertEqual(Set(embeddings.keys), ["S1"])
+    }
+
+    func testZeroVectorSpeakerIsDroppedFromTheDictionary() {
+        let embeddings = DiarizationService.speakerEmbeddings(
+            from: [
+                "S1": [Float](repeating: 0, count: SpeakerEmbedding.dimension),
+                "S2": unitVector(1),
+            ],
+            idMapping: ["S1": "S1", "S2": "S2"],
+            identity: Self.identity
+        )
+
+        XCTAssertEqual(Set(embeddings.keys), ["S2"])
+    }
+
+    func testMissingSpeakerDatabaseYieldsNoEmbeddings() {
+        XCTAssertTrue(
+            DiarizationService.speakerEmbeddings(
+                from: nil,
+                idMapping: ["S1": "S1"],
+                identity: Self.identity
+            ).isEmpty
+        )
+    }
+
+    // MARK: End to end through the service
+
+    func testDiarizeSurfacesEmbeddingsAndDurationsWithoutChangingLabels() async throws {
+        let service = makeService(
+            result: DiarizationResult(
+                segments: [
+                    // FluidAudio's "S2" speaks first, so it becomes our "S1".
+                    segment(speakerId: "S2", from: 0, to: 4),
+                    segment(speakerId: "S1", from: 4, to: 10),
+                    segment(speakerId: "S2", from: 10, to: 12),
+                ],
+                speakerDatabase: ["S1": unitVector(0), "S2": unitVector(1, scale: 0.6)]
+            )
+        )
+
+        let result = try await service.diarize(audioURL: URL(fileURLWithPath: "/tmp/meeting.wav"))
+
+        XCTAssertEqual(result.speakers.map(\.id), ["S1", "S2"])
+        XCTAssertEqual(result.speakers.map(\.label), ["Speaker 1", "Speaker 2"])
+        XCTAssertEqual(result.speakerCount, 2)
+
+        // 4 s + 2 s for the first speaker, 6 s for the second.
+        XCTAssertEqual(result.speechMsBySpeaker, ["S1": 6000, "S2": 6000])
+
+        XCTAssertEqual(try XCTUnwrap(result.speakerEmbeddings["S1"]).vector, unitVector(1))
+        XCTAssertEqual(try XCTUnwrap(result.speakerEmbeddings["S2"]).vector, unitVector(0))
+    }
+
+    func testDiarizeWithoutEmbeddingsStillReturnsSegments() async throws {
+        let service = makeService(
+            result: DiarizationResult(segments: [segment(speakerId: "S1", from: 0, to: 3)])
+        )
+
+        let result = try await service.diarize(audioURL: URL(fileURLWithPath: "/tmp/meeting.wav"))
+
+        XCTAssertEqual(result.segments.count, 1)
+        XCTAssertEqual(result.speechMsBySpeaker, ["S1": 3000])
+        XCTAssertTrue(result.speakerEmbeddings.isEmpty)
+    }
+
+    // MARK: Model identity
+
+    func testAggregationProfileChangesWithClusteringConfiguration() {
+        let base = DiarizationService.highAccuracyConfig
+        var altered = base
+        altered.clustering.threshold += 0.1
+
+        let baseIdentity = DiarizationService.modelIdentity(for: base)
+        let alteredIdentity = DiarizationService.modelIdentity(for: altered)
+
+        XCTAssertEqual(baseIdentity.embeddingModelId, alteredIdentity.embeddingModelId)
+        XCTAssertNotEqual(baseIdentity.aggregationProfileId, alteredIdentity.aggregationProfileId)
+    }
+
+    /// A per-run speaker count is a caller hint, not a different representation:
+    /// folding it into the identity would make a profile enrolled under a hint
+    /// incomparable with the same voice heard without one.
+    func testAggregationProfileIgnoresPerRunSpeakerConstraints() {
+        let base = DiarizationService.highAccuracyConfig
+        let constrained = DiarizationService.applying(.exact(3), to: base)
+
+        XCTAssertEqual(
+            DiarizationService.modelIdentity(for: base),
+            DiarizationService.modelIdentity(for: constrained)
+        )
+    }
+
+    func testAggregationProfileIsStableAcrossCalls() {
+        XCTAssertEqual(
+            DiarizationService.modelIdentity(for: DiarizationService.highAccuracyConfig),
+            DiarizationService.modelIdentity(for: DiarizationService.highAccuracyConfig)
+        )
+    }
+
+    // MARK: Helpers
+
+    private func segment(speakerId: String, from start: Float, to end: Float) -> TimedSpeakerSegment {
+        TimedSpeakerSegment(
+            speakerId: speakerId,
+            embedding: [Float](repeating: 0, count: SpeakerEmbedding.dimension),
+            startTimeSeconds: start,
+            endTimeSeconds: end,
+            qualityScore: 1
+        )
+    }
+
+    private func makeService(result: DiarizationResult) -> DiarizationService {
+        let manager = StubOfflineDiarizerManager(result: result)
+        return DiarizationService(
+            loadManagerFactory: { _ in { _ in manager } },
+            modelsDirectory: FileManager.default.temporaryDirectory,
+            explicitConstraint: nil,
+            inferenceGate: ANEInferenceGate(serializationRequired: false),
+            modelIdentity: Self.identity
+        )
+    }
+}
+
+private final class StubOfflineDiarizerManager: OfflineDiarizerManaging, @unchecked Sendable {
+    private let result: DiarizationResult
+
+    init(result: DiarizationResult) {
+        self.result = result
+    }
+
+    func process(audioURL: URL) async throws -> DiarizationResult {
+        result
+    }
+}

--- a/Tests/MacParakeetTests/Services/Diarization/SpeakerEmbeddingTests.swift
+++ b/Tests/MacParakeetTests/Services/Diarization/SpeakerEmbeddingTests.swift
@@ -1,0 +1,164 @@
+import XCTest
+@testable import MacParakeetCore
+
+final class SpeakerEmbeddingTests: XCTestCase {
+
+    // MARK: Fixtures
+
+    /// Orthonormal basis vectors from a fixed seed, so distances are exact
+    /// rather than approximate: a voice is `e_i`, and a noisy observation at
+    /// angle theta is `cos(theta) * e_i + sin(theta) * e_j`, whose cosine
+    /// distance to `e_i` is exactly `1 - cos(theta)`.
+    private static func basisVector(_ index: Int) -> [Float] {
+        var values = [Float](repeating: 0, count: SpeakerEmbedding.dimension)
+        values[index] = 1
+        return values
+    }
+
+    private static func observation(of speaker: Int, towards other: Int, degrees: Double) -> [Float] {
+        let radians = degrees * .pi / 180
+        var values = [Float](repeating: 0, count: SpeakerEmbedding.dimension)
+        values[speaker] = Float(cos(radians))
+        values[other] = Float(sin(radians))
+        return values
+    }
+
+    private static let identity = SpeakerModelIdentity(
+        embeddingModelId: "test-model",
+        aggregationProfileId: "test-aggregation"
+    )
+
+    private func embedding(
+        _ raw: [Float],
+        identity: SpeakerModelIdentity = SpeakerEmbeddingTests.identity
+    ) -> SpeakerEmbedding {
+        guard let embedding = SpeakerEmbedding(rawVector: raw, identity: identity) else {
+            preconditionFailure("fixture vector must be valid")
+        }
+        return embedding
+    }
+
+    // MARK: Normalization
+
+    func testInitNormalizesToUnitLength() {
+        let scaled = Self.observation(of: 0, towards: 1, degrees: 25).map { $0 * 0.83 }
+        let embedding = embedding(scaled)
+
+        let norm = embedding.vector.reduce(Float(0)) { $0 + $1 * $1 }.squareRoot()
+        XCTAssertEqual(norm, 1, accuracy: 1e-5)
+    }
+
+    /// The regression that matters: an un-normalized pair must produce the same
+    /// decision as a normalized one, *and* the bare dot product must be shown to
+    /// differ — otherwise this test would still pass if normalization were
+    /// removed.
+    func testScalingDoesNotChangeDistanceButWouldChangeABareDotProduct() throws {
+        let rawA = Self.basisVector(0).map { $0 * 0.85 }
+        let rawB = Self.observation(of: 0, towards: 1, degrees: 25).map { $0 * 0.85 }
+
+        let distance = try XCTUnwrap(embedding(rawA).cosineDistance(to: embedding(rawB)))
+        let expected = 1 - cos(25 * Double.pi / 180)
+        XCTAssertEqual(distance, expected, accuracy: 1e-5)
+
+        // What the July plan's "embeddings are already normalized" shortcut
+        // would have computed instead.
+        let bareDot = zip(rawA, rawB).reduce(Float(0)) { $0 + $1.0 * $1.1 }
+        let bareDistance = 1 - Double(bareDot)
+        XCTAssertGreaterThan(bareDistance - distance, 0.15)
+    }
+
+    func testDistanceToOwnScaledCopyIsZero() throws {
+        let raw = Self.observation(of: 3, towards: 7, degrees: 40)
+        let distance = try XCTUnwrap(
+            embedding(raw).cosineDistance(to: embedding(raw.map { $0 * 0.5 }))
+        )
+        XCTAssertEqual(distance, 0, accuracy: 1e-6)
+    }
+
+    func testDistanceMatchesTheFixtureAngle() throws {
+        for degrees in [0.0, 25.0, 41.4, 60.0] {
+            let distance = try XCTUnwrap(
+                embedding(Self.basisVector(0))
+                    .cosineDistance(to: embedding(Self.observation(of: 0, towards: 1, degrees: degrees)))
+            )
+            XCTAssertEqual(distance, 1 - cos(degrees * .pi / 180), accuracy: 1e-5)
+        }
+    }
+
+    // MARK: Rejected input
+
+    func testRejectsZeroVector() {
+        // FluidAudio emits this when a cluster's responsibility denominator is zero.
+        let zeros = [Float](repeating: 0, count: SpeakerEmbedding.dimension)
+        XCTAssertNil(SpeakerEmbedding(rawVector: zeros, identity: Self.identity))
+    }
+
+    func testRejectsVectorBelowMinimumNorm() {
+        let tiny = Self.basisVector(0).map { $0 * 1e-9 }
+        XCTAssertNil(SpeakerEmbedding(rawVector: tiny, identity: Self.identity))
+    }
+
+    func testRejectsNonFiniteValues() {
+        var withNaN = Self.basisVector(0)
+        withNaN[5] = .nan
+        XCTAssertNil(SpeakerEmbedding(rawVector: withNaN, identity: Self.identity))
+
+        var withInfinity = Self.basisVector(0)
+        withInfinity[5] = .infinity
+        XCTAssertNil(SpeakerEmbedding(rawVector: withInfinity, identity: Self.identity))
+    }
+
+    func testRejectsWrongDimension() {
+        XCTAssertNil(SpeakerEmbedding(rawVector: [1, 0, 0], identity: Self.identity))
+        XCTAssertNil(
+            SpeakerEmbedding(
+                rawVector: [Float](repeating: 0.1, count: SpeakerEmbedding.dimension + 1),
+                identity: Self.identity
+            )
+        )
+    }
+
+    // MARK: Storage round trip
+
+    func testDataRoundTripIsBitExact() throws {
+        let original = embedding(Self.observation(of: 2, towards: 9, degrees: 33))
+        let data = original.data
+        XCTAssertEqual(data.count, SpeakerEmbedding.byteCount)
+        XCTAssertEqual(data.count, 1024)
+
+        let restored = try XCTUnwrap(SpeakerEmbedding(data: data, identity: Self.identity))
+        XCTAssertEqual(restored.vector, original.vector)
+        XCTAssertEqual(restored, original)
+    }
+
+    func testRejectsDataOfWrongLength() {
+        let short = Data(repeating: 0, count: SpeakerEmbedding.byteCount - 4)
+        XCTAssertNil(SpeakerEmbedding(data: short, identity: Self.identity))
+    }
+
+    func testRejectsDataThatIsNotUnitLength() {
+        // A vector that never went through `init?(rawVector:)`, so the stored
+        // invariant does not hold: reject rather than silently rescale.
+        var raw = Data()
+        for _ in 0..<SpeakerEmbedding.dimension {
+            withUnsafeBytes(of: Float(0.5).bitPattern.littleEndian) { raw.append(contentsOf: $0) }
+        }
+        XCTAssertNil(SpeakerEmbedding(data: raw, identity: Self.identity))
+    }
+
+    // MARK: Model identity
+
+    func testDistanceIsUnavailableAcrossEmbeddingModels() {
+        let other = SpeakerModelIdentity(embeddingModelId: "other-model", aggregationProfileId: "test-aggregation")
+        let lhs = embedding(Self.basisVector(0))
+        let rhs = embedding(Self.basisVector(0), identity: other)
+        XCTAssertNil(lhs.cosineDistance(to: rhs))
+    }
+
+    func testDistanceIsAvailableAcrossAggregationProfiles() throws {
+        let other = SpeakerModelIdentity(embeddingModelId: "test-model", aggregationProfileId: "other-aggregation")
+        let lhs = embedding(Self.basisVector(0))
+        let rhs = embedding(Self.basisVector(0), identity: other)
+        XCTAssertEqual(try XCTUnwrap(lhs.cosineDistance(to: rhs)), 0, accuracy: 1e-6)
+    }
+}

--- a/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintMatcherTests.swift
+++ b/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintMatcherTests.swift
@@ -144,6 +144,51 @@ final class SpeakerVoiceprintMatcherTests: XCTestCase {
         XCTAssertTrue(suggestions.isEmpty)
     }
 
+    /// The tie rule must not depend on how the margin is configured: at
+    /// `margin: 0` the difference check passes and position alone would decide.
+    func testExactTieSuggestsNobodyEvenWithoutAMargin() {
+        let zeroMargin = SpeakerMatchPolicy(
+            tau: policy.tau,
+            margin: 0,
+            minSpeechSecondsToMatch: policy.minSpeechSecondsToMatch,
+            minSpeechSecondsToEnroll: policy.minSpeechSecondsToEnroll,
+            maxReferencesPerProfile: policy.maxReferencesPerProfile,
+            crossAggregationPenalty: policy.crossAggregationPenalty,
+            pollutionGuardDistance: policy.pollutionGuardDistance
+        )
+
+        let suggestions = SpeakerVoiceprintMatcher.match(
+            clusters: [cluster("S1", voice: 0, degrees: Angle.close)],
+            profiles: [profile("Sarah", voice: 0), profile("Sasha", voice: 0)],
+            policy: zeroMargin
+        )
+        XCTAssertTrue(suggestions.isEmpty)
+    }
+
+    /// A negative cap reaches `prefix`, whose precondition would bring matching
+    /// down; the policy clamps it instead.
+    func testANegativeReferenceCapIsClampedRatherThanFatal() {
+        let negative = SpeakerMatchPolicy(
+            tau: policy.tau,
+            margin: policy.margin,
+            minSpeechSecondsToMatch: policy.minSpeechSecondsToMatch,
+            minSpeechSecondsToEnroll: policy.minSpeechSecondsToEnroll,
+            maxReferencesPerProfile: -3,
+            crossAggregationPenalty: policy.crossAggregationPenalty,
+            pollutionGuardDistance: policy.pollutionGuardDistance
+        )
+        XCTAssertEqual(negative.maxReferencesPerProfile, 0)
+
+        // No references are scored, so nothing is proposed — and nothing traps.
+        XCTAssertTrue(
+            SpeakerVoiceprintMatcher.match(
+                clusters: [cluster("S1", voice: 0, degrees: 0)],
+                profiles: [profile("Sarah", voice: 0)],
+                policy: negative
+            ).isEmpty
+        )
+    }
+
     // MARK: Injectivity
 
     func testOneProfileIsNeverSuggestedForTwoSpeakers() {

--- a/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintMatcherTests.swift
+++ b/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintMatcherTests.swift
@@ -238,6 +238,43 @@ final class SpeakerVoiceprintMatcherTests: XCTestCase {
         )
     }
 
+    /// A profile that straddles a FluidAudio upgrade holds one exemplar from
+    /// each aggregation. The penalty must follow the reference that actually
+    /// won, otherwise the presence of a current exemplar would buy full trust
+    /// for a decision an older one made.
+    func testThePenaltyFollowsTheWinningReferenceNotTheProfile() {
+        let old = SpeakerModelIdentity(
+            embeddingModelId: Self.identity.embeddingModelId,
+            aggregationProfileId: "pre-upgrade"
+        )
+        let borderline = 38.5  // 0.217: clears tau, not tau minus the penalty.
+
+        let straddling = SpeakerProfileCandidate(
+            profileId: UUID(),
+            displayName: "Sarah",
+            references: [
+                // Closest, but from the old aggregation.
+                reference(voice: 0, degrees: 0, identity: old),
+                // Current aggregation, but far away.
+                reference(voice: 7, degrees: 0),
+            ]
+        )
+
+        let suggestions = SpeakerVoiceprintMatcher.match(
+            clusters: [cluster("S1", voice: 0, degrees: borderline)],
+            profiles: [straddling],
+            policy: policy
+        )
+        XCTAssertTrue(suggestions.isEmpty)
+
+        let winning = SpeakerVoiceprintMatcher.bestReference(
+            from: cluster("S1", voice: 0, degrees: borderline),
+            to: straddling,
+            policy: policy
+        )
+        XCTAssertFalse(try XCTUnwrap(winning).sameAggregation)
+    }
+
     // MARK: Scoring across references
 
     func testProfileDistanceIsTheClosestReferenceNotTheAverage() {

--- a/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintMatcherTests.swift
+++ b/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintMatcherTests.swift
@@ -1,0 +1,361 @@
+import XCTest
+@testable import MacParakeetCore
+
+/// Fixtures are exact geometry, not random vectors: a voice is a basis vector,
+/// and an observation at angle theta has cosine distance exactly `1 - cos
+/// theta`. Every threshold below therefore reads in degrees, and a failure says
+/// which angle moved rather than which seed.
+final class SpeakerVoiceprintMatcherTests: XCTestCase {
+
+    private let policy = SpeakerMatchPolicy.v1
+
+    // 14.1 degrees -> 0.030, 25 -> 0.094, 41.4 -> 0.250 (exactly tau),
+    // 45 -> 0.293, 60 -> 0.500.
+    private enum Angle {
+        static let veryClose = 14.1
+        static let close = 25.0
+        static let atTau = 41.4
+        static let pastTau = 45.0
+        static let far = 60.0
+    }
+
+    // MARK: Acceptance
+
+    func testSuggestsTheOnlyEnrolledVoiceWhenItIsCloseEnough() {
+        let suggestions = SpeakerVoiceprintMatcher.match(
+            clusters: [cluster("S1", voice: 0, degrees: Angle.close)],
+            profiles: [profile("Sarah", voice: 0)],
+            policy: policy
+        )
+
+        XCTAssertEqual(suggestions.count, 1)
+        XCTAssertEqual(suggestions.first?.speakerId, "S1")
+        XCTAssertEqual(suggestions.first?.displayName, "Sarah")
+        XCTAssertEqual(try XCTUnwrap(suggestions.first?.distance), 0.094, accuracy: 0.002)
+        // Nothing to be separated from, so no runner-up is recorded.
+        XCTAssertNil(suggestions.first?.runnerUpDistance)
+    }
+
+    func testRejectsAVoiceBeyondTau() {
+        XCTAssertTrue(
+            SpeakerVoiceprintMatcher.match(
+                clusters: [cluster("S1", voice: 0, degrees: Angle.pastTau)],
+                profiles: [profile("Sarah", voice: 0)],
+                policy: policy
+            ).isEmpty
+        )
+    }
+
+    func testAcceptsExactlyAtTau() {
+        XCTAssertEqual(
+            SpeakerVoiceprintMatcher.match(
+                clusters: [cluster("S1", voice: 0, degrees: Angle.atTau)],
+                profiles: [profile("Sarah", voice: 0)],
+                policy: policy
+            ).count,
+            1
+        )
+    }
+
+    // MARK: Singleton sides
+
+    /// The case the first review caught: with one profile and one cluster there
+    /// is no runner-up, so a naive margin check would reject the very first
+    /// enrolled voice forever.
+    func testMarginIsVacuouslySatisfiedWhenEitherSideHasOneCandidate() {
+        XCTAssertEqual(
+            SpeakerVoiceprintMatcher.match(
+                clusters: [cluster("S1", voice: 0, degrees: Angle.veryClose)],
+                profiles: [profile("Sarah", voice: 0)],
+                policy: policy
+            ).count,
+            1
+        )
+
+        // One profile, several clusters: the profile side has no runner-up
+        // among profiles, and the far cluster does not compete.
+        XCTAssertEqual(
+            SpeakerVoiceprintMatcher.match(
+                clusters: [
+                    cluster("S1", voice: 0, degrees: Angle.veryClose),
+                    cluster("S2", voice: 5, degrees: 0),
+                ],
+                profiles: [profile("Sarah", voice: 0)],
+                policy: policy
+            ).map(\.speakerId),
+            ["S1"]
+        )
+    }
+
+    // MARK: Margins
+
+    func testRejectsWhenTwoProfilesAreTooCloseTogether() {
+        // The cluster sits 14.1 degrees off Sarah and 10.9 off Sasha: 0.030
+        // against 0.018. Both clear tau, they are 0.012 apart, and naming
+        // either one would be a coin toss.
+        let suggestions = SpeakerVoiceprintMatcher.match(
+            clusters: [cluster("S1", voice: 0, degrees: Angle.veryClose)],
+            profiles: [
+                profile("Sarah", voice: 0),
+                profile("Sasha", voice: 0, degrees: Angle.close),
+            ],
+            policy: policy
+        )
+        XCTAssertTrue(suggestions.isEmpty)
+    }
+
+    /// The two-sided rule. The diarizer over-splits, so one person often yields
+    /// two clusters; a cluster-side margin alone would let both claim the same
+    /// profile and put two "Sarah"s in one transcript.
+    func testRejectsWhenTwoClustersCompeteForTheSameProfile() {
+        let suggestions = SpeakerVoiceprintMatcher.match(
+            clusters: [
+                cluster("S1", voice: 0, degrees: Angle.veryClose),
+                cluster("S2", voice: 0, degrees: Angle.close),
+            ],
+            profiles: [profile("Sarah", voice: 0)],
+            policy: policy
+        )
+        XCTAssertTrue(suggestions.isEmpty)
+    }
+
+    func testAcceptsWhenTheCompetingClusterIsClearlyFurther() {
+        let suggestions = SpeakerVoiceprintMatcher.match(
+            clusters: [
+                cluster("S1", voice: 0, degrees: Angle.veryClose),
+                cluster("S2", voice: 0, degrees: Angle.far),
+            ],
+            profiles: [profile("Sarah", voice: 0)],
+            policy: policy
+        )
+        XCTAssertEqual(suggestions.map(\.speakerId), ["S1"])
+        XCTAssertEqual(try XCTUnwrap(suggestions.first?.runnerUpDistance), 0.5, accuracy: 0.002)
+    }
+
+    func testExactTieSuggestsNobody() {
+        let suggestions = SpeakerVoiceprintMatcher.match(
+            clusters: [cluster("S1", voice: 0, degrees: Angle.close)],
+            profiles: [
+                profile("Sarah", voice: 0),
+                profile("Sasha", voice: 0),
+            ],
+            policy: policy
+        )
+        XCTAssertTrue(suggestions.isEmpty)
+    }
+
+    // MARK: Injectivity
+
+    func testOneProfileIsNeverSuggestedForTwoSpeakers() {
+        let suggestions = SpeakerVoiceprintMatcher.match(
+            clusters: [
+                cluster("S1", voice: 0, degrees: Angle.veryClose),
+                cluster("S2", voice: 0, degrees: Angle.far),
+                cluster("S3", voice: 1, degrees: Angle.veryClose),
+            ],
+            profiles: [profile("Sarah", voice: 0), profile("Dan", voice: 1)],
+            policy: policy
+        )
+
+        XCTAssertEqual(Set(suggestions.map(\.profileId)).count, suggestions.count)
+        XCTAssertEqual(Set(suggestions.map(\.speakerId)), ["S1", "S3"])
+    }
+
+    func testTwoDistinctVoicesMatchTheirOwnProfiles() {
+        let suggestions = SpeakerVoiceprintMatcher.match(
+            clusters: [
+                cluster("S1", voice: 0, degrees: Angle.close),
+                cluster("S2", voice: 1, degrees: Angle.close),
+            ],
+            profiles: [profile("Sarah", voice: 0), profile("Dan", voice: 1)],
+            policy: policy
+        )
+
+        XCTAssertEqual(
+            Dictionary(uniqueKeysWithValues: suggestions.map { ($0.speakerId, $0.displayName) }),
+            ["S1": "Sarah", "S2": "Dan"]
+        )
+    }
+
+    // MARK: Duration gates
+
+    func testClustersBelowTheSpeechGateAreNeverScored() {
+        let suggestions = SpeakerVoiceprintMatcher.match(
+            clusters: [cluster("S1", voice: 0, degrees: 0, speechSeconds: 2.5)],
+            profiles: [profile("Sarah", voice: 0)],
+            policy: policy
+        )
+        XCTAssertTrue(suggestions.isEmpty)
+    }
+
+    func testAClusterAboveTheMatchGateButBelowTheEnrollGateStillMatches() {
+        let suggestions = SpeakerVoiceprintMatcher.match(
+            clusters: [cluster("S1", voice: 0, degrees: 0, speechSeconds: 12)],
+            profiles: [profile("Sarah", voice: 0)],
+            policy: policy
+        )
+        XCTAssertEqual(suggestions.count, 1)
+        XCTAssertLessThan(12, policy.minSpeechSecondsToEnroll)
+    }
+
+    // MARK: Model identity
+
+    func testReferencesFromAnotherEmbeddingModelAreIgnored() {
+        let otherModel = SpeakerModelIdentity(
+            embeddingModelId: "other-model",
+            aggregationProfileId: Self.identity.aggregationProfileId
+        )
+        let suggestions = SpeakerVoiceprintMatcher.match(
+            clusters: [cluster("S1", voice: 0, degrees: 0)],
+            profiles: [profile("Sarah", voice: 0, identity: otherModel)],
+            policy: policy
+        )
+        XCTAssertTrue(suggestions.isEmpty)
+    }
+
+    func testADifferentAggregationProfileTightensTheThreshold() {
+        let otherAggregation = SpeakerModelIdentity(
+            embeddingModelId: Self.identity.embeddingModelId,
+            aggregationProfileId: "other-aggregation"
+        )
+        // 0.217 clears tau (0.25) but not tau minus the 0.05 penalty (0.20).
+        let borderline = 38.5
+
+        XCTAssertEqual(
+            SpeakerVoiceprintMatcher.match(
+                clusters: [cluster("S1", voice: 0, degrees: borderline)],
+                profiles: [profile("Sarah", voice: 0)],
+                policy: policy
+            ).count,
+            1
+        )
+        XCTAssertTrue(
+            SpeakerVoiceprintMatcher.match(
+                clusters: [cluster("S1", voice: 0, degrees: borderline)],
+                profiles: [profile("Sarah", voice: 0, identity: otherAggregation)],
+                policy: policy
+            ).isEmpty
+        )
+    }
+
+    // MARK: Scoring across references
+
+    func testProfileDistanceIsTheClosestReferenceNotTheAverage() {
+        let candidate = SpeakerProfileCandidate(
+            profileId: UUID(),
+            displayName: "Sarah",
+            references: [
+                reference(voice: 0, degrees: Angle.far),
+                reference(voice: 0, degrees: Angle.close),
+            ]
+        )
+        let distance = SpeakerVoiceprintMatcher.distance(
+            from: cluster("S1", voice: 0, degrees: 0),
+            to: candidate,
+            policy: policy
+        )
+        XCTAssertEqual(try XCTUnwrap(distance), 0.094, accuracy: 0.002)
+    }
+
+    func testOnlyTheFirstReferencesUpToTheCapAreScored() {
+        var references = (0..<policy.maxReferencesPerProfile).map { _ in
+            reference(voice: 0, degrees: Angle.far)
+        }
+        references.append(reference(voice: 0, degrees: 0))
+
+        let candidate = SpeakerProfileCandidate(
+            profileId: UUID(), displayName: "Sarah", references: references
+        )
+        let distance = SpeakerVoiceprintMatcher.distance(
+            from: cluster("S1", voice: 0, degrees: 0),
+            to: candidate,
+            policy: policy
+        )
+        // The perfect reference sits past the cap and never gets scored.
+        XCTAssertEqual(try XCTUnwrap(distance), 0.5, accuracy: 0.002)
+    }
+
+    func testNoProfilesOrNoClustersYieldsNothing() {
+        XCTAssertTrue(
+            SpeakerVoiceprintMatcher.match(
+                clusters: [cluster("S1", voice: 0, degrees: 0)], profiles: [], policy: policy
+            ).isEmpty
+        )
+        XCTAssertTrue(
+            SpeakerVoiceprintMatcher.match(
+                clusters: [], profiles: [profile("Sarah", voice: 0)], policy: policy
+            ).isEmpty
+        )
+    }
+
+    func testProfileWithNoReferencesIsSkipped() {
+        let empty = SpeakerProfileCandidate(profileId: UUID(), displayName: "Sarah", references: [])
+        XCTAssertTrue(
+            SpeakerVoiceprintMatcher.match(
+                clusters: [cluster("S1", voice: 0, degrees: 0)], profiles: [empty], policy: policy
+            ).isEmpty
+        )
+    }
+
+    // MARK: Fixtures
+
+    private static let identity = SpeakerModelIdentity(
+        embeddingModelId: "test-model",
+        aggregationProfileId: "test-aggregation"
+    )
+
+    /// `cos(theta) * e_voice + sin(theta) * e_offAxis`, whose distance to
+    /// `e_voice` is exactly `1 - cos(theta)`.
+    private func embedding(
+        voice: Int,
+        degrees: Double,
+        identity: SpeakerModelIdentity = SpeakerVoiceprintMatcherTests.identity
+    ) -> SpeakerEmbedding {
+        let radians = degrees * Double.pi / 180
+        var values = [Float](repeating: 0, count: SpeakerEmbedding.dimension)
+        values[voice] = Float(cos(radians))
+        values[SpeakerEmbedding.dimension - 1 - voice] = Float(sin(radians))
+        guard let embedding = SpeakerEmbedding(rawVector: values, identity: identity) else {
+            preconditionFailure("fixture vector must be valid")
+        }
+        return embedding
+    }
+
+    private func cluster(
+        _ speakerId: String,
+        voice: Int,
+        degrees: Double,
+        speechSeconds: Double = 30
+    ) -> SpeakerClusterObservation {
+        SpeakerClusterObservation(
+            speakerId: speakerId,
+            embedding: embedding(voice: voice, degrees: degrees),
+            speechSeconds: speechSeconds,
+            captureDomain: .system
+        )
+    }
+
+    private func reference(
+        voice: Int,
+        degrees: Double,
+        identity: SpeakerModelIdentity = SpeakerVoiceprintMatcherTests.identity
+    ) -> SpeakerProfileCandidate.Reference {
+        SpeakerProfileCandidate.Reference(
+            embedding: embedding(voice: voice, degrees: degrees, identity: identity),
+            captureDomain: .system
+        )
+    }
+
+    private func profile(
+        _ name: String,
+        voice: Int,
+        degrees: Double = 0,
+        identity: SpeakerModelIdentity = SpeakerVoiceprintMatcherTests.identity
+    ) -> SpeakerProfileCandidate {
+        SpeakerProfileCandidate(
+            profileId: UUID(),
+            displayName: name,
+            references: [reference(voice: voice, degrees: degrees, identity: identity)]
+        )
+    }
+}


### PR DESCRIPTION
PR 3 of the voiceprints plan (`plans/active/2026-07-03-speaker-voiceprints.md`, as amended
in #993). Pure logic — no I/O, no persistence, no UI, and nothing calls it yet.

> **Stacked on #996, itself stacked on #994.** Review the last commit here; the diff
> shrinks as the earlier PRs merge.

## What

`SpeakerVoiceprintMatcher` decides which enrolled voices to propose for the speakers of one
recording, plus the value types it works on: `SpeakerClusterObservation`,
`SpeakerProfileCandidate`, `SpeakerMatchPolicy`, `SpeakerVoiceprintSuggestion`.

This is where the feature can be wrong about a person, so it is deliberately stateless and
dependency-free: everything it decides is reachable from fixtures alone.

## The rule

A pair is accepted only when all of these hold:

- it is a **mutual** best match — the cluster's closest profile, and that profile's closest
  cluster;
- the distance clears `tau`;
- it beats its runner-up by `margin` **on both sides**.

The two-sided margin is not belt and braces. The diarizer over-splits, so one person
routinely yields two clusters; with a cluster-side margin alone, both would clear it
against *other* profiles and both would be offered the same name, putting two "Sarah"s in
one transcript. Mutual matching also gives injectivity for free — one profile is never
suggested for two speakers.

## Two edge cases the review of #993 asked for

**Singleton sides.** With one enrolled profile and one detected cluster there is no
runner-up, so `top2 − top1` cannot be evaluated. The margin is treated as **vacuously
satisfied** and the decision rests on `tau` alone. Failing it instead would make the very
first enrolled voice unsuggestable — precisely when the feature is supposed to earn its
keep.

**Exact ties.** Two candidates at an identical distance leave a zero margin, so nothing is
suggested. No tie-break by id, insertion order or recency: an arbitrary winner is exactly
the "wrong automatic name" the design forbids.

## Shipping values

`SpeakerMatchPolicy.v1` uses `tau = 0.25`, `margin = 0.10`. Tau sits at the **bottom** of
the zero-false-positive plateau from the Phase 0b calibration (0.25–0.45, worst true pair
at 0.227) rather than mid-plateau: the plateau was measured on clean narration that real
meeting capture will not match, a missed suggestion is a non-event, and a false one is the
worst documented outcome.

The policy is injected rather than hard-coded, so calibration changes one value and no
logic.

A reference aggregated under a different clustering configuration is still compared but
trusted less, at `tau − 0.05`. Phase 0b leaves a 0.24 gap between the worst true pair and
the best impostor, and configuration drift costs hundredths, so refusing outright would
discard usable profiles for a theoretical reason. A different *embedding model* is not
comparable at all and is ignored.

## Tests

18 tests over exact geometry rather than random vectors: a voice is a basis vector and an
observation at angle θ has cosine distance exactly `1 − cos θ`, so every threshold reads in
degrees and a failure says which angle moved. Covered: acceptance at and past tau, both
singleton cases, both margin directions, exact ties, injectivity across three clusters and
two profiles, the duration gates, model and aggregation identity, and closest-reference
scoring including the reference cap.

Refs #662

https://claude.ai/code/session_01X2zJL7MPo6Yppd6ned9mAe

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the voiceprint recognition stack: `DiarizationService` now exposes normalized per-speaker embeddings and speech durations, a persistent store manages enrolled voices and exemplars, and a matcher proposes profile matches. Nothing is wired into callers yet, so existing diarization segments, labels, and durations remain unchanged.

**Matching**

- `SpeakerVoiceprintMatcher` proposes at most one enrolled profile per speaker via mutual-best matching, `tau`, and two-sided `margin`; singleton sides pass the margin vacuously, and exact ties produce no suggestion regardless of margin.
- `SpeakerMatchPolicy.v1` uses `tau = 0.25`, `margin = 0.10`, a 3-second match gate, and a 15-second enrollment gate.
- Different embedding models are ignored; aggregation drift tightens `tau` by `0.05` based on the winning reference.
- Profiles score by their closest eligible exemplar, preferring the same capture domain, checking at most 10 references (cap clamped to non-negative); references must arrive most-relevant-first.

**Storage and embeddings**

- Migration v0.39 adds profile, exemplar, and fingerprint-scoped link tables; profile deletion removes owned data, while transcript deletion keeps exemplars and clears their source references.
- Embeddings normalize 256-value vectors stored as 1024-byte blobs with model and aggregation identities; diarizer keys remap to stable speaker IDs.
- The store refuses exemplars from another embedding model, blank names, and overwriting terminal decisions; the sample cap and name claim are held in one transaction, renaming recomputes the lookup key, and link updates preserve original creation time.

<sup>Written for commit 7bd93b37915d5bd1a9825bc9707cb1d81a6ceb54. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/1000?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added local speaker profiles with support for multiple voice samples.
  - Diarization now includes speaker voice embeddings and speech-duration details.
  - Added transcript-specific speaker recognition suggestions and decisions.
  - Added safeguards for confidence thresholds, competing matches, recording sources, and model compatibility.
- **Bug Fixes**
  - Added validation for invalid or incompatible voiceprint data.
  - Preserved profile-link creation timestamps when updating recognition decisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->