### PR TITLE
fix: align bundled LocalVQE with the supported macOS minimum

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,15 @@ jobs:
           set -o pipefail
           ./scripts/check-readme-references.sh 2>&1 | tee .ci-logs/check-readme-references.log
 
+      - name: Meeting Echo Packaging Fixtures
+        timeout-minutes: 5
+        run: |
+          set -euo pipefail
+          mkdir -p .ci-logs
+          for fixture in test_macho_min_version test_prepare_meeting_echo_assets test_verify_meeting_echo_assets; do
+            bash "scripts/dist/${fixture}.sh" 2>&1 | tee ".ci-logs/${fixture}.log"
+          done
+
       - name: Swift Format Lint (informational)
         continue-on-error: true
         timeout-minutes: 3

--- a/Tests/MacParakeetTests/Services/Capture/MeetingEchoSuppressionRuntimeTests.swift
+++ b/Tests/MacParakeetTests/Services/Capture/MeetingEchoSuppressionRuntimeTests.swift
@@ -521,6 +521,12 @@ final class MeetingEchoSuppressionRuntimeTests: XCTestCase {
             at: appURL.appendingPathComponent("Contents", isDirectory: true),
             withIntermediateDirectories: true
         )
+        let plist = try PropertyListSerialization.data(
+            fromPropertyList: ["LSMinimumSystemVersion": "14.2"],
+            format: .xml,
+            options: 0
+        )
+        try plist.write(to: appURL.appendingPathComponent("Contents/Info.plist"))
         return appURL
     }
 
