### PR TITLE
Integrate experimental voice profiles behind a release gate

### DIFF
--- a/Sources/MacParakeet/App/AppEnvironment.swift
+++ b/Sources/MacParakeet/App/AppEnvironment.swift
@@ -26,6 +26,7 @@ final class AppEnvironment {
     let speakerEmbeddingCandidateRepo: SpeakerEmbeddingCandidateRepository
     let speakerMatchJournalRepo: SpeakerMatchJournalRepository
     let speakerVoiceprintService: SpeakerVoiceprintService
+    private let speakerVoiceprintRetention: SpeakerVoiceprintRetention
     let customWordRepo: CustomWordRepository
     let snippetRepo: TextSnippetRepository
     let chatConversationRepo: ChatConversationRepository
@@ -102,8 +103,10 @@ final class AppEnvironment {
             journal: speakerMatchJournalRepo,
             isEnabled: { UserDefaultsAppRuntimePreferences.rememberSpeakersEnabled() }
         )
-        // Nothing else prunes for a user who stops recording and stops naming.
-        try? speakerEmbeddingCandidateRepo.pruneExpired()
+        speakerVoiceprintRetention = SpeakerVoiceprintRetention(
+            candidates: speakerEmbeddingCandidateRepo,
+            journal: speakerMatchJournalRepo
+        )
         customWordRepo = CustomWordRepository(dbQueue: databaseManager.dbQueue)
         snippetRepo = TextSnippetRepository(dbQueue: databaseManager.dbQueue)
         chatConversationRepo = ChatConversationRepository(dbQueue: databaseManager.dbQueue)
@@ -437,7 +440,7 @@ final class AppEnvironment {
             podcastAudioFetcher: PodcastAudioDownloader(),
             diarizationService: diarizationService,
             meetingArtifactStore: meetingArtifactStore,
-            speakerVoiceprints: speakerVoiceprintService
+            speakerVoiceprints: AppFeatures.isVoiceProfilesAvailable() ? speakerVoiceprintService : nil
         )
 
         meetingRecordingRecoveryService = MeetingRecordingRecoveryService(

--- a/Sources/MacParakeet/App/AppEnvironment.swift
+++ b/Sources/MacParakeet/App/AppEnvironment.swift
@@ -22,6 +22,9 @@ final class AppEnvironment {
     let knowledgeLayerMutator: KnowledgeLayerMutationService
     let speakerAttributionReader: SpeakerAttributionReadService
     let speakerCorrectionService: SpeakerCorrectionService
+    let speakerProfileRepo: SpeakerProfileRepository
+    let speakerMatchJournalRepo: SpeakerMatchJournalRepository
+    let speakerVoiceprintService: SpeakerVoiceprintService
     let customWordRepo: CustomWordRepository
     let snippetRepo: TextSnippetRepository
     let chatConversationRepo: ChatConversationRepository
@@ -87,6 +90,13 @@ final class AppEnvironment {
         knowledgeLayerMutator = KnowledgeLayerMutationService(dbQueue: databaseManager.dbQueue)
         speakerAttributionReader = SpeakerAttributionReadService(dbQueue: databaseManager.dbQueue)
         speakerCorrectionService = SpeakerCorrectionService(dbQueue: databaseManager.dbQueue)
+        speakerProfileRepo = SpeakerProfileRepository(dbQueue: databaseManager.dbQueue)
+        speakerMatchJournalRepo = SpeakerMatchJournalRepository(dbQueue: databaseManager.dbQueue)
+        speakerVoiceprintService = SpeakerVoiceprintService(
+            profiles: speakerProfileRepo,
+            journal: speakerMatchJournalRepo,
+            isEnabled: { UserDefaultsAppRuntimePreferences.rememberSpeakersEnabled() }
+        )
         customWordRepo = CustomWordRepository(dbQueue: databaseManager.dbQueue)
         snippetRepo = TextSnippetRepository(dbQueue: databaseManager.dbQueue)
         chatConversationRepo = ChatConversationRepository(dbQueue: databaseManager.dbQueue)
@@ -419,7 +429,8 @@ final class AppEnvironment {
             podcastSearchResolver: PodcastQueryResolver(),
             podcastAudioFetcher: PodcastAudioDownloader(),
             diarizationService: diarizationService,
-            meetingArtifactStore: meetingArtifactStore
+            meetingArtifactStore: meetingArtifactStore,
+            speakerVoiceprints: speakerVoiceprintService
         )
 
         meetingRecordingRecoveryService = MeetingRecordingRecoveryService(

--- a/Sources/MacParakeet/App/AppEnvironment.swift
+++ b/Sources/MacParakeet/App/AppEnvironment.swift
@@ -23,6 +23,7 @@ final class AppEnvironment {
     let speakerAttributionReader: SpeakerAttributionReadService
     let speakerCorrectionService: SpeakerCorrectionService
     let speakerProfileRepo: SpeakerProfileRepository
+    let speakerEmbeddingCandidateRepo: SpeakerEmbeddingCandidateRepository
     let speakerMatchJournalRepo: SpeakerMatchJournalRepository
     let speakerVoiceprintService: SpeakerVoiceprintService
     let customWordRepo: CustomWordRepository
@@ -91,12 +92,18 @@ final class AppEnvironment {
         speakerAttributionReader = SpeakerAttributionReadService(dbQueue: databaseManager.dbQueue)
         speakerCorrectionService = SpeakerCorrectionService(dbQueue: databaseManager.dbQueue)
         speakerProfileRepo = SpeakerProfileRepository(dbQueue: databaseManager.dbQueue)
+        speakerEmbeddingCandidateRepo = SpeakerEmbeddingCandidateRepository(
+            dbQueue: databaseManager.dbQueue
+        )
         speakerMatchJournalRepo = SpeakerMatchJournalRepository(dbQueue: databaseManager.dbQueue)
         speakerVoiceprintService = SpeakerVoiceprintService(
             profiles: speakerProfileRepo,
+            candidates: speakerEmbeddingCandidateRepo,
             journal: speakerMatchJournalRepo,
             isEnabled: { UserDefaultsAppRuntimePreferences.rememberSpeakersEnabled() }
         )
+        // Nothing else prunes for a user who stops recording and stops naming.
+        try? speakerEmbeddingCandidateRepo.pruneExpired()
         customWordRepo = CustomWordRepository(dbQueue: databaseManager.dbQueue)
         snippetRepo = TextSnippetRepository(dbQueue: databaseManager.dbQueue)
         chatConversationRepo = ChatConversationRepository(dbQueue: databaseManager.dbQueue)

--- a/Sources/MacParakeetCore/AppFeatures.swift
+++ b/Sources/MacParakeetCore/AppFeatures.swift
@@ -4,6 +4,23 @@ import Foundation
 /// without touching every call site. Release builds should set these to the
 /// shipping configuration before tagging a version.
 public enum AppFeatures {
+    /// Experimental speaker recognition. Release availability requires a
+    /// deliberate flag change after held-out meeting evaluation passes.
+    public static let voiceProfilesEnabled: Bool = false
+    public static let voiceProfilesDeveloperLaunchArgument = "--enable-voice-profiles"
+
+    /// A saved preference or a development launch argument cannot unlock an
+    /// unreleased feature in a release build. Consent remains a separate gate.
+    public static func isVoiceProfilesAvailable(
+        arguments: [String] = ProcessInfo.processInfo.arguments
+    ) -> Bool {
+        #if DEBUG
+        voiceProfilesEnabled || arguments.contains(voiceProfilesDeveloperLaunchArgument)
+        #else
+        voiceProfilesEnabled
+        #endif
+    }
+
     /// Meeting Recording (ADR-014). When `false`, all meeting recording entry
     /// points are hidden: Transcribe tile, menu-bar "Start Recording", global
     /// meeting hotkey, settings card, library filter, and the screen recording

--- a/Sources/MacParakeetCore/AppRuntimePreferences.swift
+++ b/Sources/MacParakeetCore/AppRuntimePreferences.swift
@@ -518,7 +518,9 @@ public final class UserDefaultsAppRuntimePreferences: AppRuntimePreferencesProto
     /// Off unless the user asks: a voiceprint is biometric data.
     public static let rememberSpeakersKey = "rememberSpeakers"
     public static let defaultRememberSpeakersEnabled = false
-    /// A date rather than a flag: "when did you consent?" needs one.
+    /// A date rather than a flag: "when did you consent?" needs one. Asked when
+    /// the toggle goes on, not at the first enrollment — by then a voice has
+    /// already been stored.
     public static let voiceprintConsentAcknowledgedAtKey = "voiceprintConsentAcknowledgedAt"
     public static let aiFormatterEnabledKey = "aiFormatterEnabled"
     public static let aiFormatterEnabledForDictationKey = "aiFormatterEnabledForDictation"
@@ -586,11 +588,19 @@ public final class UserDefaultsAppRuntimePreferences: AppRuntimePreferencesProto
         defaults.object(forKey: meetingSpeakerDiarizationKey) as? Bool ?? defaultMeetingSpeakerDiarizationEnabled
     }
 
-    /// Requires speaker detection: without clusters there is nothing to match.
+    /// Requires speaker detection, since without clusters there is nothing to
+    /// match, and an acknowledged consent date, since the first thing this
+    /// feature does is store a voice.
+    ///
+    /// The consent gate is part of the resolver rather than a check at the
+    /// enrollment surface: a voice is now kept from the end of the meeting, so
+    /// a gate that only guarded naming would come too late.
     public static func rememberSpeakersEnabled(defaults: UserDefaults = .standard) -> Bool {
         let enabled = defaults.object(forKey: rememberSpeakersKey) as? Bool
             ?? defaultRememberSpeakersEnabled
-        return enabled && meetingSpeakerDiarizationEnabled(defaults: defaults)
+        return enabled
+            && meetingSpeakerDiarizationEnabled(defaults: defaults)
+            && voiceprintConsentAcknowledgedAt(defaults: defaults) != nil
     }
 
     public static func voiceprintConsentAcknowledgedAt(defaults: UserDefaults = .standard) -> Date? {

--- a/Sources/MacParakeetCore/AppRuntimePreferences.swift
+++ b/Sources/MacParakeetCore/AppRuntimePreferences.swift
@@ -595,7 +595,11 @@ public final class UserDefaultsAppRuntimePreferences: AppRuntimePreferencesProto
     /// The consent gate is part of the resolver rather than a check at the
     /// enrollment surface: a voice is now kept from the end of the meeting, so
     /// a gate that only guarded naming would come too late.
-    public static func rememberSpeakersEnabled(defaults: UserDefaults = .standard) -> Bool {
+    public static func rememberSpeakersEnabled(
+        defaults: UserDefaults = .standard,
+        arguments: [String] = ProcessInfo.processInfo.arguments
+    ) -> Bool {
+        guard AppFeatures.isVoiceProfilesAvailable(arguments: arguments) else { return false }
         let enabled = defaults.object(forKey: rememberSpeakersKey) as? Bool
             ?? defaultRememberSpeakersEnabled
         return enabled

--- a/Sources/MacParakeetCore/AppRuntimePreferences.swift
+++ b/Sources/MacParakeetCore/AppRuntimePreferences.swift
@@ -515,13 +515,10 @@ public final class UserDefaultsAppRuntimePreferences: AppRuntimePreferencesProto
     public static let defaultSpeakerDiarizationEnabled = true
     public static let meetingSpeakerDiarizationKey = "meetingSpeakerDiarization"
     public static let defaultMeetingSpeakerDiarizationEnabled = true
-    /// Persistent voice profiles. Off unless the user asks: a voiceprint is
-    /// biometric data, so it takes an explicit act, never a default.
+    /// Off unless the user asks: a voiceprint is biometric data.
     public static let rememberSpeakersKey = "rememberSpeakers"
     public static let defaultRememberSpeakersEnabled = false
-    /// When the user acknowledged that they have the participants' permission.
-    /// A date rather than a flag, because that is what the question "when did
-    /// you consent?" needs answering with.
+    /// A date rather than a flag: "when did you consent?" needs one.
     public static let voiceprintConsentAcknowledgedAtKey = "voiceprintConsentAcknowledgedAt"
     public static let aiFormatterEnabledKey = "aiFormatterEnabled"
     public static let aiFormatterEnabledForDictationKey = "aiFormatterEnabledForDictation"
@@ -589,8 +586,7 @@ public final class UserDefaultsAppRuntimePreferences: AppRuntimePreferencesProto
         defaults.object(forKey: meetingSpeakerDiarizationKey) as? Bool ?? defaultMeetingSpeakerDiarizationEnabled
     }
 
-    /// Voice profiles need speaker detection to have produced clusters in the
-    /// first place, so the two are checked together rather than separately.
+    /// Requires speaker detection: without clusters there is nothing to match.
     public static func rememberSpeakersEnabled(defaults: UserDefaults = .standard) -> Bool {
         let enabled = defaults.object(forKey: rememberSpeakersKey) as? Bool
             ?? defaultRememberSpeakersEnabled

--- a/Sources/MacParakeetCore/AppRuntimePreferences.swift
+++ b/Sources/MacParakeetCore/AppRuntimePreferences.swift
@@ -515,6 +515,14 @@ public final class UserDefaultsAppRuntimePreferences: AppRuntimePreferencesProto
     public static let defaultSpeakerDiarizationEnabled = true
     public static let meetingSpeakerDiarizationKey = "meetingSpeakerDiarization"
     public static let defaultMeetingSpeakerDiarizationEnabled = true
+    /// Persistent voice profiles. Off unless the user asks: a voiceprint is
+    /// biometric data, so it takes an explicit act, never a default.
+    public static let rememberSpeakersKey = "rememberSpeakers"
+    public static let defaultRememberSpeakersEnabled = false
+    /// When the user acknowledged that they have the participants' permission.
+    /// A date rather than a flag, because that is what the question "when did
+    /// you consent?" needs answering with.
+    public static let voiceprintConsentAcknowledgedAtKey = "voiceprintConsentAcknowledgedAt"
     public static let aiFormatterEnabledKey = "aiFormatterEnabled"
     public static let aiFormatterEnabledForDictationKey = "aiFormatterEnabledForDictation"
     public static let aiFormatterEnabledForTranscriptionsKey = "aiFormatterEnabledForTranscriptions"
@@ -579,6 +587,18 @@ public final class UserDefaultsAppRuntimePreferences: AppRuntimePreferencesProto
 
     public static func meetingSpeakerDiarizationEnabled(defaults: UserDefaults = .standard) -> Bool {
         defaults.object(forKey: meetingSpeakerDiarizationKey) as? Bool ?? defaultMeetingSpeakerDiarizationEnabled
+    }
+
+    /// Voice profiles need speaker detection to have produced clusters in the
+    /// first place, so the two are checked together rather than separately.
+    public static func rememberSpeakersEnabled(defaults: UserDefaults = .standard) -> Bool {
+        let enabled = defaults.object(forKey: rememberSpeakersKey) as? Bool
+            ?? defaultRememberSpeakersEnabled
+        return enabled && meetingSpeakerDiarizationEnabled(defaults: defaults)
+    }
+
+    public static func voiceprintConsentAcknowledgedAt(defaults: UserDefaults = .standard) -> Date? {
+        defaults.object(forKey: voiceprintConsentAcknowledgedAtKey) as? Date
     }
 
     public static func showMeetingRecordingPill(defaults: UserDefaults = .standard) -> Bool {

--- a/Sources/MacParakeetCore/Database/DatabaseManager.swift
+++ b/Sources/MacParakeetCore/Database/DatabaseManager.swift
@@ -1951,6 +1951,84 @@ public final class DatabaseManager: Sendable {
             }
         }
 
+        // v0.39 — Persistent speaker profiles (voiceprints). Enrolled voices
+        // live here so the same person can be recognized across recordings.
+        // Biometric data: every row is local-only, excluded from exports, and
+        // removable. See plans/active/2026-07-03-speaker-voiceprints.md.
+        migrator.registerMigration("v0.39-speaker-voiceprints") { db in
+            try db.execute(sql: """
+                CREATE TABLE speaker_profiles (
+                    id TEXT PRIMARY KEY NOT NULL,
+                    displayName TEXT NOT NULL,
+                    embeddingModelId TEXT NOT NULL,
+                    aggregationProfileId TEXT NOT NULL,
+                    createdAt TEXT NOT NULL,
+                    updatedAt TEXT NOT NULL,
+                    lastMatchedAt TEXT,
+                    lastEvaluatedAt TEXT,
+                    lastEvaluatedDistance REAL
+                )
+                """)
+            // Renaming a second speaker to an enrolled name must add a sample
+            // to that profile, not create a rival profile with the same name.
+            try db.execute(sql: """
+                CREATE UNIQUE INDEX idx_speaker_profiles_name
+                ON speaker_profiles (displayName COLLATE NOCASE)
+                """)
+            try db.execute(sql: """
+                CREATE TABLE speaker_profile_exemplars (
+                    id TEXT PRIMARY KEY NOT NULL,
+                    profileId TEXT NOT NULL
+                        REFERENCES speaker_profiles(id) ON DELETE CASCADE,
+                    vector BLOB NOT NULL CHECK (length(vector) = 1024),
+                    speechSeconds REAL NOT NULL CHECK (speechSeconds > 0),
+                    captureDomain TEXT NOT NULL CHECK (
+                        captureDomain IN ('system', 'microphone', 'file')
+                    ),
+                    origin TEXT NOT NULL CHECK (
+                        origin IN ('manualEnrollment', 'confirmedSuggestion')
+                    ),
+                    embeddingModelId TEXT NOT NULL,
+                    aggregationProfileId TEXT NOT NULL,
+                    sourceTranscriptionId TEXT
+                        REFERENCES transcriptions(id) ON DELETE SET NULL,
+                    sourceSpeakerId TEXT,
+                    createdAt TEXT NOT NULL,
+                    UNIQUE (profileId, sourceTranscriptionId)
+                )
+                """)
+            try db.execute(sql: """
+                CREATE INDEX idx_speaker_profile_exemplars_profile
+                ON speaker_profile_exemplars (profileId, createdAt)
+                """)
+            // Suggestion decisions, scoped by fingerprint like
+            // speaker_corrections: once a transcript is re-diarized the old
+            // rows no longer apply, so a stale dismissal cannot permanently
+            // suppress a legitimate suggestion.
+            try db.execute(sql: """
+                CREATE TABLE speaker_profile_links (
+                    transcriptionId TEXT NOT NULL
+                        REFERENCES transcriptions(id) ON DELETE CASCADE,
+                    speakerId TEXT NOT NULL,
+                    transcriptFingerprint TEXT NOT NULL,
+                    profileId TEXT NOT NULL
+                        REFERENCES speaker_profiles(id) ON DELETE CASCADE,
+                    status TEXT NOT NULL CHECK (
+                        status IN ('suggested', 'confirmed', 'dismissed')
+                    ),
+                    distance REAL NOT NULL,
+                    runnerUpDistance REAL,
+                    createdAt TEXT NOT NULL,
+                    updatedAt TEXT NOT NULL,
+                    PRIMARY KEY (transcriptionId, speakerId, transcriptFingerprint)
+                )
+                """)
+            try db.execute(sql: """
+                CREATE INDEX idx_speaker_profile_links_profile
+                ON speaker_profile_links (profileId)
+                """)
+        }
+
         return migrator
     }
 

--- a/Sources/MacParakeetCore/Database/DatabaseManager.swift
+++ b/Sources/MacParakeetCore/Database/DatabaseManager.swift
@@ -2071,6 +2071,40 @@ public final class DatabaseManager: Sendable {
                 """)
         }
 
+        // v0.41 — Enrollment needs a vector the pipeline has already discarded:
+        // the user names a speaker days after the meeting. Written only while
+        // `rememberSpeakers` is on, never read by the matcher, promotable to an
+        // exemplar, and expiring on their own. See the 2026-09-10 amendment in
+        // plans/active/2026-07-03-speaker-voiceprints.md.
+        migrator.registerMigration("v0.41-speaker-embedding-candidates") { db in
+            try db.execute(sql: """
+                CREATE TABLE speaker_embedding_candidates (
+                    id TEXT PRIMARY KEY NOT NULL,
+                    transcriptionId TEXT NOT NULL
+                        REFERENCES transcriptions(id) ON DELETE CASCADE,
+                    speakerId TEXT NOT NULL,
+                    transcriptFingerprint TEXT NOT NULL,
+                    vector BLOB NOT NULL CHECK (length(vector) = 1024),
+                    speechSeconds REAL NOT NULL CHECK (speechSeconds > 0),
+                    captureDomain TEXT NOT NULL CHECK (
+                        captureDomain IN ('system', 'microphone', 'file')
+                    ),
+                    embeddingModelId TEXT NOT NULL,
+                    aggregationProfileId TEXT NOT NULL,
+                    createdAt TEXT NOT NULL,
+                    -- Stored per row, not derived from a constant at read time:
+                    -- raising the window later must not resurrect vectors that
+                    -- were promised a shorter life.
+                    expiresAt TEXT NOT NULL,
+                    UNIQUE (transcriptionId, speakerId, transcriptFingerprint)
+                )
+                """)
+            try db.execute(sql: """
+                CREATE INDEX idx_speaker_embedding_candidates_expiry
+                ON speaker_embedding_candidates (expiresAt)
+                """)
+        }
+
         return migrator
     }
 

--- a/Sources/MacParakeetCore/Database/DatabaseManager.swift
+++ b/Sources/MacParakeetCore/Database/DatabaseManager.swift
@@ -1951,10 +1951,9 @@ public final class DatabaseManager: Sendable {
             }
         }
 
-        // v0.39 — Persistent speaker profiles (voiceprints). Enrolled voices
-        // live here so the same person can be recognized across recordings.
-        // Biometric data: every row is local-only, excluded from exports, and
-        // removable. See plans/active/2026-07-03-speaker-voiceprints.md.
+        // v0.39 — Persistent speaker profiles (voiceprints). Biometric data:
+        // local-only, excluded from exports, removable.
+        // See plans/active/2026-07-03-speaker-voiceprints.md.
         migrator.registerMigration("v0.39-speaker-voiceprints") { db in
             try db.execute(sql: """
                 CREATE TABLE speaker_profiles (
@@ -1970,15 +1969,9 @@ public final class DatabaseManager: Sendable {
                     lastEvaluatedDistance REAL
                 )
                 """)
-            // Renaming a second speaker to an enrolled name must add a sample
-            // to that profile, not create a rival profile with the same name.
-            //
-            // Uniqueness is on the normalized key rather than on
-            // `displayName COLLATE NOCASE`, because NOCASE folds only the 26
-            // ASCII letters: under it "José" and "JOSÉ" are distinct rows, and
-            // a lookup that folds the whole of Unicode would then match both
-            // with no defined winner. The stored key is what both sides agree
-            // on, so the constraint and the lookup cannot drift apart.
+            // On the normalized key, not `displayName COLLATE NOCASE`: NOCASE
+            // folds only ASCII, so "José" and "JOSÉ" would be distinct rows
+            // that a Unicode-aware lookup then matches both of.
             try db.execute(sql: """
                 CREATE UNIQUE INDEX idx_speaker_profiles_normalized_name
                 ON speaker_profiles (normalizedName)
@@ -2009,10 +2002,9 @@ public final class DatabaseManager: Sendable {
                 CREATE INDEX idx_speaker_profile_exemplars_profile
                 ON speaker_profile_exemplars (profileId, createdAt)
                 """)
-            // Suggestion decisions, scoped by fingerprint like
-            // speaker_corrections: once a transcript is re-diarized the old
-            // rows no longer apply, so a stale dismissal cannot permanently
-            // suppress a legitimate suggestion.
+            // Scoped by fingerprint like speaker_corrections: after
+            // re-diarization the old rows no longer apply, so a stale dismissal
+            // cannot permanently suppress a legitimate suggestion.
             try db.execute(sql: """
                 CREATE TABLE speaker_profile_links (
                     transcriptionId TEXT NOT NULL

--- a/Sources/MacParakeetCore/Database/DatabaseManager.swift
+++ b/Sources/MacParakeetCore/Database/DatabaseManager.swift
@@ -2039,6 +2039,38 @@ public final class DatabaseManager: Sendable {
                 """)
         }
 
+        // v0.40 — Local record of every voiceprint matching decision, kept so
+        // the shipped thresholds can be calibrated on real post-AEC meetings
+        // instead of on borrowed clean-corpus numbers. Distances joined to the
+        // label a user actually typed are identifying, so these rows stay on
+        // the machine, never enter a support bundle, and expire.
+        migrator.registerMigration("v0.40-speaker-match-journal") { db in
+            try db.execute(sql: """
+                CREATE TABLE speaker_match_journal (
+                    id TEXT PRIMARY KEY NOT NULL,
+                    transcriptionId TEXT NOT NULL
+                        REFERENCES transcriptions(id) ON DELETE CASCADE,
+                    speakerId TEXT NOT NULL,
+                    profileId TEXT
+                        REFERENCES speaker_profiles(id) ON DELETE CASCADE,
+                    outcome TEXT NOT NULL CHECK (
+                        outcome IN (
+                            'suggested', 'belowSpeechGate', 'noComparableProfile',
+                            'pastThreshold', 'marginTooSmall', 'notMutualBestMatch'
+                        )
+                    ),
+                    topDistance REAL,
+                    runnerUpDistance REAL,
+                    speechSeconds REAL NOT NULL,
+                    createdAt TEXT NOT NULL
+                )
+                """)
+            try db.execute(sql: """
+                CREATE INDEX idx_speaker_match_journal_created
+                ON speaker_match_journal (createdAt)
+                """)
+        }
+
         return migrator
     }
 

--- a/Sources/MacParakeetCore/Database/DatabaseManager.swift
+++ b/Sources/MacParakeetCore/Database/DatabaseManager.swift
@@ -2050,6 +2050,7 @@ public final class DatabaseManager: Sendable {
                     transcriptionId TEXT NOT NULL
                         REFERENCES transcriptions(id) ON DELETE CASCADE,
                     speakerId TEXT NOT NULL,
+                    transcriptFingerprint TEXT NOT NULL,
                     profileId TEXT
                         REFERENCES speaker_profiles(id) ON DELETE CASCADE,
                     outcome TEXT NOT NULL CHECK (

--- a/Sources/MacParakeetCore/Database/DatabaseManager.swift
+++ b/Sources/MacParakeetCore/Database/DatabaseManager.swift
@@ -1960,6 +1960,7 @@ public final class DatabaseManager: Sendable {
                 CREATE TABLE speaker_profiles (
                     id TEXT PRIMARY KEY NOT NULL,
                     displayName TEXT NOT NULL,
+                    normalizedName TEXT NOT NULL,
                     embeddingModelId TEXT NOT NULL,
                     aggregationProfileId TEXT NOT NULL,
                     createdAt TEXT NOT NULL,
@@ -1971,9 +1972,16 @@ public final class DatabaseManager: Sendable {
                 """)
             // Renaming a second speaker to an enrolled name must add a sample
             // to that profile, not create a rival profile with the same name.
+            //
+            // Uniqueness is on the normalized key rather than on
+            // `displayName COLLATE NOCASE`, because NOCASE folds only the 26
+            // ASCII letters: under it "José" and "JOSÉ" are distinct rows, and
+            // a lookup that folds the whole of Unicode would then match both
+            // with no defined winner. The stored key is what both sides agree
+            // on, so the constraint and the lookup cannot drift apart.
             try db.execute(sql: """
-                CREATE UNIQUE INDEX idx_speaker_profiles_name
-                ON speaker_profiles (displayName COLLATE NOCASE)
+                CREATE UNIQUE INDEX idx_speaker_profiles_normalized_name
+                ON speaker_profiles (normalizedName)
                 """)
             try db.execute(sql: """
                 CREATE TABLE speaker_profile_exemplars (

--- a/Sources/MacParakeetCore/Database/DatabaseManager.swift
+++ b/Sources/MacParakeetCore/Database/DatabaseManager.swift
@@ -1958,15 +1958,16 @@ public final class DatabaseManager: Sendable {
             try db.execute(sql: """
                 CREATE TABLE speaker_profiles (
                     id TEXT PRIMARY KEY NOT NULL,
-                    displayName TEXT NOT NULL,
-                    normalizedName TEXT NOT NULL,
+                    displayName TEXT NOT NULL CHECK (length(trim(displayName)) > 0),
+                    normalizedName TEXT NOT NULL CHECK (length(normalizedName) > 0),
                     embeddingModelId TEXT NOT NULL,
                     aggregationProfileId TEXT NOT NULL,
                     createdAt TEXT NOT NULL,
                     updatedAt TEXT NOT NULL,
                     lastMatchedAt TEXT,
                     lastEvaluatedAt TEXT,
-                    lastEvaluatedDistance REAL
+                    lastEvaluatedDistance REAL,
+                    UNIQUE (id, embeddingModelId)
                 )
                 """)
             // On the normalized key, not `displayName COLLATE NOCASE`: NOCASE
@@ -1979,8 +1980,7 @@ public final class DatabaseManager: Sendable {
             try db.execute(sql: """
                 CREATE TABLE speaker_profile_exemplars (
                     id TEXT PRIMARY KEY NOT NULL,
-                    profileId TEXT NOT NULL
-                        REFERENCES speaker_profiles(id) ON DELETE CASCADE,
+                    profileId TEXT NOT NULL,
                     vector BLOB NOT NULL CHECK (length(vector) = 1024),
                     speechSeconds REAL NOT NULL CHECK (speechSeconds > 0),
                     captureDomain TEXT NOT NULL CHECK (
@@ -1995,7 +1995,17 @@ public final class DatabaseManager: Sendable {
                         REFERENCES transcriptions(id) ON DELETE SET NULL,
                     sourceSpeakerId TEXT,
                     createdAt TEXT NOT NULL,
-                    UNIQUE (profileId, sourceTranscriptionId)
+                    UNIQUE (profileId, sourceTranscriptionId),
+                    -- Composite key rather than a plain reference to the id: a
+                    -- sample from another embedding model shares no space with
+                    -- the profile's, so it could be stored and shown while
+                    -- never scoring against anything. No ON UPDATE CASCADE —
+                    -- changing a profile's model must fail while samples in the
+                    -- old one exist. aggregationProfileId stays out: those
+                    -- remain comparable at a tightened threshold.
+                    FOREIGN KEY (profileId, embeddingModelId)
+                        REFERENCES speaker_profiles(id, embeddingModelId)
+                        ON DELETE CASCADE
                 )
                 """)
             try db.execute(sql: """

--- a/Sources/MacParakeetCore/Database/DatabaseManager.swift
+++ b/Sources/MacParakeetCore/Database/DatabaseManager.swift
@@ -2039,11 +2039,10 @@ public final class DatabaseManager: Sendable {
                 """)
         }
 
-        // v0.40 — Local record of every voiceprint matching decision, kept so
-        // the shipped thresholds can be calibrated on real post-AEC meetings
-        // instead of on borrowed clean-corpus numbers. Distances joined to the
-        // label a user actually typed are identifying, so these rows stay on
-        // the machine, never enter a support bundle, and expire.
+        // v0.40 — Local record of every matching decision, so thresholds can be
+        // calibrated on real post-AEC meetings. Distances joined to the label a
+        // user typed are identifying: local-only, never in a support bundle,
+        // and they expire.
         migrator.registerMigration("v0.40-speaker-match-journal") { db in
             try db.execute(sql: """
                 CREATE TABLE speaker_match_journal (

--- a/Sources/MacParakeetCore/Database/SpeakerEmbeddingCandidateRepository.swift
+++ b/Sources/MacParakeetCore/Database/SpeakerEmbeddingCandidateRepository.swift
@@ -41,6 +41,7 @@ public final class SpeakerEmbeddingCandidateRepository: SpeakerEmbeddingCandidat
     public func upsert(_ candidates: [SpeakerEmbeddingCandidate], now: Date = Date()) throws {
         try dbQueue.write { db in
             for candidate in candidates {
+                let key = try SpeakerTranscriptionPersistence.key(candidate.transcriptionId, in: db)
                 // Re-diarization keeps the transcription and speaker ids while
                 // changing the fingerprint, so the natural key can collide with
                 // a row that no longer describes the same person.
@@ -51,12 +52,14 @@ public final class SpeakerEmbeddingCandidateRepository: SpeakerEmbeddingCandidat
                           AND transcriptFingerprint = ?
                         """,
                     arguments: [
-                        candidate.transcriptionId,
+                        key,
                         candidate.speakerId,
                         candidate.transcriptFingerprint,
                     ]
                 )
-                try candidate.insert(db)
+                try SpeakerTranscriptionRecord(
+                    record: candidate, column: "transcriptionId", transcriptionKey: key
+                ).insert(db)
             }
             try deleteExpired(db, now: now)
         }
@@ -72,8 +75,10 @@ public final class SpeakerEmbeddingCandidateRepository: SpeakerEmbeddingCandidat
     ) throws -> SpeakerEmbeddingCandidate? {
         try pruneExpired(now: now)
         return try dbQueue.read { db in
-            try SpeakerEmbeddingCandidate
-                .filter(Column("transcriptionId") == transcriptionId)
+            let key = try SpeakerTranscriptionPersistence.key(transcriptionId, in: db)
+            return
+                try SpeakerEmbeddingCandidate
+                .filter(Column("transcriptionId") == key)
                 .filter(Column("speakerId") == speakerId)
                 .filter(Column("transcriptFingerprint") == fingerprint)
                 .fetchOne(db)
@@ -88,7 +93,7 @@ public final class SpeakerEmbeddingCandidateRepository: SpeakerEmbeddingCandidat
                     WHERE transcriptionId = ? AND speakerId = ?
                       AND transcriptFingerprint = ?
                     """,
-                arguments: [transcriptionId, speakerId, fingerprint]
+                arguments: [try SpeakerTranscriptionPersistence.key(transcriptionId, in: db), speakerId, fingerprint]
             )
         }
     }

--- a/Sources/MacParakeetCore/Database/SpeakerEmbeddingCandidateRepository.swift
+++ b/Sources/MacParakeetCore/Database/SpeakerEmbeddingCandidateRepository.swift
@@ -1,0 +1,116 @@
+import Foundation
+import GRDB
+
+public protocol SpeakerEmbeddingCandidateRepositoryProtocol: Sendable {
+    /// Records this run's candidates and drops anything already expired.
+    /// Re-recording the same speaker replaces the row rather than failing.
+    func upsert(_ candidates: [SpeakerEmbeddingCandidate], now: Date) throws
+    /// The candidate still available for this speaker, or `nil` once it has
+    /// expired or been promoted.
+    func candidate(
+        transcriptionId: UUID,
+        speakerId: String,
+        fingerprint: String,
+        now: Date
+    ) throws -> SpeakerEmbeddingCandidate?
+    /// Called once a candidate has become an exemplar: the vector now lives in
+    /// the profile, so a second copy would be biometric data kept for nothing.
+    func delete(transcriptionId: UUID, speakerId: String, fingerprint: String) throws
+    /// Removes everything past its own `expiresAt`. Safe to call at any time.
+    func pruneExpired(now: Date) throws
+    func deleteAll() throws
+}
+
+/// Short-lived voices awaiting a name.
+///
+/// Expiry is per row rather than computed from a constant at read time, so the
+/// window a user was told about is the window that applies to their data.
+public final class SpeakerEmbeddingCandidateRepository: SpeakerEmbeddingCandidateRepositoryProtocol {
+    /// Long enough to name a speaker after the fact, short enough that this is
+    /// never a record of who was in the room. Anarlog keeps 45 days; naming is a
+    /// same-week action, and unnamed vectors earn nothing by waiting.
+    public static let defaultRetention: TimeInterval = 7 * 24 * 60 * 60
+
+    private let dbQueue: DatabaseQueue
+
+    public init(dbQueue: DatabaseQueue) {
+        self.dbQueue = dbQueue
+    }
+
+    /// Writes and prunes in one transaction.
+    public func upsert(_ candidates: [SpeakerEmbeddingCandidate], now: Date = Date()) throws {
+        try dbQueue.write { db in
+            for candidate in candidates {
+                // Re-diarization keeps the transcription and speaker ids while
+                // changing the fingerprint, so the natural key can collide with
+                // a row that no longer describes the same person.
+                try db.execute(
+                    sql: """
+                        DELETE FROM speaker_embedding_candidates
+                        WHERE transcriptionId = ? AND speakerId = ?
+                          AND transcriptFingerprint = ?
+                        """,
+                    arguments: [
+                        candidate.transcriptionId,
+                        candidate.speakerId,
+                        candidate.transcriptFingerprint,
+                    ]
+                )
+                try candidate.insert(db)
+            }
+            try deleteExpired(db, now: now)
+        }
+    }
+
+    /// Expired rows are removed before reading, so a lapsed candidate can never
+    /// be handed out even if no write has happened since it lapsed.
+    public func candidate(
+        transcriptionId: UUID,
+        speakerId: String,
+        fingerprint: String,
+        now: Date = Date()
+    ) throws -> SpeakerEmbeddingCandidate? {
+        try pruneExpired(now: now)
+        return try dbQueue.read { db in
+            try SpeakerEmbeddingCandidate
+                .filter(Column("transcriptionId") == transcriptionId)
+                .filter(Column("speakerId") == speakerId)
+                .filter(Column("transcriptFingerprint") == fingerprint)
+                .fetchOne(db)
+        }
+    }
+
+    public func delete(transcriptionId: UUID, speakerId: String, fingerprint: String) throws {
+        try dbQueue.write { db in
+            try db.execute(
+                sql: """
+                    DELETE FROM speaker_embedding_candidates
+                    WHERE transcriptionId = ? AND speakerId = ?
+                      AND transcriptFingerprint = ?
+                    """,
+                arguments: [transcriptionId, speakerId, fingerprint]
+            )
+        }
+    }
+
+    /// Expiry cannot ride on writes alone: someone who stops recording stops
+    /// writing, and a seven-day window would quietly become permanent.
+    public func pruneExpired(now: Date = Date()) throws {
+        try dbQueue.write { db in
+            try deleteExpired(db, now: now)
+        }
+    }
+
+    private func deleteExpired(_ db: Database, now: Date) throws {
+        try db.execute(
+            sql: "DELETE FROM speaker_embedding_candidates WHERE expiresAt <= ?",
+            arguments: [now]
+        )
+    }
+
+    public func deleteAll() throws {
+        try dbQueue.write { db in
+            _ = try SpeakerEmbeddingCandidate.deleteAll(db)
+        }
+    }
+}

--- a/Sources/MacParakeetCore/Database/SpeakerMatchJournalRepository.swift
+++ b/Sources/MacParakeetCore/Database/SpeakerMatchJournalRepository.swift
@@ -54,8 +54,11 @@ extension SpeakerMatchJournalEntry: FetchableRecord, PersistableRecord {
 public protocol SpeakerMatchJournalRepositoryProtocol: Sendable {
     /// Records one matching pass and prunes anything past the retention window.
     func append(_ entries: [SpeakerMatchJournalEntry], retention: TimeInterval, now: Date) throws
-    /// Everything still within the window, oldest first.
-    func entries() throws -> [SpeakerMatchJournalEntry]
+    /// Everything still within the window, oldest first. Expired rows are
+    /// removed first, so reading can never surface what should have expired.
+    func entries(retention: TimeInterval, now: Date) throws -> [SpeakerMatchJournalEntry]
+    /// Removes everything past the window. Safe to call at any time.
+    func prune(retention: TimeInterval, now: Date) throws
     /// Forgets every decision. Profiles and transcripts are untouched.
     func deleteAll() throws
 }
@@ -73,29 +76,46 @@ public final class SpeakerMatchJournalRepository: SpeakerMatchJournalRepositoryP
     }
 
     /// Appends a pass and drops anything past the retention window, in one
-    /// transaction. Pruning on write means no scheduler and no cleanup task to
-    /// forget.
+    /// transaction.
     public func append(
         _ entries: [SpeakerMatchJournalEntry],
-        retention: TimeInterval = defaultRetention,
-        now: Date = Date()
+        retention: TimeInterval,
+        now: Date
     ) throws {
         try dbQueue.write { db in
             for entry in entries {
                 try entry.insert(db)
             }
-            let cutoff = now.addingTimeInterval(-retention)
-            try db.execute(
-                sql: "DELETE FROM speaker_match_journal WHERE createdAt < ?",
-                arguments: [cutoff]
-            )
+            try deleteExpired(db, retention: retention, now: now)
         }
     }
 
-    public func entries() throws -> [SpeakerMatchJournalEntry] {
-        try dbQueue.read { db in
+    /// Prunes, then reads.
+    ///
+    /// Expiry cannot ride on writes alone: a user who stops recording stops
+    /// appending, and rows past the window would then sit there indefinitely,
+    /// turning a ninety-day journal into a permanent record of who spoke.
+    public func entries(
+        retention: TimeInterval = defaultRetention,
+        now: Date = Date()
+    ) throws -> [SpeakerMatchJournalEntry] {
+        try prune(retention: retention, now: now)
+        return try dbQueue.read { db in
             try SpeakerMatchJournalEntry.order(Column("createdAt")).fetchAll(db)
         }
+    }
+
+    public func prune(retention: TimeInterval = defaultRetention, now: Date = Date()) throws {
+        try dbQueue.write { db in
+            try deleteExpired(db, retention: retention, now: now)
+        }
+    }
+
+    private func deleteExpired(_ db: Database, retention: TimeInterval, now: Date) throws {
+        try db.execute(
+            sql: "DELETE FROM speaker_match_journal WHERE createdAt < ?",
+            arguments: [now.addingTimeInterval(-retention)]
+        )
     }
 
     public func deleteAll() throws {

--- a/Sources/MacParakeetCore/Database/SpeakerMatchJournalRepository.swift
+++ b/Sources/MacParakeetCore/Database/SpeakerMatchJournalRepository.swift
@@ -3,8 +3,8 @@ import GRDB
 
 /// One matching decision, kept locally so thresholds can be calibrated on real
 /// meetings rather than the clean-corpus numbers the plan had to borrow. The
-/// label the user ends up typing is the ground truth, which makes these rows
-/// identifying: they never leave the machine, and they expire.
+/// label the user ends up typing is reviewable feedback, not independent ground
+/// truth. These identifying rows stay local and expire.
 public struct SpeakerMatchJournalEntry: Codable, Identifiable, Sendable, Equatable {
     public var id: UUID
     public var transcriptionId: UUID
@@ -62,8 +62,8 @@ public protocol SpeakerMatchJournalRepositoryProtocol: Sendable {
 }
 
 public final class SpeakerMatchJournalRepository: SpeakerMatchJournalRepositoryProtocol {
-    /// Long enough for the twenty-odd meetings calibration needs, short enough
-    /// that this never becomes an archive of who spoke to whom.
+    /// Bounds local diagnostic retention; it does not define an evaluation's
+    /// required sample size.
     public static let defaultRetention: TimeInterval = 90 * 24 * 60 * 60
 
     private let dbQueue: DatabaseQueue

--- a/Sources/MacParakeetCore/Database/SpeakerMatchJournalRepository.swift
+++ b/Sources/MacParakeetCore/Database/SpeakerMatchJournalRepository.swift
@@ -80,7 +80,10 @@ public final class SpeakerMatchJournalRepository: SpeakerMatchJournalRepositoryP
     ) throws {
         try dbQueue.write { db in
             for entry in entries {
-                try entry.insert(db)
+                try SpeakerTranscriptionRecord(
+                    record: entry, column: "transcriptionId",
+                    transcriptionKey: SpeakerTranscriptionPersistence.key(entry.transcriptionId, in: db)
+                ).insert(db)
             }
             try deleteExpired(db, retention: retention, now: now)
         }

--- a/Sources/MacParakeetCore/Database/SpeakerMatchJournalRepository.swift
+++ b/Sources/MacParakeetCore/Database/SpeakerMatchJournalRepository.swift
@@ -1,0 +1,106 @@
+import Foundation
+import GRDB
+
+/// One matching decision, kept locally so thresholds can be calibrated on real
+/// meetings rather than on the clean-corpus numbers the plan had to borrow.
+///
+/// Ground truth arrives for free: the label the user ends up typing says
+/// whether the decision was right. That makes these rows identifying, so they
+/// never leave the machine and they expire.
+public struct SpeakerMatchJournalEntry: Codable, Identifiable, Sendable, Equatable {
+    public var id: UUID
+    public var transcriptionId: UUID
+    public var speakerId: String
+    /// The profile involved, when there was one.
+    public var profileId: UUID?
+    public var outcome: SpeakerMatchOutcome
+    public var topDistance: Double?
+    public var runnerUpDistance: Double?
+    public var speechSeconds: Double
+    public var createdAt: Date
+
+    /// - Parameters:
+    ///   - profileId: the profile involved, absent when no enrolled voice was
+    ///     comparable.
+    ///   - topDistance: the closest distance considered, absent when nothing
+    ///     was scored.
+    public init(
+        id: UUID = UUID(),
+        transcriptionId: UUID,
+        speakerId: String,
+        profileId: UUID? = nil,
+        outcome: SpeakerMatchOutcome,
+        topDistance: Double? = nil,
+        runnerUpDistance: Double? = nil,
+        speechSeconds: Double,
+        createdAt: Date = Date()
+    ) {
+        self.id = id
+        self.transcriptionId = transcriptionId
+        self.speakerId = speakerId
+        self.profileId = profileId
+        self.outcome = outcome
+        self.topDistance = topDistance
+        self.runnerUpDistance = runnerUpDistance
+        self.speechSeconds = speechSeconds
+        self.createdAt = createdAt
+    }
+}
+
+extension SpeakerMatchJournalEntry: FetchableRecord, PersistableRecord {
+    public static let databaseTableName = "speaker_match_journal"
+}
+
+public protocol SpeakerMatchJournalRepositoryProtocol: Sendable {
+    /// Records one matching pass and prunes anything past the retention window.
+    func append(_ entries: [SpeakerMatchJournalEntry], retention: TimeInterval, now: Date) throws
+    /// Everything still within the window, oldest first.
+    func entries() throws -> [SpeakerMatchJournalEntry]
+    /// Forgets every decision. Profiles and transcripts are untouched.
+    func deleteAll() throws
+}
+
+public final class SpeakerMatchJournalRepository: SpeakerMatchJournalRepositoryProtocol {
+    /// Long enough to accumulate the twenty-odd meetings calibration needs,
+    /// short enough that the journal never becomes an archive of who spoke to
+    /// whom.
+    public static let defaultRetention: TimeInterval = 90 * 24 * 60 * 60
+
+    private let dbQueue: DatabaseQueue
+
+    public init(dbQueue: DatabaseQueue) {
+        self.dbQueue = dbQueue
+    }
+
+    /// Appends a pass and drops anything past the retention window, in one
+    /// transaction. Pruning on write means no scheduler and no cleanup task to
+    /// forget.
+    public func append(
+        _ entries: [SpeakerMatchJournalEntry],
+        retention: TimeInterval = defaultRetention,
+        now: Date = Date()
+    ) throws {
+        try dbQueue.write { db in
+            for entry in entries {
+                try entry.insert(db)
+            }
+            let cutoff = now.addingTimeInterval(-retention)
+            try db.execute(
+                sql: "DELETE FROM speaker_match_journal WHERE createdAt < ?",
+                arguments: [cutoff]
+            )
+        }
+    }
+
+    public func entries() throws -> [SpeakerMatchJournalEntry] {
+        try dbQueue.read { db in
+            try SpeakerMatchJournalEntry.order(Column("createdAt")).fetchAll(db)
+        }
+    }
+
+    public func deleteAll() throws {
+        try dbQueue.write { db in
+            _ = try SpeakerMatchJournalEntry.deleteAll(db)
+        }
+    }
+}

--- a/Sources/MacParakeetCore/Database/SpeakerMatchJournalRepository.swift
+++ b/Sources/MacParakeetCore/Database/SpeakerMatchJournalRepository.swift
@@ -9,6 +9,10 @@ public struct SpeakerMatchJournalEntry: Codable, Identifiable, Sendable, Equatab
     public var id: UUID
     public var transcriptionId: UUID
     public var speakerId: String
+    /// Which version of the transcript produced this decision. `speakerId` is
+    /// positional, so without it calibration cannot join a decision to the
+    /// label that answered it.
+    public var transcriptFingerprint: String
     /// The profile involved, when there was one.
     public var profileId: UUID?
     public var outcome: SpeakerMatchOutcome
@@ -21,6 +25,7 @@ public struct SpeakerMatchJournalEntry: Codable, Identifiable, Sendable, Equatab
         id: UUID = UUID(),
         transcriptionId: UUID,
         speakerId: String,
+        transcriptFingerprint: String,
         profileId: UUID? = nil,
         outcome: SpeakerMatchOutcome,
         topDistance: Double? = nil,
@@ -31,6 +36,7 @@ public struct SpeakerMatchJournalEntry: Codable, Identifiable, Sendable, Equatab
         self.id = id
         self.transcriptionId = transcriptionId
         self.speakerId = speakerId
+        self.transcriptFingerprint = transcriptFingerprint
         self.profileId = profileId
         self.outcome = outcome
         self.topDistance = topDistance

--- a/Sources/MacParakeetCore/Database/SpeakerMatchJournalRepository.swift
+++ b/Sources/MacParakeetCore/Database/SpeakerMatchJournalRepository.swift
@@ -2,11 +2,9 @@ import Foundation
 import GRDB
 
 /// One matching decision, kept locally so thresholds can be calibrated on real
-/// meetings rather than on the clean-corpus numbers the plan had to borrow.
-///
-/// Ground truth arrives for free: the label the user ends up typing says
-/// whether the decision was right. That makes these rows identifying, so they
-/// never leave the machine and they expire.
+/// meetings rather than the clean-corpus numbers the plan had to borrow. The
+/// label the user ends up typing is the ground truth, which makes these rows
+/// identifying: they never leave the machine, and they expire.
 public struct SpeakerMatchJournalEntry: Codable, Identifiable, Sendable, Equatable {
     public var id: UUID
     public var transcriptionId: UUID
@@ -19,11 +17,6 @@ public struct SpeakerMatchJournalEntry: Codable, Identifiable, Sendable, Equatab
     public var speechSeconds: Double
     public var createdAt: Date
 
-    /// - Parameters:
-    ///   - profileId: the profile involved, absent when no enrolled voice was
-    ///     comparable.
-    ///   - topDistance: the closest distance considered, absent when nothing
-    ///     was scored.
     public init(
         id: UUID = UUID(),
         transcriptionId: UUID,
@@ -59,14 +52,12 @@ public protocol SpeakerMatchJournalRepositoryProtocol: Sendable {
     func entries(retention: TimeInterval, now: Date) throws -> [SpeakerMatchJournalEntry]
     /// Removes everything past the window. Safe to call at any time.
     func prune(retention: TimeInterval, now: Date) throws
-    /// Forgets every decision. Profiles and transcripts are untouched.
     func deleteAll() throws
 }
 
 public final class SpeakerMatchJournalRepository: SpeakerMatchJournalRepositoryProtocol {
-    /// Long enough to accumulate the twenty-odd meetings calibration needs,
-    /// short enough that the journal never becomes an archive of who spoke to
-    /// whom.
+    /// Long enough for the twenty-odd meetings calibration needs, short enough
+    /// that this never becomes an archive of who spoke to whom.
     public static let defaultRetention: TimeInterval = 90 * 24 * 60 * 60
 
     private let dbQueue: DatabaseQueue
@@ -75,8 +66,7 @@ public final class SpeakerMatchJournalRepository: SpeakerMatchJournalRepositoryP
         self.dbQueue = dbQueue
     }
 
-    /// Appends a pass and drops anything past the retention window, in one
-    /// transaction.
+    /// Appends and prunes in one transaction.
     public func append(
         _ entries: [SpeakerMatchJournalEntry],
         retention: TimeInterval,
@@ -90,11 +80,8 @@ public final class SpeakerMatchJournalRepository: SpeakerMatchJournalRepositoryP
         }
     }
 
-    /// Prunes, then reads.
-    ///
     /// Expiry cannot ride on writes alone: a user who stops recording stops
-    /// appending, and rows past the window would then sit there indefinitely,
-    /// turning a ninety-day journal into a permanent record of who spoke.
+    /// appending, and a ninety-day journal would quietly become permanent.
     public func entries(
         retention: TimeInterval = defaultRetention,
         now: Date = Date()

--- a/Sources/MacParakeetCore/Database/SpeakerProfileRepository.swift
+++ b/Sources/MacParakeetCore/Database/SpeakerProfileRepository.swift
@@ -9,6 +9,12 @@ public enum SpeakerProfileStoreError: Error, Equatable {
     /// A profile's embedding model cannot change while it holds samples in the
     /// old one. Re-enrollment creates fresh samples instead.
     case embeddingModelChangeWithExemplars(UUID)
+    /// A name that normalizes to nothing has no lookup key, so it could neither
+    /// be found again nor keep a second blank name from colliding with it.
+    case emptyDisplayName
+    /// A decision the user already made is not overwritten by a fresh
+    /// suggestion.
+    case terminalDecisionAlreadyRecorded(status: SpeakerProfileLink.Status)
 }
 
 public protocol SpeakerProfileRepositoryProtocol: Sendable {
@@ -77,7 +83,11 @@ public final class SpeakerProfileRepository: SpeakerProfileRepositoryProtocol {
     /// unscoreable, leaving a profile that looks populated and matches nothing.
     public func save(_ profile: SpeakerProfile) throws {
         var profile = profile
+        profile.displayName = profile.displayName.trimmingCharacters(in: .whitespacesAndNewlines)
         profile.normalizedName = SpeakerProfile.normalizedName(for: profile.displayName)
+        guard !profile.normalizedName.isEmpty else {
+            throw SpeakerProfileStoreError.emptyDisplayName
+        }
         try dbQueue.write { db in
             if let existing = try SpeakerProfile.fetchOne(db, key: profile.id),
                existing.embeddingModelId != profile.embeddingModelId,
@@ -160,6 +170,14 @@ public final class SpeakerProfileRepository: SpeakerProfileRepositoryProtocol {
                 .filter(Column("transcriptFingerprint") == link.transcriptFingerprint)
                 .fetchOne(db)
             if let existing {
+                // A suggestion may become confirmed or dismissed, never the
+                // other way round: a second evaluation of the same transcript
+                // would otherwise erase what the user answered.
+                if link.status == .suggested, existing.status != .suggested {
+                    throw SpeakerProfileStoreError.terminalDecisionAlreadyRecorded(
+                        status: existing.status
+                    )
+                }
                 link.createdAt = existing.createdAt
             }
             try link.save(db)

--- a/Sources/MacParakeetCore/Database/SpeakerProfileRepository.swift
+++ b/Sources/MacParakeetCore/Database/SpeakerProfileRepository.swift
@@ -1,0 +1,128 @@
+import Foundation
+import GRDB
+
+public protocol SpeakerProfileRepositoryProtocol: Sendable {
+    func profiles() throws -> [SpeakerProfile]
+    func profile(id: UUID) throws -> SpeakerProfile?
+    func profile(named name: String) throws -> SpeakerProfile?
+    func save(_ profile: SpeakerProfile) throws
+    func exemplars(profileId: UUID) throws -> [SpeakerProfileExemplar]
+    func exemplarsByProfile() throws -> [UUID: [SpeakerProfileExemplar]]
+    func insert(_ exemplar: SpeakerProfileExemplar) throws
+    func deleteExemplar(id: UUID) throws -> Bool
+    func links(transcriptionId: UUID, fingerprint: String) throws -> [SpeakerProfileLink]
+    func save(_ link: SpeakerProfileLink) throws
+    func deleteProfile(id: UUID) throws -> Bool
+    func deleteAllProfiles() throws
+}
+
+/// Stores enrolled voices. Persistence only: thresholds, gates and matching
+/// policy live in the matcher, and nothing here decides whether two voices are
+/// the same person.
+public final class SpeakerProfileRepository: SpeakerProfileRepositoryProtocol {
+    private let dbQueue: DatabaseQueue
+
+    public init(dbQueue: DatabaseQueue) {
+        self.dbQueue = dbQueue
+    }
+
+    // MARK: Profiles
+
+    public func profiles() throws -> [SpeakerProfile] {
+        try dbQueue.read { db in
+            try SpeakerProfile
+                .order(Column("displayName").collating(.localizedCaseInsensitiveCompare))
+                .fetchAll(db)
+        }
+    }
+
+    public func profile(id: UUID) throws -> SpeakerProfile? {
+        try dbQueue.read { db in
+            try SpeakerProfile.fetchOne(db, key: id)
+        }
+    }
+
+    /// Case-insensitive, matching the unique index: "sarah" and "Sarah" are the
+    /// same person as far as enrollment is concerned.
+    public func profile(named name: String) throws -> SpeakerProfile? {
+        try dbQueue.read { db in
+            try SpeakerProfile
+                .filter(Column("displayName").collating(.nocase) == name)
+                .fetchOne(db)
+        }
+    }
+
+    public func save(_ profile: SpeakerProfile) throws {
+        try dbQueue.write { db in
+            try profile.save(db)
+        }
+    }
+
+    // MARK: Exemplars
+
+    public func exemplars(profileId: UUID) throws -> [SpeakerProfileExemplar] {
+        try dbQueue.read { db in
+            try SpeakerProfileExemplar
+                .filter(Column("profileId") == profileId)
+                .order(Column("createdAt"))
+                .fetchAll(db)
+        }
+    }
+
+    /// Every exemplar, grouped by profile — one read for a whole matching pass
+    /// rather than one per profile.
+    public func exemplarsByProfile() throws -> [UUID: [SpeakerProfileExemplar]] {
+        let all = try dbQueue.read { db in
+            try SpeakerProfileExemplar.order(Column("createdAt")).fetchAll(db)
+        }
+        return Dictionary(grouping: all, by: \.profileId)
+    }
+
+    public func insert(_ exemplar: SpeakerProfileExemplar) throws {
+        try dbQueue.write { db in
+            try exemplar.insert(db)
+        }
+    }
+
+    public func deleteExemplar(id: UUID) throws -> Bool {
+        try dbQueue.write { db in
+            try SpeakerProfileExemplar.deleteOne(db, key: id)
+        }
+    }
+
+    // MARK: Links
+
+    public func links(transcriptionId: UUID, fingerprint: String) throws -> [SpeakerProfileLink] {
+        try dbQueue.read { db in
+            try SpeakerProfileLink
+                .filter(Column("transcriptionId") == transcriptionId)
+                .filter(Column("transcriptFingerprint") == fingerprint)
+                .fetchAll(db)
+        }
+    }
+
+    public func save(_ link: SpeakerProfileLink) throws {
+        try dbQueue.write { db in
+            try link.save(db)
+        }
+    }
+
+    // MARK: Deletion
+
+    /// Removes a profile and everything it owns in one transaction.
+    ///
+    /// Exemplars and links go with it through their cascades; transcripts and
+    /// any label already applied are untouched, because deleting a voiceprint
+    /// must not rewrite the user's history.
+    public func deleteProfile(id: UUID) throws -> Bool {
+        try dbQueue.write { db in
+            try SpeakerProfile.deleteOne(db, key: id)
+        }
+    }
+
+    public func deleteAllProfiles() throws {
+        try dbQueue.write { db in
+            _ = try SpeakerProfile.deleteAll(db)
+        }
+    }
+}

--- a/Sources/MacParakeetCore/Database/SpeakerProfileRepository.swift
+++ b/Sources/MacParakeetCore/Database/SpeakerProfileRepository.swift
@@ -42,12 +42,19 @@ public final class SpeakerProfileRepository: SpeakerProfileRepositoryProtocol {
         }
     }
 
-    /// Case-insensitive, matching the unique index: "sarah" and "Sarah" are the
-    /// same person as far as enrollment is concerned.
+    /// Case-insensitive lookup: "sarah" and "Sarah" are the same person as far
+    /// as enrollment is concerned.
+    ///
+    /// Uses a localized collation rather than SQLite's `NOCASE`, which folds
+    /// only the 26 ASCII letters — under it "josé" and "JOSÉ" would be two
+    /// different people, and the second enrollment would silently create a
+    /// rival profile instead of adding a sample. The unique index keeps
+    /// `NOCASE` as a backstop, so this lookup is deliberately the wider of the
+    /// two.
     public func profile(named name: String) throws -> SpeakerProfile? {
         try dbQueue.read { db in
             try SpeakerProfile
-                .filter(Column("displayName").collating(.nocase) == name)
+                .filter(Column("displayName").collating(.localizedCaseInsensitiveCompare) == name)
                 .fetchOne(db)
         }
     }
@@ -101,8 +108,24 @@ public final class SpeakerProfileRepository: SpeakerProfileRepositoryProtocol {
         }
     }
 
+    /// Upserts a decision, keeping the original `createdAt`.
+    ///
+    /// A link is saved again whenever its status moves — suggested, then
+    /// confirmed or dismissed — and each caller builds a fresh value. Without
+    /// this, the moment the suggestion was first made would be overwritten by
+    /// the moment the user answered, and the journal would lose the interval
+    /// between them.
     public func save(_ link: SpeakerProfileLink) throws {
         try dbQueue.write { db in
+            var link = link
+            let existing = try SpeakerProfileLink
+                .filter(Column("transcriptionId") == link.transcriptionId)
+                .filter(Column("speakerId") == link.speakerId)
+                .filter(Column("transcriptFingerprint") == link.transcriptFingerprint)
+                .fetchOne(db)
+            if let existing {
+                link.createdAt = existing.createdAt
+            }
             try link.save(db)
         }
     }

--- a/Sources/MacParakeetCore/Database/SpeakerProfileRepository.swift
+++ b/Sources/MacParakeetCore/Database/SpeakerProfileRepository.swift
@@ -42,6 +42,15 @@ public protocol SpeakerProfileRepositoryProtocol: Sendable {
     /// rather than `save` for a new profile: a lookup followed by `save` lets
     /// two concurrent enrollments of one name both find nothing.
     func insert(_ profile: SpeakerProfile) throws
+    /// Creates a profile and its first sample together. A racing enrollment of
+    /// the same name must not be able to observe an empty profile and skip the
+    /// pollution guard. Failures and cap refusals leave no row.
+    func insert(
+        _ profile: SpeakerProfile,
+        firstExemplar: SpeakerProfileExemplar,
+        maxPerProfile: Int,
+        evicting: SpeakerProfileExemplar.Origin
+    ) throws -> SpeakerExemplarInsertion
     func save(_ profile: SpeakerProfile) throws
     func exemplars(profileId: UUID) throws -> [SpeakerProfileExemplar]
     /// One read for a whole matching pass.
@@ -64,6 +73,34 @@ public protocol SpeakerProfileRepositoryProtocol: Sendable {
     /// Transcripts and labels already applied are untouched.
     func deleteProfile(id: UUID) throws -> Bool
     func deleteAllProfiles() throws
+}
+
+extension SpeakerProfileRepositoryProtocol {
+    /// Two writes, used only by mocks that do not own a database queue. The
+    /// concrete store overrides this with a single transaction.
+    public func insert(
+        _ profile: SpeakerProfile,
+        firstExemplar: SpeakerProfileExemplar,
+        maxPerProfile: Int,
+        evicting: SpeakerProfileExemplar.Origin
+    ) throws -> SpeakerExemplarInsertion {
+        try insert(profile)
+        do {
+            let result = try insertExemplar(
+                firstExemplar, maxPerProfile: maxPerProfile, evicting: evicting
+            )
+            switch result {
+            case .inserted, .insertedEvicting:
+                return result
+            case .rejectedAlreadySampled, .rejectedProfileFull:
+                _ = try deleteProfile(id: profile.id)
+                return result
+            }
+        } catch {
+            _ = try? deleteProfile(id: profile.id)
+            throw error
+        }
+    }
 }
 
 /// Stores enrolled voices. Persistence only — thresholds and matching policy
@@ -110,16 +147,45 @@ public final class SpeakerProfileRepository: SpeakerProfileRepositoryProtocol {
     public func insert(_ profile: SpeakerProfile) throws {
         let profile = try normalized(profile)
         try dbQueue.write { db in
-            if try SpeakerProfile
-                .filter(Column("normalizedName") == profile.normalizedName)
-                .fetchCount(db) > 0
-            {
-                throw SpeakerProfileStoreError.nameAlreadyTaken(
-                    normalizedName: profile.normalizedName
-                )
-            }
-            try profile.insert(db)
+            try claimAndInsert(profile, db: db)
         }
+    }
+
+    /// Profile and first sample commit together, or neither does. Returning a
+    /// cap refusal from inside `write` would still commit the empty profile,
+    /// so a refused first sample deletes that row before the transaction ends.
+    public func insert(
+        _ profile: SpeakerProfile,
+        firstExemplar: SpeakerProfileExemplar,
+        maxPerProfile: Int,
+        evicting: SpeakerProfileExemplar.Origin
+    ) throws -> SpeakerExemplarInsertion {
+        let profile = try normalized(profile)
+        return try dbQueue.write { db in
+            try claimAndInsert(profile, db: db)
+            let result = try insertCappedExemplar(
+                firstExemplar, maxPerProfile: maxPerProfile, evicting: evicting, db: db
+            )
+            switch result {
+            case .inserted, .insertedEvicting:
+                return result
+            case .rejectedAlreadySampled, .rejectedProfileFull:
+                _ = try SpeakerProfile.deleteOne(db, key: profile.id)
+                return result
+            }
+        }
+    }
+
+    private func claimAndInsert(_ profile: SpeakerProfile, db: Database) throws {
+        if try SpeakerProfile
+            .filter(Column("normalizedName") == profile.normalizedName)
+            .fetchCount(db) > 0
+        {
+            throw SpeakerProfileStoreError.nameAlreadyTaken(
+                normalizedName: profile.normalizedName
+            )
+        }
+        try profile.insert(db)
     }
 
     /// Recomputes the normalized key before writing: `displayName` is mutable,
@@ -207,37 +273,57 @@ public final class SpeakerProfileRepository: SpeakerProfileRepositoryProtocol {
         evicting: SpeakerProfileExemplar.Origin
     ) throws -> SpeakerExemplarInsertion {
         try dbQueue.write { db in
-            if let profile = try SpeakerProfile.fetchOne(db, key: exemplar.profileId),
-               profile.embeddingModelId != exemplar.embeddingModelId
-            {
-                throw SpeakerProfileStoreError.incompatibleEmbeddingModel(
-                    profile: profile.embeddingModelId,
-                    exemplar: exemplar.embeddingModelId
-                )
-            }
-
-            let existing = try SpeakerProfileExemplar
-                .filter(Column("profileId") == exemplar.profileId)
-                .order(Column("createdAt"))
-                .fetchAll(db)
-            if let sampled = exemplar.sourceTranscriptionId,
-               existing.contains(where: { $0.sourceTranscriptionId == sampled })
-            {
-                return .rejectedAlreadySampled
-            }
-
-            var evicted: UUID?
-            if existing.count >= max(0, maxPerProfile) {
-                guard let target = existing.first(where: { $0.origin == evicting }) else {
-                    return .rejectedProfileFull
-                }
-                _ = try SpeakerProfileExemplar.deleteOne(db, key: target.id)
-                evicted = target.id
-            }
-
-            try exemplar.insert(db)
-            return evicted.map { .insertedEvicting($0) } ?? .inserted
+            try insertCappedExemplar(
+                exemplar, maxPerProfile: maxPerProfile, evicting: evicting, db: db
+            )
         }
+    }
+
+    /// Zero refuses without touching stored samples. A reduced cap that the
+    /// profile already exceeds also refuses: shrinking the policy must not
+    /// silently delete several user samples to make room for one more. At the
+    /// exact cap, one eligible sample is evicted as before.
+    private func insertCappedExemplar(
+        _ exemplar: SpeakerProfileExemplar,
+        maxPerProfile: Int,
+        evicting: SpeakerProfileExemplar.Origin,
+        db: Database
+    ) throws -> SpeakerExemplarInsertion {
+        if let profile = try SpeakerProfile.fetchOne(db, key: exemplar.profileId),
+           profile.embeddingModelId != exemplar.embeddingModelId
+        {
+            throw SpeakerProfileStoreError.incompatibleEmbeddingModel(
+                profile: profile.embeddingModelId,
+                exemplar: exemplar.embeddingModelId
+            )
+        }
+
+        let existing = try SpeakerProfileExemplar
+            .filter(Column("profileId") == exemplar.profileId)
+            .order(Column("createdAt"))
+            .fetchAll(db)
+        if let sampled = exemplar.sourceTranscriptionId,
+           existing.contains(where: { $0.sourceTranscriptionId == sampled })
+        {
+            return .rejectedAlreadySampled
+        }
+
+        let cap = max(0, maxPerProfile)
+        if cap == 0 || existing.count > cap {
+            return .rejectedProfileFull
+        }
+
+        var evicted: UUID?
+        if existing.count == cap {
+            guard let target = existing.first(where: { $0.origin == evicting }) else {
+                return .rejectedProfileFull
+            }
+            _ = try SpeakerProfileExemplar.deleteOne(db, key: target.id)
+            evicted = target.id
+        }
+
+        try exemplar.insert(db)
+        return evicted.map { .insertedEvicting($0) } ?? .inserted
     }
 
     public func deleteExemplar(id: UUID) throws -> Bool {
@@ -269,13 +355,17 @@ public final class SpeakerProfileRepository: SpeakerProfileRepositoryProtocol {
                 .filter(Column("transcriptFingerprint") == link.transcriptFingerprint)
                 .fetchOne(db)
             if let existing {
-                // A suggestion may become confirmed or dismissed, never the
-                // other way round: a second evaluation of the same transcript
-                // would otherwise erase what the user answered.
-                if link.status == .suggested, existing.status != .suggested {
-                    throw SpeakerProfileStoreError.terminalDecisionAlreadyRecorded(
-                        status: existing.status
-                    )
+                // A suggestion may become confirmed or dismissed. A terminal
+                // choice does not flip, and it does not move to another profile:
+                // repeating the same status and profile is the only no-op.
+                if existing.status != .suggested {
+                    let sameChoice =
+                        existing.status == link.status && existing.profileId == link.profileId
+                    guard sameChoice else {
+                        throw SpeakerProfileStoreError.terminalDecisionAlreadyRecorded(
+                            status: existing.status
+                        )
+                    }
                 }
                 link.createdAt = existing.createdAt
             }

--- a/Sources/MacParakeetCore/Database/SpeakerProfileRepository.swift
+++ b/Sources/MacParakeetCore/Database/SpeakerProfileRepository.swift
@@ -15,6 +15,21 @@ public enum SpeakerProfileStoreError: Error, Equatable {
     /// A decision the user already made is not overwritten by a fresh
     /// suggestion.
     case terminalDecisionAlreadyRecorded(status: SpeakerProfileLink.Status)
+    /// Another profile already holds this name. Raised instead of letting the
+    /// unique index surface a raw `DatabaseError`, so a caller racing another
+    /// enrollment of the same name can add a sample to the winner instead.
+    case nameAlreadyTaken(normalizedName: String)
+}
+
+/// What the store did with a sample offered under a cap.
+public enum SpeakerExemplarInsertion: Sendable, Equatable {
+    case inserted
+    /// The cap was reached, so this sample replaced the evicted one.
+    case insertedEvicting(UUID)
+    /// The cap is reached and nothing may be evicted.
+    case rejectedProfileFull
+    /// The profile already holds a sample from this recording.
+    case rejectedAlreadySampled
 }
 
 public protocol SpeakerProfileRepositoryProtocol: Sendable {
@@ -23,11 +38,24 @@ public protocol SpeakerProfileRepositoryProtocol: Sendable {
     /// Case-insensitive; what enrollment uses to choose between adding a sample
     /// and creating a profile.
     func profile(named name: String) throws -> SpeakerProfile?
+    /// Creates a profile, claiming its name in the same transaction. Use this
+    /// rather than `save` for a new profile: a lookup followed by `save` lets
+    /// two concurrent enrollments of one name both find nothing.
+    func insert(_ profile: SpeakerProfile) throws
     func save(_ profile: SpeakerProfile) throws
     func exemplars(profileId: UUID) throws -> [SpeakerProfileExemplar]
     /// One read for a whole matching pass.
     func exemplarsByProfile() throws -> [UUID: [SpeakerProfileExemplar]]
     func insert(_ exemplar: SpeakerProfileExemplar) throws
+    /// Enforces the sample cap in the same transaction as the insert, evicting
+    /// the oldest sample of `evicting` to make room. Checking the count from
+    /// outside cannot hold the cap: two callers both read a count below it and
+    /// both insert.
+    func insertExemplar(
+        _ exemplar: SpeakerProfileExemplar,
+        maxPerProfile: Int,
+        evicting: SpeakerProfileExemplar.Origin
+    ) throws -> SpeakerExemplarInsertion
     func deleteExemplar(id: UUID) throws -> Bool
     /// Rows from an earlier fingerprint are deliberately invisible here.
     func links(transcriptionId: UUID, fingerprint: String) throws -> [SpeakerProfileLink]
@@ -74,6 +102,26 @@ public final class SpeakerProfileRepository: SpeakerProfileRepositoryProtocol {
         }
     }
 
+    /// Claims the name in the transaction that creates the profile. A caller
+    /// that looks the name up first and then saves leaves a window where two
+    /// enrollments of "Sarah" both find nothing; the unique index would then
+    /// fail the loser with a raw `DatabaseError` instead of a refusal it can
+    /// act on.
+    public func insert(_ profile: SpeakerProfile) throws {
+        let profile = try normalized(profile)
+        try dbQueue.write { db in
+            if try SpeakerProfile
+                .filter(Column("normalizedName") == profile.normalizedName)
+                .fetchCount(db) > 0
+            {
+                throw SpeakerProfileStoreError.nameAlreadyTaken(
+                    normalizedName: profile.normalizedName
+                )
+            }
+            try profile.insert(db)
+        }
+    }
+
     /// Recomputes the normalized key before writing: `displayName` is mutable,
     /// so a rename would otherwise leave the old key enforcing uniqueness while
     /// a lookup by the new name found nothing.
@@ -82,12 +130,7 @@ public final class SpeakerProfileRepository: SpeakerProfileRepositoryProtocol {
     /// samples: those samples would stay in the old representation and become
     /// unscoreable, leaving a profile that looks populated and matches nothing.
     public func save(_ profile: SpeakerProfile) throws {
-        var profile = profile
-        profile.displayName = profile.displayName.trimmingCharacters(in: .whitespacesAndNewlines)
-        profile.normalizedName = SpeakerProfile.normalizedName(for: profile.displayName)
-        guard !profile.normalizedName.isEmpty else {
-            throw SpeakerProfileStoreError.emptyDisplayName
-        }
+        let profile = try normalized(profile)
         try dbQueue.write { db in
             if let existing = try SpeakerProfile.fetchOne(db, key: profile.id),
                existing.embeddingModelId != profile.embeddingModelId,
@@ -99,6 +142,16 @@ public final class SpeakerProfileRepository: SpeakerProfileRepositoryProtocol {
             }
             try profile.save(db)
         }
+    }
+
+    private func normalized(_ profile: SpeakerProfile) throws -> SpeakerProfile {
+        var profile = profile
+        profile.displayName = profile.displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+        profile.normalizedName = SpeakerProfile.normalizedName(for: profile.displayName)
+        guard !profile.normalizedName.isEmpty else {
+            throw SpeakerProfileStoreError.emptyDisplayName
+        }
+        return profile
     }
 
     // MARK: Exemplars
@@ -138,6 +191,52 @@ public final class SpeakerProfileRepository: SpeakerProfileRepositoryProtocol {
                 )
             }
             try exemplar.insert(db)
+        }
+    }
+
+    /// Count, eviction and insert in one transaction, so the cap holds under
+    /// concurrent enrollments. The caller owns the policy — how many, and which
+    /// origin may be evicted — while the store owns the atomicity.
+    ///
+    /// `rejectedAlreadySampled` comes from the schema's
+    /// `UNIQUE (profileId, sourceTranscriptionId)` rather than a prior read, so
+    /// the answer reflects the state the insert actually met.
+    public func insertExemplar(
+        _ exemplar: SpeakerProfileExemplar,
+        maxPerProfile: Int,
+        evicting: SpeakerProfileExemplar.Origin
+    ) throws -> SpeakerExemplarInsertion {
+        try dbQueue.write { db in
+            if let profile = try SpeakerProfile.fetchOne(db, key: exemplar.profileId),
+               profile.embeddingModelId != exemplar.embeddingModelId
+            {
+                throw SpeakerProfileStoreError.incompatibleEmbeddingModel(
+                    profile: profile.embeddingModelId,
+                    exemplar: exemplar.embeddingModelId
+                )
+            }
+
+            let existing = try SpeakerProfileExemplar
+                .filter(Column("profileId") == exemplar.profileId)
+                .order(Column("createdAt"))
+                .fetchAll(db)
+            if let sampled = exemplar.sourceTranscriptionId,
+               existing.contains(where: { $0.sourceTranscriptionId == sampled })
+            {
+                return .rejectedAlreadySampled
+            }
+
+            var evicted: UUID?
+            if existing.count >= max(0, maxPerProfile) {
+                guard let target = existing.first(where: { $0.origin == evicting }) else {
+                    return .rejectedProfileFull
+                }
+                _ = try SpeakerProfileExemplar.deleteOne(db, key: target.id)
+                evicted = target.id
+            }
+
+            try exemplar.insert(db)
+            return evicted.map { .insertedEvicting($0) } ?? .inserted
         }
     }
 

--- a/Sources/MacParakeetCore/Database/SpeakerProfileRepository.swift
+++ b/Sources/MacParakeetCore/Database/SpeakerProfileRepository.swift
@@ -51,6 +51,7 @@ public protocol SpeakerProfileRepositoryProtocol: Sendable {
         maxPerProfile: Int,
         evicting: SpeakerProfileExemplar.Origin
     ) throws -> SpeakerExemplarInsertion
+    /// Updates an existing profile; a stale write cannot recreate a deleted one.
     func save(_ profile: SpeakerProfile) throws
     func exemplars(profileId: UUID) throws -> [SpeakerProfileExemplar]
     /// One read for a whole matching pass.
@@ -73,34 +74,6 @@ public protocol SpeakerProfileRepositoryProtocol: Sendable {
     /// Transcripts and labels already applied are untouched.
     func deleteProfile(id: UUID) throws -> Bool
     func deleteAllProfiles() throws
-}
-
-extension SpeakerProfileRepositoryProtocol {
-    /// Two writes, used only by mocks that do not own a database queue. The
-    /// concrete store overrides this with a single transaction.
-    public func insert(
-        _ profile: SpeakerProfile,
-        firstExemplar: SpeakerProfileExemplar,
-        maxPerProfile: Int,
-        evicting: SpeakerProfileExemplar.Origin
-    ) throws -> SpeakerExemplarInsertion {
-        try insert(profile)
-        do {
-            let result = try insertExemplar(
-                firstExemplar, maxPerProfile: maxPerProfile, evicting: evicting
-            )
-            switch result {
-            case .inserted, .insertedEvicting:
-                return result
-            case .rejectedAlreadySampled, .rejectedProfileFull:
-                _ = try deleteProfile(id: profile.id)
-                return result
-            }
-        } catch {
-            _ = try? deleteProfile(id: profile.id)
-            throw error
-        }
-    }
 }
 
 /// Stores enrolled voices. Persistence only — thresholds and matching policy
@@ -199,14 +172,14 @@ public final class SpeakerProfileRepository: SpeakerProfileRepositoryProtocol {
         let profile = try normalized(profile)
         try dbQueue.write { db in
             if let existing = try SpeakerProfile.fetchOne(db, key: profile.id),
-               existing.embeddingModelId != profile.embeddingModelId,
-               try SpeakerProfileExemplar
-                   .filter(Column("profileId") == profile.id)
-                   .fetchCount(db) > 0
+                existing.embeddingModelId != profile.embeddingModelId,
+                try SpeakerProfileExemplar
+                    .filter(Column("profileId") == profile.id)
+                    .fetchCount(db) > 0
             {
                 throw SpeakerProfileStoreError.embeddingModelChangeWithExemplars(profile.id)
             }
-            try profile.save(db)
+            try profile.update(db)
         }
     }
 
@@ -249,7 +222,7 @@ public final class SpeakerProfileRepository: SpeakerProfileRepositoryProtocol {
     public func insert(_ exemplar: SpeakerProfileExemplar) throws {
         try dbQueue.write { db in
             if let profile = try SpeakerProfile.fetchOne(db, key: exemplar.profileId),
-               profile.embeddingModelId != exemplar.embeddingModelId
+                profile.embeddingModelId != exemplar.embeddingModelId
             {
                 throw SpeakerProfileStoreError.incompatibleEmbeddingModel(
                     profile: profile.embeddingModelId,
@@ -264,9 +237,8 @@ public final class SpeakerProfileRepository: SpeakerProfileRepositoryProtocol {
     /// concurrent enrollments. The caller owns the policy — how many, and which
     /// origin may be evicted — while the store owns the atomicity.
     ///
-    /// `rejectedAlreadySampled` comes from the schema's
-    /// `UNIQUE (profileId, sourceTranscriptionId)` rather than a prior read, so
-    /// the answer reflects the state the insert actually met.
+    /// `rejectedAlreadySampled` comes from the existing-row read inside the
+    /// same write transaction; the schema also enforces uniqueness.
     public func insertExemplar(
         _ exemplar: SpeakerProfileExemplar,
         maxPerProfile: Int,
@@ -290,7 +262,7 @@ public final class SpeakerProfileRepository: SpeakerProfileRepositoryProtocol {
         db: Database
     ) throws -> SpeakerExemplarInsertion {
         if let profile = try SpeakerProfile.fetchOne(db, key: exemplar.profileId),
-           profile.embeddingModelId != exemplar.embeddingModelId
+            profile.embeddingModelId != exemplar.embeddingModelId
         {
             throw SpeakerProfileStoreError.incompatibleEmbeddingModel(
                 profile: profile.embeddingModelId,
@@ -298,12 +270,13 @@ public final class SpeakerProfileRepository: SpeakerProfileRepositoryProtocol {
             )
         }
 
-        let existing = try SpeakerProfileExemplar
+        let existing =
+            try SpeakerProfileExemplar
             .filter(Column("profileId") == exemplar.profileId)
             .order(Column("createdAt"))
             .fetchAll(db)
         if let sampled = exemplar.sourceTranscriptionId,
-           existing.contains(where: { $0.sourceTranscriptionId == sampled })
+            existing.contains(where: { $0.sourceTranscriptionId == sampled })
         {
             return .rejectedAlreadySampled
         }
@@ -349,7 +322,8 @@ public final class SpeakerProfileRepository: SpeakerProfileRepositoryProtocol {
     public func save(_ link: SpeakerProfileLink) throws {
         try dbQueue.write { db in
             var link = link
-            let existing = try SpeakerProfileLink
+            let existing =
+                try SpeakerProfileLink
                 .filter(Column("transcriptionId") == link.transcriptionId)
                 .filter(Column("speakerId") == link.speakerId)
                 .filter(Column("transcriptFingerprint") == link.transcriptFingerprint)
@@ -385,6 +359,10 @@ public final class SpeakerProfileRepository: SpeakerProfileRepositoryProtocol {
 
     public func deleteAllProfiles() throws {
         try dbQueue.write { db in
+            // Candidates and unmatched decisions have no profile foreign key.
+            // The explicit global delete must remove these too, atomically.
+            _ = try SpeakerEmbeddingCandidate.deleteAll(db)
+            _ = try SpeakerMatchJournalEntry.deleteAll(db)
             _ = try SpeakerProfile.deleteAll(db)
         }
     }

--- a/Sources/MacParakeetCore/Database/SpeakerProfileRepository.swift
+++ b/Sources/MacParakeetCore/Database/SpeakerProfileRepository.swift
@@ -1,6 +1,16 @@
 import Foundation
 import GRDB
 
+/// Refusals the store raises to keep a profile's samples comparable.
+public enum SpeakerProfileStoreError: Error, Equatable {
+    /// The exemplar was produced by a different embedding model than the
+    /// profile it targets, so matching could never score it.
+    case incompatibleEmbeddingModel(profile: String, exemplar: String)
+    /// A profile's embedding model cannot change while it holds samples in the
+    /// old one. Re-enrollment creates fresh samples instead.
+    case embeddingModelChangeWithExemplars(UUID)
+}
+
 public protocol SpeakerProfileRepositoryProtocol: Sendable {
     func profiles() throws -> [SpeakerProfile]
     func profile(id: UUID) throws -> SpeakerProfile?
@@ -61,10 +71,22 @@ public final class SpeakerProfileRepository: SpeakerProfileRepositoryProtocol {
     /// Recomputes the normalized key before writing: `displayName` is mutable,
     /// so a rename would otherwise leave the old key enforcing uniqueness while
     /// a lookup by the new name found nothing.
+    ///
+    /// Throws when the embedding model changes on a profile that already holds
+    /// samples: those samples would stay in the old representation and become
+    /// unscoreable, leaving a profile that looks populated and matches nothing.
     public func save(_ profile: SpeakerProfile) throws {
         var profile = profile
         profile.normalizedName = SpeakerProfile.normalizedName(for: profile.displayName)
         try dbQueue.write { db in
+            if let existing = try SpeakerProfile.fetchOne(db, key: profile.id),
+               existing.embeddingModelId != profile.embeddingModelId,
+               try SpeakerProfileExemplar
+                   .filter(Column("profileId") == profile.id)
+                   .fetchCount(db) > 0
+            {
+                throw SpeakerProfileStoreError.embeddingModelChangeWithExemplars(profile.id)
+            }
             try profile.save(db)
         }
     }
@@ -88,8 +110,23 @@ public final class SpeakerProfileRepository: SpeakerProfileRepositoryProtocol {
         return Dictionary(grouping: all, by: \.profileId)
     }
 
+    /// Throws when the exemplar comes from a different embedding model than its
+    /// profile. Vectors from two models share no space, so such a sample would
+    /// be stored, counted and shown to the user while never scoring against
+    /// anything — a ghost with no signal to reveal it.
+    ///
+    /// A differing aggregation profile is accepted: that stays comparable, at a
+    /// tightened threshold the matcher applies.
     public func insert(_ exemplar: SpeakerProfileExemplar) throws {
         try dbQueue.write { db in
+            if let profile = try SpeakerProfile.fetchOne(db, key: exemplar.profileId),
+               profile.embeddingModelId != exemplar.embeddingModelId
+            {
+                throw SpeakerProfileStoreError.incompatibleEmbeddingModel(
+                    profile: profile.embeddingModelId,
+                    exemplar: exemplar.embeddingModelId
+                )
+            }
             try exemplar.insert(db)
         }
     }

--- a/Sources/MacParakeetCore/Database/SpeakerProfileRepository.swift
+++ b/Sources/MacParakeetCore/Database/SpeakerProfileRepository.swift
@@ -2,40 +2,28 @@ import Foundation
 import GRDB
 
 public protocol SpeakerProfileRepositoryProtocol: Sendable {
-    /// Every enrolled voice, ordered by name.
     func profiles() throws -> [SpeakerProfile]
     func profile(id: UUID) throws -> SpeakerProfile?
-    /// Case-insensitive lookup, the one enrollment uses to decide between
-    /// adding a sample and creating a profile.
+    /// Case-insensitive; what enrollment uses to choose between adding a sample
+    /// and creating a profile.
     func profile(named name: String) throws -> SpeakerProfile?
-    /// Inserts or updates. Names are unique, so saving a second profile under
-    /// an existing name throws rather than creating a duplicate.
     func save(_ profile: SpeakerProfile) throws
-    /// A profile's samples, oldest first.
     func exemplars(profileId: UUID) throws -> [SpeakerProfileExemplar]
-    /// Every sample grouped by profile — one read for a whole matching pass.
+    /// One read for a whole matching pass.
     func exemplarsByProfile() throws -> [UUID: [SpeakerProfileExemplar]]
-    /// Adds a sample. Throws when the profile already holds one from the same
-    /// recording, which the schema forbids.
     func insert(_ exemplar: SpeakerProfileExemplar) throws
-    /// Removes one sample, leaving its profile in place. `false` when it was
-    /// already gone.
     func deleteExemplar(id: UUID) throws -> Bool
-    /// Decisions recorded for one transcript at one fingerprint. Rows from an
-    /// earlier fingerprint are deliberately invisible here.
+    /// Rows from an earlier fingerprint are deliberately invisible here.
     func links(transcriptionId: UUID, fingerprint: String) throws -> [SpeakerProfileLink]
-    /// Inserts or updates a decision, preserving its original creation time.
     func save(_ link: SpeakerProfileLink) throws
-    /// Removes a profile with its samples and decisions, in one transaction.
+    /// Removes a profile with its samples and decisions in one transaction.
     /// Transcripts and labels already applied are untouched.
     func deleteProfile(id: UUID) throws -> Bool
-    /// Forgets every voice. Same guarantees as `deleteProfile`, applied at once.
     func deleteAllProfiles() throws
 }
 
-/// Stores enrolled voices. Persistence only: thresholds, gates and matching
-/// policy live in the matcher, and nothing here decides whether two voices are
-/// the same person.
+/// Stores enrolled voices. Persistence only — thresholds and matching policy
+/// live in the matcher.
 public final class SpeakerProfileRepository: SpeakerProfileRepositoryProtocol {
     private let dbQueue: DatabaseQueue
 
@@ -59,14 +47,10 @@ public final class SpeakerProfileRepository: SpeakerProfileRepositoryProtocol {
         }
     }
 
-    /// Case-insensitive lookup: "sarah" and "Sarah" are the same person as far
-    /// as enrollment is concerned.
-    ///
-    /// Queries the stored normalized key, the same one the unique index is
-    /// built on. Matching on a collation instead would let the lookup and the
-    /// constraint disagree — SQLite's `NOCASE` folds only ASCII, so two rows
-    /// that a Unicode-aware lookup considers equal could both exist, and
-    /// `fetchOne` would pick between them arbitrarily.
+    /// Queries the stored normalized key, the same one the unique index uses.
+    /// A collation here instead would let lookup and constraint disagree:
+    /// `NOCASE` folds only ASCII, so two rows a Unicode-aware lookup considers
+    /// equal could both exist and `fetchOne` would pick arbitrarily.
     public func profile(named name: String) throws -> SpeakerProfile? {
         let key = SpeakerProfile.normalizedName(for: name)
         return try dbQueue.read { db in
@@ -91,8 +75,7 @@ public final class SpeakerProfileRepository: SpeakerProfileRepositoryProtocol {
         }
     }
 
-    /// Every exemplar, grouped by profile — one read for a whole matching pass
-    /// rather than one per profile.
+    /// One read for a whole matching pass rather than one per profile.
     public func exemplarsByProfile() throws -> [UUID: [SpeakerProfileExemplar]] {
         let all = try dbQueue.read { db in
             try SpeakerProfileExemplar.order(Column("createdAt")).fetchAll(db)
@@ -123,13 +106,9 @@ public final class SpeakerProfileRepository: SpeakerProfileRepositoryProtocol {
         }
     }
 
-    /// Upserts a decision, keeping the original `createdAt`.
-    ///
-    /// A link is saved again whenever its status moves — suggested, then
-    /// confirmed or dismissed — and each caller builds a fresh value. Without
-    /// this, the moment the suggestion was first made would be overwritten by
-    /// the moment the user answered, and the journal would lose the interval
-    /// between them.
+    /// Upserts a decision, keeping the original `createdAt`: status moves from
+    /// suggested to confirmed or dismissed, and each caller builds a fresh
+    /// value, so otherwise the offer time is overwritten by the answer time.
     public func save(_ link: SpeakerProfileLink) throws {
         try dbQueue.write { db in
             var link = link
@@ -147,11 +126,8 @@ public final class SpeakerProfileRepository: SpeakerProfileRepositoryProtocol {
 
     // MARK: Deletion
 
-    /// Removes a profile and everything it owns in one transaction.
-    ///
     /// Exemplars and links go with it through their cascades; transcripts and
-    /// any label already applied are untouched, because deleting a voiceprint
-    /// must not rewrite the user's history.
+    /// any label already applied are untouched.
     public func deleteProfile(id: UUID) throws -> Bool {
         try dbQueue.write { db in
             try SpeakerProfile.deleteOne(db, key: id)

--- a/Sources/MacParakeetCore/Database/SpeakerProfileRepository.swift
+++ b/Sources/MacParakeetCore/Database/SpeakerProfileRepository.swift
@@ -62,17 +62,15 @@ public final class SpeakerProfileRepository: SpeakerProfileRepositoryProtocol {
     /// Case-insensitive lookup: "sarah" and "Sarah" are the same person as far
     /// as enrollment is concerned.
     ///
-    /// Uses a localized collation rather than SQLite's `NOCASE`, which folds
-    /// only the 26 ASCII letters — under it "josé" and "JOSÉ" would be two
-    /// different people, and the second enrollment would silently create a
-    /// rival profile instead of adding a sample. The unique index keeps
-    /// `NOCASE` as a backstop, so this lookup is deliberately the wider of the
-    /// two.
+    /// Queries the stored normalized key, the same one the unique index is
+    /// built on. Matching on a collation instead would let the lookup and the
+    /// constraint disagree — SQLite's `NOCASE` folds only ASCII, so two rows
+    /// that a Unicode-aware lookup considers equal could both exist, and
+    /// `fetchOne` would pick between them arbitrarily.
     public func profile(named name: String) throws -> SpeakerProfile? {
-        try dbQueue.read { db in
-            try SpeakerProfile
-                .filter(Column("displayName").collating(.localizedCaseInsensitiveCompare) == name)
-                .fetchOne(db)
+        let key = SpeakerProfile.normalizedName(for: name)
+        return try dbQueue.read { db in
+            try SpeakerProfile.filter(Column("normalizedName") == key).fetchOne(db)
         }
     }
 

--- a/Sources/MacParakeetCore/Database/SpeakerProfileRepository.swift
+++ b/Sources/MacParakeetCore/Database/SpeakerProfileRepository.swift
@@ -58,7 +58,12 @@ public final class SpeakerProfileRepository: SpeakerProfileRepositoryProtocol {
         }
     }
 
+    /// Recomputes the normalized key before writing: `displayName` is mutable,
+    /// so a rename would otherwise leave the old key enforcing uniqueness while
+    /// a lookup by the new name found nothing.
     public func save(_ profile: SpeakerProfile) throws {
+        var profile = profile
+        profile.normalizedName = SpeakerProfile.normalizedName(for: profile.displayName)
         try dbQueue.write { db in
             try profile.save(db)
         }

--- a/Sources/MacParakeetCore/Database/SpeakerProfileRepository.swift
+++ b/Sources/MacParakeetCore/Database/SpeakerProfileRepository.swift
@@ -12,6 +12,8 @@ public enum SpeakerProfileStoreError: Error, Equatable {
     /// A name that normalizes to nothing has no lookup key, so it could neither
     /// be found again nor keep a second blank name from colliding with it.
     case emptyDisplayName
+    /// A replacement may contain only pending links for its requested scope.
+    case invalidSuggestionScope
     /// A decision the user already made is not overwritten by a fresh
     /// suggestion.
     case terminalDecisionAlreadyRecorded(status: SpeakerProfileLink.Status)
@@ -70,6 +72,11 @@ public protocol SpeakerProfileRepositoryProtocol: Sendable {
     /// Rows from an earlier fingerprint are deliberately invisible here.
     func links(transcriptionId: UUID, fingerprint: String) throws -> [SpeakerProfileLink]
     func save(_ link: SpeakerProfileLink) throws
+    /// Replaces pending offers for one run atomically, preserving terminal choices.
+    /// Returns the offers still allowed after checking current terminal decisions.
+    func replaceSuggestions(
+        transcriptionId: UUID, fingerprint: String, with links: [SpeakerProfileLink]
+    ) throws -> [SpeakerProfileLink]
     /// Removes a profile with its samples and decisions in one transaction.
     /// Transcripts and labels already applied are untouched.
     func deleteProfile(id: UUID) throws -> Bool
@@ -229,7 +236,7 @@ public final class SpeakerProfileRepository: SpeakerProfileRepositoryProtocol {
                     exemplar: exemplar.embeddingModelId
                 )
             }
-            try exemplar.insert(db)
+            try insertExemplarRecord(exemplar, db: db)
         }
     }
 
@@ -295,8 +302,19 @@ public final class SpeakerProfileRepository: SpeakerProfileRepositoryProtocol {
             evicted = target.id
         }
 
-        try exemplar.insert(db)
+        try insertExemplarRecord(exemplar, db: db)
         return evicted.map { .insertedEvicting($0) } ?? .inserted
+    }
+
+    private func insertExemplarRecord(_ exemplar: SpeakerProfileExemplar, db: Database) throws {
+        guard let sourceId = exemplar.sourceTranscriptionId else {
+            try exemplar.insert(db)
+            return
+        }
+        try SpeakerTranscriptionRecord(
+            record: exemplar, column: "sourceTranscriptionId",
+            transcriptionKey: SpeakerTranscriptionPersistence.key(sourceId, in: db)
+        ).insert(db)
     }
 
     public func deleteExemplar(id: UUID) throws -> Bool {
@@ -309,8 +327,10 @@ public final class SpeakerProfileRepository: SpeakerProfileRepositoryProtocol {
 
     public func links(transcriptionId: UUID, fingerprint: String) throws -> [SpeakerProfileLink] {
         try dbQueue.read { db in
-            try SpeakerProfileLink
-                .filter(Column("transcriptionId") == transcriptionId)
+            let key = try SpeakerTranscriptionPersistence.key(transcriptionId, in: db)
+            return
+                try SpeakerProfileLink
+                .filter(Column("transcriptionId") == key)
                 .filter(Column("transcriptFingerprint") == fingerprint)
                 .fetchAll(db)
         }
@@ -322,9 +342,10 @@ public final class SpeakerProfileRepository: SpeakerProfileRepositoryProtocol {
     public func save(_ link: SpeakerProfileLink) throws {
         try dbQueue.write { db in
             var link = link
+            let key = try SpeakerTranscriptionPersistence.key(link.transcriptionId, in: db)
             let existing =
                 try SpeakerProfileLink
-                .filter(Column("transcriptionId") == link.transcriptionId)
+                .filter(Column("transcriptionId") == key)
                 .filter(Column("speakerId") == link.speakerId)
                 .filter(Column("transcriptFingerprint") == link.transcriptFingerprint)
                 .fetchOne(db)
@@ -343,7 +364,49 @@ public final class SpeakerProfileRepository: SpeakerProfileRepositoryProtocol {
                 }
                 link.createdAt = existing.createdAt
             }
-            try link.save(db)
+            try SpeakerTranscriptionRecord(
+                record: link, column: "transcriptionId", transcriptionKey: key
+            ).save(db)
+        }
+    }
+
+    public func replaceSuggestions(
+        transcriptionId: UUID, fingerprint: String, with links: [SpeakerProfileLink]
+    ) throws -> [SpeakerProfileLink] {
+        guard
+            links.allSatisfy({
+                $0.status == .suggested && $0.transcriptionId == transcriptionId
+                    && $0.transcriptFingerprint == fingerprint
+            })
+        else {
+            throw SpeakerProfileStoreError.invalidSuggestionScope
+        }
+        return try dbQueue.write { db in
+            let key = try SpeakerTranscriptionPersistence.key(transcriptionId, in: db)
+            let scope =
+                SpeakerProfileLink
+                .filter(Column("transcriptionId") == key)
+                .filter(Column("transcriptFingerprint") == fingerprint)
+            let existing = try scope.fetchAll(db)
+            let terminalSpeakers = Set(existing.filter { $0.status != .suggested }.map(\.speakerId))
+            let reservedProfiles = Set(existing.filter { $0.status == .confirmed }.map(\.profileId))
+            let originalDates = Dictionary(uniqueKeysWithValues: existing.map { ($0.speakerId, $0.createdAt) })
+            try scope.filter(Column("status") == SpeakerProfileLink.Status.suggested.rawValue).deleteAll(db)
+
+            var stored: [SpeakerProfileLink] = []
+            for var link in links {
+                // Recheck inside this write: a user may have answered while the
+                // matcher was scoring. Never replace that answer or its name.
+                guard !terminalSpeakers.contains(link.speakerId), !reservedProfiles.contains(link.profileId) else {
+                    continue
+                }
+                link.createdAt = originalDates[link.speakerId] ?? link.createdAt
+                try SpeakerTranscriptionRecord(
+                    record: link, column: "transcriptionId", transcriptionKey: key
+                ).insert(db)
+                stored.append(link)
+            }
+            return stored
         }
     }
 

--- a/Sources/MacParakeetCore/Database/SpeakerProfileRepository.swift
+++ b/Sources/MacParakeetCore/Database/SpeakerProfileRepository.swift
@@ -2,17 +2,34 @@ import Foundation
 import GRDB
 
 public protocol SpeakerProfileRepositoryProtocol: Sendable {
+    /// Every enrolled voice, ordered by name.
     func profiles() throws -> [SpeakerProfile]
     func profile(id: UUID) throws -> SpeakerProfile?
+    /// Case-insensitive lookup, the one enrollment uses to decide between
+    /// adding a sample and creating a profile.
     func profile(named name: String) throws -> SpeakerProfile?
+    /// Inserts or updates. Names are unique, so saving a second profile under
+    /// an existing name throws rather than creating a duplicate.
     func save(_ profile: SpeakerProfile) throws
+    /// A profile's samples, oldest first.
     func exemplars(profileId: UUID) throws -> [SpeakerProfileExemplar]
+    /// Every sample grouped by profile — one read for a whole matching pass.
     func exemplarsByProfile() throws -> [UUID: [SpeakerProfileExemplar]]
+    /// Adds a sample. Throws when the profile already holds one from the same
+    /// recording, which the schema forbids.
     func insert(_ exemplar: SpeakerProfileExemplar) throws
+    /// Removes one sample, leaving its profile in place. `false` when it was
+    /// already gone.
     func deleteExemplar(id: UUID) throws -> Bool
+    /// Decisions recorded for one transcript at one fingerprint. Rows from an
+    /// earlier fingerprint are deliberately invisible here.
     func links(transcriptionId: UUID, fingerprint: String) throws -> [SpeakerProfileLink]
+    /// Inserts or updates a decision, preserving its original creation time.
     func save(_ link: SpeakerProfileLink) throws
+    /// Removes a profile with its samples and decisions, in one transaction.
+    /// Transcripts and labels already applied are untouched.
     func deleteProfile(id: UUID) throws -> Bool
+    /// Forgets every voice. Same guarantees as `deleteProfile`, applied at once.
     func deleteAllProfiles() throws
 }
 

--- a/Sources/MacParakeetCore/Database/SpeakerTranscriptionPersistence.swift
+++ b/Sources/MacParakeetCore/Database/SpeakerTranscriptionPersistence.swift
@@ -1,0 +1,35 @@
+import Foundation
+import GRDB
+
+/// Voiceprint children must copy the parent's SQLite value: supported older
+/// transcriptions use UUID text, while current Codable records use UUID blobs.
+enum SpeakerTranscriptionPersistence {
+    static func key(_ id: UUID, in db: Database) throws -> DatabaseValue {
+        if let row = try Row.fetchOne(db, sql: "SELECT id FROM transcriptions WHERE id = ?", arguments: [id]) {
+            return row["id"]
+        }
+        if let row = try Row.fetchOne(
+            db,
+            sql: "SELECT id FROM transcriptions WHERE typeof(id) = 'text' AND id = ? COLLATE NOCASE",
+            arguments: [id.uuidString]
+        ) {
+            return row["id"]
+        }
+        // Reads of a missing recording stay empty; writes still fail their FK.
+        return id.databaseValue
+    }
+}
+
+/// Keeps each record's ordinary GRDB encoding, replacing only its resolved FK.
+struct SpeakerTranscriptionRecord<Record: PersistableRecord>: PersistableRecord {
+    static var databaseTableName: String { Record.databaseTableName }
+
+    let record: Record
+    let column: String
+    let transcriptionKey: DatabaseValue
+
+    func encode(to container: inout PersistenceContainer) throws {
+        try record.encode(to: &container)
+        container[column] = transcriptionKey
+    }
+}

--- a/Sources/MacParakeetCore/Models/SpeakerEmbeddingCandidate.swift
+++ b/Sources/MacParakeetCore/Models/SpeakerEmbeddingCandidate.swift
@@ -1,0 +1,74 @@
+import Foundation
+import GRDB
+
+/// A voice held briefly so the user can still enroll it after the fact.
+///
+/// The pipeline computes one vector per detected speaker, uses it for scoring,
+/// and drops it. But naming happens later — often the next day — and by then
+/// there is nothing left to remember. These rows close that gap without
+/// becoming an archive: they are written only while `rememberSpeakers` is on,
+/// never compared against each other, and they expire.
+public struct SpeakerEmbeddingCandidate: Codable, Identifiable, Sendable, Equatable {
+    public var id: UUID
+    public var transcriptionId: UUID
+    /// Positional ("S1", "system:S1"), hence the fingerprint alongside it.
+    public var speakerId: String
+    public var transcriptFingerprint: String
+    /// 1024 bytes of little-endian Float32, same shape as an exemplar's.
+    public var vector: Data
+    public var speechSeconds: Double
+    public var captureDomain: SpeakerCaptureDomain
+    public var embeddingModelId: String
+    public var aggregationProfileId: String
+    public var createdAt: Date
+    public var expiresAt: Date
+
+    public init(
+        id: UUID = UUID(),
+        transcriptionId: UUID,
+        speakerId: String,
+        transcriptFingerprint: String,
+        embedding: SpeakerEmbedding,
+        speechSeconds: Double,
+        captureDomain: SpeakerCaptureDomain,
+        createdAt: Date = Date(),
+        expiresAt: Date
+    ) {
+        self.id = id
+        self.transcriptionId = transcriptionId
+        self.speakerId = speakerId
+        self.transcriptFingerprint = transcriptFingerprint
+        self.vector = embedding.data
+        self.speechSeconds = speechSeconds
+        self.captureDomain = captureDomain
+        self.embeddingModelId = embedding.identity.embeddingModelId
+        self.aggregationProfileId = embedding.identity.aggregationProfileId
+        self.createdAt = createdAt
+        self.expiresAt = expiresAt
+    }
+
+    public var identity: SpeakerModelIdentity {
+        SpeakerModelIdentity(
+            embeddingModelId: embeddingModelId,
+            aggregationProfileId: aggregationProfileId
+        )
+    }
+
+    /// `nil` when the blob no longer satisfies the embedding invariants, in
+    /// which case this candidate cannot be enrolled.
+    public var observation: SpeakerClusterObservation? {
+        guard let embedding = SpeakerEmbedding(data: vector, identity: identity) else {
+            return nil
+        }
+        return SpeakerClusterObservation(
+            speakerId: speakerId,
+            embedding: embedding,
+            speechSeconds: speechSeconds,
+            captureDomain: captureDomain
+        )
+    }
+}
+
+extension SpeakerEmbeddingCandidate: FetchableRecord, PersistableRecord {
+    public static let databaseTableName = "speaker_embedding_candidates"
+}

--- a/Sources/MacParakeetCore/Models/SpeakerProfile.swift
+++ b/Sources/MacParakeetCore/Models/SpeakerProfile.swift
@@ -24,6 +24,11 @@ public struct SpeakerProfile: Codable, Identifiable, Sendable, Equatable {
     public var lastEvaluatedAt: Date?
     public var lastEvaluatedDistance: Double?
 
+    /// - Parameters:
+    ///   - displayName: unique case-insensitively; enrollment looks a profile
+    ///     up by this name before deciding to create one.
+    ///   - identity: the representation this profile's samples live in. Samples
+    ///     from another embedding model are never compared against it.
     public init(
         id: UUID = UUID(),
         displayName: String,
@@ -89,6 +94,11 @@ public struct SpeakerProfileExemplar: Codable, Identifiable, Sendable, Equatable
     public var sourceSpeakerId: String?
     public var createdAt: Date
 
+    /// - Parameters:
+    ///   - embedding: stored as bytes; its model identity is copied alongside
+    ///     so a later upgrade can tell which representation this sample is in.
+    ///   - sourceTranscriptionId: the recording it came from, cleared rather
+    ///     than cascaded when that recording is deleted.
     public init(
         id: UUID = UUID(),
         profileId: UUID,
@@ -159,6 +169,11 @@ public struct SpeakerProfileLink: Codable, Sendable, Equatable {
     public var createdAt: Date
     public var updatedAt: Date
 
+    /// - Parameters:
+    ///   - speakerId: the diarizer's positional id, meaningful only together
+    ///     with `transcriptFingerprint`.
+    ///   - distance: what the decision was based on, kept so calibration can
+    ///     read it back.
     public init(
         transcriptionId: UUID,
         speakerId: String,

--- a/Sources/MacParakeetCore/Models/SpeakerProfile.swift
+++ b/Sources/MacParakeetCore/Models/SpeakerProfile.swift
@@ -1,0 +1,187 @@
+import Foundation
+import GRDB
+
+/// A voice the user has explicitly enrolled, so the same person can be
+/// recognized across recordings.
+///
+/// Deliberately holds no centroid column: scoring takes the minimum distance
+/// over the profile's exemplars, which preserves per-domain modes, so a derived
+/// aggregate would be an unused cache with its own coherency bugs.
+public struct SpeakerProfile: Codable, Identifiable, Sendable, Equatable {
+    public var id: UUID
+    /// Unique case-insensitively: renaming another speaker to this name adds an
+    /// exemplar here rather than creating a rival profile.
+    public var displayName: String
+    public var embeddingModelId: String
+    public var aggregationProfileId: String
+    public var createdAt: Date
+    public var updatedAt: Date
+    /// Last time this profile was actually suggested for a speaker.
+    public var lastMatchedAt: Date?
+    /// Last time it was scored at all, matched or not, with its best distance.
+    /// The pair is what lets the admin screen answer "why does this profile
+    /// never match?" with a number instead of a shrug.
+    public var lastEvaluatedAt: Date?
+    public var lastEvaluatedDistance: Double?
+
+    public init(
+        id: UUID = UUID(),
+        displayName: String,
+        identity: SpeakerModelIdentity,
+        createdAt: Date = Date(),
+        updatedAt: Date = Date(),
+        lastMatchedAt: Date? = nil,
+        lastEvaluatedAt: Date? = nil,
+        lastEvaluatedDistance: Double? = nil
+    ) {
+        self.id = id
+        self.displayName = displayName
+        self.embeddingModelId = identity.embeddingModelId
+        self.aggregationProfileId = identity.aggregationProfileId
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.lastMatchedAt = lastMatchedAt
+        self.lastEvaluatedAt = lastEvaluatedAt
+        self.lastEvaluatedDistance = lastEvaluatedDistance
+    }
+
+    public var identity: SpeakerModelIdentity {
+        SpeakerModelIdentity(
+            embeddingModelId: embeddingModelId,
+            aggregationProfileId: aggregationProfileId
+        )
+    }
+}
+
+extension SpeakerProfile: FetchableRecord, PersistableRecord {
+    public static let databaseTableName = "speaker_profiles"
+}
+
+/// One recording's worth of voice evidence for a profile.
+///
+/// At most one per profile per recording, enforced by a unique constraint
+/// rather than by code: offline segment embeddings within a recording all
+/// derive from the same cluster centroid, so storing several would inflate the
+/// sample count without adding any diversity.
+public struct SpeakerProfileExemplar: Codable, Identifiable, Sendable, Equatable {
+    public enum Origin: String, Codable, Sendable {
+        /// The user named this speaker themselves.
+        case manualEnrollment
+        /// The user confirmed a suggestion, which also improves the profile.
+        case confirmedSuggestion
+    }
+
+    public var id: UUID
+    public var profileId: UUID
+    /// The embedding, 1024 bytes of little-endian Float32. Stored as a blob
+    /// rather than JSON: SQLite validates the length, and an accidental
+    /// serialization yields opaque bytes instead of a readable voiceprint.
+    public var vector: Data
+    public var speechSeconds: Double
+    public var captureDomain: SpeakerCaptureDomain
+    public var origin: Origin
+    public var embeddingModelId: String
+    public var aggregationProfileId: String
+    /// Cleared rather than cascaded when the transcript goes: the user enrolled
+    /// a person, not a recording, so tidying the library must not quietly
+    /// degrade a profile.
+    public var sourceTranscriptionId: UUID?
+    public var sourceSpeakerId: String?
+    public var createdAt: Date
+
+    public init(
+        id: UUID = UUID(),
+        profileId: UUID,
+        embedding: SpeakerEmbedding,
+        speechSeconds: Double,
+        captureDomain: SpeakerCaptureDomain,
+        origin: Origin,
+        sourceTranscriptionId: UUID? = nil,
+        sourceSpeakerId: String? = nil,
+        createdAt: Date = Date()
+    ) {
+        self.id = id
+        self.profileId = profileId
+        self.vector = embedding.data
+        self.speechSeconds = speechSeconds
+        self.captureDomain = captureDomain
+        self.origin = origin
+        self.embeddingModelId = embedding.identity.embeddingModelId
+        self.aggregationProfileId = embedding.identity.aggregationProfileId
+        self.sourceTranscriptionId = sourceTranscriptionId
+        self.sourceSpeakerId = sourceSpeakerId
+        self.createdAt = createdAt
+    }
+
+    public var identity: SpeakerModelIdentity {
+        SpeakerModelIdentity(
+            embeddingModelId: embeddingModelId,
+            aggregationProfileId: aggregationProfileId
+        )
+    }
+
+    /// Decodes the stored vector. `nil` means the blob no longer satisfies the
+    /// embedding invariants, in which case the exemplar cannot take part in
+    /// matching.
+    public var embedding: SpeakerEmbedding? {
+        SpeakerEmbedding(data: vector, identity: identity)
+    }
+}
+
+extension SpeakerProfileExemplar: FetchableRecord, PersistableRecord {
+    public static let databaseTableName = "speaker_profile_exemplars"
+}
+
+/// What was decided about one detected speaker in one transcript.
+///
+/// Carries no label: the label lives in `speaker_corrections`, which already
+/// owns provenance and undo. This table exists for the three things that layer
+/// cannot express — that a dismissal must not be repeated, that a profile has
+/// already taken a sample from this recording, and that everything disappears
+/// with its profile.
+public struct SpeakerProfileLink: Codable, Sendable, Equatable {
+    public enum Status: String, Codable, Sendable {
+        case suggested
+        case confirmed
+        case dismissed
+    }
+
+    public var transcriptionId: UUID
+    /// The diarizer's id for this run ("S1", "system:S1"). Positional, which is
+    /// exactly why rows are fingerprint-scoped: after re-diarization the same
+    /// id can mean a different person.
+    public var speakerId: String
+    public var transcriptFingerprint: String
+    public var profileId: UUID
+    public var status: Status
+    public var distance: Double
+    public var runnerUpDistance: Double?
+    public var createdAt: Date
+    public var updatedAt: Date
+
+    public init(
+        transcriptionId: UUID,
+        speakerId: String,
+        transcriptFingerprint: String,
+        profileId: UUID,
+        status: Status,
+        distance: Double,
+        runnerUpDistance: Double? = nil,
+        createdAt: Date = Date(),
+        updatedAt: Date = Date()
+    ) {
+        self.transcriptionId = transcriptionId
+        self.speakerId = speakerId
+        self.transcriptFingerprint = transcriptFingerprint
+        self.profileId = profileId
+        self.status = status
+        self.distance = distance
+        self.runnerUpDistance = runnerUpDistance
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+}
+
+extension SpeakerProfileLink: FetchableRecord, PersistableRecord {
+    public static let databaseTableName = "speaker_profile_links"
+}

--- a/Sources/MacParakeetCore/Models/SpeakerProfile.swift
+++ b/Sources/MacParakeetCore/Models/SpeakerProfile.swift
@@ -1,39 +1,27 @@
 import Foundation
 import GRDB
 
-/// A voice the user has explicitly enrolled, so the same person can be
-/// recognized across recordings.
+/// A voice the user has explicitly enrolled.
 ///
-/// Deliberately holds no centroid column: scoring takes the minimum distance
-/// over the profile's exemplars, which preserves per-domain modes, so a derived
-/// aggregate would be an unused cache with its own coherency bugs.
+/// No centroid column: scoring takes the minimum distance over the exemplars,
+/// which preserves per-domain modes, so an aggregate would be an unused cache.
 public struct SpeakerProfile: Codable, Identifiable, Sendable, Equatable {
     public var id: UUID
     /// As the user typed it. Display only — never compared directly.
     public var displayName: String
-    /// The key uniqueness and lookup both use, derived from `displayName`.
-    ///
-    /// Kept as a column rather than computed in a query so that the database
-    /// constraint and the Swift lookup can never disagree about what counts as
-    /// the same name. Set it through ``normalizedName(for:)``.
+    /// The key both uniqueness and lookup use, so the database constraint and
+    /// the Swift lookup cannot disagree on what counts as the same name.
     public var normalizedName: String
     public var embeddingModelId: String
     public var aggregationProfileId: String
     public var createdAt: Date
     public var updatedAt: Date
-    /// Last time this profile was actually suggested for a speaker.
     public var lastMatchedAt: Date?
-    /// Last time it was scored at all, matched or not, with its best distance.
-    /// The pair is what lets the admin screen answer "why does this profile
-    /// never match?" with a number instead of a shrug.
+    /// Scored at all, matched or not: what answers "why does this profile never
+    /// match?" with a number.
     public var lastEvaluatedAt: Date?
     public var lastEvaluatedDistance: Double?
 
-    /// - Parameters:
-    ///   - displayName: unique case-insensitively; enrollment looks a profile
-    ///     up by this name before deciding to create one.
-    ///   - identity: the representation this profile's samples live in. Samples
-    ///     from another embedding model are never compared against it.
     public init(
         id: UUID = UUID(),
         displayName: String,
@@ -63,14 +51,9 @@ public struct SpeakerProfile: Codable, Identifiable, Sendable, Equatable {
         )
     }
 
-    /// The comparison key for a display name: trimmed, then case-folded across
-    /// the whole of Unicode.
-    ///
-    /// Accents are deliberately kept. Folding them too would make "Jose" and
-    /// "José" one person, which is a guess about identity rather than about
-    /// typography — and the wrong guess merges two colleagues silently. When
-    /// two people really do share a name, the enrollment guard catches it by
-    /// voice instead.
+    /// Trimmed, then case-folded across all of Unicode. Accents are kept:
+    /// folding them would decide that "Jose" and "José" are one person, which
+    /// is a guess about identity, not typography.
     public static func normalizedName(for displayName: String) -> String {
         displayName
             .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -84,10 +67,9 @@ extension SpeakerProfile: FetchableRecord, PersistableRecord {
 
 /// One recording's worth of voice evidence for a profile.
 ///
-/// At most one per profile per recording, enforced by a unique constraint
-/// rather than by code: offline segment embeddings within a recording all
-/// derive from the same cluster centroid, so storing several would inflate the
-/// sample count without adding any diversity.
+/// At most one per profile per recording, enforced by the schema: segment
+/// embeddings within a recording all derive from the same centroid, so several
+/// would inflate the sample count without adding diversity.
 public struct SpeakerProfileExemplar: Codable, Identifiable, Sendable, Equatable {
     public enum Origin: String, Codable, Sendable {
         /// The user named this speaker themselves.
@@ -98,27 +80,20 @@ public struct SpeakerProfileExemplar: Codable, Identifiable, Sendable, Equatable
 
     public var id: UUID
     public var profileId: UUID
-    /// The embedding, 1024 bytes of little-endian Float32. Stored as a blob
-    /// rather than JSON: SQLite validates the length, and an accidental
-    /// serialization yields opaque bytes instead of a readable voiceprint.
+    /// 1024 bytes of little-endian Float32. A blob rather than JSON so SQLite
+    /// validates the length and an accidental serialization stays opaque.
     public var vector: Data
     public var speechSeconds: Double
     public var captureDomain: SpeakerCaptureDomain
     public var origin: Origin
     public var embeddingModelId: String
     public var aggregationProfileId: String
-    /// Cleared rather than cascaded when the transcript goes: the user enrolled
-    /// a person, not a recording, so tidying the library must not quietly
-    /// degrade a profile.
+    /// Cleared rather than cascaded: the user enrolled a person, not a
+    /// recording, so tidying the library must not degrade a profile.
     public var sourceTranscriptionId: UUID?
     public var sourceSpeakerId: String?
     public var createdAt: Date
 
-    /// - Parameters:
-    ///   - embedding: stored as bytes; its model identity is copied alongside
-    ///     so a later upgrade can tell which representation this sample is in.
-    ///   - sourceTranscriptionId: the recording it came from, cleared rather
-    ///     than cascaded when that recording is deleted.
     public init(
         id: UUID = UUID(),
         profileId: UUID,
@@ -150,9 +125,8 @@ public struct SpeakerProfileExemplar: Codable, Identifiable, Sendable, Equatable
         )
     }
 
-    /// Decodes the stored vector. `nil` means the blob no longer satisfies the
-    /// embedding invariants, in which case the exemplar cannot take part in
-    /// matching.
+    /// `nil` when the blob no longer satisfies the embedding invariants, in
+    /// which case this exemplar cannot take part in matching.
     public var embedding: SpeakerEmbedding? {
         SpeakerEmbedding(data: vector, identity: identity)
     }
@@ -164,11 +138,9 @@ extension SpeakerProfileExemplar: FetchableRecord, PersistableRecord {
 
 /// What was decided about one detected speaker in one transcript.
 ///
-/// Carries no label: the label lives in `speaker_corrections`, which already
-/// owns provenance and undo. This table exists for the three things that layer
-/// cannot express — that a dismissal must not be repeated, that a profile has
-/// already taken a sample from this recording, and that everything disappears
-/// with its profile.
+/// Carries no label — that lives in `speaker_corrections` with provenance and
+/// undo. This exists for what that layer cannot express: that a dismissal must
+/// not repeat, and that everything disappears with its profile.
 public struct SpeakerProfileLink: Codable, Sendable, Equatable {
     public enum Status: String, Codable, Sendable {
         case suggested
@@ -177,9 +149,8 @@ public struct SpeakerProfileLink: Codable, Sendable, Equatable {
     }
 
     public var transcriptionId: UUID
-    /// The diarizer's id for this run ("S1", "system:S1"). Positional, which is
-    /// exactly why rows are fingerprint-scoped: after re-diarization the same
-    /// id can mean a different person.
+    /// Positional ("S1", "system:S1"), which is why rows are fingerprint-scoped:
+    /// after re-diarization the same id can mean a different person.
     public var speakerId: String
     public var transcriptFingerprint: String
     public var profileId: UUID
@@ -189,11 +160,6 @@ public struct SpeakerProfileLink: Codable, Sendable, Equatable {
     public var createdAt: Date
     public var updatedAt: Date
 
-    /// - Parameters:
-    ///   - speakerId: the diarizer's positional id, meaningful only together
-    ///     with `transcriptFingerprint`.
-    ///   - distance: what the decision was based on, kept so calibration can
-    ///     read it back.
     public init(
         transcriptionId: UUID,
         speakerId: String,

--- a/Sources/MacParakeetCore/Models/SpeakerProfile.swift
+++ b/Sources/MacParakeetCore/Models/SpeakerProfile.swift
@@ -9,9 +9,14 @@ import GRDB
 /// aggregate would be an unused cache with its own coherency bugs.
 public struct SpeakerProfile: Codable, Identifiable, Sendable, Equatable {
     public var id: UUID
-    /// Unique case-insensitively: renaming another speaker to this name adds an
-    /// exemplar here rather than creating a rival profile.
+    /// As the user typed it. Display only — never compared directly.
     public var displayName: String
+    /// The key uniqueness and lookup both use, derived from `displayName`.
+    ///
+    /// Kept as a column rather than computed in a query so that the database
+    /// constraint and the Swift lookup can never disagree about what counts as
+    /// the same name. Set it through ``normalizedName(for:)``.
+    public var normalizedName: String
     public var embeddingModelId: String
     public var aggregationProfileId: String
     public var createdAt: Date
@@ -41,6 +46,7 @@ public struct SpeakerProfile: Codable, Identifiable, Sendable, Equatable {
     ) {
         self.id = id
         self.displayName = displayName
+        self.normalizedName = Self.normalizedName(for: displayName)
         self.embeddingModelId = identity.embeddingModelId
         self.aggregationProfileId = identity.aggregationProfileId
         self.createdAt = createdAt
@@ -55,6 +61,20 @@ public struct SpeakerProfile: Codable, Identifiable, Sendable, Equatable {
             embeddingModelId: embeddingModelId,
             aggregationProfileId: aggregationProfileId
         )
+    }
+
+    /// The comparison key for a display name: trimmed, then case-folded across
+    /// the whole of Unicode.
+    ///
+    /// Accents are deliberately kept. Folding them too would make "Jose" and
+    /// "José" one person, which is a guess about identity rather than about
+    /// typography — and the wrong guess merges two colleagues silently. When
+    /// two people really do share a name, the enrollment guard catches it by
+    /// voice instead.
+    public static func normalizedName(for displayName: String) -> String {
+        displayName
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .folding(options: [.caseInsensitive, .widthInsensitive], locale: nil)
     }
 }
 

--- a/Sources/MacParakeetCore/Services/Diarization/DiarizationService.swift
+++ b/Sources/MacParakeetCore/Services/Diarization/DiarizationService.swift
@@ -14,6 +14,12 @@ public struct MacParakeetDiarizationResult: Sendable {
     /// exclusive, so these are plain sums.
     public let speechMsBySpeaker: [String: Int]
 
+    /// - Parameters:
+    ///   - speakerEmbeddings: keyed by the same stable ids as `speakers`, and
+    ///     empty when the diarizer produced none. Callers must treat a missing
+    ///     entry as "not matchable", never as an error.
+    ///   - speechMsBySpeaker: total speech per speaker id. Offline segments are
+    ///     exclusive, so these are plain sums.
     public init(
         segments: [SpeakerSegment],
         speakerCount: Int,

--- a/Sources/MacParakeetCore/Services/Diarization/DiarizationService.swift
+++ b/Sources/MacParakeetCore/Services/Diarization/DiarizationService.swift
@@ -6,20 +6,12 @@ public struct MacParakeetDiarizationResult: Sendable {
     public let segments: [SpeakerSegment]
     public let speakerCount: Int
     public let speakers: [SpeakerInfo]
-    /// Voice embedding per detected speaker, keyed by the same stable ids as
-    /// `speakers`. A speaker is absent when its centroid carried no usable
-    /// direction; it keeps its segments and its `SpeakerInfo` either way.
+    /// Keyed by the same stable ids as `speakers`. A speaker is absent when its
+    /// centroid carried no direction; it keeps its segments and label either way.
     public let speakerEmbeddings: [String: SpeakerEmbedding]
-    /// Total speech per speaker id, in milliseconds. Offline segments are
-    /// exclusive, so these are plain sums.
+    /// Offline segments are exclusive, so these are plain sums.
     public let speechMsBySpeaker: [String: Int]
 
-    /// - Parameters:
-    ///   - speakerEmbeddings: keyed by the same stable ids as `speakers`, and
-    ///     empty when the diarizer produced none. Callers must treat a missing
-    ///     entry as "not matchable", never as an error.
-    ///   - speechMsBySpeaker: total speech per speaker id. Offline segments are
-    ///     exclusive, so these are plain sums.
     public init(
         segments: [SpeakerSegment],
         speakerCount: Int,
@@ -34,16 +26,11 @@ public struct MacParakeetDiarizationResult: Sendable {
         self.speechMsBySpeaker = speechMsBySpeaker
     }
 
-    /// Speech for one speaker, in seconds.
+    /// Speech for one speaker, in seconds; 0 when it has none.
     ///
-    /// The single conversion point between this type's milliseconds — the unit
-    /// every other diarization value uses — and the seconds that duration gates
-    /// are expressed in. Dividing at each call site invites the one mistake
-    /// nothing would catch: a factor of a thousand turns a three-second gate
-    /// into a fifty-minute one, so every speaker silently stops qualifying and
-    /// the feature just never fires.
-    ///
-    /// Returns 0 for a speaker with no recorded speech.
+    /// The single conversion point to the unit the duration gates use. A stray
+    /// factor of a thousand turns a 3 s gate into 50 minutes, and nothing would
+    /// catch it: every speaker would just silently stop qualifying.
     public func speechSeconds(forSpeaker speakerId: String) -> Double {
         Double(speechMsBySpeaker[speakerId] ?? 0) / 1000
     }
@@ -306,17 +293,14 @@ public actor DiarizationService: DiarizationServiceProtocol {
         )
     }
 
-    /// Rekeys FluidAudio's speaker database onto our stable ids and normalizes
+    /// Rekeys FluidAudio's speaker database onto our stable ids, normalizing
     /// each centroid.
     ///
-    /// The remap is not cosmetic: FluidAudio also names its clusters `S1`, `S2`,
-    /// but numbered by cluster index, while ours are numbered by who speaks
-    /// first. Carrying the keys over untouched would silently attach one
-    /// speaker's voice to another's label.
-    ///
-    /// Speakers whose centroid fails validation are dropped from the dictionary
-    /// only. They keep their segments, their `SpeakerInfo` and their duration —
-    /// diarization output is unchanged, and they are merely unmatchable.
+    /// The remap is load-bearing: FluidAudio also uses `S1`/`S2`, numbered by
+    /// cluster index where ours are numbered by who speaks first, so copying the
+    /// keys would attach one speaker's voice to another's label. Centroids that
+    /// fail validation are dropped from this dictionary only — the speaker keeps
+    /// its segments and label, and is merely unmatchable.
     static func speakerEmbeddings(
         from speakerDatabase: [String: [Float]]?,
         idMapping: [String: String],
@@ -475,22 +459,18 @@ public actor DiarizationService: DiarizationServiceProtocol {
         return config
     }
 
-    /// The WeSpeaker embedding model behind FluidAudio's offline diarizer.
-    /// Change it only when the model itself changes: vectors from two different
-    /// models share no space and are never compared.
+    /// Change only when the model changes: vectors from two models share no
+    /// space and are never compared.
     public nonisolated static let embeddingModelId = "fluidaudio-wespeaker-256"
 
     /// Bump on any FluidAudio upgrade that could move the clustering centroid,
     /// even when the embedding model is untouched.
     private nonisolated static let pipelineRevision = "fluidaudio-0.15.6"
 
-    /// Identity of the representation `config` produces.
-    ///
-    /// The centroid depends on the clustering configuration as much as on the
-    /// model, so the aggregation half hashes every setting that can move it.
-    /// The per-run speaker-count constraint is deliberately excluded: it varies
-    /// call to call, and folding it in would make a profile enrolled under a
-    /// count hint incomparable with the same voice heard without one.
+    /// Identity of the representation `config` produces. The aggregation half
+    /// hashes every setting that can move the centroid. The per-run speaker
+    /// count is excluded on purpose: it varies call to call, and folding it in
+    /// would make a profile enrolled under a hint incomparable without one.
     /// Identity of the representation the shipping configuration produces.
     nonisolated static var defaultModelIdentity: SpeakerModelIdentity {
         modelIdentity(for: highAccuracyConfig)

--- a/Sources/MacParakeetCore/Services/Diarization/DiarizationService.swift
+++ b/Sources/MacParakeetCore/Services/Diarization/DiarizationService.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import FluidAudio
 import Foundation
 
@@ -5,11 +6,26 @@ public struct MacParakeetDiarizationResult: Sendable {
     public let segments: [SpeakerSegment]
     public let speakerCount: Int
     public let speakers: [SpeakerInfo]
+    /// Voice embedding per detected speaker, keyed by the same stable ids as
+    /// `speakers`. A speaker is absent when its centroid carried no usable
+    /// direction; it keeps its segments and its `SpeakerInfo` either way.
+    public let speakerEmbeddings: [String: SpeakerEmbedding]
+    /// Total speech per speaker id, in milliseconds. Offline segments are
+    /// exclusive, so these are plain sums.
+    public let speechMsBySpeaker: [String: Int]
 
-    public init(segments: [SpeakerSegment], speakerCount: Int, speakers: [SpeakerInfo]) {
+    public init(
+        segments: [SpeakerSegment],
+        speakerCount: Int,
+        speakers: [SpeakerInfo],
+        speakerEmbeddings: [String: SpeakerEmbedding] = [:],
+        speechMsBySpeaker: [String: Int] = [:]
+    ) {
         self.segments = segments
         self.speakerCount = speakerCount
         self.speakers = speakers
+        self.speakerEmbeddings = speakerEmbeddings
+        self.speechMsBySpeaker = speechMsBySpeaker
     }
 }
 
@@ -151,6 +167,7 @@ public actor DiarizationService: DiarizationServiceProtocol {
     private let modelsDirectory: URL
     private let inferenceGate: ANEInferenceGate
     private let explicitConstraint: SpeakerDiarizationConstraint?
+    private let modelIdentity: SpeakerModelIdentity
     private var managerFactory: ManagerFactory?
     private var preparation: Task<Void, Error>?
 
@@ -163,7 +180,8 @@ public actor DiarizationService: DiarizationServiceProtocol {
         self.init(
             loadManagerFactory: Self.modelLoader(config: config),
             modelsDirectory: modelsDirectory ?? AppPaths.fluidAudioModelsDirURL,
-            explicitConstraint: nil
+            explicitConstraint: nil,
+            modelIdentity: Self.modelIdentity(for: config)
         )
     }
 
@@ -174,7 +192,8 @@ public actor DiarizationService: DiarizationServiceProtocol {
         self.init(
             loadManagerFactory: Self.modelLoader(config: Self.highAccuracyConfig),
             modelsDirectory: modelsDirectory ?? AppPaths.fluidAudioModelsDirURL,
-            explicitConstraint: speakerConstraint
+            explicitConstraint: speakerConstraint,
+            modelIdentity: Self.modelIdentity(for: Self.highAccuracyConfig)
         )
     }
 
@@ -182,12 +201,14 @@ public actor DiarizationService: DiarizationServiceProtocol {
         loadManagerFactory: @escaping ManagerFactoryLoader,
         modelsDirectory: URL,
         explicitConstraint: SpeakerDiarizationConstraint? = nil,
-        inferenceGate: ANEInferenceGate = .shared
+        inferenceGate: ANEInferenceGate = .shared,
+        modelIdentity: SpeakerModelIdentity = DiarizationService.defaultModelIdentity
     ) {
         self.loadManagerFactory = loadManagerFactory
         self.modelsDirectory = modelsDirectory.standardizedFileURL
         self.explicitConstraint = explicitConstraint
         self.inferenceGate = inferenceGate
+        self.modelIdentity = modelIdentity
     }
 
     public func diarize(
@@ -247,11 +268,49 @@ public actor DiarizationService: DiarizationServiceProtocol {
                 return SpeakerInfo(id: stableId, label: "Speaker \(number)")
             }
 
+        var speechMsBySpeaker: [String: Int] = [:]
+        for segment in segments {
+            speechMsBySpeaker[segment.speakerId, default: 0] += max(0, segment.endMs - segment.startMs)
+        }
+
         return MacParakeetDiarizationResult(
             segments: segments,
             speakerCount: speakers.count,
-            speakers: speakers
+            speakers: speakers,
+            speakerEmbeddings: Self.speakerEmbeddings(
+                from: fluidResult.speakerDatabase,
+                idMapping: idMapping,
+                identity: modelIdentity
+            ),
+            speechMsBySpeaker: speechMsBySpeaker
         )
+    }
+
+    /// Rekeys FluidAudio's speaker database onto our stable ids and normalizes
+    /// each centroid.
+    ///
+    /// The remap is not cosmetic: FluidAudio also names its clusters `S1`, `S2`,
+    /// but numbered by cluster index, while ours are numbered by who speaks
+    /// first. Carrying the keys over untouched would silently attach one
+    /// speaker's voice to another's label.
+    ///
+    /// Speakers whose centroid fails validation are dropped from the dictionary
+    /// only. They keep their segments, their `SpeakerInfo` and their duration —
+    /// diarization output is unchanged, and they are merely unmatchable.
+    static func speakerEmbeddings(
+        from speakerDatabase: [String: [Float]]?,
+        idMapping: [String: String],
+        identity: SpeakerModelIdentity
+    ) -> [String: SpeakerEmbedding] {
+        guard let speakerDatabase else { return [:] }
+
+        var embeddings: [String: SpeakerEmbedding] = [:]
+        for (fluidID, rawVector) in speakerDatabase {
+            guard let stableID = idMapping[fluidID] else { continue }
+            guard let embedding = SpeakerEmbedding(rawVector: rawVector, identity: identity) else { continue }
+            embeddings[stableID] = embedding
+        }
+        return embeddings
     }
 
     public func prepareModels(onProgress: (@Sendable (String) -> Void)? = nil) async throws {
@@ -394,6 +453,49 @@ public actor DiarizationService: DiarizationServiceProtocol {
         // the surrounding speaker).
         config.zeroVoteReembed = OfflineDiarizerConfig.ZeroVoteReembed(enabled: true)
         return config
+    }
+
+    /// The WeSpeaker embedding model behind FluidAudio's offline diarizer.
+    /// Change it only when the model itself changes: vectors from two different
+    /// models share no space and are never compared.
+    public nonisolated static let embeddingModelId = "fluidaudio-wespeaker-256"
+
+    /// Bump on any FluidAudio upgrade that could move the clustering centroid,
+    /// even when the embedding model is untouched.
+    private nonisolated static let pipelineRevision = "fluidaudio-0.15.6"
+
+    /// Identity of the representation `config` produces.
+    ///
+    /// The centroid depends on the clustering configuration as much as on the
+    /// model, so the aggregation half hashes every setting that can move it.
+    /// The per-run speaker-count constraint is deliberately excluded: it varies
+    /// call to call, and folding it in would make a profile enrolled under a
+    /// count hint incomparable with the same voice heard without one.
+    /// Identity of the representation the shipping configuration produces.
+    nonisolated static var defaultModelIdentity: SpeakerModelIdentity {
+        modelIdentity(for: highAccuracyConfig)
+    }
+
+    nonisolated static func modelIdentity(for config: OfflineDiarizerConfig) -> SpeakerModelIdentity {
+        let canonical = [
+            "pipeline=\(pipelineRevision)",
+            "windowDuration=\(config.segmentation.windowDurationSeconds)",
+            "stepRatio=\(config.segmentation.stepRatio)",
+            "minSegmentDuration=\(config.embedding.minSegmentDurationSeconds)",
+            "excludeOverlap=\(config.embedding.excludeOverlap)",
+            "clusteringThreshold=\(config.clustering.threshold)",
+            "constrainedAssignment=\(config.clustering.constrainedAssignment)",
+            "warmStartFa=\(config.clustering.warmStartFa)",
+            "warmStartFb=\(config.clustering.warmStartFb)",
+            "zeroVoteReembed=\(config.zeroVoteReembed.enabled)",
+            "zeroVoteMinDuration=\(config.zeroVoteReembed.minDurationSeconds)",
+        ].joined(separator: ";")
+
+        let digest = SHA256.hash(data: Data(canonical.utf8))
+        return SpeakerModelIdentity(
+            embeddingModelId: embeddingModelId,
+            aggregationProfileId: digest.prefix(8).map { String(format: "%02x", $0) }.joined()
+        )
     }
 
     nonisolated static func offlineConfig(

--- a/Sources/MacParakeetCore/Services/Diarization/DiarizationService.swift
+++ b/Sources/MacParakeetCore/Services/Diarization/DiarizationService.swift
@@ -468,9 +468,14 @@ public actor DiarizationService: DiarizationServiceProtocol {
     private nonisolated static let pipelineRevision = "fluidaudio-0.15.6"
 
     /// Identity of the representation `config` produces. The aggregation half
-    /// hashes every setting that can move the centroid. The per-run speaker
-    /// count is excluded on purpose: it varies call to call, and folding it in
-    /// would make a profile enrolled under a hint incomparable without one.
+    /// hashes the settings that shape the centroid, VBx refinement included,
+    /// so a FluidAudio upgrade that retunes them is caught without anyone
+    /// remembering to bump `pipelineRevision`.
+    ///
+    /// The per-run speaker count is excluded on purpose. It is derived from the
+    /// calendar attendee count, so it changes from meeting to meeting: folding
+    /// it in would make a profile cross-aggregation against its own samples and
+    /// keep tau permanently reduced by `crossAggregationPenalty`.
     /// Identity of the representation the shipping configuration produces.
     nonisolated static var defaultModelIdentity: SpeakerModelIdentity {
         modelIdentity(for: highAccuracyConfig)
@@ -489,6 +494,8 @@ public actor DiarizationService: DiarizationServiceProtocol {
             "warmStartFb=\(config.clustering.warmStartFb)",
             "zeroVoteReembed=\(config.zeroVoteReembed.enabled)",
             "zeroVoteMinDuration=\(config.zeroVoteReembed.minDurationSeconds)",
+            "vbxMaxIterations=\(config.vbx.maxIterations)",
+            "vbxConvergenceTolerance=\(config.vbx.convergenceTolerance)",
         ].joined(separator: ";")
 
         let digest = SHA256.hash(data: Data(canonical.utf8))

--- a/Sources/MacParakeetCore/Services/Diarization/DiarizationService.swift
+++ b/Sources/MacParakeetCore/Services/Diarization/DiarizationService.swift
@@ -33,6 +33,20 @@ public struct MacParakeetDiarizationResult: Sendable {
         self.speakerEmbeddings = speakerEmbeddings
         self.speechMsBySpeaker = speechMsBySpeaker
     }
+
+    /// Speech for one speaker, in seconds.
+    ///
+    /// The single conversion point between this type's milliseconds — the unit
+    /// every other diarization value uses — and the seconds that duration gates
+    /// are expressed in. Dividing at each call site invites the one mistake
+    /// nothing would catch: a factor of a thousand turns a three-second gate
+    /// into a fifty-minute one, so every speaker silently stops qualifying and
+    /// the feature just never fires.
+    ///
+    /// Returns 0 for a speaker with no recorded speech.
+    public func speechSeconds(forSpeaker speakerId: String) -> Double {
+        Double(speechMsBySpeaker[speakerId] ?? 0) / 1000
+    }
 }
 
 public struct SpeakerSegment: Sendable {

--- a/Sources/MacParakeetCore/Services/Diarization/DiarizationService.swift
+++ b/Sources/MacParakeetCore/Services/Diarization/DiarizationService.swift
@@ -467,20 +467,28 @@ public actor DiarizationService: DiarizationServiceProtocol {
     /// even when the embedding model is untouched.
     private nonisolated static let pipelineRevision = "fluidaudio-0.15.6"
 
-    /// Identity of the representation `config` produces. The aggregation half
-    /// hashes the settings that shape the centroid, VBx refinement included,
-    /// so a FluidAudio upgrade that retunes them is caught without anyone
-    /// remembering to bump `pipelineRevision`.
-    ///
-    /// The per-run speaker count is excluded on purpose. It is derived from the
-    /// calendar attendee count, so it changes from meeting to meeting: folding
-    /// it in would make a profile cross-aggregation against its own samples and
-    /// keep tau permanently reduced by `crossAggregationPenalty`.
     /// Identity of the representation the shipping configuration produces.
     nonisolated static var defaultModelIdentity: SpeakerModelIdentity {
         modelIdentity(for: highAccuracyConfig)
     }
 
+    /// Identity of the representation `config` produces. The aggregation half
+    /// hashes the settings that shape the centroid, VBx refinement included,
+    /// so a FluidAudio upgrade that retunes them is caught without anyone
+    /// remembering to bump `pipelineRevision`.
+    ///
+    /// The per-run speaker count is excluded on purpose, even though it reaches
+    /// the clusterer through `config`. It comes from the calendar attendee
+    /// count, so it changes from meeting to meeting: folding it in would make a
+    /// profile cross-aggregation against its own samples and keep tau
+    /// permanently reduced by `crossAggregationPenalty` — below the worst true
+    /// positive Phase 0b measured, so correct pairs would start being refused.
+    ///
+    /// What the app passes is also a cap, never an exact count
+    /// (`MeetingSpeakerPrior` bounds are `min 1, max n + 1`), so it re-clusters
+    /// nothing unless the diarizer oversplits past it. The exact form that does
+    /// move the partition (FluidAudio #801) arrives only from the CLI's
+    /// `--speaker-count`, and that path enrolls nothing in v1.
     nonisolated static func modelIdentity(for config: OfflineDiarizerConfig) -> SpeakerModelIdentity {
         let canonical = [
             "pipeline=\(pipelineRevision)",

--- a/Sources/MacParakeetCore/Services/Diarization/SpeakerEmbedding.swift
+++ b/Sources/MacParakeetCore/Services/Diarization/SpeakerEmbedding.swift
@@ -26,6 +26,11 @@ public struct SpeakerModelIdentity: Sendable, Equatable, Hashable, Codable {
     /// comparable but less trustworthy, so callers tighten their threshold.
     public let aggregationProfileId: String
 
+    /// - Parameters:
+    ///   - embeddingModelId: the model that produced the vector.
+    ///   - aggregationProfileId: the clustering configuration that shaped the
+    ///     centroid, so a configuration change is visible even when the model
+    ///     is unchanged.
     public init(embeddingModelId: String, aggregationProfileId: String) {
         self.embeddingModelId = embeddingModelId
         self.aggregationProfileId = aggregationProfileId

--- a/Sources/MacParakeetCore/Services/Diarization/SpeakerEmbedding.swift
+++ b/Sources/MacParakeetCore/Services/Diarization/SpeakerEmbedding.swift
@@ -1,0 +1,130 @@
+import Foundation
+
+/// Where a voice sample was captured.
+///
+/// Embeddings only compare meaningfully inside one domain: the same person
+/// heard over a compressed conference stream and over a local microphone lands
+/// in different regions of the embedding space. Every stored sample carries its
+/// domain so matching can prefer like-for-like references.
+public enum SpeakerCaptureDomain: String, Sendable, Codable, CaseIterable {
+    case system
+    case microphone
+    case file
+}
+
+/// Identifies the representation an embedding was produced in.
+///
+/// Two identifiers rather than one, because the vector FluidAudio hands back is
+/// the VBx *clustering* centroid, not a raw model output. It therefore moves
+/// when the clustering configuration moves, even if the embedding model itself
+/// is untouched — a change that a model-only identifier would miss. See the
+/// 2026-09-09 amendment to `plans/active/2026-07-03-speaker-voiceprints.md`.
+public struct SpeakerModelIdentity: Sendable, Equatable, Hashable, Codable {
+    /// The embedding model. A mismatch makes two vectors incomparable.
+    public let embeddingModelId: String
+    /// The aggregation configuration that produced the centroid. A mismatch is
+    /// comparable but less trustworthy, so callers tighten their threshold.
+    public let aggregationProfileId: String
+
+    public init(embeddingModelId: String, aggregationProfileId: String) {
+        self.embeddingModelId = embeddingModelId
+        self.aggregationProfileId = aggregationProfileId
+    }
+}
+
+/// A speaker voice embedding, L2-normalized on construction.
+///
+/// Normalization happens here and nowhere else. FluidAudio's `speakerDatabase`
+/// vectors are un-normalized centroids, and comparing them with a bare dot
+/// product scales every distance by `‖a‖·‖b‖` — which silently pushes
+/// same-speaker pairs past any calibrated threshold, with no error to observe.
+/// Worse, the centroid norm shrinks as a cluster gets noisier, so the bias is
+/// anti-correlated with signal quality. Normalizing at the boundary makes every
+/// downstream comparison correct by construction.
+public struct SpeakerEmbedding: Sendable, Equatable {
+    /// WeSpeaker embedding width.
+    public static let dimension = 256
+    /// Serialized size: 256 × Float32.
+    public static let byteCount = dimension * MemoryLayout<Float32>.size
+    /// Below this, a vector carries no usable direction. FluidAudio emits an
+    /// all-zero centroid when a cluster's responsibility denominator is zero.
+    static let minimumNorm: Float = 1e-6
+    /// Tolerance when re-reading a stored vector that is already normalized.
+    static let normTolerance: Float = 1e-3
+
+    /// Unit-length, `dimension` values.
+    public let vector: [Float]
+    public let identity: SpeakerModelIdentity
+
+    /// Normalizes `rawVector`. Returns `nil` for the wrong width, non-finite
+    /// values, or a vector too short to carry a direction.
+    public init?(rawVector: [Float], identity: SpeakerModelIdentity) {
+        guard rawVector.count == Self.dimension else { return nil }
+        guard rawVector.allSatisfy(\.isFinite) else { return nil }
+
+        let norm = Self.norm(of: rawVector)
+        guard norm.isFinite, norm >= Self.minimumNorm else { return nil }
+
+        self.vector = rawVector.map { $0 / norm }
+        self.identity = identity
+    }
+
+    /// Rebuilds a vector previously produced by ``data``.
+    ///
+    /// Deliberately does not re-normalize: the bytes are already unit-length, and
+    /// dividing again by a norm that floating-point rounding puts at 0.99999994
+    /// would make a store/load round trip lossy. The norm is validated instead,
+    /// so corruption is rejected rather than silently rescaled.
+    public init?(data: Data, identity: SpeakerModelIdentity) {
+        guard data.count == Self.byteCount else { return nil }
+
+        var values = [Float]()
+        values.reserveCapacity(Self.dimension)
+        for index in 0..<Self.dimension {
+            let start = data.startIndex + index * MemoryLayout<Float32>.size
+            let bits = data[start..<start + MemoryLayout<Float32>.size]
+                .withUnsafeBytes { $0.loadUnaligned(as: UInt32.self) }
+            values.append(Float(bitPattern: UInt32(littleEndian: bits)))
+        }
+
+        guard values.allSatisfy(\.isFinite) else { return nil }
+        guard abs(Self.norm(of: values) - 1) <= Self.normTolerance else { return nil }
+
+        self.vector = values
+        self.identity = identity
+    }
+
+    /// Little-endian Float32, `byteCount` bytes. The stored form.
+    public var data: Data {
+        var output = Data(capacity: Self.byteCount)
+        for value in vector {
+            withUnsafeBytes(of: value.bitPattern.littleEndian) { output.append(contentsOf: $0) }
+        }
+        return output
+    }
+
+    /// Cosine distance in FluidAudio's convention: 0 is identical, 1 is
+    /// unrelated. Both operands are unit-length, so the dot product is the
+    /// cosine and no rescaling is needed.
+    ///
+    /// Returns `nil` when the embedding models differ, since vectors from
+    /// different models share no space. A differing aggregation profile is
+    /// comparable and left to the caller's threshold policy.
+    public func cosineDistance(to other: SpeakerEmbedding) -> Double? {
+        guard identity.embeddingModelId == other.identity.embeddingModelId else { return nil }
+
+        var dot: Float = 0
+        for index in 0..<Self.dimension {
+            dot += vector[index] * other.vector[index]
+        }
+        return 1 - Double(min(max(dot, -1), 1))
+    }
+
+    private static func norm(of values: [Float]) -> Float {
+        var sumOfSquares: Float = 0
+        for value in values {
+            sumOfSquares += value * value
+        }
+        return sumOfSquares.squareRoot()
+    }
+}

--- a/Sources/MacParakeetCore/Services/Diarization/SpeakerEmbedding.swift
+++ b/Sources/MacParakeetCore/Services/Diarization/SpeakerEmbedding.swift
@@ -1,11 +1,8 @@
 import Foundation
 
-/// Where a voice sample was captured.
-///
-/// Embeddings only compare meaningfully inside one domain: the same person
-/// heard over a compressed conference stream and over a local microphone lands
-/// in different regions of the embedding space. Every stored sample carries its
-/// domain so matching can prefer like-for-like references.
+/// Where a voice sample was captured. The same person lands in a different
+/// region of the embedding space over a compressed stream than over a local
+/// microphone, so matching prefers like-for-like references.
 public enum SpeakerCaptureDomain: String, Sendable, Codable, CaseIterable {
     case system
     case microphone
@@ -14,23 +11,14 @@ public enum SpeakerCaptureDomain: String, Sendable, Codable, CaseIterable {
 
 /// Identifies the representation an embedding was produced in.
 ///
-/// Two identifiers rather than one, because the vector FluidAudio hands back is
-/// the VBx *clustering* centroid, not a raw model output. It therefore moves
-/// when the clustering configuration moves, even if the embedding model itself
-/// is untouched — a change that a model-only identifier would miss. See the
-/// 2026-09-09 amendment to `plans/active/2026-07-03-speaker-voiceprints.md`.
+/// Two ids, not one: FluidAudio returns the VBx clustering centroid, which
+/// moves when the clustering configuration moves even if the model does not.
 public struct SpeakerModelIdentity: Sendable, Equatable, Hashable, Codable {
-    /// The embedding model. A mismatch makes two vectors incomparable.
+    /// A mismatch makes two vectors incomparable.
     public let embeddingModelId: String
-    /// The aggregation configuration that produced the centroid. A mismatch is
-    /// comparable but less trustworthy, so callers tighten their threshold.
+    /// A mismatch is comparable but less trusted, so callers tighten tau.
     public let aggregationProfileId: String
 
-    /// - Parameters:
-    ///   - embeddingModelId: the model that produced the vector.
-    ///   - aggregationProfileId: the clustering configuration that shaped the
-    ///     centroid, so a configuration change is visible even when the model
-    ///     is unchanged.
     public init(embeddingModelId: String, aggregationProfileId: String) {
         self.embeddingModelId = embeddingModelId
         self.aggregationProfileId = aggregationProfileId
@@ -39,30 +27,23 @@ public struct SpeakerModelIdentity: Sendable, Equatable, Hashable, Codable {
 
 /// A speaker voice embedding, L2-normalized on construction.
 ///
-/// Normalization happens here and nowhere else. FluidAudio's `speakerDatabase`
-/// vectors are un-normalized centroids, and comparing them with a bare dot
-/// product scales every distance by `‖a‖·‖b‖` — which silently pushes
-/// same-speaker pairs past any calibrated threshold, with no error to observe.
-/// Worse, the centroid norm shrinks as a cluster gets noisier, so the bias is
-/// anti-correlated with signal quality. Normalizing at the boundary makes every
-/// downstream comparison correct by construction.
+/// Normalization happens here and nowhere else: FluidAudio's centroids are
+/// un-normalized, so a bare dot product scales distances by `‖a‖·‖b‖` and
+/// silently pushes same-speaker pairs past tau. The centroid norm also shrinks
+/// as a cluster gets noisier, making the bias worst where accuracy matters most.
 public struct SpeakerEmbedding: Sendable, Equatable {
-    /// WeSpeaker embedding width.
     public static let dimension = 256
-    /// Serialized size: 256 × Float32.
     public static let byteCount = dimension * MemoryLayout<Float32>.size
-    /// Below this, a vector carries no usable direction. FluidAudio emits an
-    /// all-zero centroid when a cluster's responsibility denominator is zero.
+    /// FluidAudio emits an all-zero centroid when a cluster's responsibility
+    /// denominator is zero; below this a vector carries no direction.
     static let minimumNorm: Float = 1e-6
-    /// Tolerance when re-reading a stored vector that is already normalized.
     static let normTolerance: Float = 1e-3
 
     /// Unit-length, `dimension` values.
     public let vector: [Float]
     public let identity: SpeakerModelIdentity
 
-    /// Normalizes `rawVector`. Returns `nil` for the wrong width, non-finite
-    /// values, or a vector too short to carry a direction.
+    /// Returns `nil` for the wrong width, non-finite values, or no direction.
     public init?(rawVector: [Float], identity: SpeakerModelIdentity) {
         guard rawVector.count == Self.dimension else { return nil }
         guard rawVector.allSatisfy(\.isFinite) else { return nil }
@@ -74,12 +55,9 @@ public struct SpeakerEmbedding: Sendable, Equatable {
         self.identity = identity
     }
 
-    /// Rebuilds a vector previously produced by ``data``.
-    ///
-    /// Deliberately does not re-normalize: the bytes are already unit-length, and
-    /// dividing again by a norm that floating-point rounding puts at 0.99999994
-    /// would make a store/load round trip lossy. The norm is validated instead,
-    /// so corruption is rejected rather than silently rescaled.
+    /// Rebuilds a vector produced by ``data``. Does not re-normalize — dividing
+    /// again by a norm rounding puts at 0.99999994 would make the round trip
+    /// lossy — but validates it, so corruption is rejected not rescaled.
     public init?(data: Data, identity: SpeakerModelIdentity) {
         guard data.count == Self.byteCount else { return nil }
 
@@ -108,13 +86,9 @@ public struct SpeakerEmbedding: Sendable, Equatable {
         return output
     }
 
-    /// Cosine distance in FluidAudio's convention: 0 is identical, 1 is
-    /// unrelated. Both operands are unit-length, so the dot product is the
-    /// cosine and no rescaling is needed.
-    ///
-    /// Returns `nil` when the embedding models differ, since vectors from
-    /// different models share no space. A differing aggregation profile is
-    /// comparable and left to the caller's threshold policy.
+    /// Cosine distance, FluidAudio's convention: 0 identical, 1 unrelated.
+    /// `nil` when the embedding models differ, since they share no space; a
+    /// differing aggregation profile is left to the caller's threshold policy.
     public func cosineDistance(to other: SpeakerEmbedding) -> Double? {
         guard identity.embeddingModelId == other.identity.embeddingModelId else { return nil }
 

--- a/Sources/MacParakeetCore/Services/Diarization/SpeakerVoiceprintMatcher.swift
+++ b/Sources/MacParakeetCore/Services/Diarization/SpeakerVoiceprintMatcher.swift
@@ -248,7 +248,7 @@ public enum SpeakerVoiceprintMatcher {
             // `runnerUp - best < 0` and position alone would decide.
             let runnerUp = [best.runnerUp, bestForProfile?.runnerUp].compactMap { $0 }.min()
             if let runnerUp,
-               runnerUp == best.distance || runnerUp - best.distance < policy.margin
+                runnerUp == best.distance || runnerUp - best.distance < policy.margin
             {
                 decisions.append(
                     rejection(
@@ -323,7 +323,8 @@ public enum SpeakerVoiceprintMatcher {
         for reference in profile.references.prefix(policy.maxReferencesPerProfile) {
             guard let distance = cluster.embedding.cosineDistance(to: reference.embedding) else { continue }
             let sameDomain = reference.captureDomain == cluster.captureDomain
-            let sameAggregation = reference.embedding.identity.aggregationProfileId
+            let sameAggregation =
+                reference.embedding.identity.aggregationProfileId
                 == cluster.embedding.identity.aggregationProfileId
 
             guard let current = best else {

--- a/Sources/MacParakeetCore/Services/Diarization/SpeakerVoiceprintMatcher.swift
+++ b/Sources/MacParakeetCore/Services/Diarization/SpeakerVoiceprintMatcher.swift
@@ -146,10 +146,11 @@ public enum SpeakerVoiceprintMatcher {
         let scorable = clusters.filter { $0.speechSeconds >= policy.minSpeechSecondsToMatch }
         guard !scorable.isEmpty, !profiles.isEmpty else { return [] }
 
-        // distances[clusterIndex][profileIndex], nil when incomparable.
-        let distances: [[Double?]] = scorable.map { cluster in
-            profiles.map { profile in distance(from: cluster, to: profile, policy: policy) }
+        // matches[clusterIndex][profileIndex], nil when incomparable.
+        let matches: [[ReferenceMatch?]] = scorable.map { cluster in
+            profiles.map { profile in bestReference(from: cluster, to: profile, policy: policy) }
         }
+        let distances: [[Double?]] = matches.map { $0.map(\.?.distance) }
 
         var suggestions: [SpeakerVoiceprintSuggestion] = []
         for (clusterIndex, cluster) in scorable.enumerated() {
@@ -164,7 +165,9 @@ public enum SpeakerVoiceprintMatcher {
             }
 
             let profile = profiles[best.index]
-            guard best.distance <= effectiveTau(cluster: cluster, profile: profile, policy: policy) else { continue }
+            guard let winning = matches[clusterIndex][best.index],
+                  best.distance <= effectiveTau(for: winning, policy: policy)
+            else { continue }
 
             // A side with no second candidate has nothing to be separated
             // from, so its margin is vacuously satisfied. Failing it instead
@@ -186,6 +189,18 @@ public enum SpeakerVoiceprintMatcher {
         return suggestions
     }
 
+    /// The closest reference of a profile, and whether it was aggregated the
+    /// same way as the cluster.
+    public struct ReferenceMatch: Sendable, Equatable {
+        public let distance: Double
+        /// Whether the *winning* reference shares the cluster's aggregation
+        /// profile. Carried alongside the distance rather than derived later,
+        /// because the two must describe the same reference: a profile holding
+        /// both pre- and post-upgrade exemplars would otherwise be scored on an
+        /// old reference while being trusted as if it were current.
+        public let sameAggregation: Bool
+    }
+
     /// Distance from a cluster to a profile: the closest reference, preferring
     /// one captured in the same domain when two are equally close. `nil` when
     /// no reference is comparable at all.
@@ -194,39 +209,44 @@ public enum SpeakerVoiceprintMatcher {
         to profile: SpeakerProfileCandidate,
         policy: SpeakerMatchPolicy
     ) -> Double? {
-        var best: (distance: Double, sameDomain: Bool)?
+        bestReference(from: cluster, to: profile, policy: policy)?.distance
+    }
+
+    /// As `distance`, keeping the winning reference's aggregation identity.
+    public static func bestReference(
+        from cluster: SpeakerClusterObservation,
+        to profile: SpeakerProfileCandidate,
+        policy: SpeakerMatchPolicy
+    ) -> ReferenceMatch? {
+        var best: (distance: Double, sameDomain: Bool, sameAggregation: Bool)?
 
         for reference in profile.references.prefix(policy.maxReferencesPerProfile) {
             guard let distance = cluster.embedding.cosineDistance(to: reference.embedding) else { continue }
             let sameDomain = reference.captureDomain == cluster.captureDomain
+            let sameAggregation = reference.embedding.identity.aggregationProfileId
+                == cluster.embedding.identity.aggregationProfileId
 
             guard let current = best else {
-                best = (distance, sameDomain)
+                best = (distance, sameDomain, sameAggregation)
                 continue
             }
             if distance < current.distance {
-                best = (distance, sameDomain)
+                best = (distance, sameDomain, sameAggregation)
             } else if distance == current.distance, sameDomain, !current.sameDomain {
-                best = (distance, sameDomain)
+                best = (distance, sameDomain, sameAggregation)
             }
         }
 
-        return best?.distance
+        guard let best else { return nil }
+        return ReferenceMatch(distance: best.distance, sameAggregation: best.sameAggregation)
     }
 
-    /// The threshold for this pair. A reference aggregated under a different
+    /// The threshold for one pair. A reference aggregated under a different
     /// clustering configuration is still comparable — Phase 0b leaves a 0.24
     /// gap between the worst true pair and the best impostor, and configuration
     /// drift costs hundredths — but it is trusted less.
-    private static func effectiveTau(
-        cluster: SpeakerClusterObservation,
-        profile: SpeakerProfileCandidate,
-        policy: SpeakerMatchPolicy
-    ) -> Double {
-        let sameAggregation = profile.references.contains {
-            $0.embedding.identity.aggregationProfileId == cluster.embedding.identity.aggregationProfileId
-        }
-        return sameAggregation ? policy.tau : policy.tau - policy.crossAggregationPenalty
+    private static func effectiveTau(for match: ReferenceMatch, policy: SpeakerMatchPolicy) -> Double {
+        match.sameAggregation ? policy.tau : policy.tau - policy.crossAggregationPenalty
     }
 
     private struct Candidate {

--- a/Sources/MacParakeetCore/Services/Diarization/SpeakerVoiceprintMatcher.swift
+++ b/Sources/MacParakeetCore/Services/Diarization/SpeakerVoiceprintMatcher.swift
@@ -2,14 +2,12 @@ import Foundation
 
 /// One detected speaker in one recording, as offered to the matcher.
 public struct SpeakerClusterObservation: Sendable, Equatable {
-    /// The diarizer's id for this run ("S1", "system:S1"). Positional.
+    /// Positional id for this run ("S1", "system:S1").
     public let speakerId: String
     public let embedding: SpeakerEmbedding
     public let speechSeconds: Double
     public let captureDomain: SpeakerCaptureDomain
 
-    /// - Parameter speechSeconds: total clean speech for this cluster; the
-    ///   duration gates read it, and a short cluster is never scored.
     public init(
         speakerId: String,
         embedding: SpeakerEmbedding,
@@ -25,14 +23,10 @@ public struct SpeakerClusterObservation: Sendable, Equatable {
 
 /// An enrolled voice, reduced to what scoring needs.
 public struct SpeakerProfileCandidate: Sendable, Equatable {
-    /// One stored sample of the voice, with the domain it was captured in.
     public struct Reference: Sendable, Equatable {
         public let embedding: SpeakerEmbedding
         public let captureDomain: SpeakerCaptureDomain
 
-        /// - Parameter captureDomain: preferred when two references are
-        ///   equally close, since the same voice sits elsewhere in the space
-        ///   over a compressed stream than over a local microphone.
         public init(embedding: SpeakerEmbedding, captureDomain: SpeakerCaptureDomain) {
             self.embedding = embedding
             self.captureDomain = captureDomain
@@ -43,8 +37,6 @@ public struct SpeakerProfileCandidate: Sendable, Equatable {
     public let displayName: String
     public let references: [Reference]
 
-    /// - Parameter references: scored as a set, closest wins; a profile with
-    ///   none is skipped rather than treated as distant.
     public init(profileId: UUID, displayName: String, references: [Reference]) {
         self.profileId = profileId
         self.displayName = displayName
@@ -52,26 +44,21 @@ public struct SpeakerProfileCandidate: Sendable, Equatable {
     }
 }
 
-/// Thresholds and gates. Injected rather than hard-coded so calibration changes
-/// one value and nothing else, and so tests state their own.
+/// Thresholds and gates, injected so calibration changes values and no logic.
 public struct SpeakerMatchPolicy: Sendable, Equatable {
     /// Accept only below this cosine distance.
     public let tau: Double
     /// Required separation from the runner-up, on both sides.
     public let margin: Double
-    /// A cluster below this much speech is never scored.
     public let minSpeechSecondsToMatch: Double
-    /// A cluster below this much speech may match but never enroll.
+    /// A cluster above the match gate but below this may match, never enroll.
     public let minSpeechSecondsToEnroll: Double
     public let maxReferencesPerProfile: Int
-    /// Tightening applied when the reference was aggregated under a different
-    /// clustering configuration.
+    /// Tightening when the reference came from another clustering config.
     public let crossAggregationPenalty: Double
-    /// Above this, a name-based enrollment is treated as a different person
-    /// rather than merged into the existing profile.
+    /// Above this, a name-based enrollment is a different person, not a merge.
     public let pollutionGuardDistance: Double
 
-    /// Use ``v1`` unless a test or a calibration run needs its own values.
     public init(
         tau: Double,
         margin: Double,
@@ -90,13 +77,9 @@ public struct SpeakerMatchPolicy: Sendable, Equatable {
         self.pollutionGuardDistance = pollutionGuardDistance
     }
 
-    /// Shipping values.
-    ///
-    /// `tau` sits at the bottom of the zero-false-positive plateau measured in
-    /// the Phase 0b calibration (0.25 to 0.45, worst true pair at 0.227) rather
-    /// than mid-plateau: a missed suggestion is a non-event, a false one is the
-    /// worst documented outcome, and the plateau was measured on clean audio
-    /// that real meeting captures will not match.
+    /// `tau` sits at the bottom of the Phase 0b zero-false-positive plateau
+    /// (0.25 to 0.45, worst true pair 0.227), not mid-plateau: that plateau came
+    /// from clean audio, and a false suggestion costs more than a missed one.
     public static let v1 = SpeakerMatchPolicy(
         tau: 0.25,
         margin: 0.10,
@@ -114,12 +97,9 @@ public struct SpeakerVoiceprintSuggestion: Sendable, Equatable {
     public let profileId: UUID
     public let displayName: String
     public let distance: Double
-    /// Next-best distance on either side, whichever is closer — what the
-    /// decision had to beat. `nil` when there was no second candidate at all.
+    /// What the decision had to beat; `nil` when there was no second candidate.
     public let runnerUpDistance: Double?
 
-    /// - Parameter runnerUpDistance: what this decision had to beat, or `nil`
-    ///   when there was no second candidate on either side.
     public init(
         speakerId: String,
         profileId: UUID,
@@ -135,7 +115,7 @@ public struct SpeakerVoiceprintSuggestion: Sendable, Equatable {
     }
 }
 
-/// Decides which enrolled voices to propose for the speakers of one recording.
+/// Decides which enrolled voices to propose for one recording's speakers.
 ///
 /// Stateless and I/O-free on purpose: this is where the feature can be wrong
 /// about a person, so it must be testable on fixtures alone.
@@ -181,9 +161,8 @@ public enum SpeakerVoiceprintMatcher {
             else { continue }
 
             // A side with no second candidate has nothing to be separated
-            // from, so its margin is vacuously satisfied. Failing it instead
-            // would make the very first enrolled voice unsuggestable, which is
-            // precisely when the feature is supposed to earn its keep.
+            // from, so its margin is vacuously satisfied. Failing it would make
+            // the first enrolled voice unsuggestable.
             if let runnerUp = best.runnerUp, runnerUp - best.distance < policy.margin { continue }
             if let runnerUp = bestForProfile.runnerUp, runnerUp - best.distance < policy.margin { continue }
 
@@ -200,15 +179,12 @@ public enum SpeakerVoiceprintMatcher {
         return suggestions
     }
 
-    /// The closest reference of a profile, and whether it was aggregated the
-    /// same way as the cluster.
     public struct ReferenceMatch: Sendable, Equatable {
         public let distance: Double
-        /// Whether the *winning* reference shares the cluster's aggregation
-        /// profile. Carried alongside the distance rather than derived later,
-        /// because the two must describe the same reference: a profile holding
-        /// both pre- and post-upgrade exemplars would otherwise be scored on an
-        /// old reference while being trusted as if it were current.
+        /// Of the *winning* reference, carried alongside the distance so the
+        /// two describe the same one: a profile holding both pre- and
+        /// post-upgrade exemplars would otherwise be scored on an old reference
+        /// while trusted as current.
         public let sameAggregation: Bool
     }
 
@@ -252,10 +228,8 @@ public enum SpeakerVoiceprintMatcher {
         return ReferenceMatch(distance: best.distance, sameAggregation: best.sameAggregation)
     }
 
-    /// The threshold for one pair. A reference aggregated under a different
-    /// clustering configuration is still comparable — Phase 0b leaves a 0.24
-    /// gap between the worst true pair and the best impostor, and configuration
-    /// drift costs hundredths — but it is trusted less.
+    /// A cross-aggregation reference stays comparable — Phase 0b leaves a 0.24
+    /// gap between worst true pair and best impostor — but is trusted less.
     private static func effectiveTau(for match: ReferenceMatch, policy: SpeakerMatchPolicy) -> Double {
         match.sameAggregation ? policy.tau : policy.tau - policy.crossAggregationPenalty
     }
@@ -268,9 +242,8 @@ public enum SpeakerVoiceprintMatcher {
     }
 
     /// Smallest distance in `row`, with the next smallest. An exact tie leaves
-    /// a zero margin, which the caller rejects — no tie-break by index or
-    /// insertion order, because an arbitrary winner is exactly the wrong
-    /// automatic name the design forbids.
+    /// a zero margin, which the caller rejects: no tie-break by index or
+    /// insertion order, since an arbitrary winner is a wrong automatic name.
     private static func bestCandidate(in row: [Double?]) -> Candidate? {
         var best: (index: Int, distance: Double)?
         var runnerUp: Double?

--- a/Sources/MacParakeetCore/Services/Diarization/SpeakerVoiceprintMatcher.swift
+++ b/Sources/MacParakeetCore/Services/Diarization/SpeakerVoiceprintMatcher.swift
@@ -1,0 +1,264 @@
+import Foundation
+
+/// One detected speaker in one recording, as offered to the matcher.
+public struct SpeakerClusterObservation: Sendable, Equatable {
+    /// The diarizer's id for this run ("S1", "system:S1"). Positional.
+    public let speakerId: String
+    public let embedding: SpeakerEmbedding
+    public let speechSeconds: Double
+    public let captureDomain: SpeakerCaptureDomain
+
+    public init(
+        speakerId: String,
+        embedding: SpeakerEmbedding,
+        speechSeconds: Double,
+        captureDomain: SpeakerCaptureDomain
+    ) {
+        self.speakerId = speakerId
+        self.embedding = embedding
+        self.speechSeconds = speechSeconds
+        self.captureDomain = captureDomain
+    }
+}
+
+/// An enrolled voice, reduced to what scoring needs.
+public struct SpeakerProfileCandidate: Sendable, Equatable {
+    public struct Reference: Sendable, Equatable {
+        public let embedding: SpeakerEmbedding
+        public let captureDomain: SpeakerCaptureDomain
+
+        public init(embedding: SpeakerEmbedding, captureDomain: SpeakerCaptureDomain) {
+            self.embedding = embedding
+            self.captureDomain = captureDomain
+        }
+    }
+
+    public let profileId: UUID
+    public let displayName: String
+    public let references: [Reference]
+
+    public init(profileId: UUID, displayName: String, references: [Reference]) {
+        self.profileId = profileId
+        self.displayName = displayName
+        self.references = references
+    }
+}
+
+/// Thresholds and gates. Injected rather than hard-coded so calibration changes
+/// one value and nothing else, and so tests state their own.
+public struct SpeakerMatchPolicy: Sendable, Equatable {
+    /// Accept only below this cosine distance.
+    public let tau: Double
+    /// Required separation from the runner-up, on both sides.
+    public let margin: Double
+    /// A cluster below this much speech is never scored.
+    public let minSpeechSecondsToMatch: Double
+    /// A cluster below this much speech may match but never enroll.
+    public let minSpeechSecondsToEnroll: Double
+    public let maxReferencesPerProfile: Int
+    /// Tightening applied when the reference was aggregated under a different
+    /// clustering configuration.
+    public let crossAggregationPenalty: Double
+    /// Above this, a name-based enrollment is treated as a different person
+    /// rather than merged into the existing profile.
+    public let pollutionGuardDistance: Double
+
+    public init(
+        tau: Double,
+        margin: Double,
+        minSpeechSecondsToMatch: Double,
+        minSpeechSecondsToEnroll: Double,
+        maxReferencesPerProfile: Int,
+        crossAggregationPenalty: Double,
+        pollutionGuardDistance: Double
+    ) {
+        self.tau = tau
+        self.margin = margin
+        self.minSpeechSecondsToMatch = minSpeechSecondsToMatch
+        self.minSpeechSecondsToEnroll = minSpeechSecondsToEnroll
+        self.maxReferencesPerProfile = maxReferencesPerProfile
+        self.crossAggregationPenalty = crossAggregationPenalty
+        self.pollutionGuardDistance = pollutionGuardDistance
+    }
+
+    /// Shipping values.
+    ///
+    /// `tau` sits at the bottom of the zero-false-positive plateau measured in
+    /// the Phase 0b calibration (0.25 to 0.45, worst true pair at 0.227) rather
+    /// than mid-plateau: a missed suggestion is a non-event, a false one is the
+    /// worst documented outcome, and the plateau was measured on clean audio
+    /// that real meeting captures will not match.
+    public static let v1 = SpeakerMatchPolicy(
+        tau: 0.25,
+        margin: 0.10,
+        minSpeechSecondsToMatch: 3,
+        minSpeechSecondsToEnroll: 15,
+        maxReferencesPerProfile: 10,
+        crossAggregationPenalty: 0.05,
+        pollutionGuardDistance: 0.45
+    )
+}
+
+/// A proposed name for a detected speaker. Never applied on its own.
+public struct SpeakerVoiceprintSuggestion: Sendable, Equatable {
+    public let speakerId: String
+    public let profileId: UUID
+    public let displayName: String
+    public let distance: Double
+    /// Next-best distance on either side, whichever is closer — what the
+    /// decision had to beat. `nil` when there was no second candidate at all.
+    public let runnerUpDistance: Double?
+
+    public init(
+        speakerId: String,
+        profileId: UUID,
+        displayName: String,
+        distance: Double,
+        runnerUpDistance: Double?
+    ) {
+        self.speakerId = speakerId
+        self.profileId = profileId
+        self.displayName = displayName
+        self.distance = distance
+        self.runnerUpDistance = runnerUpDistance
+    }
+}
+
+/// Decides which enrolled voices to propose for the speakers of one recording.
+///
+/// Stateless and I/O-free on purpose: this is where the feature can be wrong
+/// about a person, so it must be testable on fixtures alone.
+public enum SpeakerVoiceprintMatcher {
+
+    /// Suggestions for `clusters`, at most one per cluster and one per profile.
+    ///
+    /// A pair is accepted only when it is each other's best match, clears the
+    /// threshold, and beats its runner-up by `margin` **on both sides**. The
+    /// two-sided rule is not belt and braces: the diarizer over-splits, so one
+    /// person routinely yields two clusters, and a cluster-side margin alone
+    /// would let both of them claim the same profile and put two "Sarah"s in
+    /// one transcript.
+    public static func match(
+        clusters: [SpeakerClusterObservation],
+        profiles: [SpeakerProfileCandidate],
+        policy: SpeakerMatchPolicy
+    ) -> [SpeakerVoiceprintSuggestion] {
+        let scorable = clusters.filter { $0.speechSeconds >= policy.minSpeechSecondsToMatch }
+        guard !scorable.isEmpty, !profiles.isEmpty else { return [] }
+
+        // distances[clusterIndex][profileIndex], nil when incomparable.
+        let distances: [[Double?]] = scorable.map { cluster in
+            profiles.map { profile in distance(from: cluster, to: profile, policy: policy) }
+        }
+
+        var suggestions: [SpeakerVoiceprintSuggestion] = []
+        for (clusterIndex, cluster) in scorable.enumerated() {
+            let row = distances[clusterIndex]
+            guard let best = bestCandidate(in: row) else { continue }
+
+            let column = distances.map { $0[best.index] }
+            guard let bestForProfile = bestCandidate(in: column), bestForProfile.index == clusterIndex else {
+                // Some other cluster is a better fit for this profile, so this
+                // pairing is not mutual and nothing is proposed.
+                continue
+            }
+
+            let profile = profiles[best.index]
+            guard best.distance <= effectiveTau(cluster: cluster, profile: profile, policy: policy) else { continue }
+
+            // A side with no second candidate has nothing to be separated
+            // from, so its margin is vacuously satisfied. Failing it instead
+            // would make the very first enrolled voice unsuggestable, which is
+            // precisely when the feature is supposed to earn its keep.
+            if let runnerUp = best.runnerUp, runnerUp - best.distance < policy.margin { continue }
+            if let runnerUp = bestForProfile.runnerUp, runnerUp - best.distance < policy.margin { continue }
+
+            suggestions.append(
+                SpeakerVoiceprintSuggestion(
+                    speakerId: cluster.speakerId,
+                    profileId: profile.profileId,
+                    displayName: profile.displayName,
+                    distance: best.distance,
+                    runnerUpDistance: [best.runnerUp, bestForProfile.runnerUp].compactMap { $0 }.min()
+                )
+            )
+        }
+        return suggestions
+    }
+
+    /// Distance from a cluster to a profile: the closest reference, preferring
+    /// one captured in the same domain when two are equally close. `nil` when
+    /// no reference is comparable at all.
+    public static func distance(
+        from cluster: SpeakerClusterObservation,
+        to profile: SpeakerProfileCandidate,
+        policy: SpeakerMatchPolicy
+    ) -> Double? {
+        var best: (distance: Double, sameDomain: Bool)?
+
+        for reference in profile.references.prefix(policy.maxReferencesPerProfile) {
+            guard let distance = cluster.embedding.cosineDistance(to: reference.embedding) else { continue }
+            let sameDomain = reference.captureDomain == cluster.captureDomain
+
+            guard let current = best else {
+                best = (distance, sameDomain)
+                continue
+            }
+            if distance < current.distance {
+                best = (distance, sameDomain)
+            } else if distance == current.distance, sameDomain, !current.sameDomain {
+                best = (distance, sameDomain)
+            }
+        }
+
+        return best?.distance
+    }
+
+    /// The threshold for this pair. A reference aggregated under a different
+    /// clustering configuration is still comparable — Phase 0b leaves a 0.24
+    /// gap between the worst true pair and the best impostor, and configuration
+    /// drift costs hundredths — but it is trusted less.
+    private static func effectiveTau(
+        cluster: SpeakerClusterObservation,
+        profile: SpeakerProfileCandidate,
+        policy: SpeakerMatchPolicy
+    ) -> Double {
+        let sameAggregation = profile.references.contains {
+            $0.embedding.identity.aggregationProfileId == cluster.embedding.identity.aggregationProfileId
+        }
+        return sameAggregation ? policy.tau : policy.tau - policy.crossAggregationPenalty
+    }
+
+    private struct Candidate {
+        let index: Int
+        let distance: Double
+        /// Second-best distance, or nil when there was only one candidate.
+        let runnerUp: Double?
+    }
+
+    /// Smallest distance in `row`, with the next smallest. An exact tie leaves
+    /// a zero margin, which the caller rejects — no tie-break by index or
+    /// insertion order, because an arbitrary winner is exactly the wrong
+    /// automatic name the design forbids.
+    private static func bestCandidate(in row: [Double?]) -> Candidate? {
+        var best: (index: Int, distance: Double)?
+        var runnerUp: Double?
+
+        for (index, value) in row.enumerated() {
+            guard let value else { continue }
+            if let current = best {
+                if value < current.distance {
+                    runnerUp = current.distance
+                    best = (index, value)
+                } else if runnerUp == nil || value < runnerUp! {
+                    runnerUp = value
+                }
+            } else {
+                best = (index, value)
+            }
+        }
+
+        guard let best else { return nil }
+        return Candidate(index: best.index, distance: best.distance, runnerUp: runnerUp)
+    }
+}

--- a/Sources/MacParakeetCore/Services/Diarization/SpeakerVoiceprintMatcher.swift
+++ b/Sources/MacParakeetCore/Services/Diarization/SpeakerVoiceprintMatcher.swift
@@ -74,7 +74,10 @@ public struct SpeakerMatchPolicy: Sendable, Equatable {
         self.margin = margin
         self.minSpeechSecondsToMatch = minSpeechSecondsToMatch
         self.minSpeechSecondsToEnroll = minSpeechSecondsToEnroll
-        self.maxReferencesPerProfile = maxReferencesPerProfile
+        // Clamped rather than trusted: `prefix` precondition-fails on a
+        // negative length, and no configuration mistake should be able to bring
+        // matching down.
+        self.maxReferencesPerProfile = max(0, maxReferencesPerProfile)
         self.crossAggregationPenalty = crossAggregationPenalty
         self.pollutionGuardDistance = pollutionGuardDistance
     }
@@ -121,6 +124,12 @@ public struct SpeakerVoiceprintSuggestion: Sendable, Equatable {
 ///
 /// Stateless and I/O-free on purpose: this is where the feature can be wrong
 /// about a person, so it must be testable on fixtures alone.
+///
+/// `profileId` and `speakerId` must each be unique across the inputs. Scoring
+/// works on positions and results carry ids, so duplicates would yield two
+/// suggestions naming the same profile. Both callers satisfy this by
+/// construction — profiles come from a primary key, clusters from one
+/// diarization run.
 public enum SpeakerVoiceprintMatcher {
 
     /// Suggestions for `clusters`, at most one per cluster and one per profile.
@@ -165,8 +174,15 @@ public enum SpeakerVoiceprintMatcher {
             // A side with no second candidate has nothing to be separated
             // from, so its margin is vacuously satisfied. Failing it would make
             // the first enrolled voice unsuggestable.
-            if let runnerUp = best.runnerUp, runnerUp - best.distance < policy.margin { continue }
-            if let runnerUp = bestForProfile.runnerUp, runnerUp - best.distance < policy.margin { continue }
+            // Equality is checked before the configurable margin, which a
+            // policy may set to zero: a tie would then pass
+            // `runnerUp - best < 0` and position alone would decide.
+            if let runnerUp = best.runnerUp,
+               runnerUp == best.distance || runnerUp - best.distance < policy.margin
+            { continue }
+            if let runnerUp = bestForProfile.runnerUp,
+               runnerUp == best.distance || runnerUp - best.distance < policy.margin
+            { continue }
 
             suggestions.append(
                 SpeakerVoiceprintSuggestion(

--- a/Sources/MacParakeetCore/Services/Diarization/SpeakerVoiceprintMatcher.swift
+++ b/Sources/MacParakeetCore/Services/Diarization/SpeakerVoiceprintMatcher.swift
@@ -102,7 +102,8 @@ public struct SpeakerVoiceprintSuggestion: Sendable, Equatable {
     public let profileId: UUID
     public let displayName: String
     public let distance: Double
-    /// What the decision had to beat; `nil` when there was no second candidate.
+    /// Next-best distance on either side, whichever is closer — what the
+    /// decision had to beat. `nil` when there was no second candidate at all.
     public let runnerUpDistance: Double?
 
     public init(
@@ -120,6 +121,44 @@ public struct SpeakerVoiceprintSuggestion: Sendable, Equatable {
     }
 }
 
+/// Why a detected speaker did or did not get a name.
+public enum SpeakerMatchOutcome: String, Sendable, Codable {
+    case suggested
+    /// Too little speech to score at all.
+    case belowSpeechGate
+    /// No enrolled profile shared this embedding model.
+    case noComparableProfile
+    /// The closest profile was past the threshold.
+    case pastThreshold
+    /// Cleared the threshold but not the two-sided margin.
+    case marginTooSmall
+    /// Another cluster was a better fit for the same profile.
+    case notMutualBestMatch
+}
+
+/// What the matcher concluded about one detected speaker. Rejections carry
+/// their reason and distances, which is what calibration reads.
+public struct SpeakerMatchDecision: Sendable, Equatable {
+    public let speakerId: String
+    public let speechSeconds: Double
+    public let outcome: SpeakerMatchOutcome
+    public let profileId: UUID?
+    public let displayName: String?
+    public let distance: Double?
+    public let runnerUpDistance: Double?
+
+    public var suggestion: SpeakerVoiceprintSuggestion? {
+        guard outcome == .suggested, let profileId, let displayName, let distance else { return nil }
+        return SpeakerVoiceprintSuggestion(
+            speakerId: speakerId,
+            profileId: profileId,
+            displayName: displayName,
+            distance: distance,
+            runnerUpDistance: runnerUpDistance
+        )
+    }
+}
+
 /// Decides which enrolled voices to propose for one recording's speakers.
 ///
 /// Stateless and I/O-free on purpose: this is where the feature can be wrong
@@ -133,20 +172,32 @@ public struct SpeakerVoiceprintSuggestion: Sendable, Equatable {
 public enum SpeakerVoiceprintMatcher {
 
     /// Suggestions for `clusters`, at most one per cluster and one per profile.
-    ///
-    /// A pair is accepted only when it is each other's best match, clears the
-    /// threshold, and beats its runner-up by `margin` **on both sides**. The
-    /// two-sided rule is not belt and braces: the diarizer over-splits, so one
-    /// person routinely yields two clusters, and a cluster-side margin alone
-    /// would let both of them claim the same profile and put two "Sarah"s in
-    /// one transcript.
     public static func match(
         clusters: [SpeakerClusterObservation],
         profiles: [SpeakerProfileCandidate],
         policy: SpeakerMatchPolicy
     ) -> [SpeakerVoiceprintSuggestion] {
+        decisions(clusters: clusters, profiles: profiles, policy: policy).compactMap(\.suggestion)
+    }
+
+    /// One decision per cluster, accepted or not.
+    ///
+    /// A pair is accepted only when it is each other's best match, clears tau,
+    /// and beats its runner-up by `margin` on both sides. The second side is
+    /// load-bearing: the diarizer over-splits, so one person often yields two
+    /// clusters that would both claim the same profile.
+    public static func decisions(
+        clusters: [SpeakerClusterObservation],
+        profiles: [SpeakerProfileCandidate],
+        policy: SpeakerMatchPolicy
+    ) -> [SpeakerMatchDecision] {
         let scorable = clusters.filter { $0.speechSeconds >= policy.minSpeechSecondsToMatch }
-        guard !scorable.isEmpty, !profiles.isEmpty else { return [] }
+        let gated = clusters.filter { $0.speechSeconds < policy.minSpeechSecondsToMatch }
+            .map { rejection($0, .belowSpeechGate) }
+
+        guard !scorable.isEmpty, !profiles.isEmpty else {
+            return gated + scorable.map { rejection($0, .noComparableProfile) }
+        }
 
         // matches[clusterIndex][profileIndex], nil when incomparable.
         let matches: [[ReferenceMatch?]] = scorable.map { cluster in
@@ -154,22 +205,40 @@ public enum SpeakerVoiceprintMatcher {
         }
         let distances: [[Double?]] = matches.map { $0.map(\.?.distance) }
 
-        var suggestions: [SpeakerVoiceprintSuggestion] = []
+        var decisions = gated
         for (clusterIndex, cluster) in scorable.enumerated() {
-            let row = distances[clusterIndex]
-            guard let best = bestCandidate(in: row) else { continue }
-
-            let column = distances.map { $0[best.index] }
-            guard let bestForProfile = bestCandidate(in: column), bestForProfile.index == clusterIndex else {
-                // Some other cluster is a better fit for this profile, so this
-                // pairing is not mutual and nothing is proposed.
+            guard let best = bestCandidate(in: distances[clusterIndex]) else {
+                decisions.append(rejection(cluster, .noComparableProfile))
                 continue
             }
 
             let profile = profiles[best.index]
-            guard let winning = matches[clusterIndex][best.index],
-                  best.distance <= effectiveTau(for: winning, policy: policy)
-            else { continue }
+            guard let winning = matches[clusterIndex][best.index] else {
+                decisions.append(rejection(cluster, .noComparableProfile))
+                continue
+            }
+
+            // Threshold before mutuality so the journal stays truthful: a
+            // cluster whose closest profile is a stranger is unknown, not in
+            // conflict.
+            guard best.distance <= effectiveTau(for: winning, policy: policy) else {
+                decisions.append(
+                    rejection(cluster, .pastThreshold, profile: profile, distance: best.distance)
+                )
+                continue
+            }
+
+            let column = distances.map { $0[best.index] }
+            let bestForProfile = bestCandidate(in: column)
+
+            guard bestForProfile?.index == clusterIndex else {
+                // Some other cluster is a better fit for this profile, so the
+                // pairing is not mutual and nothing is proposed.
+                decisions.append(
+                    rejection(cluster, .notMutualBestMatch, profile: profile, distance: best.distance)
+                )
+                continue
+            }
 
             // A side with no second candidate has nothing to be separated
             // from, so its margin is vacuously satisfied. Failing it would make
@@ -177,24 +246,50 @@ public enum SpeakerVoiceprintMatcher {
             // Equality is checked before the configurable margin, which a
             // policy may set to zero: a tie would then pass
             // `runnerUp - best < 0` and position alone would decide.
-            if let runnerUp = best.runnerUp,
+            let runnerUp = [best.runnerUp, bestForProfile?.runnerUp].compactMap { $0 }.min()
+            if let runnerUp,
                runnerUp == best.distance || runnerUp - best.distance < policy.margin
-            { continue }
-            if let runnerUp = bestForProfile.runnerUp,
-               runnerUp == best.distance || runnerUp - best.distance < policy.margin
-            { continue }
+            {
+                decisions.append(
+                    rejection(
+                        cluster, .marginTooSmall, profile: profile,
+                        distance: best.distance, runnerUp: runnerUp
+                    )
+                )
+                continue
+            }
 
-            suggestions.append(
-                SpeakerVoiceprintSuggestion(
+            decisions.append(
+                SpeakerMatchDecision(
                     speakerId: cluster.speakerId,
+                    speechSeconds: cluster.speechSeconds,
+                    outcome: .suggested,
                     profileId: profile.profileId,
                     displayName: profile.displayName,
                     distance: best.distance,
-                    runnerUpDistance: [best.runnerUp, bestForProfile.runnerUp].compactMap { $0 }.min()
+                    runnerUpDistance: runnerUp
                 )
             )
         }
-        return suggestions
+        return decisions
+    }
+
+    private static func rejection(
+        _ cluster: SpeakerClusterObservation,
+        _ outcome: SpeakerMatchOutcome,
+        profile: SpeakerProfileCandidate? = nil,
+        distance: Double? = nil,
+        runnerUp: Double? = nil
+    ) -> SpeakerMatchDecision {
+        SpeakerMatchDecision(
+            speakerId: cluster.speakerId,
+            speechSeconds: cluster.speechSeconds,
+            outcome: outcome,
+            profileId: profile?.profileId,
+            displayName: profile?.displayName,
+            distance: distance,
+            runnerUpDistance: runnerUp
+        )
     }
 
     public struct ReferenceMatch: Sendable, Equatable {

--- a/Sources/MacParakeetCore/Services/Diarization/SpeakerVoiceprintMatcher.swift
+++ b/Sources/MacParakeetCore/Services/Diarization/SpeakerVoiceprintMatcher.swift
@@ -8,6 +8,8 @@ public struct SpeakerClusterObservation: Sendable, Equatable {
     public let speechSeconds: Double
     public let captureDomain: SpeakerCaptureDomain
 
+    /// - Parameter speechSeconds: total clean speech for this cluster; the
+    ///   duration gates read it, and a short cluster is never scored.
     public init(
         speakerId: String,
         embedding: SpeakerEmbedding,
@@ -23,10 +25,14 @@ public struct SpeakerClusterObservation: Sendable, Equatable {
 
 /// An enrolled voice, reduced to what scoring needs.
 public struct SpeakerProfileCandidate: Sendable, Equatable {
+    /// One stored sample of the voice, with the domain it was captured in.
     public struct Reference: Sendable, Equatable {
         public let embedding: SpeakerEmbedding
         public let captureDomain: SpeakerCaptureDomain
 
+        /// - Parameter captureDomain: preferred when two references are
+        ///   equally close, since the same voice sits elsewhere in the space
+        ///   over a compressed stream than over a local microphone.
         public init(embedding: SpeakerEmbedding, captureDomain: SpeakerCaptureDomain) {
             self.embedding = embedding
             self.captureDomain = captureDomain
@@ -37,6 +43,8 @@ public struct SpeakerProfileCandidate: Sendable, Equatable {
     public let displayName: String
     public let references: [Reference]
 
+    /// - Parameter references: scored as a set, closest wins; a profile with
+    ///   none is skipped rather than treated as distant.
     public init(profileId: UUID, displayName: String, references: [Reference]) {
         self.profileId = profileId
         self.displayName = displayName
@@ -63,6 +71,7 @@ public struct SpeakerMatchPolicy: Sendable, Equatable {
     /// rather than merged into the existing profile.
     public let pollutionGuardDistance: Double
 
+    /// Use ``v1`` unless a test or a calibration run needs its own values.
     public init(
         tau: Double,
         margin: Double,
@@ -109,6 +118,8 @@ public struct SpeakerVoiceprintSuggestion: Sendable, Equatable {
     /// decision had to beat. `nil` when there was no second candidate at all.
     public let runnerUpDistance: Double?
 
+    /// - Parameter runnerUpDistance: what this decision had to beat, or `nil`
+    ///   when there was no second candidate on either side.
     public init(
         speakerId: String,
         profileId: UUID,

--- a/Sources/MacParakeetCore/Services/Diarization/SpeakerVoiceprintMatcher.swift
+++ b/Sources/MacParakeetCore/Services/Diarization/SpeakerVoiceprintMatcher.swift
@@ -35,6 +35,8 @@ public struct SpeakerProfileCandidate: Sendable, Equatable {
 
     public let profileId: UUID
     public let displayName: String
+    /// Most relevant first: only the first `maxReferencesPerProfile` are scored,
+    /// so a caller passing oldest-first would hide its newest samples.
     public let references: [Reference]
 
     public init(profileId: UUID, displayName: String, references: [Reference]) {

--- a/Sources/MacParakeetCore/Services/Diarization/SpeakerVoiceprintRetention.swift
+++ b/Sources/MacParakeetCore/Services/Diarization/SpeakerVoiceprintRetention.swift
@@ -1,0 +1,58 @@
+import Foundation
+import os
+
+/// Enforces voice-data expiry even when the user stops recording or disables
+/// speaker recognition. Retain this for the lifetime of the app environment.
+public final class SpeakerVoiceprintRetention: Sendable {
+    private let task: Task<Void, Never>
+
+    public init(
+        candidates: SpeakerEmbeddingCandidateRepositoryProtocol,
+        journal: SpeakerMatchJournalRepositoryProtocol,
+        now: @escaping @Sendable () -> Date = { Date() },
+        sleep: @escaping @Sendable (Duration) async throws -> Void = {
+            try await Task.sleep(for: $0)
+        }
+    ) {
+        // Capture dependencies, never self: releasing the owner must cancel
+        // the sleeping task rather than leave an ownership cycle behind.
+        task = Task.detached(priority: .utility) {
+            let logger = Logger(
+                subsystem: "com.macparakeet.core",
+                category: "SpeakerVoiceprintRetention"
+            )
+            while !Task.isCancelled {
+                let date = now()
+                do {
+                    try candidates.pruneExpired(now: date)
+                } catch {
+                    logger.warning(
+                        "speaker_candidate_retention_failed error=\(error.localizedDescription, privacy: .private)"
+                    )
+                }
+                // A failure in either store must not suppress the other's
+                // cleanup or prevent another attempt on the next tick.
+                do {
+                    try journal.prune(
+                        retention: SpeakerMatchJournalRepository.defaultRetention,
+                        now: date
+                    )
+                } catch {
+                    logger.warning(
+                        "speaker_journal_retention_failed error=\(error.localizedDescription, privacy: .private)"
+                    )
+                }
+
+                do {
+                    try await sleep(.seconds(60 * 60))
+                } catch {
+                    return
+                }
+            }
+        }
+    }
+
+    deinit {
+        task.cancel()
+    }
+}

--- a/Sources/MacParakeetCore/Services/Diarization/SpeakerVoiceprintService.swift
+++ b/Sources/MacParakeetCore/Services/Diarization/SpeakerVoiceprintService.swift
@@ -133,36 +133,72 @@ public final class SpeakerVoiceprintService: SpeakerVoiceprintServicing, @unchec
             return .rejectedTooShort(speechSeconds: observation.speechSeconds)
         }
 
-        guard var existing = try profiles.profile(named: name) else {
-            let profile = SpeakerProfile(
-                displayName: name,
-                identity: observation.embedding.identity,
-                createdAt: now(),
-                updatedAt: now()
-            )
-            try profiles.save(profile)
-            try addExemplar(
-                to: profile,
+        if let existing = try profiles.profile(named: name) {
+            return try sample(
+                existing,
                 observation: observation,
-                origin: .manualEnrollment,
-                transcriptionId: transcriptionId
+                transcriptionId: transcriptionId,
+                allowMergeIntoExistingName: allowMergeIntoExistingName
             )
-            return .created(profile)
         }
 
+        let profile = SpeakerProfile(
+            displayName: name,
+            identity: observation.embedding.identity,
+            createdAt: now(),
+            updatedAt: now()
+        )
+        do {
+            try profiles.insert(profile)
+        } catch SpeakerProfileStoreError.nameAlreadyTaken {
+            // Another enrollment claimed the name between the lookup and the
+            // insert. The user asked for a name, not for a row, so the second
+            // one samples the winner instead of failing.
+            guard let winner = try profiles.profile(named: name) else {
+                throw SpeakerProfileStoreError.nameAlreadyTaken(
+                    normalizedName: SpeakerProfile.normalizedName(for: name)
+                )
+            }
+            return try sample(
+                winner,
+                observation: observation,
+                transcriptionId: transcriptionId,
+                allowMergeIntoExistingName: allowMergeIntoExistingName
+            )
+        }
+
+        _ = try addExemplar(
+            to: profile,
+            observation: observation,
+            origin: .manualEnrollment,
+            transcriptionId: transcriptionId
+        )
+        return .created(profile)
+    }
+
+    /// Adds this voice to a profile that already exists, which is where the
+    /// pollution guard applies: the name is a claim about identity that no
+    /// threshold has checked.
+    private func sample(
+        _ profile: SpeakerProfile,
+        observation: SpeakerClusterObservation,
+        transcriptionId: UUID,
+        allowMergeIntoExistingName: Bool
+    ) throws -> SpeakerProfileEnrollment {
+        var profile = profile
         // Checked before the pollution guard and regardless of the override:
         // the store refuses samples from another embedding model, and a forced
         // merge is the caller overriding a judgement about *which person* this
         // is, not about whether the two vectors can be compared at all.
-        guard existing.embeddingModelId == observation.embedding.identity.embeddingModelId else {
-            return .needsDisambiguation(existing: existing, distance: 1)
+        guard profile.embeddingModelId == observation.embedding.identity.embeddingModelId else {
+            return .needsDisambiguation(existing: profile, distance: 1)
         }
 
-        let references = try references(for: existing.id)
+        let references = try references(for: profile.id)
         if !allowMergeIntoExistingName, !references.isEmpty {
             let candidate = SpeakerProfileCandidate(
-                profileId: existing.id,
-                displayName: existing.displayName,
+                profileId: profile.id,
+                displayName: profile.displayName,
                 references: references
             )
             // A nil distance is less evidence than a far one, not more: treat
@@ -171,23 +207,25 @@ public final class SpeakerVoiceprintService: SpeakerVoiceprintServicing, @unchec
                 from: observation, to: candidate, policy: policy
             )
             if distance ?? .infinity > policy.pollutionGuardDistance {
-                return .needsDisambiguation(existing: existing, distance: distance ?? 1)
+                return .needsDisambiguation(existing: profile, distance: distance ?? 1)
             }
         }
 
-        let sampled = try profiles.exemplars(profileId: existing.id)
-            .contains { $0.sourceTranscriptionId == transcriptionId }
-        guard !sampled else { return .alreadySampled(existing) }
-
-        guard try addExemplar(
-            to: existing,
+        switch try addExemplar(
+            to: profile,
             observation: observation,
             origin: .manualEnrollment,
             transcriptionId: transcriptionId
-        ) else { return .rejectedProfileFull(existing) }
-        existing.updatedAt = now()
-        try profiles.save(existing)
-        return .addedExemplar(existing)
+        ) {
+        case .rejectedProfileFull:
+            return .rejectedProfileFull(profile)
+        case .rejectedAlreadySampled:
+            return .alreadySampled(profile)
+        case .inserted, .insertedEvicting:
+            profile.updatedAt = now()
+            try profiles.save(profile)
+            return .addedExemplar(profile)
+        }
     }
 
     // MARK: Decisions
@@ -219,12 +257,10 @@ public final class SpeakerVoiceprintService: SpeakerVoiceprintServicing, @unchec
         )
 
         // A profile born of one enrollment cannot amplify itself on its own
-        // suggestion: two manual enrollments must anchor the voice first.
+        // suggestion: two manual enrollments must anchor the voice first. The
+        // one-sample-per-recording rule is the store's, so no check here.
         let exemplars = try profiles.exemplars(profileId: profile.id)
-        let manualCount = exemplars.filter { $0.origin == .manualEnrollment }.count
-        let alreadySampled = exemplars.contains { $0.sourceTranscriptionId == transcriptionId }
-
-        if manualCount >= 2, !alreadySampled {
+        if exemplars.filter({ $0.origin == .manualEnrollment }).count >= 2 {
             try addExemplar(
                 to: profile,
                 observation: observation,
@@ -298,8 +334,7 @@ public final class SpeakerVoiceprintService: SpeakerVoiceprintServicing, @unchec
         )
     }
 
-    /// Adds a sample, evicting the oldest confirmation once the cap is reached.
-    /// Returns `false` when the profile is full of manual enrollments.
+    /// Adds a sample under the cap, in the store's transaction.
     ///
     /// The cap bounds storage, not just scoring: keeping vectors the matcher
     /// will never reach would accumulate biometric data for nothing. Eviction
@@ -312,17 +347,8 @@ public final class SpeakerVoiceprintService: SpeakerVoiceprintServicing, @unchec
         observation: SpeakerClusterObservation,
         origin: SpeakerProfileExemplar.Origin,
         transcriptionId: UUID?
-    ) throws -> Bool {
-        let existing = try profiles.exemplars(profileId: profile.id)
-        if existing.count >= policy.maxReferencesPerProfile {
-            guard let evictable = existing
-                .filter({ $0.origin == .confirmedSuggestion })
-                .min(by: { $0.createdAt < $1.createdAt })
-            else { return false }
-            _ = try profiles.deleteExemplar(id: evictable.id)
-        }
-
-        try profiles.insert(
+    ) throws -> SpeakerExemplarInsertion {
+        try profiles.insertExemplar(
             SpeakerProfileExemplar(
                 profileId: profile.id,
                 embedding: observation.embedding,
@@ -332,9 +358,10 @@ public final class SpeakerVoiceprintService: SpeakerVoiceprintServicing, @unchec
                 sourceTranscriptionId: transcriptionId,
                 sourceSpeakerId: observation.speakerId,
                 createdAt: now()
-            )
+            ),
+            maxPerProfile: policy.maxReferencesPerProfile,
+            evicting: .confirmedSuggestion
         )
-        return true
     }
 
     /// Pending links for suggestions, and every decision to the local journal.

--- a/Sources/MacParakeetCore/Services/Diarization/SpeakerVoiceprintService.swift
+++ b/Sources/MacParakeetCore/Services/Diarization/SpeakerVoiceprintService.swift
@@ -20,12 +20,26 @@ public enum SpeakerProfileEnrollment: Sendable, Equatable {
 }
 
 public protocol SpeakerVoiceprintServicing: Sendable {
-    /// Names worth proposing. Applies nothing, and does no work when off.
+    /// Names worth proposing, and the voices this run leaves available for
+    /// enrollment. Applies nothing, and does no work when off.
     func evaluate(
         transcriptionId: UUID,
         fingerprint: TranscriptFingerprint,
         clusters: [SpeakerClusterObservation]
     ) async throws -> [SpeakerVoiceprintSuggestion]
+
+    /// The voice still available for this speaker, or `nil` when the window has
+    /// lapsed, the cluster was too short, or the feature was off at capture.
+    /// This is what makes "remember this voice" possible after the fact.
+    func enrollmentCandidate(
+        transcriptionId: UUID,
+        speakerId: String,
+        fingerprint: TranscriptFingerprint
+    ) async throws -> SpeakerClusterObservation?
+
+    /// Drops candidates past their window. Reads and writes prune too; this
+    /// covers the user who stops recording and stops naming.
+    func pruneExpiredCandidates() async throws
 
     /// Creates the profile or adds a sample. Refuses short clusters, and asks
     /// rather than merges when the name is taken by a voice that differs.
@@ -33,6 +47,7 @@ public protocol SpeakerVoiceprintServicing: Sendable {
         displayName: String,
         observation: SpeakerClusterObservation,
         transcriptionId: UUID,
+        fingerprint: TranscriptFingerprint,
         allowMergeIntoExistingName: Bool
     ) async throws -> SpeakerProfileEnrollment
 
@@ -59,22 +74,28 @@ public protocol SpeakerVoiceprintServicing: Sendable {
 /// GRDB already serializes through the database queue.
 public final class SpeakerVoiceprintService: SpeakerVoiceprintServicing, @unchecked Sendable {
     private let profiles: SpeakerProfileRepositoryProtocol
+    private let candidates: SpeakerEmbeddingCandidateRepositoryProtocol
     private let journal: SpeakerMatchJournalRepositoryProtocol
     private let policy: SpeakerMatchPolicy
+    private let candidateRetention: TimeInterval
     /// Read per call, so turning the preference off takes effect immediately.
     private let isEnabled: @Sendable () -> Bool
     private let now: @Sendable () -> Date
 
     public init(
         profiles: SpeakerProfileRepositoryProtocol,
+        candidates: SpeakerEmbeddingCandidateRepositoryProtocol,
         journal: SpeakerMatchJournalRepositoryProtocol,
         policy: SpeakerMatchPolicy = .v1,
+        candidateRetention: TimeInterval = SpeakerEmbeddingCandidateRepository.defaultRetention,
         isEnabled: @escaping @Sendable () -> Bool,
         now: @escaping @Sendable () -> Date = { Date() }
     ) {
         self.profiles = profiles
+        self.candidates = candidates
         self.journal = journal
         self.policy = policy
+        self.candidateRetention = candidateRetention
         self.isEnabled = isEnabled
         self.now = now
     }
@@ -90,7 +111,12 @@ public final class SpeakerVoiceprintService: SpeakerVoiceprintServicing, @unchec
     ) async throws -> [SpeakerVoiceprintSuggestion] {
         guard isEnabled(), !clusters.isEmpty else { return [] }
 
-        let candidates = try candidates()
+        // Ahead of every matching early return: the run that matters most for
+        // enrollment is the first one, when no profile exists yet and there is
+        // nothing to score against.
+        try retainCandidates(clusters, transcriptionId: transcriptionId, fingerprint: fingerprint)
+
+        let candidates = try profileCandidates()
         guard !candidates.isEmpty else { return [] }
 
         // Both terminal statuses are excluded, not just refusals: rescoring a
@@ -116,13 +142,36 @@ public final class SpeakerVoiceprintService: SpeakerVoiceprintServicing, @unchec
 
     // MARK: Enrollment
 
+    /// Gated on the preference like everything else: a candidate captured while
+    /// the feature was on must not stay reachable after it is turned off.
+    public func enrollmentCandidate(
+        transcriptionId: UUID,
+        speakerId: String,
+        fingerprint: TranscriptFingerprint
+    ) async throws -> SpeakerClusterObservation? {
+        guard isEnabled() else { return nil }
+        return try candidates.candidate(
+            transcriptionId: transcriptionId,
+            speakerId: speakerId,
+            fingerprint: fingerprint.rawValue,
+            now: now()
+        )?.observation
+    }
+
+    public func pruneExpiredCandidates() async throws {
+        try candidates.pruneExpired(now: now())
+    }
+
     /// The pollution guard lives here, not in the matcher: naming a speaker is
     /// a user action that bypasses every threshold, so two colleagues called
     /// Sarah, or one misclick, would fuse two voices with no way back.
+    ///
+    /// On success the candidate is dropped: its vector now lives in the profile.
     public func enroll(
         displayName: String,
         observation: SpeakerClusterObservation,
         transcriptionId: UUID,
+        fingerprint: TranscriptFingerprint,
         allowMergeIntoExistingName: Bool
     ) async throws -> SpeakerProfileEnrollment {
         let name = displayName.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -138,6 +187,7 @@ public final class SpeakerVoiceprintService: SpeakerVoiceprintServicing, @unchec
                 existing,
                 observation: observation,
                 transcriptionId: transcriptionId,
+                fingerprint: fingerprint,
                 allowMergeIntoExistingName: allowMergeIntoExistingName
             )
         }
@@ -163,6 +213,7 @@ public final class SpeakerVoiceprintService: SpeakerVoiceprintServicing, @unchec
                 winner,
                 observation: observation,
                 transcriptionId: transcriptionId,
+                fingerprint: fingerprint,
                 allowMergeIntoExistingName: allowMergeIntoExistingName
             )
         }
@@ -172,6 +223,11 @@ public final class SpeakerVoiceprintService: SpeakerVoiceprintServicing, @unchec
             observation: observation,
             origin: .manualEnrollment,
             transcriptionId: transcriptionId
+        )
+        try consumeCandidate(
+            transcriptionId: transcriptionId,
+            speakerId: observation.speakerId,
+            fingerprint: fingerprint
         )
         return .created(profile)
     }
@@ -183,6 +239,7 @@ public final class SpeakerVoiceprintService: SpeakerVoiceprintServicing, @unchec
         _ profile: SpeakerProfile,
         observation: SpeakerClusterObservation,
         transcriptionId: UUID,
+        fingerprint: TranscriptFingerprint,
         allowMergeIntoExistingName: Bool
     ) throws -> SpeakerProfileEnrollment {
         var profile = profile
@@ -222,6 +279,11 @@ public final class SpeakerVoiceprintService: SpeakerVoiceprintServicing, @unchec
         case .rejectedAlreadySampled:
             return .alreadySampled(profile)
         case .inserted, .insertedEvicting:
+            try consumeCandidate(
+                transcriptionId: transcriptionId,
+                speakerId: observation.speakerId,
+                fingerprint: fingerprint
+            )
             profile.updatedAt = now()
             try profiles.save(profile)
             return .addedExemplar(profile)
@@ -267,6 +329,11 @@ public final class SpeakerVoiceprintService: SpeakerVoiceprintServicing, @unchec
                 origin: .confirmedSuggestion,
                 transcriptionId: transcriptionId
             )
+            try consumeCandidate(
+                transcriptionId: transcriptionId,
+                speakerId: suggestion.speakerId,
+                fingerprint: fingerprint
+            )
         }
 
         profile.lastMatchedAt = now()
@@ -296,7 +363,48 @@ public final class SpeakerVoiceprintService: SpeakerVoiceprintServicing, @unchec
 
     // MARK: Internals
 
-    private func candidates() throws -> [SpeakerProfileCandidate] {
+    /// Only clusters the enrollment gate would accept are retained. A vector
+    /// below it can never become an exemplar, so keeping it would be biometric
+    /// data stored for an offer the user will never be shown.
+    private func retainCandidates(
+        _ clusters: [SpeakerClusterObservation],
+        transcriptionId: UUID,
+        fingerprint: TranscriptFingerprint
+    ) throws {
+        let enrollable = clusters.filter { $0.speechSeconds >= policy.minSpeechSecondsToEnroll }
+        guard !enrollable.isEmpty else { return }
+
+        let captured = now()
+        try candidates.upsert(
+            enrollable.map { cluster in
+                SpeakerEmbeddingCandidate(
+                    transcriptionId: transcriptionId,
+                    speakerId: cluster.speakerId,
+                    transcriptFingerprint: fingerprint.rawValue,
+                    embedding: cluster.embedding,
+                    speechSeconds: cluster.speechSeconds,
+                    captureDomain: cluster.captureDomain,
+                    createdAt: captured,
+                    expiresAt: captured.addingTimeInterval(candidateRetention)
+                )
+            },
+            now: captured
+        )
+    }
+
+    private func consumeCandidate(
+        transcriptionId: UUID,
+        speakerId: String,
+        fingerprint: TranscriptFingerprint
+    ) throws {
+        try candidates.delete(
+            transcriptionId: transcriptionId,
+            speakerId: speakerId,
+            fingerprint: fingerprint.rawValue
+        )
+    }
+
+    private func profileCandidates() throws -> [SpeakerProfileCandidate] {
         let stored = try profiles.profiles()
         guard !stored.isEmpty else { return [] }
 

--- a/Sources/MacParakeetCore/Services/Diarization/SpeakerVoiceprintService.swift
+++ b/Sources/MacParakeetCore/Services/Diarization/SpeakerVoiceprintService.swift
@@ -113,7 +113,7 @@ public final class SpeakerVoiceprintService: SpeakerVoiceprintServicing, @unchec
         displayName: String,
         observation: SpeakerClusterObservation,
         transcriptionId: UUID,
-        allowMergeIntoExistingName: Bool = false
+        allowMergeIntoExistingName: Bool
     ) async throws -> SpeakerProfileEnrollment {
         let name = displayName.trimmingCharacters(in: .whitespacesAndNewlines)
         guard observation.speechSeconds >= policy.minSpeechSecondsToEnroll else {
@@ -196,11 +196,9 @@ public final class SpeakerVoiceprintService: SpeakerVoiceprintServicing, @unchec
 
         // A profile born of one enrollment cannot amplify itself on its own
         // suggestion: two manual enrollments must anchor the voice first.
-        let manualCount = try profiles.exemplars(profileId: profile.id)
-            .filter { $0.origin == .manualEnrollment }
-            .count
-        let alreadySampled = try profiles.exemplars(profileId: profile.id)
-            .contains { $0.sourceTranscriptionId == transcriptionId }
+        let exemplars = try profiles.exemplars(profileId: profile.id)
+        let manualCount = exemplars.filter { $0.origin == .manualEnrollment }.count
+        let alreadySampled = exemplars.contains { $0.sourceTranscriptionId == transcriptionId }
 
         if manualCount >= 2, !alreadySampled {
             try addExemplar(

--- a/Sources/MacParakeetCore/Services/Diarization/SpeakerVoiceprintService.swift
+++ b/Sources/MacParakeetCore/Services/Diarization/SpeakerVoiceprintService.swift
@@ -13,6 +13,10 @@ public enum SpeakerProfileEnrollment: Sendable, Equatable {
     case rejectedTooShort(speechSeconds: Double)
     /// The profile already holds a sample from this recording.
     case alreadySampled(SpeakerProfile)
+    /// The profile is at its sample cap and every sample is a manual
+    /// enrollment, so there is nothing to evict without weakening the anchor
+    /// that lets it learn.
+    case rejectedProfileFull(SpeakerProfile)
 }
 
 public protocol SpeakerVoiceprintServicing: Sendable {
@@ -175,12 +179,12 @@ public final class SpeakerVoiceprintService: SpeakerVoiceprintServicing, @unchec
             .contains { $0.sourceTranscriptionId == transcriptionId }
         guard !sampled else { return .alreadySampled(existing) }
 
-        try addExemplar(
+        guard try addExemplar(
             to: existing,
             observation: observation,
             origin: .manualEnrollment,
             transcriptionId: transcriptionId
-        )
+        ) else { return .rejectedProfileFull(existing) }
         existing.updatedAt = now()
         try profiles.save(existing)
         return .addedExemplar(existing)
@@ -294,12 +298,30 @@ public final class SpeakerVoiceprintService: SpeakerVoiceprintServicing, @unchec
         )
     }
 
+    /// Adds a sample, evicting the oldest confirmation once the cap is reached.
+    /// Returns `false` when the profile is full of manual enrollments.
+    ///
+    /// The cap bounds storage, not just scoring: keeping vectors the matcher
+    /// will never reach would accumulate biometric data for nothing. Eviction
+    /// spares manual enrollments because `confirm` counts them to decide
+    /// whether a profile may learn at all — evicting them oldest-first would
+    /// drop a mature profile back below that anchor for no visible reason.
+    @discardableResult
     private func addExemplar(
         to profile: SpeakerProfile,
         observation: SpeakerClusterObservation,
         origin: SpeakerProfileExemplar.Origin,
         transcriptionId: UUID?
-    ) throws {
+    ) throws -> Bool {
+        let existing = try profiles.exemplars(profileId: profile.id)
+        if existing.count >= policy.maxReferencesPerProfile {
+            guard let evictable = existing
+                .filter({ $0.origin == .confirmedSuggestion })
+                .min(by: { $0.createdAt < $1.createdAt })
+            else { return false }
+            _ = try profiles.deleteExemplar(id: evictable.id)
+        }
+
         try profiles.insert(
             SpeakerProfileExemplar(
                 profileId: profile.id,
@@ -312,6 +334,7 @@ public final class SpeakerVoiceprintService: SpeakerVoiceprintServicing, @unchec
                 createdAt: now()
             )
         )
+        return true
     }
 
     /// Pending links for suggestions, and every decision to the local journal.

--- a/Sources/MacParakeetCore/Services/Diarization/SpeakerVoiceprintService.swift
+++ b/Sources/MacParakeetCore/Services/Diarization/SpeakerVoiceprintService.swift
@@ -117,7 +117,13 @@ public final class SpeakerVoiceprintService: SpeakerVoiceprintServicing, @unchec
         fingerprint: TranscriptFingerprint,
         clusters: [SpeakerClusterObservation]
     ) async throws -> [SpeakerVoiceprintSuggestion] {
-        guard isEnabled(), !clusters.isEmpty else { return [] }
+        guard isEnabled() else { return [] }
+        guard !clusters.isEmpty else {
+            _ = try profiles.replaceSuggestions(
+                transcriptionId: transcriptionId, fingerprint: fingerprint.rawValue, with: []
+            )
+            return []
+        }
 
         // Ahead of every matching early return: the run that matters most for
         // enrollment is the first one, when no profile exists yet and there is
@@ -125,7 +131,12 @@ public final class SpeakerVoiceprintService: SpeakerVoiceprintServicing, @unchec
         try retainCandidates(clusters, transcriptionId: transcriptionId, fingerprint: fingerprint)
 
         let candidates = try profileCandidates()
-        guard !candidates.isEmpty else { return [] }
+        guard !candidates.isEmpty else {
+            _ = try profiles.replaceSuggestions(
+                transcriptionId: transcriptionId, fingerprint: fingerprint.rawValue, with: []
+            )
+            return []
+        }
 
         // Terminal clusters still compete: dropping them before scoring lets a
         // sibling inherit the same voice with a manufactured margin. Confirmed
@@ -154,8 +165,7 @@ public final class SpeakerVoiceprintService: SpeakerVoiceprintServicing, @unchec
             )
         }
 
-        try record(decisions, transcriptionId: transcriptionId, fingerprint: fingerprint)
-        return decisions.compactMap(\.suggestion)
+        return try record(decisions, transcriptionId: transcriptionId, fingerprint: fingerprint)
     }
 
     // MARK: Enrollment
@@ -350,9 +360,12 @@ public final class SpeakerVoiceprintService: SpeakerVoiceprintServicing, @unchec
 
         // A profile born of one enrollment cannot amplify itself on its own
         // suggestion: two manual enrollments must anchor the voice first. The
-        // one-sample-per-recording rule is the store's, so no check here.
+        // one-sample-per-recording rule is the store's. A short match can be
+        // confirmed, but it cannot bypass the minimum duration for learning.
         let exemplars = try profiles.exemplars(profileId: profile.id)
-        if exemplars.filter({ $0.origin == .manualEnrollment }).count >= 2 {
+        if observation.speechSeconds >= policy.minSpeechSecondsToEnroll,
+            exemplars.filter({ $0.origin == .manualEnrollment }).count >= 2
+        {
             switch try addExemplar(
                 to: profile,
                 observation: observation,
@@ -550,10 +563,12 @@ public final class SpeakerVoiceprintService: SpeakerVoiceprintServicing, @unchec
         _ decisions: [SpeakerMatchDecision],
         transcriptionId: UUID,
         fingerprint: TranscriptFingerprint
-    ) throws {
-        for decision in decisions {
-            guard let suggestion = decision.suggestion else { continue }
-            try profiles.save(
+    ) throws -> [SpeakerVoiceprintSuggestion] {
+        let suggestions = decisions.compactMap(\.suggestion)
+        let stored = try profiles.replaceSuggestions(
+            transcriptionId: transcriptionId,
+            fingerprint: fingerprint.rawValue,
+            with: suggestions.map { suggestion in
                 SpeakerProfileLink(
                     transcriptionId: transcriptionId,
                     speakerId: suggestion.speakerId,
@@ -565,8 +580,9 @@ public final class SpeakerVoiceprintService: SpeakerVoiceprintServicing, @unchec
                     createdAt: now(),
                     updatedAt: now()
                 )
-            )
-        }
+            }
+        )
+        let offeredSpeakers = Set(stored.map(\.speakerId))
 
         // Scored is not matched: this is what tells "never recognized" apart
         // from "recognized and wrong".
@@ -600,5 +616,6 @@ public final class SpeakerVoiceprintService: SpeakerVoiceprintServicing, @unchec
             retention: SpeakerMatchJournalRepository.defaultRetention,
             now: now()
         )
+        return suggestions.filter { offeredSpeakers.contains($0.speakerId) }
     }
 }

--- a/Sources/MacParakeetCore/Services/Diarization/SpeakerVoiceprintService.swift
+++ b/Sources/MacParakeetCore/Services/Diarization/SpeakerVoiceprintService.swift
@@ -144,10 +144,14 @@ public final class SpeakerVoiceprintService: SpeakerVoiceprintServicing, @unchec
                 displayName: existing.displayName,
                 references: references
             )
-            if let distance = SpeakerVoiceprintMatcher.distance(
+            // A nil distance means the models are incomparable, which is less
+            // evidence than a far one, not more: treat it as a mismatch rather
+            // than letting it fall through into a silent merge.
+            let distance = SpeakerVoiceprintMatcher.distance(
                 from: observation, to: candidate, policy: policy
-            ), distance > policy.pollutionGuardDistance {
-                return .needsDisambiguation(existing: existing, distance: distance)
+            )
+            if distance ?? .infinity > policy.pollutionGuardDistance {
+                return .needsDisambiguation(existing: existing, distance: distance ?? 1)
             }
         }
 
@@ -242,7 +246,9 @@ public final class SpeakerVoiceprintService: SpeakerVoiceprintServicing, @unchec
 
         let exemplars = try profiles.exemplarsByProfile()
         return stored.compactMap { profile in
-            let references = (exemplars[profile.id] ?? []).compactMap(reference(from:))
+            let references = (exemplars[profile.id] ?? [])
+                .sorted { $0.createdAt > $1.createdAt }
+                .compactMap(reference(from:))
             guard !references.isEmpty else { return nil }
             return SpeakerProfileCandidate(
                 profileId: profile.id,
@@ -252,8 +258,14 @@ public final class SpeakerVoiceprintService: SpeakerVoiceprintServicing, @unchec
         }
     }
 
+    /// Newest first: the matcher scores only the first `maxReferencesPerProfile`,
+    /// and the repository returns exemplars oldest first, so passing them
+    /// straight through would hide every sample added after the cap was reached
+    /// — the ones most likely to share the current aggregation identity.
     private func references(for profileId: UUID) throws -> [SpeakerProfileCandidate.Reference] {
-        try profiles.exemplars(profileId: profileId).compactMap(reference(from:))
+        try profiles.exemplars(profileId: profileId)
+            .sorted { $0.createdAt > $1.createdAt }
+            .compactMap(reference(from:))
     }
 
     private func reference(
@@ -329,6 +341,7 @@ public final class SpeakerVoiceprintService: SpeakerVoiceprintServicing, @unchec
                 SpeakerMatchJournalEntry(
                     transcriptionId: transcriptionId,
                     speakerId: decision.speakerId,
+                    transcriptFingerprint: fingerprint.rawValue,
                     profileId: decision.profileId,
                     outcome: decision.outcome,
                     topDistance: decision.distance,

--- a/Sources/MacParakeetCore/Services/Diarization/SpeakerVoiceprintService.swift
+++ b/Sources/MacParakeetCore/Services/Diarization/SpeakerVoiceprintService.swift
@@ -72,7 +72,7 @@ public protocol SpeakerVoiceprintServicing: Sendable {
 public enum SpeakerVoiceprintServiceError: Error, Equatable, Sendable {
     /// The preference is off. Enrollment and decisions must not write, and
     /// must not look like they succeeded. Pruning expired candidates stays
-    /// available so turning the feature off can still drop retained audio.
+    /// available so turning the feature off can still drop retained voice candidates.
     case disabled
 }
 

--- a/Sources/MacParakeetCore/Services/Diarization/SpeakerVoiceprintService.swift
+++ b/Sources/MacParakeetCore/Services/Diarization/SpeakerVoiceprintService.swift
@@ -1,0 +1,346 @@
+import Foundation
+
+/// What happened when the user asked to remember a voice.
+public enum SpeakerProfileEnrollment: Sendable, Equatable {
+    case created(SpeakerProfile)
+    case addedExemplar(SpeakerProfile)
+    /// The name is taken by a profile whose voice does not match. Merging would
+    /// fuse two people, so the caller must ask.
+    case needsDisambiguation(existing: SpeakerProfile, distance: Double)
+    case rejectedTooShort(speechSeconds: Double)
+    /// The profile already holds a sample from this recording.
+    case alreadySampled(SpeakerProfile)
+}
+
+public protocol SpeakerVoiceprintServicing: Sendable {
+    /// Names worth proposing. Applies nothing, and does no work when off.
+    func evaluate(
+        transcriptionId: UUID,
+        fingerprint: TranscriptFingerprint,
+        clusters: [SpeakerClusterObservation]
+    ) async throws -> [SpeakerVoiceprintSuggestion]
+
+    /// Creates the profile or adds a sample. Refuses short clusters, and asks
+    /// rather than merges when the name is taken by a voice that differs.
+    func enroll(
+        displayName: String,
+        observation: SpeakerClusterObservation,
+        transcriptionId: UUID,
+        allowMergeIntoExistingName: Bool
+    ) async throws -> SpeakerProfileEnrollment
+
+    /// Records acceptance and, once two manual enrollments anchor the profile,
+    /// lets it learn. The label is written by the correction layer, not here.
+    func confirm(
+        _ suggestion: SpeakerVoiceprintSuggestion,
+        observation: SpeakerClusterObservation,
+        transcriptionId: UUID,
+        fingerprint: TranscriptFingerprint
+    ) async throws
+
+    /// Not offered again for this version of the transcript.
+    func dismiss(
+        _ suggestion: SpeakerVoiceprintSuggestion,
+        transcriptionId: UUID,
+        fingerprint: TranscriptFingerprint
+    ) async throws
+}
+
+/// Owns enrolled voices: scoring, enrolling, and recording what the user chose.
+///
+/// A `final class` like its neighbour `SpeakerCorrectionService`, not an actor:
+/// GRDB already serializes through the database queue.
+public final class SpeakerVoiceprintService: SpeakerVoiceprintServicing, @unchecked Sendable {
+    private let profiles: SpeakerProfileRepositoryProtocol
+    private let journal: SpeakerMatchJournalRepositoryProtocol
+    private let policy: SpeakerMatchPolicy
+    /// Read per call, so turning the preference off takes effect immediately.
+    private let isEnabled: @Sendable () -> Bool
+    private let now: @Sendable () -> Date
+
+    public init(
+        profiles: SpeakerProfileRepositoryProtocol,
+        journal: SpeakerMatchJournalRepositoryProtocol,
+        policy: SpeakerMatchPolicy = .v1,
+        isEnabled: @escaping @Sendable () -> Bool,
+        now: @escaping @Sendable () -> Date = { Date() }
+    ) {
+        self.profiles = profiles
+        self.journal = journal
+        self.policy = policy
+        self.isEnabled = isEnabled
+        self.now = now
+    }
+
+    // MARK: Matching
+
+    /// Suggestions only; nothing is applied. When off, reads nothing and writes
+    /// nothing, so no voiceprint work happens behind a user who never opted in.
+    public func evaluate(
+        transcriptionId: UUID,
+        fingerprint: TranscriptFingerprint,
+        clusters: [SpeakerClusterObservation]
+    ) async throws -> [SpeakerVoiceprintSuggestion] {
+        guard isEnabled(), !clusters.isEmpty else { return [] }
+
+        let candidates = try candidates()
+        guard !candidates.isEmpty else { return [] }
+
+        let dismissed = try Set(
+            profiles.links(transcriptionId: transcriptionId, fingerprint: fingerprint.rawValue)
+                .filter { $0.status == .dismissed }
+                .map(\.speakerId)
+        )
+        let scored = clusters.filter { !dismissed.contains($0.speakerId) }
+        guard !scored.isEmpty else { return [] }
+
+        let decisions = SpeakerVoiceprintMatcher.decisions(
+            clusters: scored,
+            profiles: candidates,
+            policy: policy
+        )
+
+        try record(decisions, transcriptionId: transcriptionId, fingerprint: fingerprint)
+        return decisions.compactMap(\.suggestion)
+    }
+
+    // MARK: Enrollment
+
+    /// The pollution guard lives here, not in the matcher: naming a speaker is
+    /// a user action that bypasses every threshold, so two colleagues called
+    /// Sarah, or one misclick, would fuse two voices with no way back.
+    public func enroll(
+        displayName: String,
+        observation: SpeakerClusterObservation,
+        transcriptionId: UUID,
+        allowMergeIntoExistingName: Bool = false
+    ) async throws -> SpeakerProfileEnrollment {
+        let name = displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard observation.speechSeconds >= policy.minSpeechSecondsToEnroll else {
+            return .rejectedTooShort(speechSeconds: observation.speechSeconds)
+        }
+
+        guard var existing = try profiles.profile(named: name) else {
+            let profile = SpeakerProfile(
+                displayName: name,
+                identity: observation.embedding.identity,
+                createdAt: now(),
+                updatedAt: now()
+            )
+            try profiles.save(profile)
+            try addExemplar(
+                to: profile,
+                observation: observation,
+                origin: .manualEnrollment,
+                transcriptionId: transcriptionId
+            )
+            return .created(profile)
+        }
+
+        let references = try references(for: existing.id)
+        if !allowMergeIntoExistingName, !references.isEmpty {
+            let candidate = SpeakerProfileCandidate(
+                profileId: existing.id,
+                displayName: existing.displayName,
+                references: references
+            )
+            if let distance = SpeakerVoiceprintMatcher.distance(
+                from: observation, to: candidate, policy: policy
+            ), distance > policy.pollutionGuardDistance {
+                return .needsDisambiguation(existing: existing, distance: distance)
+            }
+        }
+
+        let sampled = try profiles.exemplars(profileId: existing.id)
+            .contains { $0.sourceTranscriptionId == transcriptionId }
+        guard !sampled else { return .alreadySampled(existing) }
+
+        try addExemplar(
+            to: existing,
+            observation: observation,
+            origin: .manualEnrollment,
+            transcriptionId: transcriptionId
+        )
+        existing.updatedAt = now()
+        try profiles.save(existing)
+        return .addedExemplar(existing)
+    }
+
+    // MARK: Decisions
+
+    /// The label is not written here — that goes through
+    /// `SpeakerCorrectionService`, inheriting undo and provenance. The caller
+    /// renames first, so a crash between the two leaves a correct name and a
+    /// profile that did not learn, rather than a poisoned profile.
+    public func confirm(
+        _ suggestion: SpeakerVoiceprintSuggestion,
+        observation: SpeakerClusterObservation,
+        transcriptionId: UUID,
+        fingerprint: TranscriptFingerprint
+    ) async throws {
+        guard var profile = try profiles.profile(id: suggestion.profileId) else { return }
+
+        try profiles.save(
+            SpeakerProfileLink(
+                transcriptionId: transcriptionId,
+                speakerId: suggestion.speakerId,
+                transcriptFingerprint: fingerprint.rawValue,
+                profileId: suggestion.profileId,
+                status: .confirmed,
+                distance: suggestion.distance,
+                runnerUpDistance: suggestion.runnerUpDistance,
+                createdAt: now(),
+                updatedAt: now()
+            )
+        )
+
+        // A profile born of one enrollment cannot amplify itself on its own
+        // suggestion: two manual enrollments must anchor the voice first.
+        let manualCount = try profiles.exemplars(profileId: profile.id)
+            .filter { $0.origin == .manualEnrollment }
+            .count
+        let alreadySampled = try profiles.exemplars(profileId: profile.id)
+            .contains { $0.sourceTranscriptionId == transcriptionId }
+
+        if manualCount >= 2, !alreadySampled {
+            try addExemplar(
+                to: profile,
+                observation: observation,
+                origin: .confirmedSuggestion,
+                transcriptionId: transcriptionId
+            )
+        }
+
+        profile.lastMatchedAt = now()
+        profile.updatedAt = now()
+        try profiles.save(profile)
+    }
+
+    public func dismiss(
+        _ suggestion: SpeakerVoiceprintSuggestion,
+        transcriptionId: UUID,
+        fingerprint: TranscriptFingerprint
+    ) async throws {
+        try profiles.save(
+            SpeakerProfileLink(
+                transcriptionId: transcriptionId,
+                speakerId: suggestion.speakerId,
+                transcriptFingerprint: fingerprint.rawValue,
+                profileId: suggestion.profileId,
+                status: .dismissed,
+                distance: suggestion.distance,
+                runnerUpDistance: suggestion.runnerUpDistance,
+                createdAt: now(),
+                updatedAt: now()
+            )
+        )
+    }
+
+    // MARK: Internals
+
+    private func candidates() throws -> [SpeakerProfileCandidate] {
+        let stored = try profiles.profiles()
+        guard !stored.isEmpty else { return [] }
+
+        let exemplars = try profiles.exemplarsByProfile()
+        return stored.compactMap { profile in
+            let references = (exemplars[profile.id] ?? []).compactMap(reference(from:))
+            guard !references.isEmpty else { return nil }
+            return SpeakerProfileCandidate(
+                profileId: profile.id,
+                displayName: profile.displayName,
+                references: references
+            )
+        }
+    }
+
+    private func references(for profileId: UUID) throws -> [SpeakerProfileCandidate.Reference] {
+        try profiles.exemplars(profileId: profileId).compactMap(reference(from:))
+    }
+
+    private func reference(
+        from exemplar: SpeakerProfileExemplar
+    ) -> SpeakerProfileCandidate.Reference? {
+        guard let embedding = exemplar.embedding else { return nil }
+        return SpeakerProfileCandidate.Reference(
+            embedding: embedding,
+            captureDomain: exemplar.captureDomain
+        )
+    }
+
+    private func addExemplar(
+        to profile: SpeakerProfile,
+        observation: SpeakerClusterObservation,
+        origin: SpeakerProfileExemplar.Origin,
+        transcriptionId: UUID?
+    ) throws {
+        try profiles.insert(
+            SpeakerProfileExemplar(
+                profileId: profile.id,
+                embedding: observation.embedding,
+                speechSeconds: observation.speechSeconds,
+                captureDomain: observation.captureDomain,
+                origin: origin,
+                sourceTranscriptionId: transcriptionId,
+                sourceSpeakerId: observation.speakerId,
+                createdAt: now()
+            )
+        )
+    }
+
+    /// Pending links for suggestions, and every decision to the local journal.
+    private func record(
+        _ decisions: [SpeakerMatchDecision],
+        transcriptionId: UUID,
+        fingerprint: TranscriptFingerprint
+    ) throws {
+        for decision in decisions {
+            guard let suggestion = decision.suggestion else { continue }
+            try profiles.save(
+                SpeakerProfileLink(
+                    transcriptionId: transcriptionId,
+                    speakerId: suggestion.speakerId,
+                    transcriptFingerprint: fingerprint.rawValue,
+                    profileId: suggestion.profileId,
+                    status: .suggested,
+                    distance: suggestion.distance,
+                    runnerUpDistance: suggestion.runnerUpDistance,
+                    createdAt: now(),
+                    updatedAt: now()
+                )
+            )
+        }
+
+        // Scored is not matched: this is what tells "never recognized" apart
+        // from "recognized and wrong".
+        var evaluated: [UUID: (date: Date, distance: Double)] = [:]
+        for decision in decisions {
+            guard let profileId = decision.profileId, let distance = decision.distance else { continue }
+            if let current = evaluated[profileId], current.distance <= distance { continue }
+            evaluated[profileId] = (now(), distance)
+        }
+        for (profileId, evaluation) in evaluated {
+            guard var profile = try profiles.profile(id: profileId) else { continue }
+            profile.lastEvaluatedAt = evaluation.date
+            profile.lastEvaluatedDistance = evaluation.distance
+            try profiles.save(profile)
+        }
+
+        try journal.append(
+            decisions.map { decision in
+                SpeakerMatchJournalEntry(
+                    transcriptionId: transcriptionId,
+                    speakerId: decision.speakerId,
+                    profileId: decision.profileId,
+                    outcome: decision.outcome,
+                    topDistance: decision.distance,
+                    runnerUpDistance: decision.runnerUpDistance,
+                    speechSeconds: decision.speechSeconds,
+                    createdAt: now()
+                )
+            },
+            retention: SpeakerMatchJournalRepository.defaultRetention,
+            now: now()
+        )
+    }
+}

--- a/Sources/MacParakeetCore/Services/Diarization/SpeakerVoiceprintService.swift
+++ b/Sources/MacParakeetCore/Services/Diarization/SpeakerVoiceprintService.swift
@@ -68,6 +68,14 @@ public protocol SpeakerVoiceprintServicing: Sendable {
     ) async throws
 }
 
+/// Refusals the service raises before it touches stored voices.
+public enum SpeakerVoiceprintServiceError: Error, Equatable, Sendable {
+    /// The preference is off. Enrollment and decisions must not write, and
+    /// must not look like they succeeded. Pruning expired candidates stays
+    /// available so turning the feature off can still drop retained audio.
+    case disabled
+}
+
 /// Owns enrolled voices: scoring, enrolling, and recording what the user chose.
 ///
 /// A `final class` like its neighbour `SpeakerCorrectionService`, not an actor:
@@ -119,22 +127,32 @@ public final class SpeakerVoiceprintService: SpeakerVoiceprintServicing, @unchec
         let candidates = try profileCandidates()
         guard !candidates.isEmpty else { return [] }
 
-        // Both terminal statuses are excluded, not just refusals: rescoring a
-        // confirmed speaker would write a fresh suggestion over the answer the
-        // user already gave, and the store now refuses that outright.
-        let decided = try Set(
-            profiles.links(transcriptionId: transcriptionId, fingerprint: fingerprint.rawValue)
-                .filter { $0.status != .suggested }
-                .map(\.speakerId)
+        // Terminal clusters still compete: dropping them before scoring lets a
+        // sibling inherit the same voice with a manufactured margin. Confirmed
+        // profile ids are reserved afterwards so a second cluster cannot be
+        // assigned a name the user already gave.
+        let existingLinks = try profiles.links(
+            transcriptionId: transcriptionId, fingerprint: fingerprint.rawValue
         )
-        let scored = clusters.filter { !decided.contains($0.speakerId) }
-        guard !scored.isEmpty else { return [] }
+        let terminalSpeakerIds = Set(
+            existingLinks.filter { $0.status != .suggested }.map(\.speakerId)
+        )
+        let reservedProfileIds = Set(
+            existingLinks.filter { $0.status == .confirmed }.map(\.profileId)
+        )
 
-        let decisions = SpeakerVoiceprintMatcher.decisions(
-            clusters: scored,
+        let scored = SpeakerVoiceprintMatcher.decisions(
+            clusters: clusters,
             profiles: candidates,
             policy: policy
         )
+        let decisions = scored.map { decision in
+            publishedDecision(
+                decision,
+                terminalSpeakerIds: terminalSpeakerIds,
+                reservedProfileIds: reservedProfileIds
+            )
+        }
 
         try record(decisions, transcriptionId: transcriptionId, fingerprint: fingerprint)
         return decisions.compactMap(\.suggestion)
@@ -174,6 +192,7 @@ public final class SpeakerVoiceprintService: SpeakerVoiceprintServicing, @unchec
         fingerprint: TranscriptFingerprint,
         allowMergeIntoExistingName: Bool
     ) async throws -> SpeakerProfileEnrollment {
+        guard isEnabled() else { throw SpeakerVoiceprintServiceError.disabled }
         let name = displayName.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !SpeakerProfile.normalizedName(for: name).isEmpty else {
             return .rejectedEmptyName
@@ -199,11 +218,34 @@ public final class SpeakerVoiceprintService: SpeakerVoiceprintServicing, @unchec
             updatedAt: now()
         )
         do {
-            try profiles.insert(profile)
+            switch try profiles.insert(
+                profile,
+                firstExemplar: exemplar(
+                    for: profile,
+                    observation: observation,
+                    origin: .manualEnrollment,
+                    transcriptionId: transcriptionId
+                ),
+                maxPerProfile: policy.maxReferencesPerProfile,
+                evicting: .confirmedSuggestion
+            ) {
+            case .inserted, .insertedEvicting:
+                try consumeCandidate(
+                    transcriptionId: transcriptionId,
+                    speakerId: observation.speakerId,
+                    fingerprint: fingerprint
+                )
+                return .created(profile)
+            case .rejectedAlreadySampled:
+                return .alreadySampled(profile)
+            case .rejectedProfileFull:
+                return .rejectedProfileFull(profile)
+            }
         } catch SpeakerProfileStoreError.nameAlreadyTaken {
             // Another enrollment claimed the name between the lookup and the
             // insert. The user asked for a name, not for a row, so the second
-            // one samples the winner instead of failing.
+            // one samples the winner instead of failing. The winner already
+            // holds its first sample, so the pollution guard can run.
             guard let winner = try profiles.profile(named: name) else {
                 throw SpeakerProfileStoreError.nameAlreadyTaken(
                     normalizedName: SpeakerProfile.normalizedName(for: name)
@@ -217,19 +259,6 @@ public final class SpeakerVoiceprintService: SpeakerVoiceprintServicing, @unchec
                 allowMergeIntoExistingName: allowMergeIntoExistingName
             )
         }
-
-        _ = try addExemplar(
-            to: profile,
-            observation: observation,
-            origin: .manualEnrollment,
-            transcriptionId: transcriptionId
-        )
-        try consumeCandidate(
-            transcriptionId: transcriptionId,
-            speakerId: observation.speakerId,
-            fingerprint: fingerprint
-        )
-        return .created(profile)
     }
 
     /// Adds this voice to a profile that already exists, which is where the
@@ -302,6 +331,7 @@ public final class SpeakerVoiceprintService: SpeakerVoiceprintServicing, @unchec
         transcriptionId: UUID,
         fingerprint: TranscriptFingerprint
     ) async throws {
+        guard isEnabled() else { throw SpeakerVoiceprintServiceError.disabled }
         guard var profile = try profiles.profile(id: suggestion.profileId) else { return }
 
         try profiles.save(
@@ -323,17 +353,21 @@ public final class SpeakerVoiceprintService: SpeakerVoiceprintServicing, @unchec
         // one-sample-per-recording rule is the store's, so no check here.
         let exemplars = try profiles.exemplars(profileId: profile.id)
         if exemplars.filter({ $0.origin == .manualEnrollment }).count >= 2 {
-            try addExemplar(
+            switch try addExemplar(
                 to: profile,
                 observation: observation,
                 origin: .confirmedSuggestion,
                 transcriptionId: transcriptionId
-            )
-            try consumeCandidate(
-                transcriptionId: transcriptionId,
-                speakerId: suggestion.speakerId,
-                fingerprint: fingerprint
-            )
+            ) {
+            case .inserted, .insertedEvicting:
+                try consumeCandidate(
+                    transcriptionId: transcriptionId,
+                    speakerId: suggestion.speakerId,
+                    fingerprint: fingerprint
+                )
+            case .rejectedAlreadySampled, .rejectedProfileFull:
+                break
+            }
         }
 
         profile.lastMatchedAt = now()
@@ -346,6 +380,7 @@ public final class SpeakerVoiceprintService: SpeakerVoiceprintServicing, @unchec
         transcriptionId: UUID,
         fingerprint: TranscriptFingerprint
     ) async throws {
+        guard isEnabled() else { throw SpeakerVoiceprintServiceError.disabled }
         try profiles.save(
             SpeakerProfileLink(
                 transcriptionId: transcriptionId,
@@ -362,6 +397,30 @@ public final class SpeakerVoiceprintService: SpeakerVoiceprintServicing, @unchec
     }
 
     // MARK: Internals
+
+    /// Matcher truth is preserved; only the published suggestion is withheld.
+    /// A dismissed closer cluster must still occupy the profile so its sibling
+    /// cannot look more confident than it was.
+    private func publishedDecision(
+        _ decision: SpeakerMatchDecision,
+        terminalSpeakerIds: Set<String>,
+        reservedProfileIds: Set<UUID>
+    ) -> SpeakerMatchDecision {
+        guard decision.outcome == .suggested else { return decision }
+        let reserved = decision.profileId.map(reservedProfileIds.contains) ?? false
+        guard terminalSpeakerIds.contains(decision.speakerId) || reserved else {
+            return decision
+        }
+        return SpeakerMatchDecision(
+            speakerId: decision.speakerId,
+            speechSeconds: decision.speechSeconds,
+            outcome: .notMutualBestMatch,
+            profileId: decision.profileId,
+            displayName: decision.displayName,
+            distance: decision.distance,
+            runnerUpDistance: decision.runnerUpDistance
+        )
+    }
 
     /// Only clusters the enrollment gate would accept are retained. A vector
     /// below it can never become an exemplar, so keeping it would be biometric
@@ -449,6 +508,24 @@ public final class SpeakerVoiceprintService: SpeakerVoiceprintServicing, @unchec
     /// spares manual enrollments because `confirm` counts them to decide
     /// whether a profile may learn at all — evicting them oldest-first would
     /// drop a mature profile back below that anchor for no visible reason.
+    private func exemplar(
+        for profile: SpeakerProfile,
+        observation: SpeakerClusterObservation,
+        origin: SpeakerProfileExemplar.Origin,
+        transcriptionId: UUID?
+    ) -> SpeakerProfileExemplar {
+        SpeakerProfileExemplar(
+            profileId: profile.id,
+            embedding: observation.embedding,
+            speechSeconds: observation.speechSeconds,
+            captureDomain: observation.captureDomain,
+            origin: origin,
+            sourceTranscriptionId: transcriptionId,
+            sourceSpeakerId: observation.speakerId,
+            createdAt: now()
+        )
+    }
+
     @discardableResult
     private func addExemplar(
         to profile: SpeakerProfile,
@@ -457,15 +534,11 @@ public final class SpeakerVoiceprintService: SpeakerVoiceprintServicing, @unchec
         transcriptionId: UUID?
     ) throws -> SpeakerExemplarInsertion {
         try profiles.insertExemplar(
-            SpeakerProfileExemplar(
-                profileId: profile.id,
-                embedding: observation.embedding,
-                speechSeconds: observation.speechSeconds,
-                captureDomain: observation.captureDomain,
+            exemplar(
+                for: profile,
+                observation: observation,
                 origin: origin,
-                sourceTranscriptionId: transcriptionId,
-                sourceSpeakerId: observation.speakerId,
-                createdAt: now()
+                transcriptionId: transcriptionId
             ),
             maxPerProfile: policy.maxReferencesPerProfile,
             evicting: .confirmedSuggestion

--- a/Sources/MacParakeetCore/Services/Diarization/SpeakerVoiceprintService.swift
+++ b/Sources/MacParakeetCore/Services/Diarization/SpeakerVoiceprintService.swift
@@ -3,6 +3,9 @@ import Foundation
 /// What happened when the user asked to remember a voice.
 public enum SpeakerProfileEnrollment: Sendable, Equatable {
     case created(SpeakerProfile)
+    /// The name was blank once trimmed. It would have no lookup key, so the
+    /// profile could never be found again nor collide with a second blank one.
+    case rejectedEmptyName
     case addedExemplar(SpeakerProfile)
     /// The name is taken by a profile whose voice does not match. Merging would
     /// fuse two people, so the caller must ask.
@@ -86,12 +89,15 @@ public final class SpeakerVoiceprintService: SpeakerVoiceprintServicing, @unchec
         let candidates = try candidates()
         guard !candidates.isEmpty else { return [] }
 
-        let dismissed = try Set(
+        // Both terminal statuses are excluded, not just refusals: rescoring a
+        // confirmed speaker would write a fresh suggestion over the answer the
+        // user already gave, and the store now refuses that outright.
+        let decided = try Set(
             profiles.links(transcriptionId: transcriptionId, fingerprint: fingerprint.rawValue)
-                .filter { $0.status == .dismissed }
+                .filter { $0.status != .suggested }
                 .map(\.speakerId)
         )
-        let scored = clusters.filter { !dismissed.contains($0.speakerId) }
+        let scored = clusters.filter { !decided.contains($0.speakerId) }
         guard !scored.isEmpty else { return [] }
 
         let decisions = SpeakerVoiceprintMatcher.decisions(
@@ -116,6 +122,9 @@ public final class SpeakerVoiceprintService: SpeakerVoiceprintServicing, @unchec
         allowMergeIntoExistingName: Bool
     ) async throws -> SpeakerProfileEnrollment {
         let name = displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !SpeakerProfile.normalizedName(for: name).isEmpty else {
+            return .rejectedEmptyName
+        }
         guard observation.speechSeconds >= policy.minSpeechSecondsToEnroll else {
             return .rejectedTooShort(speechSeconds: observation.speechSeconds)
         }

--- a/Sources/MacParakeetCore/Services/Diarization/SpeakerVoiceprintService.swift
+++ b/Sources/MacParakeetCore/Services/Diarization/SpeakerVoiceprintService.swift
@@ -137,6 +137,14 @@ public final class SpeakerVoiceprintService: SpeakerVoiceprintServicing, @unchec
             return .created(profile)
         }
 
+        // Checked before the pollution guard and regardless of the override:
+        // the store refuses samples from another embedding model, and a forced
+        // merge is the caller overriding a judgement about *which person* this
+        // is, not about whether the two vectors can be compared at all.
+        guard existing.embeddingModelId == observation.embedding.identity.embeddingModelId else {
+            return .needsDisambiguation(existing: existing, distance: 1)
+        }
+
         let references = try references(for: existing.id)
         if !allowMergeIntoExistingName, !references.isEmpty {
             let candidate = SpeakerProfileCandidate(
@@ -144,9 +152,8 @@ public final class SpeakerVoiceprintService: SpeakerVoiceprintServicing, @unchec
                 displayName: existing.displayName,
                 references: references
             )
-            // A nil distance means the models are incomparable, which is less
-            // evidence than a far one, not more: treat it as a mismatch rather
-            // than letting it fall through into a silent merge.
+            // A nil distance is less evidence than a far one, not more: treat
+            // it as a mismatch rather than a silent merge.
             let distance = SpeakerVoiceprintMatcher.distance(
                 from: observation, to: candidate, policy: policy
             )

--- a/Sources/MacParakeetCore/Services/Diarization/SpeakerVoiceprintService.swift
+++ b/Sources/MacParakeetCore/Services/Diarization/SpeakerVoiceprintService.swift
@@ -157,15 +157,16 @@ public final class SpeakerVoiceprintService: SpeakerVoiceprintServicing, @unchec
             profiles: candidates,
             policy: policy
         )
-        let decisions = scored.map { decision in
-            publishedDecision(
-                decision,
-                terminalSpeakerIds: terminalSpeakerIds,
-                reservedProfileIds: reservedProfileIds
-            )
+        // User decisions suppress publication without changing the matcher's
+        // evidence in the calibration journal.
+        let suggestions = scored.compactMap(\.suggestion).filter { suggestion in
+            !terminalSpeakerIds.contains(suggestion.speakerId)
+                && !reservedProfileIds.contains(suggestion.profileId)
         }
 
-        return try record(decisions, transcriptionId: transcriptionId, fingerprint: fingerprint)
+        return try record(
+            scored, suggestions: suggestions, transcriptionId: transcriptionId, fingerprint: fingerprint
+        )
     }
 
     // MARK: Enrollment
@@ -411,30 +412,6 @@ public final class SpeakerVoiceprintService: SpeakerVoiceprintServicing, @unchec
 
     // MARK: Internals
 
-    /// Matcher truth is preserved; only the published suggestion is withheld.
-    /// A dismissed closer cluster must still occupy the profile so its sibling
-    /// cannot look more confident than it was.
-    private func publishedDecision(
-        _ decision: SpeakerMatchDecision,
-        terminalSpeakerIds: Set<String>,
-        reservedProfileIds: Set<UUID>
-    ) -> SpeakerMatchDecision {
-        guard decision.outcome == .suggested else { return decision }
-        let reserved = decision.profileId.map(reservedProfileIds.contains) ?? false
-        guard terminalSpeakerIds.contains(decision.speakerId) || reserved else {
-            return decision
-        }
-        return SpeakerMatchDecision(
-            speakerId: decision.speakerId,
-            speechSeconds: decision.speechSeconds,
-            outcome: .notMutualBestMatch,
-            profileId: decision.profileId,
-            displayName: decision.displayName,
-            distance: decision.distance,
-            runnerUpDistance: decision.runnerUpDistance
-        )
-    }
-
     /// Only clusters the enrollment gate would accept are retained. A vector
     /// below it can never become an exemplar, so keeping it would be biometric
     /// data stored for an offer the user will never be shown.
@@ -558,13 +535,14 @@ public final class SpeakerVoiceprintService: SpeakerVoiceprintServicing, @unchec
         )
     }
 
-    /// Pending links for suggestions, and every decision to the local journal.
+    /// Pending links for publishable suggestions, and every matcher decision
+    /// to the local journal, including matches withheld by a user decision.
     private func record(
         _ decisions: [SpeakerMatchDecision],
+        suggestions: [SpeakerVoiceprintSuggestion],
         transcriptionId: UUID,
         fingerprint: TranscriptFingerprint
     ) throws -> [SpeakerVoiceprintSuggestion] {
-        let suggestions = decisions.compactMap(\.suggestion)
         let stored = try profiles.replaceSuggestions(
             transcriptionId: transcriptionId,
             fingerprint: fingerprint.rawValue,

--- a/Sources/MacParakeetCore/Services/MeetingRecording/MeetingTranscriptFinalizer.swift
+++ b/Sources/MacParakeetCore/Services/MeetingRecording/MeetingTranscriptFinalizer.swift
@@ -10,6 +10,23 @@ struct MeetingTranscriptFinalizer {
     struct SystemDiarization: Sendable {
         let speakers: [SpeakerInfo]
         let segments: [SpeakerSegment]
+        /// Keyed by the same source-prefixed ids as `speakers`, empty when the
+        /// diarizer produced none.
+        let speakerEmbeddings: [String: SpeakerEmbedding]
+        /// Speech per speaker id, in milliseconds.
+        let speechMsBySpeaker: [String: Int]
+
+        init(
+            speakers: [SpeakerInfo],
+            segments: [SpeakerSegment],
+            speakerEmbeddings: [String: SpeakerEmbedding] = [:],
+            speechMsBySpeaker: [String: Int] = [:]
+        ) {
+            self.speakers = speakers
+            self.segments = segments
+            self.speakerEmbeddings = speakerEmbeddings
+            self.speechMsBySpeaker = speechMsBySpeaker
+        }
     }
 
     struct FinalizedTranscript: Sendable {

--- a/Sources/MacParakeetCore/Services/TranscriptionService.swift
+++ b/Sources/MacParakeetCore/Services/TranscriptionService.swift
@@ -1687,7 +1687,7 @@ public actor TranscriptionService: SpeakerConfiguredRetranscriptionService, Audi
             )
         } catch {
             logger.error(
-                "meeting_voiceprint_failed error=\(error.localizedDescription, privacy: .public)"
+                "meeting_voiceprint_failed error=\(error.localizedDescription, privacy: .private)"
             )
         }
     }

--- a/Sources/MacParakeetCore/Services/TranscriptionService.swift
+++ b/Sources/MacParakeetCore/Services/TranscriptionService.swift
@@ -1670,15 +1670,10 @@ public actor TranscriptionService: SpeakerConfiguredRetranscriptionService, Audi
         guard let speakerVoiceprints, let systemDiarization else { return }
         guard !systemDiarization.speakerEmbeddings.isEmpty else { return }
 
-        let observations = systemDiarization.speakers.compactMap { speaker -> SpeakerClusterObservation? in
-            guard let embedding = systemDiarization.speakerEmbeddings[speaker.id] else { return nil }
-            return SpeakerClusterObservation(
-                speakerId: speaker.id,
-                embedding: embedding,
-                speechSeconds: Double(systemDiarization.speechMsBySpeaker[speaker.id] ?? 0) / 1000,
-                captureDomain: .system
-            )
-        }
+        let observations = Self.voiceprintObservations(
+            systemDiarization: systemDiarization,
+            persistedSpeakers: transcription.speakers ?? []
+        )
         guard !observations.isEmpty else { return }
 
         do {
@@ -1693,6 +1688,31 @@ public actor TranscriptionService: SpeakerConfiguredRetranscriptionService, Audi
         } catch {
             logger.error(
                 "meeting_voiceprint_failed error=\(error.localizedDescription, privacy: .public)"
+            )
+        }
+    }
+
+    /// Observations for the speakers the saved transcript actually contains.
+    ///
+    /// Scoped to the persisted speakers, not the diarizer's full output: the
+    /// finalizer drops any cluster whose segments won no words, so scoring the
+    /// raw list would write a suggestion keyed to a speaker the transcript does
+    /// not have — one the UI could never resolve.
+    ///
+    /// Durations arrive in milliseconds and the matching gates are in seconds.
+    static func voiceprintObservations(
+        systemDiarization: MeetingTranscriptFinalizer.SystemDiarization,
+        persistedSpeakers: [SpeakerInfo]
+    ) -> [SpeakerClusterObservation] {
+        let persistedIDs = Set(persistedSpeakers.map(\.id))
+        return systemDiarization.speakers.compactMap { speaker in
+            guard persistedIDs.contains(speaker.id) else { return nil }
+            guard let embedding = systemDiarization.speakerEmbeddings[speaker.id] else { return nil }
+            return SpeakerClusterObservation(
+                speakerId: speaker.id,
+                embedding: embedding,
+                speechSeconds: Double(systemDiarization.speechMsBySpeaker[speaker.id] ?? 0) / 1000,
+                captureDomain: .system
             )
         }
     }

--- a/Sources/MacParakeetCore/Services/TranscriptionService.swift
+++ b/Sources/MacParakeetCore/Services/TranscriptionService.swift
@@ -330,6 +330,7 @@ public actor TranscriptionService: SpeakerConfiguredRetranscriptionService, Audi
     private let meetingAutomationHookRunner: MeetingAutomationHookRunning?
     private let meetingCleanedMicrophoneReadinessPolicy: MeetingCleanedMicrophoneReadinessPolicy
     private let meetingFinalizationBenchmarkObserver: MeetingFinalizationBenchmarkObserver?
+    private let speakerVoiceprints: SpeakerVoiceprintServicing?
 
     public init(
         audioProcessor: AudioProcessorProtocol,
@@ -362,7 +363,8 @@ public actor TranscriptionService: SpeakerConfiguredRetranscriptionService, Audi
         playbackConverter: YouTubeAudioPlaybackConverting = YouTubeAudioPlaybackConverter(),
         meetingArtifactStore: MeetingArtifactStoring? = MeetingArtifactStore(),
         meetingAutomationHookRunner: MeetingAutomationHookRunning? = MeetingAutomationHookRunner(),
-        meetingCleanedMicrophoneReadinessPolicy: MeetingCleanedMicrophoneReadinessPolicy = .production
+        meetingCleanedMicrophoneReadinessPolicy: MeetingCleanedMicrophoneReadinessPolicy = .production,
+        speakerVoiceprints: SpeakerVoiceprintServicing? = nil
     ) {
         self.init(
             audioProcessor: audioProcessor,
@@ -396,7 +398,8 @@ public actor TranscriptionService: SpeakerConfiguredRetranscriptionService, Audi
             meetingArtifactStore: meetingArtifactStore,
             meetingAutomationHookRunner: meetingAutomationHookRunner,
             meetingCleanedMicrophoneReadinessPolicy: meetingCleanedMicrophoneReadinessPolicy,
-            meetingFinalizationBenchmarkObserver: nil
+            meetingFinalizationBenchmarkObserver: nil,
+            speakerVoiceprints: speakerVoiceprints
         )
     }
 
@@ -432,7 +435,8 @@ public actor TranscriptionService: SpeakerConfiguredRetranscriptionService, Audi
         meetingArtifactStore: MeetingArtifactStoring? = MeetingArtifactStore(),
         meetingAutomationHookRunner: MeetingAutomationHookRunning? = MeetingAutomationHookRunner(),
         meetingCleanedMicrophoneReadinessPolicy: MeetingCleanedMicrophoneReadinessPolicy = .production,
-        meetingFinalizationBenchmarkObserver: MeetingFinalizationBenchmarkObserver?
+        meetingFinalizationBenchmarkObserver: MeetingFinalizationBenchmarkObserver?,
+        speakerVoiceprints: SpeakerVoiceprintServicing? = nil
     ) {
         self.audioProcessor = audioProcessor
         self.sttTranscriber = sttTranscriber
@@ -468,6 +472,7 @@ public actor TranscriptionService: SpeakerConfiguredRetranscriptionService, Audi
         self.meetingAutomationHookRunner = meetingAutomationHookRunner
         self.meetingCleanedMicrophoneReadinessPolicy = meetingCleanedMicrophoneReadinessPolicy
         self.meetingFinalizationBenchmarkObserver = meetingFinalizationBenchmarkObserver
+        self.speakerVoiceprints = speakerVoiceprints
     }
 
     public func transcribe(
@@ -1517,6 +1522,8 @@ public actor TranscriptionService: SpeakerConfiguredRetranscriptionService, Audi
                 diarizationApplied: systemDiarization != nil
             )
 
+            await scoreVoiceprintsIfEnabled(for: completed, systemDiarization: systemDiarization)
+
             return completed
         } catch {
             let audioDurationSeconds = transcription.durationMs.map { Double($0) / 1000.0 } ?? recording.durationSeconds
@@ -1646,6 +1653,50 @@ public actor TranscriptionService: SpeakerConfiguredRetranscriptionService, Audi
         return outputs
     }
 
+    /// Scores this meeting's system-track speakers against enrolled voices.
+    ///
+    /// Runs after the transcript is persisted: the fingerprint is derived from
+    /// the saved words and segments, and the suggestion rows carry a foreign key
+    /// to the transcription. The service itself is the gate — with the
+    /// preference off it reads nothing and writes nothing.
+    ///
+    /// Failures are logged and swallowed on purpose. A suggestion that did not
+    /// appear costs the user a rename they were going to do anyway; a meeting
+    /// that fails to finish costs them the recording.
+    private func scoreVoiceprintsIfEnabled(
+        for transcription: Transcription,
+        systemDiarization: MeetingTranscriptFinalizer.SystemDiarization?
+    ) async {
+        guard let speakerVoiceprints, let systemDiarization else { return }
+        guard !systemDiarization.speakerEmbeddings.isEmpty else { return }
+
+        let observations = systemDiarization.speakers.compactMap { speaker -> SpeakerClusterObservation? in
+            guard let embedding = systemDiarization.speakerEmbeddings[speaker.id] else { return nil }
+            return SpeakerClusterObservation(
+                speakerId: speaker.id,
+                embedding: embedding,
+                speechSeconds: Double(systemDiarization.speechMsBySpeaker[speaker.id] ?? 0) / 1000,
+                captureDomain: .system
+            )
+        }
+        guard !observations.isEmpty else { return }
+
+        do {
+            let suggestions = try await speakerVoiceprints.evaluate(
+                transcriptionId: transcription.id,
+                fingerprint: SpeakerAttributionResolver.fingerprint(for: transcription),
+                clusters: observations
+            )
+            logger.info(
+                "meeting_voiceprint_evaluated speakers=\(observations.count, privacy: .public) suggestions=\(suggestions.count, privacy: .public)"
+            )
+        } catch {
+            logger.error(
+                "meeting_voiceprint_failed error=\(error.localizedDescription, privacy: .public)"
+            )
+        }
+    }
+
     private func diarizeMeetingSystemIfNeeded(
         recording: MeetingRecordingOutput,
         sourceWavURLs: [AudioSource: URL],
@@ -1709,9 +1760,25 @@ public actor TranscriptionService: SpeakerConfiguredRetranscriptionService, Audi
                 )
             }
 
+            // Embeddings and durations follow the same remap as the segments:
+            // the diarizer's "S1" becomes "system:S1", and carrying the raw
+            // keys over would attach one speaker's voice to another's label.
+            let mappedEmbeddings = Dictionary(
+                uniqueKeysWithValues: diarResult.speakerEmbeddings.compactMap { id, embedding in
+                    speakerIDMap[id].map { ($0, embedding) }
+                }
+            )
+            let mappedSpeechMs = Dictionary(
+                uniqueKeysWithValues: diarResult.speechMsBySpeaker.compactMap { id, ms in
+                    speakerIDMap[id].map { ($0, ms) }
+                }
+            )
+
             return MeetingTranscriptFinalizer.SystemDiarization(
                 speakers: mappedSpeakers,
-                segments: mappedSegments
+                segments: mappedSegments,
+                speakerEmbeddings: mappedEmbeddings,
+                speechMsBySpeaker: mappedSpeechMs
             )
         } catch is CancellationError {
             throw CancellationError()

--- a/Tests/CLITests/ExportCommandTests.swift
+++ b/Tests/CLITests/ExportCommandTests.swift
@@ -1,4 +1,5 @@
 import ArgumentParser
+import GRDB
 import XCTest
 @testable import CLI
 @testable import MacParakeetCore
@@ -186,6 +187,73 @@ final class ExportCommandTests: XCTestCase {
         XCTAssertEqual(object["ok"] as? Bool, false)
         XCTAssertEqual(object["errorType"] as? String, "lookup")
         XCTAssertTrue((object["error"] as? String)?.contains("No transcription matching") == true)
+    }
+
+    func testJSONStdoutDoesNotExportPopulatedVoiceprintTables() async throws {
+        let dbURL = temporaryDatabaseURL()
+        defer { try? FileManager.default.removeItem(at: dbURL) }
+        let manager = try DatabaseManager(path: dbURL.path)
+        let repository = TranscriptionRepository(dbQueue: manager.dbQueue)
+        let speaker = SpeakerInfo(id: "system:S1", label: "Others 1")
+        let enrollment = Transcription(
+            fileName: "enrollment.wav", speakerCount: 1, speakers: [speaker],
+            status: .completed, sourceType: .meeting
+        )
+        let meeting = Transcription(
+            fileName: "export.wav", rawTranscript: "Visible meeting transcript.",
+            speakerCount: 1, speakers: [speaker], status: .completed, sourceType: .meeting
+        )
+        try repository.save(enrollment)
+        try repository.save(meeting)
+        let command = try ExportCommand.parse([
+            meeting.id.uuidString, "--format", "json", "--stdout", "--database", dbURL.path,
+        ])
+        let before = try await captureStandardOutput { try await command.run() }
+
+        let voiceprints = SpeakerVoiceprintService(
+            profiles: SpeakerProfileRepository(dbQueue: manager.dbQueue),
+            candidates: SpeakerEmbeddingCandidateRepository(dbQueue: manager.dbQueue),
+            journal: SpeakerMatchJournalRepository(dbQueue: manager.dbQueue),
+            isEnabled: { true }
+        )
+        let embedding = try XCTUnwrap(SpeakerEmbedding(
+            rawVector: [1] + [Float](repeating: 0, count: SpeakerEmbedding.dimension - 1),
+            identity: SpeakerModelIdentity(
+                embeddingModelId: "private-cli-voice-model", aggregationProfileId: "private-cli-voice-config"
+            )
+        ))
+        let observation = SpeakerClusterObservation(
+            speakerId: speaker.id, embedding: embedding, speechSeconds: 30, captureDomain: .system
+        )
+        _ = try await voiceprints.enroll(
+            displayName: "PrivateCLIProfileName", observation: observation,
+            transcriptionId: enrollment.id,
+            fingerprint: SpeakerAttributionResolver.fingerprint(for: enrollment),
+            allowMergeIntoExistingName: false
+        )
+        let suggestions = try await voiceprints.evaluate(
+            transcriptionId: meeting.id,
+            fingerprint: SpeakerAttributionResolver.fingerprint(for: meeting), clusters: [observation]
+        )
+        let suggestion = try XCTUnwrap(suggestions.first)
+        try await manager.dbQueue.read { db in
+            for table in [
+                "speaker_profiles", "speaker_profile_exemplars", "speaker_profile_links",
+                "speaker_match_journal", "speaker_embedding_candidates",
+            ] {
+                XCTAssertEqual(try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM \(table)"), 1, table)
+            }
+        }
+
+        let after = try await captureStandardOutput { try await command.run() }
+        XCTAssertEqual(after, before, "Voiceprint storage must not change the CLI's public JSON projection")
+        XCTAssertTrue(after.contains("Visible meeting transcript."))
+        for secret in [
+            "PrivateCLIProfileName", "private-cli-voice-model", "private-cli-voice-config",
+            suggestion.profileId.uuidString, embedding.data.base64EncodedString(),
+        ] {
+            XCTAssertFalse(after.contains(secret), secret)
+        }
     }
 
     @MainActor func testExportToTxtWritesFile() throws {

--- a/Tests/MacParakeetTests/AppRuntimePreferencesTests.swift
+++ b/Tests/MacParakeetTests/AppRuntimePreferencesTests.swift
@@ -603,7 +603,9 @@ final class AppRuntimePreferencesTests: XCTestCase {
                     forKey: UserDefaultsAppRuntimePreferences.voiceprintConsentAcknowledgedAtKey
                 )
             }
-            return UserDefaultsAppRuntimePreferences.rememberSpeakersEnabled(defaults: defaults)
+            return UserDefaultsAppRuntimePreferences.rememberSpeakersEnabled(
+                defaults: defaults, arguments: [AppFeatures.voiceProfilesDeveloperLaunchArgument]
+            )
         }
 
         let consented = Date()

--- a/Tests/MacParakeetTests/AppRuntimePreferencesTests.swift
+++ b/Tests/MacParakeetTests/AppRuntimePreferencesTests.swift
@@ -577,4 +577,42 @@ final class AppRuntimePreferencesTests: XCTestCase {
         XCTAssertFalse(transcriptionGate(global: false, transcripts: nil))
         XCTAssertFalse(transcriptionGate(global: false, transcripts: true))
     }
+
+    /// Three conditions, and consent is one of them: the feature stores a voice
+    /// at the end of every meeting, so a gate that only guarded naming would
+    /// come after the data was already on disk.
+    func testRememberSpeakersNeedsTheToggleDetectionAndConsent() {
+        func gate(toggle: Bool?, detection: Bool?, consentedAt: Date?) -> Bool {
+            let suite = "voiceprint-consent-\(UUID().uuidString)"
+            let defaults = UserDefaults(suiteName: suite)!
+            addTeardownBlock {
+                UserDefaults(suiteName: suite)?.removePersistentDomain(forName: suite)
+            }
+            if let toggle {
+                defaults.set(toggle, forKey: UserDefaultsAppRuntimePreferences.rememberSpeakersKey)
+            }
+            if let detection {
+                defaults.set(
+                    detection,
+                    forKey: UserDefaultsAppRuntimePreferences.meetingSpeakerDiarizationKey
+                )
+            }
+            if let consentedAt {
+                defaults.set(
+                    consentedAt,
+                    forKey: UserDefaultsAppRuntimePreferences.voiceprintConsentAcknowledgedAtKey
+                )
+            }
+            return UserDefaultsAppRuntimePreferences.rememberSpeakersEnabled(defaults: defaults)
+        }
+
+        let consented = Date()
+        XCTAssertTrue(gate(toggle: true, detection: true, consentedAt: consented))
+        // The toggle alone is not consent.
+        XCTAssertFalse(gate(toggle: true, detection: true, consentedAt: nil))
+        XCTAssertFalse(gate(toggle: true, detection: false, consentedAt: consented))
+        XCTAssertFalse(gate(toggle: false, detection: true, consentedAt: consented))
+        // Off until asked, whatever else is set.
+        XCTAssertFalse(gate(toggle: nil, detection: true, consentedAt: consented))
+    }
 }

--- a/Tests/MacParakeetTests/Database/SpeakerEmbeddingCandidateRepositoryTests.swift
+++ b/Tests/MacParakeetTests/Database/SpeakerEmbeddingCandidateRepositoryTests.swift
@@ -1,0 +1,237 @@
+import XCTest
+import GRDB
+@testable import MacParakeetCore
+
+final class SpeakerEmbeddingCandidateRepositoryTests: XCTestCase {
+    private var dbQueue: DatabaseQueue!
+    private var repo: SpeakerEmbeddingCandidateRepository!
+    private var transcriptions: TranscriptionRepository!
+
+    private let identity = SpeakerModelIdentity(
+        embeddingModelId: "test-model",
+        aggregationProfileId: "test-aggregation"
+    )
+    private let epoch = Date(timeIntervalSince1970: 1_757_000_000)
+
+    override func setUp() async throws {
+        let manager = try DatabaseManager()
+        dbQueue = manager.dbQueue
+        repo = SpeakerEmbeddingCandidateRepository(dbQueue: manager.dbQueue)
+        transcriptions = TranscriptionRepository(dbQueue: manager.dbQueue)
+    }
+
+    // MARK: Schema
+
+    func testMigrationCreatesTheCandidateTable() throws {
+        try dbQueue.read { db in
+            XCTAssertTrue(try db.tableExists("speaker_embedding_candidates"))
+            XCTAssertEqual(
+                Set(try db.columns(in: "speaker_embedding_candidates").map(\.name)),
+                [
+                    "id", "transcriptionId", "speakerId", "transcriptFingerprint",
+                    "vector", "speechSeconds", "captureDomain", "embeddingModelId",
+                    "aggregationProfileId", "createdAt", "expiresAt",
+                ]
+            )
+        }
+    }
+
+    func testAVectorOfTheWrongLengthIsRejected() throws {
+        let recording = try savedTranscription()
+        try dbQueue.write { db in
+            XCTAssertThrowsError(
+                try db.execute(
+                    sql: """
+                        INSERT INTO speaker_embedding_candidates
+                        (id, transcriptionId, speakerId, transcriptFingerprint, vector,
+                         speechSeconds, captureDomain, embeddingModelId,
+                         aggregationProfileId, createdAt, expiresAt)
+                        VALUES (?, ?, 'S1', 'fp', ?, 30, 'system', 'm', 'a', ?, ?)
+                        """,
+                    arguments: [
+                        UUID(), recording.id, Data(repeating: 0, count: 1020), epoch, epoch,
+                    ]
+                )
+            )
+        }
+    }
+
+    // MARK: Round trip
+
+    func testTheVectorRoundTripsBitExact() throws {
+        let recording = try savedTranscription()
+        let embedding = makeEmbedding(index: 7)
+        try repo.upsert([candidate(recording.id, embedding: embedding)], now: epoch)
+
+        let stored = try XCTUnwrap(
+            repo.candidate(
+                transcriptionId: recording.id, speakerId: "S1", fingerprint: "fp", now: epoch
+            )
+        )
+        XCTAssertEqual(stored.vector.count, 1024)
+        let observation = try XCTUnwrap(stored.observation)
+        XCTAssertEqual(observation.embedding.vector, embedding.vector)
+        XCTAssertEqual(observation.speakerId, "S1")
+        XCTAssertEqual(observation.captureDomain, .system)
+    }
+
+    // MARK: Expiry
+
+    /// The window is stored per row, so lengthening the constant later cannot
+    /// bring back vectors that were promised a shorter life.
+    func testACandidateIsGoneOnceItsOwnWindowLapses() throws {
+        let recording = try savedTranscription()
+        try repo.upsert(
+            [candidate(recording.id, expiresAt: epoch.addingTimeInterval(60))], now: epoch
+        )
+
+        XCTAssertNotNil(
+            try repo.candidate(
+                transcriptionId: recording.id, speakerId: "S1", fingerprint: "fp",
+                now: epoch.addingTimeInterval(59)
+            )
+        )
+        XCTAssertNil(
+            try repo.candidate(
+                transcriptionId: recording.id, speakerId: "S1", fingerprint: "fp",
+                now: epoch.addingTimeInterval(60)
+            )
+        )
+        XCTAssertEqual(try count(), 0, "the lapsed row must be deleted, not just hidden")
+    }
+
+    /// A user who stops recording stops writing, so expiry cannot ride on
+    /// writes alone.
+    func testPruningRemovesLapsedRowsWithoutAnyWrite() throws {
+        let recording = try savedTranscription()
+        try repo.upsert([candidate(recording.id, expiresAt: epoch.addingTimeInterval(60))], now: epoch)
+
+        try repo.pruneExpired(now: epoch.addingTimeInterval(3600))
+
+        XCTAssertEqual(try count(), 0)
+    }
+
+    // MARK: Scoping
+
+    func testAnotherFingerprintIsANotherCandidate() throws {
+        let recording = try savedTranscription()
+        try repo.upsert([candidate(recording.id, fingerprint: "fp-1")], now: epoch)
+
+        XCTAssertNil(
+            try repo.candidate(
+                transcriptionId: recording.id, speakerId: "S1", fingerprint: "fp-2", now: epoch
+            )
+        )
+    }
+
+    /// Rescoring the same transcript must replace the row, not fail on the
+    /// natural key.
+    func testRecordingTheSameSpeakerTwiceReplacesTheRow() throws {
+        let recording = try savedTranscription()
+        try repo.upsert([candidate(recording.id, embedding: makeEmbedding(index: 3))], now: epoch)
+        try repo.upsert([candidate(recording.id, embedding: makeEmbedding(index: 9))], now: epoch)
+
+        XCTAssertEqual(try count(), 1)
+        let stored = try XCTUnwrap(
+            repo.candidate(
+                transcriptionId: recording.id, speakerId: "S1", fingerprint: "fp", now: epoch
+            )
+        )
+        XCTAssertEqual(
+            try XCTUnwrap(stored.observation).embedding.vector, makeEmbedding(index: 9).vector
+        )
+    }
+
+    /// The natural key does not carry the model or clustering identity, which is
+    /// deliberate: two rows per speaker, one per configuration, would store more
+    /// biometric data and leave promotion with no defined winner. Instead the
+    /// row carries its own identity and the replacement is atomic, so a rescore
+    /// under a new configuration cannot leave a stale one behind.
+    func testReplacementCarriesTheNewConfigurationIdentity() throws {
+        let recording = try savedTranscription()
+        try repo.upsert([candidate(recording.id)], now: epoch)
+
+        let retuned = SpeakerModelIdentity(
+            embeddingModelId: identity.embeddingModelId,
+            aggregationProfileId: "retuned-aggregation"
+        )
+        var values = [Float](repeating: 0, count: SpeakerEmbedding.dimension)
+        values[5] = 1
+        let reclustered = try XCTUnwrap(SpeakerEmbedding(rawVector: values, identity: retuned))
+        try repo.upsert([candidate(recording.id, embedding: reclustered)], now: epoch)
+
+        XCTAssertEqual(try count(), 1)
+        let stored = try XCTUnwrap(
+            repo.candidate(
+                transcriptionId: recording.id, speakerId: "S1", fingerprint: "fp", now: epoch
+            )
+        )
+        XCTAssertEqual(stored.identity, retuned)
+        XCTAssertEqual(try XCTUnwrap(stored.observation).embedding.identity, retuned)
+    }
+
+    // MARK: Deletion
+
+    func testDeletingTheTranscriptionTakesItsCandidates() throws {
+        let recording = try savedTranscription()
+        try repo.upsert([candidate(recording.id)], now: epoch)
+
+        try dbQueue.write { db in
+            _ = try Transcription.deleteOne(db, key: recording.id)
+        }
+
+        XCTAssertEqual(try count(), 0)
+    }
+
+    func testDeleteAllRemovesEveryCandidate() throws {
+        let first = try savedTranscription()
+        let second = try savedTranscription()
+        try repo.upsert([candidate(first.id), candidate(second.id)], now: epoch)
+
+        try repo.deleteAll()
+
+        XCTAssertEqual(try count(), 0)
+    }
+
+    // MARK: Helpers
+
+    private func count() throws -> Int {
+        try dbQueue.read { db in
+            try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM speaker_embedding_candidates") ?? -1
+        }
+    }
+
+    private func savedTranscription() throws -> Transcription {
+        let transcription = Transcription(fileName: "meeting.wav", sourceType: .meeting)
+        try transcriptions.save(transcription)
+        return transcription
+    }
+
+    private func candidate(
+        _ transcriptionId: UUID,
+        speakerId: String = "S1",
+        fingerprint: String = "fp",
+        embedding: SpeakerEmbedding? = nil,
+        expiresAt: Date? = nil
+    ) -> SpeakerEmbeddingCandidate {
+        SpeakerEmbeddingCandidate(
+            transcriptionId: transcriptionId,
+            speakerId: speakerId,
+            transcriptFingerprint: fingerprint,
+            embedding: embedding ?? makeEmbedding(index: 0),
+            speechSeconds: 30,
+            captureDomain: .system,
+            createdAt: epoch,
+            expiresAt: expiresAt ?? epoch.addingTimeInterval(7 * 24 * 60 * 60)
+        )
+    }
+
+    private func makeEmbedding(index: Int) -> SpeakerEmbedding {
+        var values = [Float](repeating: 0, count: SpeakerEmbedding.dimension)
+        values[index] = 1
+        guard let embedding = SpeakerEmbedding(rawVector: values, identity: identity) else {
+            preconditionFailure("fixture vector must be valid")
+        }
+        return embedding
+    }
+}

--- a/Tests/MacParakeetTests/Database/SpeakerProfileRepositoryTests.swift
+++ b/Tests/MacParakeetTests/Database/SpeakerProfileRepositoryTests.swift
@@ -341,6 +341,158 @@ final class SpeakerProfileRepositoryTests: XCTestCase {
         )
     }
 
+    // MARK: The sample cap
+
+    func testASampleBelowTheCapIsSimplyInserted() throws {
+        let profile = try enrolledProfile(named: "Sarah")
+
+        let outcome = try repo.insertExemplar(
+            exemplar(profileId: profile.id, embedding: makeEmbedding(index: 1)),
+            maxPerProfile: 3,
+            evicting: .confirmedSuggestion
+        )
+
+        XCTAssertEqual(outcome, .inserted)
+        XCTAssertEqual(try repo.exemplars(profileId: profile.id).count, 1)
+    }
+
+    func testAtTheCapTheOldestEvictableSampleMakesRoom() throws {
+        let profile = try enrolledProfile(named: "Sarah")
+        let epoch = Date(timeIntervalSince1970: 1_757_000_000)
+        let oldest = exemplar(
+            profileId: profile.id, embedding: makeEmbedding(index: 1),
+            origin: .confirmedSuggestion, createdAt: epoch
+        )
+        try repo.insert(oldest)
+        try repo.insert(
+            exemplar(
+                profileId: profile.id, embedding: makeEmbedding(index: 2),
+                origin: .confirmedSuggestion, createdAt: epoch.addingTimeInterval(60)
+            )
+        )
+
+        let outcome = try repo.insertExemplar(
+            exemplar(profileId: profile.id, embedding: makeEmbedding(index: 3)),
+            maxPerProfile: 2,
+            evicting: .confirmedSuggestion
+        )
+
+        XCTAssertEqual(outcome, .insertedEvicting(oldest.id))
+        let stored = try repo.exemplars(profileId: profile.id)
+        XCTAssertEqual(stored.count, 2)
+        XCTAssertFalse(stored.contains { $0.id == oldest.id })
+    }
+
+    func testAtTheCapWithNothingEvictableTheSampleIsRefused() throws {
+        let profile = try enrolledProfile(named: "Sarah")
+        try repo.insert(exemplar(profileId: profile.id, embedding: makeEmbedding(index: 1)))
+
+        let outcome = try repo.insertExemplar(
+            exemplar(profileId: profile.id, embedding: makeEmbedding(index: 2)),
+            maxPerProfile: 1,
+            evicting: .confirmedSuggestion
+        )
+
+        XCTAssertEqual(outcome, .rejectedProfileFull)
+        XCTAssertEqual(try repo.exemplars(profileId: profile.id).count, 1)
+    }
+
+    func testASecondSampleFromOneRecordingIsRefused() throws {
+        let profile = try enrolledProfile(named: "Sarah")
+        let recording = try savedTranscription()
+        try repo.insert(
+            exemplar(
+                profileId: profile.id, embedding: makeEmbedding(index: 1),
+                sourceTranscriptionId: recording.id
+            )
+        )
+
+        let outcome = try repo.insertExemplar(
+            exemplar(
+                profileId: profile.id, embedding: makeEmbedding(index: 2),
+                sourceTranscriptionId: recording.id
+            ),
+            maxPerProfile: 5,
+            evicting: .confirmedSuggestion
+        )
+
+        XCTAssertEqual(outcome, .rejectedAlreadySampled)
+        XCTAssertEqual(try repo.exemplars(profileId: profile.id).count, 1)
+    }
+
+    /// The cap bounds stored biometric data, so it has to hold when several
+    /// callers offer samples at once. Counting from outside the transaction
+    /// lets each of them read a count below the cap and insert anyway.
+    func testTheCapHoldsUnderConcurrentInserts() throws {
+        let profile = try enrolledProfile(named: "Sarah")
+
+        // Built up front, and only `store` and the samples cross into the
+        // closure: reaching back through `self` for a helper would capture the
+        // test case itself.
+        let store = repo!
+        let samples = (1...12).map {
+            exemplar(profileId: profile.id, embedding: makeEmbedding(index: $0))
+        }
+
+        DispatchQueue.concurrentPerform(iterations: samples.count) { index in
+            _ = try? store.insertExemplar(
+                samples[index],
+                maxPerProfile: 3,
+                evicting: .confirmedSuggestion
+            )
+        }
+
+        XCTAssertEqual(try store.exemplars(profileId: profile.id).count, 3)
+    }
+
+    /// The guard must survive on the capped path too: a sample from another
+    /// embedding model would be stored and counted while scoring against
+    /// nothing.
+    func testTheCappedInsertStillRefusesAnotherEmbeddingModel() throws {
+        let profile = try enrolledProfile(named: "Sarah")
+        let other = SpeakerModelIdentity(
+            embeddingModelId: "other-model", aggregationProfileId: "test-aggregation"
+        )
+        var values = [Float](repeating: 0, count: SpeakerEmbedding.dimension)
+        values[4] = 1
+        let foreign = try XCTUnwrap(SpeakerEmbedding(rawVector: values, identity: other))
+
+        XCTAssertThrowsError(
+            try repo.insertExemplar(
+                exemplar(profileId: profile.id, embedding: foreign),
+                maxPerProfile: 5,
+                evicting: .confirmedSuggestion
+            )
+        )
+        XCTAssertTrue(try repo.exemplars(profileId: profile.id).isEmpty)
+    }
+
+    // MARK: Claiming a name
+
+    /// Two enrollments of one name can both find nothing before either writes,
+    /// so the check belongs in the transaction that creates the profile.
+    func testCreatingAProfileUnderATakenNameIsRefused() throws {
+        try repo.insert(SpeakerProfile(displayName: "Sarah", identity: identity))
+
+        XCTAssertThrowsError(
+            try repo.insert(SpeakerProfile(displayName: "  SARAH ", identity: identity))
+        ) { error in
+            XCTAssertEqual(
+                error as? SpeakerProfileStoreError,
+                .nameAlreadyTaken(normalizedName: "sarah")
+            )
+        }
+        XCTAssertEqual(try repo.profiles().count, 1)
+    }
+
+    func testCreatingAProfileWithABlankNameIsRefused() throws {
+        XCTAssertThrowsError(
+            try repo.insert(SpeakerProfile(displayName: "   ", identity: identity))
+        ) { error in
+            XCTAssertEqual(error as? SpeakerProfileStoreError, .emptyDisplayName)
+        }
+    }
+
     // MARK: Deletion
 
     func testDeletingAProfileRemovesItsExemplarsAndLinks() throws {
@@ -580,16 +732,19 @@ final class SpeakerProfileRepositoryTests: XCTestCase {
         profileId: UUID,
         embedding: SpeakerEmbedding,
         speechSeconds: Double = 20,
-        sourceTranscriptionId: UUID? = nil
+        origin: SpeakerProfileExemplar.Origin = .manualEnrollment,
+        sourceTranscriptionId: UUID? = nil,
+        createdAt: Date = Date()
     ) -> SpeakerProfileExemplar {
         SpeakerProfileExemplar(
             profileId: profileId,
             embedding: embedding,
             speechSeconds: speechSeconds,
             captureDomain: .system,
-            origin: .manualEnrollment,
+            origin: origin,
             sourceTranscriptionId: sourceTranscriptionId,
-            sourceSpeakerId: "S1"
+            sourceSpeakerId: "S1",
+            createdAt: createdAt
         )
     }
 

--- a/Tests/MacParakeetTests/Database/SpeakerProfileRepositoryTests.swift
+++ b/Tests/MacParakeetTests/Database/SpeakerProfileRepositoryTests.swift
@@ -150,6 +150,112 @@ final class SpeakerProfileRepositoryTests: XCTestCase {
         XCTAssertEqual(try repo.exemplars(profileId: profile.id).count, 2)
     }
 
+    func testRejectsAnExemplarFromAnotherEmbeddingModel() throws {
+        let profile = try enrolledProfile(named: "Sarah")
+        let otherModel = SpeakerModelIdentity(
+            embeddingModelId: "other-model",
+            aggregationProfileId: identity.aggregationProfileId
+        )
+        var values = [Float](repeating: 0, count: SpeakerEmbedding.dimension)
+        values[0] = 1
+        let foreign = try XCTUnwrap(SpeakerEmbedding(rawVector: values, identity: otherModel))
+
+        XCTAssertThrowsError(
+            try repo.insert(
+                SpeakerProfileExemplar(
+                    profileId: profile.id,
+                    embedding: foreign,
+                    speechSeconds: 20,
+                    captureDomain: .system,
+                    origin: .manualEnrollment
+                )
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? SpeakerProfileStoreError,
+                .incompatibleEmbeddingModel(profile: "test-model", exemplar: "other-model")
+            )
+        }
+        XCTAssertTrue(try repo.exemplars(profileId: profile.id).isEmpty)
+    }
+
+    /// A differing aggregation profile stays comparable — the matcher tightens
+    /// its threshold for it — so the store must not refuse it.
+    func testAcceptsAnExemplarFromAnotherAggregationProfile() throws {
+        let profile = try enrolledProfile(named: "Sarah")
+        let otherAggregation = SpeakerModelIdentity(
+            embeddingModelId: identity.embeddingModelId,
+            aggregationProfileId: "other-aggregation"
+        )
+        var values = [Float](repeating: 0, count: SpeakerEmbedding.dimension)
+        values[1] = 1
+        let embedding = try XCTUnwrap(SpeakerEmbedding(rawVector: values, identity: otherAggregation))
+
+        XCTAssertNoThrow(
+            try repo.insert(
+                SpeakerProfileExemplar(
+                    profileId: profile.id,
+                    embedding: embedding,
+                    speechSeconds: 20,
+                    captureDomain: .system,
+                    origin: .manualEnrollment
+                )
+            )
+        )
+        XCTAssertEqual(try repo.exemplars(profileId: profile.id).count, 1)
+    }
+
+    func testRejectsAModelChangeOnAProfileThatHasSamples() throws {
+        var profile = try enrolledProfile(named: "Sarah")
+        try repo.insert(exemplar(profileId: profile.id, embedding: makeEmbedding(index: 1)))
+
+        profile = SpeakerProfile(
+            id: profile.id,
+            displayName: profile.displayName,
+            identity: SpeakerModelIdentity(
+                embeddingModelId: "next-model",
+                aggregationProfileId: identity.aggregationProfileId
+            )
+        )
+        XCTAssertThrowsError(try repo.save(profile)) { error in
+            XCTAssertEqual(
+                error as? SpeakerProfileStoreError, .embeddingModelChangeWithExemplars(profile.id)
+            )
+        }
+        XCTAssertEqual(try repo.profile(id: profile.id)?.embeddingModelId, "test-model")
+    }
+
+    func testAModelChangeIsAllowedWhileAProfileHasNoSamples() throws {
+        let profile = try enrolledProfile(named: "Sarah")
+        let migrated = SpeakerProfile(
+            id: profile.id,
+            displayName: profile.displayName,
+            identity: SpeakerModelIdentity(
+                embeddingModelId: "next-model",
+                aggregationProfileId: identity.aggregationProfileId
+            )
+        )
+        XCTAssertNoThrow(try repo.save(migrated))
+        XCTAssertEqual(try repo.profile(id: profile.id)?.embeddingModelId, "next-model")
+    }
+
+    /// The stored key must not depend on the device locale: under a Turkish
+    /// locale, localized folding maps "I" to a dotless i, and every profile
+    /// whose name contains one would become unfindable after a locale change.
+    func testNormalizedKeyIsIndependentOfLocale() throws {
+        let profile = SpeakerProfile(displayName: "ISTANBUL", identity: identity)
+        try repo.save(profile)
+
+        XCTAssertEqual(
+            SpeakerProfile.normalizedName(for: "ISTANBUL"),
+            SpeakerProfile.normalizedName(for: "Istanbul")
+        )
+        XCTAssertEqual(try repo.profile(named: "istanbul")?.id, profile.id)
+        // Localized folding would give "ıstanbul" here; the canonical mapping
+        // must not.
+        XCTAssertEqual(SpeakerProfile.normalizedName(for: "ISTANBUL"), "istanbul")
+    }
+
     // MARK: Deletion
 
     func testDeletingAProfileRemovesItsExemplarsAndLinks() throws {

--- a/Tests/MacParakeetTests/Database/SpeakerProfileRepositoryTests.swift
+++ b/Tests/MacParakeetTests/Database/SpeakerProfileRepositoryTests.swift
@@ -77,9 +77,12 @@ final class SpeakerProfileRepositoryTests: XCTestCase {
                         INSERT INTO speaker_profile_exemplars
                         (id, profileId, vector, speechSeconds, captureDomain, origin,
                          embeddingModelId, aggregationProfileId, createdAt)
-                        VALUES (?, ?, ?, ?, 'system', 'manualEnrollment', 'm', 'a', ?)
+                        VALUES (?, ?, ?, ?, 'system', 'manualEnrollment', ?, ?, ?)
                         """,
-                    arguments: [UUID(), profile.id, Data(repeating: 0, count: 1020), 20.0, Date()]
+                    arguments: [
+                        UUID(), profile.id, Data(repeating: 0, count: 1020), 20.0,
+                        identity.embeddingModelId, identity.aggregationProfileId, Date(),
+                    ]
                 )
             }
         )
@@ -102,11 +105,12 @@ final class SpeakerProfileRepositoryTests: XCTestCase {
                             INSERT INTO speaker_profile_exemplars
                             (id, profileId, vector, speechSeconds, captureDomain, origin,
                              embeddingModelId, aggregationProfileId, createdAt)
-                            VALUES (?, ?, ?, ?, ?, ?, 'm', 'a', ?)
+                            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
                             """,
                         arguments: [
                             UUID(), profile.id, makeEmbedding(index: 1).data, 20.0,
-                            domain, origin, Date(),
+                            domain, origin,
+                            identity.embeddingModelId, identity.aggregationProfileId, Date(),
                         ]
                     )
                 }

--- a/Tests/MacParakeetTests/Database/SpeakerProfileRepositoryTests.swift
+++ b/Tests/MacParakeetTests/Database/SpeakerProfileRepositoryTests.swift
@@ -948,6 +948,56 @@ final class SpeakerProfileRepositoryTests: XCTestCase {
         XCTAssertEqual(stored.first?.status, .dismissed)
     }
 
+    func testReplacingSuggestionsRechecksTerminalDecisionsInsideTheWrite() throws {
+        let profile = try enrolledProfile(named: "Sarah")
+        let otherProfile = try enrolledProfile(named: "Alex")
+        let recording = try savedTranscription()
+        let staleOffer = link(transcriptionId: recording.id, profileId: profile.id)
+        try repo.save(staleOffer)
+
+        // Simulate an answer after the matcher took its snapshot.
+        var confirmed = staleOffer
+        confirmed.status = .confirmed
+        try repo.save(confirmed)
+        var siblingOffer = staleOffer
+        siblingOffer.speakerId = "system:S2"
+        var unrelatedOffer = staleOffer
+        unrelatedOffer.speakerId = "system:S3"
+        unrelatedOffer.profileId = otherProfile.id
+        var oldScope = staleOffer
+        oldScope.transcriptFingerprint = "other-fingerprint"
+        try repo.save(oldScope)
+
+        let published = try repo.replaceSuggestions(
+            transcriptionId: recording.id, fingerprint: "fingerprint",
+            with: [staleOffer, siblingOffer, unrelatedOffer]
+        )
+        XCTAssertEqual(published.map(\.speakerId), ["system:S3"])
+        let links = try repo.links(transcriptionId: recording.id, fingerprint: "fingerprint")
+        XCTAssertEqual(Set(links.map(\.speakerId)), ["system:S1", "system:S3"])
+        XCTAssertEqual(links.first { $0.speakerId == "system:S1" }?.status, .confirmed)
+        let untouched = try repo.links(transcriptionId: recording.id, fingerprint: "other-fingerprint")
+        XCTAssertEqual(untouched.count, 1)
+        XCTAssertEqual(untouched.first?.status, .suggested)
+        XCTAssertEqual(untouched.first?.profileId, profile.id)
+    }
+
+    func testFailedSuggestionReplacementRollsBackRemovedOffers() throws {
+        let profile = try enrolledProfile(named: "Sarah")
+        let recording = try savedTranscription()
+        let original = link(transcriptionId: recording.id, profileId: profile.id)
+        try repo.save(original)
+        var invalid = original
+        invalid.profileId = UUID()
+        XCTAssertThrowsError(
+            try repo.replaceSuggestions(transcriptionId: recording.id, fingerprint: "fingerprint", with: [invalid])
+        )
+        let remaining = try repo.links(transcriptionId: recording.id, fingerprint: "fingerprint")
+        XCTAssertEqual(remaining.count, 1)
+        XCTAssertEqual(remaining.first?.profileId, profile.id)
+        XCTAssertEqual(remaining.first?.status, .suggested)
+    }
+
     // MARK: Helpers
 
     private func makeEmbedding(index: Int) -> SpeakerEmbedding {

--- a/Tests/MacParakeetTests/Database/SpeakerProfileRepositoryTests.swift
+++ b/Tests/MacParakeetTests/Database/SpeakerProfileRepositoryTests.swift
@@ -1,0 +1,350 @@
+import XCTest
+import GRDB
+@testable import MacParakeetCore
+
+final class SpeakerProfileRepositoryTests: XCTestCase {
+    private var dbQueue: DatabaseQueue!
+    private var repo: SpeakerProfileRepository!
+    private var transcriptions: TranscriptionRepository!
+
+    private let identity = SpeakerModelIdentity(
+        embeddingModelId: "test-model",
+        aggregationProfileId: "test-aggregation"
+    )
+
+    override func setUp() async throws {
+        let manager = try DatabaseManager()
+        dbQueue = manager.dbQueue
+        repo = SpeakerProfileRepository(dbQueue: manager.dbQueue)
+        transcriptions = TranscriptionRepository(dbQueue: manager.dbQueue)
+    }
+
+    // MARK: Schema
+
+    func testMigrationCreatesTheThreeVoiceprintTables() throws {
+        try dbQueue.read { db in
+            XCTAssertTrue(try db.tableExists("speaker_profiles"))
+            XCTAssertTrue(try db.tableExists("speaker_profile_exemplars"))
+            XCTAssertTrue(try db.tableExists("speaker_profile_links"))
+
+            XCTAssertEqual(
+                Set(try db.columns(in: "speaker_profiles").map(\.name)),
+                [
+                    "id", "displayName", "embeddingModelId", "aggregationProfileId",
+                    "createdAt", "updatedAt", "lastMatchedAt", "lastEvaluatedAt",
+                    "lastEvaluatedDistance",
+                ]
+            )
+            XCTAssertEqual(
+                Set(try db.columns(in: "speaker_profile_exemplars").map(\.name)),
+                [
+                    "id", "profileId", "vector", "speechSeconds", "captureDomain",
+                    "origin", "embeddingModelId", "aggregationProfileId",
+                    "sourceTranscriptionId", "sourceSpeakerId", "createdAt",
+                ]
+            )
+            XCTAssertEqual(
+                Set(try db.columns(in: "speaker_profile_links").map(\.name)),
+                [
+                    "transcriptionId", "speakerId", "transcriptFingerprint", "profileId",
+                    "status", "distance", "runnerUpDistance", "createdAt", "updatedAt",
+                ]
+            )
+        }
+    }
+
+    // MARK: Round trip
+
+    func testExemplarVectorRoundTripsBitExact() throws {
+        let profile = try enrolledProfile(named: "Sarah")
+        let embedding = makeEmbedding(index: 7)
+        try repo.insert(exemplar(profileId: profile.id, embedding: embedding))
+
+        let stored = try XCTUnwrap(try repo.exemplars(profileId: profile.id).first)
+        XCTAssertEqual(stored.vector.count, 1024)
+        XCTAssertEqual(try XCTUnwrap(stored.embedding).vector, embedding.vector)
+        XCTAssertEqual(stored.identity, identity)
+    }
+
+    // MARK: Constraints
+
+    func testRejectsVectorOfTheWrongLength() throws {
+        let profile = try enrolledProfile(named: "Sarah")
+        XCTAssertThrowsError(
+            try dbQueue.write { db in
+                try db.execute(
+                    sql: """
+                        INSERT INTO speaker_profile_exemplars
+                        (id, profileId, vector, speechSeconds, captureDomain, origin,
+                         embeddingModelId, aggregationProfileId, createdAt)
+                        VALUES (?, ?, ?, ?, 'system', 'manualEnrollment', 'm', 'a', ?)
+                        """,
+                    arguments: [UUID(), profile.id, Data(repeating: 0, count: 1020), 20.0, Date()]
+                )
+            }
+        )
+    }
+
+    func testRejectsNonPositiveSpeechDuration() throws {
+        let profile = try enrolledProfile(named: "Sarah")
+        XCTAssertThrowsError(
+            try repo.insert(exemplar(profileId: profile.id, embedding: makeEmbedding(index: 1), speechSeconds: 0))
+        )
+    }
+
+    func testRejectsUnknownCaptureDomainOrOrigin() throws {
+        let profile = try enrolledProfile(named: "Sarah")
+        for (domain, origin) in [("hologram", "manualEnrollment"), ("system", "osmosis")] {
+            XCTAssertThrowsError(
+                try dbQueue.write { db in
+                    try db.execute(
+                        sql: """
+                            INSERT INTO speaker_profile_exemplars
+                            (id, profileId, vector, speechSeconds, captureDomain, origin,
+                             embeddingModelId, aggregationProfileId, createdAt)
+                            VALUES (?, ?, ?, ?, ?, ?, 'm', 'a', ?)
+                            """,
+                        arguments: [
+                            UUID(), profile.id, makeEmbedding(index: 1).data, 20.0,
+                            domain, origin, Date(),
+                        ]
+                    )
+                }
+            )
+        }
+    }
+
+    func testNamesAreUniqueCaseInsensitively() throws {
+        _ = try enrolledProfile(named: "Sarah")
+        XCTAssertThrowsError(try repo.save(SpeakerProfile(displayName: "sarah", identity: identity)))
+    }
+
+    func testOneExemplarPerProfilePerRecording() throws {
+        let profile = try enrolledProfile(named: "Sarah")
+        let transcription = try savedTranscription()
+
+        try repo.insert(
+            exemplar(
+                profileId: profile.id,
+                embedding: makeEmbedding(index: 1),
+                sourceTranscriptionId: transcription.id
+            )
+        )
+        XCTAssertThrowsError(
+            try repo.insert(
+                exemplar(
+                    profileId: profile.id,
+                    embedding: makeEmbedding(index: 2),
+                    sourceTranscriptionId: transcription.id
+                )
+            )
+        )
+    }
+
+    /// SQLite treats NULLs as distinct in a UNIQUE constraint, which is what we
+    /// want: exemplars whose recording was deleted must not start colliding.
+    func testExemplarsWithoutARecordingDoNotCollide() throws {
+        let profile = try enrolledProfile(named: "Sarah")
+        try repo.insert(exemplar(profileId: profile.id, embedding: makeEmbedding(index: 1)))
+        try repo.insert(exemplar(profileId: profile.id, embedding: makeEmbedding(index: 2)))
+        XCTAssertEqual(try repo.exemplars(profileId: profile.id).count, 2)
+    }
+
+    // MARK: Deletion
+
+    func testDeletingAProfileRemovesItsExemplarsAndLinks() throws {
+        let profile = try enrolledProfile(named: "Sarah")
+        let transcription = try savedTranscription()
+        try repo.insert(
+            exemplar(
+                profileId: profile.id,
+                embedding: makeEmbedding(index: 1),
+                sourceTranscriptionId: transcription.id
+            )
+        )
+        try repo.save(link(transcriptionId: transcription.id, profileId: profile.id))
+
+        XCTAssertTrue(try repo.deleteProfile(id: profile.id))
+
+        try dbQueue.read { db in
+            XCTAssertEqual(try SpeakerProfileExemplar.fetchCount(db), 0)
+            XCTAssertEqual(try SpeakerProfileLink.fetchCount(db), 0)
+        }
+        // The recording itself is untouched: deleting a voiceprint never
+        // rewrites the user's transcripts.
+        XCTAssertNotNil(try transcriptions.fetch(id: transcription.id))
+    }
+
+    func testDeletingARecordingKeepsTheExemplarButClearsItsSource() throws {
+        let profile = try enrolledProfile(named: "Sarah")
+        let transcription = try savedTranscription()
+        try repo.insert(
+            exemplar(
+                profileId: profile.id,
+                embedding: makeEmbedding(index: 1),
+                sourceTranscriptionId: transcription.id
+            )
+        )
+
+        XCTAssertTrue(try transcriptions.delete(id: transcription.id))
+
+        let stored = try XCTUnwrap(try repo.exemplars(profileId: profile.id).first)
+        XCTAssertNil(stored.sourceTranscriptionId)
+        XCTAssertNotNil(stored.embedding)
+    }
+
+    func testDeletingARecordingRemovesItsLinks() throws {
+        let profile = try enrolledProfile(named: "Sarah")
+        let transcription = try savedTranscription()
+        try repo.save(link(transcriptionId: transcription.id, profileId: profile.id))
+
+        XCTAssertTrue(try transcriptions.delete(id: transcription.id))
+
+        try dbQueue.read { db in
+            XCTAssertEqual(try SpeakerProfileLink.fetchCount(db), 0)
+        }
+    }
+
+    func testDeleteAllProfilesEmptiesEveryVoiceprintTable() throws {
+        let first = try enrolledProfile(named: "Sarah")
+        let second = try enrolledProfile(named: "Dan")
+        let transcription = try savedTranscription()
+        try repo.insert(
+            exemplar(
+                profileId: first.id,
+                embedding: makeEmbedding(index: 1),
+                sourceTranscriptionId: transcription.id
+            )
+        )
+        try repo.save(link(transcriptionId: transcription.id, profileId: second.id))
+
+        try repo.deleteAllProfiles()
+
+        try dbQueue.read { db in
+            XCTAssertEqual(try SpeakerProfile.fetchCount(db), 0)
+            XCTAssertEqual(try SpeakerProfileExemplar.fetchCount(db), 0)
+            XCTAssertEqual(try SpeakerProfileLink.fetchCount(db), 0)
+        }
+        XCTAssertNotNil(try transcriptions.fetch(id: transcription.id))
+    }
+
+    func testDeleteExemplarRemovesOnlyThatSample() throws {
+        let profile = try enrolledProfile(named: "Sarah")
+        try repo.insert(exemplar(profileId: profile.id, embedding: makeEmbedding(index: 1)))
+        let second = exemplar(profileId: profile.id, embedding: makeEmbedding(index: 2))
+        try repo.insert(second)
+
+        XCTAssertTrue(try repo.deleteExemplar(id: second.id))
+        XCTAssertEqual(try repo.exemplars(profileId: profile.id).count, 1)
+        XCTAssertNotNil(try repo.profile(id: profile.id))
+    }
+
+    // MARK: Lookups
+
+    func testProfileLookupByNameIgnoresCase() throws {
+        let profile = try enrolledProfile(named: "Sarah")
+        XCTAssertEqual(try repo.profile(named: "sarah")?.id, profile.id)
+        XCTAssertEqual(try repo.profile(named: "SARAH")?.id, profile.id)
+        XCTAssertNil(try repo.profile(named: "Dan"))
+    }
+
+    func testExemplarsByProfileGroupsEveryProfile() throws {
+        let first = try enrolledProfile(named: "Sarah")
+        let second = try enrolledProfile(named: "Dan")
+        try repo.insert(exemplar(profileId: first.id, embedding: makeEmbedding(index: 1)))
+        try repo.insert(exemplar(profileId: first.id, embedding: makeEmbedding(index: 2)))
+        try repo.insert(exemplar(profileId: second.id, embedding: makeEmbedding(index: 3)))
+
+        let grouped = try repo.exemplarsByProfile()
+        XCTAssertEqual(grouped[first.id]?.count, 2)
+        XCTAssertEqual(grouped[second.id]?.count, 1)
+    }
+
+    func testLinksAreScopedToTheirFingerprint() throws {
+        let profile = try enrolledProfile(named: "Sarah")
+        let transcription = try savedTranscription()
+        try repo.save(
+            link(transcriptionId: transcription.id, profileId: profile.id, fingerprint: "before")
+        )
+
+        XCTAssertEqual(
+            try repo.links(transcriptionId: transcription.id, fingerprint: "before").count,
+            1
+        )
+        // After re-diarization the fingerprint changes and old decisions no
+        // longer apply, so a stale dismissal cannot suppress a fresh suggestion.
+        XCTAssertTrue(
+            try repo.links(transcriptionId: transcription.id, fingerprint: "after").isEmpty
+        )
+    }
+
+    func testSavingALinkTwiceUpdatesItInPlace() throws {
+        let profile = try enrolledProfile(named: "Sarah")
+        let transcription = try savedTranscription()
+        try repo.save(link(transcriptionId: transcription.id, profileId: profile.id))
+
+        var updated = link(transcriptionId: transcription.id, profileId: profile.id)
+        updated.status = .dismissed
+        try repo.save(updated)
+
+        let stored = try repo.links(transcriptionId: transcription.id, fingerprint: "fingerprint")
+        XCTAssertEqual(stored.count, 1)
+        XCTAssertEqual(stored.first?.status, .dismissed)
+    }
+
+    // MARK: Helpers
+
+    private func makeEmbedding(index: Int) -> SpeakerEmbedding {
+        var values = [Float](repeating: 0, count: SpeakerEmbedding.dimension)
+        values[index] = 1
+        guard let embedding = SpeakerEmbedding(rawVector: values, identity: identity) else {
+            preconditionFailure("fixture vector must be valid")
+        }
+        return embedding
+    }
+
+    private func enrolledProfile(named name: String) throws -> SpeakerProfile {
+        let profile = SpeakerProfile(displayName: name, identity: identity)
+        try repo.save(profile)
+        return profile
+    }
+
+    private func savedTranscription() throws -> Transcription {
+        let transcription = Transcription(fileName: "meeting.wav", sourceType: .meeting)
+        try transcriptions.save(transcription)
+        return transcription
+    }
+
+    private func exemplar(
+        profileId: UUID,
+        embedding: SpeakerEmbedding,
+        speechSeconds: Double = 20,
+        sourceTranscriptionId: UUID? = nil
+    ) -> SpeakerProfileExemplar {
+        SpeakerProfileExemplar(
+            profileId: profileId,
+            embedding: embedding,
+            speechSeconds: speechSeconds,
+            captureDomain: .system,
+            origin: .manualEnrollment,
+            sourceTranscriptionId: sourceTranscriptionId,
+            sourceSpeakerId: "S1"
+        )
+    }
+
+    private func link(
+        transcriptionId: UUID,
+        profileId: UUID,
+        fingerprint: String = "fingerprint"
+    ) -> SpeakerProfileLink {
+        SpeakerProfileLink(
+            transcriptionId: transcriptionId,
+            speakerId: "system:S1",
+            transcriptFingerprint: fingerprint,
+            profileId: profileId,
+            status: .suggested,
+            distance: 0.12,
+            runnerUpDistance: 0.44
+        )
+    }
+}

--- a/Tests/MacParakeetTests/Database/SpeakerProfileRepositoryTests.swift
+++ b/Tests/MacParakeetTests/Database/SpeakerProfileRepositoryTests.swift
@@ -256,6 +256,87 @@ final class SpeakerProfileRepositoryTests: XCTestCase {
         XCTAssertEqual(SpeakerProfile.normalizedName(for: "ISTANBUL"), "istanbul")
     }
 
+    func testRejectsAProfileWhoseNameNormalizesToNothing() throws {
+        for blank in ["", "   ", "\n\t "] {
+            XCTAssertThrowsError(
+                try repo.save(SpeakerProfile(displayName: blank, identity: identity))
+            ) { error in
+                XCTAssertEqual(error as? SpeakerProfileStoreError, .emptyDisplayName)
+            }
+        }
+        XCTAssertTrue(try repo.profiles().isEmpty)
+    }
+
+    func testASuggestionCannotOverwriteAConfirmedDecision() throws {
+        let profile = try enrolledProfile(named: "Sarah")
+        let transcription = try savedTranscription()
+
+        var confirmed = link(transcriptionId: transcription.id, profileId: profile.id)
+        confirmed.status = .confirmed
+        try repo.save(confirmed)
+
+        XCTAssertThrowsError(
+            try repo.save(link(transcriptionId: transcription.id, profileId: profile.id))
+        ) { error in
+            XCTAssertEqual(
+                error as? SpeakerProfileStoreError,
+                .terminalDecisionAlreadyRecorded(status: .confirmed)
+            )
+        }
+        XCTAssertEqual(
+            try repo.links(transcriptionId: transcription.id, fingerprint: "fingerprint")
+                .map(\.status),
+            [.confirmed]
+        )
+    }
+
+    func testASuggestionCannotOverwriteADismissedDecision() throws {
+        let profile = try enrolledProfile(named: "Sarah")
+        let transcription = try savedTranscription()
+
+        var dismissed = link(transcriptionId: transcription.id, profileId: profile.id)
+        dismissed.status = .dismissed
+        try repo.save(dismissed)
+
+        XCTAssertThrowsError(
+            try repo.save(link(transcriptionId: transcription.id, profileId: profile.id))
+        )
+    }
+
+    func testASuggestionStillBecomesTerminal() throws {
+        let profile = try enrolledProfile(named: "Sarah")
+        let transcription = try savedTranscription()
+        try repo.save(link(transcriptionId: transcription.id, profileId: profile.id))
+
+        var confirmed = link(transcriptionId: transcription.id, profileId: profile.id)
+        confirmed.status = .confirmed
+        XCTAssertNoThrow(try repo.save(confirmed))
+        XCTAssertEqual(
+            try repo.links(transcriptionId: transcription.id, fingerprint: "fingerprint")
+                .map(\.status),
+            [.confirmed]
+        )
+    }
+
+    /// The composite foreign key is what makes the model invariant structural
+    /// rather than merely enforced in Swift.
+    func testTheDatabaseItselfRefusesAMismatchedExemplarModel() throws {
+        let profile = try enrolledProfile(named: "Sarah")
+        XCTAssertThrowsError(
+            try dbQueue.write { db in
+                try db.execute(
+                    sql: """
+                        INSERT INTO speaker_profile_exemplars
+                        (id, profileId, vector, speechSeconds, captureDomain, origin,
+                         embeddingModelId, aggregationProfileId, createdAt)
+                        VALUES (?, ?, ?, ?, 'system', 'manualEnrollment', 'other-model', 'a', ?)
+                        """,
+                    arguments: [UUID(), profile.id, makeEmbedding(index: 1).data, 20.0, Date()]
+                )
+            }
+        )
+    }
+
     // MARK: Deletion
 
     func testDeletingAProfileRemovesItsExemplarsAndLinks() throws {

--- a/Tests/MacParakeetTests/Database/SpeakerProfileRepositoryTests.swift
+++ b/Tests/MacParakeetTests/Database/SpeakerProfileRepositoryTests.swift
@@ -30,7 +30,7 @@ final class SpeakerProfileRepositoryTests: XCTestCase {
             XCTAssertEqual(
                 Set(try db.columns(in: "speaker_profiles").map(\.name)),
                 [
-                    "id", "displayName", "embeddingModelId", "aggregationProfileId",
+                    "id", "displayName", "normalizedName", "embeddingModelId", "aggregationProfileId",
                     "createdAt", "updatedAt", "lastMatchedAt", "lastEvaluatedAt",
                     "lastEvaluatedDistance",
                 ]
@@ -285,6 +285,32 @@ final class SpeakerProfileRepositoryTests: XCTestCase {
         try repo.save(profile)
         XCTAssertEqual(try repo.profile(named: "josé")?.id, profile.id)
         XCTAssertEqual(try repo.profile(named: "JOSÉ")?.id, profile.id)
+    }
+
+    /// The constraint and the lookup must agree on what one name is, otherwise
+    /// two rows can exist that a lookup considers equal and picks between at
+    /// random.
+    func testNonAsciiCaseVariantsCannotBothBeStored() throws {
+        try repo.save(SpeakerProfile(displayName: "José", identity: identity))
+        XCTAssertThrowsError(try repo.save(SpeakerProfile(displayName: "JOSÉ", identity: identity)))
+    }
+
+    func testLookupIgnoresSurroundingWhitespace() throws {
+        let profile = SpeakerProfile(displayName: "Sarah", identity: identity)
+        try repo.save(profile)
+        XCTAssertEqual(try repo.profile(named: "  sarah  ")?.id, profile.id)
+    }
+
+    /// Accents are typography; dropping them would be a guess about identity.
+    /// Two colleagues named Jose and José stay two people, and the enrollment
+    /// guard is what catches a genuine name clash, by voice.
+    func testAccentsDistinguishNames() throws {
+        let plain = SpeakerProfile(displayName: "Jose", identity: identity)
+        let accented = SpeakerProfile(displayName: "José", identity: identity)
+        try repo.save(plain)
+        try repo.save(accented)
+        XCTAssertEqual(try repo.profile(named: "jose")?.id, plain.id)
+        XCTAssertEqual(try repo.profile(named: "josé")?.id, accented.id)
     }
 
     func testUpdatingALinkKeepsItsOriginalCreationTime() throws {

--- a/Tests/MacParakeetTests/Database/SpeakerProfileRepositoryTests.swift
+++ b/Tests/MacParakeetTests/Database/SpeakerProfileRepositoryTests.swift
@@ -278,6 +278,37 @@ final class SpeakerProfileRepositoryTests: XCTestCase {
         )
     }
 
+    func testProfileLookupHandlesNonAsciiCase() throws {
+        // SQLite's NOCASE folds only ASCII, so this is the case that would
+        // silently create a second profile for the same person.
+        let profile = SpeakerProfile(displayName: "José", identity: identity)
+        try repo.save(profile)
+        XCTAssertEqual(try repo.profile(named: "josé")?.id, profile.id)
+        XCTAssertEqual(try repo.profile(named: "JOSÉ")?.id, profile.id)
+    }
+
+    func testUpdatingALinkKeepsItsOriginalCreationTime() throws {
+        let profile = try enrolledProfile(named: "Sarah")
+        let transcription = try savedTranscription()
+        let suggestedAt = Date(timeIntervalSince1970: 1_000_000)
+
+        var suggestion = link(transcriptionId: transcription.id, profileId: profile.id)
+        suggestion.createdAt = suggestedAt
+        suggestion.updatedAt = suggestedAt
+        try repo.save(suggestion)
+
+        var confirmation = link(transcriptionId: transcription.id, profileId: profile.id)
+        confirmation.status = .confirmed
+        try repo.save(confirmation)
+
+        let stored = try XCTUnwrap(
+            try repo.links(transcriptionId: transcription.id, fingerprint: "fingerprint").first
+        )
+        XCTAssertEqual(stored.status, .confirmed)
+        XCTAssertEqual(stored.createdAt.timeIntervalSince1970, suggestedAt.timeIntervalSince1970, accuracy: 0.001)
+        XCTAssertGreaterThan(stored.updatedAt, suggestedAt)
+    }
+
     func testSavingALinkTwiceUpdatesItInPlace() throws {
         let profile = try enrolledProfile(named: "Sarah")
         let transcription = try savedTranscription()

--- a/Tests/MacParakeetTests/Database/SpeakerProfileRepositoryTests.swift
+++ b/Tests/MacParakeetTests/Database/SpeakerProfileRepositoryTests.swift
@@ -120,7 +120,7 @@ final class SpeakerProfileRepositoryTests: XCTestCase {
 
     func testNamesAreUniqueCaseInsensitively() throws {
         _ = try enrolledProfile(named: "Sarah")
-        XCTAssertThrowsError(try repo.save(SpeakerProfile(displayName: "sarah", identity: identity)))
+        XCTAssertThrowsError(try repo.insert(SpeakerProfile(displayName: "sarah", identity: identity)))
     }
 
     func testOneExemplarPerProfilePerRecording() throws {
@@ -248,7 +248,7 @@ final class SpeakerProfileRepositoryTests: XCTestCase {
     /// whose name contains one would become unfindable after a locale change.
     func testNormalizedKeyIsIndependentOfLocale() throws {
         let profile = SpeakerProfile(displayName: "ISTANBUL", identity: identity)
-        try repo.save(profile)
+        try repo.insert(profile)
 
         XCTAssertEqual(
             SpeakerProfile.normalizedName(for: "ISTANBUL"),
@@ -263,7 +263,7 @@ final class SpeakerProfileRepositoryTests: XCTestCase {
     func testRejectsAProfileWhoseNameNormalizesToNothing() throws {
         for blank in ["", "   ", "\n\t "] {
             XCTAssertThrowsError(
-                try repo.save(SpeakerProfile(displayName: blank, identity: identity))
+                try repo.insert(SpeakerProfile(displayName: blank, identity: identity))
             ) { error in
                 XCTAssertEqual(error as? SpeakerProfileStoreError, .emptyDisplayName)
             }
@@ -868,7 +868,7 @@ final class SpeakerProfileRepositoryTests: XCTestCase {
         // SQLite's NOCASE folds only ASCII, so this is the case that would
         // silently create a second profile for the same person.
         let profile = SpeakerProfile(displayName: "José", identity: identity)
-        try repo.save(profile)
+        try repo.insert(profile)
         XCTAssertEqual(try repo.profile(named: "josé")?.id, profile.id)
         XCTAssertEqual(try repo.profile(named: "JOSÉ")?.id, profile.id)
     }
@@ -877,13 +877,13 @@ final class SpeakerProfileRepositoryTests: XCTestCase {
     /// two rows can exist that a lookup considers equal and picks between at
     /// random.
     func testNonAsciiCaseVariantsCannotBothBeStored() throws {
-        try repo.save(SpeakerProfile(displayName: "José", identity: identity))
-        XCTAssertThrowsError(try repo.save(SpeakerProfile(displayName: "JOSÉ", identity: identity)))
+        try repo.insert(SpeakerProfile(displayName: "José", identity: identity))
+        XCTAssertThrowsError(try repo.insert(SpeakerProfile(displayName: "JOSÉ", identity: identity)))
     }
 
     func testRenamingAProfileMovesItsLookupKey() throws {
         var profile = SpeakerProfile(displayName: "Sarah", identity: identity)
-        try repo.save(profile)
+        try repo.insert(profile)
 
         profile.displayName = "Sarah Chen"
         try repo.save(profile)
@@ -891,12 +891,12 @@ final class SpeakerProfileRepositoryTests: XCTestCase {
         XCTAssertEqual(try repo.profile(named: "sarah chen")?.id, profile.id)
         XCTAssertNil(try repo.profile(named: "Sarah"))
         // The old key must not keep enforcing uniqueness either.
-        XCTAssertNoThrow(try repo.save(SpeakerProfile(displayName: "Sarah", identity: identity)))
+        XCTAssertNoThrow(try repo.insert(SpeakerProfile(displayName: "Sarah", identity: identity)))
     }
 
     func testLookupIgnoresSurroundingWhitespace() throws {
         let profile = SpeakerProfile(displayName: "Sarah", identity: identity)
-        try repo.save(profile)
+        try repo.insert(profile)
         XCTAssertEqual(try repo.profile(named: "  sarah  ")?.id, profile.id)
     }
 
@@ -906,8 +906,8 @@ final class SpeakerProfileRepositoryTests: XCTestCase {
     func testAccentsDistinguishNames() throws {
         let plain = SpeakerProfile(displayName: "Jose", identity: identity)
         let accented = SpeakerProfile(displayName: "José", identity: identity)
-        try repo.save(plain)
-        try repo.save(accented)
+        try repo.insert(plain)
+        try repo.insert(accented)
         XCTAssertEqual(try repo.profile(named: "jose")?.id, plain.id)
         XCTAssertEqual(try repo.profile(named: "josé")?.id, accented.id)
     }
@@ -961,7 +961,7 @@ final class SpeakerProfileRepositoryTests: XCTestCase {
 
     private func enrolledProfile(named name: String) throws -> SpeakerProfile {
         let profile = SpeakerProfile(displayName: name, identity: identity)
-        try repo.save(profile)
+        try repo.insert(profile)
         return profile
     }
 

--- a/Tests/MacParakeetTests/Database/SpeakerProfileRepositoryTests.swift
+++ b/Tests/MacParakeetTests/Database/SpeakerProfileRepositoryTests.swift
@@ -295,6 +295,19 @@ final class SpeakerProfileRepositoryTests: XCTestCase {
         XCTAssertThrowsError(try repo.save(SpeakerProfile(displayName: "JOSÉ", identity: identity)))
     }
 
+    func testRenamingAProfileMovesItsLookupKey() throws {
+        var profile = SpeakerProfile(displayName: "Sarah", identity: identity)
+        try repo.save(profile)
+
+        profile.displayName = "Sarah Chen"
+        try repo.save(profile)
+
+        XCTAssertEqual(try repo.profile(named: "sarah chen")?.id, profile.id)
+        XCTAssertNil(try repo.profile(named: "Sarah"))
+        // The old key must not keep enforcing uniqueness either.
+        XCTAssertNoThrow(try repo.save(SpeakerProfile(displayName: "Sarah", identity: identity)))
+    }
+
     func testLookupIgnoresSurroundingWhitespace() throws {
         let profile = SpeakerProfile(displayName: "Sarah", identity: identity)
         try repo.save(profile)

--- a/Tests/MacParakeetTests/Database/SpeakerProfileRepositoryTests.swift
+++ b/Tests/MacParakeetTests/Database/SpeakerProfileRepositoryTests.swift
@@ -322,6 +322,93 @@ final class SpeakerProfileRepositoryTests: XCTestCase {
         )
     }
 
+    func testAConfirmedLinkCannotBecomeDismissed() throws {
+        let profile = try enrolledProfile(named: "Sarah")
+        let transcription = try savedTranscription()
+        var confirmed = link(transcriptionId: transcription.id, profileId: profile.id)
+        confirmed.status = .confirmed
+        try repo.save(confirmed)
+
+        var dismissed = link(transcriptionId: transcription.id, profileId: profile.id)
+        dismissed.status = .dismissed
+        XCTAssertThrowsError(try repo.save(dismissed)) { error in
+            XCTAssertEqual(
+                error as? SpeakerProfileStoreError,
+                .terminalDecisionAlreadyRecorded(status: .confirmed)
+            )
+        }
+        XCTAssertEqual(
+            try repo.links(transcriptionId: transcription.id, fingerprint: "fingerprint")
+                .map(\.status),
+            [.confirmed]
+        )
+    }
+
+    func testADismissedLinkCannotBecomeConfirmed() throws {
+        let profile = try enrolledProfile(named: "Sarah")
+        let transcription = try savedTranscription()
+        var dismissed = link(transcriptionId: transcription.id, profileId: profile.id)
+        dismissed.status = .dismissed
+        try repo.save(dismissed)
+
+        var confirmed = link(transcriptionId: transcription.id, profileId: profile.id)
+        confirmed.status = .confirmed
+        XCTAssertThrowsError(try repo.save(confirmed)) { error in
+            XCTAssertEqual(
+                error as? SpeakerProfileStoreError,
+                .terminalDecisionAlreadyRecorded(status: .dismissed)
+            )
+        }
+        XCTAssertEqual(
+            try repo.links(transcriptionId: transcription.id, fingerprint: "fingerprint")
+                .map(\.status),
+            [.dismissed]
+        )
+    }
+
+    func testATerminalLinkCannotChangeProfile() throws {
+        let sarah = try enrolledProfile(named: "Sarah")
+        let dan = try enrolledProfile(named: "Dan")
+        let transcription = try savedTranscription()
+        var confirmed = link(transcriptionId: transcription.id, profileId: sarah.id)
+        confirmed.status = .confirmed
+        try repo.save(confirmed)
+
+        var moved = link(transcriptionId: transcription.id, profileId: dan.id)
+        moved.status = .confirmed
+        XCTAssertThrowsError(try repo.save(moved)) { error in
+            XCTAssertEqual(
+                error as? SpeakerProfileStoreError,
+                .terminalDecisionAlreadyRecorded(status: .confirmed)
+            )
+        }
+        XCTAssertEqual(
+            try repo.links(transcriptionId: transcription.id, fingerprint: "fingerprint")
+                .map(\.profileId),
+            [sarah.id]
+        )
+    }
+
+    func testRepeatingTheSameTerminalDecisionIsIdempotent() throws {
+        let profile = try enrolledProfile(named: "Sarah")
+        let transcription = try savedTranscription()
+        var confirmed = link(transcriptionId: transcription.id, profileId: profile.id)
+        confirmed.status = .confirmed
+        confirmed.distance = 0.12
+        try repo.save(confirmed)
+
+        var again = link(transcriptionId: transcription.id, profileId: profile.id)
+        again.status = .confirmed
+        again.distance = 0.18
+        XCTAssertNoThrow(try repo.save(again))
+        let stored = try XCTUnwrap(
+            try repo.links(transcriptionId: transcription.id, fingerprint: "fingerprint").first
+        )
+        XCTAssertEqual(stored.status, .confirmed)
+        XCTAssertEqual(stored.profileId, profile.id)
+        XCTAssertEqual(stored.distance, 0.18, accuracy: 0.0001)
+    }
+
     /// The composite foreign key is what makes the model invariant structural
     /// rather than merely enforced in Swift.
     func testTheDatabaseItselfRefusesAMismatchedExemplarModel() throws {
@@ -420,6 +507,58 @@ final class SpeakerProfileRepositoryTests: XCTestCase {
         XCTAssertEqual(try repo.exemplars(profileId: profile.id).count, 1)
     }
 
+    func testAZeroCapRefusesWithoutDeleting() throws {
+        let profile = try enrolledProfile(named: "Sarah")
+        let kept = exemplar(
+            profileId: profile.id, embedding: makeEmbedding(index: 1),
+            origin: .confirmedSuggestion
+        )
+        try repo.insert(kept)
+
+        let outcome = try repo.insertExemplar(
+            exemplar(profileId: profile.id, embedding: makeEmbedding(index: 2)),
+            maxPerProfile: 0,
+            evicting: .confirmedSuggestion
+        )
+
+        XCTAssertEqual(outcome, .rejectedProfileFull)
+        let stored = try repo.exemplars(profileId: profile.id)
+        XCTAssertEqual(stored.map(\.id), [kept.id])
+    }
+
+    /// Shrinking the cap below a profile that already exceeds it must not
+    /// silently delete several user samples just to insert one more.
+    func testAReducedCapAboveTheStoredCountRefusesWithoutDeleting() throws {
+        let profile = try enrolledProfile(named: "Sarah")
+        try repo.insert(
+            exemplar(
+                profileId: profile.id, embedding: makeEmbedding(index: 1),
+                origin: .confirmedSuggestion
+            )
+        )
+        try repo.insert(
+            exemplar(
+                profileId: profile.id, embedding: makeEmbedding(index: 2),
+                origin: .confirmedSuggestion
+            )
+        )
+        try repo.insert(
+            exemplar(
+                profileId: profile.id, embedding: makeEmbedding(index: 3),
+                origin: .confirmedSuggestion
+            )
+        )
+
+        let outcome = try repo.insertExemplar(
+            exemplar(profileId: profile.id, embedding: makeEmbedding(index: 4)),
+            maxPerProfile: 1,
+            evicting: .confirmedSuggestion
+        )
+
+        XCTAssertEqual(outcome, .rejectedProfileFull)
+        XCTAssertEqual(try repo.exemplars(profileId: profile.id).count, 3)
+    }
+
     /// The cap bounds stored biometric data, so it has to hold when several
     /// callers offer samples at once. Counting from outside the transaction
     /// lets each of them read a count below the cap and insert anyway.
@@ -434,14 +573,32 @@ final class SpeakerProfileRepositoryTests: XCTestCase {
             exemplar(profileId: profile.id, embedding: makeEmbedding(index: $0))
         }
 
+        let lock = NSLock()
+        var outcomes: [Result<SpeakerExemplarInsertion, Error>] = []
+        outcomes.reserveCapacity(samples.count)
+
         DispatchQueue.concurrentPerform(iterations: samples.count) { index in
-            _ = try? store.insertExemplar(
-                samples[index],
-                maxPerProfile: 3,
-                evicting: .confirmedSuggestion
-            )
+            let outcome = Result {
+                try store.insertExemplar(
+                    samples[index],
+                    maxPerProfile: 3,
+                    evicting: .confirmedSuggestion
+                )
+            }
+            lock.lock()
+            outcomes.append(outcome)
+            lock.unlock()
         }
 
+        let insertions = try outcomes.map { try $0.get() }
+        let accepted = insertions.filter {
+            switch $0 {
+            case .inserted, .insertedEvicting: return true
+            case .rejectedProfileFull, .rejectedAlreadySampled: return false
+            }
+        }
+        XCTAssertEqual(accepted.count, 3)
+        XCTAssertEqual(insertions.filter { $0 == .rejectedProfileFull }.count, 9)
         XCTAssertEqual(try store.exemplars(profileId: profile.id).count, 3)
     }
 
@@ -491,6 +648,92 @@ final class SpeakerProfileRepositoryTests: XCTestCase {
         ) { error in
             XCTAssertEqual(error as? SpeakerProfileStoreError, .emptyDisplayName)
         }
+    }
+
+    func testAFailedFirstExemplarLeavesNoEmptyProfile() throws {
+        let profile = SpeakerProfile(displayName: "Sarah", identity: identity)
+        let other = SpeakerModelIdentity(
+            embeddingModelId: "other-model", aggregationProfileId: "test-aggregation"
+        )
+        var values = [Float](repeating: 0, count: SpeakerEmbedding.dimension)
+        values[4] = 1
+        let foreign = try XCTUnwrap(SpeakerEmbedding(rawVector: values, identity: other))
+
+        XCTAssertThrowsError(
+            try repo.insert(
+                profile,
+                firstExemplar: exemplar(profileId: profile.id, embedding: foreign),
+                maxPerProfile: 10,
+                evicting: .confirmedSuggestion
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? SpeakerProfileStoreError,
+                .incompatibleEmbeddingModel(profile: "test-model", exemplar: "other-model")
+            )
+        }
+        XCTAssertTrue(try repo.profiles().isEmpty)
+        XCTAssertTrue(try repo.exemplars(profileId: profile.id).isEmpty)
+    }
+
+    func testAZeroCapFirstExemplarLeavesNoProfile() throws {
+        let profile = SpeakerProfile(displayName: "Sarah", identity: identity)
+        let outcome = try repo.insert(
+            profile,
+            firstExemplar: exemplar(profileId: profile.id, embedding: makeEmbedding(index: 1)),
+            maxPerProfile: 0,
+            evicting: .confirmedSuggestion
+        )
+        XCTAssertEqual(outcome, .rejectedProfileFull)
+        XCTAssertTrue(try repo.profiles().isEmpty)
+    }
+
+    func testConcurrentFirstExemplarsOfOneNameLeaveOneInitializedProfile() throws {
+        let store = repo!
+        let identity = identity
+        let attempts = (1...8).map { index -> (SpeakerProfile, SpeakerProfileExemplar) in
+            let profile = SpeakerProfile(displayName: "Sarah", identity: identity)
+            return (
+                profile,
+                exemplar(profileId: profile.id, embedding: makeEmbedding(index: min(index, 10)))
+            )
+        }
+
+        let lock = NSLock()
+        var outcomes: [Result<SpeakerExemplarInsertion, Error>] = []
+        outcomes.reserveCapacity(attempts.count)
+
+        DispatchQueue.concurrentPerform(iterations: attempts.count) { index in
+            let (profile, sample) = attempts[index]
+            let outcome = Result {
+                try store.insert(
+                    profile,
+                    firstExemplar: sample,
+                    maxPerProfile: 10,
+                    evicting: .confirmedSuggestion
+                )
+            }
+            lock.lock()
+            outcomes.append(outcome)
+            lock.unlock()
+        }
+
+        let accepted = try outcomes.compactMap { result -> SpeakerExemplarInsertion? in
+            switch result {
+            case .success(let insertion):
+                return insertion
+            case .failure(let error as SpeakerProfileStoreError):
+                guard case .nameAlreadyTaken = error else { throw error }
+                return nil
+            case .failure(let error):
+                throw error
+            }
+        }
+        XCTAssertEqual(accepted.count, 1)
+        XCTAssertEqual(try XCTUnwrap(accepted.first), .inserted)
+        XCTAssertEqual(try store.profiles().count, 1)
+        let winner = try XCTUnwrap(try store.profiles().first)
+        XCTAssertEqual(try store.exemplars(profileId: winner.id).count, 1)
     }
 
     // MARK: Deletion

--- a/Tests/MacParakeetTests/Database/SpeakerVoiceprintLegacyTranscriptionTests.swift
+++ b/Tests/MacParakeetTests/Database/SpeakerVoiceprintLegacyTranscriptionTests.swift
@@ -1,0 +1,146 @@
+import Foundation
+import GRDB
+import XCTest
+@testable import MacParakeetCore
+
+final class SpeakerVoiceprintLegacyTranscriptionTests: XCTestCase {
+    private let transcriptionId = UUID(uuidString: "DDBBAAEE-1111-1111-1111-111111111111")!
+
+    func testBlobParentSupportsAllVoiceprintChildren() throws {
+        try exerciseChildren(parentKey: transcriptionId.databaseValue)
+    }
+
+    func testUppercaseTextParentSupportsAllVoiceprintChildren() throws {
+        try exerciseChildren(parentKey: transcriptionId.uuidString.databaseValue)
+    }
+
+    func testLowercaseTextParentSupportsAllVoiceprintChildren() throws {
+        try exerciseChildren(parentKey: transcriptionId.uuidString.lowercased().databaseValue)
+    }
+
+    private func exerciseChildren(parentKey: DatabaseValue) throws {
+        let database = try DatabaseManager()
+        let profiles = SpeakerProfileRepository(dbQueue: database.dbQueue)
+        let candidates = SpeakerEmbeddingCandidateRepository(dbQueue: database.dbQueue)
+        let journal = SpeakerMatchJournalRepository(dbQueue: database.dbQueue)
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        try database.dbQueue.write { db in
+            try db.execute(
+                sql: """
+                    INSERT INTO transcriptions (id, createdAt, fileName, updatedAt, sourceType)
+                    VALUES (?, ?, ?, ?, ?)
+                    """,
+                arguments: [parentKey, now, "Legacy meeting", now, "meeting"]
+            )
+        }
+        let identity = SpeakerModelIdentity(embeddingModelId: "test", aggregationProfileId: "test")
+        var vector = [Float](repeating: 0, count: SpeakerEmbedding.dimension)
+        vector[0] = 1
+        let embedding = try XCTUnwrap(SpeakerEmbedding(rawVector: vector, identity: identity))
+        let profile = SpeakerProfile(displayName: "Sarah", identity: identity)
+        let exemplar = SpeakerProfileExemplar(
+            profileId: profile.id, embedding: embedding, speechSeconds: 30,
+            captureDomain: .system, origin: .manualEnrollment,
+            sourceTranscriptionId: transcriptionId, sourceSpeakerId: "S1"
+        )
+        XCTAssertEqual(
+            try profiles.insert(profile, firstExemplar: exemplar, maxPerProfile: 5, evicting: .confirmedSuggestion),
+            .inserted
+        )
+        XCTAssertEqual(try profiles.exemplars(profileId: profile.id).first?.sourceTranscriptionId, transcriptionId)
+        XCTAssertEqual(
+            try profiles.insertExemplar(exemplar, maxPerProfile: 5, evicting: .confirmedSuggestion),
+            .rejectedAlreadySampled
+        )
+
+        // Both other exemplar insertion paths must resolve the same source FK.
+        for (name, capped) in [("Alex", false), ("Jordan", true)] {
+            let other = SpeakerProfile(displayName: name, identity: identity)
+            try profiles.insert(other)
+            var sample = exemplar
+            sample.id = UUID()
+            sample.profileId = other.id
+            if capped {
+                XCTAssertEqual(
+                    try profiles.insertExemplar(sample, maxPerProfile: 5, evicting: .confirmedSuggestion), .inserted
+                )
+            } else {
+                try profiles.insert(sample)
+            }
+        }
+
+        var candidate = SpeakerEmbeddingCandidate(
+            transcriptionId: transcriptionId, speakerId: "S1", transcriptFingerprint: "fingerprint",
+            embedding: embedding, speechSeconds: 30, captureDomain: .system,
+            createdAt: now, expiresAt: now.addingTimeInterval(60)
+        )
+        try candidates.upsert([candidate], now: now)
+        candidate.id = UUID()
+        candidate.speechSeconds = 45
+        try candidates.upsert([candidate], now: now)
+        XCTAssertEqual(
+            try candidates.candidate(
+                transcriptionId: transcriptionId, speakerId: "S1", fingerprint: "fingerprint", now: now
+            ), candidate
+        )
+        try candidates.delete(transcriptionId: transcriptionId, speakerId: "S1", fingerprint: "fingerprint")
+        XCTAssertNil(
+            try candidates.candidate(
+                transcriptionId: transcriptionId, speakerId: "S1", fingerprint: "fingerprint", now: now
+            )
+        )
+        try candidates.upsert([candidate], now: now)
+
+        var link = SpeakerProfileLink(
+            transcriptionId: transcriptionId, speakerId: "S1", transcriptFingerprint: "fingerprint",
+            profileId: profile.id, status: .suggested, distance: 0.1, createdAt: now, updatedAt: now
+        )
+        try profiles.save(link)
+        link.status = .confirmed
+        try profiles.save(link)
+        XCTAssertEqual(try profiles.links(transcriptionId: transcriptionId, fingerprint: "fingerprint"), [link])
+
+        var pending = link
+        pending.status = .suggested
+        pending.transcriptFingerprint = "other-fingerprint"
+        XCTAssertEqual(
+            try profiles.replaceSuggestions(
+                transcriptionId: transcriptionId, fingerprint: "other-fingerprint", with: [pending]
+            ), [pending]
+        )
+        _ = try profiles.replaceSuggestions(
+            transcriptionId: transcriptionId, fingerprint: "other-fingerprint", with: [])
+        XCTAssertTrue(try profiles.links(transcriptionId: transcriptionId, fingerprint: "other-fingerprint").isEmpty)
+        XCTAssertEqual(try profiles.links(transcriptionId: transcriptionId, fingerprint: "fingerprint"), [link])
+
+        let entry = SpeakerMatchJournalEntry(
+            transcriptionId: transcriptionId, speakerId: "S1", transcriptFingerprint: "fingerprint",
+            profileId: profile.id, outcome: .suggested, speechSeconds: 30, createdAt: now
+        )
+        try journal.append([entry], retention: 60, now: now)
+        XCTAssertEqual(try journal.entries(retention: 60, now: now), [entry])
+
+        try database.dbQueue.write { db in
+            for (table, column) in [
+                ("speaker_profile_exemplars", "sourceTranscriptionId"),
+                ("speaker_profile_links", "transcriptionId"),
+                ("speaker_embedding_candidates", "transcriptionId"),
+                ("speaker_match_journal", "transcriptionId"),
+            ] {
+                for row in try Row.fetchAll(db, sql: "SELECT \(column) AS storedKey FROM \(table)") {
+                    XCTAssertEqual(row["storedKey"] as DatabaseValue, parentKey)
+                }
+            }
+            let parent = try XCTUnwrap(try Row.fetchOne(db, sql: "SELECT id FROM transcriptions"))
+            XCTAssertEqual(parent["id"] as DatabaseValue, parentKey)
+            // Delete the actual parent key. The unrelated legacy behavior of
+            // TranscriptionRepository.delete is deliberately outside this test.
+            try db.execute(sql: "DELETE FROM transcriptions WHERE id = ?", arguments: [parentKey])
+            XCTAssertEqual(try SpeakerProfileLink.fetchCount(db), 0)
+            XCTAssertEqual(try SpeakerEmbeddingCandidate.fetchCount(db), 0)
+            XCTAssertEqual(try SpeakerMatchJournalEntry.fetchCount(db), 0)
+            XCTAssertEqual(try SpeakerProfileExemplar.fetchCount(db), 3)
+            XCTAssertTrue(try SpeakerProfileExemplar.fetchAll(db).allSatisfy { $0.sourceTranscriptionId == nil })
+        }
+    }
+}

--- a/Tests/MacParakeetTests/Services/Diarization/DiarizationServiceEmbeddingTests.swift
+++ b/Tests/MacParakeetTests/Services/Diarization/DiarizationServiceEmbeddingTests.swift
@@ -146,6 +146,17 @@ final class DiarizationServiceEmbeddingTests: XCTestCase {
         XCTAssertNotEqual(baseIdentity.aggregationProfileId, alteredIdentity.aggregationProfileId)
     }
 
+    func testAggregationProfileChangesWithVBxRefinement() {
+        let base = DiarizationService.highAccuracyConfig
+        var altered = base
+        altered.vbx.maxIterations += 1
+
+        XCTAssertNotEqual(
+            DiarizationService.modelIdentity(for: base).aggregationProfileId,
+            DiarizationService.modelIdentity(for: altered).aggregationProfileId
+        )
+    }
+
     /// A per-run speaker count is a caller hint, not a different representation:
     /// folding it into the identity would make a profile enrolled under a hint
     /// incomparable with the same voice heard without one.

--- a/Tests/MacParakeetTests/Services/Diarization/DiarizationServiceEmbeddingTests.swift
+++ b/Tests/MacParakeetTests/Services/Diarization/DiarizationServiceEmbeddingTests.swift
@@ -118,6 +118,20 @@ final class DiarizationServiceEmbeddingTests: XCTestCase {
         XCTAssertTrue(result.speakerEmbeddings.isEmpty)
     }
 
+    /// The gates are in seconds and everything else here is in milliseconds, so
+    /// the conversion lives in one tested place rather than at each call site.
+    func testSpeechSecondsConvertsFromMilliseconds() {
+        let result = MacParakeetDiarizationResult(
+            segments: [],
+            speakerCount: 1,
+            speakers: [SpeakerInfo(id: "S1", label: "Speaker 1")],
+            speechMsBySpeaker: ["S1": 12_500]
+        )
+
+        XCTAssertEqual(result.speechSeconds(forSpeaker: "S1"), 12.5, accuracy: 1e-9)
+        XCTAssertEqual(result.speechSeconds(forSpeaker: "S2"), 0)
+    }
+
     // MARK: Model identity
 
     func testAggregationProfileChangesWithClusteringConfiguration() {

--- a/Tests/MacParakeetTests/Services/Diarization/DiarizationServiceEmbeddingTests.swift
+++ b/Tests/MacParakeetTests/Services/Diarization/DiarizationServiceEmbeddingTests.swift
@@ -1,0 +1,189 @@
+import XCTest
+import FluidAudio
+@testable import MacParakeetCore
+
+/// Covers what the diarization adapter now carries out of FluidAudio:
+/// per-speaker embeddings, rekeyed onto our stable ids, plus speech durations.
+final class DiarizationServiceEmbeddingTests: XCTestCase {
+
+    private static let identity = SpeakerModelIdentity(
+        embeddingModelId: "test-model",
+        aggregationProfileId: "test-aggregation"
+    )
+
+    private func unitVector(_ index: Int, scale: Float = 1) -> [Float] {
+        var values = [Float](repeating: 0, count: SpeakerEmbedding.dimension)
+        values[index] = scale
+        return values
+    }
+
+    // MARK: Rekeying
+
+    /// FluidAudio numbers clusters by cluster index; we renumber by who speaks
+    /// first. Both use the "S1", "S2" shape, so carrying the database keys over
+    /// untouched would attach one speaker's voice to another's label without
+    /// any type error to catch it.
+    func testEmbeddingsFollowTheChronologicalRemapNotTheFluidAudioKeys() throws {
+        let embeddings = DiarizationService.speakerEmbeddings(
+            from: ["S1": unitVector(0), "S2": unitVector(1)],
+            idMapping: ["S2": "S1", "S1": "S2"],
+            identity: Self.identity
+        )
+
+        XCTAssertEqual(embeddings.count, 2)
+        XCTAssertEqual(try XCTUnwrap(embeddings["S1"]).vector, unitVector(1))
+        XCTAssertEqual(try XCTUnwrap(embeddings["S2"]).vector, unitVector(0))
+    }
+
+    func testEmbeddingsAreNormalizedOnTheWayOut() throws {
+        let embeddings = DiarizationService.speakerEmbeddings(
+            from: ["S1": unitVector(0, scale: 0.42)],
+            idMapping: ["S1": "S1"],
+            identity: Self.identity
+        )
+
+        XCTAssertEqual(try XCTUnwrap(embeddings["S1"]).vector, unitVector(0))
+    }
+
+    func testUnmappedSpeakersAreDropped() {
+        let embeddings = DiarizationService.speakerEmbeddings(
+            from: ["S1": unitVector(0), "S9": unitVector(1)],
+            idMapping: ["S1": "S1"],
+            identity: Self.identity
+        )
+
+        XCTAssertEqual(Set(embeddings.keys), ["S1"])
+    }
+
+    func testZeroVectorSpeakerIsDroppedFromTheDictionary() {
+        let embeddings = DiarizationService.speakerEmbeddings(
+            from: [
+                "S1": [Float](repeating: 0, count: SpeakerEmbedding.dimension),
+                "S2": unitVector(1),
+            ],
+            idMapping: ["S1": "S1", "S2": "S2"],
+            identity: Self.identity
+        )
+
+        XCTAssertEqual(Set(embeddings.keys), ["S2"])
+    }
+
+    func testMissingSpeakerDatabaseYieldsNoEmbeddings() {
+        XCTAssertTrue(
+            DiarizationService.speakerEmbeddings(
+                from: nil,
+                idMapping: ["S1": "S1"],
+                identity: Self.identity
+            ).isEmpty
+        )
+    }
+
+    // MARK: End to end through the service
+
+    func testDiarizeSurfacesEmbeddingsAndDurationsWithoutChangingLabels() async throws {
+        let service = makeService(
+            result: DiarizationResult(
+                segments: [
+                    // FluidAudio's "S2" speaks first, so it becomes our "S1".
+                    segment(speakerId: "S2", from: 0, to: 4),
+                    segment(speakerId: "S1", from: 4, to: 10),
+                    segment(speakerId: "S2", from: 10, to: 12),
+                ],
+                speakerDatabase: ["S1": unitVector(0), "S2": unitVector(1, scale: 0.6)]
+            )
+        )
+
+        let result = try await service.diarize(audioURL: URL(fileURLWithPath: "/tmp/meeting.wav"))
+
+        XCTAssertEqual(result.speakers.map(\.id), ["S1", "S2"])
+        XCTAssertEqual(result.speakers.map(\.label), ["Speaker 1", "Speaker 2"])
+        XCTAssertEqual(result.speakerCount, 2)
+
+        // 4 s + 2 s for the first speaker, 6 s for the second.
+        XCTAssertEqual(result.speechMsBySpeaker, ["S1": 6000, "S2": 6000])
+
+        XCTAssertEqual(try XCTUnwrap(result.speakerEmbeddings["S1"]).vector, unitVector(1))
+        XCTAssertEqual(try XCTUnwrap(result.speakerEmbeddings["S2"]).vector, unitVector(0))
+    }
+
+    func testDiarizeWithoutEmbeddingsStillReturnsSegments() async throws {
+        let service = makeService(
+            result: DiarizationResult(segments: [segment(speakerId: "S1", from: 0, to: 3)])
+        )
+
+        let result = try await service.diarize(audioURL: URL(fileURLWithPath: "/tmp/meeting.wav"))
+
+        XCTAssertEqual(result.segments.count, 1)
+        XCTAssertEqual(result.speechMsBySpeaker, ["S1": 3000])
+        XCTAssertTrue(result.speakerEmbeddings.isEmpty)
+    }
+
+    // MARK: Model identity
+
+    func testAggregationProfileChangesWithClusteringConfiguration() {
+        let base = DiarizationService.highAccuracyConfig
+        var altered = base
+        altered.clustering.threshold += 0.1
+
+        let baseIdentity = DiarizationService.modelIdentity(for: base)
+        let alteredIdentity = DiarizationService.modelIdentity(for: altered)
+
+        XCTAssertEqual(baseIdentity.embeddingModelId, alteredIdentity.embeddingModelId)
+        XCTAssertNotEqual(baseIdentity.aggregationProfileId, alteredIdentity.aggregationProfileId)
+    }
+
+    /// A per-run speaker count is a caller hint, not a different representation:
+    /// folding it into the identity would make a profile enrolled under a hint
+    /// incomparable with the same voice heard without one.
+    func testAggregationProfileIgnoresPerRunSpeakerConstraints() {
+        let base = DiarizationService.highAccuracyConfig
+        let constrained = DiarizationService.applying(.exact(3), to: base)
+
+        XCTAssertEqual(
+            DiarizationService.modelIdentity(for: base),
+            DiarizationService.modelIdentity(for: constrained)
+        )
+    }
+
+    func testAggregationProfileIsStableAcrossCalls() {
+        XCTAssertEqual(
+            DiarizationService.modelIdentity(for: DiarizationService.highAccuracyConfig),
+            DiarizationService.modelIdentity(for: DiarizationService.highAccuracyConfig)
+        )
+    }
+
+    // MARK: Helpers
+
+    private func segment(speakerId: String, from start: Float, to end: Float) -> TimedSpeakerSegment {
+        TimedSpeakerSegment(
+            speakerId: speakerId,
+            embedding: [Float](repeating: 0, count: SpeakerEmbedding.dimension),
+            startTimeSeconds: start,
+            endTimeSeconds: end,
+            qualityScore: 1
+        )
+    }
+
+    private func makeService(result: DiarizationResult) -> DiarizationService {
+        let manager = StubOfflineDiarizerManager(result: result)
+        return DiarizationService(
+            loadManagerFactory: { _ in { _ in manager } },
+            modelsDirectory: FileManager.default.temporaryDirectory,
+            explicitConstraint: nil,
+            inferenceGate: ANEInferenceGate(serializationRequired: false),
+            modelIdentity: Self.identity
+        )
+    }
+}
+
+private final class StubOfflineDiarizerManager: OfflineDiarizerManaging, @unchecked Sendable {
+    private let result: DiarizationResult
+
+    init(result: DiarizationResult) {
+        self.result = result
+    }
+
+    func process(audioURL: URL) async throws -> DiarizationResult {
+        result
+    }
+}

--- a/Tests/MacParakeetTests/Services/Diarization/SpeakerEmbeddingTests.swift
+++ b/Tests/MacParakeetTests/Services/Diarization/SpeakerEmbeddingTests.swift
@@ -1,0 +1,164 @@
+import XCTest
+@testable import MacParakeetCore
+
+final class SpeakerEmbeddingTests: XCTestCase {
+
+    // MARK: Fixtures
+
+    /// Orthonormal basis vectors from a fixed seed, so distances are exact
+    /// rather than approximate: a voice is `e_i`, and a noisy observation at
+    /// angle theta is `cos(theta) * e_i + sin(theta) * e_j`, whose cosine
+    /// distance to `e_i` is exactly `1 - cos(theta)`.
+    private static func basisVector(_ index: Int) -> [Float] {
+        var values = [Float](repeating: 0, count: SpeakerEmbedding.dimension)
+        values[index] = 1
+        return values
+    }
+
+    private static func observation(of speaker: Int, towards other: Int, degrees: Double) -> [Float] {
+        let radians = degrees * .pi / 180
+        var values = [Float](repeating: 0, count: SpeakerEmbedding.dimension)
+        values[speaker] = Float(cos(radians))
+        values[other] = Float(sin(radians))
+        return values
+    }
+
+    private static let identity = SpeakerModelIdentity(
+        embeddingModelId: "test-model",
+        aggregationProfileId: "test-aggregation"
+    )
+
+    private func embedding(
+        _ raw: [Float],
+        identity: SpeakerModelIdentity = SpeakerEmbeddingTests.identity
+    ) -> SpeakerEmbedding {
+        guard let embedding = SpeakerEmbedding(rawVector: raw, identity: identity) else {
+            preconditionFailure("fixture vector must be valid")
+        }
+        return embedding
+    }
+
+    // MARK: Normalization
+
+    func testInitNormalizesToUnitLength() {
+        let scaled = Self.observation(of: 0, towards: 1, degrees: 25).map { $0 * 0.83 }
+        let embedding = embedding(scaled)
+
+        let norm = embedding.vector.reduce(Float(0)) { $0 + $1 * $1 }.squareRoot()
+        XCTAssertEqual(norm, 1, accuracy: 1e-5)
+    }
+
+    /// The regression that matters: an un-normalized pair must produce the same
+    /// decision as a normalized one, *and* the bare dot product must be shown to
+    /// differ — otherwise this test would still pass if normalization were
+    /// removed.
+    func testScalingDoesNotChangeDistanceButWouldChangeABareDotProduct() throws {
+        let rawA = Self.basisVector(0).map { $0 * 0.85 }
+        let rawB = Self.observation(of: 0, towards: 1, degrees: 25).map { $0 * 0.85 }
+
+        let distance = try XCTUnwrap(embedding(rawA).cosineDistance(to: embedding(rawB)))
+        let expected = 1 - cos(25 * Double.pi / 180)
+        XCTAssertEqual(distance, expected, accuracy: 1e-5)
+
+        // What the July plan's "embeddings are already normalized" shortcut
+        // would have computed instead.
+        let bareDot = zip(rawA, rawB).reduce(Float(0)) { $0 + $1.0 * $1.1 }
+        let bareDistance = 1 - Double(bareDot)
+        XCTAssertGreaterThan(bareDistance - distance, 0.15)
+    }
+
+    func testDistanceToOwnScaledCopyIsZero() throws {
+        let raw = Self.observation(of: 3, towards: 7, degrees: 40)
+        let distance = try XCTUnwrap(
+            embedding(raw).cosineDistance(to: embedding(raw.map { $0 * 0.5 }))
+        )
+        XCTAssertEqual(distance, 0, accuracy: 1e-6)
+    }
+
+    func testDistanceMatchesTheFixtureAngle() throws {
+        for degrees in [0.0, 25.0, 41.4, 60.0] {
+            let distance = try XCTUnwrap(
+                embedding(Self.basisVector(0))
+                    .cosineDistance(to: embedding(Self.observation(of: 0, towards: 1, degrees: degrees)))
+            )
+            XCTAssertEqual(distance, 1 - cos(degrees * .pi / 180), accuracy: 1e-5)
+        }
+    }
+
+    // MARK: Rejected input
+
+    func testRejectsZeroVector() {
+        // FluidAudio emits this when a cluster's responsibility denominator is zero.
+        let zeros = [Float](repeating: 0, count: SpeakerEmbedding.dimension)
+        XCTAssertNil(SpeakerEmbedding(rawVector: zeros, identity: Self.identity))
+    }
+
+    func testRejectsVectorBelowMinimumNorm() {
+        let tiny = Self.basisVector(0).map { $0 * 1e-9 }
+        XCTAssertNil(SpeakerEmbedding(rawVector: tiny, identity: Self.identity))
+    }
+
+    func testRejectsNonFiniteValues() {
+        var withNaN = Self.basisVector(0)
+        withNaN[5] = .nan
+        XCTAssertNil(SpeakerEmbedding(rawVector: withNaN, identity: Self.identity))
+
+        var withInfinity = Self.basisVector(0)
+        withInfinity[5] = .infinity
+        XCTAssertNil(SpeakerEmbedding(rawVector: withInfinity, identity: Self.identity))
+    }
+
+    func testRejectsWrongDimension() {
+        XCTAssertNil(SpeakerEmbedding(rawVector: [1, 0, 0], identity: Self.identity))
+        XCTAssertNil(
+            SpeakerEmbedding(
+                rawVector: [Float](repeating: 0.1, count: SpeakerEmbedding.dimension + 1),
+                identity: Self.identity
+            )
+        )
+    }
+
+    // MARK: Storage round trip
+
+    func testDataRoundTripIsBitExact() throws {
+        let original = embedding(Self.observation(of: 2, towards: 9, degrees: 33))
+        let data = original.data
+        XCTAssertEqual(data.count, SpeakerEmbedding.byteCount)
+        XCTAssertEqual(data.count, 1024)
+
+        let restored = try XCTUnwrap(SpeakerEmbedding(data: data, identity: Self.identity))
+        XCTAssertEqual(restored.vector, original.vector)
+        XCTAssertEqual(restored, original)
+    }
+
+    func testRejectsDataOfWrongLength() {
+        let short = Data(repeating: 0, count: SpeakerEmbedding.byteCount - 4)
+        XCTAssertNil(SpeakerEmbedding(data: short, identity: Self.identity))
+    }
+
+    func testRejectsDataThatIsNotUnitLength() {
+        // A vector that never went through `init?(rawVector:)`, so the stored
+        // invariant does not hold: reject rather than silently rescale.
+        var raw = Data()
+        for _ in 0..<SpeakerEmbedding.dimension {
+            withUnsafeBytes(of: Float(0.5).bitPattern.littleEndian) { raw.append(contentsOf: $0) }
+        }
+        XCTAssertNil(SpeakerEmbedding(data: raw, identity: Self.identity))
+    }
+
+    // MARK: Model identity
+
+    func testDistanceIsUnavailableAcrossEmbeddingModels() {
+        let other = SpeakerModelIdentity(embeddingModelId: "other-model", aggregationProfileId: "test-aggregation")
+        let lhs = embedding(Self.basisVector(0))
+        let rhs = embedding(Self.basisVector(0), identity: other)
+        XCTAssertNil(lhs.cosineDistance(to: rhs))
+    }
+
+    func testDistanceIsAvailableAcrossAggregationProfiles() throws {
+        let other = SpeakerModelIdentity(embeddingModelId: "test-model", aggregationProfileId: "other-aggregation")
+        let lhs = embedding(Self.basisVector(0))
+        let rhs = embedding(Self.basisVector(0), identity: other)
+        XCTAssertEqual(try XCTUnwrap(lhs.cosineDistance(to: rhs)), 0, accuracy: 1e-6)
+    }
+}

--- a/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintDeletionTests.swift
+++ b/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintDeletionTests.swift
@@ -1,0 +1,102 @@
+import Foundation
+import GRDB
+import XCTest
+@testable import MacParakeetCore
+
+final class SpeakerVoiceprintDeletionTests: XCTestCase {
+    func testDeletingAllProfilesAlsoDeletesUnownedCandidatesAndJournalRows() async throws {
+        let (database, profiles) = try await populatedStore()
+        try profiles.deleteAllProfiles()
+        XCTAssertTrue(try voiceRowCounts(database).allSatisfy { $0 == 0 })
+        XCTAssertEqual(try transcriptionCount(database), 1)
+    }
+
+    func testGlobalDeletionRollsBackEveryTableWhenProfileDeletionFails() async throws {
+        let (database, profiles) = try await populatedStore()
+        let before = try voiceRowCounts(database)
+        try await database.dbQueue.write { db in
+            try db.execute(
+                sql: """
+                    CREATE TRIGGER reject_profile_delete BEFORE DELETE ON speaker_profiles
+                    BEGIN SELECT RAISE(ABORT, 'test deletion failure'); END
+                    """)
+        }
+        XCTAssertThrowsError(try profiles.deleteAllProfiles())
+        XCTAssertEqual(try voiceRowCounts(database), before)
+        XCTAssertEqual(try transcriptionCount(database), 1)
+    }
+
+    func testAnUpdateCannotRecreateADeletedProfile() throws {
+        let database = try DatabaseManager()
+        let profiles = SpeakerProfileRepository(dbQueue: database.dbQueue)
+        let profile = SpeakerProfile(
+            displayName: "Forgotten Person",
+            identity: SpeakerModelIdentity(embeddingModelId: "test", aggregationProfileId: "test")
+        )
+        try profiles.insert(profile)
+        XCTAssertTrue(try profiles.deleteProfile(id: profile.id))
+        XCTAssertThrowsError(try profiles.save(profile))
+        XCTAssertNil(try profiles.profile(id: profile.id))
+    }
+
+    private func populatedStore() async throws -> (DatabaseManager, SpeakerProfileRepository) {
+        let database = try DatabaseManager()
+        let profiles = SpeakerProfileRepository(dbQueue: database.dbQueue)
+        let journal = SpeakerMatchJournalRepository(dbQueue: database.dbQueue)
+        let service = SpeakerVoiceprintService(
+            profiles: profiles,
+            candidates: SpeakerEmbeddingCandidateRepository(dbQueue: database.dbQueue),
+            journal: journal, isEnabled: { true }
+        )
+        let recording = Transcription(fileName: "meeting.wav", status: .completed)
+        try TranscriptionRepository(dbQueue: database.dbQueue).save(recording)
+        var vector = [Float](repeating: 0, count: 256)
+        vector[0] = 1
+        let observation = SpeakerClusterObservation(
+            speakerId: "system:S1",
+            embedding: try XCTUnwrap(
+                SpeakerEmbedding(
+                    rawVector: vector,
+                    identity: SpeakerModelIdentity(embeddingModelId: "test", aggregationProfileId: "test")
+                )),
+            speechSeconds: 30, captureDomain: .system
+        )
+        let fingerprint = SpeakerAttributionResolver.fingerprint(for: recording)
+        _ = try await service.enroll(
+            displayName: "Remembered Person", observation: observation,
+            transcriptionId: recording.id, fingerprint: fingerprint, allowMergeIntoExistingName: false
+        )
+        _ = try await service.evaluate(
+            transcriptionId: recording.id, fingerprint: fingerprint, clusters: [observation]
+        )
+        // This decision has no profile FK, so deleting profile rows cannot
+        // remove it through a cascade.
+        try journal.append(
+            [
+                SpeakerMatchJournalEntry(
+                    transcriptionId: recording.id, speakerId: "system:S2",
+                    transcriptFingerprint: fingerprint.rawValue,
+                    outcome: .noComparableProfile, speechSeconds: 30, createdAt: Date()
+                )
+            ], retention: SpeakerMatchJournalRepository.defaultRetention, now: Date())
+        XCTAssertTrue(try voiceRowCounts(database).allSatisfy { $0 > 0 })
+        return (database, profiles)
+    }
+
+    private func voiceRowCounts(_ database: DatabaseManager) throws -> [Int] {
+        try database.dbQueue.read { db in
+            try [
+                "speaker_profiles", "speaker_profile_exemplars", "speaker_profile_links",
+                "speaker_embedding_candidates", "speaker_match_journal",
+            ].map { table in
+                try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM \(table)")!
+            }
+        }
+    }
+
+    private func transcriptionCount(_ database: DatabaseManager) throws -> Int {
+        try database.dbQueue.read { db in
+            try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM transcriptions")!
+        }
+    }
+}

--- a/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintExportTests.swift
+++ b/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintExportTests.swift
@@ -1,0 +1,70 @@
+import Foundation
+import GRDB
+import XCTest
+@testable import MacParakeetCore
+
+final class SpeakerVoiceprintExportTests: XCTestCase {
+    func testPopulatedVoiceprintTablesDoNotEnterTranscriptExports() async throws {
+        let database = try DatabaseManager()
+        let transcriptions = TranscriptionRepository(dbQueue: database.dbQueue)
+        let profiles = SpeakerProfileRepository(dbQueue: database.dbQueue)
+        let service = SpeakerVoiceprintService(
+            profiles: profiles,
+            candidates: SpeakerEmbeddingCandidateRepository(dbQueue: database.dbQueue),
+            journal: SpeakerMatchJournalRepository(dbQueue: database.dbQueue),
+            isEnabled: { true }
+        )
+        let enrollment = Transcription(fileName: "enrollment.wav", status: .completed)
+        let meeting = Transcription(
+            fileName: "meeting.wav", rawTranscript: "Hello from the meeting.",
+            speakerCount: 1, speakers: [SpeakerInfo(id: "system:S1", label: "Others 1")],
+            status: .completed
+        )
+        try transcriptions.save(enrollment)
+        try transcriptions.save(meeting)
+        let output = FileManager.default.temporaryDirectory
+            .appendingPathComponent("voiceprint-export-\(UUID().uuidString).json")
+        defer { try? FileManager.default.removeItem(at: output) }
+        let exporter = ExportService()
+        try exporter.exportToJSON(transcription: meeting, url: output)
+        let before = try Data(contentsOf: output)
+        var vector = [Float](repeating: 0, count: 256)
+        vector[0] = 1
+        let embedding = try XCTUnwrap(SpeakerEmbedding(
+            rawVector: vector,
+            identity: SpeakerModelIdentity(embeddingModelId: "private-model", aggregationProfileId: "private-config")
+        ))
+        let observation = SpeakerClusterObservation(
+            speakerId: "system:S1", embedding: embedding, speechSeconds: 30, captureDomain: .system
+        )
+        _ = try await service.enroll(
+            displayName: "VoiceprintOnlyName", observation: observation,
+            transcriptionId: enrollment.id,
+            fingerprint: SpeakerAttributionResolver.fingerprint(for: enrollment),
+            allowMergeIntoExistingName: false
+        )
+        let suggestions = try await service.evaluate(
+            transcriptionId: meeting.id,
+            fingerprint: SpeakerAttributionResolver.fingerprint(for: meeting), clusters: [observation]
+        )
+        XCTAssertEqual(suggestions.count, 1)
+        try await database.dbQueue.read { db in
+            for table in ["speaker_profiles", "speaker_profile_exemplars", "speaker_profile_links",
+                          "speaker_match_journal", "speaker_embedding_candidates"] {
+                XCTAssertEqual(try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM \(table)"), 1, table)
+            }
+        }
+        try exporter.exportToJSON(transcription: meeting, url: output)
+        XCTAssertEqual(try Data(contentsOf: output), before)
+        let rendered = [
+            String(decoding: before, as: UTF8.self), exporter.formatPlainText(transcription: meeting),
+            exporter.formatMarkdown(transcription: meeting), exporter.formatSRT(transcription: meeting),
+            exporter.formatVTT(transcription: meeting), exporter.formatDAPT(transcription: meeting),
+        ]
+        for text in rendered {
+            for secret in ["VoiceprintOnlyName", "private-model", "private-config", suggestions[0].profileId.uuidString] {
+                XCTAssertFalse(text.contains(secret))
+            }
+        }
+    }
+}

--- a/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintExportTests.swift
+++ b/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintExportTests.swift
@@ -30,10 +30,12 @@ final class SpeakerVoiceprintExportTests: XCTestCase {
         let before = try Data(contentsOf: output)
         var vector = [Float](repeating: 0, count: 256)
         vector[0] = 1
-        let embedding = try XCTUnwrap(SpeakerEmbedding(
-            rawVector: vector,
-            identity: SpeakerModelIdentity(embeddingModelId: "private-model", aggregationProfileId: "private-config")
-        ))
+        let embedding = try XCTUnwrap(
+            SpeakerEmbedding(
+                rawVector: vector,
+                identity: SpeakerModelIdentity(
+                    embeddingModelId: "private-model", aggregationProfileId: "private-config")
+            ))
         let observation = SpeakerClusterObservation(
             speakerId: "system:S1", embedding: embedding, speechSeconds: 30, captureDomain: .system
         )
@@ -49,8 +51,10 @@ final class SpeakerVoiceprintExportTests: XCTestCase {
         )
         XCTAssertEqual(suggestions.count, 1)
         try await database.dbQueue.read { db in
-            for table in ["speaker_profiles", "speaker_profile_exemplars", "speaker_profile_links",
-                          "speaker_match_journal", "speaker_embedding_candidates"] {
+            for table in [
+                "speaker_profiles", "speaker_profile_exemplars", "speaker_profile_links",
+                "speaker_match_journal", "speaker_embedding_candidates",
+            ] {
                 XCTAssertEqual(try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM \(table)"), 1, table)
             }
         }
@@ -62,7 +66,9 @@ final class SpeakerVoiceprintExportTests: XCTestCase {
             exporter.formatVTT(transcription: meeting), exporter.formatDAPT(transcription: meeting),
         ]
         for text in rendered {
-            for secret in ["VoiceprintOnlyName", "private-model", "private-config", suggestions[0].profileId.uuidString] {
+            for secret in [
+                "VoiceprintOnlyName", "private-model", "private-config", suggestions[0].profileId.uuidString,
+            ] {
                 XCTAssertFalse(text.contains(secret))
             }
         }

--- a/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintMatcherTests.swift
+++ b/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintMatcherTests.swift
@@ -144,6 +144,51 @@ final class SpeakerVoiceprintMatcherTests: XCTestCase {
         XCTAssertTrue(suggestions.isEmpty)
     }
 
+    /// The tie rule must not depend on how the margin is configured: at
+    /// `margin: 0` the difference check passes and position alone would decide.
+    func testExactTieSuggestsNobodyEvenWithoutAMargin() {
+        let zeroMargin = SpeakerMatchPolicy(
+            tau: policy.tau,
+            margin: 0,
+            minSpeechSecondsToMatch: policy.minSpeechSecondsToMatch,
+            minSpeechSecondsToEnroll: policy.minSpeechSecondsToEnroll,
+            maxReferencesPerProfile: policy.maxReferencesPerProfile,
+            crossAggregationPenalty: policy.crossAggregationPenalty,
+            pollutionGuardDistance: policy.pollutionGuardDistance
+        )
+
+        let suggestions = SpeakerVoiceprintMatcher.match(
+            clusters: [cluster("S1", voice: 0, degrees: Angle.close)],
+            profiles: [profile("Sarah", voice: 0), profile("Sasha", voice: 0)],
+            policy: zeroMargin
+        )
+        XCTAssertTrue(suggestions.isEmpty)
+    }
+
+    /// A negative cap reaches `prefix`, whose precondition would bring matching
+    /// down; the policy clamps it instead.
+    func testANegativeReferenceCapIsClampedRatherThanFatal() {
+        let negative = SpeakerMatchPolicy(
+            tau: policy.tau,
+            margin: policy.margin,
+            minSpeechSecondsToMatch: policy.minSpeechSecondsToMatch,
+            minSpeechSecondsToEnroll: policy.minSpeechSecondsToEnroll,
+            maxReferencesPerProfile: -3,
+            crossAggregationPenalty: policy.crossAggregationPenalty,
+            pollutionGuardDistance: policy.pollutionGuardDistance
+        )
+        XCTAssertEqual(negative.maxReferencesPerProfile, 0)
+
+        // No references are scored, so nothing is proposed — and nothing traps.
+        XCTAssertTrue(
+            SpeakerVoiceprintMatcher.match(
+                clusters: [cluster("S1", voice: 0, degrees: 0)],
+                profiles: [profile("Sarah", voice: 0)],
+                policy: negative
+            ).isEmpty
+        )
+    }
+
     // MARK: Injectivity
 
     func testOneProfileIsNeverSuggestedForTwoSpeakers() {

--- a/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintMatcherTests.swift
+++ b/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintMatcherTests.swift
@@ -238,6 +238,43 @@ final class SpeakerVoiceprintMatcherTests: XCTestCase {
         )
     }
 
+    /// A profile that straddles a FluidAudio upgrade holds one exemplar from
+    /// each aggregation. The penalty must follow the reference that actually
+    /// won, otherwise the presence of a current exemplar would buy full trust
+    /// for a decision an older one made.
+    func testThePenaltyFollowsTheWinningReferenceNotTheProfile() {
+        let old = SpeakerModelIdentity(
+            embeddingModelId: Self.identity.embeddingModelId,
+            aggregationProfileId: "pre-upgrade"
+        )
+        let borderline = 38.5  // 0.217: clears tau, not tau minus the penalty.
+
+        let straddling = SpeakerProfileCandidate(
+            profileId: UUID(),
+            displayName: "Sarah",
+            references: [
+                // Closest, but from the old aggregation.
+                reference(voice: 0, degrees: 0, identity: old),
+                // Current aggregation, but far away.
+                reference(voice: 7, degrees: 0),
+            ]
+        )
+
+        let suggestions = SpeakerVoiceprintMatcher.match(
+            clusters: [cluster("S1", voice: 0, degrees: borderline)],
+            profiles: [straddling],
+            policy: policy
+        )
+        XCTAssertTrue(suggestions.isEmpty)
+
+        let winning = SpeakerVoiceprintMatcher.bestReference(
+            from: cluster("S1", voice: 0, degrees: borderline),
+            to: straddling,
+            policy: policy
+        )
+        XCTAssertFalse(try XCTUnwrap(winning).sameAggregation)
+    }
+
     // MARK: Scoring across references
 
     func testProfileDistanceIsTheClosestReferenceNotTheAverage() {

--- a/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintMatcherTests.swift
+++ b/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintMatcherTests.swift
@@ -1,0 +1,361 @@
+import XCTest
+@testable import MacParakeetCore
+
+/// Fixtures are exact geometry, not random vectors: a voice is a basis vector,
+/// and an observation at angle theta has cosine distance exactly `1 - cos
+/// theta`. Every threshold below therefore reads in degrees, and a failure says
+/// which angle moved rather than which seed.
+final class SpeakerVoiceprintMatcherTests: XCTestCase {
+
+    private let policy = SpeakerMatchPolicy.v1
+
+    // 14.1 degrees -> 0.030, 25 -> 0.094, 41.4 -> 0.250 (exactly tau),
+    // 45 -> 0.293, 60 -> 0.500.
+    private enum Angle {
+        static let veryClose = 14.1
+        static let close = 25.0
+        static let atTau = 41.4
+        static let pastTau = 45.0
+        static let far = 60.0
+    }
+
+    // MARK: Acceptance
+
+    func testSuggestsTheOnlyEnrolledVoiceWhenItIsCloseEnough() {
+        let suggestions = SpeakerVoiceprintMatcher.match(
+            clusters: [cluster("S1", voice: 0, degrees: Angle.close)],
+            profiles: [profile("Sarah", voice: 0)],
+            policy: policy
+        )
+
+        XCTAssertEqual(suggestions.count, 1)
+        XCTAssertEqual(suggestions.first?.speakerId, "S1")
+        XCTAssertEqual(suggestions.first?.displayName, "Sarah")
+        XCTAssertEqual(try XCTUnwrap(suggestions.first?.distance), 0.094, accuracy: 0.002)
+        // Nothing to be separated from, so no runner-up is recorded.
+        XCTAssertNil(suggestions.first?.runnerUpDistance)
+    }
+
+    func testRejectsAVoiceBeyondTau() {
+        XCTAssertTrue(
+            SpeakerVoiceprintMatcher.match(
+                clusters: [cluster("S1", voice: 0, degrees: Angle.pastTau)],
+                profiles: [profile("Sarah", voice: 0)],
+                policy: policy
+            ).isEmpty
+        )
+    }
+
+    func testAcceptsExactlyAtTau() {
+        XCTAssertEqual(
+            SpeakerVoiceprintMatcher.match(
+                clusters: [cluster("S1", voice: 0, degrees: Angle.atTau)],
+                profiles: [profile("Sarah", voice: 0)],
+                policy: policy
+            ).count,
+            1
+        )
+    }
+
+    // MARK: Singleton sides
+
+    /// The case the first review caught: with one profile and one cluster there
+    /// is no runner-up, so a naive margin check would reject the very first
+    /// enrolled voice forever.
+    func testMarginIsVacuouslySatisfiedWhenEitherSideHasOneCandidate() {
+        XCTAssertEqual(
+            SpeakerVoiceprintMatcher.match(
+                clusters: [cluster("S1", voice: 0, degrees: Angle.veryClose)],
+                profiles: [profile("Sarah", voice: 0)],
+                policy: policy
+            ).count,
+            1
+        )
+
+        // One profile, several clusters: the profile side has no runner-up
+        // among profiles, and the far cluster does not compete.
+        XCTAssertEqual(
+            SpeakerVoiceprintMatcher.match(
+                clusters: [
+                    cluster("S1", voice: 0, degrees: Angle.veryClose),
+                    cluster("S2", voice: 5, degrees: 0),
+                ],
+                profiles: [profile("Sarah", voice: 0)],
+                policy: policy
+            ).map(\.speakerId),
+            ["S1"]
+        )
+    }
+
+    // MARK: Margins
+
+    func testRejectsWhenTwoProfilesAreTooCloseTogether() {
+        // The cluster sits 14.1 degrees off Sarah and 10.9 off Sasha: 0.030
+        // against 0.018. Both clear tau, they are 0.012 apart, and naming
+        // either one would be a coin toss.
+        let suggestions = SpeakerVoiceprintMatcher.match(
+            clusters: [cluster("S1", voice: 0, degrees: Angle.veryClose)],
+            profiles: [
+                profile("Sarah", voice: 0),
+                profile("Sasha", voice: 0, degrees: Angle.close),
+            ],
+            policy: policy
+        )
+        XCTAssertTrue(suggestions.isEmpty)
+    }
+
+    /// The two-sided rule. The diarizer over-splits, so one person often yields
+    /// two clusters; a cluster-side margin alone would let both claim the same
+    /// profile and put two "Sarah"s in one transcript.
+    func testRejectsWhenTwoClustersCompeteForTheSameProfile() {
+        let suggestions = SpeakerVoiceprintMatcher.match(
+            clusters: [
+                cluster("S1", voice: 0, degrees: Angle.veryClose),
+                cluster("S2", voice: 0, degrees: Angle.close),
+            ],
+            profiles: [profile("Sarah", voice: 0)],
+            policy: policy
+        )
+        XCTAssertTrue(suggestions.isEmpty)
+    }
+
+    func testAcceptsWhenTheCompetingClusterIsClearlyFurther() {
+        let suggestions = SpeakerVoiceprintMatcher.match(
+            clusters: [
+                cluster("S1", voice: 0, degrees: Angle.veryClose),
+                cluster("S2", voice: 0, degrees: Angle.far),
+            ],
+            profiles: [profile("Sarah", voice: 0)],
+            policy: policy
+        )
+        XCTAssertEqual(suggestions.map(\.speakerId), ["S1"])
+        XCTAssertEqual(try XCTUnwrap(suggestions.first?.runnerUpDistance), 0.5, accuracy: 0.002)
+    }
+
+    func testExactTieSuggestsNobody() {
+        let suggestions = SpeakerVoiceprintMatcher.match(
+            clusters: [cluster("S1", voice: 0, degrees: Angle.close)],
+            profiles: [
+                profile("Sarah", voice: 0),
+                profile("Sasha", voice: 0),
+            ],
+            policy: policy
+        )
+        XCTAssertTrue(suggestions.isEmpty)
+    }
+
+    // MARK: Injectivity
+
+    func testOneProfileIsNeverSuggestedForTwoSpeakers() {
+        let suggestions = SpeakerVoiceprintMatcher.match(
+            clusters: [
+                cluster("S1", voice: 0, degrees: Angle.veryClose),
+                cluster("S2", voice: 0, degrees: Angle.far),
+                cluster("S3", voice: 1, degrees: Angle.veryClose),
+            ],
+            profiles: [profile("Sarah", voice: 0), profile("Dan", voice: 1)],
+            policy: policy
+        )
+
+        XCTAssertEqual(Set(suggestions.map(\.profileId)).count, suggestions.count)
+        XCTAssertEqual(Set(suggestions.map(\.speakerId)), ["S1", "S3"])
+    }
+
+    func testTwoDistinctVoicesMatchTheirOwnProfiles() {
+        let suggestions = SpeakerVoiceprintMatcher.match(
+            clusters: [
+                cluster("S1", voice: 0, degrees: Angle.close),
+                cluster("S2", voice: 1, degrees: Angle.close),
+            ],
+            profiles: [profile("Sarah", voice: 0), profile("Dan", voice: 1)],
+            policy: policy
+        )
+
+        XCTAssertEqual(
+            Dictionary(uniqueKeysWithValues: suggestions.map { ($0.speakerId, $0.displayName) }),
+            ["S1": "Sarah", "S2": "Dan"]
+        )
+    }
+
+    // MARK: Duration gates
+
+    func testClustersBelowTheSpeechGateAreNeverScored() {
+        let suggestions = SpeakerVoiceprintMatcher.match(
+            clusters: [cluster("S1", voice: 0, degrees: 0, speechSeconds: 2.5)],
+            profiles: [profile("Sarah", voice: 0)],
+            policy: policy
+        )
+        XCTAssertTrue(suggestions.isEmpty)
+    }
+
+    func testAClusterAboveTheMatchGateButBelowTheEnrollGateStillMatches() {
+        let suggestions = SpeakerVoiceprintMatcher.match(
+            clusters: [cluster("S1", voice: 0, degrees: 0, speechSeconds: 12)],
+            profiles: [profile("Sarah", voice: 0)],
+            policy: policy
+        )
+        XCTAssertEqual(suggestions.count, 1)
+        XCTAssertLessThan(12, policy.minSpeechSecondsToEnroll)
+    }
+
+    // MARK: Model identity
+
+    func testReferencesFromAnotherEmbeddingModelAreIgnored() {
+        let otherModel = SpeakerModelIdentity(
+            embeddingModelId: "other-model",
+            aggregationProfileId: Self.identity.aggregationProfileId
+        )
+        let suggestions = SpeakerVoiceprintMatcher.match(
+            clusters: [cluster("S1", voice: 0, degrees: 0)],
+            profiles: [profile("Sarah", voice: 0, identity: otherModel)],
+            policy: policy
+        )
+        XCTAssertTrue(suggestions.isEmpty)
+    }
+
+    func testADifferentAggregationProfileTightensTheThreshold() {
+        let otherAggregation = SpeakerModelIdentity(
+            embeddingModelId: Self.identity.embeddingModelId,
+            aggregationProfileId: "other-aggregation"
+        )
+        // 0.217 clears tau (0.25) but not tau minus the 0.05 penalty (0.20).
+        let borderline = 38.5
+
+        XCTAssertEqual(
+            SpeakerVoiceprintMatcher.match(
+                clusters: [cluster("S1", voice: 0, degrees: borderline)],
+                profiles: [profile("Sarah", voice: 0)],
+                policy: policy
+            ).count,
+            1
+        )
+        XCTAssertTrue(
+            SpeakerVoiceprintMatcher.match(
+                clusters: [cluster("S1", voice: 0, degrees: borderline)],
+                profiles: [profile("Sarah", voice: 0, identity: otherAggregation)],
+                policy: policy
+            ).isEmpty
+        )
+    }
+
+    // MARK: Scoring across references
+
+    func testProfileDistanceIsTheClosestReferenceNotTheAverage() {
+        let candidate = SpeakerProfileCandidate(
+            profileId: UUID(),
+            displayName: "Sarah",
+            references: [
+                reference(voice: 0, degrees: Angle.far),
+                reference(voice: 0, degrees: Angle.close),
+            ]
+        )
+        let distance = SpeakerVoiceprintMatcher.distance(
+            from: cluster("S1", voice: 0, degrees: 0),
+            to: candidate,
+            policy: policy
+        )
+        XCTAssertEqual(try XCTUnwrap(distance), 0.094, accuracy: 0.002)
+    }
+
+    func testOnlyTheFirstReferencesUpToTheCapAreScored() {
+        var references = (0..<policy.maxReferencesPerProfile).map { _ in
+            reference(voice: 0, degrees: Angle.far)
+        }
+        references.append(reference(voice: 0, degrees: 0))
+
+        let candidate = SpeakerProfileCandidate(
+            profileId: UUID(), displayName: "Sarah", references: references
+        )
+        let distance = SpeakerVoiceprintMatcher.distance(
+            from: cluster("S1", voice: 0, degrees: 0),
+            to: candidate,
+            policy: policy
+        )
+        // The perfect reference sits past the cap and never gets scored.
+        XCTAssertEqual(try XCTUnwrap(distance), 0.5, accuracy: 0.002)
+    }
+
+    func testNoProfilesOrNoClustersYieldsNothing() {
+        XCTAssertTrue(
+            SpeakerVoiceprintMatcher.match(
+                clusters: [cluster("S1", voice: 0, degrees: 0)], profiles: [], policy: policy
+            ).isEmpty
+        )
+        XCTAssertTrue(
+            SpeakerVoiceprintMatcher.match(
+                clusters: [], profiles: [profile("Sarah", voice: 0)], policy: policy
+            ).isEmpty
+        )
+    }
+
+    func testProfileWithNoReferencesIsSkipped() {
+        let empty = SpeakerProfileCandidate(profileId: UUID(), displayName: "Sarah", references: [])
+        XCTAssertTrue(
+            SpeakerVoiceprintMatcher.match(
+                clusters: [cluster("S1", voice: 0, degrees: 0)], profiles: [empty], policy: policy
+            ).isEmpty
+        )
+    }
+
+    // MARK: Fixtures
+
+    private static let identity = SpeakerModelIdentity(
+        embeddingModelId: "test-model",
+        aggregationProfileId: "test-aggregation"
+    )
+
+    /// `cos(theta) * e_voice + sin(theta) * e_offAxis`, whose distance to
+    /// `e_voice` is exactly `1 - cos(theta)`.
+    private func embedding(
+        voice: Int,
+        degrees: Double,
+        identity: SpeakerModelIdentity = SpeakerVoiceprintMatcherTests.identity
+    ) -> SpeakerEmbedding {
+        let radians = degrees * Double.pi / 180
+        var values = [Float](repeating: 0, count: SpeakerEmbedding.dimension)
+        values[voice] = Float(cos(radians))
+        values[SpeakerEmbedding.dimension - 1 - voice] = Float(sin(radians))
+        guard let embedding = SpeakerEmbedding(rawVector: values, identity: identity) else {
+            preconditionFailure("fixture vector must be valid")
+        }
+        return embedding
+    }
+
+    private func cluster(
+        _ speakerId: String,
+        voice: Int,
+        degrees: Double,
+        speechSeconds: Double = 30
+    ) -> SpeakerClusterObservation {
+        SpeakerClusterObservation(
+            speakerId: speakerId,
+            embedding: embedding(voice: voice, degrees: degrees),
+            speechSeconds: speechSeconds,
+            captureDomain: .system
+        )
+    }
+
+    private func reference(
+        voice: Int,
+        degrees: Double,
+        identity: SpeakerModelIdentity = SpeakerVoiceprintMatcherTests.identity
+    ) -> SpeakerProfileCandidate.Reference {
+        SpeakerProfileCandidate.Reference(
+            embedding: embedding(voice: voice, degrees: degrees, identity: identity),
+            captureDomain: .system
+        )
+    }
+
+    private func profile(
+        _ name: String,
+        voice: Int,
+        degrees: Double = 0,
+        identity: SpeakerModelIdentity = SpeakerVoiceprintMatcherTests.identity
+    ) -> SpeakerProfileCandidate {
+        SpeakerProfileCandidate(
+            profileId: UUID(),
+            displayName: name,
+            references: [reference(voice: voice, degrees: degrees, identity: identity)]
+        )
+    }
+}

--- a/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintRetentionTests.swift
+++ b/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintRetentionTests.swift
@@ -89,13 +89,14 @@ private struct RetentionFixture {
 
         var vector = [Float](repeating: 0, count: SpeakerEmbedding.dimension)
         vector[0] = 1
-        let embedding = try XCTUnwrap(SpeakerEmbedding(
-            rawVector: vector,
-            identity: SpeakerModelIdentity(
-                embeddingModelId: "test-model",
-                aggregationProfileId: "test-aggregation"
-            )
-        ))
+        let embedding = try XCTUnwrap(
+            SpeakerEmbedding(
+                rawVector: vector,
+                identity: SpeakerModelIdentity(
+                    embeddingModelId: "test-model",
+                    aggregationProfileId: "test-aggregation"
+                )
+            ))
 
         // Seed persisted rows directly so already-expired data survives until
         // the app lifecycle starts. One row per store expires at the next tick.

--- a/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintRetentionTests.swift
+++ b/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintRetentionTests.swift
@@ -1,0 +1,212 @@
+import Foundation
+import GRDB
+import XCTest
+
+@testable import MacParakeetCore
+
+final class SpeakerVoiceprintRetentionTests: XCTestCase {
+    func testLaunchAndHourlyTickPruneBothStoresWithoutVoiceActivity() async throws {
+        let clock = RetentionTestClock()
+        let fixture = try RetentionFixture(now: clock.now)
+        let retention = SpeakerVoiceprintRetention(
+            candidates: fixture.candidates,
+            journal: fixture.journal,
+            now: { clock.now },
+            sleep: { try await clock.sleep($0) }
+        )
+        defer { withExtendedLifetime(retention) {} }
+
+        await fulfillment(of: [clock.firstSweep], timeout: 2)
+        // Inspect raw rows: repository reads themselves prune, which would
+        // hide a missing lifecycle sweep.
+        XCTAssertEqual(try fixture.candidateCount(), 1)
+        XCTAssertEqual(try fixture.journalCount(), 1)
+        XCTAssertEqual(clock.sleepDurations, [.seconds(3600)])
+
+        clock.advance(by: 3600)
+        await fulfillment(of: [clock.secondSweep], timeout: 2)
+        XCTAssertEqual(try fixture.candidateCount(), 0)
+        XCTAssertEqual(try fixture.journalCount(), 0)
+        XCTAssertEqual(clock.sleepDurations, [.seconds(3600), .seconds(3600)])
+    }
+
+    func testCandidateFailureDoesNotSuppressJournalPruningAndRetriesNextTick() async throws {
+        let clock = RetentionTestClock()
+        let fixture = try RetentionFixture(now: clock.now)
+        let candidates = FailingOnceCandidateRepository(wrapped: fixture.candidates)
+        let retention = SpeakerVoiceprintRetention(
+            candidates: candidates,
+            journal: fixture.journal,
+            now: { clock.now },
+            sleep: { try await clock.sleep($0) }
+        )
+        defer { withExtendedLifetime(retention) {} }
+
+        await fulfillment(of: [clock.firstSweep], timeout: 2)
+        XCTAssertEqual(try fixture.candidateCount(), 2)
+        XCTAssertEqual(try fixture.journalCount(), 1)
+
+        clock.advance(by: 3600)
+        await fulfillment(of: [clock.secondSweep], timeout: 2)
+        XCTAssertEqual(try fixture.candidateCount(), 0)
+        XCTAssertEqual(try fixture.journalCount(), 0)
+        XCTAssertEqual(candidates.pruneCalls, 2)
+        XCTAssertFalse(candidates.prunedOnMainThread)
+    }
+
+    func testReleasingOwnerCancelsSleepAndDoesNotRetainItself() async throws {
+        let clock = RetentionTestClock()
+        let fixture = try RetentionFixture(now: clock.now)
+        var retention: SpeakerVoiceprintRetention? = SpeakerVoiceprintRetention(
+            candidates: fixture.candidates,
+            journal: fixture.journal,
+            now: { clock.now },
+            sleep: { try await clock.sleep($0) }
+        )
+        weak var weakRetention = retention
+
+        await fulfillment(of: [clock.firstSweep], timeout: 2)
+        XCTAssertNotNil(weakRetention)
+        retention = nil
+        await fulfillment(of: [clock.cancelledSleep], timeout: 2)
+
+        XCTAssertNil(weakRetention)
+        XCTAssertEqual(clock.sleepDurations, [.seconds(3600)])
+    }
+}
+
+private struct RetentionFixture {
+    let dbQueue: DatabaseQueue
+    let candidates: SpeakerEmbeddingCandidateRepository
+    let journal: SpeakerMatchJournalRepository
+
+    init(now: Date) throws {
+        dbQueue = try DatabaseManager().dbQueue
+        candidates = SpeakerEmbeddingCandidateRepository(dbQueue: dbQueue)
+        journal = SpeakerMatchJournalRepository(dbQueue: dbQueue)
+        let transcription = Transcription(fileName: "meeting.wav", sourceType: .meeting)
+        try TranscriptionRepository(dbQueue: dbQueue).save(transcription)
+
+        var vector = [Float](repeating: 0, count: SpeakerEmbedding.dimension)
+        vector[0] = 1
+        let embedding = try XCTUnwrap(SpeakerEmbedding(
+            rawVector: vector,
+            identity: SpeakerModelIdentity(
+                embeddingModelId: "test-model",
+                aggregationProfileId: "test-aggregation"
+            )
+        ))
+
+        // Seed persisted rows directly so already-expired data survives until
+        // the app lifecycle starts. One row per store expires at the next tick.
+        try dbQueue.write { db in
+            for (index, offset) in [TimeInterval(-1), 1800].enumerated() {
+                let expiresAt = now.addingTimeInterval(offset)
+                try SpeakerEmbeddingCandidate(
+                    transcriptionId: transcription.id,
+                    speakerId: "S\(index)",
+                    transcriptFingerprint: "fp",
+                    embedding: embedding,
+                    speechSeconds: 30,
+                    captureDomain: .system,
+                    createdAt: expiresAt.addingTimeInterval(-SpeakerEmbeddingCandidateRepository.defaultRetention),
+                    expiresAt: expiresAt
+                ).insert(db)
+                try SpeakerMatchJournalEntry(
+                    transcriptionId: transcription.id,
+                    speakerId: "S\(index)",
+                    transcriptFingerprint: "fp",
+                    outcome: .noComparableProfile,
+                    speechSeconds: 30,
+                    createdAt: expiresAt.addingTimeInterval(-SpeakerMatchJournalRepository.defaultRetention)
+                ).insert(db)
+            }
+        }
+    }
+
+    func candidateCount() throws -> Int {
+        try dbQueue.read { try SpeakerEmbeddingCandidate.fetchCount($0) }
+    }
+
+    func journalCount() throws -> Int {
+        try dbQueue.read { try SpeakerMatchJournalEntry.fetchCount($0) }
+    }
+}
+
+/// The stream suspends each tick without elapsed wall-clock time. Its iterator
+/// exits on task cancellation, matching the production Task.sleep contract.
+private final class RetentionTestClock: @unchecked Sendable {
+    let firstSweep = XCTestExpectation(description: "initial retention sweep finished")
+    let secondSweep = XCTestExpectation(description: "next retention sweep finished")
+    let cancelledSleep = XCTestExpectation(description: "retention sleep cancelled")
+    private let lock = NSLock()
+    private var date = Date(timeIntervalSince1970: 1_757_000_000)
+    private var durations: [Duration] = []
+    private let ticks = AsyncStream<Void>.makeStream()
+
+    var now: Date { lock.withLock { date } }
+    var sleepDurations: [Duration] { lock.withLock { durations } }
+
+    func advance(by interval: TimeInterval) {
+        lock.withLock { date = date.addingTimeInterval(interval) }
+        ticks.continuation.yield(())
+    }
+
+    func sleep(_ duration: Duration) async throws {
+        let count = lock.withLock {
+            durations.append(duration)
+            return durations.count
+        }
+        if count == 1 { firstSweep.fulfill() }
+        if count == 2 { secondSweep.fulfill() }
+        var iterator = ticks.stream.makeAsyncIterator()
+        _ = await iterator.next()
+        if Task.isCancelled {
+            cancelledSleep.fulfill()
+            throw CancellationError()
+        }
+    }
+}
+
+private final class FailingOnceCandidateRepository: SpeakerEmbeddingCandidateRepositoryProtocol, @unchecked Sendable {
+    private enum Failure: Error { case unavailable }
+    private let wrapped: SpeakerEmbeddingCandidateRepository
+    private let lock = NSLock()
+    private var calls = 0
+    private var usedMainThread = false
+
+    init(wrapped: SpeakerEmbeddingCandidateRepository) {
+        self.wrapped = wrapped
+    }
+
+    var pruneCalls: Int { lock.withLock { calls } }
+    var prunedOnMainThread: Bool { lock.withLock { usedMainThread } }
+
+    func pruneExpired(now: Date) throws {
+        let shouldFail = lock.withLock {
+            calls += 1
+            usedMainThread = usedMainThread || Thread.isMainThread
+            return calls == 1
+        }
+        if shouldFail { throw Failure.unavailable }
+        try wrapped.pruneExpired(now: now)
+    }
+
+    func upsert(_ candidates: [SpeakerEmbeddingCandidate], now: Date) throws {
+        try wrapped.upsert(candidates, now: now)
+    }
+
+    func candidate(
+        transcriptionId: UUID, speakerId: String, fingerprint: String, now: Date
+    ) throws -> SpeakerEmbeddingCandidate? {
+        try wrapped.candidate(
+            transcriptionId: transcriptionId, speakerId: speakerId, fingerprint: fingerprint, now: now
+        )
+    }
+
+    func delete(transcriptionId: UUID, speakerId: String, fingerprint: String) throws {
+        try wrapped.delete(transcriptionId: transcriptionId, speakerId: speakerId, fingerprint: fingerprint)
+    }
+
+    func deleteAll() throws { try wrapped.deleteAll() }
+}

--- a/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintServiceTests.swift
@@ -454,6 +454,53 @@ final class SpeakerVoiceprintServiceTests: XCTestCase {
         XCTAssertEqual(try profiles.exemplars(profileId: profile.id).count, 1)
     }
 
+    func testEnrollRefusesABlankName() async throws {
+        let recording = try savedTranscription()
+        for blank in ["", "   ", "\n\t"] {
+            let result = try await makeService().enroll(
+                displayName: blank,
+                observation: cluster("S1", voice: 0, degrees: 0),
+                transcriptionId: recording.id,
+                allowMergeIntoExistingName: false
+            )
+            XCTAssertEqual(result, .rejectedEmptyName)
+        }
+        XCTAssertTrue(try profiles.profiles().isEmpty)
+    }
+
+    /// A confirmation is as final as a refusal: rescoring would write a fresh
+    /// suggestion over the answer the user gave.
+    func testConfirmedSpeakersAreNotScoredAgain() async throws {
+        let recording = try savedTranscription()
+        _ = try await enrolledSarah(transcriptionId: recording.id)
+        let next = try savedTranscription()
+        let service = makeService()
+
+        let first = try await service.evaluate(
+            transcriptionId: next.id,
+            fingerprint: fingerprint,
+            clusters: [cluster("S1", voice: 0, degrees: 14.1)]
+        )
+        try await service.confirm(
+            try XCTUnwrap(first.first),
+            observation: cluster("S1", voice: 0, degrees: 14.1),
+            transcriptionId: next.id,
+            fingerprint: fingerprint
+        )
+
+        let second = try await service.evaluate(
+            transcriptionId: next.id,
+            fingerprint: fingerprint,
+            clusters: [cluster("S1", voice: 0, degrees: 14.1)]
+        )
+        XCTAssertTrue(second.isEmpty)
+        XCTAssertEqual(
+            try profiles.links(transcriptionId: next.id, fingerprint: fingerprint.rawValue)
+                .map(\.status),
+            [.confirmed]
+        )
+    }
+
     // MARK: Confirmation
 
     func testConfirmingRecordsTheLinkButDoesNotAmplifyAYoungProfile() async throws {

--- a/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintServiceTests.swift
@@ -1,0 +1,409 @@
+import XCTest
+import GRDB
+@testable import MacParakeetCore
+
+final class SpeakerVoiceprintServiceTests: XCTestCase {
+    private var dbQueue: DatabaseQueue!
+    private var profiles: SpeakerProfileRepository!
+    private var journal: SpeakerMatchJournalRepository!
+    private var transcriptions: TranscriptionRepository!
+    private var enabled = true
+
+    private let identity = SpeakerModelIdentity(
+        embeddingModelId: "test-model",
+        aggregationProfileId: "test-aggregation"
+    )
+    private let fingerprint = TranscriptFingerprint(rawValue: "fingerprint-1")
+
+    override func setUp() async throws {
+        let manager = try DatabaseManager()
+        dbQueue = manager.dbQueue
+        profiles = SpeakerProfileRepository(dbQueue: manager.dbQueue)
+        journal = SpeakerMatchJournalRepository(dbQueue: manager.dbQueue)
+        transcriptions = TranscriptionRepository(dbQueue: manager.dbQueue)
+        enabled = true
+    }
+
+    // MARK: Gating
+
+    func testDisabledServiceReadsNothingAndWritesNothing() async throws {
+        let recording = try savedTranscription()
+        _ = try await enrolledSarah(transcriptionId: recording.id)
+        enabled = false
+
+        let suggestions = try await makeService().evaluate(
+            transcriptionId: recording.id,
+            fingerprint: fingerprint,
+            clusters: [cluster("S1", voice: 0, degrees: 0)]
+        )
+
+        XCTAssertTrue(suggestions.isEmpty)
+        XCTAssertTrue(try journal.entries().isEmpty)
+        XCTAssertTrue(try profiles.links(transcriptionId: recording.id, fingerprint: fingerprint.rawValue).isEmpty)
+    }
+
+    func testNoEnrolledProfilesYieldsNoSuggestionsAndNoJournal() async throws {
+        let recording = try savedTranscription()
+
+        let suggestions = try await makeService().evaluate(
+            transcriptionId: recording.id,
+            fingerprint: fingerprint,
+            clusters: [cluster("S1", voice: 0, degrees: 0)]
+        )
+
+        XCTAssertTrue(suggestions.isEmpty)
+        XCTAssertTrue(try journal.entries().isEmpty)
+    }
+
+    // MARK: Evaluation
+
+    func testSuggestsAnEnrolledVoiceAndRecordsAPendingLink() async throws {
+        let recording = try savedTranscription()
+        let profile = try await enrolledSarah(transcriptionId: recording.id)
+        let next = try savedTranscription()
+
+        let suggestions = try await makeService().evaluate(
+            transcriptionId: next.id,
+            fingerprint: fingerprint,
+            clusters: [cluster("S1", voice: 0, degrees: 14.1)]
+        )
+
+        XCTAssertEqual(suggestions.map(\.displayName), ["Sarah"])
+        let links = try profiles.links(transcriptionId: next.id, fingerprint: fingerprint.rawValue)
+        XCTAssertEqual(links.map(\.status), [.suggested])
+        XCTAssertEqual(links.first?.profileId, profile.id)
+    }
+
+    func testDismissedSpeakersAreNotScoredAgainForTheSameFingerprint() async throws {
+        let recording = try savedTranscription()
+        _ = try await enrolledSarah(transcriptionId: recording.id)
+        let next = try savedTranscription()
+        let service = makeService()
+
+        let first = try await service.evaluate(
+            transcriptionId: next.id,
+            fingerprint: fingerprint,
+            clusters: [cluster("S1", voice: 0, degrees: 14.1)]
+        )
+        try await service.dismiss(
+            try XCTUnwrap(first.first), transcriptionId: next.id, fingerprint: fingerprint
+        )
+
+        let second = try await service.evaluate(
+            transcriptionId: next.id,
+            fingerprint: fingerprint,
+            clusters: [cluster("S1", voice: 0, degrees: 14.1)]
+        )
+        XCTAssertTrue(second.isEmpty)
+    }
+
+    /// Re-diarization changes the fingerprint, and speaker ids are positional,
+    /// so an old refusal must not silence a fresh, possibly correct suggestion.
+    func testANewFingerprintReconsidersADismissedSpeaker() async throws {
+        let recording = try savedTranscription()
+        _ = try await enrolledSarah(transcriptionId: recording.id)
+        let next = try savedTranscription()
+        let service = makeService()
+
+        let first = try await service.evaluate(
+            transcriptionId: next.id,
+            fingerprint: fingerprint,
+            clusters: [cluster("S1", voice: 0, degrees: 14.1)]
+        )
+        try await service.dismiss(
+            try XCTUnwrap(first.first), transcriptionId: next.id, fingerprint: fingerprint
+        )
+
+        let afterRerun = try await service.evaluate(
+            transcriptionId: next.id,
+            fingerprint: TranscriptFingerprint(rawValue: "fingerprint-2"),
+            clusters: [cluster("S1", voice: 0, degrees: 14.1)]
+        )
+        XCTAssertEqual(afterRerun.map(\.displayName), ["Sarah"])
+    }
+
+    func testJournalRecordsRejectionsWithTheirReason() async throws {
+        let recording = try savedTranscription()
+        _ = try await enrolledSarah(transcriptionId: recording.id)
+        let next = try savedTranscription()
+
+        _ = try await makeService().evaluate(
+            transcriptionId: next.id,
+            fingerprint: fingerprint,
+            clusters: [
+                cluster("S1", voice: 0, degrees: 14.1),
+                cluster("S2", voice: 3, degrees: 0),
+                cluster("S3", voice: 0, degrees: 0, speechSeconds: 2),
+            ]
+        )
+
+        let outcomes = Dictionary(
+            uniqueKeysWithValues: try journal.entries().map { ($0.speakerId, $0.outcome) }
+        )
+        XCTAssertEqual(outcomes["S1"], .suggested)
+        XCTAssertEqual(outcomes["S2"], .pastThreshold)
+        XCTAssertEqual(outcomes["S3"], .belowSpeechGate)
+    }
+
+    func testEvaluationStampsTheProfileEvenWhenNothingIsSuggested() async throws {
+        let recording = try savedTranscription()
+        let profile = try await enrolledSarah(transcriptionId: recording.id)
+        let next = try savedTranscription()
+
+        _ = try await makeService().evaluate(
+            transcriptionId: next.id,
+            fingerprint: fingerprint,
+            clusters: [cluster("S1", voice: 3, degrees: 0)]
+        )
+
+        let stored = try XCTUnwrap(try profiles.profile(id: profile.id))
+        XCTAssertNotNil(stored.lastEvaluatedAt)
+        XCTAssertEqual(try XCTUnwrap(stored.lastEvaluatedDistance), 1, accuracy: 0.01)
+        // Scored, but never matched.
+        XCTAssertNil(stored.lastMatchedAt)
+    }
+
+    func testJournalDropsEntriesPastRetention() throws {
+        let recording = try savedTranscription()
+        try journal.append(
+            [
+                SpeakerMatchJournalEntry(
+                    transcriptionId: recording.id,
+                    speakerId: "S1",
+                    outcome: .noComparableProfile,
+                    speechSeconds: 30,
+                    createdAt: Date(timeIntervalSinceNow: -100 * 24 * 60 * 60)
+                )
+            ],
+            retention: SpeakerMatchJournalRepository.defaultRetention,
+            now: Date()
+        )
+        XCTAssertTrue(try journal.entries().isEmpty)
+    }
+
+    // MARK: Enrollment
+
+    func testEnrollCreatesAProfileWithOneManualExemplar() async throws {
+        let recording = try savedTranscription()
+        let result = try await makeService().enroll(
+            displayName: "  Sarah  ",
+            observation: cluster("S1", voice: 0, degrees: 0),
+            transcriptionId: recording.id,
+            allowMergeIntoExistingName: false
+        )
+
+        guard case .created(let profile) = result else {
+            return XCTFail("expected a new profile, got \(result)")
+        }
+        XCTAssertEqual(profile.displayName, "Sarah")
+        let exemplars = try profiles.exemplars(profileId: profile.id)
+        XCTAssertEqual(exemplars.map(\.origin), [.manualEnrollment])
+        XCTAssertEqual(exemplars.first?.sourceTranscriptionId, recording.id)
+    }
+
+    func testEnrollRefusesAClusterBelowTheEnrollGate() async throws {
+        let recording = try savedTranscription()
+        let result = try await makeService().enroll(
+            displayName: "Sarah",
+            observation: cluster("S1", voice: 0, degrees: 0, speechSeconds: 12),
+            transcriptionId: recording.id,
+            allowMergeIntoExistingName: false
+        )
+
+        guard case .rejectedTooShort = result else {
+            return XCTFail("expected a refusal, got \(result)")
+        }
+        XCTAssertTrue(try profiles.profiles().isEmpty)
+    }
+
+    func testEnrollingTheSameNameWithTheSameVoiceAddsASample() async throws {
+        let first = try savedTranscription()
+        let profile = try await enrolledSarah(transcriptionId: first.id)
+        let second = try savedTranscription()
+
+        let result = try await makeService().enroll(
+            displayName: "sarah",
+            observation: cluster("S1", voice: 0, degrees: 14.1),
+            transcriptionId: second.id,
+            allowMergeIntoExistingName: false
+        )
+
+        guard case .addedExemplar = result else {
+            return XCTFail("expected an added exemplar, got \(result)")
+        }
+        XCTAssertEqual(try profiles.exemplars(profileId: profile.id).count, 2)
+        XCTAssertEqual(try profiles.profiles().count, 1)
+    }
+
+    /// The widest hole in the design: naming a speaker bypasses every
+    /// threshold, so two colleagues called Sarah would silently fuse.
+    func testEnrollingAKnownNameWithADifferentVoiceAsksInstead() async throws {
+        let first = try savedTranscription()
+        let profile = try await enrolledSarah(transcriptionId: first.id)
+        let second = try savedTranscription()
+
+        let result = try await makeService().enroll(
+            displayName: "Sarah",
+            observation: cluster("S1", voice: 4, degrees: 0),
+            transcriptionId: second.id,
+            allowMergeIntoExistingName: false
+        )
+
+        guard case .needsDisambiguation(let existing, let distance) = result else {
+            return XCTFail("expected disambiguation, got \(result)")
+        }
+        XCTAssertEqual(existing.id, profile.id)
+        XCTAssertGreaterThan(distance, SpeakerMatchPolicy.v1.pollutionGuardDistance)
+        XCTAssertEqual(try profiles.exemplars(profileId: profile.id).count, 1)
+    }
+
+    func testTheUserCanOverrideTheDisambiguationGuard() async throws {
+        let first = try savedTranscription()
+        let profile = try await enrolledSarah(transcriptionId: first.id)
+        let second = try savedTranscription()
+
+        let result = try await makeService().enroll(
+            displayName: "Sarah",
+            observation: cluster("S1", voice: 4, degrees: 0),
+            transcriptionId: second.id,
+            allowMergeIntoExistingName: true
+        )
+
+        guard case .addedExemplar = result else {
+            return XCTFail("expected an added exemplar, got \(result)")
+        }
+        XCTAssertEqual(try profiles.exemplars(profileId: profile.id).count, 2)
+    }
+
+    func testAProfileTakesAtMostOneSamplePerRecording() async throws {
+        let recording = try savedTranscription()
+        let profile = try await enrolledSarah(transcriptionId: recording.id)
+
+        let result = try await makeService().enroll(
+            displayName: "Sarah",
+            observation: cluster("S2", voice: 0, degrees: 14.1),
+            transcriptionId: recording.id,
+            allowMergeIntoExistingName: false
+        )
+
+        guard case .alreadySampled = result else {
+            return XCTFail("expected a refusal, got \(result)")
+        }
+        XCTAssertEqual(try profiles.exemplars(profileId: profile.id).count, 1)
+    }
+
+    // MARK: Confirmation
+
+    func testConfirmingRecordsTheLinkButDoesNotAmplifyAYoungProfile() async throws {
+        let recording = try savedTranscription()
+        let profile = try await enrolledSarah(transcriptionId: recording.id)
+        let next = try savedTranscription()
+        let service = makeService()
+
+        let suggestions = try await service.evaluate(
+            transcriptionId: next.id,
+            fingerprint: fingerprint,
+            clusters: [cluster("S1", voice: 0, degrees: 14.1)]
+        )
+        let observation = cluster("S1", voice: 0, degrees: 14.1)
+        try await service.confirm(
+            try XCTUnwrap(suggestions.first),
+            observation: observation,
+            transcriptionId: next.id,
+            fingerprint: fingerprint
+        )
+
+        let links = try profiles.links(transcriptionId: next.id, fingerprint: fingerprint.rawValue)
+        XCTAssertEqual(links.map(\.status), [.confirmed])
+        // One manual enrollment only: a confirmation must not let the profile
+        // amplify itself on the strength of its own suggestion.
+        XCTAssertEqual(try profiles.exemplars(profileId: profile.id).count, 1)
+        XCTAssertNotNil(try profiles.profile(id: profile.id)?.lastMatchedAt)
+    }
+
+    func testConfirmingAddsASampleOnceTwoManualEnrollmentsAnchorTheVoice() async throws {
+        let first = try savedTranscription()
+        let profile = try await enrolledSarah(transcriptionId: first.id)
+        let second = try savedTranscription()
+        let service = makeService()
+        _ = try await service.enroll(
+            displayName: "Sarah",
+            observation: cluster("S1", voice: 0, degrees: 14.1),
+            transcriptionId: second.id,
+            allowMergeIntoExistingName: false
+        )
+
+        let third = try savedTranscription()
+        let suggestions = try await service.evaluate(
+            transcriptionId: third.id,
+            fingerprint: fingerprint,
+            clusters: [cluster("S1", voice: 0, degrees: 14.1)]
+        )
+        try await service.confirm(
+            try XCTUnwrap(suggestions.first),
+            observation: cluster("S1", voice: 0, degrees: 14.1),
+            transcriptionId: third.id,
+            fingerprint: fingerprint
+        )
+
+        let exemplars = try profiles.exemplars(profileId: profile.id)
+        XCTAssertEqual(exemplars.count, 3)
+        XCTAssertEqual(exemplars.filter { $0.origin == .confirmedSuggestion }.count, 1)
+    }
+
+    // MARK: Helpers
+
+    private func makeService() -> SpeakerVoiceprintService {
+        SpeakerVoiceprintService(
+            profiles: profiles,
+            journal: journal,
+            policy: .v1,
+            isEnabled: { [self] in enabled }
+        )
+    }
+
+    private func embedding(voice: Int, degrees: Double) -> SpeakerEmbedding {
+        let radians = degrees * Double.pi / 180
+        var values = [Float](repeating: 0, count: SpeakerEmbedding.dimension)
+        values[voice] = Float(cos(radians))
+        values[SpeakerEmbedding.dimension - 1 - voice] = Float(sin(radians))
+        guard let embedding = SpeakerEmbedding(rawVector: values, identity: identity) else {
+            preconditionFailure("fixture vector must be valid")
+        }
+        return embedding
+    }
+
+    private func cluster(
+        _ speakerId: String,
+        voice: Int,
+        degrees: Double,
+        speechSeconds: Double = 30
+    ) -> SpeakerClusterObservation {
+        SpeakerClusterObservation(
+            speakerId: speakerId,
+            embedding: embedding(voice: voice, degrees: degrees),
+            speechSeconds: speechSeconds,
+            captureDomain: .system
+        )
+    }
+
+    private func savedTranscription() throws -> Transcription {
+        let transcription = Transcription(fileName: "meeting.wav", sourceType: .meeting)
+        try transcriptions.save(transcription)
+        return transcription
+    }
+
+    @discardableResult
+    private func enrolledSarah(transcriptionId: UUID) async throws -> SpeakerProfile {
+        let result = try await makeService().enroll(
+            displayName: "Sarah",
+            observation: cluster("S1", voice: 0, degrees: 0),
+            transcriptionId: transcriptionId,
+            allowMergeIntoExistingName: false
+        )
+        guard case .created(let profile) = result else {
+            preconditionFailure("fixture enrollment must create a profile")
+        }
+        return profile
+    }
+}

--- a/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintServiceTests.swift
@@ -44,6 +44,92 @@ final class SpeakerVoiceprintServiceTests: XCTestCase {
         XCTAssertTrue(try profiles.links(transcriptionId: recording.id, fingerprint: fingerprint.rawValue).isEmpty)
     }
 
+    func testEnrollThrowsWhenDisabledAndDoesNotWrite() async throws {
+        let recording = try savedTranscription()
+        enabled = false
+
+        do {
+            _ = try await makeService().enroll(
+                displayName: "Sarah",
+                observation: cluster("S1", voice: 0, degrees: 0),
+                transcriptionId: recording.id,
+                fingerprint: fingerprint,
+                allowMergeIntoExistingName: false
+            )
+            XCTFail("expected a disabled refusal")
+        } catch SpeakerVoiceprintServiceError.disabled {
+        }
+
+        XCTAssertTrue(try profiles.profiles().isEmpty)
+        XCTAssertNil(
+            try candidates.candidate(
+                transcriptionId: recording.id, speakerId: "S1",
+                fingerprint: fingerprint.rawValue, now: Date()
+            )
+        )
+    }
+
+    func testConfirmAndDismissThrowWhenDisabledAndLeaveLinksUntouched() async throws {
+        let recording = try savedTranscription()
+        _ = try await enrolledSarah(transcriptionId: recording.id)
+        let next = try savedTranscription()
+        let enabledService = makeService()
+        let suggestions = try await enabledService.evaluate(
+            transcriptionId: next.id,
+            fingerprint: fingerprint,
+            clusters: [cluster("S1", voice: 0, degrees: 14.1)]
+        )
+        let suggestion = try XCTUnwrap(suggestions.first)
+
+        enabled = false
+        let disabled = makeService()
+        do {
+            try await disabled.confirm(
+                suggestion,
+                observation: cluster("S1", voice: 0, degrees: 14.1),
+                transcriptionId: next.id,
+                fingerprint: fingerprint
+            )
+            XCTFail("expected a disabled refusal")
+        } catch SpeakerVoiceprintServiceError.disabled {
+        }
+        do {
+            try await disabled.dismiss(
+                suggestion, transcriptionId: next.id, fingerprint: fingerprint
+            )
+            XCTFail("expected a disabled refusal")
+        } catch SpeakerVoiceprintServiceError.disabled {
+        }
+
+        XCTAssertEqual(
+            try profiles.links(transcriptionId: next.id, fingerprint: fingerprint.rawValue)
+                .map(\.status),
+            [.suggested]
+        )
+    }
+
+    /// Turning the preference off must not strand biometric candidates.
+    func testPruningStillRunsWhenTheFeatureIsOff() async throws {
+        let recording = try savedTranscription()
+        let captured = Date(timeIntervalSince1970: 1_757_000_000)
+        _ = try await makeService(retention: 60, now: captured).evaluate(
+            transcriptionId: recording.id,
+            fingerprint: fingerprint,
+            clusters: [cluster("S1", voice: 0, degrees: 0)]
+        )
+
+        enabled = false
+        try await makeService(retention: 60, now: captured.addingTimeInterval(120))
+            .pruneExpiredCandidates()
+
+        XCTAssertNil(
+            try candidates.candidate(
+                transcriptionId: recording.id, speakerId: "S1",
+                fingerprint: fingerprint.rawValue, now: captured.addingTimeInterval(120)
+            )
+        )
+    }
+
     func testNoEnrolledProfilesYieldsNoSuggestionsAndNoJournal() async throws {
         let recording = try savedTranscription()
 
@@ -472,6 +558,79 @@ final class SpeakerVoiceprintServiceTests: XCTestCase {
         )
     }
 
+    /// 14.1° clears tau; 41.4° is exactly tau. Together they keep the margin.
+    /// Filtering the confirmed cluster *before* scoring would let S2 inherit
+    /// Sarah with a manufactured singleton confidence.
+    func testConfirmingDoesNotGiveTheSameVoiceToASiblingCluster() async throws {
+        let recording = try savedTranscription()
+        _ = try await enrolledSarah(transcriptionId: recording.id)
+        let next = try savedTranscription()
+        let service = makeService()
+        let close = cluster("S1", voice: 0, degrees: 14.1)
+        let sibling = cluster("S2", voice: 0, degrees: 41.4)
+
+        let first = try await service.evaluate(
+            transcriptionId: next.id,
+            fingerprint: fingerprint,
+            clusters: [close, sibling]
+        )
+        XCTAssertEqual(first.map(\.speakerId), ["S1"])
+        XCTAssertEqual(first.map(\.displayName), ["Sarah"])
+
+        try await service.confirm(
+            try XCTUnwrap(first.first),
+            observation: close,
+            transcriptionId: next.id,
+            fingerprint: fingerprint
+        )
+
+        let second = try await service.evaluate(
+            transcriptionId: next.id,
+            fingerprint: fingerprint,
+            clusters: [close, sibling]
+        )
+        XCTAssertTrue(second.isEmpty)
+        let links = try profiles.links(transcriptionId: next.id, fingerprint: fingerprint.rawValue)
+        XCTAssertEqual(
+            links.filter { $0.status == .confirmed }.map(\.speakerId),
+            ["S1"]
+        )
+        XCTAssertFalse(links.contains { $0.speakerId == "S2" })
+    }
+
+    /// Dismissing the closer cluster must not manufacture a suggestion for the
+    /// farther one: it still lost the original competition.
+    func testDismissingACloserClusterDoesNotManufactureASuggestionForASibling() async throws {
+        let recording = try savedTranscription()
+        _ = try await enrolledSarah(transcriptionId: recording.id)
+        let next = try savedTranscription()
+        let service = makeService()
+        let close = cluster("S1", voice: 0, degrees: 14.1)
+        let sibling = cluster("S2", voice: 0, degrees: 41.4)
+
+        let first = try await service.evaluate(
+            transcriptionId: next.id,
+            fingerprint: fingerprint,
+            clusters: [close, sibling]
+        )
+        try await service.dismiss(
+            try XCTUnwrap(first.first), transcriptionId: next.id, fingerprint: fingerprint
+        )
+
+        let second = try await service.evaluate(
+            transcriptionId: next.id,
+            fingerprint: fingerprint,
+            clusters: [close, sibling]
+        )
+        XCTAssertTrue(second.isEmpty)
+        let links = try profiles.links(transcriptionId: next.id, fingerprint: fingerprint.rawValue)
+        XCTAssertEqual(
+            links.filter { $0.status == .dismissed }.map(\.speakerId),
+            ["S1"]
+        )
+        XCTAssertFalse(links.contains { $0.speakerId == "S2" && $0.status == .suggested })
+    }
+
     /// The cap has to bound storage, not just scoring: vectors the matcher can
     /// never reach would be biometric data kept for nothing.
     func testTheOldestConfirmationIsEvictedAtTheCap() async throws {
@@ -603,6 +762,39 @@ final class SpeakerVoiceprintServiceTests: XCTestCase {
         XCTAssertEqual(profile.id, winner.id)
         XCTAssertEqual(try profiles.profiles().count, 1)
         XCTAssertEqual(try profiles.exemplars(profileId: winner.id).count, 2)
+    }
+
+    /// The first sample has to exist before a loser can judge voices. An empty
+    /// winner would skip the pollution guard and fuse two people.
+    func testConcurrentConflictingNameEnrollmentsDoNotSkipThePollutionGuard() async throws {
+        let first = try savedTranscription()
+        let second = try savedTranscription()
+        let service = makeService()
+
+        async let left = service.enroll(
+            displayName: "Sarah",
+            observation: cluster("S1", voice: 0, degrees: 0),
+            transcriptionId: first.id,
+            fingerprint: fingerprint,
+            allowMergeIntoExistingName: false
+        )
+        async let right = service.enroll(
+            displayName: "Sarah",
+            observation: cluster("S2", voice: 4, degrees: 0),
+            transcriptionId: second.id,
+            fingerprint: fingerprint,
+            allowMergeIntoExistingName: false
+        )
+        let results = [try await left, try await right]
+
+        XCTAssertEqual(try profiles.profiles().count, 1)
+        let profile = try XCTUnwrap(try profiles.profiles().first)
+        XCTAssertEqual(try profiles.exemplars(profileId: profile.id).count, 1)
+        XCTAssertTrue(results.contains { if case .created = $0 { return true }; return false })
+        XCTAssertTrue(
+            results.contains { if case .needsDisambiguation = $0 { return true }; return false }
+        )
+        XCTAssertFalse(results.contains { if case .addedExemplar = $0 { return true }; return false })
     }
 
     // MARK: Enrollment candidates
@@ -769,6 +961,88 @@ final class SpeakerVoiceprintServiceTests: XCTestCase {
         )
     }
 
+    func testConfirmingKeepsTheCandidateWhenTheProfileIsFull() async throws {
+        let service = makeService()
+        let first = try savedTranscription()
+        let profile = try await enrolledSarah(transcriptionId: first.id)
+        while try profiles.exemplars(profileId: profile.id).count
+            < SpeakerMatchPolicy.v1.maxReferencesPerProfile
+        {
+            let recording = try savedTranscription()
+            _ = try await service.enroll(
+                displayName: "Sarah",
+                observation: cluster("S1", voice: 0, degrees: 14.1),
+                transcriptionId: recording.id,
+                fingerprint: fingerprint,
+                allowMergeIntoExistingName: false
+            )
+        }
+
+        let extra = try savedTranscription()
+        let suggestions = try await service.evaluate(
+            transcriptionId: extra.id,
+            fingerprint: fingerprint,
+            clusters: [cluster("S1", voice: 0, degrees: 14.1)]
+        )
+        XCTAssertNotNil(
+            try candidates.candidate(
+                transcriptionId: extra.id, speakerId: "S1",
+                fingerprint: fingerprint.rawValue, now: Date()
+            )
+        )
+        try await service.confirm(
+            try XCTUnwrap(suggestions.first),
+            observation: cluster("S1", voice: 0, degrees: 14.1),
+            transcriptionId: extra.id,
+            fingerprint: fingerprint
+        )
+
+        XCTAssertNotNil(
+            try candidates.candidate(
+                transcriptionId: extra.id, speakerId: "S1",
+                fingerprint: fingerprint.rawValue, now: Date()
+            )
+        )
+        XCTAssertEqual(
+            try profiles.exemplars(profileId: profile.id).count,
+            SpeakerMatchPolicy.v1.maxReferencesPerProfile
+        )
+    }
+
+    func testConfirmingKeepsTheCandidateWhenAlreadySampled() async throws {
+        let first = try savedTranscription()
+        try await enrolledSarah(transcriptionId: first.id)
+        let second = try savedTranscription()
+        let service = makeService()
+        _ = try await service.enroll(
+            displayName: "Sarah",
+            observation: cluster("S1", voice: 0, degrees: 14.1),
+            transcriptionId: second.id,
+            fingerprint: fingerprint,
+            allowMergeIntoExistingName: false
+        )
+
+        let suggestions = try await service.evaluate(
+            transcriptionId: second.id,
+            fingerprint: fingerprint,
+            clusters: [cluster("S1", voice: 0, degrees: 14.1)]
+        )
+        try await service.confirm(
+            try XCTUnwrap(suggestions.first),
+            observation: cluster("S1", voice: 0, degrees: 14.1),
+            transcriptionId: second.id,
+            fingerprint: fingerprint
+        )
+
+        XCTAssertNotNil(
+            try candidates.candidate(
+                transcriptionId: second.id, speakerId: "S1",
+                fingerprint: fingerprint.rawValue, now: Date()
+            )
+        )
+        XCTAssertEqual(try profiles.exemplars(profileId: try XCTUnwrap(try profiles.profiles().first).id).count, 2)
+    }
+
     // MARK: Confirmation
 
     func testConfirmingRecordsTheLinkButDoesNotAmplifyAYoungProfile() async throws {
@@ -921,6 +1195,19 @@ private final class NameHidingStore: SpeakerProfileRepositoryProtocol, @unchecke
     func profiles() throws -> [SpeakerProfile] { try wrapped.profiles() }
     func profile(id: UUID) throws -> SpeakerProfile? { try wrapped.profile(id: id) }
     func insert(_ profile: SpeakerProfile) throws { try wrapped.insert(profile) }
+    func insert(
+        _ profile: SpeakerProfile,
+        firstExemplar: SpeakerProfileExemplar,
+        maxPerProfile: Int,
+        evicting: SpeakerProfileExemplar.Origin
+    ) throws -> SpeakerExemplarInsertion {
+        try wrapped.insert(
+            profile,
+            firstExemplar: firstExemplar,
+            maxPerProfile: maxPerProfile,
+            evicting: evicting
+        )
+    }
     func save(_ profile: SpeakerProfile) throws { try wrapped.save(profile) }
     func exemplars(profileId: UUID) throws -> [SpeakerProfileExemplar] {
         try wrapped.exemplars(profileId: profileId)

--- a/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintServiceTests.swift
@@ -170,6 +170,7 @@ final class SpeakerVoiceprintServiceTests: XCTestCase {
                 SpeakerMatchJournalEntry(
                     transcriptionId: recording.id,
                     speakerId: "S1",
+                    transcriptFingerprint: fingerprint.rawValue,
                     outcome: .noComparableProfile,
                     speechSeconds: 30,
                     createdAt: Date(timeIntervalSinceNow: -100 * 24 * 60 * 60)
@@ -191,6 +192,7 @@ final class SpeakerVoiceprintServiceTests: XCTestCase {
                 SpeakerMatchJournalEntry(
                     transcriptionId: recording.id,
                     speakerId: "S1",
+                    transcriptFingerprint: fingerprint.rawValue,
                     outcome: .noComparableProfile,
                     speechSeconds: 30,
                     createdAt: longAgo
@@ -322,6 +324,98 @@ final class SpeakerVoiceprintServiceTests: XCTestCase {
 
         guard case .alreadySampled = result else {
             return XCTFail("expected a refusal, got \(result)")
+        }
+        XCTAssertEqual(try profiles.exemplars(profileId: profile.id).count, 1)
+    }
+
+    /// speakerId is positional, so a decision is only joinable to the label
+    /// that answered it when the transcript version is recorded with it.
+    func testJournalRecordsTheTranscriptVersionOfEachDecision() async throws {
+        let recording = try savedTranscription()
+        _ = try await enrolledSarah(transcriptionId: recording.id)
+        let next = try savedTranscription()
+
+        _ = try await makeService().evaluate(
+            transcriptionId: next.id,
+            fingerprint: fingerprint,
+            clusters: [cluster("S1", voice: 0, degrees: 14.1)]
+        )
+
+        let entries = try journal.entries(
+            retention: SpeakerMatchJournalRepository.defaultRetention, now: Date()
+        )
+        XCTAssertEqual(entries.map(\.transcriptFingerprint), [fingerprint.rawValue])
+    }
+
+    /// Only the first `maxReferencesPerProfile` are scored, so the newest
+    /// samples must be the ones that survive the cap.
+    func testTheNewestExemplarsAreTheOnesScored() async throws {
+        let service = makeService()
+        let first = try savedTranscription()
+        let profile = try await enrolledSarah(transcriptionId: first.id)
+
+        // Fill the cap with samples of one voice, then add a newer one that
+        // sits on a different voice entirely.
+        for index in 1..<SpeakerMatchPolicy.v1.maxReferencesPerProfile {
+            let recording = try savedTranscription()
+            _ = try await service.enroll(
+                displayName: "Sarah",
+                observation: cluster("S\(index)", voice: 0, degrees: 0),
+                transcriptionId: recording.id,
+                allowMergeIntoExistingName: true
+            )
+        }
+        let newest = try savedTranscription()
+        _ = try await service.enroll(
+            displayName: "Sarah",
+            observation: cluster("S99", voice: 6, degrees: 0),
+            transcriptionId: newest.id,
+            allowMergeIntoExistingName: true
+        )
+        XCTAssertEqual(
+            try profiles.exemplars(profileId: profile.id).count,
+            SpeakerMatchPolicy.v1.maxReferencesPerProfile + 1
+        )
+
+        // The newest sample decides, which it could not if the cap kept the
+        // oldest ten.
+        let suggestions = try await service.evaluate(
+            transcriptionId: try savedTranscription().id,
+            fingerprint: fingerprint,
+            clusters: [cluster("S1", voice: 6, degrees: 0)]
+        )
+        XCTAssertEqual(suggestions.map(\.displayName), ["Sarah"])
+    }
+
+    /// An embedding from another model carries no comparable evidence, so it
+    /// must not slip past the guard into a silent merge.
+    func testEnrollingWithAnIncomparableModelAsksInstead() async throws {
+        let first = try savedTranscription()
+        let profile = try await enrolledSarah(transcriptionId: first.id)
+        let second = try savedTranscription()
+
+        let otherModel = SpeakerModelIdentity(
+            embeddingModelId: "other-model",
+            aggregationProfileId: identity.aggregationProfileId
+        )
+        var values = [Float](repeating: 0, count: SpeakerEmbedding.dimension)
+        values[0] = 1
+        let observation = SpeakerClusterObservation(
+            speakerId: "S1",
+            embedding: try XCTUnwrap(SpeakerEmbedding(rawVector: values, identity: otherModel)),
+            speechSeconds: 30,
+            captureDomain: .system
+        )
+
+        let result = try await makeService().enroll(
+            displayName: "Sarah",
+            observation: observation,
+            transcriptionId: second.id,
+            allowMergeIntoExistingName: false
+        )
+
+        guard case .needsDisambiguation = result else {
+            return XCTFail("expected disambiguation, got \(result)")
         }
         XCTAssertEqual(try profiles.exemplars(profileId: profile.id).count, 1)
     }

--- a/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintServiceTests.swift
@@ -38,7 +38,7 @@ final class SpeakerVoiceprintServiceTests: XCTestCase {
         )
 
         XCTAssertTrue(suggestions.isEmpty)
-        XCTAssertTrue(try journal.entries().isEmpty)
+        XCTAssertTrue(try journal.entries(retention: SpeakerMatchJournalRepository.defaultRetention, now: Date()).isEmpty)
         XCTAssertTrue(try profiles.links(transcriptionId: recording.id, fingerprint: fingerprint.rawValue).isEmpty)
     }
 
@@ -52,7 +52,7 @@ final class SpeakerVoiceprintServiceTests: XCTestCase {
         )
 
         XCTAssertTrue(suggestions.isEmpty)
-        XCTAssertTrue(try journal.entries().isEmpty)
+        XCTAssertTrue(try journal.entries(retention: SpeakerMatchJournalRepository.defaultRetention, now: Date()).isEmpty)
     }
 
     // MARK: Evaluation
@@ -138,7 +138,7 @@ final class SpeakerVoiceprintServiceTests: XCTestCase {
         )
 
         let outcomes = Dictionary(
-            uniqueKeysWithValues: try journal.entries().map { ($0.speakerId, $0.outcome) }
+            uniqueKeysWithValues: try journal.entries(retention: SpeakerMatchJournalRepository.defaultRetention, now: Date()).map { ($0.speakerId, $0.outcome) }
         )
         XCTAssertEqual(outcomes["S1"], .suggested)
         XCTAssertEqual(outcomes["S2"], .pastThreshold)
@@ -178,7 +178,41 @@ final class SpeakerVoiceprintServiceTests: XCTestCase {
             retention: SpeakerMatchJournalRepository.defaultRetention,
             now: Date()
         )
-        XCTAssertTrue(try journal.entries().isEmpty)
+        XCTAssertTrue(try journal.entries(retention: SpeakerMatchJournalRepository.defaultRetention, now: Date()).isEmpty)
+    }
+
+    /// Expiry cannot ride on writes alone: a user who stops recording stops
+    /// appending, and a ninety-day journal would quietly become permanent.
+    func testJournalExpiresEvenWhenNothingIsWrittenAgain() throws {
+        let recording = try savedTranscription()
+        let longAgo = Date(timeIntervalSinceNow: -10 * 24 * 60 * 60)
+        try journal.append(
+            [
+                SpeakerMatchJournalEntry(
+                    transcriptionId: recording.id,
+                    speakerId: "S1",
+                    outcome: .noComparableProfile,
+                    speechSeconds: 30,
+                    createdAt: longAgo
+                )
+            ],
+            retention: SpeakerMatchJournalRepository.defaultRetention,
+            now: longAgo
+        )
+        XCTAssertEqual(
+            try journal.entries(
+                retention: SpeakerMatchJournalRepository.defaultRetention, now: longAgo
+            ).count,
+            1
+        )
+
+        // Same rows, read once the window has passed, with no write in between.
+        XCTAssertTrue(
+            try journal.entries(retention: 24 * 60 * 60, now: Date()).isEmpty
+        )
+        try dbQueue.read { db in
+            XCTAssertEqual(try SpeakerMatchJournalEntry.fetchCount(db), 0)
+        }
     }
 
     // MARK: Enrollment

--- a/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintServiceTests.swift
@@ -560,6 +560,35 @@ final class SpeakerVoiceprintServiceTests: XCTestCase {
         )
     }
 
+    /// The user asked for a name, not for a row: when another enrollment claims
+    /// it between the lookup and the insert, the second one samples the winner
+    /// rather than failing.
+    func testAnEnrollmentThatLosesTheNameRaceSamplesTheWinner() async throws {
+        let first = try savedTranscription()
+        let winner = try await enrolledSarah(transcriptionId: first.id)
+
+        let racing = SpeakerVoiceprintService(
+            profiles: NameHidingStore(profiles),
+            journal: journal,
+            policy: .v1,
+            isEnabled: { true }
+        )
+        let second = try savedTranscription()
+        let result = try await racing.enroll(
+            displayName: "Sarah",
+            observation: cluster("S1", voice: 0, degrees: 14.1),
+            transcriptionId: second.id,
+            allowMergeIntoExistingName: false
+        )
+
+        guard case .addedExemplar(let profile) = result else {
+            return XCTFail("expected the loser to sample the winner, got \(result)")
+        }
+        XCTAssertEqual(profile.id, winner.id)
+        XCTAssertEqual(try profiles.profiles().count, 1)
+        XCTAssertEqual(try profiles.exemplars(profileId: winner.id).count, 2)
+    }
+
     // MARK: Confirmation
 
     func testConfirmingRecordsTheLinkButDoesNotAmplifyAYoungProfile() async throws {
@@ -674,4 +703,50 @@ final class SpeakerVoiceprintServiceTests: XCTestCase {
         }
         return profile
     }
+}
+
+/// Hides a name from the first lookup so `enroll` takes the path where another
+/// enrollment claimed it in between.
+private final class NameHidingStore: SpeakerProfileRepositoryProtocol {
+    private let wrapped: SpeakerProfileRepository
+    private let lock = NSLock()
+    private var hidden = true
+
+    init(_ wrapped: SpeakerProfileRepository) {
+        self.wrapped = wrapped
+    }
+
+    func profile(named name: String) throws -> SpeakerProfile? {
+        lock.lock()
+        let hide = hidden
+        hidden = false
+        lock.unlock()
+        return hide ? nil : try wrapped.profile(named: name)
+    }
+
+    func profiles() throws -> [SpeakerProfile] { try wrapped.profiles() }
+    func profile(id: UUID) throws -> SpeakerProfile? { try wrapped.profile(id: id) }
+    func insert(_ profile: SpeakerProfile) throws { try wrapped.insert(profile) }
+    func save(_ profile: SpeakerProfile) throws { try wrapped.save(profile) }
+    func exemplars(profileId: UUID) throws -> [SpeakerProfileExemplar] {
+        try wrapped.exemplars(profileId: profileId)
+    }
+    func exemplarsByProfile() throws -> [UUID: [SpeakerProfileExemplar]] {
+        try wrapped.exemplarsByProfile()
+    }
+    func insert(_ exemplar: SpeakerProfileExemplar) throws { try wrapped.insert(exemplar) }
+    func insertExemplar(
+        _ exemplar: SpeakerProfileExemplar,
+        maxPerProfile: Int,
+        evicting: SpeakerProfileExemplar.Origin
+    ) throws -> SpeakerExemplarInsertion {
+        try wrapped.insertExemplar(exemplar, maxPerProfile: maxPerProfile, evicting: evicting)
+    }
+    func deleteExemplar(id: UUID) throws -> Bool { try wrapped.deleteExemplar(id: id) }
+    func links(transcriptionId: UUID, fingerprint: String) throws -> [SpeakerProfileLink] {
+        try wrapped.links(transcriptionId: transcriptionId, fingerprint: fingerprint)
+    }
+    func save(_ link: SpeakerProfileLink) throws { try wrapped.save(link) }
+    func deleteProfile(id: UUID) throws -> Bool { try wrapped.deleteProfile(id: id) }
+    func deleteAllProfiles() throws { try wrapped.deleteAllProfiles() }
 }

--- a/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintServiceTests.swift
@@ -5,6 +5,7 @@ import GRDB
 final class SpeakerVoiceprintServiceTests: XCTestCase {
     private var dbQueue: DatabaseQueue!
     private var profiles: SpeakerProfileRepository!
+    private var candidates: SpeakerEmbeddingCandidateRepository!
     private var journal: SpeakerMatchJournalRepository!
     private var transcriptions: TranscriptionRepository!
     private var enabled = true
@@ -19,6 +20,7 @@ final class SpeakerVoiceprintServiceTests: XCTestCase {
         let manager = try DatabaseManager()
         dbQueue = manager.dbQueue
         profiles = SpeakerProfileRepository(dbQueue: manager.dbQueue)
+        candidates = SpeakerEmbeddingCandidateRepository(dbQueue: manager.dbQueue)
         journal = SpeakerMatchJournalRepository(dbQueue: manager.dbQueue)
         transcriptions = TranscriptionRepository(dbQueue: manager.dbQueue)
         enabled = true
@@ -225,6 +227,7 @@ final class SpeakerVoiceprintServiceTests: XCTestCase {
             displayName: "  Sarah  ",
             observation: cluster("S1", voice: 0, degrees: 0),
             transcriptionId: recording.id,
+            fingerprint: fingerprint,
             allowMergeIntoExistingName: false
         )
 
@@ -243,6 +246,7 @@ final class SpeakerVoiceprintServiceTests: XCTestCase {
             displayName: "Sarah",
             observation: cluster("S1", voice: 0, degrees: 0, speechSeconds: 12),
             transcriptionId: recording.id,
+            fingerprint: fingerprint,
             allowMergeIntoExistingName: false
         )
 
@@ -261,6 +265,7 @@ final class SpeakerVoiceprintServiceTests: XCTestCase {
             displayName: "sarah",
             observation: cluster("S1", voice: 0, degrees: 14.1),
             transcriptionId: second.id,
+            fingerprint: fingerprint,
             allowMergeIntoExistingName: false
         )
 
@@ -282,6 +287,7 @@ final class SpeakerVoiceprintServiceTests: XCTestCase {
             displayName: "Sarah",
             observation: cluster("S1", voice: 4, degrees: 0),
             transcriptionId: second.id,
+            fingerprint: fingerprint,
             allowMergeIntoExistingName: false
         )
 
@@ -302,6 +308,7 @@ final class SpeakerVoiceprintServiceTests: XCTestCase {
             displayName: "Sarah",
             observation: cluster("S1", voice: 4, degrees: 0),
             transcriptionId: second.id,
+            fingerprint: fingerprint,
             allowMergeIntoExistingName: true
         )
 
@@ -319,6 +326,7 @@ final class SpeakerVoiceprintServiceTests: XCTestCase {
             displayName: "Sarah",
             observation: cluster("S2", voice: 0, degrees: 14.1),
             transcriptionId: recording.id,
+            fingerprint: fingerprint,
             allowMergeIntoExistingName: false
         )
 
@@ -371,6 +379,7 @@ final class SpeakerVoiceprintServiceTests: XCTestCase {
             displayName: "Sarah",
             observation: observation,
             transcriptionId: second.id,
+            fingerprint: fingerprint,
             allowMergeIntoExistingName: false
         )
 
@@ -405,6 +414,7 @@ final class SpeakerVoiceprintServiceTests: XCTestCase {
             displayName: "Sarah",
             observation: observation,
             transcriptionId: second.id,
+            fingerprint: fingerprint,
             allowMergeIntoExistingName: true
         )
 
@@ -421,6 +431,7 @@ final class SpeakerVoiceprintServiceTests: XCTestCase {
                 displayName: blank,
                 observation: cluster("S1", voice: 0, degrees: 0),
                 transcriptionId: recording.id,
+                fingerprint: fingerprint,
                 allowMergeIntoExistingName: false
             )
             XCTAssertEqual(result, .rejectedEmptyName)
@@ -474,6 +485,7 @@ final class SpeakerVoiceprintServiceTests: XCTestCase {
             displayName: "Sarah",
             observation: cluster("S1", voice: 0, degrees: 14.1),
             transcriptionId: second.id,
+            fingerprint: fingerprint,
             allowMergeIntoExistingName: false
         )
 
@@ -539,6 +551,7 @@ final class SpeakerVoiceprintServiceTests: XCTestCase {
                 displayName: "Sarah",
                 observation: cluster("S1", voice: 0, degrees: 14.1),
                 transcriptionId: recording.id,
+                fingerprint: fingerprint,
                 allowMergeIntoExistingName: false
             )
         }
@@ -548,6 +561,7 @@ final class SpeakerVoiceprintServiceTests: XCTestCase {
             displayName: "Sarah",
             observation: cluster("S1", voice: 0, degrees: 14.1),
             transcriptionId: overflow.id,
+            fingerprint: fingerprint,
             allowMergeIntoExistingName: false
         )
 
@@ -569,6 +583,7 @@ final class SpeakerVoiceprintServiceTests: XCTestCase {
 
         let racing = SpeakerVoiceprintService(
             profiles: NameHidingStore(profiles),
+            candidates: candidates,
             journal: journal,
             policy: .v1,
             isEnabled: { true }
@@ -578,6 +593,7 @@ final class SpeakerVoiceprintServiceTests: XCTestCase {
             displayName: "Sarah",
             observation: cluster("S1", voice: 0, degrees: 14.1),
             transcriptionId: second.id,
+            fingerprint: fingerprint,
             allowMergeIntoExistingName: false
         )
 
@@ -587,6 +603,170 @@ final class SpeakerVoiceprintServiceTests: XCTestCase {
         XCTAssertEqual(profile.id, winner.id)
         XCTAssertEqual(try profiles.profiles().count, 1)
         XCTAssertEqual(try profiles.exemplars(profileId: winner.id).count, 2)
+    }
+
+    // MARK: Enrollment candidates
+
+    /// The run that matters most for enrollment is the first one, when there is
+    /// no profile to score against and every matching path returns early.
+    func testAVoiceIsRetainedEvenWhenThereIsNothingToMatchAgainst() async throws {
+        let recording = try savedTranscription()
+
+        _ = try await makeService().evaluate(
+            transcriptionId: recording.id,
+            fingerprint: fingerprint,
+            clusters: [cluster("S1", voice: 0, degrees: 0)]
+        )
+
+        let observation = try await makeService().enrollmentCandidate(
+            transcriptionId: recording.id, speakerId: "S1", fingerprint: fingerprint
+        )
+        XCTAssertEqual(
+            try XCTUnwrap(observation).embedding.vector, embedding(voice: 0, degrees: 0).vector
+        )
+    }
+
+    func testNothingIsRetainedWhileTheFeatureIsOff() async throws {
+        let recording = try savedTranscription()
+        enabled = false
+
+        _ = try await makeService().evaluate(
+            transcriptionId: recording.id,
+            fingerprint: fingerprint,
+            clusters: [cluster("S1", voice: 0, degrees: 0)]
+        )
+
+        XCTAssertNil(
+            try candidates.candidate(
+                transcriptionId: recording.id, speakerId: "S1",
+                fingerprint: fingerprint.rawValue, now: Date()
+            )
+        )
+    }
+
+    /// A vector below the enrollment gate can never become an exemplar, so
+    /// keeping it would store biometric data for an offer never made.
+    func testAClusterTooShortToEnrollIsNotRetained() async throws {
+        let recording = try savedTranscription()
+
+        _ = try await makeService().evaluate(
+            transcriptionId: recording.id,
+            fingerprint: fingerprint,
+            clusters: [cluster("S1", voice: 0, degrees: 0, speechSeconds: 14)]
+        )
+
+        XCTAssertNil(
+            try candidates.candidate(
+                transcriptionId: recording.id, speakerId: "S1",
+                fingerprint: fingerprint.rawValue, now: Date()
+            )
+        )
+    }
+
+    /// Captured while on, unreachable once off: the preference governs reads as
+    /// well as writes.
+    func testARetainedVoiceIsUnreachableAfterTheFeatureIsTurnedOff() async throws {
+        let recording = try savedTranscription()
+        _ = try await makeService().evaluate(
+            transcriptionId: recording.id,
+            fingerprint: fingerprint,
+            clusters: [cluster("S1", voice: 0, degrees: 0)]
+        )
+
+        enabled = false
+
+        let offered = try await makeService().enrollmentCandidate(
+            transcriptionId: recording.id, speakerId: "S1", fingerprint: fingerprint
+        )
+        XCTAssertNil(offered)
+    }
+
+    func testARetainedVoiceStopsBeingOfferedOnceTheWindowLapses() async throws {
+        let recording = try savedTranscription()
+        let captured = Date(timeIntervalSince1970: 1_757_000_000)
+        let service = makeService(retention: 60, now: captured)
+        _ = try await service.evaluate(
+            transcriptionId: recording.id,
+            fingerprint: fingerprint,
+            clusters: [cluster("S1", voice: 0, degrees: 0)]
+        )
+
+        let withinWindow = try await makeService(retention: 60, now: captured.addingTimeInterval(59))
+            .enrollmentCandidate(
+                transcriptionId: recording.id, speakerId: "S1", fingerprint: fingerprint
+            )
+        XCTAssertNotNil(withinWindow)
+
+        let lapsed = try await makeService(retention: 60, now: captured.addingTimeInterval(60))
+            .enrollmentCandidate(
+                transcriptionId: recording.id, speakerId: "S1", fingerprint: fingerprint
+            )
+        XCTAssertNil(lapsed)
+    }
+
+    /// Once promoted, the vector lives in the profile; a second copy would be
+    /// biometric data kept for nothing.
+    func testEnrollingConsumesTheCandidate() async throws {
+        let recording = try savedTranscription()
+        let service = makeService()
+        _ = try await service.evaluate(
+            transcriptionId: recording.id,
+            fingerprint: fingerprint,
+            clusters: [cluster("S1", voice: 0, degrees: 0)]
+        )
+
+        let offered = try await service.enrollmentCandidate(
+            transcriptionId: recording.id, speakerId: "S1", fingerprint: fingerprint
+        )
+        let observation = try XCTUnwrap(offered)
+        _ = try await service.enroll(
+            displayName: "Sarah",
+            observation: observation,
+            transcriptionId: recording.id,
+            fingerprint: fingerprint,
+            allowMergeIntoExistingName: false
+        )
+
+        XCTAssertNil(
+            try candidates.candidate(
+                transcriptionId: recording.id, speakerId: "S1",
+                fingerprint: fingerprint.rawValue, now: Date()
+            )
+        )
+    }
+
+    func testConfirmingConsumesTheCandidateOnceTheProfileLearns() async throws {
+        let first = try savedTranscription()
+        try await enrolledSarah(transcriptionId: first.id)
+        let second = try savedTranscription()
+        let service = makeService()
+        _ = try await service.enroll(
+            displayName: "Sarah",
+            observation: cluster("S1", voice: 0, degrees: 14.1),
+            transcriptionId: second.id,
+            fingerprint: fingerprint,
+            allowMergeIntoExistingName: false
+        )
+
+        let third = try savedTranscription()
+        let suggestions = try await service.evaluate(
+            transcriptionId: third.id,
+            fingerprint: fingerprint,
+            clusters: [cluster("S1", voice: 0, degrees: 14.1)]
+        )
+        try await service.confirm(
+            try XCTUnwrap(suggestions.first),
+            observation: cluster("S1", voice: 0, degrees: 14.1),
+            transcriptionId: third.id,
+            fingerprint: fingerprint
+        )
+
+        XCTAssertNil(
+            try candidates.candidate(
+                transcriptionId: third.id, speakerId: "S1",
+                fingerprint: fingerprint.rawValue, now: Date()
+            )
+        )
     }
 
     // MARK: Confirmation
@@ -627,6 +807,7 @@ final class SpeakerVoiceprintServiceTests: XCTestCase {
             displayName: "Sarah",
             observation: cluster("S1", voice: 0, degrees: 14.1),
             transcriptionId: second.id,
+            fingerprint: fingerprint,
             allowMergeIntoExistingName: false
         )
 
@@ -653,13 +834,19 @@ final class SpeakerVoiceprintServiceTests: XCTestCase {
     /// Reads `enabled` once, at construction: capturing it lazily would put the
     /// test case itself inside a `@Sendable` closure. Every test that flips the
     /// preference does so before building its service.
-    private func makeService() -> SpeakerVoiceprintService {
+    private func makeService(
+        retention: TimeInterval = SpeakerEmbeddingCandidateRepository.defaultRetention,
+        now: Date? = nil
+    ) -> SpeakerVoiceprintService {
         let enabled = enabled
         return SpeakerVoiceprintService(
             profiles: profiles,
+            candidates: candidates,
             journal: journal,
             policy: .v1,
-            isEnabled: { enabled }
+            candidateRetention: retention,
+            isEnabled: { enabled },
+            now: { now ?? Date() }
         )
     }
 
@@ -700,6 +887,7 @@ final class SpeakerVoiceprintServiceTests: XCTestCase {
             displayName: "Sarah",
             observation: cluster("S1", voice: 0, degrees: 0),
             transcriptionId: transcriptionId,
+            fingerprint: fingerprint,
             allowMergeIntoExistingName: false
         )
         guard case .created(let profile) = result else {

--- a/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintServiceTests.swift
@@ -347,46 +347,6 @@ final class SpeakerVoiceprintServiceTests: XCTestCase {
         XCTAssertEqual(entries.map(\.transcriptFingerprint), [fingerprint.rawValue])
     }
 
-    /// Only the first `maxReferencesPerProfile` are scored, so the newest
-    /// samples must be the ones that survive the cap.
-    func testTheNewestExemplarsAreTheOnesScored() async throws {
-        let service = makeService()
-        let first = try savedTranscription()
-        let profile = try await enrolledSarah(transcriptionId: first.id)
-
-        // Fill the cap with samples of one voice, then add a newer one that
-        // sits on a different voice entirely.
-        for index in 1..<SpeakerMatchPolicy.v1.maxReferencesPerProfile {
-            let recording = try savedTranscription()
-            _ = try await service.enroll(
-                displayName: "Sarah",
-                observation: cluster("S\(index)", voice: 0, degrees: 0),
-                transcriptionId: recording.id,
-                allowMergeIntoExistingName: true
-            )
-        }
-        let newest = try savedTranscription()
-        _ = try await service.enroll(
-            displayName: "Sarah",
-            observation: cluster("S99", voice: 6, degrees: 0),
-            transcriptionId: newest.id,
-            allowMergeIntoExistingName: true
-        )
-        XCTAssertEqual(
-            try profiles.exemplars(profileId: profile.id).count,
-            SpeakerMatchPolicy.v1.maxReferencesPerProfile + 1
-        )
-
-        // The newest sample decides, which it could not if the cap kept the
-        // oldest ten.
-        let suggestions = try await service.evaluate(
-            transcriptionId: try savedTranscription().id,
-            fingerprint: fingerprint,
-            clusters: [cluster("S1", voice: 6, degrees: 0)]
-        )
-        XCTAssertEqual(suggestions.map(\.displayName), ["Sarah"])
-    }
-
     /// An embedding from another model carries no comparable evidence, so it
     /// must not slip past the guard into a silent merge.
     func testEnrollingWithAnIncomparableModelAsksInstead() async throws {
@@ -498,6 +458,105 @@ final class SpeakerVoiceprintServiceTests: XCTestCase {
             try profiles.links(transcriptionId: next.id, fingerprint: fingerprint.rawValue)
                 .map(\.status),
             [.confirmed]
+        )
+    }
+
+    /// The cap has to bound storage, not just scoring: vectors the matcher can
+    /// never reach would be biometric data kept for nothing.
+    func testTheOldestConfirmationIsEvictedAtTheCap() async throws {
+        let service = makeService()
+        let first = try savedTranscription()
+        let profile = try await enrolledSarah(transcriptionId: first.id)
+
+        // A second manual enrollment unlocks learning from confirmations.
+        let second = try savedTranscription()
+        _ = try await service.enroll(
+            displayName: "Sarah",
+            observation: cluster("S1", voice: 0, degrees: 14.1),
+            transcriptionId: second.id,
+            allowMergeIntoExistingName: false
+        )
+
+        // Fill the rest of the cap with confirmations.
+        var confirmedRecordings: [UUID] = []
+        while try profiles.exemplars(profileId: profile.id).count
+            < SpeakerMatchPolicy.v1.maxReferencesPerProfile
+        {
+            let recording = try savedTranscription()
+            confirmedRecordings.append(recording.id)
+            let suggestions = try await service.evaluate(
+                transcriptionId: recording.id,
+                fingerprint: fingerprint,
+                clusters: [cluster("S1", voice: 0, degrees: 14.1)]
+            )
+            try await service.confirm(
+                try XCTUnwrap(suggestions.first),
+                observation: cluster("S1", voice: 0, degrees: 14.1),
+                transcriptionId: recording.id,
+                fingerprint: fingerprint
+            )
+        }
+        XCTAssertEqual(
+            try profiles.exemplars(profileId: profile.id).count,
+            SpeakerMatchPolicy.v1.maxReferencesPerProfile
+        )
+        let oldestConfirmation = try XCTUnwrap(confirmedRecordings.first)
+
+        // One more recording: the count holds and the oldest confirmation goes.
+        let extra = try savedTranscription()
+        let suggestions = try await service.evaluate(
+            transcriptionId: extra.id,
+            fingerprint: fingerprint,
+            clusters: [cluster("S1", voice: 0, degrees: 14.1)]
+        )
+        try await service.confirm(
+            try XCTUnwrap(suggestions.first),
+            observation: cluster("S1", voice: 0, degrees: 14.1),
+            transcriptionId: extra.id,
+            fingerprint: fingerprint
+        )
+
+        let stored = try profiles.exemplars(profileId: profile.id)
+        XCTAssertEqual(stored.count, SpeakerMatchPolicy.v1.maxReferencesPerProfile)
+        XCTAssertFalse(stored.contains { $0.sourceTranscriptionId == oldestConfirmation })
+        XCTAssertTrue(stored.contains { $0.sourceTranscriptionId == extra.id })
+        // Both manual anchors survive, so the profile keeps its right to learn.
+        XCTAssertEqual(stored.filter { $0.origin == .manualEnrollment }.count, 2)
+    }
+
+    /// Ten manual enrollments are the strongest evidence there is; there is
+    /// nothing to evict without weakening the anchor.
+    func testAProfileFullOfManualEnrollmentsRefusesMore() async throws {
+        let service = makeService()
+        let first = try savedTranscription()
+        let profile = try await enrolledSarah(transcriptionId: first.id)
+
+        while try profiles.exemplars(profileId: profile.id).count
+            < SpeakerMatchPolicy.v1.maxReferencesPerProfile
+        {
+            let recording = try savedTranscription()
+            _ = try await service.enroll(
+                displayName: "Sarah",
+                observation: cluster("S1", voice: 0, degrees: 14.1),
+                transcriptionId: recording.id,
+                allowMergeIntoExistingName: false
+            )
+        }
+
+        let overflow = try savedTranscription()
+        let result = try await service.enroll(
+            displayName: "Sarah",
+            observation: cluster("S1", voice: 0, degrees: 14.1),
+            transcriptionId: overflow.id,
+            allowMergeIntoExistingName: false
+        )
+
+        guard case .rejectedProfileFull = result else {
+            return XCTFail("expected a refusal, got \(result)")
+        }
+        XCTAssertEqual(
+            try profiles.exemplars(profileId: profile.id).count,
+            SpeakerMatchPolicy.v1.maxReferencesPerProfile
         )
     }
 

--- a/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintServiceTests.swift
@@ -1119,6 +1119,128 @@ final class SpeakerVoiceprintServiceTests: XCTestCase {
         XCTAssertEqual(exemplars.filter { $0.origin == .confirmedSuggestion }.count, 1)
     }
 
+    func testConfirmedShortMatchesDoNotLearnUntilTheEnrollmentDurationBoundary() async throws {
+        let first = try savedTranscription()
+        let profile = try await enrolledSarah(transcriptionId: first.id)
+        let second = try savedTranscription()
+        let matchedAt = Date(timeIntervalSince1970: 1_800_000_000)
+        let service = makeService(now: matchedAt)
+        _ = try await service.enroll(
+            displayName: "Sarah", observation: cluster("S1", voice: 0, degrees: 14.1),
+            transcriptionId: second.id, fingerprint: fingerprint, allowMergeIntoExistingName: false
+        )
+
+        for duration in [3.0, 14.999, 15.0] {
+            let recording = try savedTranscription()
+            let observation = cluster("S1", voice: 0, degrees: 14.1, speechSeconds: duration)
+            let offers = try await service.evaluate(
+                transcriptionId: recording.id, fingerprint: fingerprint, clusters: [observation]
+            )
+            try await service.confirm(
+                try XCTUnwrap(offers.first), observation: observation,
+                transcriptionId: recording.id, fingerprint: fingerprint
+            )
+            XCTAssertEqual(
+                try profiles.links(transcriptionId: recording.id, fingerprint: fingerprint.rawValue).map(\.status),
+                [.confirmed]
+            )
+            XCTAssertEqual(try profiles.profile(id: profile.id)?.lastMatchedAt, matchedAt)
+            let learned = try profiles.exemplars(profileId: profile.id).filter { $0.origin == .confirmedSuggestion }
+            XCTAssertEqual(learned.count, duration < 15 ? 0 : 1)
+            if duration == 15 {
+                XCTAssertEqual(learned.first?.sourceTranscriptionId, recording.id)
+                XCTAssertEqual(learned.first?.speechSeconds, 15)
+            }
+        }
+    }
+
+    func testRescoringPastThresholdRemovesThePreviousPendingSuggestion() async throws {
+        let enrollment = try savedTranscription()
+        _ = try await enrolledSarah(transcriptionId: enrollment.id)
+        let recording = try savedTranscription()
+        let service = makeService()
+        let first = try await service.evaluate(
+            transcriptionId: recording.id, fingerprint: fingerprint,
+            clusters: [cluster("S1", voice: 0, degrees: 14.1)]
+        )
+        XCTAssertEqual(first.count, 1)
+        let second = try await service.evaluate(
+            transcriptionId: recording.id, fingerprint: fingerprint,
+            clusters: [cluster("S1", voice: 0, degrees: 80)]
+        )
+        XCTAssertTrue(second.isEmpty)
+        XCTAssertTrue(try profiles.links(transcriptionId: recording.id, fingerprint: fingerprint.rawValue).isEmpty)
+        XCTAssertTrue(try journal.entries().contains { $0.outcome == .pastThreshold })
+    }
+
+    func testRescoringWithAnAmbiguousProfileRemovesThePreviousPendingSuggestion() async throws {
+        let enrollment = try savedTranscription()
+        _ = try await enrolledSarah(transcriptionId: enrollment.id)
+        let recording = try savedTranscription()
+        let service = makeService()
+        let observation = cluster("S1", voice: 0, degrees: 14.1)
+        let first = try await service.evaluate(
+            transcriptionId: recording.id, fingerprint: fingerprint, clusters: [observation]
+        )
+        XCTAssertEqual(first.count, 1)
+        let other = try savedTranscription()
+        _ = try await service.enroll(
+            displayName: "Alex", observation: cluster("S1", voice: 0, degrees: 20),
+            transcriptionId: other.id, fingerprint: fingerprint, allowMergeIntoExistingName: false
+        )
+        let second = try await service.evaluate(
+            transcriptionId: recording.id, fingerprint: fingerprint, clusters: [observation]
+        )
+        XCTAssertTrue(second.isEmpty)
+        XCTAssertTrue(try profiles.links(transcriptionId: recording.id, fingerprint: fingerprint.rawValue).isEmpty)
+        XCTAssertTrue(try journal.entries().contains { $0.outcome == .marginTooSmall })
+    }
+
+    func testEmptyRescoringClearsPendingLinksButPreservesDecisionsAndOtherFingerprints() async throws {
+        let enrollment = try savedTranscription()
+        let profile = try await enrolledSarah(transcriptionId: enrollment.id)
+        let recording = try savedTranscription()
+        let service = makeService()
+        for (speaker, status, scope) in [
+            ("S1", SpeakerProfileLink.Status.suggested, fingerprint.rawValue),
+            ("S2", .confirmed, fingerprint.rawValue),
+            ("S3", .dismissed, fingerprint.rawValue),
+            ("S1", .suggested, "other-fingerprint"),
+        ] {
+            try profiles.save(
+                SpeakerProfileLink(
+                    transcriptionId: recording.id, speakerId: speaker, transcriptFingerprint: scope,
+                    profileId: profile.id, status: status, distance: 0.1
+                ))
+        }
+        _ = try await service.evaluate(transcriptionId: recording.id, fingerprint: fingerprint, clusters: [])
+        let remaining = try profiles.links(transcriptionId: recording.id, fingerprint: fingerprint.rawValue)
+        XCTAssertEqual(Set(remaining.map(\.speakerId)), ["S2", "S3"])
+        XCTAssertEqual(remaining.first { $0.speakerId == "S2" }?.status, .confirmed)
+        XCTAssertEqual(remaining.first { $0.speakerId == "S3" }?.status, .dismissed)
+        XCTAssertEqual(try profiles.links(transcriptionId: recording.id, fingerprint: "other-fingerprint").count, 1)
+    }
+
+    func testNoComparableProfilesClearsPendingLinks() async throws {
+        let enrollment = try savedTranscription()
+        let profile = try await enrolledSarah(transcriptionId: enrollment.id)
+        let recording = try savedTranscription()
+        let service = makeService()
+        let observation = cluster("S1", voice: 0, degrees: 14.1)
+        let first = try await service.evaluate(
+            transcriptionId: recording.id, fingerprint: fingerprint, clusters: [observation]
+        )
+        XCTAssertEqual(first.count, 1)
+        for exemplar in try profiles.exemplars(profileId: profile.id) {
+            XCTAssertTrue(try profiles.deleteExemplar(id: exemplar.id))
+        }
+        let second = try await service.evaluate(
+            transcriptionId: recording.id, fingerprint: fingerprint, clusters: [observation]
+        )
+        XCTAssertTrue(second.isEmpty)
+        XCTAssertTrue(try profiles.links(transcriptionId: recording.id, fingerprint: fingerprint.rawValue).isEmpty)
+    }
+
     // MARK: Helpers
 
     /// Reads `enabled` once, at construction: capturing it lazily would put the
@@ -1244,6 +1366,11 @@ private final class NameHidingStore: SpeakerProfileRepositoryProtocol, @unchecke
         try wrapped.links(transcriptionId: transcriptionId, fingerprint: fingerprint)
     }
     func save(_ link: SpeakerProfileLink) throws { try wrapped.save(link) }
+    func replaceSuggestions(
+        transcriptionId: UUID, fingerprint: String, with links: [SpeakerProfileLink]
+    ) throws -> [SpeakerProfileLink] {
+        try wrapped.replaceSuggestions(transcriptionId: transcriptionId, fingerprint: fingerprint, with: links)
+    }
     func deleteProfile(id: UUID) throws -> Bool { try wrapped.deleteProfile(id: id) }
     func deleteAllProfiles() throws { try wrapped.deleteAllProfiles() }
 }

--- a/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintServiceTests.swift
@@ -40,7 +40,8 @@ final class SpeakerVoiceprintServiceTests: XCTestCase {
         )
 
         XCTAssertTrue(suggestions.isEmpty)
-        XCTAssertTrue(try journal.entries(retention: SpeakerMatchJournalRepository.defaultRetention, now: Date()).isEmpty)
+        XCTAssertTrue(
+            try journal.entries(retention: SpeakerMatchJournalRepository.defaultRetention, now: Date()).isEmpty)
         XCTAssertTrue(try profiles.links(transcriptionId: recording.id, fingerprint: fingerprint.rawValue).isEmpty)
     }
 
@@ -140,7 +141,8 @@ final class SpeakerVoiceprintServiceTests: XCTestCase {
         )
 
         XCTAssertTrue(suggestions.isEmpty)
-        XCTAssertTrue(try journal.entries(retention: SpeakerMatchJournalRepository.defaultRetention, now: Date()).isEmpty)
+        XCTAssertTrue(
+            try journal.entries(retention: SpeakerMatchJournalRepository.defaultRetention, now: Date()).isEmpty)
     }
 
     // MARK: Evaluation
@@ -226,7 +228,9 @@ final class SpeakerVoiceprintServiceTests: XCTestCase {
         )
 
         let outcomes = Dictionary(
-            uniqueKeysWithValues: try journal.entries(retention: SpeakerMatchJournalRepository.defaultRetention, now: Date()).map { ($0.speakerId, $0.outcome) }
+            uniqueKeysWithValues: try journal.entries(
+                retention: SpeakerMatchJournalRepository.defaultRetention, now: Date()
+            ).map { ($0.speakerId, $0.outcome) }
         )
         XCTAssertEqual(outcomes["S1"], .suggested)
         XCTAssertEqual(outcomes["S2"], .pastThreshold)
@@ -267,7 +271,8 @@ final class SpeakerVoiceprintServiceTests: XCTestCase {
             retention: SpeakerMatchJournalRepository.defaultRetention,
             now: Date()
         )
-        XCTAssertTrue(try journal.entries(retention: SpeakerMatchJournalRepository.defaultRetention, now: Date()).isEmpty)
+        XCTAssertTrue(
+            try journal.entries(retention: SpeakerMatchJournalRepository.defaultRetention, now: Date()).isEmpty)
     }
 
     /// Expiry cannot ride on writes alone: a user who stops recording stops
@@ -771,18 +776,21 @@ final class SpeakerVoiceprintServiceTests: XCTestCase {
         let second = try savedTranscription()
         let service = makeService()
 
+        let firstObservation = cluster("S1", voice: 0, degrees: 0)
+        let secondObservation = cluster("S2", voice: 4, degrees: 0)
+        let transcriptFingerprint = fingerprint
         async let left = service.enroll(
             displayName: "Sarah",
-            observation: cluster("S1", voice: 0, degrees: 0),
+            observation: firstObservation,
             transcriptionId: first.id,
-            fingerprint: fingerprint,
+            fingerprint: transcriptFingerprint,
             allowMergeIntoExistingName: false
         )
         async let right = service.enroll(
             displayName: "Sarah",
-            observation: cluster("S2", voice: 4, degrees: 0),
+            observation: secondObservation,
             transcriptionId: second.id,
-            fingerprint: fingerprint,
+            fingerprint: transcriptFingerprint,
             allowMergeIntoExistingName: false
         )
         let results = [try await left, try await right]
@@ -790,11 +798,19 @@ final class SpeakerVoiceprintServiceTests: XCTestCase {
         XCTAssertEqual(try profiles.profiles().count, 1)
         let profile = try XCTUnwrap(try profiles.profiles().first)
         XCTAssertEqual(try profiles.exemplars(profileId: profile.id).count, 1)
-        XCTAssertTrue(results.contains { if case .created = $0 { return true }; return false })
         XCTAssertTrue(
-            results.contains { if case .needsDisambiguation = $0 { return true }; return false }
+            results.contains {
+                if case .created = $0 { return true }; return false
+            })
+        XCTAssertTrue(
+            results.contains {
+                if case .needsDisambiguation = $0 { return true }; return false
+            }
         )
-        XCTAssertFalse(results.contains { if case .addedExemplar = $0 { return true }; return false })
+        XCTAssertFalse(
+            results.contains {
+                if case .addedExemplar = $0 { return true }; return false
+            })
     }
 
     // MARK: Enrollment candidates

--- a/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintServiceTests.swift
@@ -420,6 +420,40 @@ final class SpeakerVoiceprintServiceTests: XCTestCase {
         XCTAssertEqual(try profiles.exemplars(profileId: profile.id).count, 1)
     }
 
+    /// Forcing a merge overrides a judgement about which person this is, not
+    /// about whether two vectors can be compared: the store would refuse the
+    /// sample anyway, so the service must stop first.
+    func testForcingAMergeStillRefusesAnIncomparableModel() async throws {
+        let first = try savedTranscription()
+        let profile = try await enrolledSarah(transcriptionId: first.id)
+        let second = try savedTranscription()
+
+        let otherModel = SpeakerModelIdentity(
+            embeddingModelId: "other-model",
+            aggregationProfileId: identity.aggregationProfileId
+        )
+        var values = [Float](repeating: 0, count: SpeakerEmbedding.dimension)
+        values[0] = 1
+        let observation = SpeakerClusterObservation(
+            speakerId: "S1",
+            embedding: try XCTUnwrap(SpeakerEmbedding(rawVector: values, identity: otherModel)),
+            speechSeconds: 30,
+            captureDomain: .system
+        )
+
+        let result = try await makeService().enroll(
+            displayName: "Sarah",
+            observation: observation,
+            transcriptionId: second.id,
+            allowMergeIntoExistingName: true
+        )
+
+        guard case .needsDisambiguation = result else {
+            return XCTFail("expected disambiguation, got \(result)")
+        }
+        XCTAssertEqual(try profiles.exemplars(profileId: profile.id).count, 1)
+    }
+
     // MARK: Confirmation
 
     func testConfirmingRecordsTheLinkButDoesNotAmplifyAYoungProfile() async throws {

--- a/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintServiceTests.swift
@@ -164,7 +164,7 @@ final class SpeakerVoiceprintServiceTests: XCTestCase {
         XCTAssertEqual(links.first?.profileId, profile.id)
     }
 
-    func testDismissedSpeakersAreNotScoredAgainForTheSameFingerprint() async throws {
+    func testDismissedSpeakersAreNotSuggestedAgainForTheSameFingerprint() async throws {
         let recording = try savedTranscription()
         _ = try await enrolledSarah(transcriptionId: recording.id)
         let next = try savedTranscription()
@@ -185,6 +185,11 @@ final class SpeakerVoiceprintServiceTests: XCTestCase {
             clusters: [cluster("S1", voice: 0, degrees: 14.1)]
         )
         XCTAssertTrue(second.isEmpty)
+        XCTAssertEqual(
+            try profiles.links(transcriptionId: next.id, fingerprint: fingerprint.rawValue).map(\.status),
+            [.dismissed]
+        )
+        XCTAssertEqual(try journal.entries().map(\.outcome), [.suggested, .suggested])
     }
 
     /// Re-diarization changes the fingerprint, and speaker ids are positional,
@@ -530,9 +535,8 @@ final class SpeakerVoiceprintServiceTests: XCTestCase {
         XCTAssertTrue(try profiles.profiles().isEmpty)
     }
 
-    /// A confirmation is as final as a refusal: rescoring would write a fresh
-    /// suggestion over the answer the user gave.
-    func testConfirmedSpeakersAreNotScoredAgain() async throws {
+    /// Re-evaluation preserves the answer while recording the matcher outcome.
+    func testConfirmedSpeakersAreNotSuggestedAgain() async throws {
         let recording = try savedTranscription()
         _ = try await enrolledSarah(transcriptionId: recording.id)
         let next = try savedTranscription()
@@ -561,6 +565,35 @@ final class SpeakerVoiceprintServiceTests: XCTestCase {
                 .map(\.status),
             [.confirmed]
         )
+        XCTAssertEqual(try journal.entries().map(\.outcome), [.suggested, .suggested])
+    }
+
+    func testJournalPreservesAMatchWithheldForAnAlreadyConfirmedProfile() async throws {
+        let enrollment = try savedTranscription()
+        let profile = try await enrolledSarah(transcriptionId: enrollment.id)
+        let recording = try savedTranscription()
+        try profiles.save(
+            SpeakerProfileLink(
+                transcriptionId: recording.id, speakerId: "S1",
+                transcriptFingerprint: fingerprint.rawValue, profileId: profile.id,
+                status: .confirmed, distance: 0.03
+            ))
+
+        let suggestions = try await makeService().evaluate(
+            transcriptionId: recording.id, fingerprint: fingerprint,
+            clusters: [cluster("S2", voice: 0, degrees: 14.1)]
+        )
+
+        XCTAssertTrue(suggestions.isEmpty)
+        let links = try profiles.links(transcriptionId: recording.id, fingerprint: fingerprint.rawValue)
+        XCTAssertEqual(links.map(\.speakerId), ["S1"])
+        XCTAssertEqual(links.map(\.status), [.confirmed])
+        let entries = try journal.entries()
+        XCTAssertEqual(entries.count, 1)
+        let entry = try XCTUnwrap(entries.first)
+        XCTAssertEqual(entry.speakerId, "S2")
+        XCTAssertEqual(entry.profileId, profile.id)
+        XCTAssertEqual(entry.outcome, .suggested)
     }
 
     /// 14.1° clears tau; 41.4° is exactly tau. Together they keep the margin.
@@ -601,6 +634,12 @@ final class SpeakerVoiceprintServiceTests: XCTestCase {
             ["S1"]
         )
         XCTAssertFalse(links.contains { $0.speakerId == "S2" })
+        let entries = try journal.entries()
+        XCTAssertEqual(entries.filter { $0.speakerId == "S1" }.map(\.outcome), [.suggested, .suggested])
+        XCTAssertEqual(
+            entries.filter { $0.speakerId == "S2" }.map(\.outcome),
+            [.notMutualBestMatch, .notMutualBestMatch]
+        )
     }
 
     /// Dismissing the closer cluster must not manufacture a suggestion for the

--- a/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintServiceTests.swift
@@ -650,12 +650,16 @@ final class SpeakerVoiceprintServiceTests: XCTestCase {
 
     // MARK: Helpers
 
+    /// Reads `enabled` once, at construction: capturing it lazily would put the
+    /// test case itself inside a `@Sendable` closure. Every test that flips the
+    /// preference does so before building its service.
     private func makeService() -> SpeakerVoiceprintService {
-        SpeakerVoiceprintService(
+        let enabled = enabled
+        return SpeakerVoiceprintService(
             profiles: profiles,
             journal: journal,
             policy: .v1,
-            isEnabled: { [self] in enabled }
+            isEnabled: { enabled }
         )
     }
 
@@ -707,7 +711,9 @@ final class SpeakerVoiceprintServiceTests: XCTestCase {
 
 /// Hides a name from the first lookup so `enroll` takes the path where another
 /// enrollment claimed it in between.
-private final class NameHidingStore: SpeakerProfileRepositoryProtocol {
+/// `@unchecked` because the lock is what makes `hidden` safe, and the compiler
+/// cannot see that.
+private final class NameHidingStore: SpeakerProfileRepositoryProtocol, @unchecked Sendable {
     private let wrapped: SpeakerProfileRepository
     private let lock = NSLock()
     private var hidden = true

--- a/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintWiringTests.swift
+++ b/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintWiringTests.swift
@@ -180,12 +180,14 @@ final class SpeakerVoiceprintWiringTests: XCTestCase {
         )
 
         defaults.set(false, forKey: UserDefaultsAppRuntimePreferences.meetingSpeakerDiarizationKey)
-        XCTAssertFalse(UserDefaultsAppRuntimePreferences.rememberSpeakersEnabled(
+        XCTAssertFalse(
+            UserDefaultsAppRuntimePreferences.rememberSpeakersEnabled(
                 defaults: defaults, arguments: [AppFeatures.voiceProfilesDeveloperLaunchArgument]
             ))
 
         defaults.set(true, forKey: UserDefaultsAppRuntimePreferences.meetingSpeakerDiarizationKey)
-        XCTAssertTrue(UserDefaultsAppRuntimePreferences.rememberSpeakersEnabled(
+        XCTAssertTrue(
+            UserDefaultsAppRuntimePreferences.rememberSpeakersEnabled(
                 defaults: defaults, arguments: [AppFeatures.voiceProfilesDeveloperLaunchArgument]
             ))
     }
@@ -193,7 +195,8 @@ final class SpeakerVoiceprintWiringTests: XCTestCase {
     func testThePreferenceIsOffUntilAsked() {
         let defaults = UserDefaults(suiteName: "voiceprint-wiring-\(UUID().uuidString)")!
         defaults.set(true, forKey: UserDefaultsAppRuntimePreferences.meetingSpeakerDiarizationKey)
-        XCTAssertFalse(UserDefaultsAppRuntimePreferences.rememberSpeakersEnabled(
+        XCTAssertFalse(
+            UserDefaultsAppRuntimePreferences.rememberSpeakersEnabled(
                 defaults: defaults, arguments: [AppFeatures.voiceProfilesDeveloperLaunchArgument]
             ))
     }

--- a/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintWiringTests.swift
+++ b/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintWiringTests.swift
@@ -75,6 +75,69 @@ final class SpeakerVoiceprintWiringTests: XCTestCase {
         )
     }
 
+    // MARK: Which speakers are scored
+
+    /// The finalizer drops any cluster whose segments won no words, and only
+    /// the surviving list is persisted. Scoring the diarizer's full output
+    /// would write a suggestion keyed to a speaker the transcript does not
+    /// have — one the UI could never resolve.
+    func testOnlyPersistedSpeakersAreScored() {
+        let diarization = MeetingTranscriptFinalizer.SystemDiarization(
+            speakers: [
+                SpeakerInfo(id: "system:S1", label: "Others 1"),
+                SpeakerInfo(id: "system:S2", label: "Others 2"),
+            ],
+            segments: [],
+            speakerEmbeddings: [
+                "system:S1": embedding(voice: 0),
+                "system:S2": embedding(voice: 1),
+            ],
+            speechMsBySpeaker: ["system:S1": 30_000, "system:S2": 30_000]
+        )
+
+        let observations = TranscriptionService.voiceprintObservations(
+            systemDiarization: diarization,
+            // S2 won no words, so the finalizer left it out of the transcript.
+            persistedSpeakers: [SpeakerInfo(id: "system:S1", label: "Others 1")]
+        )
+
+        XCTAssertEqual(observations.map(\.speakerId), ["system:S1"])
+    }
+
+    func testASpeakerWithoutAnEmbeddingIsSkipped() {
+        let diarization = MeetingTranscriptFinalizer.SystemDiarization(
+            speakers: [SpeakerInfo(id: "system:S1", label: "Others 1")],
+            segments: [],
+            speakerEmbeddings: [:],
+            speechMsBySpeaker: ["system:S1": 30_000]
+        )
+
+        XCTAssertTrue(
+            TranscriptionService.voiceprintObservations(
+                systemDiarization: diarization,
+                persistedSpeakers: [SpeakerInfo(id: "system:S1", label: "Others 1")]
+            ).isEmpty
+        )
+    }
+
+    func testObservationsConvertDurationsToSeconds() throws {
+        let diarization = MeetingTranscriptFinalizer.SystemDiarization(
+            speakers: [SpeakerInfo(id: "system:S1", label: "Others 1")],
+            segments: [],
+            speakerEmbeddings: ["system:S1": embedding(voice: 0)],
+            speechMsBySpeaker: ["system:S1": 12_500]
+        )
+
+        let observation = try XCTUnwrap(
+            TranscriptionService.voiceprintObservations(
+                systemDiarization: diarization,
+                persistedSpeakers: [SpeakerInfo(id: "system:S1", label: "Others 1")]
+            ).first
+        )
+        XCTAssertEqual(observation.speechSeconds, 12.5, accuracy: 1e-9)
+        XCTAssertEqual(observation.captureDomain, .system)
+    }
+
     // MARK: The gate
 
     func testNothingIsWrittenWhileTheFeatureIsOff() async throws {

--- a/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintWiringTests.swift
+++ b/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintWiringTests.swift
@@ -1,0 +1,170 @@
+import XCTest
+import GRDB
+@testable import MacParakeetCore
+
+/// Covers the seam between the meeting pipeline and the voiceprint service:
+/// which observations reach it, in which unit, and under which ids.
+final class SpeakerVoiceprintWiringTests: XCTestCase {
+    private var dbQueue: DatabaseQueue!
+    private var profiles: SpeakerProfileRepository!
+    private var journal: SpeakerMatchJournalRepository!
+    private var transcriptions: TranscriptionRepository!
+
+    private let identity = SpeakerModelIdentity(
+        embeddingModelId: "test-model",
+        aggregationProfileId: "test-aggregation"
+    )
+    private let fingerprint = TranscriptFingerprint(rawValue: "fingerprint-1")
+
+    override func setUp() async throws {
+        let manager = try DatabaseManager()
+        dbQueue = manager.dbQueue
+        profiles = SpeakerProfileRepository(dbQueue: manager.dbQueue)
+        journal = SpeakerMatchJournalRepository(dbQueue: manager.dbQueue)
+        transcriptions = TranscriptionRepository(dbQueue: manager.dbQueue)
+    }
+
+    // MARK: The unit the gates read
+
+    /// Durations cross this seam in milliseconds and the gates are in seconds.
+    /// A missed conversion turns the 3 s gate into 50 minutes, so nothing ever
+    /// qualifies and the feature simply never fires — silently.
+    func testMillisecondsBecomeSecondsAcrossTheSeam() async throws {
+        let recording = try savedTranscription()
+        let profile = try await enrol(name: "Sarah", voice: 0, transcriptionId: recording.id)
+        let next = try savedTranscription()
+
+        // 4 000 ms is well past the 3 s match gate; 4 s read as 4 000 s would
+        // be too, so the telling case is the one just under the gate.
+        let belowGate = try await service().evaluate(
+            transcriptionId: next.id,
+            fingerprint: fingerprint,
+            clusters: [observation(id: "system:S1", voice: 0, speechMs: 2_500)]
+        )
+        XCTAssertTrue(belowGate.isEmpty)
+
+        let aboveGate = try await service().evaluate(
+            transcriptionId: next.id,
+            fingerprint: TranscriptFingerprint(rawValue: "fingerprint-2"),
+            clusters: [observation(id: "system:S1", voice: 0, speechMs: 30_000)]
+        )
+        XCTAssertEqual(aboveGate.map(\.profileId), [profile.id])
+    }
+
+    // MARK: The ids the seam carries
+
+    /// The meeting path prefixes diarizer ids with their audio source, and the
+    /// suggestion has to name the speaker the transcript knows — otherwise the
+    /// UI would look up a speaker that does not exist.
+    func testSuggestionsCarryTheSourcePrefixedSpeakerId() async throws {
+        let recording = try savedTranscription()
+        _ = try await enrol(name: "Sarah", voice: 0, transcriptionId: recording.id)
+        let next = try savedTranscription()
+
+        let suggestions = try await service().evaluate(
+            transcriptionId: next.id,
+            fingerprint: fingerprint,
+            clusters: [observation(id: "system:S2", voice: 0, speechMs: 30_000)]
+        )
+
+        XCTAssertEqual(suggestions.map(\.speakerId), ["system:S2"])
+        XCTAssertEqual(
+            try profiles.links(transcriptionId: next.id, fingerprint: fingerprint.rawValue)
+                .map(\.speakerId),
+            ["system:S2"]
+        )
+    }
+
+    // MARK: The gate
+
+    func testNothingIsWrittenWhileTheFeatureIsOff() async throws {
+        let recording = try savedTranscription()
+        _ = try await enrol(name: "Sarah", voice: 0, transcriptionId: recording.id)
+        let next = try savedTranscription()
+
+        let off = SpeakerVoiceprintService(
+            profiles: profiles,
+            journal: journal,
+            isEnabled: { false }
+        )
+        let suggestions = try await off.evaluate(
+            transcriptionId: next.id,
+            fingerprint: fingerprint,
+            clusters: [observation(id: "system:S1", voice: 0, speechMs: 30_000)]
+        )
+
+        XCTAssertTrue(suggestions.isEmpty)
+        XCTAssertTrue(
+            try profiles.links(transcriptionId: next.id, fingerprint: fingerprint.rawValue).isEmpty
+        )
+        XCTAssertTrue(
+            try journal.entries(
+                retention: SpeakerMatchJournalRepository.defaultRetention, now: Date()
+            ).isEmpty
+        )
+    }
+
+    /// `rememberSpeakers` is meaningless without clusters to match, so it reads
+    /// as off whenever meeting speaker detection is.
+    func testThePreferenceRequiresMeetingSpeakerDetection() {
+        let defaults = UserDefaults(suiteName: "voiceprint-wiring-\(UUID().uuidString)")!
+        defaults.set(true, forKey: UserDefaultsAppRuntimePreferences.rememberSpeakersKey)
+
+        defaults.set(false, forKey: UserDefaultsAppRuntimePreferences.meetingSpeakerDiarizationKey)
+        XCTAssertFalse(UserDefaultsAppRuntimePreferences.rememberSpeakersEnabled(defaults: defaults))
+
+        defaults.set(true, forKey: UserDefaultsAppRuntimePreferences.meetingSpeakerDiarizationKey)
+        XCTAssertTrue(UserDefaultsAppRuntimePreferences.rememberSpeakersEnabled(defaults: defaults))
+    }
+
+    func testThePreferenceIsOffUntilAsked() {
+        let defaults = UserDefaults(suiteName: "voiceprint-wiring-\(UUID().uuidString)")!
+        defaults.set(true, forKey: UserDefaultsAppRuntimePreferences.meetingSpeakerDiarizationKey)
+        XCTAssertFalse(UserDefaultsAppRuntimePreferences.rememberSpeakersEnabled(defaults: defaults))
+    }
+
+    // MARK: Helpers
+
+    private func service() -> SpeakerVoiceprintService {
+        SpeakerVoiceprintService(profiles: profiles, journal: journal, isEnabled: { true })
+    }
+
+    private func embedding(voice: Int) -> SpeakerEmbedding {
+        var values = [Float](repeating: 0, count: SpeakerEmbedding.dimension)
+        values[voice] = 1
+        guard let embedding = SpeakerEmbedding(rawVector: values, identity: identity) else {
+            preconditionFailure("fixture vector must be valid")
+        }
+        return embedding
+    }
+
+    /// Mirrors what `TranscriptionService` builds from a `SystemDiarization`,
+    /// including the millisecond-to-second conversion.
+    private func observation(id: String, voice: Int, speechMs: Int) -> SpeakerClusterObservation {
+        SpeakerClusterObservation(
+            speakerId: id,
+            embedding: embedding(voice: voice),
+            speechSeconds: Double(speechMs) / 1000,
+            captureDomain: .system
+        )
+    }
+
+    private func savedTranscription() throws -> Transcription {
+        let transcription = Transcription(fileName: "meeting.wav", sourceType: .meeting)
+        try transcriptions.save(transcription)
+        return transcription
+    }
+
+    private func enrol(name: String, voice: Int, transcriptionId: UUID) async throws -> SpeakerProfile {
+        let result = try await service().enroll(
+            displayName: name,
+            observation: observation(id: "system:S1", voice: voice, speechMs: 30_000),
+            transcriptionId: transcriptionId,
+            allowMergeIntoExistingName: false
+        )
+        guard case .created(let profile) = result else {
+            preconditionFailure("fixture enrollment must create a profile, got \(result)")
+        }
+        return profile
+    }
+}

--- a/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintWiringTests.swift
+++ b/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintWiringTests.swift
@@ -7,6 +7,7 @@ import GRDB
 final class SpeakerVoiceprintWiringTests: XCTestCase {
     private var dbQueue: DatabaseQueue!
     private var profiles: SpeakerProfileRepository!
+    private var candidates: SpeakerEmbeddingCandidateRepository!
     private var journal: SpeakerMatchJournalRepository!
     private var transcriptions: TranscriptionRepository!
 
@@ -20,6 +21,7 @@ final class SpeakerVoiceprintWiringTests: XCTestCase {
         let manager = try DatabaseManager()
         dbQueue = manager.dbQueue
         profiles = SpeakerProfileRepository(dbQueue: manager.dbQueue)
+        candidates = SpeakerEmbeddingCandidateRepository(dbQueue: manager.dbQueue)
         journal = SpeakerMatchJournalRepository(dbQueue: manager.dbQueue)
         transcriptions = TranscriptionRepository(dbQueue: manager.dbQueue)
     }
@@ -147,6 +149,7 @@ final class SpeakerVoiceprintWiringTests: XCTestCase {
 
         let off = SpeakerVoiceprintService(
             profiles: profiles,
+            candidates: candidates,
             journal: journal,
             isEnabled: { false }
         )
@@ -192,7 +195,12 @@ final class SpeakerVoiceprintWiringTests: XCTestCase {
     // MARK: Helpers
 
     private func service() -> SpeakerVoiceprintService {
-        SpeakerVoiceprintService(profiles: profiles, journal: journal, isEnabled: { true })
+        SpeakerVoiceprintService(
+            profiles: profiles,
+            candidates: candidates,
+            journal: journal,
+            isEnabled: { true }
+        )
     }
 
     private func embedding(voice: Int) -> SpeakerEmbedding {
@@ -226,6 +234,7 @@ final class SpeakerVoiceprintWiringTests: XCTestCase {
             displayName: name,
             observation: observation(id: "system:S1", voice: voice, speechMs: 30_000),
             transcriptionId: transcriptionId,
+            fingerprint: fingerprint,
             allowMergeIntoExistingName: false
         )
         guard case .created(let profile) = result else {

--- a/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintWiringTests.swift
+++ b/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintWiringTests.swift
@@ -180,16 +180,22 @@ final class SpeakerVoiceprintWiringTests: XCTestCase {
         )
 
         defaults.set(false, forKey: UserDefaultsAppRuntimePreferences.meetingSpeakerDiarizationKey)
-        XCTAssertFalse(UserDefaultsAppRuntimePreferences.rememberSpeakersEnabled(defaults: defaults))
+        XCTAssertFalse(UserDefaultsAppRuntimePreferences.rememberSpeakersEnabled(
+                defaults: defaults, arguments: [AppFeatures.voiceProfilesDeveloperLaunchArgument]
+            ))
 
         defaults.set(true, forKey: UserDefaultsAppRuntimePreferences.meetingSpeakerDiarizationKey)
-        XCTAssertTrue(UserDefaultsAppRuntimePreferences.rememberSpeakersEnabled(defaults: defaults))
+        XCTAssertTrue(UserDefaultsAppRuntimePreferences.rememberSpeakersEnabled(
+                defaults: defaults, arguments: [AppFeatures.voiceProfilesDeveloperLaunchArgument]
+            ))
     }
 
     func testThePreferenceIsOffUntilAsked() {
         let defaults = UserDefaults(suiteName: "voiceprint-wiring-\(UUID().uuidString)")!
         defaults.set(true, forKey: UserDefaultsAppRuntimePreferences.meetingSpeakerDiarizationKey)
-        XCTAssertFalse(UserDefaultsAppRuntimePreferences.rememberSpeakersEnabled(defaults: defaults))
+        XCTAssertFalse(UserDefaultsAppRuntimePreferences.rememberSpeakersEnabled(
+                defaults: defaults, arguments: [AppFeatures.voiceProfilesDeveloperLaunchArgument]
+            ))
     }
 
     // MARK: Helpers

--- a/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintWiringTests.swift
+++ b/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintWiringTests.swift
@@ -172,6 +172,9 @@ final class SpeakerVoiceprintWiringTests: XCTestCase {
     func testThePreferenceRequiresMeetingSpeakerDetection() {
         let defaults = UserDefaults(suiteName: "voiceprint-wiring-\(UUID().uuidString)")!
         defaults.set(true, forKey: UserDefaultsAppRuntimePreferences.rememberSpeakersKey)
+        defaults.set(
+            Date(), forKey: UserDefaultsAppRuntimePreferences.voiceprintConsentAcknowledgedAtKey
+        )
 
         defaults.set(false, forKey: UserDefaultsAppRuntimePreferences.meetingSpeakerDiarizationKey)
         XCTAssertFalse(UserDefaultsAppRuntimePreferences.rememberSpeakersEnabled(defaults: defaults))

--- a/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintWiringTests.swift
+++ b/Tests/MacParakeetTests/Services/Diarization/SpeakerVoiceprintWiringTests.swift
@@ -186,10 +186,14 @@ final class SpeakerVoiceprintWiringTests: XCTestCase {
             ))
 
         defaults.set(true, forKey: UserDefaultsAppRuntimePreferences.meetingSpeakerDiarizationKey)
-        XCTAssertTrue(
-            UserDefaultsAppRuntimePreferences.rememberSpeakersEnabled(
-                defaults: defaults, arguments: [AppFeatures.voiceProfilesDeveloperLaunchArgument]
-            ))
+        let enabledWithOverride = UserDefaultsAppRuntimePreferences.rememberSpeakersEnabled(
+            defaults: defaults, arguments: [AppFeatures.voiceProfilesDeveloperLaunchArgument]
+        )
+        #if DEBUG
+        XCTAssertTrue(enabledWithOverride)
+        #else
+        XCTAssertFalse(enabledWithOverride)
+        #endif
     }
 
     func testThePreferenceIsOffUntilAsked() {

--- a/Tests/MacParakeetTests/Services/TranscriptionServiceTests.swift
+++ b/Tests/MacParakeetTests/Services/TranscriptionServiceTests.swift
@@ -80,6 +80,75 @@ private final class DiarizationConstraintRecorder: @unchecked Sendable {
     }
 }
 
+private actor MeetingVoiceprintSpy: SpeakerVoiceprintServicing {
+    struct Evaluation: Sendable {
+        let transcriptionId: UUID
+        let fingerprint: TranscriptFingerprint
+        let clusters: [SpeakerClusterObservation]
+        let persistedTranscription: Transcription?
+    }
+
+    enum Failure: Error {
+        case evaluationFailed
+        case unexpectedOperation
+    }
+
+    private let transcriptions: TranscriptionRepository
+    private let throwOnEvaluate: Bool
+    private(set) var evaluations: [Evaluation] = []
+
+    init(transcriptions: TranscriptionRepository, throwOnEvaluate: Bool) {
+        self.transcriptions = transcriptions
+        self.throwOnEvaluate = throwOnEvaluate
+    }
+
+    func evaluate(
+        transcriptionId: UUID,
+        fingerprint: TranscriptFingerprint,
+        clusters: [SpeakerClusterObservation]
+    ) async throws -> [SpeakerVoiceprintSuggestion] {
+        evaluations.append(Evaluation(
+            transcriptionId: transcriptionId,
+            fingerprint: fingerprint,
+            clusters: clusters,
+            persistedTranscription: try transcriptions.fetch(id: transcriptionId)
+        ))
+        if throwOnEvaluate { throw Failure.evaluationFailed }
+        return []
+    }
+
+    func enrollmentCandidate(
+        transcriptionId: UUID, speakerId: String, fingerprint: TranscriptFingerprint
+    ) async throws -> SpeakerClusterObservation? {
+        throw Failure.unexpectedOperation
+    }
+
+    func pruneExpiredCandidates() async throws {
+        throw Failure.unexpectedOperation
+    }
+
+    func enroll(
+        displayName: String, observation: SpeakerClusterObservation, transcriptionId: UUID,
+        fingerprint: TranscriptFingerprint, allowMergeIntoExistingName: Bool
+    ) async throws -> SpeakerProfileEnrollment {
+        throw Failure.unexpectedOperation
+    }
+
+    func confirm(
+        _ suggestion: SpeakerVoiceprintSuggestion, observation: SpeakerClusterObservation,
+        transcriptionId: UUID, fingerprint: TranscriptFingerprint
+    ) async throws {
+        throw Failure.unexpectedOperation
+    }
+
+    func dismiss(
+        _ suggestion: SpeakerVoiceprintSuggestion, transcriptionId: UUID,
+        fingerprint: TranscriptFingerprint
+    ) async throws {
+        throw Failure.unexpectedOperation
+    }
+}
+
 private final class TelemetrySpy: TelemetryServiceProtocol, @unchecked Sendable {
     private let lock = NSLock()
     private var events: [TelemetryEventSpec] = []
@@ -1820,6 +1889,55 @@ final class TranscriptionServiceTests: XCTestCase {
         XCTAssertEqual(fetched.status, .completed)
         XCTAssertEqual(fetched.rawTranscript, "Queued meeting finished")
         XCTAssertEqual(fetched.id, stub.id)
+    }
+
+    func testFinalizeMeetingScoresPersistedSystemSpeakersAfterCompletion() async throws {
+        let recording = try makeDualSourceMeetingRecording(displayName: "Voiceprint ordering")
+        defer { try? FileManager.default.removeItem(at: recording.folderURL) }
+        let (service, spy, embedding) = try await makeVoiceprintMeetingService()
+        let stub = try await service.prepareMeetingTranscription(recording: recording)
+
+        let completed = try await service.finalizeMeetingTranscription(
+            recording: recording, updating: stub.id, onProgress: nil
+        )
+
+        let evaluations = await spy.evaluations
+        XCTAssertEqual(evaluations.count, 1)
+        let evaluation = try XCTUnwrap(evaluations.first)
+        let persistedAtEvaluation = try XCTUnwrap(evaluation.persistedTranscription)
+        XCTAssertEqual(evaluation.transcriptionId, stub.id)
+        XCTAssertEqual(completed.id, stub.id)
+        XCTAssertEqual(completed.status, .completed)
+        XCTAssertEqual(persistedAtEvaluation.status, .completed)
+        XCTAssertEqual(persistedAtEvaluation.rawTranscript, completed.rawTranscript)
+        XCTAssertEqual(
+            evaluation.fingerprint,
+            SpeakerAttributionResolver.fingerprint(for: persistedAtEvaluation)
+        )
+        XCTAssertEqual(evaluation.fingerprint, SpeakerAttributionResolver.fingerprint(for: completed))
+        XCTAssertNotEqual(evaluation.fingerprint, SpeakerAttributionResolver.fingerprint(for: stub))
+        XCTAssertEqual(persistedAtEvaluation.speakers?.map(\.id), ["microphone", "system:S1"])
+        XCTAssertEqual(evaluation.clusters, [SpeakerClusterObservation(
+            speakerId: "system:S1", embedding: embedding, speechSeconds: 0.2, captureDomain: .system
+        )])
+        XCTAssertEqual(try transcriptionRepo.count(), 1)
+    }
+
+    func testVoiceprintEvaluationFailureDoesNotFailMeetingCompletion() async throws {
+        let recording = try makeDualSourceMeetingRecording(displayName: "Voiceprint failure")
+        defer { try? FileManager.default.removeItem(at: recording.folderURL) }
+        let (service, spy, _) = try await makeVoiceprintMeetingService(throwOnEvaluate: true)
+
+        let completed = try await service.transcribeMeeting(recording: recording)
+
+        let evaluations = await spy.evaluations
+        XCTAssertEqual(evaluations.count, 1)
+        XCTAssertEqual(evaluations.first?.persistedTranscription?.status, .completed)
+        XCTAssertEqual(completed.status, .completed)
+        let persisted = try XCTUnwrap(transcriptionRepo.fetch(id: completed.id))
+        XCTAssertEqual(persisted.status, .completed)
+        XCTAssertEqual(persisted.rawTranscript, completed.rawTranscript)
+        XCTAssertEqual(try transcriptionRepo.count(), 1)
     }
 
     func testPartialMeetingKeepsCompletedStatusAndPersistsPlayableDuration() async throws {
@@ -3764,6 +3882,42 @@ final class TranscriptionServiceTests: XCTestCase {
                 TimestampedWord(word: "remote", startMs: 0, endMs: 200, confidence: 0.9),
             ]),
         ]
+    }
+
+    private func makeVoiceprintMeetingService(
+        throwOnEvaluate: Bool = false
+    ) async throws -> (TranscriptionService, MeetingVoiceprintSpy, SpeakerEmbedding) {
+        await mockSTT.configureSequence(results: meetingSourceSTTResults())
+        let embedding = try XCTUnwrap(SpeakerEmbedding(
+            rawVector: [1] + [Float](repeating: 0, count: SpeakerEmbedding.dimension - 1),
+            identity: SpeakerModelIdentity(
+                embeddingModelId: "test-meeting-voice", aggregationProfileId: "test-meeting-config"
+            )
+        ))
+        let diarization = MockDiarizationService()
+        await diarization.configure(result: MacParakeetDiarizationResult(
+            segments: [
+                SpeakerSegment(speakerId: "S1", startMs: 0, endMs: 200),
+                // This cluster wins no words and must not reach voice matching.
+                SpeakerSegment(speakerId: "S2", startMs: 1000, endMs: 1200),
+            ],
+            speakerCount: 2,
+            speakers: [SpeakerInfo(id: "S1", label: "Speaker 1"), SpeakerInfo(id: "S2", label: "Speaker 2")],
+            speakerEmbeddings: ["S1": embedding, "S2": embedding],
+            speechMsBySpeaker: ["S1": 200, "S2": 200]
+        ))
+        let spy = MeetingVoiceprintSpy(transcriptions: transcriptionRepo, throwOnEvaluate: throwOnEvaluate)
+        let service = TranscriptionService(
+            audioProcessor: mockAudio,
+            sttTranscriber: mockSTT,
+            transcriptionRepo: transcriptionRepo,
+            shouldDiarizeMeetings: { true },
+            diarizationService: diarization,
+            meetingArtifactStore: nil,
+            meetingAutomationHookRunner: nil,
+            speakerVoiceprints: spy
+        )
+        return (service, spy, embedding)
     }
 
     private func makeTranscriptionService(cleanedMicTimeoutSeconds: TimeInterval) -> TranscriptionService {

--- a/Tests/MacParakeetTests/VoiceProfileFeatureGateTests.swift
+++ b/Tests/MacParakeetTests/VoiceProfileFeatureGateTests.swift
@@ -20,9 +20,10 @@ final class VoiceProfileFeatureGateTests: XCTestCase {
         defaults.set(true, forKey: UserDefaultsAppRuntimePreferences.rememberSpeakersKey)
         defaults.set(true, forKey: UserDefaultsAppRuntimePreferences.meetingSpeakerDiarizationKey)
         defaults.set(Date(), forKey: UserDefaultsAppRuntimePreferences.voiceprintConsentAcknowledgedAtKey)
-        XCTAssertFalse(UserDefaultsAppRuntimePreferences.rememberSpeakersEnabled(
-            defaults: defaults, arguments: []
-        ))
+        XCTAssertFalse(
+            UserDefaultsAppRuntimePreferences.rememberSpeakersEnabled(
+                defaults: defaults, arguments: []
+            ))
         let withOverride = UserDefaultsAppRuntimePreferences.rememberSpeakersEnabled(
             defaults: defaults, arguments: ["--enable-voice-profiles"]
         )

--- a/Tests/MacParakeetTests/VoiceProfileFeatureGateTests.swift
+++ b/Tests/MacParakeetTests/VoiceProfileFeatureGateTests.swift
@@ -1,0 +1,35 @@
+import Foundation
+import XCTest
+@testable import MacParakeetCore
+
+final class VoiceProfileFeatureGateTests: XCTestCase {
+    func testVoiceProfilesAreNotReleased() {
+        XCTAssertFalse(AppFeatures.voiceProfilesEnabled)
+        XCTAssertFalse(AppFeatures.isVoiceProfilesAvailable(arguments: []))
+        #if DEBUG
+        XCTAssertTrue(AppFeatures.isVoiceProfilesAvailable(arguments: ["--enable-voice-profiles"]))
+        #else
+        XCTAssertFalse(AppFeatures.isVoiceProfilesAvailable(arguments: ["--enable-voice-profiles"]))
+        #endif
+    }
+
+    func testSavedOptInAndConsentCannotBypassReleaseGate() {
+        let suite = "VoiceProfileFeatureGateTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+        defaults.set(true, forKey: UserDefaultsAppRuntimePreferences.rememberSpeakersKey)
+        defaults.set(true, forKey: UserDefaultsAppRuntimePreferences.meetingSpeakerDiarizationKey)
+        defaults.set(Date(), forKey: UserDefaultsAppRuntimePreferences.voiceprintConsentAcknowledgedAtKey)
+        XCTAssertFalse(UserDefaultsAppRuntimePreferences.rememberSpeakersEnabled(
+            defaults: defaults, arguments: []
+        ))
+        let withOverride = UserDefaultsAppRuntimePreferences.rememberSpeakersEnabled(
+            defaults: defaults, arguments: ["--enable-voice-profiles"]
+        )
+        #if DEBUG
+        XCTAssertTrue(withOverride)
+        #else
+        XCTAssertFalse(withOverride)
+        #endif
+    }
+}

--- a/plans/active/2026-07-03-speaker-voiceprints.md
+++ b/plans/active/2026-07-03-speaker-voiceprints.md
@@ -1,15 +1,15 @@
 # Persistent Speaker Profiles (Voiceprints) — Research Synthesis + Implementation Plan
 
-- **Date:** 2026-07-03 (amended 2026-09-09 — see
-  [Amendment](#amendment-2026-09-09))
-- **Status:** READY TO IMPLEMENT. Phase 0: NO-GO on the July meeting corpus
+- **Date:** 2026-07-03 (amended 2026-09-09; integration and release decision
+  2026-09-10 — see [Release gates](#integration-and-release-gates-2026-09-10))
+- **Status:** EXPERIMENTAL FOUNDATIONS, DISABLED BY DEFAULT. Phase 0: NO-GO on the July meeting corpus
   (pre-AEC echo contamination + only 3 usable sessions). Phase 0b (clean public
   corpus): **GO — embedding path validated** (no overlap: same-narrator
   0.05–0.23 vs different 0.47–0.84; tau/margin sweep = 100% TPR, 0% FPR across
-  a 0.25–0.45 plateau). Phase 1 is **no longer corpus-blocked**: the 2026-09-09
-  amendment replaces the "collect a post-AEC corpus first" gate with a local
-  decision journal that produces a labelled corpus from dogfooding, so code can
-  land behind a disabled flag while the product tau is confirmed. See
+  a 0.25–0.45 plateau). Phase 1 implementation can land behind the disabled
+  `AppFeatures.voiceProfilesEnabled` gate. The journal supports calibration and
+  dogfooding; official release still requires held-out real-meeting evidence.
+  No real-meeting accuracy benchmark or release gate is claimed complete. See
   `docs/research/2026-07-04-voiceprints-phase0-calibration.md` and
   `docs/research/2026-07-04-voiceprints-phase0b-clean-corpus.md`.
 - **Trigger:** issue #662 (yakov0922) + a Reddit voiceprint post aimed at MacWhisper;
@@ -22,15 +22,69 @@
   (names "speaker memory" as the gap; this plan is its identity layer, made concrete)
   and [`plans/active/2026-05-speaker-diarization-quality.md`](2026-05-speaker-diarization-quality.md)
 
+## Integration and release gates (2026-09-10)
+
+Daniel authorized reviewing, fixing and integrating the existing PR series into
+`main` behind an experimental flag, with official release conditional on good test
+results. This decision separates two gates; it supersedes any wording below that
+treats the journal as a substitute for a real-meeting evaluation.
+
+**Implementation and dogfooding gate:** review the combined dependency stack,
+verify migrations and focused tests for embeddings, matching, profile/candidate
+storage, consent and feature gating, deletion, expiry and export exclusion, and
+complete the repository's final verification. `AppFeatures.voiceProfilesEnabled`
+remains `false`. A DEBUG build may opt in with `--enable-voice-profiles` through
+`AppFeatures.isVoiceProfilesAvailable(arguments:)`; release builds ignore that
+argument. Availability alone grants no consent: the separate `rememberSpeakers`
+preference remains off by default and requires acknowledged consent and meeting
+speaker detection. PRs #994/#996/#1000/#1001/#1004/#1005 supply foundations and
+meeting wiring, not the consent, enrollment, suggestion or administration UI.
+Those surfaces must be complete before ordinary user dogfooding or release.
+
+**Official release gate:** publish a reviewable evaluation report for the exact
+model, aggregation settings, policy and build being considered. The report must:
+
+- Separate enrollment meetings, calibration meetings and held-out evaluation
+  meetings. Do not split clusters from the same recording across these sets.
+  Freeze profiles and policy before evaluating held-out meetings; any tuning or
+  learning from them requires a new held-out evaluation.
+- Set numeric acceptance criteria and minimum evidence requirements **before**
+  the final evaluation: suggestion precision, useful coverage, false matches of
+  unknown participants, sample sizes and uncertainty. A 99% suggestion-precision
+  target is exploratory; it is neither certified accuracy nor an accepted release
+  threshold without that documented decision.
+- Report suggestions **before user correction**: correct/incorrect suggestion
+  counts and precision, coverage of known speakers, unknown-speaker false matches
+  with their denominator, abstentions and uncertainty. Report both denominators
+  and missing/ambiguous labels; a small zero-error sample is insufficient evidence
+  of high precision.
+- Use independently checked identities and cluster attribution. User confirmations
+  and typed names are reviewable feedback, not unquestioned ground truth; a
+  suggestion may influence a confirmation and a cluster may contain two people.
+- Include separate meetings with changed microphones/capture conditions, unknown
+  participants, overlapping and brief speech, and cluster contamination. Document
+  where matching cannot repair diarization and which inputs are excluded.
+- Measure added processing time, memory and retained-data costs on the meeting
+  path, and verify the consent, correction, deletion and expiry flows in the app.
+
+The local journal helps find failures and calibrate policy; it does not supply
+independent identity labels or all required evaluation measurements by itself.
+No fixed number of dogfooded meetings automatically passes this gate. Enabling
+the release flag and publishing a stable build are subsequent explicit release
+decisions; merging foundations into `main` does neither.
+
+The current internal boundary is specified in
+[`spec/contracts/speaker-voiceprints.md`](../../spec/contracts/speaker-voiceprints.md).
+
 ## Amendment (2026-09-09)
 
-Re-verified against `main` (FluidAudio 0.15.6, speaker-correction layer shipped
+Re-verified against `main` (FluidAudio 0.15.6, speaker-correction layer merged
 in [PR #960](https://github.com/moona3k/macparakeet/pull/960)). Six errors, three
 additions. Corrections are applied in place below.
 
 **Scope locked:** meetings only · `rememberSpeakers` off by default and gated on
-acknowledged consent · tau is a compiled constant with a hidden `UserDefaults`
-override, never a user setting · calibration via a local decision journal, not an
+acknowledged consent · tau is an experimental compiled policy constant, never a
+user setting (a hidden calibration override remains proposed) · calibration via a local decision journal, not an
 on-demand re-diarization · literal #662 ask (recurring unknowns) out of scope, no
 columns, no follow-up · permanent vectors only for enrolled people, plus short-lived
 enrollment candidates that are never compared to each other (decision 9) · vectors as
@@ -95,27 +149,31 @@ us without wiring a second manager. Out of scope.
 2. **Pollution guard on name-based enrollment.** Renaming to "Sarah" bypasses
    every threshold — two colleagues or one misclick merges two voices. Beyond 0.45
    from the existing profile, ask instead of merging.
-3. **Decision journal replaces the corpus gate.** Log each decision locally
-   (distances, gates, outcome, the label the user finally types); ~20 dogfooded
-   meetings yield a labelled post-AEC corpus whose ground truth is what the user
-   wrote. Diagnostic embeddings are ephemeral and never persisted as profiles.
+3. **Decision journal supports calibration and dogfooding.** Log decisions locally
+   (distances, gates and outcomes), and relate them to reviewed speaker corrections
+   using the transcript fingerprint. This permits implementation behind the disabled
+   flag; it does not replace the held-out release evaluation above. The journal
+   stores neither vectors nor independent identity labels. Enrollment candidates
+   and explicitly enrolled exemplars have separate lifecycles below.
    Lifecycle, since distances joined to labels are identifying:
    - **Owner:** `SpeakerVoiceprintService`, the only writer. No other component
      appends to it.
    - **Location:** a table in the user database, not a loose file — so it inherits
      the existing user-data deletion rules instead of needing its own.
-   - **Retention:** 90 days, pruned on write. It exists to calibrate, not to
-     accumulate; a rolling window is more than the ~20 meetings the calibration needs.
+   - **Retention:** 90 days, pruned on reads, writes, app startup and hourly while
+     the app runs, even if the feature has since been disabled. If the app is shut
+     down, cleanup resumes at the next launch. Expired entries are never returned.
    - **Never leaves the machine:** excluded from exports, diagnostics and support
      bundles, like the profile tables.
    - **Deletion:** rows are purged atomically with whatever they reference — deleting
      a profile, a transcription, or all voice profiles takes its journal rows with it
      in the same transaction. No orphan row outlives its subject.
 
-**Threshold:** start at `tau = 0.25`, not 0.30. The zero-FPR plateau runs
+**Experimental threshold:** start at `tau = 0.25`, not 0.30. The zero-FPR plateau runs
 0.25–0.45 and the worst positive is 0.227, so 0.25 still accepts 21/21 while
-buying margin against noisier post-AEC audio. A missed suggestion is a non-event;
-a false one is the worst outcome this research documented.
+leaving room for calibration on post-AEC audio. This clean-corpus observation does
+not establish precision or useful coverage on meetings. A false suggestion is the
+costlier error; abstention and missed suggestions still count against coverage.
 
 ## Verdict
 
@@ -125,7 +183,8 @@ exists or arrives free:
 - FluidAudio's offline diarizer already returns a **256-d WeSpeaker embedding per
   detected speaker** (`DiarizationResult.speakerDatabase` — the un-normalized VBx
   clustering centroid; there is no per-segment vector, see Amendment 1-2). No new
-  model, no new runtime, no added latency.
+  model or embedding inference pass. Added matching and storage costs still need
+  measurement on the meeting path.
 - The 2026-06-14 architecture plan already defines the guardrails (suggestions never
   silently rewrite; wrong automatic names are worse than anonymous speakers; profiles
   must be deletable; don't grow `SpeakerInfo` into a pseudo-profile).
@@ -134,11 +193,11 @@ exists or arrives free:
   Apple: none. **On-device voiceprints are open competitive whitespace** aligned
   with the private-speech-memory north star.
 
-Two real risks, both handled: (a) embedding separation quality on compressed meeting
-system audio → Phase 0 calibration spike before any product code; (b) biometric
-privacy → strict enrollment-only scope + consent gate + deletion controls.
+Two unresolved risks govern release: embedding separation quality on compressed
+meeting system audio requires held-out evaluation; biometric retention requires
+consent, bounded candidate storage and verified deletion controls.
 
-## What exists today (repo-dive report)
+## Repository context recorded in research
 
 - Diarization is centralized: `DiarizationService.diarize(audioURL:)`
   (`Sources/MacParakeetCore/Services/Diarization/DiarizationService.swift:101-157`),
@@ -178,7 +237,7 @@ transplant them onto WeSpeaker. Hence Phase 0.
 
 ## Design
 
-### Product shape (v1)
+### Product shape (v1; UI still planned)
 
 Enrollment flywheel, correction-based (the Otter/Circleback pattern, minus cloud):
 
@@ -197,20 +256,23 @@ Enrollment flywheel, correction-based (the Otter/Circleback pattern, minus cloud
 5. Confirmation applies the label via the existing rename path. Adding that
    meeting's embedding as a new profile sample is part of the confirm action's
    *disclosed* semantics ("Confirm and improve Sarah's voice profile") — samples
-   are only ever added to already-enrolled profiles via this explicit act.
+   are only ever added to already-enrolled profiles via this explicit act, after
+   two manual enrollments anchor the profile and subject to duration and cap rules.
+   A confirmed label does not imply a new exemplar was accepted.
 6. Unknowns stay "Others N". Below-margin matches stay unknown ("wrong automatic
    names are worse than anonymous speakers").
 
-Scope call: v1 keeps two kinds of vector, and the difference is the whole privacy
-argument.
+Scope call: the experimental design keeps two kinds of vector, both sensitive.
 
 - **Profile exemplars** are permanent and belong to a named person. Only an explicit
   enrollment or a confirmed suggestion creates one.
 - **Enrollment candidates** (Amendment, decision 9) are short-lived and belong to no
-  one. Step 1 above happens after the meeting, when the vector has already been
-  discarded, so without them nothing can be named at all. They are consent-gated,
-  capped at seven days, deleted on promotion or with their recording, and **never
-  compared against each other**.
+  one. They make enrollment possible after the meeting without re-running
+  diarization. Ordinary transcript renaming does not require a retained vector.
+  Candidates are consent-gated, capped at seven days, deleted on successful
+  promotion or with their recording, and **never compared against each other**.
+  Expiry is enforced on reads/writes, startup and hourly while the app runs,
+  including when the feature is disabled; after shutdown it resumes next launch.
 
 That last property is what keeps the issue's literal ask — "this voice appeared in 5
 recordings, name them?" — out of scope: answering it means comparing unenrolled
@@ -222,7 +284,7 @@ a separate opt-in, decided later.
 - Open-set, **mutual best match** (Amendment, Addition 1): suggest only if
   `top1 distance ≤ τ`, the margin holds on **both** sides (`top2 − top1 ≥ margin`
   for the cluster *and* for the profile), and each is the other's best match.
-  Ship values: τ = 0.25, margin = 0.10.
+  Experimental values: τ = 0.25, margin = 0.10; subject to the release gate above.
 - **Singleton sides:** when a side has no second candidate (one enrolled profile, or
   one detected cluster) the margin is **vacuously satisfied**, not failed — the
   decision rests on τ alone. Failing it instead would make the feature unusable
@@ -231,13 +293,16 @@ a separate opt-in, decided later.
   pair is rejected. No tie-break by id, insertion order, or recency — an arbitrary
   winner is precisely the "wrong automatic name" the invariant forbids. Both cases
   need explicit fixtures (singleton profile set, singleton cluster set, exact tie).
-- Duration gates: embed only clean non-overlapped speech; per-speaker aggregate ≥3s
-  usable, profile needs ≥15s total across ≥3 turns before it may suggest; never
-  learn from <2s backchannels (snap those to the surrounding turn's label instead).
+- Current duration gates use per-cluster aggregate speech: ≥3s to match and ≥15s
+  to enroll or retain a candidate. The implementation does **not** filter clean
+  non-overlapped spans, require three turns, or snap short backchannels to another
+  label. The upstream vector is a whole-cluster centroid. Clean-span selection
+  and contaminated-cluster rejection remain evaluation/design work; duration alone
+  does not establish a clean enrollment sample.
 - Profiles: K ≤ 10 raw reference embeddings, **no stored centroid** (Amendment).
   Scoring is expressed in **cosine distance throughout**, so a profile scores as the
   **minimum** distance over its exemplars — the same rule the July text stated as
-  "max over references" in similarity terms, restated in the shipping metric to
+  "max over references" in similarity terms, restated in the implemented metric to
   remove the contradiction. It preserves per-channel modes either way. A centroid may
   be computed on the fly for display, never for scoring; samples added only on user confirmation
   (no silent EMA — poisoning/drift). **At most one sample per profile per
@@ -261,8 +326,11 @@ a separate opt-in, decided later.
 - **New GRDB migration `v0.39-speaker-voiceprints` + 3 tables** (raw SQL, style of
   `v0.32-speaker-corrections`, `DatabaseManager.swift:1374-1422`), joined by the
   decision journal in `v0.40` and enrollment candidates in `v0.41` (below):
-  - `speaker_profiles`: id, displayName (`UNIQUE … COLLATE NOCASE`, so a second
-    rename to "Sarah" adds an exemplar instead of a duplicate), embeddingModelId,
+  - `speaker_profiles`: id, displayName and a unique `normalizedName` used by both
+    lookup and the database index (trim whitespace; Unicode case/width folding;
+    preserve accents). This is not SQLite's ASCII-only `COLLATE NOCASE`.
+    An enrollment under an existing name checks the pollution guard before adding
+    an exemplar. Also embeddingModelId,
     aggregationProfileId, timestamps, lastMatchedAt, lastEvaluatedAt,
     lastEvaluatedDistance. **No `centroid` column** — scoring is `min` over
     exemplars, so a derived column would only add cache-coherency bugs.
@@ -281,11 +349,15 @@ a separate opt-in, decided later.
   after re-diarization the same id can mean another person — vector
   `BLOB CHECK (length = 1024)`, speechSeconds, captureDomain, the two model ids,
   `transcriptionId … ON DELETE CASCADE` (unlike an exemplar, a candidate *is* about
-  that recording), and `expiresAt` **stored per row**, indexed, so raising the
-  retention constant later cannot revive a vector promised a shorter life.
-  Promotion and deletion are one transaction on the exemplar side:
-  `insertExemplar` applies the cap and inserts, then the candidate row is dropped, so
-  the vector is never stored twice. Writes happen only under
+  that recording), and `expiresAt` **stored per row**, indexed, so changing the
+  default retention does not extend existing stored rows. A new evaluation can
+  replace a same-key candidate with a newly calculated expiry.
+  Promotion persists the exemplar before deleting the candidate. The capped exemplar
+  insertion is transactional; candidate deletion is a separate operation. If that
+  deletion fails, a redundant candidate can remain until retry or expiry, but its
+  voice is already persisted as an exemplar. Rejected insertions, including a full
+  profile, preserve the candidate through its existing retention window. Creation
+  of a new profile and its first exemplar is atomic. Writes happen only under the availability gate and
   `rememberSpeakersEnabled`, which requires acknowledged consent (decision 9), and
   only above `minSpeechSecondsToEnroll` — a vector that can never be promoted would
   be biometric data held for an offer never made. Never read by the matcher.
@@ -294,8 +366,8 @@ a separate opt-in, decided later.
   GRDB already serializes through `dbQueue`. Matching itself lives in a stateless,
   I/O-free `SpeakerVoiceprintMatcher` so it can be tested on fixtures alone. Cosine
   math on vectors normalized once at entry (Amendment 1); O(profiles × clusters),
-  microseconds, no scheduler involvement.
-  **Adapter prerequisite:** today `DiarizationService.diarize()` drops FluidAudio's
+  no new inference scheduling. Runtime cost remains to be measured.
+  **Adapter prerequisite in the original baseline:** `DiarizationService.diarize()` dropped FluidAudio's
   `speakerDatabase`/segment embeddings when building `MacParakeetDiarizationResult`
   — Phase 1's first change is surfacing per-speaker embeddings through that
   adapter (behind the feature flag), otherwise the matcher has nothing to score.
@@ -305,7 +377,8 @@ a separate opt-in, decided later.
   `speaker_profile_links`, which no export path touches. This also supersedes the
   2026-06-14 plan's Phase 1 step 4 ("Export `profileId`, `assignmentSource`, and
   confirmation state in JSON surfaces"): identity metadata never appears in exports.
-- **Wiring**: the two insertion points above.
+- **Wiring**: meeting observations are evaluated after the completed transcription
+  is saved. File/URL identity remains Phase 2.
 - **Settings**: "Remember speakers" toggle (default off, requires speaker detection
   on) + profile list with per-profile delete + "Delete all voice profiles".
 - **Deletion semantics**: deleting a profile runs as **one transaction**. The
@@ -315,14 +388,16 @@ a separate opt-in, decided later.
   matching decision journal is purged for that profile in the same transaction.
   Tested by asserting that no row in either table references the deleted id, and that
   transcript labels survive. "Delete all voice profiles" is the same transaction over
-  every profile, not a loop that can half-fail.
+  every profile, not a loop that can half-fail; it also clears enrollment candidates
+  and all journal rows, including entries with no profile reference.
 - **Export boundary**: `speaker_profiles`, `speaker_profile_exemplars`,
   `speaker_profile_links`, `speaker_embedding_candidates` and the decision journal are
   excluded from **every** outward surface — JSON/TXT/MD/SRT/VTT/PDF/DOCX exports,
   `ExportCommand.projectedJSON()`, diagnostics, support bundles, and any future
   database export. This holds by construction (no export path reads these tables, and
-  nothing is added to `Transcription`), and PR 10 asserts it **per table on every
-  surface**, so a table added later cannot inherit the exemption silently.
+  nothing is added to `Transcription`). Existing boundaries need focused regression
+  tests during integration; PR 10 must complete the audit for every outward surface
+  before release. A table added later cannot inherit an exemption silently.
 - **Privacy invariants**: profile store lives in the user DB, covered by existing
   user-data deletion rules.
 
@@ -345,14 +420,15 @@ differentiator, but honestly:
 
 ## Phases
 
-- **Phase 0 — calibration spike (no product code, ~1–2 days).** Harness (hidden CLI
+- **Phase 0 — historical calibration spike (July, no product code).** Harness (hidden CLI
   subcommand or script) over Daniel's retained meeting corpus: run diarization,
   dump `speakerDatabase` embeddings per meeting, compute intra-/inter-speaker
   distance distributions across meetings + channels. Output: research report with
   separation evidence, chosen τ + margin, and a GO/NO-GO. Kills the feature
   cheaply if WeSpeaker can't separate on compressed system audio.
-- **Phase 1 — core loop (meetings), ten independently shippable PRs.** PRs 1–6 are
-  invisible to users, and the numbering matches the shipped PRs one-to-one:
+- **Phase 1 — core loop (meetings), ten reviewable increments.** PRs 1–6 are
+  foundations behind the disabled gate; the existing branches are cumulative,
+  so review their dependencies and integrated state before landing:
   1. Surface embeddings through the diarization adapter: `SpeakerEmbedding` (normalizing
      on entry), `SpeakerCaptureDomain`, `SpeakerModelIdentity`, per-cluster speech
      durations, key remapping through `idMapping` (`DiarizationService.swift:227-234` —
@@ -369,20 +445,20 @@ differentiator, but honestly:
      ([#1004](https://github.com/moona3k/macparakeet/pull/1004)). Split from 4, which
      the July plan had as one item: the service is testable on fixtures alone, while
      this touches the meeting path.
-  6. Short-lived enrollment candidates (decision 9): without them nothing can be
-     enrolled after the fact, because the vector is gone by the time the user types
-     a name ([#1005](https://github.com/moona3k/macparakeet/pull/1005)).
+  6. Short-lived enrollment candidates (experimental design 9): support enrollment
+     after the fact without retaining vectors indefinitely or repeating diarization
+     ([#1005](https://github.com/moona3k/macparakeet/pull/1005)).
   7. Consent sheet on the toggle + the enrollment prompt after a rename. The consent
      gate ships with, not after, the first surface that can turn writing on.
   8. Suggestion banner (confirm/dismiss).
   9. Voice-profile admin screen + a Reset & Cleanup row.
-  10. Leak tests (export JSON, CLI `projectedJSON()`, feedback bundle), specs, ADR,
-     privacy docs, telemetry allowlist.
+  10. Complete outward-surface leak tests (export JSON, CLI `projectedJSON()`, feedback
+     bundle), feature specs, promoted ADR, privacy docs and telemetry review before
+     release. The internal contract and focused boundary tests accompany foundations.
 - **Phase 2 — breadth.** File/URL-transcription path (the Reddit author's
-  185-episode podcast case), profile management UI, confirmation-driven
-  multi-sample updates, spec/02-features + contracts + new ADR (promote the
-  2026-06-14 plan's speaker-memory section), user-facing privacy docs, CLI
-  `speakers list|delete` parity.
+  185-episode podcast case) and CLI `speakers list|delete` parity, with matching
+  feature/contract updates. Meeting profile management, deletion, confirmation
+  semantics and privacy documentation belong to Phase 1 before release.
 - **Phase 3 — judged later, each its own decision.** Recurring-unknown detection
   (the issue's literal "appeared in 5 recordings" ask — still out of scope: it needs
   unenrolled vectors compared *against each other*, which decision 9's candidates
@@ -399,11 +475,13 @@ differentiator, but honestly:
 
 ## Decisions (2026-09-09)
 
-5. **Tau is not a user setting.** Compiled constant, hidden `UserDefaults` override for
-   dogfooding. A semantic three-step control is reconsidered only if calibration shows
-   the right tau varies by user.
-6. **Calibration by decision journal**, not by assembling a corpus or re-diarizing on
-   demand. This lifts the Phase 1 corpus gate.
+5. **Tau is not a user setting.** The implementation uses an injectable policy with
+   compiled `.v1` defaults. The proposed hidden `UserDefaults` override for
+   calibration is not implemented in this series. A semantic three-step control is
+   reconsidered only if calibration shows the right tau varies by user.
+6. **Calibration supported by a local decision journal.** The 2026-09-10 integration
+   decision permits foundations behind a disabled gate, but retains a separate
+   held-out real-meeting release evaluation. The journal does not replace it.
 7. **Vectors in the user database as `BLOB`.** Not the keychain: two stores to keep in
    sync makes deletion a two-phase operation that can half-fail — the worst possible bug
    on biometric data — and keychain items are excluded from some backups.
@@ -411,9 +489,11 @@ differentiator, but honestly:
    right to erasure, which means not shippable. It also carries the diagnostic read-out
    that turns "this profile never matches" from a mystery into a number.
 
-## Decisions (2026-09-10)
+## Experimental integration design (2026-09-10)
 
-9. **Short-lived enrollment candidates**, revising decision 2. The flywheel needs the
+9. **Short-lived enrollment candidates**, a design in PR #1005 assessed as part of
+   the experimental integration, revising decision 2. This is not a July decision
+   attributed to Daniel or approval to release candidate retention. The flywheel needs the
    user to name a speaker in a finished transcript, but by then the vector is gone: it
    lives in memory during transcription, feeds scoring, and is discarded. The three
    alternatives are worse. Re-diarizing on demand needs audio that retention settings or
@@ -428,9 +508,11 @@ differentiator, but honestly:
    `speaker_embedding_candidates` therefore holds a vector per detected speaker, bounded
    on every side: written only while `rememberSpeakers` is on, only above the enrollment
    gate, never compared against each other (so this is not recurring-unknown detection),
-   promoted to an exemplar and dropped on enrollment, deleted with their transcription,
+   promoted to an exemplar and dropped only when insertion succeeds, retained on
+   rejected promotion, deleted with their transcription,
    excluded from exports, stated in the consent sheet, and expiring after seven days on
-   a per-row `expiresAt` so raising the constant cannot resurrect them. Anarlog keeps 45
+   a per-row `expiresAt` that is unchanged by later default-retention changes
+   (a new evaluation may replace the row). Anarlog keeps 45
    days; naming is a same-week action and unnamed vectors earn nothing by waiting.
 
    **The consent gate moves with the first write.** It sat at the first enrollment,
@@ -445,4 +527,4 @@ differentiator, but honestly:
    With the preference off by default nothing is stored until the user asks for the
    feature. But BIPA and the GDPR do not distinguish a useful print from a dormant one,
    and this is the first privacy invariant the series loosens rather than tightens, so it
-   goes in the promoted ADR (Phase 2) explicitly rather than into a commit message.
+   must be explicit in the promoted ADR before official release.

--- a/plans/active/2026-07-03-speaker-voiceprints.md
+++ b/plans/active/2026-07-03-speaker-voiceprints.md
@@ -225,10 +225,11 @@ accumulation). That's Phase 3, a separate opt-in, decided later.
   remove the contradiction. It preserves per-channel modes either way. A centroid may
   be computed on the fly for display, never for scoring; samples added only on user confirmation
   (no silent EMA — poisoning/drift). **At most one sample per profile per
-  recording** (the speaker-level aggregate): offline segment embeddings are
-  cluster-derived from the same centroid, so storing several from one meeting
-  would inflate `sampleCount` and fake diversity — K references should mean K
-  distinct recordings/channels.
+  recording**, and that sample is the normalized per-speaker centroid taken from
+  `DiarizationResult.speakerDatabase`, rekeyed through `idMapping` — not a
+  per-segment embedding, which the offline pipeline does not expose (Amendment 2).
+  A recording yields one vector, so storing several would inflate `sampleCount`
+  against no new evidence: K references must mean K distinct recordings.
 - Channel tags on every sample (`system`, `microphone`, `file`) — prefer
   same-channel references when scoring; channel mismatch is the default failure
   mode, not an edge case.

--- a/plans/active/2026-07-03-speaker-voiceprints.md
+++ b/plans/active/2026-07-03-speaker-voiceprints.md
@@ -230,6 +230,12 @@ accumulation). That's Phase 3, a separate opt-in, decided later.
   per-segment embedding, which the offline pipeline does not expose (Amendment 2).
   A recording yields one vector, so storing several would inflate `sampleCount`
   against no new evidence: K references must mean K distinct recordings.
+- **At the cap, evict the oldest confirmation** (Amendment). K is a storage
+  bound, not a scoring ceiling: vectors the matcher can never reach would be
+  biometric data kept for nothing. Manual enrollments are spared, because
+  `confirm` counts them to decide whether a profile may learn at all — evicting
+  oldest-first would drop a mature profile back below that anchor for no visible
+  reason. A profile holding K manual enrollments refuses further samples.
 - Channel tags on every sample (`system`, `microphone`, `file`) — prefer
   same-channel references when scoring; channel mismatch is the default failure
   mode, not an edge case.

--- a/plans/active/2026-07-03-speaker-voiceprints.md
+++ b/plans/active/2026-07-03-speaker-voiceprints.md
@@ -309,7 +309,7 @@ accumulation). That's Phase 3, a separate opt-in, decided later.
   excluded from **every** outward surface — JSON/TXT/MD/SRT/VTT/PDF/DOCX exports,
   `ExportCommand.projectedJSON()`, diagnostics, support bundles, and any future
   database export. This holds by construction (no export path reads these tables, and
-  nothing is added to `Transcription`), and PR 9 asserts it **per table on every
+  nothing is added to `Transcription`), and PR 10 asserts it **per table on every
   surface**, so a table added later cannot inherit the exemption silently.
 - **Privacy invariants**: profile store lives in the user DB, covered by existing
   user-data deletion rules.
@@ -339,23 +339,32 @@ differentiator, but honestly:
   distance distributions across meetings + channels. Output: research report with
   separation evidence, chosen τ + margin, and a GO/NO-GO. Kills the feature
   cheaply if WeSpeaker can't separate on compressed system audio.
-- **Phase 1 — core loop (meetings), nine independently shippable PRs.** PRs 1–5 are
-  invisible to users:
+- **Phase 1 — core loop (meetings), ten independently shippable PRs.** PRs 1–6 are
+  invisible to users, and the numbering matches the shipped PRs one-to-one:
   1. Surface embeddings through the diarization adapter: `SpeakerEmbedding` (normalizing
      on entry), `SpeakerCaptureDomain`, `SpeakerModelIdentity`, per-cluster speech
      durations, key remapping through `idMapping` (`DiarizationService.swift:227-234` —
-     FluidAudio also uses `S1`/`S2`, so skipping the remap silently mislabels).
-  2. Migration + `SpeakerProfileRepository`.
-  3. `SpeakerVoiceprintMatcher` — pure logic, the test-dense PR.
-  4. Service wiring + decision journal, flag off.
-  5. Short-lived enrollment candidates (decision 9): without them nothing can be
+     FluidAudio also uses `S1`/`S2`, so skipping the remap silently mislabels)
+     ([#994](https://github.com/moona3k/macparakeet/pull/994)).
+  2. Migration + `SpeakerProfileRepository`
+     ([#996](https://github.com/moona3k/macparakeet/pull/996)).
+  3. `SpeakerVoiceprintMatcher` — pure logic, the test-dense PR
+     ([#1000](https://github.com/moona3k/macparakeet/pull/1000)).
+  4. `SpeakerVoiceprintService` + decision journal + the preference, flag off
+     ([#1001](https://github.com/moona3k/macparakeet/pull/1001)).
+  5. Pipeline wiring: embeddings and durations through the finalizer, scoring after
+     the transcript is saved, injection in `AppEnvironment`
+     ([#1004](https://github.com/moona3k/macparakeet/pull/1004)). Split from 4, which
+     the July plan had as one item: the service is testable on fixtures alone, while
+     this touches the meeting path.
+  6. Short-lived enrollment candidates (decision 9): without them nothing can be
      enrolled after the fact, because the vector is gone by the time the user types
-     a name.
-  6. Consent sheet on the toggle + the enrollment prompt after a rename. The consent
+     a name ([#1005](https://github.com/moona3k/macparakeet/pull/1005)).
+  7. Consent sheet on the toggle + the enrollment prompt after a rename. The consent
      gate ships with, not after, the first surface that can turn writing on.
-  7. Suggestion banner (confirm/dismiss).
-  8. Voice-profile admin screen + a Reset & Cleanup row.
-  9. Leak tests (export JSON, CLI `projectedJSON()`, feedback bundle), specs, ADR,
+  8. Suggestion banner (confirm/dismiss).
+  9. Voice-profile admin screen + a Reset & Cleanup row.
+  10. Leak tests (export JSON, CLI `projectedJSON()`, feedback bundle), specs, ADR,
      privacy docs, telemetry allowlist.
 - **Phase 2 — breadth.** File/URL-transcription path (the Reddit author's
   185-episode podcast case), profile management UI, confirmation-driven

--- a/plans/active/2026-07-03-speaker-voiceprints.md
+++ b/plans/active/2026-07-03-speaker-voiceprints.md
@@ -28,11 +28,13 @@ Re-verified against `main` (FluidAudio 0.15.6, speaker-correction layer shipped
 in [PR #960](https://github.com/moona3k/macparakeet/pull/960)). Six errors, three
 additions. Corrections are applied in place below.
 
-**Scope locked:** meetings only · `rememberSpeakers` off by default · tau is a
-compiled constant with a hidden `UserDefaults` override, never a user setting ·
-calibration via a local decision journal, not an on-demand re-diarization ·
-literal #662 ask (recurring unknowns) out of scope, no columns, no follow-up ·
-vectors as `BLOB` in the user DB · no auto-apply.
+**Scope locked:** meetings only · `rememberSpeakers` off by default and gated on
+acknowledged consent · tau is a compiled constant with a hidden `UserDefaults`
+override, never a user setting · calibration via a local decision journal, not an
+on-demand re-diarization · literal #662 ask (recurring unknowns) out of scope, no
+columns, no follow-up · permanent vectors only for enrolled people, plus short-lived
+enrollment candidates that are never compared to each other (decision 9) · vectors as
+`BLOB` in the user DB · no auto-apply.
 
 **Corrections:**
 
@@ -195,15 +197,25 @@ Enrollment flywheel, correction-based (the Otter/Circleback pattern, minus cloud
 5. Confirmation applies the label via the existing rename path. Adding that
    meeting's embedding as a new profile sample is part of the confirm action's
    *disclosed* semantics ("Confirm and improve Sarah's voice profile") — samples
-   are only ever added to already-enrolled profiles via this explicit act, so v1
-   never retains voiceprints from ambient recordings for anyone unenrolled.
+   are only ever added to already-enrolled profiles via this explicit act.
 6. Unknowns stay "Others N". Below-margin matches stay unknown ("wrong automatic
    names are worse than anonymous speakers").
 
-Scope call (recommended): v1 stores embeddings **only for explicitly enrolled
-speakers**. The issue's literal ask — "this voice appeared in 5 recordings, name
-them?" — requires retaining voiceprints of people nobody enrolled (ambient biometric
-accumulation). That's Phase 3, a separate opt-in, decided later.
+Scope call: v1 keeps two kinds of vector, and the difference is the whole privacy
+argument.
+
+- **Profile exemplars** are permanent and belong to a named person. Only an explicit
+  enrollment or a confirmed suggestion creates one.
+- **Enrollment candidates** (Amendment, decision 9) are short-lived and belong to no
+  one. Step 1 above happens after the meeting, when the vector has already been
+  discarded, so without them nothing can be named at all. They are consent-gated,
+  capped at seven days, deleted on promotion or with their recording, and **never
+  compared against each other**.
+
+That last property is what keeps the issue's literal ask — "this voice appeared in 5
+recordings, name them?" — out of scope: answering it means comparing unenrolled
+vectors to one another, which is the ambient accumulation this plan refuses. Phase 3,
+a separate opt-in, decided later.
 
 ### Matching policy (matching-best-practices report; numbers are pre-calibration placeholders)
 
@@ -381,7 +393,7 @@ differentiator, but honestly:
 ## Decisions (Daniel, 2026-07-04)
 
 1. **Auto-apply: strict confirm in v1.** Every match surfaces as a suggestion requiring confirmation; opt-in auto-apply (provenance chip + undo) reconsidered only after dogfooding shows precision.
-2. **Ambient embeddings: NO.** v1 stores embeddings only for explicitly enrolled speakers; recurring-unknown detection remains a Phase 3 decision with its own opt-in.
+2. **Ambient embeddings: NO.** v1 stores embeddings only for explicitly enrolled speakers; recurring-unknown detection remains a Phase 3 decision with its own opt-in. (Amended 2026-09-10: permanent storage is still enrollment-only, but decision 9 adds short-lived enrollment candidates — never compared to each other, so recurring-unknown detection stays out of scope.)
 3. **BIPA posture: docs + consent gate only.** Permission acknowledgment plus plain-language guidance; no regional gating. (Amended 2026-09-10: the acknowledgment moved from the first enrollment to the toggle — see decision 9.)
 4. **Podcast/file scope: Phase 2.** v1 is meetings-only to keep the first PR series reviewable.
 

--- a/plans/active/2026-07-03-speaker-voiceprints.md
+++ b/plans/active/2026-07-03-speaker-voiceprints.md
@@ -180,10 +180,14 @@ transplant them onto WeSpeaker. Hence Phase 0.
 
 Enrollment flywheel, correction-based (the Otter/Circleback pattern, minus cloud):
 
+0. Turning "Remember speakers" on opens the consent sheet ("I have the participants'
+   permission…"). Refusing leaves the toggle off, and `rememberSpeakersEnabled`
+   resolves to off until a consent date exists (Amendment, decision 9). The gate sits
+   here rather than at the first enrollment because a voice is now kept at the end of
+   every meeting: a gate on naming would arrive after the first write.
 1. User renames "Others 1" → "Sarah" in an existing meeting transcript (existing UI).
 2. If "Remember speakers" is enabled: prompt "Remember this voice as Sarah? Future
-   meetings will suggest her name automatically." First-ever enrollment shows the
-   consent gate ("I have the participants' permission…").
+   meetings will suggest her name automatically."
 3. Profile stored locally (embeddings only, never audio).
 4. Next diarized recording: matcher compares detected-speaker embeddings against
    profiles → high-confidence matches surface as **suggestions** ("Looks like Sarah
@@ -243,7 +247,8 @@ accumulation). That's Phase 3, a separate opt-in, decided later.
 ### Architecture
 
 - **New GRDB migration `v0.39-speaker-voiceprints` + 3 tables** (raw SQL, style of
-  `v0.32-speaker-corrections`, `DatabaseManager.swift:1374-1422`):
+  `v0.32-speaker-corrections`, `DatabaseManager.swift:1374-1422`), joined by the
+  decision journal in `v0.40` and enrollment candidates in `v0.41` (below):
   - `speaker_profiles`: id, displayName (`UNIQUE … COLLATE NOCASE`, so a second
     rename to "Sarah" adds an exemplar instead of a duplicate), embeddingModelId,
     aggregationProfileId, timestamps, lastMatchedAt, lastEvaluatedAt,
@@ -258,6 +263,20 @@ accumulation). That's Phase 3, a separate opt-in, decided later.
     profileId, status (suggested/confirmed/dismissed), distance, runnerUpDistance.
     Fingerprint-scoped like `speaker_corrections`, so a stale `dismissed` cannot
     permanently suppress a legitimate suggestion.
+- **`v0.41-speaker-embedding-candidates`** (Amendment, decision 9), owned by
+  `SpeakerEmbeddingCandidateRepository`: `UNIQUE (transcriptionId, speakerId,
+  transcriptFingerprint)` — fingerprint-scoped for the same reason as the links, since
+  after re-diarization the same id can mean another person — vector
+  `BLOB CHECK (length = 1024)`, speechSeconds, captureDomain, the two model ids,
+  `transcriptionId … ON DELETE CASCADE` (unlike an exemplar, a candidate *is* about
+  that recording), and `expiresAt` **stored per row**, indexed, so raising the
+  retention constant later cannot revive a vector promised a shorter life.
+  Promotion and deletion are one transaction on the exemplar side:
+  `insertExemplar` applies the cap and inserts, then the candidate row is dropped, so
+  the vector is never stored twice. Writes happen only under
+  `rememberSpeakersEnabled`, which requires acknowledged consent (decision 9), and
+  only above `minSpeechSecondsToEnroll` — a vector that can never be promoted would
+  be biometric data held for an offer never made. Never read by the matcher.
 - **`SpeakerVoiceprintService`**, a `final class … @unchecked Sendable` — **not** an
   actor, aligning with its direct neighbour `SpeakerCorrectionService` (`:59`), since
   GRDB already serializes through `dbQueue`. Matching itself lives in a stateless,
@@ -286,12 +305,12 @@ accumulation). That's Phase 3, a separate opt-in, decided later.
   transcript labels survive. "Delete all voice profiles" is the same transaction over
   every profile, not a loop that can half-fail.
 - **Export boundary**: `speaker_profiles`, `speaker_profile_exemplars`,
-  `speaker_profile_links` and the decision journal are excluded from **every** outward
-  surface — JSON/TXT/MD/SRT/VTT/PDF/DOCX exports, `ExportCommand.projectedJSON()`,
-  diagnostics, support bundles, and any future database export. This holds by
-  construction (no export path reads these tables, and nothing is added to
-  `Transcription`), and PR 8 adds contract tests that assert it per table rather than
-  relying on that construction staying true.
+  `speaker_profile_links`, `speaker_embedding_candidates` and the decision journal are
+  excluded from **every** outward surface — JSON/TXT/MD/SRT/VTT/PDF/DOCX exports,
+  `ExportCommand.projectedJSON()`, diagnostics, support bundles, and any future
+  database export. This holds by construction (no export path reads these tables, and
+  nothing is added to `Transcription`), and PR 9 asserts it **per table on every
+  surface**, so a table added later cannot inherit the exemption silently.
 - **Privacy invariants**: profile store lives in the user DB, covered by existing
   user-data deletion rules.
 
@@ -320,7 +339,7 @@ differentiator, but honestly:
   distance distributions across meetings + channels. Output: research report with
   separation evidence, chosen τ + margin, and a GO/NO-GO. Kills the feature
   cheaply if WeSpeaker can't separate on compressed system audio.
-- **Phase 1 — core loop (meetings), eight independently shippable PRs.** PRs 1–5 are
+- **Phase 1 — core loop (meetings), nine independently shippable PRs.** PRs 1–5 are
   invisible to users:
   1. Surface embeddings through the diarization adapter: `SpeakerEmbedding` (normalizing
      on entry), `SpeakerCaptureDomain`, `SpeakerModelIdentity`, per-cluster speech
@@ -332,9 +351,11 @@ differentiator, but honestly:
   5. Short-lived enrollment candidates (decision 9): without them nothing can be
      enrolled after the fact, because the vector is gone by the time the user types
      a name.
-  6. Enrollment prompt, consent gate, suggestion banner (confirm/dismiss).
-  7. Voice-profile admin screen + a Reset & Cleanup row.
-  8. Leak tests (export JSON, CLI `projectedJSON()`, feedback bundle), specs, ADR,
+  6. Consent sheet on the toggle + the enrollment prompt after a rename. The consent
+     gate ships with, not after, the first surface that can turn writing on.
+  7. Suggestion banner (confirm/dismiss).
+  8. Voice-profile admin screen + a Reset & Cleanup row.
+  9. Leak tests (export JSON, CLI `projectedJSON()`, feedback bundle), specs, ADR,
      privacy docs, telemetry allowlist.
 - **Phase 2 — breadth.** File/URL-transcription path (the Reddit author's
   185-episode podcast case), profile management UI, confirmation-driven
@@ -352,7 +373,7 @@ differentiator, but honestly:
 
 1. **Auto-apply: strict confirm in v1.** Every match surfaces as a suggestion requiring confirmation; opt-in auto-apply (provenance chip + undo) reconsidered only after dogfooding shows precision.
 2. **Ambient embeddings: NO.** v1 stores embeddings only for explicitly enrolled speakers; recurring-unknown detection remains a Phase 3 decision with its own opt-in.
-3. **BIPA posture: docs + consent gate only.** First-enrollment permission acknowledgment plus plain-language guidance; no regional gating.
+3. **BIPA posture: docs + consent gate only.** Permission acknowledgment plus plain-language guidance; no regional gating. (Amended 2026-09-10: the acknowledgment moved from the first enrollment to the toggle — see decision 9.)
 4. **Podcast/file scope: Phase 2.** v1 is meetings-only to keep the first PR series reviewable.
 
 ## Decisions (2026-09-09)
@@ -390,6 +411,14 @@ differentiator, but honestly:
    excluded from exports, stated in the consent sheet, and expiring after seven days on
    a per-row `expiresAt` so raising the constant cannot resurrect them. Anarlog keeps 45
    days; naming is a same-week action and unnamed vectors earn nothing by waiting.
+
+   **The consent gate moves with the first write.** It sat at the first enrollment,
+   which was sound while nothing was stored before one. Keeping it there now would let
+   a user turn the toggle on and have vectors on disk having seen nothing, and gating
+   candidate writes on a consent asked at naming time is circular — naming needs a
+   candidate that would never have been written. So `rememberSpeakersEnabled` requires
+   an acknowledged consent date alongside the toggle and speaker detection, and the
+   sheet opens from the toggle. Amends decision 3.
 
    Decision 2 targeted ambient accumulation — an app that banks everyone's voice unasked.
    With the preference off by default nothing is stored until the user asks for the

--- a/plans/active/2026-07-03-speaker-voiceprints.md
+++ b/plans/active/2026-07-03-speaker-voiceprints.md
@@ -290,7 +290,7 @@ accumulation). That's Phase 3, a separate opt-in, decided later.
   surface — JSON/TXT/MD/SRT/VTT/PDF/DOCX exports, `ExportCommand.projectedJSON()`,
   diagnostics, support bundles, and any future database export. This holds by
   construction (no export path reads these tables, and nothing is added to
-  `Transcription`), and PR 7 adds contract tests that assert it per table rather than
+  `Transcription`), and PR 8 adds contract tests that assert it per table rather than
   relying on that construction staying true.
 - **Privacy invariants**: profile store lives in the user DB, covered by existing
   user-data deletion rules.
@@ -320,7 +320,7 @@ differentiator, but honestly:
   distance distributions across meetings + channels. Output: research report with
   separation evidence, chosen τ + margin, and a GO/NO-GO. Kills the feature
   cheaply if WeSpeaker can't separate on compressed system audio.
-- **Phase 1 — core loop (meetings), seven independently shippable PRs.** PRs 1–4 are
+- **Phase 1 — core loop (meetings), eight independently shippable PRs.** PRs 1–5 are
   invisible to users:
   1. Surface embeddings through the diarization adapter: `SpeakerEmbedding` (normalizing
      on entry), `SpeakerCaptureDomain`, `SpeakerModelIdentity`, per-cluster speech
@@ -329,9 +329,12 @@ differentiator, but honestly:
   2. Migration + `SpeakerProfileRepository`.
   3. `SpeakerVoiceprintMatcher` — pure logic, the test-dense PR.
   4. Service wiring + decision journal, flag off.
-  5. Enrollment prompt, consent gate, suggestion banner (confirm/dismiss).
-  6. Voice-profile admin screen + a Reset & Cleanup row.
-  7. Leak tests (export JSON, CLI `projectedJSON()`, feedback bundle), specs, ADR,
+  5. Short-lived enrollment candidates (decision 9): without them nothing can be
+     enrolled after the fact, because the vector is gone by the time the user types
+     a name.
+  6. Enrollment prompt, consent gate, suggestion banner (confirm/dismiss).
+  7. Voice-profile admin screen + a Reset & Cleanup row.
+  8. Leak tests (export JSON, CLI `projectedJSON()`, feedback bundle), specs, ADR,
      privacy docs, telemetry allowlist.
 - **Phase 2 — breadth.** File/URL-transcription path (the Reddit author's
   185-episode podcast case), profile management UI, confirmation-driven
@@ -339,8 +342,9 @@ differentiator, but honestly:
   2026-06-14 plan's speaker-memory section), user-facing privacy docs, CLI
   `speakers list|delete` parity.
 - **Phase 3 — judged later, each its own decision.** Recurring-unknown detection
-  (the issue's literal "appeared in 5 recordings" ask — needs ambient embedding
-  retention, separate opt-in); backfill scan over retained audio; live-path
+  (the issue's literal "appeared in 5 recordings" ask — still out of scope: it needs
+  unenrolled vectors compared *against each other*, which decision 9's candidates
+  never are, and its own opt-in); backfill scan over retained audio; live-path
   identity once live diarization (#430) ships; calendar-attendee hints (hints
   only, never authoritative).
 
@@ -364,3 +368,31 @@ differentiator, but honestly:
 8. **Admin screen ships with the feature, not after it.** No deletion surface means no
    right to erasure, which means not shippable. It also carries the diagnostic read-out
    that turns "this profile never matches" from a mystery into a number.
+
+## Decisions (2026-09-10)
+
+9. **Short-lived enrollment candidates**, revising decision 2. The flywheel needs the
+   user to name a speaker in a finished transcript, but by then the vector is gone: it
+   lives in memory during transcription, feeds scoring, and is discarded. The three
+   alternatives are worse. Re-diarizing on demand needs audio that retention settings or
+   "Remove Audio Only" may have purged, costs minutes for what reads as an instant
+   action, and can re-cut the clusters — so the `speakerId` mapping may not survive, and
+   a reconciliation error would enroll the wrong voice under the given name, the worst
+   failure this feature has. An in-memory window makes the offer vanish on restart with
+   no explanation a user could follow. Enrolling from a hand-picked excerpt needs a
+   second FluidAudio manager (`extractSpeakerEmbedding` exists only on the streaming
+   `DiarizerManager`) and puts the work on the user for every person.
+
+   `speaker_embedding_candidates` therefore holds a vector per detected speaker, bounded
+   on every side: written only while `rememberSpeakers` is on, only above the enrollment
+   gate, never compared against each other (so this is not recurring-unknown detection),
+   promoted to an exemplar and dropped on enrollment, deleted with their transcription,
+   excluded from exports, stated in the consent sheet, and expiring after seven days on
+   a per-row `expiresAt` so raising the constant cannot resurrect them. Anarlog keeps 45
+   days; naming is a same-week action and unnamed vectors earn nothing by waiting.
+
+   Decision 2 targeted ambient accumulation — an app that banks everyone's voice unasked.
+   With the preference off by default nothing is stored until the user asks for the
+   feature. But BIPA and the GDPR do not distinguish a useful print from a dormant one,
+   and this is the first privacy invariant the series loosens rather than tightens, so it
+   goes in the promoted ADR (Phase 2) explicitly rather than into a commit message.

--- a/plans/active/2026-07-03-speaker-voiceprints.md
+++ b/plans/active/2026-07-03-speaker-voiceprints.md
@@ -1,7 +1,7 @@
 # Persistent Speaker Profiles (Voiceprints) — Research Synthesis + Implementation Plan
 
 - **Date:** 2026-07-03 (amended 2026-09-09 — see
-  [Amendment](#amendment-2026-09-09-scope-locked-six-corrections))
+  [Amendment](#amendment-2026-09-09))
 - **Status:** READY TO IMPLEMENT. Phase 0: NO-GO on the July meeting corpus
   (pre-AEC echo contamination + only 3 usable sessions). Phase 0b (clean public
   corpus): **GO — embedding path validated** (no overlap: same-narrator
@@ -47,6 +47,11 @@ vectors as `BLOB` in the user DB · no auto-apply.
    anti-correlated with signal quality. Phase 0b stays valid because the harness
    normalizes both vectors first (`analyze_voiceprints.py:40-45`). **Fix:**
    normalize once in `SpeakerEmbedding.init?`, rejecting norms < 1e-6.
+   **Zero-vector clusters** (emitted when `computeCentroids` hits a zero denominator)
+   are dropped from the embedding dictionary only: the cluster keeps its segments,
+   its `SpeakerInfo` entry, its `idMapping` id and its duration total, so diarization
+   output is unchanged and the cluster is simply unmatchable and un-enrollable.
+   Fixture required.
 2. **No per-segment embedding exists in the offline pipeline.** Duration-weighted
    re-aggregation is a no-op, and FluidAudio's responsibility-weighted centroid
    already beats duration weighting. Nothing to build here.
@@ -91,13 +96,24 @@ us without wiring a second manager. Out of scope.
 3. **Decision journal replaces the corpus gate.** Log each decision locally
    (distances, gates, outcome, the label the user finally types); ~20 dogfooded
    meetings yield a labelled post-AEC corpus whose ground truth is what the user
-   wrote. Stays local, never in the support bundle; diagnostic embeddings are
-   ephemeral and never persisted as profiles.
+   wrote. Diagnostic embeddings are ephemeral and never persisted as profiles.
+   Lifecycle, since distances joined to labels are identifying:
+   - **Owner:** `SpeakerVoiceprintService`, the only writer. No other component
+     appends to it.
+   - **Location:** a table in the user database, not a loose file — so it inherits
+     the existing user-data deletion rules instead of needing its own.
+   - **Retention:** 90 days, pruned on write. It exists to calibrate, not to
+     accumulate; a rolling window is more than the ~20 meetings the calibration needs.
+   - **Never leaves the machine:** excluded from exports, diagnostics and support
+     bundles, like the profile tables.
+   - **Deletion:** rows are purged atomically with whatever they reference — deleting
+     a profile, a transcription, or all voice profiles takes its journal rows with it
+     in the same transaction. No orphan row outlives its subject.
 
 **Threshold:** start at `tau = 0.25`, not 0.30. The zero-FPR plateau runs
 0.25–0.45 and the worst positive is 0.227, so 0.25 still accepts 21/21 while
 buying margin against noisier post-AEC audio. A missed suggestion is a non-event;
-a false one is the worst documented outcome.
+a false one is the worst outcome this research documented.
 
 ## Verdict
 
@@ -191,11 +207,23 @@ accumulation). That's Phase 3, a separate opt-in, decided later.
   `top1 distance ≤ τ`, the margin holds on **both** sides (`top2 − top1 ≥ margin`
   for the cluster *and* for the profile), and each is the other's best match.
   Ship values: τ = 0.25, margin = 0.10.
+- **Singleton sides:** when a side has no second candidate (one enrolled profile, or
+  one detected cluster) the margin is **vacuously satisfied**, not failed — the
+  decision rests on τ alone. Failing it instead would make the feature unusable
+  exactly when it matters most: the first enrolled speaker would never be suggested.
+- **Ties:** if two candidates sit at an identical distance, the margin is 0 and the
+  pair is rejected. No tie-break by id, insertion order, or recency — an arbitrary
+  winner is precisely the "wrong automatic name" the invariant forbids. Both cases
+  need explicit fixtures (singleton profile set, singleton cluster set, exact tie).
 - Duration gates: embed only clean non-overlapped speech; per-speaker aggregate ≥3s
   usable, profile needs ≥15s total across ≥3 turns before it may suggest; never
   learn from <2s backchannels (snap those to the surrounding turn's label instead).
-- Profiles: K ≤ 10 raw reference embeddings + recomputed centroid; score = max over
-  references (preserves per-channel modes); samples added only on user confirmation
+- Profiles: K ≤ 10 raw reference embeddings, **no stored centroid** (Amendment).
+  Scoring is expressed in **cosine distance throughout**, so a profile scores as the
+  **minimum** distance over its exemplars — the same rule the July text stated as
+  "max over references" in similarity terms, restated in the shipping metric to
+  remove the contradiction. It preserves per-channel modes either way. A centroid may
+  be computed on the fly for display, never for scoring; samples added only on user confirmation
   (no silent EMA — poisoning/drift). **At most one sample per profile per
   recording** (the speaker-level aggregate): offline segment embeddings are
   cluster-derived from the same centroid, so storing several from one meeting
@@ -242,9 +270,23 @@ accumulation). That's Phase 3, a separate opt-in, decided later.
 - **Wiring**: the two insertion points above.
 - **Settings**: "Remember speakers" toggle (default off, requires speaker detection
   on) + profile list with per-profile delete + "Delete all voice profiles".
-- **Privacy invariants**: profiles excluded from exports, diagnostics, and support
-  bundles; deleting a profile never touches transcripts; profile store lives in the
-  user DB (covered by existing user-data deletion rules).
+- **Deletion semantics**: deleting a profile runs as **one transaction**. The
+  `ON DELETE CASCADE` on `speaker_profile_exemplars.profileId` and
+  `speaker_profile_links.profileId` removes every profile-owned row; transcriptions,
+  their `speaker_corrections`, and any label already applied are untouched. The
+  matching decision journal is purged for that profile in the same transaction.
+  Tested by asserting that no row in either table references the deleted id, and that
+  transcript labels survive. "Delete all voice profiles" is the same transaction over
+  every profile, not a loop that can half-fail.
+- **Export boundary**: `speaker_profiles`, `speaker_profile_exemplars`,
+  `speaker_profile_links` and the decision journal are excluded from **every** outward
+  surface — JSON/TXT/MD/SRT/VTT/PDF/DOCX exports, `ExportCommand.projectedJSON()`,
+  diagnostics, support bundles, and any future database export. This holds by
+  construction (no export path reads these tables, and nothing is added to
+  `Transcription`), and PR 7 adds contract tests that assert it per table rather than
+  relying on that construction staying true.
+- **Privacy invariants**: profile store lives in the user DB, covered by existing
+  user-data deletion rules.
 
 ## Privacy stance (privacy-biometrics report)
 

--- a/plans/active/2026-07-03-speaker-voiceprints.md
+++ b/plans/active/2026-07-03-speaker-voiceprints.md
@@ -1,14 +1,17 @@
 # Persistent Speaker Profiles (Voiceprints) — Research Synthesis + Implementation Plan
 
-- **Date:** 2026-07-03
-- **Status:** PROPOSED — decisions settled 2026-07-04. Phase 0: NO-GO on the
-  current meeting corpus (pre-AEC echo contamination + only 3 usable sessions).
-  Phase 0b (clean public corpus): **GO — embedding path validated** (no overlap:
-  same-narrator 0.05–0.23 vs different 0.47–0.84; tau=0.30/margin 0.10 = 100%
-  TPR, 0% FPR). Phase 1 blocked only on a representative post-AEC meeting
-  corpus: ship #605 AEC (0.6.25) → dogfood recordings → re-run harness → set
-  product tau. See `docs/research/2026-07-04-voiceprints-phase0-calibration.md`
-  and `docs/research/2026-07-04-voiceprints-phase0b-clean-corpus.md`.
+- **Date:** 2026-07-03 (amended 2026-09-09 — see
+  [Amendment](#amendment-2026-09-09-scope-locked-six-corrections))
+- **Status:** READY TO IMPLEMENT. Phase 0: NO-GO on the July meeting corpus
+  (pre-AEC echo contamination + only 3 usable sessions). Phase 0b (clean public
+  corpus): **GO — embedding path validated** (no overlap: same-narrator
+  0.05–0.23 vs different 0.47–0.84; tau/margin sweep = 100% TPR, 0% FPR across
+  a 0.25–0.45 plateau). Phase 1 is **no longer corpus-blocked**: the 2026-09-09
+  amendment replaces the "collect a post-AEC corpus first" gate with a local
+  decision journal that produces a labelled corpus from dogfooding, so code can
+  land behind a disabled flag while the product tau is confirmed. See
+  `docs/research/2026-07-04-voiceprints-phase0-calibration.md` and
+  `docs/research/2026-07-04-voiceprints-phase0b-clean-corpus.md`.
 - **Trigger:** issue #662 (yakov0922) + a Reddit voiceprint post aimed at MacWhisper;
   related demand in #430, #106
 - **Research:** 5 delegated reports in
@@ -19,14 +22,92 @@
   (names "speaker memory" as the gap; this plan is its identity layer, made concrete)
   and [`plans/active/2026-05-speaker-diarization-quality.md`](2026-05-speaker-diarization-quality.md)
 
+## Amendment (2026-09-09)
+
+Re-verified against `main` (FluidAudio 0.15.6, speaker-correction layer shipped
+in [PR #960](https://github.com/moona3k/macparakeet/pull/960)). Six errors, three
+additions. Corrections are applied in place below.
+
+**Scope locked:** meetings only · `rememberSpeakers` off by default · tau is a
+compiled constant with a hidden `UserDefaults` override, never a user setting ·
+calibration via a local decision journal, not an on-demand re-diarization ·
+literal #662 ask (recurring unknowns) out of scope, no columns, no follow-up ·
+vectors as `BLOB` in the user DB · no auto-apply.
+
+**Corrections:**
+
+1. **"Embeddings are already L2-normalized → dot product" is false, and fails
+   silently.** `speakerDatabase` is the VBx *clustering centroid*, un-normalized:
+   every segment of a cluster carries a copy of it
+   (`OfflineReconstruction.swift:414-427`, `:302-356`), and `computeCentroids`
+   (`:655-680`) never renormalizes and emits a zero vector when the denominator is
+   zero. Two centroids of norm 0.85 with true similarity 0.90 score `1 − 0.85² ×
+   0.90 = 0.350`, above tau: correct pairs rejected, no error, no log. Not fixable
+   by moving tau — `‖centroid‖` shrinks with dispersion, so the bias is
+   anti-correlated with signal quality. Phase 0b stays valid because the harness
+   normalizes both vectors first (`analyze_voiceprints.py:40-45`). **Fix:**
+   normalize once in `SpeakerEmbedding.init?`, rejecting norms < 1e-6.
+2. **No per-segment embedding exists in the offline pipeline.** Duration-weighted
+   re-aggregation is a no-op, and FluidAudio's responsibility-weighted centroid
+   already beats duration weighting. Nothing to build here.
+3. **The meeting insertion point is unreachable.** Before `finalize` the
+   transcription is unpersisted (FK fails) and the fingerprint needs
+   `transcriptSegments` (`TranscriptionService.swift:1503-1506`). Correct anchor:
+   after `completeTranscription` returns (`:1509-1517`).
+4. **Drop `transcriptions.speakerAssignments`.** `speaker_corrections` already
+   owns label provenance, and `exportToJSON` encodes the whole `Transcription`
+   struct (`ExportService.swift:228-234`) — the column would leak `profileId` by
+   construction. Schema choice beats added redaction. Likewise no
+   `.confirmVoiceProfile` command: a confirmation is an ordinary `.rename`.
+5. **Model versioning was missing, and naive versioning is insufficient.** The
+   centroid depends on clustering config the app already overrides, so a bump can
+   move it without moving the model. Two ids: `embeddingModelId` (mismatch ⇒
+   ignore) and `aggregationProfileId` (mismatch ⇒ compared at `tau − 0.05`;
+   Phase 0b leaves a 0.24 gap, config drift costs hundredths). Never delete
+   profiles on a bump — mark them and offer re-enrollment.
+6. **The "speaker detection is opt-in, default off" premise is stale.** Both
+   saved detection preferences currently resolve to `true`
+   (`AppRuntimePreferences.swift:514-517`, ADR-010 July amendments). This plan
+   neither relies on nor changes that: it adds `rememberSpeakers`, which stays
+   off, and voiceprints never activate without it. Revisiting the detection
+   default itself is an ADR-010 decision, out of scope here.
+
+Also: `extractSpeakerEmbedding(from:)` lives on the streaming `DiarizerManager`
+(`:92`), not on `OfflineDiarizerManager` — ad-hoc enrollment is not available to
+us without wiring a second manager. Out of scope.
+
+**Additions:**
+
+1. **Mutual best match, with a margin on both sides.** The diarizer over-splits,
+   so one speaker yields two clusters that each clear a cluster-side margin
+   against *other* profiles — suggesting "Sarah" twice in one meeting. Mutual
+   matching gives injectivity for free; the profile-side margin additionally
+   rejects two clusters at 0.12 and 0.13 from the same profile as noise. Prior-art
+   constants do not transfer (different model, similarity not distance); the
+   policy does.
+2. **Pollution guard on name-based enrollment.** Renaming to "Sarah" bypasses
+   every threshold — two colleagues or one misclick merges two voices. Beyond 0.45
+   from the existing profile, ask instead of merging.
+3. **Decision journal replaces the corpus gate.** Log each decision locally
+   (distances, gates, outcome, the label the user finally types); ~20 dogfooded
+   meetings yield a labelled post-AEC corpus whose ground truth is what the user
+   wrote. Stays local, never in the support bundle; diagnostic embeddings are
+   ephemeral and never persisted as profiles.
+
+**Threshold:** start at `tau = 0.25`, not 0.30. The zero-FPR plateau runs
+0.25–0.45 and the worst positive is 0.227, so 0.25 still accepts 21/21 while
+buying margin against noisier post-AEC audio. A missed suggestion is a non-event;
+a false one is the worst documented outcome.
+
 ## Verdict
 
 Build it, phased, opt-in. The core is small because every layer below it already
 exists or arrives free:
 
-- FluidAudio 0.15.4's offline diarizer already returns a **256-d WeSpeaker embedding
-  per detected speaker** (`DiarizationResult.speakerDatabase`, per-segment
-  `TimedSpeakerSegment.embedding`). No new model, no new runtime, no added latency.
+- FluidAudio's offline diarizer already returns a **256-d WeSpeaker embedding per
+  detected speaker** (`DiarizationResult.speakerDatabase` — the un-normalized VBx
+  clustering centroid; there is no per-segment vector, see Amendment 1-2). No new
+  model, no new runtime, no added latency.
 - The 2026-06-14 architecture plan already defines the guardrails (suggestions never
   silently rewrite; wrong automatic names are worse than anonymous speakers; profiles
   must be deletable; don't grow `SpeakerInfo` into a pseudo-profile).
@@ -52,21 +133,21 @@ privacy → strict enrollment-only scope + consent gate + deletion controls.
 - Labels are structured, not baked into text: `transcriptions.speakers` JSON via
   `TranscriptionRepository.updateSpeakers` (`TranscriptionRepository.swift:433-439`).
   Rename UI: `TranscriptResultView.swift:2872-2990` → `TranscriptionViewModel.renameSpeaker`.
-- Insertion points (exact): file path after `diarResult` returns, before merge
-  (`TranscriptionService.swift:1446-1458`); meeting path after
-  `diarizeMeetingSystemIfNeeded`, before `MeetingTranscriptFinalizer.finalize`
-  (`TranscriptionService.swift:1099-1109`).
+- Insertion point (meetings, v1): **after `completeTranscription` returns**
+  (`TranscriptionService.swift:1509-1517`). The earlier "before `finalize`" anchor
+  is unreachable — see Amendment 3.
 - Audio retention (`deleteImmediately`, "Remove Audio Only") means **backfill of old
   recordings cannot be assumed** → embeddings must be captured at transcription time.
-- Speaker detection is opt-in, default off (`speakerDiarizationKey`,
-  `AppRuntimePreferences.swift:501`).
+- This plan does not change the speaker-detection defaults. It adds one new
+  preference, `rememberSpeakers`, which stays **off**. See Amendment 6 for the
+  stale premise this replaces.
 
 ## What FluidAudio gives us vs what we build (fluidaudio-api report)
 
-| Layer | FluidAudio 0.15.4 | We build |
+| Layer | FluidAudio 0.15.6 | We build |
 |---|---|---|
-| Embeddings | ✅ 256-d WeSpeaker, L2-normalized, in every offline diarization result | — |
-| Ad-hoc extraction | ✅ `extractSpeakerEmbedding(from:)` (enrollment from arbitrary clips) | — |
+| Embeddings | ✅ 256-d WeSpeaker centroid per speaker in every offline result — **not** L2-normalized (Amendment 1) | normalization on entry |
+| Ad-hoc extraction | ❌ `extractSpeakerEmbedding(from:)` exists on the streaming `DiarizerManager` only, not on `OfflineDiarizerManager` | out of scope in v1 |
 | Profile struct | ✅ `Speaker` + `RawEmbedding` are `Codable` (raw cap 50, centroid recompute, EMA update) | — |
 | Persistence | ❌ `SpeakerManager` is in-memory only, and **explicitly unsupported with `OfflineDiarizerManager`** | GRDB store |
 | Pre-matched diarization | ❌ offline labels are always fresh `S{n}` clusters | post-hoc matcher |
@@ -106,8 +187,10 @@ accumulation). That's Phase 3, a separate opt-in, decided later.
 
 ### Matching policy (matching-best-practices report; numbers are pre-calibration placeholders)
 
-- Open-set: suggest only if `top1 distance ≤ τ` AND `top2 − top1 ≥ margin` (start
-  grid: τ ∈ {0.35, 0.45, 0.55}, margin ≥ 0.10 — Phase 0 picks real values).
+- Open-set, **mutual best match** (Amendment, Addition 1): suggest only if
+  `top1 distance ≤ τ`, the margin holds on **both** sides (`top2 − top1 ≥ margin`
+  for the cluster *and* for the profile), and each is the other's best match.
+  Ship values: τ = 0.25, margin = 0.10.
 - Duration gates: embed only clean non-overlapped speech; per-speaker aggregate ≥3s
   usable, profile needs ≥15s total across ≥3 turns before it may suggest; never
   learn from <2s backchannels (snap those to the surrounding turn's label instead).
@@ -124,29 +207,38 @@ accumulation). That's Phase 3, a separate opt-in, decided later.
 
 ### Architecture
 
-- **New GRDB migration + 2 tables** (repo-per-table convention):
-  - `speakerProfile`: id UUID PK, name, centroid BLOB(256×Float32), sampleCount,
-    createdAt, updatedAt, lastMatchedAt.
-  - `speakerProfileSample`: id, profileId FK, embedding BLOB, durationSec, channel,
-    sourceTranscriptionId, createdAt.
-- **`SpeakerProfileService` actor** (`Sources/MacParakeetCore/Services/Diarization/`):
-  `matches(for:channel:)`, `enroll(...)`, `recordConfirmation(...)`, `deleteProfile(...)`,
-  `deleteAll()`. Pure-Swift cosine math (embeddings already L2-normalized → dot
-  product); O(profiles × detected speakers) — microseconds, no scheduler involvement.
+- **New GRDB migration `v0.39-speaker-voiceprints` + 3 tables** (raw SQL, style of
+  `v0.32-speaker-corrections`, `DatabaseManager.swift:1374-1422`):
+  - `speaker_profiles`: id, displayName (`UNIQUE … COLLATE NOCASE`, so a second
+    rename to "Sarah" adds an exemplar instead of a duplicate), embeddingModelId,
+    aggregationProfileId, timestamps, lastMatchedAt, lastEvaluatedAt,
+    lastEvaluatedDistance. **No `centroid` column** — scoring is `min` over
+    exemplars, so a derived column would only add cache-coherency bugs.
+  - `speaker_profile_exemplars`: vector `BLOB CHECK (length = 1024)`, speechSeconds,
+    captureDomain, origin, the two model ids, `sourceTranscriptionId` with
+    **`ON DELETE SET NULL`** (the user enrolled a person, not a recording),
+    `UNIQUE (profileId, sourceTranscriptionId)` — the "one exemplar per recording"
+    rule enforced by the schema rather than by code.
+  - `speaker_profile_links`: (transcriptionId, speakerId, transcriptFingerprint) PK,
+    profileId, status (suggested/confirmed/dismissed), distance, runnerUpDistance.
+    Fingerprint-scoped like `speaker_corrections`, so a stale `dismissed` cannot
+    permanently suppress a legitimate suggestion.
+- **`SpeakerVoiceprintService`**, a `final class … @unchecked Sendable` — **not** an
+  actor, aligning with its direct neighbour `SpeakerCorrectionService` (`:59`), since
+  GRDB already serializes through `dbQueue`. Matching itself lives in a stateless,
+  I/O-free `SpeakerVoiceprintMatcher` so it can be tested on fixtures alone. Cosine
+  math on vectors normalized once at entry (Amendment 1); O(profiles × clusters),
+  microseconds, no scheduler involvement.
   **Adapter prerequisite:** today `DiarizationService.diarize()` drops FluidAudio's
   `speakerDatabase`/segment embeddings when building `MacParakeetDiarizationResult`
   — Phase 1's first change is surfacing per-speaker embeddings through that
   adapter (behind the feature flag), otherwise the matcher has nothing to score.
-- **Assignment provenance**: per the 2026-06-14 plan, do NOT extend `SpeakerInfo`.
-  New `transcriptions.speakerAssignments` JSON column keyed by speakerId:
-  `{source: channel|diarization|userCorrection|profileSuggestion|profileConfirmed,
-  profileId?, confidence?}`. `profileId`/`confidence` are sensitive identity
-  metadata: default exports, diagnostics, and support bundles carry display
-  labels only and omit/redact assignment metadata. **This supersedes the
-  2026-06-14 plan's Phase 1 step 4 ("Export `profileId`, `assignmentSource`,
-  and confirmation state in JSON surfaces")** — identity metadata appears in
-  JSON exports only behind an explicit user-requested identity-metadata option,
-  never by default. Matching `spec/contracts/` doc updated in the same PR.
+- **Assignment provenance**: do NOT extend `SpeakerInfo`, and do NOT add a column to
+  `transcriptions` (Amendment 4). `speaker_corrections` already owns label
+  provenance with undo/redo and a single read model; identity metadata lives only in
+  `speaker_profile_links`, which no export path touches. This also supersedes the
+  2026-06-14 plan's Phase 1 step 4 ("Export `profileId`, `assignmentSource`, and
+  confirmation state in JSON surfaces"): identity metadata never appears in exports.
 - **Wiring**: the two insertion points above.
 - **Settings**: "Remember speakers" toggle (default off, requires speaker detection
   on) + profile list with per-profile delete + "Delete all voice profiles".
@@ -179,10 +271,19 @@ differentiator, but honestly:
   distance distributions across meetings + channels. Output: research report with
   separation evidence, chosen τ + margin, and a GO/NO-GO. Kills the feature
   cheaply if WeSpeaker can't separate on compressed system audio.
-- **Phase 1 — core loop (meetings).** Migration + repositories + SpeakerProfileService
-  + meeting-path matching + rename-triggered enrollment + suggestion UI
-  (confirm/dismiss) + consent gate + settings toggle + tests (matcher math on
-  fixture embeddings; service; migration; suggestion flow). Feature-flagged.
+- **Phase 1 — core loop (meetings), seven independently shippable PRs.** PRs 1–4 are
+  invisible to users:
+  1. Surface embeddings through the diarization adapter: `SpeakerEmbedding` (normalizing
+     on entry), `SpeakerCaptureDomain`, `SpeakerModelIdentity`, per-cluster speech
+     durations, key remapping through `idMapping` (`DiarizationService.swift:227-234` —
+     FluidAudio also uses `S1`/`S2`, so skipping the remap silently mislabels).
+  2. Migration + `SpeakerProfileRepository`.
+  3. `SpeakerVoiceprintMatcher` — pure logic, the test-dense PR.
+  4. Service wiring + decision journal, flag off.
+  5. Enrollment prompt, consent gate, suggestion banner (confirm/dismiss).
+  6. Voice-profile admin screen + a Reset & Cleanup row.
+  7. Leak tests (export JSON, CLI `projectedJSON()`, feedback bundle), specs, ADR,
+     privacy docs, telemetry allowlist.
 - **Phase 2 — breadth.** File/URL-transcription path (the Reddit author's
   185-episode podcast case), profile management UI, confirmation-driven
   multi-sample updates, spec/02-features + contracts + new ADR (promote the
@@ -200,3 +301,17 @@ differentiator, but honestly:
 2. **Ambient embeddings: NO.** v1 stores embeddings only for explicitly enrolled speakers; recurring-unknown detection remains a Phase 3 decision with its own opt-in.
 3. **BIPA posture: docs + consent gate only.** First-enrollment permission acknowledgment plus plain-language guidance; no regional gating.
 4. **Podcast/file scope: Phase 2.** v1 is meetings-only to keep the first PR series reviewable.
+
+## Decisions (2026-09-09)
+
+5. **Tau is not a user setting.** Compiled constant, hidden `UserDefaults` override for
+   dogfooding. A semantic three-step control is reconsidered only if calibration shows
+   the right tau varies by user.
+6. **Calibration by decision journal**, not by assembling a corpus or re-diarizing on
+   demand. This lifts the Phase 1 corpus gate.
+7. **Vectors in the user database as `BLOB`.** Not the keychain: two stores to keep in
+   sync makes deletion a two-phase operation that can half-fail — the worst possible bug
+   on biometric data — and keychain items are excluded from some backups.
+8. **Admin screen ships with the feature, not after it.** No deletion surface means no
+   right to erasure, which means not shippable. It also carries the diagnostic read-out
+   that turns "this profile never matches" from a mystery into a number.

--- a/spec/01-data-model.md
+++ b/spec/01-data-model.md
@@ -52,6 +52,34 @@ Classification names are local user data and are not telemetry dimensions.
 SQLite is the mutable source of truth; meeting artifact JSON and Markdown are
 materialized projections refreshed after classification changes.
 
+## Experimental speaker identity memory (2026-09-10)
+
+Migrations v0.39–v0.41 add optional local voice profiles. The compiled release
+flag remains off; creating the schema does not opt the user into retaining voices.
+The [speaker voiceprint contract](contracts/speaker-voiceprints.md) governs
+consent, matching, retention, deletion and export exclusion.
+
+| Table | Identity and constraints | Ownership |
+|-------|--------------------------|-----------|
+| `speaker_profiles` (v0.39) | UUID `id`, unique Unicode-normalized name, display name, embedding-model ID, timestamps and latest evaluation/match metadata. | Explicitly enrolled identity; retained until deletion. |
+| `speaker_profile_exemplars` (v0.39) | UUID `id`; 1024-byte vector; positive speech duration; capture domain, origin and model/aggregation IDs. Unique `(profileId, sourceTranscriptionId)`. | Composite `(profileId, embeddingModelId)` foreign key cascades on profile deletion. Source transcription is nullable and uses `ON DELETE SET NULL`. |
+| `speaker_profile_links` (v0.39) | Primary key `(transcriptionId, speakerId, transcriptFingerprint)`; profile ID, suggested/confirmed/dismissed status, distances and timestamps. | Transcription and profile foreign keys both cascade on deletion. Terminal choices survive re-evaluation; rejected pending suggestions are withdrawn. |
+| `speaker_match_journal` (v0.40) | UUID `id`; transcript/speaker/fingerprint, nullable profile ID, decision outcome, distances, speech duration and creation time. No vector. | Transcription and profile references cascade on deletion. Rows expire after 90 days. |
+| `speaker_embedding_candidates` (v0.41) | UUID `id`; unique `(transcriptionId, speakerId, transcriptFingerprint)`; vector, duration, capture/model identity, creation and explicit expiry timestamps. | Transcription deletion cascades. Unnamed voices expire after seven days and are never matching references. |
+
+The exemplar count is enforced transactionally by the repository, with a current
+policy cap of ten. New-profile creation includes its first exemplar in the same
+transaction. Global voice-profile deletion clears all five tables atomically;
+it preserves transcripts, source audio and applied speaker labels. Cleanup runs
+at startup and hourly even when the feature is disabled.
+
+Transcription foreign keys reuse the parent's actual SQLite value: existing TEXT
+UUIDs and current BLOB UUIDs retain their representation. Voiceprint repositories
+resolve that value for writes and lookups without rewriting parent records.
+Automatic speaker rosters and transcript attribution remain on `transcriptions`
+and in the correction layer; profile identity is separate and excluded from
+exports, diagnostics, feedback, telemetry and external AI context.
+
 ## Relationship Diagram (selected domains)
 
 ```
@@ -1449,6 +1477,9 @@ migrator.registerMigration("v0.7-prompts-and-summaries") { db in
 // v0.32-speaker-corrections — speaker_corrections + speaker_correction_states
 // v0.33-prompt-meeting-notes-context —
 // prompts.includeMeetingNotes and summaries.includeMeetingNotesSnapshot
+// v0.39-speaker-voiceprints — profiles, exemplars and transcript-scoped links
+// v0.40-speaker-match-journal — local expiring decision metadata
+// v0.41-speaker-embedding-candidates — expiring voices awaiting enrollment
 ```
 
 ### Migration Rules
@@ -1496,6 +1527,9 @@ migrator.registerMigration("v0.7-prompts-and-summaries") { db in
 | `prompts.inferenceSettings` | v0.31 | Nullable JSON requested settings for custom result prompts; `NULL` inherits MacParakeet defaults |
 | `summaries.inferenceSettingsSnapshot` | v0.31 | Nullable JSON receipt of effective settings sent after provider/model filtering |
 | `speaker_corrections` / `speaker_correction_states` | v0.32-speaker-corrections | Append-only attribution journal, replay index and persistent transcript-scoped undo/redo cursor |
+| `speaker_profiles` / `speaker_profile_exemplars` / `speaker_profile_links` | v0.39-speaker-voiceprints | Experimental local identity memory, samples and fingerprint-scoped decisions; release flag off |
+| `speaker_match_journal` | v0.40-speaker-match-journal | Local decision metadata with 90-day expiry; no vectors |
+| `speaker_embedding_candidates` | v0.41-speaker-embedding-candidates | Consent-gated temporary vectors with per-row seven-day expiry |
 | `prompts.includeMeetingNotes` | v0.33-prompt-meeting-notes-context | Result-prompt opt-in for automatic meeting-notes context; non-null, default false |
 | `summaries.includeMeetingNotesSnapshot` | v0.33-prompt-meeting-notes-context | Generation-time receipt of the prompt's notes-context opt-in; non-null, default false |
 | `lifetime_dictation_stats` | v0.7.4 | Singleton lifetime voice-stat counters |
@@ -1525,10 +1559,6 @@ These might be needed someday but are explicitly deferred:
 
 - **`settings`** -- Use `UserDefaults` / plist. No need for a settings table.
 - **`exports`** -- Track via `exportPath` on `transcriptions`. No separate table.
-- **`speakers`** -- The automatic roster and per-word speaker IDs remain JSON
-  on `transcriptions`; v0.32 adds only transcript-scoped correction history,
-  not a cross-recording speaker identity table. Revisit identity storage only
-  if cross-file speaker recognition is added.
 - **`usage_stats`** -- Derive aggregate usage from existing tables and `llm_runs` queries. No separate aggregate tracking table.
 
 ---

--- a/spec/README.md
+++ b/spec/README.md
@@ -32,6 +32,10 @@ semi-public boundaries such as meeting artifact folders, recovery/retention
 safety, and CLI JSON output. Update the matching contract doc and focused tests
 when changing one of those surfaces.
 
+[Speaker Voiceprints](contracts/speaker-voiceprints.md) defines the experimental
+voice-profile gate, local storage lifecycle and export exclusion. Implementation
+behind that gate is separate from accuracy evaluation and official release.
+
 ## Design References
 
 - [UI Patterns](04-ui-patterns.md) is the active product UI contract.
@@ -76,6 +80,7 @@ Feature gates in the current source (`Sources/MacParakeetCore/AppFeatures.swift`
 | `meetingCaptureReliabilityEnabled` | `true` | Default-on kill switch for ADR-025 signal-based mic-health monitoring and telemetry; direct source lifecycle recovery is independent |
 | `meetingSourceHealthUIEnabled` | `false` | Routine source-health chips/pill glyph/tile mirror stay hidden; actionable recovering, stalled, interrupted, or unavailable warnings bypass this presentation flag |
 | `meetingActivityDetectionEnabled` | `false` | ADR-024 collectors/detector are compiled but runtime coordinator/UI remain gated |
+| `voiceProfilesEnabled` | `false` | Experimental meeting voice-profile foundations; DEBUG builds may opt in with `--enable-voice-profiles`, but the preference remains off and requires consent plus meeting speaker detection. Release builds ignore that argument. Consent/enrollment/suggestion/admin UI and held-out real-meeting release evaluation remain outstanding; see the [contract](contracts/speaker-voiceprints.md) and [release gates](../plans/active/2026-07-03-speaker-voiceprints.md#integration-and-release-gates-2026-09-10). |
 | `transformsEnabled` | `true` | Productized Transforms shipping surface |
 | `cohereEngineEnabled` | `true` | Settings exposes Cohere Transcribe as an opt-in, downloaded, batch-only local engine; no live preview/timestamps |
 | `meetingVadLiveChunkingEnabled` | `true` | VAD-guided meeting live-preview chunking; final post-stop transcript path unchanged |

--- a/spec/contracts/speaker-voiceprints.md
+++ b/spec/contracts/speaker-voiceprints.md
@@ -57,8 +57,9 @@ The future opt-in UI must disclose candidate retention before the first write.
   rename a transcript automatically; confirmation uses the existing correction
   path, and profile links carry identity provenance separately.
 - Current policy is experimental: cosine distance `tau = 0.25`, margin `0.10`,
-  minimum cluster speech of 3 seconds to match and 15 seconds to enroll or retain
-  a candidate. These are duration gates, not clean-span or overlap filtering.
+  minimum cluster speech of 3 seconds to match and 15 seconds to enroll, learn
+  from a confirmation or retain a candidate. A shorter match can still be
+  confirmed without storing an exemplar. These are duration gates, not clean-span or overlap filtering.
   Whole-cluster centroids can contain diarization errors; naming a cluster does
   not repair its attribution.
 - An embedding-model mismatch prevents comparison. An aggregation-profile
@@ -98,7 +99,15 @@ can leave a redundant, expiring copy; it must never discard a candidate before
 its exemplar is persisted. A rejected insertion, including a profile filled with
 manual enrollments, preserves the candidate for its remaining retention window. A
 confirmed label does not imply a sample was learned: confirmation-driven learning
-requires two manual enrollment anchors and must respect the cap and model rules.
+requires two manual enrollment anchors and must respect the duration, cap and
+model rules. Re-evaluation replaces pending suggestions for that transcript
+fingerprint while preserving confirmed and dismissed choices.
+Journal outcomes describe scoring, not proof that an offer was displayed: a
+concurrent terminal choice may suppress publication after the score was computed.
+
+Voiceprint repositories preserve the actual SQLite representation of each parent
+transcription identifier when writing or querying references. Both historical
+TEXT UUIDs and current BLOB UUIDs are supported without rewriting existing rows.
 
 Deleting a profile atomically removes its exemplars, links and referenced journal
 rows; transcript labels and speaker corrections survive. Deleting a transcription
@@ -143,11 +152,14 @@ deletion cascades and transcript-label preservation. Flag verification must also
 check that a release build ignores the DEBUG override.
 
 Outward-boundary verification must exercise populated voiceprint tables against
-the app and CLI export projections and feedback/diagnostic builders. Relevant
-existing suites include `SpeakerVoiceprintExportTests`, `ExportServiceTests`,
-`ExportCommandTests` and `FeedbackServiceTests`; a release review must record which surfaces were tested
-and which were only inspected. Tests listed here are required coverage, not a
-claim that every release surface or real-audio scenario has already passed.
+the app and CLI export projections. Inspect feedback and diagnostic builders for
+database access and attachment selection, and run their existing tests. If these
+builders gain library-storage inputs, add populated-table exclusion fixtures at
+that boundary. Relevant suites include `SpeakerVoiceprintExportTests`,
+`ExportServiceTests`, `ExportCommandTests` and `FeedbackServiceTests`. A release
+review must record which surfaces were tested and which were only inspected.
+Tests listed here are required coverage, not a claim that every release surface
+or real-audio scenario has already passed.
 
 Before official release, record held-out meeting precision and coverage before
 correction, unknown-speaker false matches, sample counts and uncertainty under

--- a/spec/contracts/speaker-voiceprints.md
+++ b/spec/contracts/speaker-voiceprints.md
@@ -1,0 +1,163 @@
+# Speaker Voiceprints
+
+> Status: EXPERIMENTAL — internal meeting voice-profile foundations, disabled by
+> default. No user-facing enrollment or suggestion UI is included in this series.
+
+## Purpose
+
+Keep optional speaker identity memory local, explicitly enabled and separate from
+transcript labels. Protect its availability, persistence and deletion boundaries
+while real-meeting matching quality is evaluated. The
+[implementation plan](../../plans/active/2026-07-03-speaker-voiceprints.md#integration-and-release-gates-2026-09-10)
+defines separate integration and official-release gates; passing fixture tests or
+merging into `main` does not establish meeting accuracy or authorize release.
+
+## Producers And Consumers
+
+- `DiarizationService` normalizes and remaps offline speaker centroids into
+  `SpeakerEmbedding` values, preserving the detected speaker IDs and durations.
+- `TranscriptionService` passes eligible meeting observations to
+  `SpeakerVoiceprintService` after the transcription is persisted. The service
+  uses the pure `SpeakerVoiceprintMatcher` and GRDB repositories for profiles,
+  exemplars, links, enrollment candidates and the match journal.
+- `AppEnvironment` supplies feature/preference gating and starts
+  `SpeakerVoiceprintRetention` maintenance.
+  Planned enrollment and suggestion UI must call the gated service; ordinary
+  speaker renames continue through the speaker-correction layer.
+- Export, CLI JSON, diagnostics, feedback/support bundles and external AI context
+  are not consumers of the voiceprint tables. They may use transcript labels
+  explicitly applied through the existing correction path.
+
+## Availability And Consent
+
+`AppFeatures.voiceProfilesEnabled` is `false`. The availability helper
+`AppFeatures.isVoiceProfilesAvailable(arguments:)` accepts
+`--enable-voice-profiles` only in DEBUG builds. A release build ignores the
+argument while the compiled gate remains disabled.
+
+Availability is necessary but does not grant consent. The effective
+`rememberSpeakersEnabled` preference also requires the separately saved
+`rememberSpeakers` opt-in, an acknowledged consent date and meeting speaker
+detection. The preference defaults off. Neither an existing preference nor a
+previously retained candidate bypasses a disabled availability gate.
+
+Matching, candidate access and enrollment/confirmation/dismissal mutations honor
+the effective gate at the service boundary. Turning the feature off prevents
+further feature use; it does not itself erase enrolled profiles. Retention cleanup
+continues while disabled, and explicit deletion remains available to the owner.
+The future opt-in UI must disclose candidate retention before the first write.
+
+## Identity And Matching Semantics
+
+- Embeddings contain 256 finite Float32 components, are normalized once on entry
+  and reject invalid or near-zero vectors. Dropping an invalid embedding must not
+  remove the diarizer's speaker, segments, ID mapping or duration information.
+- Suggestions require mutual best matches, a distance threshold and margins on
+  both sides. Unknown or ambiguous voices may remain unnamed. Suggestions never
+  rename a transcript automatically; confirmation uses the existing correction
+  path, and profile links carry identity provenance separately.
+- Current policy is experimental: cosine distance `tau = 0.25`, margin `0.10`,
+  minimum cluster speech of 3 seconds to match and 15 seconds to enroll or retain
+  a candidate. These are duration gates, not clean-span or overlap filtering.
+  Whole-cluster centroids can contain diarization errors; naming a cluster does
+  not repair its attribution.
+- An embedding-model mismatch prevents comparison. An aggregation-profile
+  mismatch tightens the experimental threshold. Neither change deletes profiles.
+- Profile-name lookup and uniqueness share the persisted `normalizedName`: trim
+  surrounding whitespace and fold Unicode case and width while preserving
+  accents. `displayName` remains display text; SQLite `COLLATE NOCASE` does not
+  define identity. Name collisions still require the enrollment pollution guard.
+
+## Local Storage And Lifecycle
+
+Migrations `v0.39-speaker-voiceprints`, `v0.40-speaker-match-journal` and
+`v0.41-speaker-embedding-candidates` create these tables in the user database:
+
+| Table | Ownership and lifecycle |
+|-------|-------------------------|
+| `speaker_profiles` | Explicitly enrolled identities; retained until deletion. |
+| `speaker_profile_exemplars` | Profile-owned 1024-byte vectors with model/aggregation identity, duration, capture domain and enrollment origin. At most one exemplar per profile per source recording; at most 10 under current policy. |
+| `speaker_profile_links` | Suggested, confirmed or dismissed identities scoped to transcription ID, speaker ID and transcript fingerprint. Re-evaluation must not overwrite a terminal decision. |
+| `speaker_embedding_candidates` | Consent-gated temporary voices for later enrollment, scoped to the same transcript/speaker/fingerprint. Never compared against each other or read as references by the matcher. |
+| `speaker_match_journal` | Local decision distances, outcomes and references; no vectors or independent identity labels. Supports calibration, not automatic ground truth. |
+
+Candidate retention is seven days, stored as `expiresAt` per row. Changing the
+default retention does not extend existing stored rows; a new evaluation may
+replace a same-key candidate with a newly calculated expiry. Journal retention
+is 90 days. Repositories prune on reads and writes and never return expired rows.
+`SpeakerVoiceprintRetention` also prunes at startup and hourly while the app runs,
+including with the feature disabled, and attempts both stores independently when
+one cleanup fails. No background process runs after app shutdown: cleanup resumes
+at the next launch. These are logical expiry and database cleanup guarantees,
+not a claim of immediate physical removal from every disk page or user backup.
+
+New-profile creation and its first exemplar insertion are atomic. Subsequent
+capped exemplar insertion is transactional; candidate consumption is a separate
+operation that runs only after insertion succeeds. A failed candidate deletion
+can leave a redundant, expiring copy; it must never discard a candidate before
+its exemplar is persisted. A rejected insertion, including a profile filled with
+manual enrollments, preserves the candidate for its remaining retention window. A
+confirmed label does not imply a sample was learned: confirmation-driven learning
+requires two manual enrollment anchors and must respect the cap and model rules.
+
+Deleting a profile atomically removes its exemplars, links and referenced journal
+rows; transcript labels and speaker corrections survive. Deleting a transcription
+removes its links, candidates and journal rows while retaining explicitly enrolled
+exemplars with their source-transcription reference cleared. Deleting all voice
+profiles clears all five tables, including unowned candidates and journal entries,
+in one transaction. None of these operations deletes source audio or transcripts.
+
+## Export Exclusion
+
+Voiceprint vectors, profile identifiers, candidate data and journal metadata must
+not enter JSON/TXT/MD/SRT/VTT/PDF/DOCX exports, CLI `projectedJSON()`, diagnostics,
+feedback/support bundles, telemetry or external AI requests. `Transcription` and
+`SpeakerInfo` gain no profile fields; applied names remain ordinary transcript
+labels. Any future database-export surface must explicitly exclude these tables.
+
+## Non-stable Details
+
+Generated IDs, timestamps, display ordering, UI copy and experimental matching
+thresholds are not frozen by this contract. Threshold changes require a documented
+evaluation; they cannot silently be treated as release-qualified values. Retention,
+consent, deletion and export semantics require deliberate contract changes.
+
+## Versioning And Compatibility
+
+This is an internal experimental boundary, not a new public CLI schema. Additive
+schema changes follow GRDB migrations; do not repurpose an applied migration or
+delete enrolled data on a model/configuration change. Public UI or agent access
+requires its own reviewed consent, deletion and compatibility design.
+
+## Tests And Required Evidence
+
+Focused fixture coverage lives in `SpeakerEmbeddingTests`,
+`SpeakerVoiceprintMatcherTests`, `SpeakerProfileRepositoryTests`,
+`SpeakerEmbeddingCandidateRepositoryTests`, `SpeakerVoiceprintServiceTests` and
+`SpeakerVoiceprintWiringTests`. `VoiceProfileFeatureGateTests` and
+`SpeakerVoiceprintRetentionTests` cover availability and scheduled cleanup.
+Integration must cover disabled gates despite saved
+preferences or stale observations, consent prerequisites, fingerprint isolation,
+candidate preservation after rejected insertion, expiry without new meetings,
+deletion cascades and transcript-label preservation. Flag verification must also
+check that a release build ignores the DEBUG override.
+
+Outward-boundary verification must exercise populated voiceprint tables against
+the app and CLI export projections and feedback/diagnostic builders. Relevant
+existing suites include `SpeakerVoiceprintExportTests`, `ExportServiceTests`,
+`ExportCommandTests` and `FeedbackServiceTests`; a release review must record which surfaces were tested
+and which were only inspected. Tests listed here are required coverage, not a
+claim that every release surface or real-audio scenario has already passed.
+
+Before official release, record held-out meeting precision and coverage before
+correction, unknown-speaker false matches, sample counts and uncertainty under
+criteria fixed before final evaluation. Include changed capture conditions,
+overlap, brief speech and mixed-speaker clusters, plus actual app consent,
+deletion and retention flows. User confirmations need independent checking.
+
+## When This Changes
+
+Update this contract, the focused tests and the governing plan when availability,
+consent, identity, persistence, retention or outward-data behavior changes. Update
+the [spec index](../README.md#release-channels-and-feature-flags) when the compiled
+flag changes. Record release evidence separately from implementation status.


### PR DESCRIPTION
## What voice profiles are for

Meeting diarization answers **“which parts of this recording came from the same speaker?”** Its speaker IDs belong to that recording. A person who appears as “Others 1” today can appear as “Others 2” in the next meeting, so their name has to be supplied again.

Voice profiles add optional, local memory of people the user explicitly enrolls. The intended experience is: identify a participant as Sarah, save a voice sample with consent, and receive a suggestion that a speaker in a later meeting may be Sarah. The user decides whether to apply that name. Unknown or ambiguous voices can remain unnamed.

This PR implements the foundations for that experience: reusable speaker embeddings, profile storage, conservative matching, enrollment and decision APIs, temporary enrollment candidates, and the hook into completed meetings. **The consent, enrollment, suggestion and profile-management UI is follow-up work.** This walkthrough describes the implemented backend and marks where a future UI must connect.

It integrates @k1n0b0n's seven PRs while preserving their commits:

| PR | Part of the feature |
| --- | --- |
| #993 | Research synthesis and implementation plan |
| #994 | Validated speaker embeddings from offline diarization |
| #996 | Persistent profiles, reference samples and identity links |
| #1000 | Pure speaker-to-profile matcher |
| #1001 | Service coordinating matching, enrollment and decisions |
| #1004 | Completed-meeting integration |
| #1005 | Expiring candidates for enrollment after a meeting |

The integration also adds persistence, consent, retention and boundary fixes found during review. The release decision is described at the end.

## The building blocks

| Concept | Meaning |
| --- | --- |
| **Speaker cluster** | Speech attributed to one speaker within one recording. A cluster can still contain attribution errors. |
| **Embedding** | A 256-number representation of a cluster's voice characteristics, used for acoustic comparison. |
| **Profile** | A deliberately enrolled identity, such as Sarah, with a display name and retained reference samples. |
| **Exemplar** | One retained reference embedding belonging to a profile, with its source recording, duration, capture domain and model/configuration identity. |
| **Candidate** | A temporary embedding kept for enrollment after the meeting. Candidates are never matching references and are never compared with one another. |
| **Identity link** | A suggested, confirmed or dismissed profile association for one speaker in one version of a transcript. |
| **Match journal** | Local scores, gates and outcomes for investigating matching behavior. It contains no vectors or independent identity labels. |

A transcript fingerprint identifies the words and segmentation to which a decision applies. Together with the transcription ID and speaker ID, it prevents a choice for one transcript version from being reused for another version's clusters.

## Architecture

The feature reuses the existing offline diarizer's cluster centroids. It introduces no additional embedding model or embedding inference pass, and does not train a personalized model. Matching and storage still add work after transcription; their real-meeting cost remains to be measured.

```mermaid
flowchart TD
    A[Meeting system audio] --> B[DiarizationService]
    B --> C[Validated speaker embeddings]
    B --> D[TranscriptionService persists completed meeting]
    C --> E[SpeakerVoiceprintService]
    D -->|then evaluate saved speakers| E
    E --> F[Pure SpeakerVoiceprintMatcher]
    G[(Enrolled profiles and exemplars)] --> F
    F -->|scores and decisions| E
    E --> H[(Local links, candidates and journal)]
    I[Explicit enrollment and decision APIs] --> E
    E -->|accepted enrollment or learning| G
    J[Startup and hourly retention] -->|prune expired rows| H
```

Feature logic lives in `MacParakeetCore`; the app's `AppEnvironment` assembles repositories, injects the service and owns the retention task. Database access goes through GRDB repositories. The matcher is a pure function over observations, reference samples and policy, so its decisions can be tested without audio hardware or a database.

The existing speaker-correction layer continues to own transcript names. Profile provenance stays in separate tables rather than adding profile IDs or vectors to `Transcription` or `SpeakerInfo`. That separation also keeps ordinary exports from acquiring biometric fields through model serialization.

### What happens when a meeting finishes

1. The existing meeting pipeline diarizes the **system-audio track**. The microphone participant already has the meeting's “Me” identity and is outside this matching path. File imports and dictation are not wired into voice-profile evaluation here.
2. `DiarizationService` carries the diarizer's embeddings through speaker-ID remapping. `SpeakerEmbedding` normalizes each valid vector once. Wrong-size, non-finite or near-zero vectors are rejected without dropping that speaker's words, segments or duration from the transcript.
3. `TranscriptionService` completes and persists the meeting before requesting evaluation. The saved transcript supplies the foreign-key parent and fingerprint. Only system speakers actually present in the saved transcript become observations.
4. With availability and consent prerequisites satisfied, the service retains eligible temporary candidates and compares observations with enrolled reference samples. An eligible candidate can be retained even when there are no profiles yet, allowing first-time enrollment after capture.
5. The service persists pending identity suggestions and local scoring records. It returns suggestions without renaming the transcript. Reevaluation replaces obsolete pending suggestions for that fingerprint while preserving confirmed and dismissed decisions.
6. Voice-profile errors are caught and logged privately. The already-completed meeting remains usable. Evaluation is awaited after persistence; it is not a detached job or a claim of zero added completion latency.

## How matching makes a suggestion

Matching uses **cosine distance** between normalized embeddings: a smaller value means more similar voices. A profile's score is the distance to its closest compatible retained exemplar. The matcher then checks whether the best pairing is sufficiently strong and unambiguous:

1. **Distance:** the pairing must be close enough under the policy threshold.
2. **Mutual best match:** the profile must be the cluster's best choice, and the cluster must be that profile's best choice in the meeting.
3. **Margins on both sides:** the winning pairing must be sufficiently better than competing profiles for that cluster and competing clusters for that profile. Ties are rejected; a side with no competitor satisfies its margin automatically.

If two clusters are almost equally close to Sarah, the matcher can abstain rather than suggesting Sarah for both. If a cluster is almost equally close to Sarah and Alex, it can also abstain. This matters because diarization can split one person's speech into multiple clusters or mix speech from different people.

| Experimental policy | Current value |
| --- | --- |
| Maximum cosine distance (`tau`) | `0.25` |
| Required margin | `0.10` on both sides |
| Minimum cluster speech to match | 3 seconds |
| Minimum cluster speech to enroll, retain a candidate or learn from confirmation | 15 seconds |
| Reference-sample cap | 10 per profile; at most one per source recording |

Each embedding carries two version identifiers. An embedding-model mismatch prevents comparison. An aggregation-configuration mismatch tightens the distance threshold by `0.05`, to `0.20`; clustering changes can affect the centroid even when the embedding model is unchanged. Neither case deletes enrolled profiles. Capture domain is recorded, with like-for-like samples preferred only when distances tie; there is no separate cross-domain penalty.

These checks govern whether to offer an identity. They do not repair speaker attribution. The observations are whole-cluster centroids, and 15 seconds of accumulated speech is a duration requirement, not proof that the sample is clean or free of overlap.

## Enrollment, confirmation and correction

**Enrollment is explicit.** A future enrollment surface can submit an eligible observation or an unexpired candidate. Profile-name lookup trims surrounding whitespace and folds Unicode case and width while preserving accents. A matching name still goes through an acoustic pollution guard: a distance above `0.45`, or an incomparable voice, requests disambiguation. A caller may explicitly override a same-name voice mismatch, but cannot override an embedding-model mismatch.

Creating a profile and storing its first exemplar happen in one transaction. This prevents concurrent enrollments from seeing a half-created profile without the sample needed to check whether the next enrollment belongs to that person.

**Confirmation and learning are separate.** The intended caller ordering is to apply the ordinary speaker rename through the existing correction path and then record profile confirmation. The service does not implement that UI. Confirmation records identity provenance and updates matching metadata; it only adds a reference sample when the profile already has two manual enrollment anchors and the observation passes duration, model, source-recording and cap rules. A 3–14.999-second match can therefore be confirmed without permanently learning its vector.

**Terminal decisions survive reevaluation.** Rescoring cannot change a confirmed/dismissed decision or switch its profile. Repeating the identical decision is allowed. Confirmed profiles are reserved against conflicting sibling suggestions. Terminal clusters remain in matching competition so removing them cannot manufacture a larger margin for another cluster. The database transaction rechecks concurrent decisions before replacing pending links.

**Rejected learning preserves the candidate.** At the sample cap, eligible confirmation-derived samples may be replaced while manual anchors are protected. A zero cap or a cap already below the retained sample count rejects insertion without deleting existing samples. Candidate consumption happens only after successful exemplar insertion. It is a separate transaction, so failed cleanup can leave a redundant copy until expiry; it cannot discard the only candidate before the exemplar is saved.

## Local data, consent and deletion

Voice memory introduces retained biometric data, so consent applies before the first candidate write, not only when a name is enrolled. The effective preference requires the separate `rememberSpeakers` opt-in, an acknowledged consent date and meeting speaker detection. A future opt-in UI must explain temporary retention as well as permanent enrollment. Turning the preference off stops feature use while leaving explicit deletion available.

The additive GRDB migrations create five tables in the existing user database:

| Table | Retention and purpose |
| --- | --- |
| `speaker_profiles` | Enrolled identities, retained until deletion. |
| `speaker_profile_exemplars` | Profile-owned reference vectors and provenance, retained until deletion or permitted capped replacement. |
| `speaker_profile_links` | Identity decisions scoped to a transcription, speaker and fingerprint. |
| `speaker_embedding_candidates` | Temporary enrollment vectors with a stored seven-day expiry. |
| `speaker_match_journal` | Local scoring records retained for 90 days. |

Repositories prune expired rows on access. An app-owned task also attempts candidate and journal cleanup independently at startup and hourly, including when voice profiles are disabled. If the app is closed, maintenance resumes on the next launch. This is logical expiry and database cleanup, not a promise of secure erasure from every disk page or backup.

| Deletion operation | Result |
| --- | --- |
| Delete a profile | Atomically removes its exemplars, links and referenced journal rows. Existing transcript names and corrections remain; unowned candidates follow their normal expiry. |
| Delete a transcription | Removes its links, candidates and journal rows. Explicitly enrolled exemplars survive with their source-transcription reference cleared. |
| Delete all voice profiles | Clears all five tables atomically, including candidates and journal rows without a profile owner. This operation does not delete transcripts, source audio or applied names. |

Historical transcription IDs can be TEXT UUIDs or BLOB UUIDs. The new repositories reuse the parent's actual SQLite representation for child references and lookups; existing library identifiers are not rewritten.

Vectors, profile IDs, candidates and journal metadata are excluded from ordinary exports, public CLI JSON, feedback/support payloads, diagnostics, telemetry and external AI context. Names explicitly applied through the existing speaker-correction path remain ordinary transcript labels and can appear in existing exports.

## Review map and verification

The main review areas are ambiguous matching, concurrent enrollment and decisions, retention/deletion, legacy foreign keys, and accidental data exposure at outward boundaries. The integration resolved all five findings from the completed independent review: legacy-ID compatibility, canonical schema documentation, confirmation duration, stale pending suggestions, and meeting/CLI integration coverage. A targeted independent review of those fixes found no remaining blockers.

Start with the [feature contract](https://github.com/moona3k/macparakeet/blob/bb4341b61f73162fce58359f90f670a2d5c5495c/spec/contracts/speaker-voiceprints.md), [implementation plan](https://github.com/moona3k/macparakeet/blob/bb4341b61f73162fce58359f90f670a2d5c5495c/plans/active/2026-07-03-speaker-voiceprints.md) and [canonical data model](https://github.com/moona3k/macparakeet/blob/bb4341b61f73162fce58359f90f670a2d5c5495c/spec/01-data-model.md#experimental-speaker-identity-memory-2026-09-10). The implementation follows the plan's first six foundation steps; the amended plan separates them from the remaining UI and release evaluation.

| Code entry point | What to inspect |
| --- | --- |
| [`SpeakerEmbedding.swift`](https://github.com/moona3k/macparakeet/blob/bb4341b61f73162fce58359f90f670a2d5c5495c/Sources/MacParakeetCore/Services/Diarization/SpeakerEmbedding.swift) and [`DiarizationService.swift`](https://github.com/moona3k/macparakeet/blob/bb4341b61f73162fce58359f90f670a2d5c5495c/Sources/MacParakeetCore/Services/Diarization/DiarizationService.swift) | Vector validity, normalization and speaker-ID preservation. |
| [`SpeakerVoiceprintMatcher.swift`](https://github.com/moona3k/macparakeet/blob/bb4341b61f73162fce58359f90f670a2d5c5495c/Sources/MacParakeetCore/Services/Diarization/SpeakerVoiceprintMatcher.swift) | Distance, mutual-best and ambiguity policy. |
| [`SpeakerVoiceprintService.swift`](https://github.com/moona3k/macparakeet/blob/bb4341b61f73162fce58359f90f670a2d5c5495c/Sources/MacParakeetCore/Services/Diarization/SpeakerVoiceprintService.swift) | Consent checks, enrollment, confirmation and reevaluation ordering. |
| [`SpeakerProfileRepository.swift`](https://github.com/moona3k/macparakeet/blob/bb4341b61f73162fce58359f90f670a2d5c5495c/Sources/MacParakeetCore/Database/SpeakerProfileRepository.swift) and [`SpeakerTranscriptionPersistence.swift`](https://github.com/moona3k/macparakeet/blob/bb4341b61f73162fce58359f90f670a2d5c5495c/Sources/MacParakeetCore/Database/SpeakerTranscriptionPersistence.swift) | Transactions, deletion and legacy key compatibility. |
| [`TranscriptionService.swift`](https://github.com/moona3k/macparakeet/blob/bb4341b61f73162fce58359f90f670a2d5c5495c/Sources/MacParakeetCore/Services/TranscriptionService.swift) and [`SpeakerVoiceprintRetention.swift`](https://github.com/moona3k/macparakeet/blob/bb4341b61f73162fce58359f90f670a2d5c5495c/Sources/MacParakeetCore/Services/Diarization/SpeakerVoiceprintRetention.swift) | Completed-meeting integration and cleanup lifetime. |

Baseline verification on commit `bd87e656`:

- Full local suite: 6,079 XCTest cases reported, 21 skipped, zero failures; plus 29 Swift Testing tests passed.
- 235 focused tests passed, including BLOB/uppercase-TEXT/lowercase-TEXT parents, duration boundaries, stale suggestions, terminal decisions, rollback, deletion and expiry.
- Actual meeting-finalization tests verify scoring follows persistence and scoring errors preserve completed meetings. Real CLI JSON is byte-identical before and after all five voiceprint tables are populated; app export exclusion is also covered.
- Swift 6 source build passed using the repository's `MACPARAKEET_SKIP_WHISPERKIT=1` compatibility mode. Normal test builds include WhisperKit.
- Production `AppFeatures.swift` was compiled and executed in release and DEBUG assertion harnesses: the release override is ignored, the DEBUG override works, and both default off.
- Strict formatting passed for all 22 newly added Swift files; `git diff --check` and README reference checks passed. Existing repository-wide formatting warnings remain informational.
- Feedback/diagnostic builders were inspected for attachment selection and database access. They accept explicit logs, screenshots, form data and system information, with no library database input. Their existing tests ran in the full suite; this is inspection plus builder coverage, not a populated-database fixture at those boundaries.

The subsequent CodeRabbit fixes in `bb4341b6` preserve original matcher outcomes in the journal while filtering only published suggestions, and make the wiring test assert DEBUG/release behavior explicitly. Four regressions reproduced the prior journal failure; all 56 focused service, wiring and feature-gate tests passed after the fix, along with strict lint and the release flag harness. The full local suite was not repeated for this follow-up.

Final-head [GitHub CI](https://github.com/moona3k/macparakeet/actions/runs/34566395730) passed on `bb4341b6`: Release compilation, CLI contract smoke, app-bundle smoke, concurrency checks, Swift 6 compilation and the test suite. The merged tree in `5b6ffcd5` is identical to that tested head.

Replay the focused tests from this branch with:

```sh
swift test --jobs 4 --filter 'SpeakerVoiceprint|SpeakerProfileRepositoryTests|SpeakerEmbedding|DiarizationServiceEmbeddingTests|VoiceProfileFeatureGateTests|AppRuntimePreferencesTests|TranscriptionServiceTests.testFinalizeMeetingScores|TranscriptionServiceTests.testVoiceprintEvaluationFailure|ExportCommandTests'
```

The full-suite command was `swift test --jobs 4`. The Swift 6 compatibility build was:

```sh
MACPARAKEET_SKIP_WHISPERKIT=1 swift build --build-path .build-swift6-no-whisper --jobs 4 --force-resolved-versions -Xswiftc -swift-version -Xswiftc 6
```

Completed `ce-code-review` receipt: `20260910-214102-609b1920` (`status: complete`); its five findings were resolved in `bd87e656`. The Grok implementation unit completed its scoped verification. Local `no-mistakes` was unavailable and Greptile CLI was unauthenticated; neither is represented as a passed gate. GitHub's checks and review threads record subsequent CI and bot review results.

## Release gate and what comes next

This PR brings the foundations into development for controlled evaluation. **`AppFeatures.voiceProfilesEnabled` remains `false`.** Only DEBUG builds accept `--enable-voice-profiles`; release builds ignore it. The override provides availability only: the separate opt-in, consent acknowledgement and meeting speaker-detection requirements still apply. Existing saved preferences cannot bypass the disabled release gate.

Before ordinary user dogfooding, complete the consent, enrollment, suggestion and profile-management UI using the service boundaries above. Before official release, produce an evaluation report for the exact model, aggregation settings, policy and build under consideration:

- Keep enrollment, calibration and held-out evaluation meetings separate, then freeze profiles and policy before evaluating.
- Set numeric acceptance criteria and minimum evidence requirements in advance. Report suggestion precision before correction, useful coverage, unknown-speaker false matches, abstentions, sample counts and uncertainty.
- Independently check participant identities and cluster attribution. Include changed microphones/capture conditions, overlap, short speech and mixed-speaker clusters.
- Measure added processing time, memory and retained-data costs, and exercise the actual consent, correction, deletion and expiry flows in the app.

Fixture tests establish implementation behavior; they do not establish real-meeting recognition accuracy. The journal helps diagnose and calibrate matching, but confirmations are not automatic ground truth. The journal preserves original matcher outcomes even when a terminal choice suppresses publication. Those outcomes describe scoring, not proof that an offer was displayed.

## Post-Deploy Monitoring & Validation

After integration, verify the compiled flag stays false and normal meeting completion and public exports behave as before. During later DEBUG evaluation, inspect retention across launch/relaunch, preservation of terminal choices and private scoring-error logs. If capture or completion regresses, disable the developer override and preserve recordings and the database for diagnosis. Cleanup must continue while disabled.

Enabling the release flag and publishing a stable build remain subsequent explicit release decisions, supported by that evaluation. Merging this PR does neither.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