@@ -593,7 +599,7 @@ final class MeetingEchoSuppressionRuntimeTests: XCTestCase {
 
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/clang")
-        var arguments = ["-dynamiclib", sourceURL.path]
+        var arguments = ["-dynamiclib", "-mmacosx-version-min=14.2", sourceURL.path]
         if universal {
             arguments += ["-arch", "arm64", "-arch", "x86_64"]
         }

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -63,6 +63,17 @@ LocalVQE source checkout under `.build/`, the prep script discards that generate
 checkout and clones it again. Custom `LOCALVQE_SOURCE_DIR` checkouts are left in
 place and require manual cleanup on lock errors.
 
+`prepare_meeting_echo_assets.sh` passes `CMAKE_OSX_DEPLOYMENT_TARGET` to the
+LocalVQE build, aligned with the app's `MIN_MACOS_VERSION` (default `14.2`) so
+the shipped `liblocalvqe.dylib` never requires a newer macOS than the app
+advertises support for. `build_app_bundle.sh` propagates its own
+`MIN_MACOS_VERSION` into the auto-prepared build automatically. To pin a
+different deployment target for the LocalVQE runtime specifically (still no
+higher than the app's minimum), set `LOCALVQE_MIN_MACOS_VERSION`; a value
+above the app's minimum is a build error. The runtime cache stamp keys on the
+deployment target, so changing it (or picking up this fix over an older
+cached build) forces a rebuild rather than reusing a stale dylib.
+
 For a deliberately serialized release build, set:
 
 ```bash
@@ -95,6 +106,19 @@ if required LocalVQE C symbols are not exported, or if `otool -L` shows
 non-portable dylib references outside `@rpath`, `@loader_path`, `/System/Library`,
 or `/usr/lib`. Without `REQUIRE_MEETING_ECHO_ASSETS=1`, missing assets are
 accepted and the app intentionally runs the meeting echo path as passthrough.
+
+The verifier also inspects every bundled LocalVQE dylib (`liblocalvqe.dylib`
+and any dependency copied into `Contents/Frameworks/`) and every architecture
+slice of each, reading the Mach-O minimum-OS-version load command
+(`LC_BUILD_VERSION minos`, or legacy `LC_VERSION_MIN_MACOSX`) and rejecting
+any slice higher than the app's `LSMinimumSystemVersion`. A missing/malformed
+version is always a hard failure; a missing `otool`/`lipo` is a hard failure
+only under `STRICT_MEETING_ECHO_ASSETS=1` (implied by
+`REQUIRE_MEETING_ECHO_ASSETS=1`) and otherwise a skipped-check warning. When
+run as part of `build_app_bundle.sh`, the expected minimum is the build's
+`MIN_MACOS_VERSION`; run standalone against an already-built bundle, it reads
+`LSMinimumSystemVersion` from the bundle's `Info.plist` unless
+`MACPARAKEET_MEETING_ECHO_MIN_MACOS_VERSION` overrides it.
 
 Retained purchase activation config (normally unset in current free builds):
 

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -67,12 +67,10 @@ place and require manual cleanup on lock errors.
 LocalVQE build, aligned with the app's `MIN_MACOS_VERSION` (default `14.2`) so
 the shipped `liblocalvqe.dylib` never requires a newer macOS than the app
 advertises support for. `build_app_bundle.sh` propagates its own
-`MIN_MACOS_VERSION` into the auto-prepared build automatically. To pin a
-different deployment target for the LocalVQE runtime specifically (still no
-higher than the app's minimum), set `LOCALVQE_MIN_MACOS_VERSION`; a value
-above the app's minimum is a build error. The runtime cache stamp keys on the
-deployment target, so changing it (or picking up this fix over an older
-cached build) forces a rebuild rather than reusing a stale dylib.
+`MIN_MACOS_VERSION` into the auto-prepared build automatically. The runtime
+cache stamp keys on the deployment target, so changing it (or picking up this
+fix over an older cached build) forces a rebuild rather than reusing a stale
+dylib.
 
 For a deliberately serialized release build, set:
 

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -117,8 +117,14 @@ only under `STRICT_MEETING_ECHO_ASSETS=1` (implied by
 `REQUIRE_MEETING_ECHO_ASSETS=1`) and otherwise a skipped-check warning. When
 run as part of `build_app_bundle.sh`, the expected minimum is the build's
 `MIN_MACOS_VERSION`; run standalone against an already-built bundle, it reads
-`LSMinimumSystemVersion` from the bundle's `Info.plist` unless
-`MACPARAKEET_MEETING_ECHO_MIN_MACOS_VERSION` overrides it.
+`LSMinimumSystemVersion` from the bundle's `Info.plist`.
+`MACPARAKEET_MEETING_ECHO_MIN_MACOS_VERSION` can supply or tighten this: it
+is used on its own if the bundle has no `Info.plist` yet, but once the
+bundle's `Info.plist` exists, it must contain a valid minimum even when an
+override is supplied. The effective ceiling is the lower of the
+override and `LSMinimumSystemVersion` — an override can only make the check
+stricter, never raise it above what the bundle's `Info.plist` actually
+advertises.
 
 Retained purchase activation config (normally unset in current free builds):
 

--- a/scripts/dist/build_app_bundle.sh
+++ b/scripts/dist/build_app_bundle.sh
@@ -41,6 +41,9 @@ set -euo pipefail
 #   MACPARAKEET_MEETING_ECHO_MODEL source GGUF model for meeting echo suppression
 #   MACPARAKEET_MEETING_ECHO_MODEL_NAME optional bundled GGUF filename (default: source basename)
 #   MACPARAKEET_MEETING_ECHO_MODEL_SHA256 optional expected model SHA256
+#   MIN_MACOS_VERSION is the ceiling for the auto-prepared LocalVQE runtime's
+#   CMAKE_OSX_DEPLOYMENT_TARGET; bundled dylib slices with a higher minimum OS
+#   version load command than MIN_MACOS_VERSION fail verification
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 DIST_DIR="$ROOT_DIR/dist"
@@ -53,7 +56,7 @@ VERSION="${VERSION:-0.0.0}"
 BUILD_NUMBER="${BUILD_NUMBER:-$(date -u +%Y%m%d%H%M%S)}"
 BUILD_GIT_COMMIT="${BUILD_GIT_COMMIT:-$(git -C "$ROOT_DIR" rev-parse --short=12 HEAD 2>/dev/null || echo unknown)}"
 BUILD_DATE_UTC="${BUILD_DATE_UTC:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
-MIN_MACOS_VERSION="${MIN_MACOS_VERSION:-14.2}"
+MIN_MACOS_VERSION="${MIN_MACOS_VERSION:-$DEFAULT_MEETING_ECHO_MIN_MACOS_VERSION}"
 UNIVERSAL="${UNIVERSAL:-0}"
 SKIP_BUILD="${SKIP_BUILD:-0}"
 BUILD_SYSTEM="${BUILD_SYSTEM:-xcodebuild}"
@@ -459,6 +462,7 @@ bundle_meeting_echo_assets() {
       MACPARAKEET_MEETING_ECHO_MODEL_NAME="$prepared_model_name" \
       MACPARAKEET_MEETING_ECHO_MODEL_SHA256="$prepared_model_sha" \
       MACPARAKEET_MEETING_ECHO_UNIVERSAL="${MACPARAKEET_MEETING_ECHO_UNIVERSAL:-$UNIVERSAL}" \
+      MACPARAKEET_MEETING_ECHO_APP_MIN_MACOS_VERSION="$MIN_MACOS_VERSION" \
       "$ROOT_DIR/scripts/dist/prepare_meeting_echo_assets.sh"
 
     library_src="$prepared_assets_dir/lib/liblocalvqe.dylib"
@@ -530,8 +534,12 @@ bundle_meeting_echo_assets() {
   echo "Bundled meeting echo runtime: $FRAMEWORKS_DIR/liblocalvqe.dylib"
   echo "Bundled meeting echo model: $RESOURCES_DIR/MeetingEchoSuppression/$model_name"
 
+  # Info.plist (and its LSMinimumSystemVersion) is not written until later in
+  # this script, so pass the app minimum explicitly rather than letting the
+  # verifier fall back to reading a not-yet-existing plist.
   MACPARAKEET_MEETING_ECHO_MODEL_NAME="$model_name" \
     MACPARAKEET_MEETING_ECHO_MODEL_SHA256="$expected_model_sha" \
+    MACPARAKEET_MEETING_ECHO_MIN_MACOS_VERSION="$MIN_MACOS_VERSION" \
     "$ROOT_DIR/scripts/dist/verify_meeting_echo_assets.sh" "$APP_DIR"
 }
 

--- a/scripts/dist/macho_min_version.sh
+++ b/scripts/dist/macho_min_version.sh
@@ -67,8 +67,15 @@ macho_minos() {
   local archs arch
   archs="$(macho_archs "$path")" || return 1
 
+  local -a arch_list
+  read -ra arch_list <<<"$archs"
+  if [[ "${#arch_list[@]}" -eq 0 ]]; then
+    echo "Error: 'lipo -info' reported no architecture slices for '$path'." >&2
+    return 1
+  fi
+
   local status=0
-  for arch in $archs; do
+  for arch in "${arch_list[@]}"; do
     local lc_output minos
     if ! lc_output="$(otool -arch "$arch" -l "$path" 2>&1)"; then
       echo "Error: 'otool -l' failed for '$path' (arch $arch): $lc_output" >&2

--- a/scripts/dist/macho_min_version.sh
+++ b/scripts/dist/macho_min_version.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Mach-O minimum-OS-version inspection and numeric macOS version comparison.
+#
+# Sourced by scripts/dist/prepare_meeting_echo_assets.sh and
+# scripts/dist/verify_meeting_echo_assets.sh. Can also run standalone for
+# inspection/testing:
+#   scripts/dist/macho_min_version.sh <path-to-macho-file>
+# prints one "<arch>\t<minos>" line per architecture slice found in the file.
+
+is_macos_version() {
+  [[ "$1" =~ ^[0-9]+(\.[0-9]+){0,2}$ ]]
+}
+
+# Numerically compares dot-separated macOS version strings (e.g. "14.10" >
+# "14.2"), padding missing trailing components with 0. Callers must validate
+# both inputs with is_macos_version first; behavior on malformed input is
+# undefined.
+version_compare() {
+  local a="$1" b="$2"
+  local -a a_parts b_parts
+  IFS='.' read -r -a a_parts <<<"$a"
+  IFS='.' read -r -a b_parts <<<"$b"
+  local len=${#a_parts[@]}
+  ((${#b_parts[@]} > len)) && len=${#b_parts[@]}
+  local i ac bc
+  for ((i = 0; i < len; i++)); do
+    ac=$((10#${a_parts[i]:-0}))
+    bc=$((10#${b_parts[i]:-0}))
+    if ((ac > bc)); then
+      printf '1\n'
+      return 0
+    fi
+    if ((ac < bc)); then
+      printf -- '-1\n'
+      return 0
+    fi
+  done
+  printf '0\n'
+}
+
+version_gt() { [[ "$(version_compare "$1" "$2")" == "1" ]]; }
+
+macho_archs() {
+  local path="$1"
+  local info
+  if ! info="$(lipo -info "$path" 2>&1)"; then
+    echo "Error: 'lipo -info' failed for '$path': $info" >&2
+    return 1
+  fi
+  if [[ "$info" == *"Non-fat file:"* ]]; then
+    awk -F'is architecture: ' '{print $2}' <<<"$info"
+  elif [[ "$info" == *"Architectures in the fat file:"* ]]; then
+    awk -F'are: ' '{print $2}' <<<"$info"
+  else
+    echo "Error: could not parse 'lipo -info' output for '$path': $info" >&2
+    return 1
+  fi
+}
+
+# Prints "<arch>\t<minos>" for each architecture slice of $1 to stdout.
+# Returns non-zero (with details on stderr) if any slice's minimum-OS-version
+# load command (LC_BUILD_VERSION minos, or legacy LC_VERSION_MIN_MACOSX
+# version) is missing or malformed. Never silently drops a slice: the caller's
+# stdout output is only as complete as its exit status is zero.
+macho_minos() {
+  local path="$1"
+  local archs arch
+  archs="$(macho_archs "$path")" || return 1
+
+  local status=0
+  for arch in $archs; do
+    local lc_output minos
+    if ! lc_output="$(otool -arch "$arch" -l "$path" 2>&1)"; then
+      echo "Error: 'otool -l' failed for '$path' (arch $arch): $lc_output" >&2
+      status=1
+      continue
+    fi
+
+    minos="$(awk '
+      /^[[:space:]]*cmd LC_BUILD_VERSION/ { in_bv=1; in_vm=0; next }
+      /^[[:space:]]*cmd LC_VERSION_MIN_MACOSX/ { in_vm=1; in_bv=0; next }
+      /^[[:space:]]*cmd / { in_bv=0; in_vm=0 }
+      in_bv && /^[[:space:]]*minos / { print $2; exit }
+      in_vm && /^[[:space:]]*version / { print $2; exit }
+    ' <<<"$lc_output")"
+
+    if [[ -z "$minos" ]] || ! is_macos_version "$minos"; then
+      echo "Error: no parseable minimum OS version load command for '$path' (arch $arch)." >&2
+      status=1
+      continue
+    fi
+    printf '%s\t%s\n' "$arch" "$minos"
+  done
+  return "$status"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  set -euo pipefail
+  if [[ "$#" -ne 1 ]]; then
+    echo "Usage: $0 <path-to-macho-file>" >&2
+    exit 2
+  fi
+  macho_minos "$1"
+fi

--- a/scripts/dist/meeting_echo_asset_defaults.sh
+++ b/scripts/dist/meeting_echo_asset_defaults.sh
@@ -3,3 +3,8 @@
 
 DEFAULT_MEETING_ECHO_MODEL_NAME="localvqe-v1.4-aec-200K-f32.gguf"
 DEFAULT_MEETING_ECHO_MODEL_SHA256="b6e43138588a83bfe903ab5e143b4020b91c1e1629f5a575ac5855ff0003c731"
+
+# Single source of truth for the app's minimum macOS version, shared by
+# build_app_bundle.sh's MIN_MACOS_VERSION default, the LocalVQE runtime's
+# CMAKE_OSX_DEPLOYMENT_TARGET, and the bundle verifier's rejection ceiling.
+DEFAULT_MEETING_ECHO_MIN_MACOS_VERSION="14.2"

--- a/scripts/dist/prepare_meeting_echo_assets.sh
+++ b/scripts/dist/prepare_meeting_echo_assets.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 . "$ROOT_DIR/scripts/dist/meeting_echo_asset_defaults.sh"
+. "$ROOT_DIR/scripts/dist/macho_min_version.sh"
 
 DEFAULT_LOCALVQE_REPO_URL="https://github.com/localai-org/LocalVQE.git"
 DEFAULT_LOCALVQE_REF="35b116d5eb059d552fa46fac3ce2963ed13ce153"
@@ -31,6 +32,25 @@ MODEL_URL="${MACPARAKEET_MEETING_ECHO_MODEL_URL:-$DEFAULT_MODEL_URL}"
 MODEL_SHA256="${MACPARAKEET_MEETING_ECHO_MODEL_SHA256:-}"
 UNIVERSAL="${MACPARAKEET_MEETING_ECHO_UNIVERSAL:-${UNIVERSAL:-0}}"
 CMAKE_BUILD_TYPE="${LOCALVQE_CMAKE_BUILD_TYPE:-Release}"
+
+# The app's advertised minimum macOS version is the ceiling: the runtime we
+# build must not require a newer OS than the app itself claims to support.
+APP_MIN_MACOS_VERSION="${MACPARAKEET_MEETING_ECHO_APP_MIN_MACOS_VERSION:-$DEFAULT_MEETING_ECHO_MIN_MACOS_VERSION}"
+LOCALVQE_MIN_MACOS_VERSION="${LOCALVQE_MIN_MACOS_VERSION:-$APP_MIN_MACOS_VERSION}"
+
+if ! is_macos_version "$APP_MIN_MACOS_VERSION"; then
+  echo "Error: MACPARAKEET_MEETING_ECHO_APP_MIN_MACOS_VERSION must be a macOS version like 14.2: '$APP_MIN_MACOS_VERSION'." >&2
+  exit 1
+fi
+if ! is_macos_version "$LOCALVQE_MIN_MACOS_VERSION"; then
+  echo "Error: LOCALVQE_MIN_MACOS_VERSION must be a macOS version like 14.2: '$LOCALVQE_MIN_MACOS_VERSION'." >&2
+  exit 1
+fi
+if version_gt "$LOCALVQE_MIN_MACOS_VERSION" "$APP_MIN_MACOS_VERSION"; then
+  echo "Error: LOCALVQE_MIN_MACOS_VERSION ($LOCALVQE_MIN_MACOS_VERSION) exceeds the app's minimum macOS version ($APP_MIN_MACOS_VERSION)." >&2
+  echo "  A LocalVQE runtime built for a newer minimum than the app claims to support would crash on OS versions the app advertises as supported." >&2
+  exit 1
+fi
 
 require_tool() {
   local tool="$1"
@@ -202,6 +222,7 @@ configure_localvqe_runtime() {
     -DCMAKE_RUNTIME_OUTPUT_DIRECTORY="$BUILD_DIR"
     "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_${cmake_build_type_upper}=$BUILD_DIR"
     "-DCMAKE_RUNTIME_OUTPUT_DIRECTORY_${cmake_build_type_upper}=$BUILD_DIR"
+    -DCMAKE_OSX_DEPLOYMENT_TARGET="$LOCALVQE_MIN_MACOS_VERSION"
     -DLOCALVQE_BUILD_SHARED=ON
     -DLOCALVQE_VULKAN=OFF
     -DLOCALVQE_CUDA=OFF
@@ -240,6 +261,7 @@ runtime_stamp_value() {
   printf 'ref=%s\n' "$LOCALVQE_REF"
   printf 'build_type=%s\n' "$CMAKE_BUILD_TYPE"
   printf 'universal=%s\n' "$UNIVERSAL"
+  printf 'min_macos_version=%s\n' "$LOCALVQE_MIN_MACOS_VERSION"
 }
 
 runtime_dylib_manifest_value() {

--- a/scripts/dist/prepare_meeting_echo_assets.sh
+++ b/scripts/dist/prepare_meeting_echo_assets.sh
@@ -33,22 +33,12 @@ MODEL_SHA256="${MACPARAKEET_MEETING_ECHO_MODEL_SHA256:-}"
 UNIVERSAL="${MACPARAKEET_MEETING_ECHO_UNIVERSAL:-${UNIVERSAL:-0}}"
 CMAKE_BUILD_TYPE="${LOCALVQE_CMAKE_BUILD_TYPE:-Release}"
 
-# The app's advertised minimum macOS version is the ceiling: the runtime we
-# build must not require a newer OS than the app itself claims to support.
+# The LocalVQE runtime must not require a newer OS than the app itself claims
+# to support, so it is built for the app's advertised minimum macOS version.
 APP_MIN_MACOS_VERSION="${MACPARAKEET_MEETING_ECHO_APP_MIN_MACOS_VERSION:-$DEFAULT_MEETING_ECHO_MIN_MACOS_VERSION}"
-LOCALVQE_MIN_MACOS_VERSION="${LOCALVQE_MIN_MACOS_VERSION:-$APP_MIN_MACOS_VERSION}"
 
 if ! is_macos_version "$APP_MIN_MACOS_VERSION"; then
   echo "Error: MACPARAKEET_MEETING_ECHO_APP_MIN_MACOS_VERSION must be a macOS version like 14.2: '$APP_MIN_MACOS_VERSION'." >&2
-  exit 1
-fi
-if ! is_macos_version "$LOCALVQE_MIN_MACOS_VERSION"; then
-  echo "Error: LOCALVQE_MIN_MACOS_VERSION must be a macOS version like 14.2: '$LOCALVQE_MIN_MACOS_VERSION'." >&2
-  exit 1
-fi
-if version_gt "$LOCALVQE_MIN_MACOS_VERSION" "$APP_MIN_MACOS_VERSION"; then
-  echo "Error: LOCALVQE_MIN_MACOS_VERSION ($LOCALVQE_MIN_MACOS_VERSION) exceeds the app's minimum macOS version ($APP_MIN_MACOS_VERSION)." >&2
-  echo "  A LocalVQE runtime built for a newer minimum than the app claims to support would crash on OS versions the app advertises as supported." >&2
   exit 1
 fi
 
@@ -222,7 +212,7 @@ configure_localvqe_runtime() {
     -DCMAKE_RUNTIME_OUTPUT_DIRECTORY="$BUILD_DIR"
     "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_${cmake_build_type_upper}=$BUILD_DIR"
     "-DCMAKE_RUNTIME_OUTPUT_DIRECTORY_${cmake_build_type_upper}=$BUILD_DIR"
-    -DCMAKE_OSX_DEPLOYMENT_TARGET="$LOCALVQE_MIN_MACOS_VERSION"
+    -DCMAKE_OSX_DEPLOYMENT_TARGET="$APP_MIN_MACOS_VERSION"
     -DLOCALVQE_BUILD_SHARED=ON
     -DLOCALVQE_VULKAN=OFF
     -DLOCALVQE_CUDA=OFF
@@ -261,7 +251,7 @@ runtime_stamp_value() {
   printf 'ref=%s\n' "$LOCALVQE_REF"
   printf 'build_type=%s\n' "$CMAKE_BUILD_TYPE"
   printf 'universal=%s\n' "$UNIVERSAL"
-  printf 'min_macos_version=%s\n' "$LOCALVQE_MIN_MACOS_VERSION"
+  printf 'min_macos_version=%s\n' "$APP_MIN_MACOS_VERSION"
 }
 
 runtime_dylib_manifest_value() {

--- a/scripts/dist/test_macho_min_version.sh
+++ b/scripts/dist/test_macho_min_version.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Regression coverage for scripts/dist/macho_min_version.sh: numeric macOS
+# version comparison (patch levels, "14.10" > "14.2" not lexical), and
+# per-architecture Mach-O minimum-OS-version extraction against real
+# synthetic dylibs (thin and universal), plus malformed-input handling.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HELPER="$ROOT_DIR/scripts/dist/macho_min_version.sh"
+TMP_DIR="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+# shellcheck source=scripts/dist/macho_min_version.sh
+. "$HELPER"
+
+assert_eq() {
+  local label="$1" actual="$2" expected="$3"
+  if [[ "$actual" != "$expected" ]]; then
+    printf 'FAIL: %s: expected %q, got %q\n' "$label" "$expected" "$actual" >&2
+    exit 1
+  fi
+}
+
+assert_true() {
+  local label="$1"
+  shift
+  if ! "$@"; then
+    printf 'FAIL: %s expected true\n' "$label" >&2
+    exit 1
+  fi
+}
+
+assert_false() {
+  local label="$1"
+  shift
+  if "$@"; then
+    printf 'FAIL: %s expected false\n' "$label" >&2
+    exit 1
+  fi
+}
+
+# --- is_macos_version --------------------------------------------------
+assert_true "14.2 is a valid version" is_macos_version "14.2"
+assert_true "14 is a valid version" is_macos_version "14"
+assert_true "14.2.3 is a valid version" is_macos_version "14.2.3"
+assert_false "empty string is invalid" is_macos_version ""
+assert_false "trailing dot is invalid" is_macos_version "14."
+assert_false "four components is invalid" is_macos_version "1.2.3.4"
+assert_false "non-numeric is invalid" is_macos_version "abc"
+assert_false "leading v is invalid" is_macos_version "v14.2"
+echo "PASS: is_macos_version accepts 1-3 numeric dot components only"
+
+# --- version_compare / version_gt: numeric, not lexical -----------------
+assert_eq "14.10 vs 14.2" "$(version_compare 14.10 14.2)" "1"
+assert_eq "14.2 vs 14.10" "$(version_compare 14.2 14.10)" "-1"
+assert_eq "14.2 vs 14.2" "$(version_compare 14.2 14.2)" "0"
+assert_eq "14 vs 14.0 (missing trailing components pad as zero)" "$(version_compare 14 14.0)" "0"
+assert_eq "14.2.1 vs 14.2 (patch beats missing patch)" "$(version_compare 14.2.1 14.2)" "1"
+assert_eq "14.2 vs 14.2.1" "$(version_compare 14.2 14.2.1)" "-1"
+
+assert_true "14.10 > 14.2" version_gt 14.10 14.2
+assert_false "14.2 > 14.10" version_gt 14.2 14.10
+assert_false "14.2 > 14.2 (equal is not greater)" version_gt 14.2 14.2
+assert_true "26.0 > 14.2 (the pre-fix regression case)" version_gt 26.0 14.2
+echo "PASS: version_compare/version_gt compare numerically by dot component, not lexically"
+
+command -v clang >/dev/null 2>&1 || {
+  echo "SKIP: clang unavailable; skipping real Mach-O synthetic dylib coverage" >&2
+  echo "test_macho_min_version fixture tests passed (partial: clang unavailable)"
+  exit 0
+}
+
+cat >"$TMP_DIR/stub.c" <<'EOF'
+int localvqe_stub(void) { return 0; }
+EOF
+
+# --- macho_minos: thin dylib ---------------------------------------------
+clang -arch arm64 -shared -o "$TMP_DIR/thin.dylib" "$TMP_DIR/stub.c" -mmacosx-version-min=14.2
+thin_out="$(macho_minos "$TMP_DIR/thin.dylib")"
+assert_eq "thin dylib reports its single slice" "$thin_out" "$(printf 'arm64\t14.2')"
+echo "PASS: macho_minos reports the minos for a thin dylib"
+
+# --- macho_minos: universal dylib with mixed per-arch minimums, including
+# a patch-level value, and a path containing spaces. ----------------------
+SPACED_DIR="$TMP_DIR/dir with spaces"
+mkdir -p "$SPACED_DIR"
+clang -arch arm64 -shared -o "$TMP_DIR/arm.dylib" "$TMP_DIR/stub.c" -mmacosx-version-min=14.2
+clang -arch x86_64 -shared -o "$TMP_DIR/x86.dylib" "$TMP_DIR/stub.c" -mmacosx-version-min=15.7
+lipo -create "$TMP_DIR/arm.dylib" "$TMP_DIR/x86.dylib" -output "$SPACED_DIR/universal lib.dylib"
+
+universal_out="$(macho_minos "$SPACED_DIR/universal lib.dylib")"
+[[ "$universal_out" == *$'arm64\t14.2'* ]] || {
+  printf 'FAIL: universal output missing arm64 slice: %s\n' "$universal_out" >&2
+  exit 1
+}
+[[ "$universal_out" == *$'x86_64\t15.7'* ]] || {
+  printf 'FAIL: universal output missing x86_64 slice: %s\n' "$universal_out" >&2
+  exit 1
+}
+echo "PASS: macho_minos reports mixed per-architecture minimums for a universal dylib at a path with spaces"
+
+# --- macho_minos: malformed/non-Mach-O input is a hard failure, not a
+# silently empty/successful result. ---------------------------------------
+echo "not a mach-o file" >"$TMP_DIR/bogus.dylib"
+if bogus_out="$(macho_minos "$TMP_DIR/bogus.dylib" 2>/dev/null)"; then
+  printf 'FAIL: macho_minos should fail on a non-Mach-O file, got: %s\n' "$bogus_out" >&2
+  exit 1
+fi
+echo "PASS: macho_minos fails (rather than silently succeeding) on a non-Mach-O file"
+
+# Truncated/corrupted Mach-O: lipo -info fails outright, still a hard failure.
+head -c 32 "$TMP_DIR/thin.dylib" >"$TMP_DIR/truncated.dylib"
+if truncated_out="$(macho_minos "$TMP_DIR/truncated.dylib" 2>/dev/null)"; then
+  printf 'FAIL: macho_minos should fail on a truncated Mach-O file, got: %s\n' "$truncated_out" >&2
+  exit 1
+fi
+echo "PASS: macho_minos fails on a truncated/corrupt Mach-O file"
+
+echo "test_macho_min_version fixture tests passed"

--- a/scripts/dist/test_macho_min_version.sh
+++ b/scripts/dist/test_macho_min_version.sh
@@ -121,4 +121,25 @@ if truncated_out="$(macho_minos "$TMP_DIR/truncated.dylib" 2>/dev/null)"; then
 fi
 echo "PASS: macho_minos fails on a truncated/corrupt Mach-O file"
 
+# --- macho_minos: a `lipo -info` report of zero architecture slices must be
+# a hard failure, not a silent success with no output (the pre-fix regression
+# case: an empty $archs made `for arch in $archs` iterate zero times, leaving
+# `status` at its initial 0 and returning success with nothing printed). -----
+FAKE_LIPO_DIR="$TMP_DIR/fake-lipo-empty-archs"
+mkdir -p "$FAKE_LIPO_DIR"
+cat >"$FAKE_LIPO_DIR/lipo" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1" == "-info" ]]; then
+  echo "Architectures in the fat file: $2 are: "
+  exit 0
+fi
+exit 1
+EOF
+chmod +x "$FAKE_LIPO_DIR/lipo"
+if empty_archs_out="$(PATH="$FAKE_LIPO_DIR:$PATH" macho_minos "$TMP_DIR/thin.dylib" 2>/dev/null)"; then
+  printf 'FAIL: macho_minos should fail when lipo reports zero architecture slices, got: %s\n' "$empty_archs_out" >&2
+  exit 1
+fi
+echo "PASS: macho_minos fails (rather than silently succeeding) when lipo reports zero architecture slices"
+
 echo "test_macho_min_version fixture tests passed"

--- a/scripts/dist/test_prepare_meeting_echo_assets.sh
+++ b/scripts/dist/test_prepare_meeting_echo_assets.sh
@@ -4,8 +4,8 @@ set -euo pipefail
 # Regression coverage for the LocalVQE deployment-target propagation added to
 # scripts/dist/prepare_meeting_echo_assets.sh: CMAKE_OSX_DEPLOYMENT_TARGET
 # must reach cmake, the runtime cache stamp must key on it so stale (e.g.
-# pre-fix) caches rebuild, and an override above the app's minimum must fail
-# before any tool/network use.
+# pre-fix) caches rebuild, and a malformed app minimum must fail before any
+# tool/network use.
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 PREPARE_SCRIPT="$ROOT_DIR/scripts/dist/prepare_meeting_echo_assets.sh"
@@ -232,30 +232,11 @@ assert_fail_contains_no_tools() {
 }
 
 assert_fail_contains_no_tools \
-  "override above app minimum is rejected" \
-  "exceeds the app's minimum macOS version" \
-  MACPARAKEET_MEETING_ECHO_APP_MIN_MACOS_VERSION=14.2 LOCALVQE_MIN_MACOS_VERSION=15.0 \
-  MACPARAKEET_MEETING_ECHO_ASSETS_DIR="$TMP_DIR/assets-reject-1" LOCALVQE_SOURCE_DIR="$TMP_DIR/src-reject-1"
-
-# Numeric comparison, not lexical: 14.10 > 14.2.
-assert_fail_contains_no_tools \
-  "numeric override comparison (14.10 > 14.2)" \
-  "exceeds the app's minimum macOS version" \
-  MACPARAKEET_MEETING_ECHO_APP_MIN_MACOS_VERSION=14.2 LOCALVQE_MIN_MACOS_VERSION=14.10 \
-  MACPARAKEET_MEETING_ECHO_ASSETS_DIR="$TMP_DIR/assets-reject-2" LOCALVQE_SOURCE_DIR="$TMP_DIR/src-reject-2"
-
-assert_fail_contains_no_tools \
-  "malformed override is rejected" \
-  "must be a macOS version like 14.2" \
-  LOCALVQE_MIN_MACOS_VERSION=not-a-version \
-  MACPARAKEET_MEETING_ECHO_ASSETS_DIR="$TMP_DIR/assets-reject-3" LOCALVQE_SOURCE_DIR="$TMP_DIR/src-reject-3"
-
-assert_fail_contains_no_tools \
   "malformed app minimum is rejected" \
   "must be a macOS version like 14.2" \
   MACPARAKEET_MEETING_ECHO_APP_MIN_MACOS_VERSION=not-a-version \
   MACPARAKEET_MEETING_ECHO_ASSETS_DIR="$TMP_DIR/assets-reject-4" LOCALVQE_SOURCE_DIR="$TMP_DIR/src-reject-4"
 
-echo "PASS: overrides above the app minimum, and malformed versions, are rejected before tool use"
+echo "PASS: a malformed app minimum is rejected before tool use"
 
 echo "test_prepare_meeting_echo_assets fixture tests passed"

--- a/scripts/dist/test_prepare_meeting_echo_assets.sh
+++ b/scripts/dist/test_prepare_meeting_echo_assets.sh
@@ -1,0 +1,261 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Regression coverage for the LocalVQE deployment-target propagation added to
+# scripts/dist/prepare_meeting_echo_assets.sh: CMAKE_OSX_DEPLOYMENT_TARGET
+# must reach cmake, the runtime cache stamp must key on it so stale (e.g.
+# pre-fix) caches rebuild, and an override above the app's minimum must fail
+# before any tool/network use.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PREPARE_SCRIPT="$ROOT_DIR/scripts/dist/prepare_meeting_echo_assets.sh"
+TMP_DIR="$(mktemp -d)"
+FAKE_BIN="$TMP_DIR/bin"
+CMAKE_LOG="$TMP_DIR/cmake.log"
+
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+mkdir -p "$FAKE_BIN"
+
+# A real (tiny) local upstream repo with a submodule at ggml/vendor/ggml, so
+# ensure_localvqe_source/localvqe_source_is_current exercise real git rather
+# than a git double. cmake itself is faked below so the "build" never touches
+# the fixture's (nonexistent) CMakeLists.
+make_upstream_repo() {
+  local sub_dir="$TMP_DIR/upstream-sub"
+  local upstream_dir="$TMP_DIR/upstream.git"
+
+  git init -q --initial-branch=main "$sub_dir"
+  printf 'sub\n' >"$sub_dir/file.txt"
+  git -C "$sub_dir" add file.txt
+  git -C "$sub_dir" -c user.email=test@example.com -c user.name=test commit -q -m init
+
+  git init -q --initial-branch=main "$upstream_dir"
+  mkdir -p "$upstream_dir/ggml"
+  printf 'root\n' >"$upstream_dir/root.txt"
+  git -C "$upstream_dir" add root.txt
+  git -C "$upstream_dir" -c user.email=test@example.com -c user.name=test commit -q -m root
+  GIT_ALLOW_PROTOCOL=file git -C "$upstream_dir" submodule add -q "$sub_dir" ggml/vendor/ggml
+  git -C "$upstream_dir" -c user.email=test@example.com -c user.name=test commit -q -m submodule
+
+  printf '%s\n' "$upstream_dir"
+}
+
+UPSTREAM_REPO="$(make_upstream_repo)"
+UPSTREAM_REF="$(git -C "$UPSTREAM_REPO" rev-parse HEAD)"
+
+cat >"$FAKE_BIN/cmake" <<'SCRIPT'
+#!/usr/bin/env bash
+set -euo pipefail
+: "${CMAKE_LOG:?}"
+
+{
+  printf '%s\n' "--- cmake call ---"
+  for a in "$@"; do printf '%s\n' "$a"; done
+} >>"$CMAKE_LOG"
+
+mode="configure"
+build_dir=""
+target=""
+argc=$#
+i=1
+while [[ $i -le $argc ]]; do
+  a="${!i}"
+  case "$a" in
+    --build)
+      i=$((i + 1))
+      mode="build"
+      build_dir="${!i}"
+      ;;
+    -B)
+      i=$((i + 1))
+      build_dir="${!i}"
+      ;;
+    -DCMAKE_OSX_DEPLOYMENT_TARGET=*)
+      target="${a#-DCMAKE_OSX_DEPLOYMENT_TARGET=}"
+      ;;
+  esac
+  i=$((i + 1))
+done
+
+if [[ "$mode" == "build" ]]; then
+  if [[ -n "${FAKE_CMAKE_FAIL_ONCE_MARKER:-}" && ! -f "$FAKE_CMAKE_FAIL_ONCE_MARKER" ]]; then
+    touch "$FAKE_CMAKE_FAIL_ONCE_MARKER"
+    echo "fake cmake: simulated parallel build failure" >&2
+    exit 1
+  fi
+  mkdir -p "$build_dir"
+  target="$(cat "$build_dir/.fake_deployment_target" 2>/dev/null || echo 11.0)"
+  clang -shared -o "$build_dir/liblocalvqe.dylib" "$FAKE_CMAKE_SRC" -mmacosx-version-min="$target"
+  exit 0
+fi
+
+mkdir -p "$build_dir"
+printf '%s' "$target" >"$build_dir/.fake_deployment_target"
+exit 0
+SCRIPT
+chmod +x "$FAKE_BIN/cmake"
+
+cat >"$FAKE_BIN/curl" <<'SCRIPT'
+#!/usr/bin/env bash
+set -euo pipefail
+: "${FAKE_CURL_CONTENT:?}"
+output=""
+argc=$#
+i=1
+while [[ $i -le $argc ]]; do
+  a="${!i}"
+  if [[ "$a" == "--output" ]]; then
+    i=$((i + 1))
+    output="${!i}"
+  fi
+  i=$((i + 1))
+done
+: "${output:?fake curl: no --output path given}"
+printf '%s' "$FAKE_CURL_CONTENT" >"$output"
+SCRIPT
+chmod +x "$FAKE_BIN/curl"
+
+FAKE_CMAKE_SRC="$TMP_DIR/localvqe_stub.c"
+cat >"$FAKE_CMAKE_SRC" <<'EOF'
+int localvqe_new(void) { return 0; }
+int localvqe_process_frame_f32(void) { return 0; }
+int localvqe_reset(void) { return 0; }
+int localvqe_free(void) { return 0; }
+EOF
+
+FAKE_CURL_CONTENT="synthetic localvqe model fixture"
+FAKE_MODEL_SHA256="$(printf '%s' "$FAKE_CURL_CONTENT" | shasum -a 256 | awk '{print $1}')"
+
+run_prepare() {
+  local assets_dir="$1"
+  local source_dir="$2"
+  shift 2
+  PATH="$FAKE_BIN:$PATH" \
+    GIT_ALLOW_PROTOCOL=file \
+    CMAKE_LOG="$CMAKE_LOG" \
+    FAKE_CMAKE_SRC="$FAKE_CMAKE_SRC" \
+    FAKE_CURL_CONTENT="$FAKE_CURL_CONTENT" \
+    MACPARAKEET_MEETING_ECHO_ASSETS_DIR="$assets_dir" \
+    LOCALVQE_SOURCE_DIR="$source_dir" \
+    LOCALVQE_REPO_URL="$UPSTREAM_REPO" \
+    LOCALVQE_REF="$UPSTREAM_REF" \
+    LOCALVQE_FETCH_REF="refs/heads/main" \
+    MACPARAKEET_MEETING_ECHO_MODEL_SHA256="$FAKE_MODEL_SHA256" \
+    "$@" \
+    "$PREPARE_SCRIPT" 2>&1
+}
+
+assert_contains() {
+  local label="$1" haystack="$2" needle="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    printf 'FAIL: %s expected output containing %q\n%s\n' "$label" "$needle" "$haystack" >&2
+    exit 1
+  fi
+}
+
+assert_not_contains() {
+  local label="$1" haystack="$2" needle="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    printf 'FAIL: %s expected output NOT to contain %q\n%s\n' "$label" "$needle" "$haystack" >&2
+    exit 1
+  fi
+}
+
+# --- CMake receives an explicit, non-default deployment target -------------
+: >"$CMAKE_LOG"
+ASSETS_1="$TMP_DIR/assets-1"
+SRC_1="$TMP_DIR/src-1"
+out="$(run_prepare "$ASSETS_1" "$SRC_1" env MACPARAKEET_MEETING_ECHO_APP_MIN_MACOS_VERSION=15.5)"
+if [[ ! -f "$ASSETS_1/lib/liblocalvqe.dylib" ]]; then
+  printf 'FAIL: first prepare run did not produce liblocalvqe.dylib\n%s\n' "$out" >&2
+  exit 1
+fi
+assert_contains "cmake configure args" "$(cat "$CMAKE_LOG")" "-DCMAKE_OSX_DEPLOYMENT_TARGET=15.5"
+built_minos="$("$ROOT_DIR/scripts/dist/macho_min_version.sh" "$ASSETS_1/lib/liblocalvqe.dylib")"
+assert_contains "built dylib honors requested deployment target" "$built_minos" $'\t15.5'
+echo "PASS: cmake receives explicit CMAKE_OSX_DEPLOYMENT_TARGET"
+
+# --- Re-running with identical inputs is a cache hit (no rebuild) ----------
+first_build_calls="$(grep -c -- '--build' "$CMAKE_LOG")"
+out="$(run_prepare "$ASSETS_1" "$SRC_1" env MACPARAKEET_MEETING_ECHO_APP_MIN_MACOS_VERSION=15.5)"
+second_build_calls="$(grep -c -- '--build' "$CMAKE_LOG")"
+if [[ "$second_build_calls" != "$first_build_calls" ]]; then
+  printf 'FAIL: unchanged inputs should be a cache hit (no extra cmake --build calls)\n%s\n' "$out" >&2
+  exit 1
+fi
+assert_contains "unchanged inputs report cache hit" "$out" "already present"
+echo "PASS: identical re-run is a cache hit"
+
+# --- A stale/pre-fix stamp (no min_macos_version key) forces a rebuild -----
+ASSETS_2="$TMP_DIR/assets-2"
+SRC_2="$TMP_DIR/src-2"
+mkdir -p "$ASSETS_2/lib"
+clang -shared -o "$ASSETS_2/lib/liblocalvqe.dylib" "$FAKE_CMAKE_SRC" -mmacosx-version-min=26.0
+printf 'repo=%s\nref=%s\nbuild_type=Release\nuniversal=0\n' "$UPSTREAM_REPO" "$UPSTREAM_REF" >"$ASSETS_2/lib/.localvqe-runtime.stamp"
+printf 'liblocalvqe.dylib\n' >"$ASSETS_2/lib/.localvqe-runtime.dylibs"
+: >"$CMAKE_LOG"
+out="$(run_prepare "$ASSETS_2" "$SRC_2" env MACPARAKEET_MEETING_ECHO_APP_MIN_MACOS_VERSION=14.2)"
+assert_not_contains "stale pre-fix stamp is not treated as current" "$out" "already present"
+assert_contains "stale pre-fix stamp triggers a real build" "$(cat "$CMAKE_LOG")" "-DCMAKE_OSX_DEPLOYMENT_TARGET=14.2"
+rebuilt_minos="$("$ROOT_DIR/scripts/dist/macho_min_version.sh" "$ASSETS_2/lib/liblocalvqe.dylib")"
+assert_contains "rebuilt dylib no longer carries the stale 26.0 minimum" "$rebuilt_minos" $'\t14.2'
+echo "PASS: stale stamp without min_macos_version forces a rebuild"
+
+# --- Parallel build failure retries once with -j1 --------------------------
+ASSETS_3="$TMP_DIR/assets-3"
+SRC_3="$TMP_DIR/src-3"
+: >"$CMAKE_LOG"
+FAIL_MARKER="$TMP_DIR/fail-once-marker"
+rm -f "$FAIL_MARKER"
+out="$(run_prepare "$ASSETS_3" "$SRC_3" env MACPARAKEET_MEETING_ECHO_APP_MIN_MACOS_VERSION=14.2 LOCALVQE_CMAKE_BUILD_JOBS=4 FAKE_CMAKE_FAIL_ONCE_MARKER="$FAIL_MARKER")"
+assert_contains "parallel failure is retried at -j1" "$out" "retrying once with LOCALVQE_CMAKE_BUILD_JOBS=1"
+if [[ ! -f "$ASSETS_3/lib/liblocalvqe.dylib" ]]; then
+  printf 'FAIL: retried build did not eventually produce liblocalvqe.dylib\n%s\n' "$out" >&2
+  exit 1
+fi
+echo "PASS: failed parallel build retries once at -j1"
+
+# --- Override validation fails before any tool/network use -----------------
+assert_fail_contains_no_tools() {
+  local label="$1" expected="$2"
+  shift 2
+  local out
+  if out="$(env "$@" "$PREPARE_SCRIPT" 2>&1)"; then
+    printf 'FAIL: %s should fail\n%s\n' "$label" "$out" >&2
+    exit 1
+  fi
+  assert_contains "$label" "$out" "$expected"
+}
+
+assert_fail_contains_no_tools \
+  "override above app minimum is rejected" \
+  "exceeds the app's minimum macOS version" \
+  MACPARAKEET_MEETING_ECHO_APP_MIN_MACOS_VERSION=14.2 LOCALVQE_MIN_MACOS_VERSION=15.0 \
+  MACPARAKEET_MEETING_ECHO_ASSETS_DIR="$TMP_DIR/assets-reject-1" LOCALVQE_SOURCE_DIR="$TMP_DIR/src-reject-1"
+
+# Numeric comparison, not lexical: 14.10 > 14.2.
+assert_fail_contains_no_tools \
+  "numeric override comparison (14.10 > 14.2)" \
+  "exceeds the app's minimum macOS version" \
+  MACPARAKEET_MEETING_ECHO_APP_MIN_MACOS_VERSION=14.2 LOCALVQE_MIN_MACOS_VERSION=14.10 \
+  MACPARAKEET_MEETING_ECHO_ASSETS_DIR="$TMP_DIR/assets-reject-2" LOCALVQE_SOURCE_DIR="$TMP_DIR/src-reject-2"
+
+assert_fail_contains_no_tools \
+  "malformed override is rejected" \
+  "must be a macOS version like 14.2" \
+  LOCALVQE_MIN_MACOS_VERSION=not-a-version \
+  MACPARAKEET_MEETING_ECHO_ASSETS_DIR="$TMP_DIR/assets-reject-3" LOCALVQE_SOURCE_DIR="$TMP_DIR/src-reject-3"
+
+assert_fail_contains_no_tools \
+  "malformed app minimum is rejected" \
+  "must be a macOS version like 14.2" \
+  MACPARAKEET_MEETING_ECHO_APP_MIN_MACOS_VERSION=not-a-version \
+  MACPARAKEET_MEETING_ECHO_ASSETS_DIR="$TMP_DIR/assets-reject-4" LOCALVQE_SOURCE_DIR="$TMP_DIR/src-reject-4"
+
+echo "PASS: overrides above the app minimum, and malformed versions, are rejected before tool use"
+
+echo "test_prepare_meeting_echo_assets fixture tests passed"

--- a/scripts/dist/test_verify_meeting_echo_assets.sh
+++ b/scripts/dist/test_verify_meeting_echo_assets.sh
@@ -27,11 +27,20 @@ int localvqe_free(void) { return 0; }
 EOF
 
 # A full clone of the system PATH (every /usr/bin and /bin executable
-# symlinked in), minus any tool names passed after $dir. Used as a
+# forwarded in), minus any tool names passed after $dir. Used as a
 # stand-alone PATH (not prepended) so specific tools (otool, lipo) can be made
 # truly absent -- not merely shadowed -- to exercise the missing-tool paths
 # without disturbing every other real tool (nm, file, shasum, codesign, bash
 # itself via the script's `#!/usr/bin/env bash` shebang, etc).
+#
+# Each forwarded tool is a small shell wrapper that execs the original tool
+# by its absolute path, rather than a symlink to it. Some system tools (e.g.
+# shasum) are Perl scripts whose interpreter resolves a version-specific
+# sibling next to the path it was invoked as; invoked through a symlink that
+# relocates it to this directory, that sibling lookup fails even though the
+# tool is otherwise fully present. Execing the absolute path keeps the
+# interpreter's view of "where this script lives" pointed at the real
+# directory, sidestepping that lookup entirely.
 make_restricted_path() {
   local dir="$1"
   shift
@@ -47,7 +56,8 @@ make_restricted_path() {
         [[ "$o" == "$base" ]] && skip=1
       done
       [[ "$skip" == "1" ]] && continue
-      ln -sf "$f" "$dir/$base"
+      printf '#!/bin/sh\nexec "%s" "$@"\n' "$f" >"$dir/$base"
+      chmod +x "$dir/$base"
     done
   done
 }
@@ -263,6 +273,15 @@ add_fixture_model "$APP9"
 run_restricted() {
   PATH="$RESTRICTED_BIN" "$@" "$VERIFY_SCRIPT" "$APP9" 2>&1
 }
+# Canary: a tool that is NOT meant to be restricted (shasum, used by the
+# verify script itself before it ever reaches the otool/lipo checks below)
+# must still run under the restricted PATH. If this fails, the assertions
+# below would instead report a misleading "expected a missing-tool error"
+# for a broken test fixture rather than the behavior under test.
+if ! restricted_shasum_out="$(PATH="$RESTRICTED_BIN" shasum -a 256 "$APP9/Contents/Resources/MeetingEchoSuppression/fixture-model.gguf" 2>&1)"; then
+  printf 'FAIL: restricted PATH fixture cannot run shasum, a tool that should not be restricted\n%s\n' "$restricted_shasum_out" >&2
+  exit 1
+fi
 FIXTURE_MODEL_SHA256="$(shasum -a 256 "$APP9/Contents/Resources/MeetingEchoSuppression/fixture-model.gguf" | awk '{print $1}')"
 if out="$(run_restricted env MACPARAKEET_MEETING_ECHO_MIN_MACOS_VERSION=14.2 STRICT_MEETING_ECHO_ASSETS=1 MACPARAKEET_MEETING_ECHO_MODEL_SHA256="$FIXTURE_MODEL_SHA256")"; then
   printf 'FAIL: strict mode should fail when otool/lipo are unavailable\n%s\n' "$out" >&2

--- a/scripts/dist/test_verify_meeting_echo_assets.sh
+++ b/scripts/dist/test_verify_meeting_echo_assets.sh
@@ -202,20 +202,47 @@ assert_fail_contains \
   env MACPARAKEET_MEETING_ECHO_MIN_MACOS_VERSION=14.2
 echo "PASS: malformed/unparseable dylib version is rejected"
 
-# --- Expected minimum resolution: explicit override wins; Info.plist is the
-# fallback; absent both, verification fails clearly (never silently passes).
+# --- Expected minimum resolution: overrides can tighten the bundle ceiling;
+# absent both, verification fails clearly (never silently passes).
 APP7="$(make_app "Fixture Plist")"
 make_dylib "$APP7/Contents/Frameworks/liblocalvqe.dylib" "arm64:14.2"
 add_fixture_model "$APP7"
 write_info_plist_min_version "$APP7" "14.2"
 assert_pass "expected minimum read from Info.plist LSMinimumSystemVersion" "$APP7" >/dev/null
-write_info_plist_min_version "$APP7" "14.0"
+write_info_plist_min_version "$APP7" "14.2"
 assert_fail_contains \
-  "override takes precedence over a looser Info.plist minimum" \
+  "override tightens a looser Info.plist ceiling" \
   "$APP7" \
   "requires a newer macOS than the app supports" \
   env MACPARAKEET_MEETING_ECHO_MIN_MACOS_VERSION=14.0
-echo "PASS: MACPARAKEET_MEETING_ECHO_MIN_MACOS_VERSION overrides, Info.plist is the fallback"
+# An override may tighten the ceiling, but cannot weaken the bundle contract.
+write_info_plist_min_version "$APP7" "14.0"
+assert_fail_contains \
+  "override cannot raise the ceiling above the advertised minimum" \
+  "$APP7" \
+  "requires a newer macOS than the app supports" \
+  env MACPARAKEET_MEETING_ECHO_MIN_MACOS_VERSION=26.0
+echo "PASS: explicit ceilings cannot weaken the bundle's advertised minimum"
+
+# An explicit ceiling cannot conceal invalid bundle metadata.
+for invalid_min in invalid missing; do
+  write_info_plist_min_version "$APP7" "$invalid_min"
+  if [[ "$invalid_min" == missing ]]; then
+    /usr/libexec/PlistBuddy -c 'Delete :LSMinimumSystemVersion' "$APP7/Contents/Info.plist"
+  fi
+  assert_fail_contains \
+    "override cannot hide an invalid or absent plist minimum" \
+    "$APP7" \
+    "bundle Info.plist must carry a valid LSMinimumSystemVersion" \
+    env MACPARAKEET_MEETING_ECHO_MIN_MACOS_VERSION=26
+done
+write_info_plist_min_version "$APP7" "14.2"
+assert_fail_contains \
+  "invalid override cannot hide behind valid plist minimum" \
+  "$APP7" \
+  "MACPARAKEET_MEETING_ECHO_MIN_MACOS_VERSION must be a valid macOS version" \
+  env MACPARAKEET_MEETING_ECHO_MIN_MACOS_VERSION=invalid
+echo "PASS: existing plist and explicit override must each be valid"
 
 APP8="$(make_app "Fixture No Minimum")"
 make_dylib "$APP8/Contents/Frameworks/liblocalvqe.dylib" "arm64:14.2"
@@ -256,6 +283,36 @@ fi
   exit 1
 }
 echo "PASS: non-strict mode warns and skips when otool/lipo are unavailable"
+
+# --- A symlinked bundled dylib is inspected like a regular file, not skipped
+# by a `find -type f` that only matches literal regular files. --------------
+APP11="$(make_app "Fixture Symlink")"
+make_dylib "$APP11/Contents/Frameworks/liblocalvqe.dylib" "arm64:14.2"
+make_dylib "$TMP_DIR/libggml-symlink-target.dylib" "arm64:15.7"
+ln -s "$TMP_DIR/libggml-symlink-target.dylib" "$APP11/Contents/Frameworks/libggml-symlinked.dylib"
+add_fixture_model "$APP11"
+assert_fail_contains \
+  "a symlinked bundled dylib above app minimum is still inspected and rejected" \
+  "$APP11" \
+  "libggml-symlinked.dylib" \
+  env MACPARAKEET_MEETING_ECHO_MIN_MACOS_VERSION=14.2
+echo "PASS: symlinked bundled dylibs are inspected like regular files"
+
+# A searchable but unreadable directory permits opening known assets while
+# preventing a complete inventory of dependent dylibs.
+if [[ "$EUID" -ne 0 ]]; then
+  chmod 111 "$APP11/Contents/Frameworks"
+  inventory_status=0
+  inventory_output="$(run_verifier "$APP11" env MACPARAKEET_MEETING_ECHO_MIN_MACOS_VERSION=14.2)" || inventory_status=$?
+  chmod 755 "$APP11/Contents/Frameworks"
+  if [[ "$inventory_status" -eq 0 || "$inventory_output" != *"could not enumerate bundled LocalVQE dylibs"* ]]; then
+    printf 'FAIL: unreadable dylib inventory must fail explicitly\n%s\n' "$inventory_output" >&2
+    exit 1
+  fi
+  echo "PASS: unreadable Frameworks inventory cannot silently pass"
+else
+  echo "SKIP: root can enumerate unreadable directories"
+fi
 
 # --- Preserve existing behavior: no assets bundled is still a passthrough --
 APP10="$(make_app "Fixture Passthrough")"

--- a/scripts/dist/test_verify_meeting_echo_assets.sh
+++ b/scripts/dist/test_verify_meeting_echo_assets.sh
@@ -1,0 +1,269 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Regression coverage for the LocalVQE bundled-dylib deployment-target check
+# added to scripts/dist/verify_meeting_echo_assets.sh: every bundled LocalVQE
+# dylib and architecture slice must carry a minimum-OS-version load command
+# no higher than the app's LSMinimumSystemVersion, malformed/missing versions
+# are rejected, and missing inspection tools are only tolerated outside
+# strict mode. Existing missing-asset passthrough and model checks must keep
+# working.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+VERIFY_SCRIPT="$ROOT_DIR/scripts/dist/verify_meeting_echo_assets.sh"
+TMP_DIR="$(mktemp -d)"
+SRC_C="$TMP_DIR/localvqe_stub.c"
+
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+cat >"$SRC_C" <<'EOF'
+int localvqe_new(void) { return 0; }
+int localvqe_process_frame_f32(void) { return 0; }
+int localvqe_reset(void) { return 0; }
+int localvqe_free(void) { return 0; }
+EOF
+
+# A full clone of the system PATH (every /usr/bin and /bin executable
+# symlinked in), minus any tool names passed after $dir. Used as a
+# stand-alone PATH (not prepended) so specific tools (otool, lipo) can be made
+# truly absent -- not merely shadowed -- to exercise the missing-tool paths
+# without disturbing every other real tool (nm, file, shasum, codesign, bash
+# itself via the script's `#!/usr/bin/env bash` shebang, etc).
+make_restricted_path() {
+  local dir="$1"
+  shift
+  local omit=("$@")
+  mkdir -p "$dir"
+  local src f base o skip
+  for src in /usr/bin /bin; do
+    for f in "$src"/*; do
+      [[ -f "$f" ]] || continue
+      base="$(basename "$f")"
+      skip=0
+      for o in "${omit[@]}"; do
+        [[ "$o" == "$base" ]] && skip=1
+      done
+      [[ "$skip" == "1" ]] && continue
+      ln -sf "$f" "$dir/$base"
+    done
+  done
+}
+
+# make_dylib <out_path> <arch:minos> [<arch:minos> ...]
+make_dylib() {
+  local out="$1"
+  shift
+  local slices=()
+  local spec arch minos slice_path
+  for spec in "$@"; do
+    arch="${spec%%:*}"
+    minos="${spec#*:}"
+    slice_path="$TMP_DIR/slice-$(basename "$out")-$arch-$RANDOM.dylib"
+    clang -arch "$arch" -shared -o "$slice_path" "$SRC_C" -mmacosx-version-min="$minos"
+    slices+=("$slice_path")
+  done
+  if [[ "${#slices[@]}" -eq 1 ]]; then
+    cp "${slices[0]}" "$out"
+  else
+    lipo -create "${slices[@]}" -output "$out"
+  fi
+  install_name_tool -id "@rpath/$(basename "$out")" "$out"
+  chmod +x "$out"
+}
+
+# make_app <name> writes a minimal fixture bundle (no dylib/model yet) and
+# prints its path. Space in the default name exercises path-with-spaces
+# handling end to end.
+make_app() {
+  local name="${1:-My Fixture}"
+  local app_path="$TMP_DIR/${name}.app"
+  mkdir -p "$app_path/Contents/Frameworks" "$app_path/Contents/Resources/MeetingEchoSuppression"
+  printf '%s\n' "$app_path"
+}
+
+write_info_plist_min_version() {
+  local app_path="$1" version="$2"
+  local plist="$app_path/Contents/Info.plist"
+  /usr/libexec/PlistBuddy -c 'Clear dict' "$plist" >/dev/null 2>&1 || true
+  /usr/libexec/PlistBuddy -c "Add :LSMinimumSystemVersion string $version" "$plist"
+}
+
+add_fixture_model() {
+  local app_path="$1"
+  printf 'fixture model content\n' >"$app_path/Contents/Resources/MeetingEchoSuppression/fixture-model.gguf"
+}
+
+run_verifier() {
+  local app_path="$1"
+  shift
+  "$@" "$VERIFY_SCRIPT" "$app_path" 2>&1
+}
+
+assert_pass() {
+  local label="$1" app_path="$2"
+  shift 2
+  local output
+  if ! output="$(run_verifier "$app_path" "$@")"; then
+    printf 'FAIL: %s should pass\n%s\n' "$label" "$output" >&2
+    exit 1
+  fi
+  printf '%s\n' "$output"
+}
+
+assert_fail_contains() {
+  local label="$1" app_path="$2" expected="$3"
+  shift 3
+  local output
+  if output="$(run_verifier "$app_path" "$@")"; then
+    printf 'FAIL: %s should fail\n%s\n' "$label" "$output" >&2
+    exit 1
+  fi
+  if [[ "$output" != *"$expected"* ]]; then
+    printf 'FAIL: %s expected error containing %q\n%s\n' "$label" "$expected" "$output" >&2
+    exit 1
+  fi
+}
+
+# --- Baseline: exactly-at-minimum passes ------------------------------------
+APP1="$(make_app "Fixture Exact")"
+make_dylib "$APP1/Contents/Frameworks/liblocalvqe.dylib" "arm64:14.2"
+add_fixture_model "$APP1"
+out="$(assert_pass "dylib minos equal to app minimum" "$APP1" env MACPARAKEET_MEETING_ECHO_MIN_MACOS_VERSION=14.2)"
+[[ "$out" == *"deployment targets verified against app minimum: 14.2"* ]] || {
+  printf 'FAIL: expected deployment target success message\n%s\n' "$out" >&2
+  exit 1
+}
+echo "PASS: dylib minos exactly at app minimum passes"
+
+# --- A dylib above the app minimum is rejected ------------------------------
+APP2="$(make_app "Fixture Too New")"
+make_dylib "$APP2/Contents/Frameworks/liblocalvqe.dylib" "arm64:15.7"
+add_fixture_model "$APP2"
+assert_fail_contains \
+  "dylib above app minimum is rejected" \
+  "$APP2" \
+  "requires a newer macOS than the app supports" \
+  env MACPARAKEET_MEETING_ECHO_MIN_MACOS_VERSION=14.2
+echo "PASS: dylib above app minimum is rejected"
+
+# --- Universal dylib with mixed per-arch minimums: only the offending slice
+# is rejected, both slices are actually inspected. ---------------------------
+APP3="$(make_app "Fixture Universal")"
+make_dylib "$APP3/Contents/Frameworks/liblocalvqe.dylib" "arm64:14.2" "x86_64:15.7"
+add_fixture_model "$APP3"
+assert_fail_contains \
+  "universal dylib with one over-limit slice is rejected" \
+  "$APP3" \
+  "Architecture: x86_64" \
+  env MACPARAKEET_MEETING_ECHO_MIN_MACOS_VERSION=14.2
+
+APP3b="$(make_app "Fixture Universal OK")"
+make_dylib "$APP3b/Contents/Frameworks/liblocalvqe.dylib" "arm64:14.2" "x86_64:14.2"
+add_fixture_model "$APP3b"
+assert_pass "universal dylib with both slices at the limit passes" "$APP3b" env MACPARAKEET_MEETING_ECHO_MIN_MACOS_VERSION=14.2 >/dev/null
+echo "PASS: universal dylibs are inspected per architecture slice"
+
+# --- Numeric comparison, not lexical: 14.10 dylib against 14.2 app minimum
+# must be rejected (14.10 > 14.2 numerically). -------------------------------
+APP4="$(make_app "Fixture Numeric")"
+make_dylib "$APP4/Contents/Frameworks/liblocalvqe.dylib" "arm64:14.10"
+add_fixture_model "$APP4"
+assert_fail_contains \
+  "numeric comparison rejects 14.10 against app minimum 14.2" \
+  "$APP4" \
+  "requires a newer macOS than the app supports" \
+  env MACPARAKEET_MEETING_ECHO_MIN_MACOS_VERSION=14.2
+echo "PASS: version comparison is numeric, not lexical"
+
+# --- Every bundled LocalVQE dependency is inspected, not just liblocalvqe ---
+APP5="$(make_app "Fixture Dependency")"
+make_dylib "$APP5/Contents/Frameworks/liblocalvqe.dylib" "arm64:14.2"
+make_dylib "$APP5/Contents/Frameworks/libggml-cpu.dylib" "arm64:15.7"
+add_fixture_model "$APP5"
+assert_fail_contains \
+  "a bundled dependency other than liblocalvqe.dylib is also inspected" \
+  "$APP5" \
+  "libggml-cpu.dylib" \
+  env MACPARAKEET_MEETING_ECHO_MIN_MACOS_VERSION=14.2
+echo "PASS: every bundled LocalVQE dylib is inspected, not only liblocalvqe.dylib"
+
+# --- Malformed/corrupt dylib (no parseable version) is rejected ------------
+APP6="$(make_app "Fixture Malformed")"
+make_dylib "$APP6/Contents/Frameworks/liblocalvqe.dylib" "arm64:14.2"
+head -c 64 "$APP6/Contents/Frameworks/liblocalvqe.dylib" >"$APP6/Contents/Frameworks/libggml-corrupt.dylib"
+add_fixture_model "$APP6"
+assert_fail_contains \
+  "a corrupt/unparseable bundled dylib is rejected" \
+  "$APP6" \
+  "could not determine a minimum OS version" \
+  env MACPARAKEET_MEETING_ECHO_MIN_MACOS_VERSION=14.2
+echo "PASS: malformed/unparseable dylib version is rejected"
+
+# --- Expected minimum resolution: explicit override wins; Info.plist is the
+# fallback; absent both, verification fails clearly (never silently passes).
+APP7="$(make_app "Fixture Plist")"
+make_dylib "$APP7/Contents/Frameworks/liblocalvqe.dylib" "arm64:14.2"
+add_fixture_model "$APP7"
+write_info_plist_min_version "$APP7" "14.2"
+assert_pass "expected minimum read from Info.plist LSMinimumSystemVersion" "$APP7" >/dev/null
+write_info_plist_min_version "$APP7" "14.0"
+assert_fail_contains \
+  "override takes precedence over a looser Info.plist minimum" \
+  "$APP7" \
+  "requires a newer macOS than the app supports" \
+  env MACPARAKEET_MEETING_ECHO_MIN_MACOS_VERSION=14.0
+echo "PASS: MACPARAKEET_MEETING_ECHO_MIN_MACOS_VERSION overrides, Info.plist is the fallback"
+
+APP8="$(make_app "Fixture No Minimum")"
+make_dylib "$APP8/Contents/Frameworks/liblocalvqe.dylib" "arm64:14.2"
+add_fixture_model "$APP8"
+assert_fail_contains \
+  "no override and no Info.plist minimum fails clearly rather than silently passing" \
+  "$APP8" \
+  "could not determine a valid app LSMinimumSystemVersion"
+echo "PASS: an unresolvable app minimum is a hard failure, not a silent pass"
+
+# --- Missing inspection tools: strict mode rejects, non-strict warns/skips -
+RESTRICTED_BIN="$TMP_DIR/bin-no-otool-lipo"
+make_restricted_path "$RESTRICTED_BIN" otool lipo
+APP9="$(make_app "Fixture No Tools")"
+make_dylib "$APP9/Contents/Frameworks/liblocalvqe.dylib" "arm64:14.2"
+add_fixture_model "$APP9"
+
+run_restricted() {
+  PATH="$RESTRICTED_BIN" "$@" "$VERIFY_SCRIPT" "$APP9" 2>&1
+}
+FIXTURE_MODEL_SHA256="$(shasum -a 256 "$APP9/Contents/Resources/MeetingEchoSuppression/fixture-model.gguf" | awk '{print $1}')"
+if out="$(run_restricted env MACPARAKEET_MEETING_ECHO_MIN_MACOS_VERSION=14.2 STRICT_MEETING_ECHO_ASSETS=1 MACPARAKEET_MEETING_ECHO_MODEL_SHA256="$FIXTURE_MODEL_SHA256")"; then
+  printf 'FAIL: strict mode should fail when otool/lipo are unavailable\n%s\n' "$out" >&2
+  exit 1
+fi
+[[ "$out" == *"is not available"* ]] || {
+  printf 'FAIL: expected a missing-tool error\n%s\n' "$out" >&2
+  exit 1
+}
+echo "PASS: strict mode rejects when otool/lipo are unavailable"
+
+if ! out="$(run_restricted env MACPARAKEET_MEETING_ECHO_MIN_MACOS_VERSION=14.2 STRICT_MEETING_ECHO_ASSETS=0)"; then
+  printf 'FAIL: non-strict mode should tolerate missing otool/lipo\n%s\n' "$out" >&2
+  exit 1
+fi
+[[ "$out" == *"Warning: skipped"* ]] || {
+  printf 'FAIL: expected a skip warning in non-strict mode\n%s\n' "$out" >&2
+  exit 1
+}
+echo "PASS: non-strict mode warns and skips when otool/lipo are unavailable"
+
+# --- Preserve existing behavior: no assets bundled is still a passthrough --
+APP10="$(make_app "Fixture Passthrough")"
+out="$(assert_pass "no assets bundled remains a passthrough pass" "$APP10")"
+[[ "$out" == *"passthrough"* ]] || {
+  printf 'FAIL: expected passthrough message\n%s\n' "$out" >&2
+  exit 1
+}
+echo "PASS: bundles with no meeting echo assets remain a passthrough pass"
+
+echo "test_verify_meeting_echo_assets fixture tests passed"

--- a/scripts/dist/test_verify_meeting_echo_assets.sh
+++ b/scripts/dist/test_verify_meeting_echo_assets.sh
@@ -200,6 +200,19 @@ assert_fail_contains \
   env MACPARAKEET_MEETING_ECHO_MIN_MACOS_VERSION=14.2
 echo "PASS: every bundled LocalVQE dylib is inspected, not only liblocalvqe.dylib"
 
+# --- A hidden (dot-prefixed) bundled dependency is inspected too, not
+# skipped by a bash glob that excludes dotfiles by default. ------------------
+APP5b="$(make_app "Fixture Hidden Dependency")"
+make_dylib "$APP5b/Contents/Frameworks/liblocalvqe.dylib" "arm64:14.2"
+make_dylib "$APP5b/Contents/Frameworks/.libggml-hidden.dylib" "arm64:15.7"
+add_fixture_model "$APP5b"
+assert_fail_contains \
+  "a hidden dot-prefixed bundled dependency is also inspected" \
+  "$APP5b" \
+  ".libggml-hidden.dylib" \
+  env MACPARAKEET_MEETING_ECHO_MIN_MACOS_VERSION=14.2
+echo "PASS: hidden dot-prefixed bundled dylibs are inspected, not skipped"
+
 # --- Malformed/corrupt dylib (no parseable version) is rejected ------------
 APP6="$(make_app "Fixture Malformed")"
 make_dylib "$APP6/Contents/Frameworks/liblocalvqe.dylib" "arm64:14.2"

--- a/scripts/dist/verify_meeting_echo_assets.sh
+++ b/scripts/dist/verify_meeting_echo_assets.sh
@@ -81,6 +81,14 @@ verify_deployment_targets() {
 
   local failed=0
   local dylib
+  # build_app_bundle.sh copies dependent dylibs via `find -name '*.dylib'`,
+  # which (unlike this loop's default bash glob) also matches dot-prefixed
+  # hidden files. Enable dotglob for this enumeration so a hidden dependency
+  # can't bypass the deployment-target check; restore the prior setting
+  # afterward since dotglob is process-wide, not loop-scoped.
+  local dotglob_was_set=0
+  shopt -q dotglob && dotglob_was_set=1
+  shopt -s dotglob
   for dylib in "$FRAMEWORKS_DIR"/*.dylib; do
     if [[ ! -f "$dylib" && ! -L "$dylib" ]]; then
       echo "Error: could not enumerate bundled LocalVQE dylibs: $FRAMEWORKS_DIR" >&2
@@ -106,6 +114,7 @@ verify_deployment_targets() {
       fi
     done <<<"$minos_output"
   done
+  [[ "$dotglob_was_set" == "1" ]] || shopt -u dotglob
 
   if [[ "$failed" == "1" ]]; then
     exit 1

--- a/scripts/dist/verify_meeting_echo_assets.sh
+++ b/scripts/dist/verify_meeting_echo_assets.sh
@@ -4,13 +4,15 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 . "$ROOT_DIR/scripts/dist/meeting_echo_asset_defaults.sh"
+. "$ROOT_DIR/scripts/dist/macho_min_version.sh"
 
 APP_PATH="${1:-${APP_PATH:-$ROOT_DIR/dist/MacParakeet.app}}"
 REQUIRE_MEETING_ECHO_ASSETS="${REQUIRE_MEETING_ECHO_ASSETS:-0}"
 VERIFY_CODE_SIGNATURES="${VERIFY_CODE_SIGNATURES:-0}"
 STRICT_MEETING_ECHO_ASSETS="${STRICT_MEETING_ECHO_ASSETS:-$REQUIRE_MEETING_ECHO_ASSETS}"
 
-LIB_PATH="$APP_PATH/Contents/Frameworks/liblocalvqe.dylib"
+FRAMEWORKS_DIR="$APP_PATH/Contents/Frameworks"
+LIB_PATH="$FRAMEWORKS_DIR/liblocalvqe.dylib"
 MODEL_DIR="$APP_PATH/Contents/Resources/MeetingEchoSuppression"
 MODEL_PATH=""
 REQUIRED_SYMBOLS=(
@@ -28,6 +30,67 @@ missing_tool() {
     exit 1
   fi
   echo "Warning: skipped ${check}; '${tool}' is not available." >&2
+}
+
+# Rejects any bundled LocalVQE dylib/architecture slice whose Mach-O minimum
+# OS version load command exceeds the app's LSMinimumSystemVersion. A dylib
+# built for a newer macOS than the app advertises support for can crash at
+# launch on older, "supported" systems. This check is a hard failure (not
+# gated by STRICT_MEETING_ECHO_ASSETS) whenever otool/lipo are available and
+# the expected minimum can be determined; only the availability of otool/lipo
+# themselves is gated by strict mode, consistent with the other checks below.
+verify_deployment_targets() {
+  local expected_min="${MACPARAKEET_MEETING_ECHO_MIN_MACOS_VERSION:-}"
+  if [[ -z "$expected_min" ]]; then
+    local plist="$APP_PATH/Contents/Info.plist"
+    if [[ -f "$plist" ]]; then
+      expected_min="$(/usr/libexec/PlistBuddy -c 'Print :LSMinimumSystemVersion' "$plist" 2>/dev/null || true)"
+    fi
+  fi
+
+  if [[ -z "$expected_min" ]] || ! is_macos_version "$expected_min"; then
+    echo "Error: could not determine a valid app LSMinimumSystemVersion to verify bundled LocalVQE dylib deployment targets against." >&2
+    echo "  Set MACPARAKEET_MEETING_ECHO_MIN_MACOS_VERSION, or ensure $APP_PATH/Contents/Info.plist carries a valid LSMinimumSystemVersion." >&2
+    exit 1
+  fi
+
+  if ! command -v otool >/dev/null 2>&1; then
+    missing_tool "otool" "meeting echo runtime deployment target"
+    return 0
+  fi
+  if ! command -v lipo >/dev/null 2>&1; then
+    missing_tool "lipo" "meeting echo runtime deployment target"
+    return 0
+  fi
+
+  local failed=0
+  local dylib
+  while IFS= read -r -d '' dylib; do
+    local minos_output
+    if ! minos_output="$(macho_minos "$dylib")"; then
+      echo "Error: could not determine a minimum OS version for bundled LocalVQE dylib: $dylib" >&2
+      echo "$minos_output" >&2
+      failed=1
+      continue
+    fi
+    local arch minos
+    while IFS=$'\t' read -r arch minos; do
+      [[ -z "$arch" ]] && continue
+      if version_gt "$minos" "$expected_min"; then
+        echo "Error: bundled LocalVQE dylib requires a newer macOS than the app supports." >&2
+        echo "  Dylib:        $dylib" >&2
+        echo "  Architecture: $arch" >&2
+        echo "  Dylib minos:  $minos" >&2
+        echo "  App minimum:  $expected_min" >&2
+        failed=1
+      fi
+    done <<<"$minos_output"
+  done < <(find "$FRAMEWORKS_DIR" -maxdepth 1 -type f -name '*.dylib' -print0)
+
+  if [[ "$failed" == "1" ]]; then
+    exit 1
+  fi
+  echo "Meeting echo runtime deployment targets verified against app minimum: $expected_min"
 }
 
 if [[ ! -d "$APP_PATH" ]]; then
@@ -162,6 +225,8 @@ if command -v otool >/dev/null 2>&1; then
 else
   missing_tool "otool" "meeting echo runtime dylib references"
 fi
+
+verify_deployment_targets
 
 if [[ "$VERIFY_CODE_SIGNATURES" == "1" ]]; then
   codesign --verify --strict --verbose=2 "$LIB_PATH"

--- a/scripts/dist/verify_meeting_echo_assets.sh
+++ b/scripts/dist/verify_meeting_echo_assets.sh
@@ -40,15 +40,31 @@ missing_tool() {
 # the expected minimum can be determined; only the availability of otool/lipo
 # themselves is gated by strict mode, consistent with the other checks below.
 verify_deployment_targets() {
-  local expected_min="${MACPARAKEET_MEETING_ECHO_MIN_MACOS_VERSION:-}"
-  if [[ -z "$expected_min" ]]; then
-    local plist="$APP_PATH/Contents/Info.plist"
-    if [[ -f "$plist" ]]; then
-      expected_min="$(/usr/libexec/PlistBuddy -c 'Print :LSMinimumSystemVersion' "$plist" 2>/dev/null || true)"
-    fi
+  local override_min="${MACPARAKEET_MEETING_ECHO_MIN_MACOS_VERSION:-}"
+  local plist="$APP_PATH/Contents/Info.plist"
+  local plist_min=""
+  if [[ -f "$plist" ]]; then
+    plist_min="$(/usr/libexec/PlistBuddy -c 'Print :LSMinimumSystemVersion' "$plist" 2>/dev/null || true)"
   fi
 
-  if [[ -z "$expected_min" ]] || ! is_macos_version "$expected_min"; then
+  if [[ -n "$override_min" ]] && ! is_macos_version "$override_min"; then
+    echo "Error: MACPARAKEET_MEETING_ECHO_MIN_MACOS_VERSION must be a valid macOS version." >&2
+    exit 1
+  fi
+  if [[ -e "$plist" ]] && ! is_macos_version "$plist_min"; then
+    echo "Error: bundle Info.plist must carry a valid LSMinimumSystemVersion." >&2
+    exit 1
+  fi
+
+  # Before app assembly the override stands alone; afterward it can only
+  # tighten the minimum advertised by the bundle.
+  local expected_min="$plist_min"
+  if [[ -n "$override_min" ]]; then
+    if [[ -z "$expected_min" ]] || version_gt "$expected_min" "$override_min"; then
+      expected_min="$override_min"
+    fi
+  fi
+  if [[ -z "$expected_min" ]]; then
     echo "Error: could not determine a valid app LSMinimumSystemVersion to verify bundled LocalVQE dylib deployment targets against." >&2
     echo "  Set MACPARAKEET_MEETING_ECHO_MIN_MACOS_VERSION, or ensure $APP_PATH/Contents/Info.plist carries a valid LSMinimumSystemVersion." >&2
     exit 1
@@ -65,7 +81,11 @@ verify_deployment_targets() {
 
   local failed=0
   local dylib
-  while IFS= read -r -d '' dylib; do
+  for dylib in "$FRAMEWORKS_DIR"/*.dylib; do
+    if [[ ! -f "$dylib" && ! -L "$dylib" ]]; then
+      echo "Error: could not enumerate bundled LocalVQE dylibs: $FRAMEWORKS_DIR" >&2
+      exit 1
+    fi
     local minos_output
     if ! minos_output="$(macho_minos "$dylib")"; then
       echo "Error: could not determine a minimum OS version for bundled LocalVQE dylib: $dylib" >&2
@@ -85,7 +105,7 @@ verify_deployment_targets() {
         failed=1
       fi
     done <<<"$minos_output"
-  done < <(find "$FRAMEWORKS_DIR" -maxdepth 1 -type f -name '*.dylib' -print0)
+  done
 
   if [[ "$failed" == "1" ]]; then
     exit 1


### PR DESCRIPTION
The v0.8.0 DMG ships a LocalVQE library built for **macOS 26.0** while the app advertises **macOS 14.2**. That mismatch is the inspected release artifact, not a new packaging path. Since meeting-echo assets were first bundled, the prep script inherited the build host's deployment target, and neither the cache key nor bundle verification compared each dylib's `minos` to `LSMinimumSystemVersion`. A host newer than 14.2 could have shipped the same class of mismatch; v0.8.0 is the build that made it visible.

This change sets an explicit CMake deployment target, includes it in the native cache stamp, and verifies the minimum OS of every bundled dylib architecture. Environment overrides may tighten the app's advertised minimum; they cannot weaken it. Invalid metadata, missing architecture slices, symlinked incompatible libraries, and unreadable library inventories cannot silently pass. Bundles that intentionally omit echo suppression assets keep their existing passthrough behavior.

## Evidence and validation

- Inspected the exact [v0.8.0 release](https://github.com/moona3k/macparakeet/releases/tag/v0.8.0) DMG, SHA256 `a82b5f5e1c64272766e09a1985b627aad41960c6eba3ac7b1b9359927b8da474`. Its library declares `minos 26.0`; the app plist declares `14.2`.
- Rebuilt the pinned native source with target 14.2. The result declares `minos 14.2` and processed 100 synthetic microphone/reference frames successfully on the current Apple Silicon host.
- The final verifier rejects the released binary, including with the former override bypass, and accepts the rebuilt library.
- Distribution fixture suites — Mach-O minimum parsing, native preparation/cache behavior, echo asset verification, app privacy surface, and release version verification — pass locally. The restricted-PATH fixture fix (`b9309d8c`) passes all three affected shell suites, and the hidden dot-prefixed dylib inspection (`fc9ed61f`) passes the verifier fixtures. Shell syntax and diff whitespace checks pass.
- A combined local integration run at `6dfafdc6` (this branch's `00c26f74` plus the crash-hardening branch) ran 6,113 XCTest tests with 21 skips and one failure — an unrelated `ENOSPC` temp-file-creation error in `TranscriptionServiceTests.testTranscribeMeetingDoesNotReplaceCalendarOrCustomTitle` — plus 29 Swift Testing tests, all passing. This packaging change's own `MeetingEchoSuppressionRuntimeTests` passed. A focused rerun of the failed test plus 17 capture-lifecycle tests (18 total) subsequently passed. This is not a fully green full local suite; hosted CI on the exact current head (`fc9ed61f`) has since completed — [run 34712966366](https://github.com/moona3k/macparakeet/actions/runs/34712966366) is a verified SUCCESS, covering the 3 packaging fixtures, release build, CLI smoke, bundle smoke, concurrency, Swift 6, and full Swift test jobs.
- Independent Sonnet and Fable 5.1 review completed. Review found existing Swift verifier fixtures lacked an app plist/deployment target; those fixtures are corrected. The no-mistakes gate also removed an unnecessary second deployment-target override; the native target now derives directly from the app minimum.

This closes the demonstrated packaging gap. It does not establish the faulting instruction for reported native LocalVQE crashes, and runtime validation on macOS 14/15 remains a release check. No Swift application behavior changes here; callback and signal-reporter hardening is the separate PR, [#1021](https://github.com/moona3k/macparakeet/pull/1021).

## Post-Deploy Monitoring & Validation

The next release maintainer should run strict asset verification on the final app bundle and inspect every bundled dylib's minimum OS before signing/releasing. Exercise echo-enabled meeting capture on macOS 14 and 15 before claiming those runtime paths validated. During the first week after release, compare LocalVQE load/process failures and `crash_occurred` reports by crashed app version and OS in Cloudflare D1. Upload time may follow the actual incident.

A new library-load failure or echo-path regression on a supported OS blocks release and warrants reverting/rebuilding the native asset. Do not bypass the new verifier to accept a library requiring a newer OS. No production rollout is part of this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes LocalVQE dylibs being built with a minimum macOS version newer than the app's advertised 14.2, which could crash on supported systems. LocalVQE now builds against the app minimum, and the bundle verifier hard-fails any dylib slice that exceeds it.

**Bug Fixes**
- `prepare_meeting_echo_assets.sh` passes `CMAKE_OSX_DEPLOYMENT_TARGET` from the app minimum and keys the cache stamp on it.
- `verify_meeting_echo_assets.sh` inspects every bundled dylib and architecture slice, including symlinks and hidden dot-prefixed dependencies, rejecting any above the app's `LSMinimumSystemVersion`.
- Overrides can only tighten the ceiling; missing or malformed versions, symlinked dylibs, and unreadable inventories fail rather than pass.
- New shell regression suites run in CI; Swift fixtures now use `-mmacosx-version-min=14.2` with a matching `Info.plist`.

<sup>Written for commit fc9ed61fbaedb243ed8011f2bb835ca70dbfba34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/moona3k/macparakeet/pull/1020?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added compatibility coverage for Meeting Echo components targeting macOS 14.2.
  - Added automated packaging fixture checks with strict error handling and time limits.

- **Build & Distribution**
  - Improved Meeting Echo asset builds to consistently respect the app’s minimum macOS version.
  - Added validation to ensure bundled components support the app’s declared macOS version across all architectures.
  - Improved handling and reporting of missing or invalid compatibility metadata.

- **Documentation**
  - Documented Meeting Echo asset building, verification, and minimum macOS version behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

